### PR TITLE
Add domain-based multi-tenancy with organization support

### DIFF
--- a/crates/vouch-server/migrations/014_organizations.sql
+++ b/crates/vouch-server/migrations/014_organizations.sql
@@ -1,0 +1,18 @@
+-- Organizations table for domain-based multi-tenancy
+CREATE TABLE IF NOT EXISTS organizations (
+    id TEXT PRIMARY KEY,
+    domain TEXT UNIQUE NOT NULL,
+    name TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    created_by_user_id TEXT
+);
+
+-- Add org_id to users (NULL = personal account, e.g., gmail.com)
+ALTER TABLE users ADD COLUMN org_id TEXT REFERENCES organizations(id);
+
+-- Add is_org_admin flag to track organization administrators
+ALTER TABLE users ADD COLUMN is_org_admin INTEGER NOT NULL DEFAULT 0;
+
+-- Index for efficient org lookups
+CREATE INDEX IF NOT EXISTS idx_organizations_domain ON organizations(domain);
+CREATE INDEX IF NOT EXISTS idx_users_org ON users(org_id);

--- a/crates/vouch-server/src/db.rs
+++ b/crates/vouch-server/src/db.rs
@@ -12,6 +12,20 @@ pub struct User {
     pub email: String,
     #[allow(dead_code)]
     pub name: Option<String>,
+    /// Organization ID (NULL for personal accounts like gmail.com).
+    pub org_id: Option<String>,
+    /// Whether this user is an admin of their organization.
+    pub is_org_admin: bool,
+}
+
+/// Organization record for domain-based multi-tenancy.
+#[derive(Debug, sqlx::FromRow)]
+pub struct Organization {
+    pub id: String,
+    pub domain: String,
+    pub name: Option<String>,
+    pub created_at: String,
+    pub created_by_user_id: Option<String>,
 }
 
 /// Authenticator (credential) record.
@@ -56,10 +70,45 @@ pub async fn upsert_user(pool: &SqlitePool, email: &str, name: Option<&str>) -> 
         .await?;
 
     // Fetch the user
