### PR TITLE
Add privacy policy and terms of service pages

### DIFF
--- a/crates/vouch-server/src/handlers/legal.rs
+++ b/crates/vouch-server/src/handlers/legal.rs
@@ -1,0 +1,66 @@
+//! Legal pages handler (privacy policy and terms of service).
+
+use crate::AppState;
+use askama::Template;
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{Html, IntoResponse, Response},
+};
+use std::sync::Arc;
+
+/// Privacy policy page template.
+#[derive(Template)]
+#[template(path = "privacy.html")]
+pub struct PrivacyTemplate {
+    pub org_name: String,
+}
+
+impl IntoResponse for PrivacyTemplate {
+    fn into_response(self) -> Response {
+        match self.render() {
+            Ok(html) => Html(html).into_response(),
+            Err(e) => {
+                tracing::error!("Template render error: {}", e);
+                StatusCode::INTERNAL_SERVER_ERROR.into_response()
+            }
+        }
+    }
+}
+
+/// Terms of service page template.
+#[derive(Template)]
+#[template(path = "terms.html")]
+pub struct TermsTemplate {
+    pub org_name: String,
+}
+
+impl IntoResponse for TermsTemplate {
+    fn into_response(self) -> Response {
+        match self.render() {
+            Ok(html) => Html(html).into_response(),
+            Err(e) => {
+                tracing::error!("Template render error: {}", e);
+                StatusCode::INTERNAL_SERVER_ERROR.into_response()
+            }
+        }
+    }
+}
+
+/// Privacy policy page.
+/// GET /privacy
+#[allow(clippy::unused_async)]
+pub async fn privacy_page(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    PrivacyTemplate {
+        org_name: state.config.get_org_display_name().to_string(),
+    }
+}
+
+/// Terms of service page.
+/// GET /terms
+#[allow(clippy::unused_async)]
+pub async fn terms_page(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    TermsTemplate {
+        org_name: state.config.get_org_display_name().to_string(),
+    }
+}

--- a/crates/vouch-server/src/handlers/mod.rs
+++ b/crates/vouch-server/src/handlers/mod.rs
@@ -9,5 +9,6 @@ pub mod enroll;
 pub mod home;
 pub mod keys;
 pub mod landing;
+pub mod legal;
 pub mod oidc;
 pub mod scim;

--- a/crates/vouch-server/src/main.rs
+++ b/crates/vouch-server/src/main.rs
@@ -131,6 +131,9 @@ async fn main() -> Result<()> {
             get(handlers::home::developer_setup_page),
         )
         .route("/health", get(|| async { "ok" }))
+        // Legal pages
+        .route("/privacy", get(handlers::legal::privacy_page))
+        .route("/terms", get(handlers::legal::terms_page))
         // OIDC Provider endpoints
         .route(
             "/.well-known/openid-configuration",

--- a/crates/vouch-server/templates/privacy.html
+++ b/crates/vouch-server/templates/privacy.html
@@ -1,0 +1,100 @@
+{% extends "base.html" %}
+
+{% block title %}Privacy Policy - {{ org_name }}{% endblock %}
+
+{% block content %}
+<div class="flex items-center justify-center min-h-screen p-5">
+    <div class="card max-w-3xl w-full">
+        <div class="mb-6">
+            <a href="/" class="text-vouch-500 hover:text-vouch-600 text-sm">&larr; Back to Home</a>
+        </div>
+
+        <h1 class="text-3xl font-bold text-gray-900 mb-2">Privacy Policy</h1>
+        <p class="text-gray-500 text-sm mb-8">Last updated: January 2025</p>
+
+        <div class="prose prose-gray max-w-none">
+            <section class="mb-8">
+                <h2 class="text-xl font-semibold text-gray-900 mb-3">Introduction</h2>
+                <p class="text-gray-600 mb-4">
+                    {{ org_name }} ("we", "our", or "us") operates the Vouch authentication service.
+                    This Privacy Policy explains how we collect, use, and protect your information when you use our service.
+                </p>
+            </section>
+
+            <section class="mb-8">
+                <h2 class="text-xl font-semibold text-gray-900 mb-3">Information We Collect</h2>
+                <p class="text-gray-600 mb-4">We collect the following types of information:</p>
+                <ul class="list-disc list-inside text-gray-600 space-y-2 ml-4">
+                    <li><strong>Account Information:</strong> Email address and identity information provided through your organization's identity provider.</li>
+                    <li><strong>Authentication Data:</strong> FIDO2/WebAuthn credential identifiers (public keys) associated with your security keys. We never store private keys.</li>
+                    <li><strong>Usage Logs:</strong> Authentication events, including timestamps, IP addresses, and credential usage for security auditing.</li>
+                    <li><strong>Device Information:</strong> Security key metadata (e.g., authenticator type) for compatibility and security purposes.</li>
+                </ul>
+            </section>
+
+            <section class="mb-8">
+                <h2 class="text-xl font-semibold text-gray-900 mb-3">How We Use Your Information</h2>
+                <p class="text-gray-600 mb-4">We use your information to:</p>
+                <ul class="list-disc list-inside text-gray-600 space-y-2 ml-4">
+                    <li>Authenticate your identity and issue short-lived credentials</li>
+                    <li>Maintain security and detect unauthorized access attempts</li>
+                    <li>Comply with legal obligations and organizational security policies</li>
+                    <li>Improve and maintain our service</li>
+                </ul>
+            </section>
+
+            <section class="mb-8">
+                <h2 class="text-xl font-semibold text-gray-900 mb-3">Data Retention</h2>
+                <p class="text-gray-600 mb-4">
+                    Authentication logs are retained according to your organization's security policies.
+                    Credential data is retained until you or your administrator removes it.
+                    Session tokens are short-lived (typically 8 hours) and automatically expire.
+                </p>
+            </section>
+
+            <section class="mb-8">
+                <h2 class="text-xl font-semibold text-gray-900 mb-3">Data Security</h2>
+                <p class="text-gray-600 mb-4">
+                    We implement industry-standard security measures to protect your data:
+                </p>
+                <ul class="list-disc list-inside text-gray-600 space-y-2 ml-4">
+                    <li>All communications are encrypted using TLS</li>
+                    <li>FIDO2/WebAuthn ensures phishing-resistant authentication</li>
+                    <li>Private keys never leave your security device</li>
+                    <li>Short-lived credentials minimize exposure from potential breaches</li>
+                </ul>
+            </section>
+
+            <section class="mb-8">
+                <h2 class="text-xl font-semibold text-gray-900 mb-3">Your Rights</h2>
+                <p class="text-gray-600 mb-4">
+                    Depending on your jurisdiction, you may have rights regarding your personal data, including:
+                </p>
+                <ul class="list-disc list-inside text-gray-600 space-y-2 ml-4">
+                    <li>Access to your personal data</li>
+                    <li>Correction of inaccurate data</li>
+                    <li>Deletion of your data (subject to retention requirements)</li>
+                    <li>Data portability</li>
+                </ul>
+                <p class="text-gray-600 mt-4">
+                    Contact your organization's administrator to exercise these rights.
+                </p>
+            </section>
+
+            <section class="mb-8">
+                <h2 class="text-xl font-semibold text-gray-900 mb-3">Contact Us</h2>
+                <p class="text-gray-600">
+                    If you have questions about this Privacy Policy, please contact your organization's IT administrator
+                    or security team.
+                </p>
+            </section>
+        </div>
+
+        <div class="mt-8 pt-6 border-t border-gray-200">
+            <p class="text-gray-500 text-sm text-center">
+                <a href="/terms" class="text-vouch-500 hover:text-vouch-600">Terms of Service</a>
+            </p>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/crates/vouch-server/templates/terms.html
+++ b/crates/vouch-server/templates/terms.html
@@ -1,0 +1,123 @@
+{% extends "base.html" %}
+
+{% block title %}Terms of Service - {{ org_name }}{% endblock %}
+
+{% block content %}
+<div class="flex items-center justify-center min-h-screen p-5">
+    <div class="card max-w-3xl w-full">
+        <div class="mb-6">
+            <a href="/" class="text-vouch-500 hover:text-vouch-600 text-sm">&larr; Back to Home</a>
+        </div>
+
+        <h1 class="text-3xl font-bold text-gray-900 mb-2">Terms of Service</h1>
+        <p class="text-gray-500 text-sm mb-8">Last updated: January 2025</p>
+
+        <div class="prose prose-gray max-w-none">
+            <section class="mb-8">
+                <h2 class="text-xl font-semibold text-gray-900 mb-3">Acceptance of Terms</h2>
+                <p class="text-gray-600 mb-4">
+                    By accessing or using the Vouch authentication service provided by {{ org_name }},
+                    you agree to be bound by these Terms of Service. If you do not agree to these terms,
+                    do not use the service.
+                </p>
+            </section>
+
+            <section class="mb-8">
+                <h2 class="text-xl font-semibold text-gray-900 mb-3">Description of Service</h2>
+                <p class="text-gray-600 mb-4">
+                    Vouch is a hardware-backed authentication service that issues short-lived credentials
+                    after FIDO2 verification with a compatible security key (e.g., YubiKey). The service provides:
+                </p>
+                <ul class="list-disc list-inside text-gray-600 space-y-2 ml-4">
+                    <li>Phishing-resistant authentication using FIDO2/WebAuthn</li>
+                    <li>Short-lived SSH certificates and other credentials</li>
+                    <li>Integration with your organization's identity provider</li>
+                </ul>
+            </section>
+
+            <section class="mb-8">
+                <h2 class="text-xl font-semibold text-gray-900 mb-3">User Responsibilities</h2>
+                <p class="text-gray-600 mb-4">As a user of this service, you agree to:</p>
+                <ul class="list-disc list-inside text-gray-600 space-y-2 ml-4">
+                    <li>Keep your security key physically secure and report any loss or theft immediately</li>
+                    <li>Not share your security key or credentials with others</li>
+                    <li>Use the service only for authorized purposes within your organization</li>
+                    <li>Comply with your organization's security policies and acceptable use guidelines</li>
+                    <li>Not attempt to circumvent, disable, or interfere with security features</li>
+                </ul>
+            </section>
+
+            <section class="mb-8">
+                <h2 class="text-xl font-semibold text-gray-900 mb-3">Security Key Requirements</h2>
+                <p class="text-gray-600 mb-4">
+                    This service requires a FIDO2-compatible security key with user verification capability.
+                    You are responsible for:
+                </p>
+                <ul class="list-disc list-inside text-gray-600 space-y-2 ml-4">
+                    <li>Obtaining and maintaining a compatible security key</li>
+                    <li>Setting up a PIN on your security key as required</li>
+                    <li>Registering backup security keys as recommended by your organization</li>
+                </ul>
+            </section>
+
+            <section class="mb-8">
+                <h2 class="text-xl font-semibold text-gray-900 mb-3">Service Availability</h2>
+                <p class="text-gray-600 mb-4">
+                    We strive to maintain high availability but do not guarantee uninterrupted service.
+                    The service may be temporarily unavailable due to maintenance, updates, or circumstances
+                    beyond our control. Credential validity periods are designed to minimize disruption
+                    during brief outages.
+                </p>
+            </section>
+
+            <section class="mb-8">
+                <h2 class="text-xl font-semibold text-gray-900 mb-3">Limitation of Liability</h2>
+                <p class="text-gray-600 mb-4">
+                    To the maximum extent permitted by law, {{ org_name }} shall not be liable for any
+                    indirect, incidental, special, consequential, or punitive damages resulting from
+                    your use or inability to use the service. This includes but is not limited to
+                    damages for loss of data, unauthorized access, or service interruption.
+                </p>
+            </section>
+
+            <section class="mb-8">
+                <h2 class="text-xl font-semibold text-gray-900 mb-3">Termination</h2>
+                <p class="text-gray-600 mb-4">
+                    Your access to this service may be terminated:
+                </p>
+                <ul class="list-disc list-inside text-gray-600 space-y-2 ml-4">
+                    <li>By your organization at any time for any reason</li>
+                    <li>Upon termination of your employment or affiliation with the organization</li>
+                    <li>For violation of these terms or your organization's policies</li>
+                </ul>
+                <p class="text-gray-600 mt-4">
+                    Upon termination, your credentials will be revoked and you must discontinue use of the service.
+                </p>
+            </section>
+
+            <section class="mb-8">
+                <h2 class="text-xl font-semibold text-gray-900 mb-3">Changes to Terms</h2>
+                <p class="text-gray-600 mb-4">
+                    We may update these Terms of Service from time to time. Continued use of the service
+                    after changes constitutes acceptance of the updated terms. Material changes will be
+                    communicated through your organization's standard notification channels.
+                </p>
+            </section>
+
+            <section class="mb-8">
+                <h2 class="text-xl font-semibold text-gray-900 mb-3">Contact</h2>
+                <p class="text-gray-600">
+                    For questions about these Terms of Service, please contact your organization's
+                    IT administrator or security team.
+                </p>
+            </section>
+        </div>
+
+        <div class="mt-8 pt-6 border-t border-gray-200">
+            <p class="text-gray-500 text-sm text-center">
+                <a href="/privacy" class="text-vouch-500 hover:text-vouch-600">Privacy Policy</a>
+            </p>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
Add legal pages (Privacy Policy and Terms of Service) to the Vouch authentication service with proper templating and routing.

## Changes
- **New handler module** (`handlers/legal.rs`): Implements two page handlers
  - `privacy_page()`: Serves the privacy policy at `/privacy`
  - `terms_page()`: Serves the terms of service at `/terms`
  - Both handlers use Askama templates and inject the organization name from config

- **New templates**:
  - `privacy.html`: Comprehensive privacy policy covering data collection, usage, retention, security measures, and user rights
  - `terms.html`: Terms of service covering service description, user responsibilities, security key requirements, liability limitations, and termination policies

- **Route registration**: Added `/privacy` and `/terms` routes to the main router in `main.rs`

- **Module export**: Added `legal` module to `handlers/mod.rs`

## Implementation Details
- Both templates extend the existing `base.html` template for consistent styling and layout
- Templates use Tailwind CSS classes matching the existing design system
- Organization name is dynamically injected from `AppState.config` for multi-tenant support
- Error handling follows existing patterns with proper logging and HTTP 500 responses
- Templates include cross-links between privacy policy and terms of service for easy navigation
- Both pages include a back-to-home link for improved UX