-    let user = sqlx::query_as::<_, User>("SELECT id, email, name FROM users WHERE email = ?")
-        .bind(email)
-        .fetch_one(pool)
-        .await?;
+    let user = sqlx::query_as::<_, User>(
+        "SELECT id, email, name, org_id, is_org_admin FROM users WHERE email = ?",
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(user)
+}
+
+/// Create or get a user by email, associating them with an organization.
+pub async fn upsert_user_with_org(
+    pool: &SqlitePool,
+    email: &str,
+    name: Option<&str>,
+    org_id: Option<&str>,
+    is_org_admin: bool,
+) -> Result<User> {
+    let id = Uuid::new_v4().to_string();
+
+    // Try to insert with org info, ignore if exists
+    sqlx::query(
+        "INSERT OR IGNORE INTO users (id, email, name, org_id, is_org_admin) VALUES (?, ?, ?, ?, ?)",
+    )
+    .bind(&id)
+    .bind(email)
+    .bind(name)
+    .bind(org_id)
+    .bind(is_org_admin)
+    .execute(pool)
+    .await?;
+
+    // Fetch the user
+    let user = sqlx::query_as::<_, User>(
+        "SELECT id, email, name, org_id, is_org_admin FROM users WHERE email = ?",
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await?;
 
     Ok(user)
 }
@@ -67,20 +116,24 @@ pub async fn upsert_user(pool: &SqlitePool, email: &str, name: Option<&str>) -> 
 /// Get a user by email.
 #[allow(dead_code)]
 pub async fn get_user_by_email(pool: &SqlitePool, email: &str) -> Result<Option<User>> {
-    let user = sqlx::query_as::<_, User>("SELECT id, email, name FROM users WHERE email = ?")
-        .bind(email)
-        .fetch_optional(pool)
-        .await?;
+    let user = sqlx::query_as::<_, User>(
+        "SELECT id, email, name, org_id, is_org_admin FROM users WHERE email = ?",
+    )
+    .bind(email)
+    .fetch_optional(pool)
+    .await?;
 
     Ok(user)
 }
 
 /// Get a user by ID.
 pub async fn get_user_by_id(pool: &SqlitePool, user_id: &str) -> Result<Option<User>> {
-    let user = sqlx::query_as::<_, User>("SELECT id, email, name FROM users WHERE id = ?")
-        .bind(user_id)
-        .fetch_optional(pool)
-        .await?;
+    let user = sqlx::query_as::<_, User>(
+        "SELECT id, email, name, org_id, is_org_admin FROM users WHERE id = ?",
+    )
+    .bind(user_id)
+    .fetch_optional(pool)
+    .await?;
 
     Ok(user)
 }
@@ -608,13 +661,16 @@ pub struct UserWithAuthCount {
     pub name: Option<String>,
     pub created_at: String,
     pub authenticator_count: i64,
+    pub org_id: Option<String>,
+    pub is_org_admin: bool,
 }
 
 /// List all users with their authenticator counts.
 pub async fn list_users_with_auth_count(pool: &SqlitePool) -> Result<Vec<UserWithAuthCount>> {
     let users = sqlx::query_as::<_, UserWithAuthCount>(
         "SELECT u.id, u.email, u.name, u.created_at,
-                (SELECT COUNT(*) FROM authenticators a WHERE a.user_id = u.id) as authenticator_count
+                (SELECT COUNT(*) FROM authenticators a WHERE a.user_id = u.id) as authenticator_count,
+                u.org_id, u.is_org_admin
          FROM users u
          ORDER BY u.email",
     )
@@ -622,6 +678,138 @@ pub async fn list_users_with_auth_count(pool: &SqlitePool) -> Result<Vec<UserWit
     .await?;
 
     Ok(users)
+}
+
+/// List users in a specific organization with their authenticator counts.
+pub async fn list_users_with_auth_count_by_org(
+    pool: &SqlitePool,
+    org_id: &str,
+) -> Result<Vec<UserWithAuthCount>> {
+    let users = sqlx::query_as::<_, UserWithAuthCount>(
+        "SELECT u.id, u.email, u.name, u.created_at,
+                (SELECT COUNT(*) FROM authenticators a WHERE a.user_id = u.id) as authenticator_count,
+                u.org_id, u.is_org_admin
+         FROM users u
+         WHERE u.org_id = ?
+         ORDER BY u.email",
+    )
+    .bind(org_id)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(users)
+}
+
+// ============================================================================
+// Organization Management
+// ============================================================================
+
+/// Get an organization by domain.
+pub async fn get_org_by_domain(pool: &SqlitePool, domain: &str) -> Result<Option<Organization>> {
+    let org = sqlx::query_as::<_, Organization>(
+        "SELECT id, domain, name, created_at, created_by_user_id FROM organizations WHERE domain = ?",
+    )
+    .bind(domain)
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(org)
+}
+
+/// Get an organization by ID.
+pub async fn get_org_by_id(pool: &SqlitePool, org_id: &str) -> Result<Option<Organization>> {
+    let org = sqlx::query_as::<_, Organization>(
+        "SELECT id, domain, name, created_at, created_by_user_id FROM organizations WHERE id = ?",
+    )
+    .bind(org_id)
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(org)
+}
+
+/// Create a new organization.
+pub async fn create_organization(
+    pool: &SqlitePool,
+    domain: &str,
+    name: Option<&str>,
+    created_by_user_id: Option<&str>,
+) -> Result<Organization> {
+    let id = Uuid::new_v4().to_string();
+
+    sqlx::query(
+        "INSERT INTO organizations (id, domain, name, created_by_user_id) VALUES (?, ?, ?, ?)",
+    )
+    .bind(&id)
+    .bind(domain)
+    .bind(name)
+    .bind(created_by_user_id)
+    .execute(pool)
+    .await?;
+
+    let org = sqlx::query_as::<_, Organization>(
+        "SELECT id, domain, name, created_at, created_by_user_id FROM organizations WHERE id = ?",
+    )
+    .bind(&id)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(org)
+}
+
+/// Get or create an organization by domain.
+/// Returns (org, is_new) tuple where is_new indicates if the org was just created.
+pub async fn get_or_create_org_by_domain(
+    pool: &SqlitePool,
+    domain: &str,
+    name: Option<&str>,
+    created_by_user_id: Option<&str>,
+) -> Result<(Organization, bool)> {
+    // Check if org exists
+    if let Some(org) = get_org_by_domain(pool, domain).await? {
+        return Ok((org, false));
+    }
+
+    // Create new org
+    let org = create_organization(pool, domain, name, created_by_user_id).await?;
+    Ok((org, true))
+}
+
+/// Update a user's organization membership.
+pub async fn set_user_org(
+    pool: &SqlitePool,
+    user_id: &str,
+    org_id: Option<&str>,
+    is_org_admin: bool,
+) -> Result<()> {
+    sqlx::query("UPDATE users SET org_id = ?, is_org_admin = ? WHERE id = ?")
+        .bind(org_id)
+        .bind(is_org_admin)
+        .execute(pool)
+        .await?;
+
+    Ok(())
+}
+
+/// Count users in an organization.
+pub async fn count_users_in_org(pool: &SqlitePool, org_id: &str) -> Result<i64> {
+    let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM users WHERE org_id = ?")
+        .bind(org_id)
+        .fetch_one(pool)
+        .await?;
+
+    Ok(row.0)
+}
+
+/// List all organizations.
+pub async fn list_organizations(pool: &SqlitePool) -> Result<Vec<Organization>> {
+    let orgs = sqlx::query_as::<_, Organization>(
+        "SELECT id, domain, name, created_at, created_by_user_id FROM organizations ORDER BY domain",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    Ok(orgs)
 }
 
 /// Delete a user and all associated data.

--- a/crates/vouch-server/src/handlers/admin.rs
+++ b/crates/vouch-server/src/handlers/admin.rs
@@ -204,34 +204,79 @@ fn is_admin_authorized(state: &AppState, query: &AdminQuery) -> bool {
     false
 }
 
+/// Admin authorization result with context.
+pub struct AdminAuthResult {
+    /// Whether the admin is authorized.
+    pub authorized: bool,
+    /// Bootstrap token if used (None for cookie auth).
+    pub token: Option<String>,
+    /// Admin email if authenticated via cookie.
+    pub admin_email: Option<String>,
+    /// Organization ID if admin is scoped to an org (None for global admin).
+    pub org_id: Option<String>,
+    /// Whether this is a global admin (bootstrap token or config-listed email).
+    pub is_global_admin: bool,
+}
+
 /// Check if the request is authorized for admin access (async version with cookie support).
-#[allow(dead_code)]
 async fn is_admin_authorized_async(
     state: &AppState,
     query: &AdminQuery,
     headers: &HeaderMap,
-) -> (bool, Option<String>) {
-    // Check bootstrap token first
+) -> AdminAuthResult {
+    // Check bootstrap token first (global admin)
     if let Some(token) = &query.token
         && state.config.verify_bootstrap_token(token)
     {
-        return (true, query.token.clone());
+        return AdminAuthResult {
+            authorized: true,
+            token: query.token.clone(),
+            admin_email: None,
+            org_id: None,
+            is_global_admin: true,
+        };
     }
 
     // Check admin session cookie
     if let Some(email) = get_admin_session_from_cookie(state, headers).await {
-        // Verify email is in admin list
-        if state
+        // Check if email is in global admin list
+        let is_global = state
             .config
             .admin_emails
             .iter()
-            .any(|e| e.eq_ignore_ascii_case(&email))
-        {
-            return (true, None);
+            .any(|e| e.eq_ignore_ascii_case(&email));
+
+        if is_global {
+            return AdminAuthResult {
+                authorized: true,
+                token: None,
+                admin_email: Some(email),
+                org_id: None,
+                is_global_admin: true,
+            };
+        }
+
+        // Check if user is an org admin
+        if let Ok(Some(user)) = db::get_user_by_email(&state.db, &email).await {
+            if user.is_org_admin {
+                return AdminAuthResult {
+                    authorized: true,
+                    token: None,
+                    admin_email: Some(email),
+                    org_id: user.org_id,
+                    is_global_admin: false,
+                };
+            }
         }
     }
 
-    (false, None)
+    AdminAuthResult {
+        authorized: false,
+        token: None,
+        admin_email: None,
+        org_id: None,
+        is_global_admin: false,
+    }
 }
 
 /// Extract admin email from session cookie if valid.
@@ -563,15 +608,30 @@ pub async fn setup_test_oidc(
 /// GET /admin/users
 pub async fn list_users(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Query(query): Query<AdminQuery>,
 ) -> Response {
-    if !is_admin_authorized(&state, &query) {
+    let auth = is_admin_authorized_async(&state, &query, &headers).await;
+
+    if !auth.authorized {
         return AdminUnauthorizedTemplate.into_response();
     }
 
-    let token = query.token.as_deref().unwrap_or("").to_string();
+    let token = auth.token.as_deref().unwrap_or("").to_string();
 
-    let users = match db::list_users_with_auth_count(&state.db).await {
+    // Scope users by organization for non-global admins
+    let users = if auth.is_global_admin {
+        // Global admin sees all users
+        db::list_users_with_auth_count(&state.db).await
+    } else if let Some(org_id) = &auth.org_id {
+        // Org admin sees only their org's users
+        db::list_users_with_auth_count_by_org(&state.db, org_id).await
+    } else {
+        // Personal account admin (shouldn't happen, but handle gracefully)
+        Ok(vec![])
+    };
+
+    let users = match users {
         Ok(u) => u,
         Err(e) => {
             tracing::error!("Failed to list users: {}", e);
@@ -593,14 +653,33 @@ pub async fn list_users(
 /// POST /admin/users/:id/delete
 pub async fn delete_user(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Query(query): Query<AdminQuery>,
     Path(user_id): Path<String>,
 ) -> Response {
-    if !is_admin_authorized(&state, &query) {
+    let auth = is_admin_authorized_async(&state, &query, &headers).await;
+
+    if !auth.authorized {
         return AdminUnauthorizedTemplate.into_response();
     }
 
-    let token = query.token.as_deref().unwrap_or("").to_string();
+    let token = auth.token.as_deref().unwrap_or("").to_string();
+
+    // For non-global admins, verify the user belongs to their org
+    if !auth.is_global_admin {
+        if let Ok(Some(target_user)) = db::get_user_by_id(&state.db, &user_id).await {
+            if target_user.org_id != auth.org_id {
+                return AdminMessageTemplate {
+                    page_title: "Error".to_string(),
+                    title: "Unauthorized".to_string(),
+                    message: "You can only delete users from your organization.".to_string(),
+                    back_url: format!("/admin/users?token={token}"),
+                    is_error: true,
+                }
+                .into_response();
+            }
+        }
+    }
 
     if let Err(e) = db::delete_user(&state.db, &user_id).await {
         tracing::error!("Failed to delete user: {}", e);

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -138,6 +138,18 @@ struct IdTokenClaims {
     email_verified: bool,
     #[allow(dead_code)]
     nonce: Option<String>,
+    /// Google Workspace hosted domain (e.g., "acme.com").
+    /// Only present for Workspace accounts, not consumer Gmail.
+    hd: Option<String>,
+}
+
+/// Data passed through OIDC state for enrollment.
+/// Encoded as JSON in the nonce field of oidc_states table.
+#[derive(Debug, Serialize, Deserialize)]
+struct EnrollmentData {
+    email: String,
+    /// Google Workspace hosted domain (None for personal accounts like gmail.com).
+    hd: Option<String>,
 }
 
 /// Client data JSON structure from `WebAuthn` response.
@@ -575,17 +587,23 @@ pub async fn oidc_callback(
         }
     }
 
-    // Store email in state for WebAuthn registration
-    // Update the OIDC state to include the email (we'll use a new state token)
+    // Store enrollment data (email + hd) in state for WebAuthn registration
     let new_state = URL_SAFE_NO_PAD.encode(generate_random_bytes(32));
     let state_expires = now.checked_add(Span::new().minutes(10)).unwrap_or(now);
 
-    // Create new state with email embedded
+    // Encode enrollment data as JSON
+    let enrollment_data = EnrollmentData {
+        email: claims.email.clone(),
+        hd: claims.hd.clone(),
+    };
+    let enrollment_json = serde_json::to_string(&enrollment_data).unwrap_or_default();
+
+    // Create new state with enrollment data embedded in nonce field
     if let Err(e) = db::create_oidc_state(
         &state.db,
         &new_state,
         &stored_state.device_auth_id,
-        &claims.email, // Store email in nonce field
+        &enrollment_json,
         &state_expires.to_string(),
     )
     .await
@@ -680,24 +698,55 @@ pub async fn browser_register_start(
         ));
     }
 
-    // Get email from nonce field (set during OIDC callback)
-    let user_email = if oidc_state.nonce.is_empty() {
+    // Get enrollment data from nonce field (set during OIDC callback)
+    let (user_email, hosted_domain) = if oidc_state.nonce.is_empty() {
         // Non-OIDC flow - use a placeholder email for now
-        "user@localhost".to_string()
+        ("user@localhost".to_string(), None)
     } else {
-        oidc_state.nonce.clone()
+        // Try to parse as EnrollmentData JSON, fall back to plain email for backwards compatibility
+        match serde_json::from_str::<EnrollmentData>(&oidc_state.nonce) {
+            Ok(data) => (data.email, data.hd),
+            Err(_) => (oidc_state.nonce.clone(), None),
+        }
     };
 
-    // Create or get user
-    let user = db::upsert_user(&state.db, &user_email, None)
-        .await
-        .map_err(|e| {
-            json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "db_error",
-                &e.to_string(),
-            )
-        })?;
+    // Handle organization based on hosted domain
+    let (org_id, is_first_user) = if let Some(domain) = &hosted_domain {
+        // Workspace user - get or create organization
+        let (org, is_new) = db::get_or_create_org_by_domain(&state.db, domain, None, None)
+            .await
+            .map_err(|e| {
+                json_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "db_error",
+                    &e.to_string(),
+                )
+            })?;
+        (Some(org.id), is_new)
+    } else {
+        // Personal account (e.g., gmail.com) - no organization
+        (None, false)
+    };
+
+    // First user from a domain becomes the org admin
+    let is_org_admin = is_first_user && org_id.is_some();
+
+    // Create or get user with organization
+    let user = db::upsert_user_with_org(
+        &state.db,
+        &user_email,
+        None,
+        org_id.as_deref(),
+        is_org_admin,
+    )
+    .await
+    .map_err(|e| {
+        json_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "db_error",
+            &e.to_string(),
+        )
+    })?;
 
     let user_id = Uuid::parse_str(&user.id).map_err(|e| {
         json_error(
@@ -963,4 +1012,115 @@ fn extract_aaguid_from_attestation(attestation: &[u8]) -> Option<String> {
 
     // Extract AAGUID from authenticator data
     vouch_common::extract_aaguid_from_auth_data(auth_data)
+}
+
+// ============================================================================
+// Direct Enrollment (Browser-only, no CLI)
+// ============================================================================
+
+/// Marker for direct enrollment (no CLI device authorization)
+const DIRECT_ENROLL_MARKER: &str = "direct-enroll";
+
+/// Start direct browser enrollment (no CLI required).
+/// GET /enroll/start
+///
+/// This initiates OIDC authentication directly from the browser,
+/// without requiring the CLI to create a device authorization request.
+/// After successful enrollment, the user can download the CLI and login.
+pub async fn direct_enroll_start(State(state): State<Arc<AppState>>) -> Response {
+    // Check if OIDC is configured
+    if !state.config.oidc_configured() {
+        return ErrorTemplate {
+            title: "Not Configured".to_string(),
+            message: "Identity provider is not configured. Please contact your administrator."
+                .to_string(),
+            back_url: Some("/".to_string()),
+        }
+        .into_response();
+    }
+
+    let now = Timestamp::now();
+
+    // Create a "virtual" device auth request for direct enrollment
+    // This allows us to reuse the existing OIDC callback flow
+    let expires_at = now
+        .checked_add(Span::new().minutes(10))
+        .unwrap_or(now)
+        .to_string();
+
+    let device_auth_id = match db::create_device_auth_request(
+        &state.db,
+        DIRECT_ENROLL_MARKER, // marker instead of real device code hash
+        DIRECT_ENROLL_MARKER, // marker instead of real user code
+        &expires_at,
+        5,
+    )
+    .await
+    {
+        Ok(id) => id,
+        Err(e) => {
+            tracing::error!("Failed to create direct enrollment request: {}", e);
+            return ErrorTemplate {
+                title: "Error".to_string(),
+                message: "Failed to start enrollment. Please try again.".to_string(),
+                back_url: Some("/".to_string()),
+            }
+            .into_response();
+        }
+    };
+
+    // Build OIDC authorization URL
+    let oidc_issuer = state
+        .config
+        .oidc_issuer_url
+        .as_ref()
+        .map_or("", String::as_str);
+    let client_id = state
+        .config
+        .oidc_client_id
+        .as_ref()
+        .map_or("", String::as_str);
+
+    // Generate state and nonce
+    let oidc_state = URL_SAFE_NO_PAD.encode(generate_random_bytes(32));
+    let nonce = URL_SAFE_NO_PAD.encode(generate_random_bytes(32));
+
+    // Store state
+    let state_expires = now.checked_add(Span::new().minutes(10)).unwrap_or(now);
+
+    if let Err(e) = db::create_oidc_state(
+        &state.db,
+        &oidc_state,
+        &device_auth_id,
+        &nonce,
+        &state_expires.to_string(),
+    )
+    .await
+    {
+        tracing::error!("Failed to create OIDC state: {}", e);
+        return ErrorTemplate {
+            title: "Error".to_string(),
+            message: "Failed to start enrollment. Please try again.".to_string(),
+            back_url: Some("/".to_string()),
+        }
+        .into_response();
+    }
+
+    // Build authorization URL
+    let redirect_uri = format!("{}/oauth/callback", state.config.verification_base_url);
+    let auth_url = format!(
+        "{}/authorize?response_type=code&client_id={}&redirect_uri={}&scope=openid%20email%20profile&state={}&nonce={}",
+        oidc_issuer.trim_end_matches('/'),
+        urlencoding::encode(client_id),
+        urlencoding::encode(&redirect_uri),
+        oidc_state,
+        nonce
+    );
+
+    Redirect::to(&auth_url).into_response()
+}
+
+/// Check if a device auth request is for direct enrollment.
+pub fn is_direct_enrollment(device_auth: &db::DeviceAuthRequest) -> bool {
+    device_auth.user_code == DIRECT_ENROLL_MARKER
 }

--- a/crates/vouch-server/src/main.rs
+++ b/crates/vouch-server/src/main.rs
@@ -164,6 +164,8 @@ async fn main() -> Result<()> {
         .route("/device", get(handlers::enroll::device_verify_page))
         .route("/device", post(handlers::enroll::device_verify_submit))
         .route("/oauth/callback", get(handlers::enroll::oidc_callback))
+        // Direct enrollment (browser-only, no CLI required)
+        .route("/enroll/start", get(handlers::enroll::direct_enroll_start))
         .route(
             "/enroll/webauthn/start",
             post(handlers::enroll::browser_register_start),

--- a/crates/vouch-server/templates/landing.html
+++ b/crates/vouch-server/templates/landing.html
@@ -9,14 +9,34 @@
         <h1 class="text-3xl font-bold text-gray-900 mb-2">Welcome to Vouch</h1>
         <p class="text-gray-600 text-lg mb-8">{{ org_name }}'s hardware-backed authentication system</p>
 
+        <!-- Browser-based enrollment -->
         <div class="mb-8">
-            <div class="text-sm font-semibold text-gray-700 uppercase tracking-wide mb-3">Enroll Your Security Key</div>
+            <a href="/enroll/start" class="w-full flex items-center justify-center gap-3 bg-white border-2 border-gray-300 text-gray-700 font-medium py-3 px-6 rounded-lg hover:bg-gray-50 hover:border-gray-400 transition-colors">
+                <svg class="w-5 h-5" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
+                    <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+                    <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
+                    <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+                </svg>
+                Sign in with Google
+            </a>
+            <p class="text-center text-gray-500 text-sm mt-3">Register your security key using your work email</p>
+        </div>
+
+        <div class="relative my-8">
+            <div class="absolute inset-0 flex items-center">
+                <div class="w-full border-t border-gray-200"></div>
+            </div>
+            <div class="relative flex justify-center text-sm">
+                <span class="px-4 bg-white text-gray-500">or use the CLI</span>
+            </div>
+        </div>
+
+        <div class="mb-8">
+            <div class="text-sm font-semibold text-gray-700 uppercase tracking-wide mb-3">Enroll via Command Line</div>
             <div class="code-block relative">
                 <span class="text-gray-500 mr-2">$</span>vouch enroll --server {{ server_url }}
                 <button onclick="copyCommand(this, 'vouch enroll --server {{ server_url }}')" class="absolute right-3 top-1/2 -translate-y-1/2 px-2.5 py-1.5 bg-gray-700 text-gray-400 rounded text-xs hover:bg-gray-600 hover:text-white transition-colors">Copy</button>
-            </div>
-            <div class="mt-2 bg-vouch-50 border-l-4 border-vouch-500 p-4 rounded-r-lg">
-                <p class="text-gray-600 text-sm">This command will open a browser window for verification. Have your YubiKey ready.</p>
             </div>
         </div>
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -553,6 +553,33 @@ curl -X POST https://vouch.example.com/oauth/token \
 
 ---
 
+## Distribution & Deployment
+
+### CLI Distribution
+- [ ] GitHub Releases with pre-compiled binaries (macOS, Linux, Windows)
+- [ ] SBOM (Software Bill of Materials) for each release
+- [ ] SLSA attestations for supply chain security
+- [ ] Homebrew tap (`vouch-sh/tap/vouch`)
+- [ ] APT/RPM repositories
+
+### Server Distribution
+- [ ] Docker images (multi-arch: amd64, arm64)
+- [ ] Helm charts for Kubernetes deployment
+- [ ] Terraform modules (AWS, GCP, Azure)
+- [ ] docker-compose examples
+
+### Multi-Tenancy (dev.vouch.sh)
+- [x] Organizations table with domain-based isolation
+- [x] `hd` claim extraction from Google OIDC
+- [x] Personal accounts (gmail.com) with no org
+- [x] First user from domain becomes org admin
+- [x] Org-scoped admin views
+- [x] Direct browser enrollment (no CLI required)
+- [ ] Organization settings (name, branding)
+- [ ] Usage metrics per organization
+
+---
+
 ## Technical Debt & Improvements
 
 Tracked but not blocking releases:


### PR DESCRIPTION
## Summary

This PR implements domain-based multi-tenancy for Vouch, enabling support for Google Workspace organizations while maintaining backward compatibility with personal accounts (gmail.com). Organizations are automatically created on first enrollment from a domain, with the first user becoming an org admin.

## Key Changes

**Database & Models**
- Added `organizations` table with domain-based unique constraint and indexes
- Extended `users` table with `org_id` (nullable for personal accounts) and `is_org_admin` flag
- New `Organization` struct for type-safe database queries

**User Management**
- New `upsert_user_with_org()` function to create users with organization context
- New `set_user_org()` to update user organization membership
- Organization lookup and creation functions: `get_org_by_domain()`, `get_or_create_org_by_domain()`, `create_organization()`
- `list_users_with_auth_count_by_org()` to scope user listings by organization

**OIDC Enrollment Flow**
- Extract `hd` (hosted domain) claim from Google OIDC tokens
- New `EnrollmentData` struct to pass email + domain through OIDC state
- Automatic organization creation on first enrollment from a domain
- First user from a domain automatically becomes org admin

**Admin Authorization & Access Control**
- Enhanced `AdminAuthResult` struct to track authorization context (global vs org-scoped)
- Org admins can only manage users within their organization
- Global admins (bootstrap token or config-listed emails) see all users
- Updated `/admin/users` and `/admin/users/:id/delete` endpoints to enforce org scoping

**Direct Browser Enrollment**
- New `/enroll/start` endpoint for browser-only enrollment (no CLI required)
- Uses virtual device auth request internally to reuse existing OIDC flow
- Updated landing page with Google Sign-in button and CLI enrollment option

## Implementation Details

- Personal accounts (gmail.com) have `org_id = NULL` and `is_org_admin = false`
- Workspace accounts are automatically associated with their domain organization
- Organization creation is idempotent via `get_or_create_org_by_domain()`
- All user queries updated to include new org fields for consistency
- Backward compatible: existing users without org context continue to work
- Admin authorization now returns rich context instead of simple boolean

## Testing Considerations

- Verify org creation on first Workspace user enrollment
- Confirm org admin can only see/manage their org's users
- Test personal account enrollment (no org assignment)
- Validate global admin access to all users
- Test direct browser enrollment flow