### PR TITLE
feat: AWS multi-account SSO discovery and role chaining

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5485,7 +5485,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vouch-agent"
-version = "2026.4.4"
+version = "2026.4.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5511,7 +5511,7 @@ dependencies = [
 
 [[package]]
 name = "vouch-cli"
-version = "2026.4.4"
+version = "2026.4.5"
 dependencies = [
  "anyhow",
  "aws-lc-rs",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "vouch-common"
-version = "2026.4.4"
+version = "2026.4.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5582,7 +5582,7 @@ dependencies = [
 
 [[package]]
 name = "vouch-httpsig"
-version = "2026.4.4"
+version = "2026.4.5"
 dependencies = [
  "aws-lc-rs",
  "axum",
@@ -5598,7 +5598,7 @@ dependencies = [
 
 [[package]]
 name = "vouch-server"
-version = "2026.4.4"
+version = "2026.4.5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -5680,7 +5680,7 @@ dependencies = [
 
 [[package]]
 name = "vouch-tests"
-version = "2026.4.4"
+version = "2026.4.5"
 dependencies = [
  "anyhow",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "2026.4.4"
+version = "2026.4.5"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 rust-version = "1.94.1"

--- a/crates/vouch-cli/src/commands/aws/accounts.rs
+++ b/crates/vouch-cli/src/commands/aws/accounts.rs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! `vouch aws accounts` — list AWS accounts via Identity Center.
+
+use anyhow::{Context, Result};
+
+use crate::integrations::aws::config::AwsConfig;
+use crate::integrations::aws::sso::{SsoConfig, load_cached_token};
+use crate::integrations::aws::sso_portal::list_accounts;
+
+/// Arguments for `vouch aws accounts`.
+#[derive(clap::Args)]
+pub(crate) struct AccountsArgs {
+    /// SSO session name from ~/.aws/config (default: first found).
+    #[arg(long)]
+    pub sso_session: Option<String>,
+    /// Output as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// Run `vouch aws accounts`.
+pub(crate) async fn run(args: AccountsArgs) -> Result<()> {
+    let aws_config = AwsConfig::load()?;
+    let session = super::resolve_sso_session(&aws_config, args.sso_session.as_deref())?;
+    let sso_config = SsoConfig::from_session(&session);
+
+    let token = load_cached_token(&sso_config).ok_or_else(|| {
+        crate::exit_code::CliError::NotAuthenticated {
+            reason: "SSO session expired or missing. Run 'vouch aws login' first.".to_string(),
+        }
+    })?;
+
+    let http_client =
+        vouch_common::http::credential_client(&format!("vouch-cli/{}", env!("CARGO_PKG_VERSION")))
+            .context("failed to create HTTP client")?;
+
+    let accounts = list_accounts(&http_client, &session.region, &token.token())
+        .await
+        .context("failed to list SSO accounts")?;
+
+    if args.json {
+        let json = serde_json::to_string_pretty(
+            &accounts
+                .iter()
+                .map(|a| {
+                    serde_json::json!({
+                        "accountId": a.account_id,
+                        "accountName": a.account_name,
+                        "emailAddress": a.email_address,
+                    })
+                })
+                .collect::<Vec<_>>(),
+        )
+        .context("failed to serialize accounts")?;
+        println!("{json}");
+    } else {
+        println!("{:<14} {:<40} EMAIL", "ACCOUNT ID", "NAME");
+        println!("{}", "-".repeat(80));
+        for account in &accounts {
+            println!(
+                "{:<14} {:<40} {}",
+                account.account_id, account.account_name, account.email_address
+            );
+        }
+        println!();
+        println!("{} account(s)", accounts.len());
+    }
+
+    Ok(())
+}

--- a/crates/vouch-cli/src/commands/aws/login.rs
+++ b/crates/vouch-cli/src/commands/aws/login.rs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! `vouch aws login` — authenticate to AWS IAM Identity Center.
+
+use anyhow::{Context, Result};
+
+use crate::integrations::aws::config::AwsConfig;
+use crate::integrations::aws::sso::{
+    SsoConfig, load_cached_token, poll_for_token, register_client, save_access_token,
+    start_device_authorization,
+};
+
+/// Arguments for `vouch aws login`.
+#[derive(clap::Args)]
+pub(crate) struct LoginArgs {
+    /// SSO session name from ~/.aws/config (default: first found).
+    #[arg(long)]
+    pub sso_session: Option<String>,
+}
+
+/// Run `vouch aws login`.
+pub(crate) async fn run(args: LoginArgs) -> Result<()> {
+    let aws_config = AwsConfig::load()?;
+    let session = super::resolve_sso_session(&aws_config, args.sso_session.as_deref())?;
+    let sso_config = SsoConfig::from_session(&session);
+
+    // Check if already authenticated
+    if let Some(token) = load_cached_token(&sso_config) {
+        let expires_at = token.expires_at.clone();
+        println!("Already authenticated (expires {expires_at})");
+        return Ok(());
+    }
+
+    let http_client =
+        vouch_common::http::credential_client(&format!("vouch-cli/{}", env!("CARGO_PKG_VERSION")))
+            .context("failed to create HTTP client")?;
+
+    // Register or reuse cached client
+    let registration = register_client(&http_client, &sso_config)
+        .await
+        .context("failed to register SSO OIDC client")?;
+
+    // Start device authorization
+    let device_auth = start_device_authorization(&http_client, &sso_config, &registration)
+        .await
+        .context("failed to start device authorization")?;
+
+    println!("Open the following URL in your browser:");
+    println!();
+    println!("  {}", device_auth.verification_uri_complete);
+    println!();
+    println!("Enter code: {}", device_auth.user_code);
+    println!();
+
+    // Best-effort browser open
+    if let Err(e) = open::that(&device_auth.verification_uri_complete) {
+        tracing::debug!("failed to open browser: {e}");
+    }
+
+    println!("Waiting for authorization...");
+
+    let token = poll_for_token(&http_client, &sso_config, &registration, &device_auth)
+        .await
+        .context("SSO authorization failed")?;
+
+    let expires_at = token.expires_at.clone();
+    save_access_token(&sso_config, &token).context("failed to cache SSO access token")?;
+
+    println!("Authenticated successfully. Token expires at {expires_at}");
+    Ok(())
+}

--- a/crates/vouch-cli/src/commands/aws/mod.rs
+++ b/crates/vouch-cli/src/commands/aws/mod.rs
@@ -46,25 +46,21 @@ pub(crate) fn resolve_sso_session(
     }
 
     // No explicit selection — use first found, with a hint if multiple exist
-    let all = aws_config.find_all_sso_sessions();
-    match all.len() {
-        0 => Err(crate::exit_code::CliError::ConfigError(
-            "No SSO session found in ~/.aws/config. Run 'aws configure sso' first.".to_string(),
+    let mut all = aws_config.find_all_sso_sessions();
+    if all.is_empty() {
+        return Err(crate::exit_code::CliError::ConfigError(
+            "No SSO session found in ~/.aws/config. \
+             Run 'aws configure sso' first."
+                .to_string(),
         )
-        .into()),
-        1 => all
-            .into_iter()
-            .next()
-            .ok_or_else(|| anyhow::anyhow!("internal: list was empty after length check")),
-        _ => {
-            let Some(first) = all.into_iter().next() else {
-                anyhow::bail!("internal: list was empty after length check");
-            };
-            eprintln!(
-                "Using SSO session '{}'. Specify --sso-session to use a different one.",
-                first.name
-            );
-            Ok(first)
-        }
+        .into());
     }
+    if all.len() > 1 {
+        eprintln!(
+            "Using SSO session '{}'. \
+             Specify --sso-session to use a different one.",
+            all.first().map_or("", |s| &s.name)
+        );
+    }
+    Ok(all.swap_remove(0))
 }

--- a/crates/vouch-cli/src/commands/aws/mod.rs
+++ b/crates/vouch-cli/src/commands/aws/mod.rs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! AWS Identity Center commands for multi-account management.
+
+use anyhow::Result;
+use clap::Subcommand;
+
+use crate::integrations::aws::config::{AwsConfig, SsoSession};
+
+pub(crate) mod accounts;
+pub(crate) mod login;
+pub(crate) mod roles;
+
+/// AWS Identity Center subcommands.
+#[derive(Subcommand)]
+pub(crate) enum AwsCommands {
+    /// Authenticate to AWS IAM Identity Center for account discovery.
+    Login(login::LoginArgs),
+    /// List AWS accounts you have access to via Identity Center.
+    Accounts(accounts::AccountsArgs),
+    /// List available roles across your AWS accounts.
+    Roles(roles::RolesArgs),
+}
+
+/// Resolve which SSO session to use.
+///
+/// Resolution order:
+/// 1. `--sso-session` CLI flag
+/// 2. First `[sso-session]` in `~/.aws/config` (with hint if multiple exist)
+///
+/// Prints a hint to stderr when multiple sessions are found and none was specified,
+/// so the user knows how to switch.
+pub(crate) fn resolve_sso_session(
+    aws_config: &AwsConfig,
+    flag: Option<&str>,
+) -> Result<SsoSession> {
+    let explicit = flag;
+
+    if let Some(name) = explicit {
+        return aws_config.find_sso_session(Some(name)).ok_or_else(|| {
+            crate::exit_code::CliError::ConfigError(format!(
+                "SSO session '{name}' not found in ~/.aws/config. \
+                 Run 'aws configure sso' or check --sso-session."
+            ))
+            .into()
+        });
+    }
+
+    // No explicit selection — use first found, with a hint if multiple exist
+    let all = aws_config.find_all_sso_sessions();
+    match all.len() {
+        0 => Err(crate::exit_code::CliError::ConfigError(
+            "No SSO session found in ~/.aws/config. Run 'aws configure sso' first.".to_string(),
+        )
+        .into()),
+        1 => all
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("internal: list was empty after length check")),
+        _ => {
+            let Some(first) = all.into_iter().next() else {
+                anyhow::bail!("internal: list was empty after length check");
+            };
+            eprintln!(
+                "Using SSO session '{}'. Specify --sso-session to use a different one.",
+                first.name
+            );
+            Ok(first)
+        }
+    }
+}

--- a/crates/vouch-cli/src/commands/aws/roles.rs
+++ b/crates/vouch-cli/src/commands/aws/roles.rs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! `vouch aws roles` — list available roles across AWS accounts.
+
+use anyhow::{Context, Result};
+
+use crate::integrations::aws::config::AwsConfig;
+use crate::integrations::aws::sso::{SsoConfig, load_cached_token};
+use crate::integrations::aws::sso_portal::{SsoAccount, list_account_roles, list_accounts};
+
+/// Arguments for `vouch aws roles`.
+#[derive(clap::Args)]
+pub(crate) struct RolesArgs {
+    /// SSO session name from ~/.aws/config (default: first found).
+    #[arg(long)]
+    pub sso_session: Option<String>,
+    /// Filter by account ID (show roles for a single account only).
+    #[arg(long)]
+    pub account: Option<String>,
+    /// Output as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// A role entry for display/output.
+struct RoleEntry {
+    account_id: String,
+    account_name: String,
+    role_name: String,
+}
+
+/// Run `vouch aws roles`.
+pub(crate) async fn run(args: RolesArgs) -> Result<()> {
+    let aws_config = AwsConfig::load()?;
+    let session = super::resolve_sso_session(&aws_config, args.sso_session.as_deref())?;
+    let sso_config = SsoConfig::from_session(&session);
+
+    let token = load_cached_token(&sso_config).ok_or_else(|| {
+        crate::exit_code::CliError::NotAuthenticated {
+            reason: "SSO session expired or missing. Run 'vouch aws login' first.".to_string(),
+        }
+    })?;
+    let bearer = token.token();
+    let region = session.region.clone();
+
+    let http_client =
+        vouch_common::http::credential_client(&format!("vouch-cli/{}", env!("CARGO_PKG_VERSION")))
+            .context("failed to create HTTP client")?;
+
+    // Determine which accounts to query
+    let accounts: Vec<SsoAccount> = if let Some(ref account_id) = args.account {
+        // User filtered to a single account — build a synthetic entry
+        vec![SsoAccount {
+            account_id: account_id.clone(),
+            account_name: account_id.clone(),
+            email_address: String::new(),
+        }]
+    } else {
+        list_accounts(&http_client, &region, &bearer)
+            .await
+            .context("failed to list SSO accounts")?
+    };
+
+    // Collect roles for each account (O(N) sequential — acceptable for v1)
+    let mut entries: Vec<RoleEntry> = Vec::new();
+    for account in &accounts {
+        let roles = list_account_roles(&http_client, &region, &bearer, &account.account_id)
+            .await
+            .with_context(|| format!("failed to list roles for account {}", account.account_id))?;
+
+        for role in roles {
+            entries.push(RoleEntry {
+                account_id: account.account_id.clone(),
+                account_name: account.account_name.clone(),
+                role_name: role.role_name,
+            });
+        }
+    }
+
+    if args.json {
+        let json = serde_json::to_string_pretty(
+            &entries
+                .iter()
+                .map(|e| {
+                    serde_json::json!({
+                        "accountId": e.account_id,
+                        "accountName": e.account_name,
+                        "roleName": e.role_name,
+                    })
+                })
+                .collect::<Vec<_>>(),
+        )
+        .context("failed to serialize roles")?;
+        println!("{json}");
+    } else {
+        println!("{:<14} {:<35} ROLE NAME", "ACCOUNT ID", "ACCOUNT NAME");
+        println!("{}", "-".repeat(80));
+        for entry in &entries {
+            println!(
+                "{:<14} {:<35} {}",
+                entry.account_id, entry.account_name, entry.role_name
+            );
+        }
+        println!();
+        println!("{} role(s)", entries.len());
+    }
+
+    Ok(())
+}

--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -124,6 +124,11 @@ pub(crate) struct StsExchangeResult {
 /// Handles the full flow: OIDC token fetch → JWT decode for session tags →
 /// role ARN validation → `AssumeRoleWithWebIdentity`.
 ///
+/// If a management role is configured (via vouch config) and differs from
+/// `role_arn`, automatically chains: AssumeRoleWithWebIdentity into the
+/// management role, then AssumeRole into the target role. All callers get
+/// chaining transparently with no code changes.
+///
 /// The STS session name is always the user's email address (for CloudTrail
 /// visibility). Falls back to `fallback_label` if email is unavailable.
 /// Sets `SourceIdentity` and `TransitiveTagKeys` for audit trails through chains.
@@ -134,7 +139,7 @@ pub(crate) async fn exchange_for_sts_credentials(
     fallback_label: &str,
 ) -> Result<StsExchangeResult> {
     use crate::integrations::aws::sts::{
-        WebIdentityRequest, assume_role_with_web_identity, parse_role_arn,
+        WebIdentityRequest, assume_role, assume_role_with_web_identity, parse_role_arn,
     };
 
     let arn = parse_role_arn(role_arn)?;
@@ -158,6 +163,43 @@ pub(crate) async fn exchange_for_sts_credentials(
 
     let email = get_user_email(server).await;
     let session = email.as_deref().unwrap_or(fallback_label);
+
+    // Check if management role chaining is configured
+    let vouch_config = crate::config::Config::load()?;
+    let management_role = resolve_management_role(&vouch_config)?;
+
+    if let Some(mgmt_role_arn) = management_role.filter(|m| m != role_arn) {
+        // Chain: AssumeRoleWithWebIdentity into management role, then AssumeRole into target
+        let mgmt_arn = parse_role_arn(&mgmt_role_arn)?;
+        let mgmt_domain_suffix = mgmt_arn.partition.dns_suffix();
+        let transitive_keys: Vec<&str> = tags.iter().map(|(k, _)| k.as_str()).collect();
+
+        let mgmt_credentials = assume_role_with_web_identity(WebIdentityRequest {
+            http_client: &http_client,
+            role_arn: &mgmt_role_arn,
+            role_session_name: session,
+            web_identity_token: id_token,
+            region,
+            domain_suffix: mgmt_domain_suffix,
+            tags: &tags,
+            source_identity: None,
+            transitive_tag_keys: &transitive_keys,
+        })
+        .await
+        .context("failed to assume management role")?;
+
+        let credentials = assume_role(&http_client, role_arn, session, region, &mgmt_credentials)
+            .await
+            .context("failed to assume target role via chaining")?;
+
+        return Ok(StsExchangeResult {
+            http_client,
+            credentials,
+            domain_suffix,
+        });
+    }
+
+    // Direct AssumeRoleWithWebIdentity (no chaining needed)
     let transitive_keys: Vec<&str> = tags.iter().map(|(k, _)| k.as_str()).collect();
     let credentials = assume_role_with_web_identity(WebIdentityRequest {
         http_client: &http_client,
@@ -167,7 +209,7 @@ pub(crate) async fn exchange_for_sts_credentials(
         region,
         domain_suffix,
         tags: &tags,
-        source_identity: Some(session),
+        source_identity: None, // extracted from JWT claim by AWS
         transitive_tag_keys: &transitive_keys,
     })
     .await
@@ -180,45 +222,67 @@ pub(crate) async fn exchange_for_sts_credentials(
     })
 }
 
-/// Resolve the management role ARN for the active SSO session.
+/// Resolve the management role ARN from vouch config.
 ///
-/// Looks up the first SSO session from `~/.aws/config`, then checks
-/// `~/.vouch/config.json` for a matching entry in `aws.sso_sessions`.
+/// Tries to match an SSO session from `~/.aws/config` to a key in
+/// `aws.sso_sessions`. If no SSO session is found but there's exactly
+/// one entry in `sso_sessions`, uses that directly (chaining doesn't
+/// require SSO discovery).
 /// Returns `None` if no chaining config is found (direct auth is used).
-fn resolve_management_role(vouch_config: &crate::config::Config) -> Result<Option<String>> {
+pub(crate) fn resolve_management_role(
+    vouch_config: &crate::config::Config,
+) -> Result<Option<String>> {
+    let aws_cfg = match vouch_config.aws() {
+        Some(cfg) if !cfg.sso_sessions.is_empty() => cfg,
+        _ => return Ok(None),
+    };
+
+    // Try to match via SSO session name from ~/.aws/config
     let aws_config = crate::integrations::aws::config::AwsConfig::load()?;
-    let sso_session = aws_config.find_sso_session(None);
-    let session_name = sso_session.as_ref().map(|s| s.name.as_str());
+    if let Some(session_cfg) = aws_config
+        .find_sso_session(None)
+        .and_then(|s| aws_cfg.sso_sessions.get(&s.name))
+    {
+        return Ok(Some(session_cfg.management_role.clone()));
+    }
 
-    let mgmt_role = vouch_config
-        .aws()
-        .and_then(|a| session_name.and_then(|name| a.sso_sessions.get(name)))
-        .map(|s| s.management_role.clone());
+    // Fallback: if there's exactly one sso_sessions entry, use it
+    if let [only] = aws_cfg.sso_sessions.values().collect::<Vec<_>>().as_slice() {
+        return Ok(Some(only.management_role.clone()));
+    }
 
-    Ok(mgmt_role)
+    Ok(None)
 }
 
-/// Run the AWS credential command.
+/// Get cached AWS credentials, fetching fresh ones if needed.
 ///
-/// Uses a cache-first strategy via [`super::cache::get_or_fetch`]:
-/// 1. Check agent cache — return immediately if valid cached credentials exist
-/// 2. Fetch fresh OIDC token from Vouch server, call STS, cache the result
-/// 3. On network error, fall back to cached credentials (if any)
-pub(crate) async fn run(server: &str, role_arn: &str) -> Result<()> {
+/// This is the shared entry point for all code paths that need AWS
+/// STS credentials: `vouch credential aws`, `vouch credential codecommit`,
+/// and `vouch exec`. It handles:
+/// 1. Cache key generation (includes chain path when chaining is configured)
+/// 2. Cache-first fetch via the vouch agent
+pub(crate) async fn get_aws_credentials(server: &str, role_arn: &str) -> Result<serde_json::Value> {
     let vouch_config = crate::config::Config::load()?;
-    let cache_key = if let Some(mgmt_role) = resolve_management_role(&vouch_config)? {
+    let management_role = resolve_management_role(&vouch_config)?;
+    let cache_key = if let Some(ref mgmt_role) = management_role {
         format!("aws:chain:{mgmt_role}:{role_arn}")
     } else {
         format!("aws:{role_arn}")
     };
 
-    let data = super::cache::get_or_fetch(&cache_key, "AWS credentials", || async {
+    super::cache::get_or_fetch(&cache_key, "AWS credentials", || async move {
         let output = fetch_and_assume(server, role_arn).await?;
         let expires_at = output.expiration.clone();
         Ok((output.to_json(), expires_at))
     })
-    .await?;
+    .await
+}
 
+/// Run the AWS credential command.
+///
+/// Outputs AWS credential_process JSON to stdout.
+pub(crate) async fn run(server: &str, role_arn: &str) -> Result<()> {
+    let data = get_aws_credentials(server, role_arn).await?;
     let json = serde_json::to_string(&data).context("failed to serialize credentials")?;
     println!("{json}");
     Ok(())
@@ -226,15 +290,15 @@ pub(crate) async fn run(server: &str, role_arn: &str) -> Result<()> {
 
 /// Fetch an OIDC token from the Vouch server and exchange it for STS credentials.
 ///
-/// If `aws.management_role` is configured and the target role differs from the
-/// management role, chains through the management role (AssumeRoleWithWebIdentity →
-/// AssumeRole). Otherwise uses direct AssumeRoleWithWebIdentity.
+/// Resolves the AWS region, calls `exchange_for_sts_credentials` (which
+/// handles management role chaining internally), and wraps the result in
+/// `CredentialProcessOutput`.
 pub(crate) async fn fetch_and_assume(
     server: &str,
     role_arn: &str,
 ) -> Result<CredentialProcessOutput> {
     use crate::integrations::aws;
-    use crate::integrations::aws::sts::{assume_role, parse_role_arn};
+    use crate::integrations::aws::sts::parse_role_arn;
 
     let profile_name = aws::resolve_profile(None).unwrap_or_default();
     let region = match aws::resolve_region(None, &profile_name) {
@@ -247,40 +311,6 @@ pub(crate) async fn fetch_and_assume(
         }
     };
 
-    let vouch_config = crate::config::Config::load()?;
-    let management_role = resolve_management_role(&vouch_config)?;
-
-    if let Some(mgmt_role_arn) = management_role.filter(|m| m != role_arn) {
-        // Target differs from management role: chain management → target
-        let mgmt_result =
-            exchange_for_sts_credentials(server, &mgmt_role_arn, &region, "vouch-session")
-                .await
-                .context("failed to assume management role")?;
-
-        // Derive a session name from the email for CloudTrail visibility
-        let email = crate::session::get_user_email(server).await;
-        let session_name = email.as_deref().unwrap_or("vouch-session");
-
-        let chained_creds = assume_role(
-            &mgmt_result.http_client,
-            role_arn,
-            session_name,
-            &region,
-            &mgmt_result.credentials,
-        )
-        .await
-        .context("failed to assume target role via chaining")?;
-
-        return Ok(CredentialProcessOutput {
-            version: 1,
-            access_key_id: chained_creds.access_key_id.clone(),
-            secret_access_key: chained_creds.secret_access_key.clone(),
-            session_token: chained_creds.session_token.clone(),
-            expiration: chained_creds.expiration.to_string(),
-        });
-    }
-
-    // Direct AssumeRoleWithWebIdentity (no chaining needed)
     let result = exchange_for_sts_credentials(server, role_arn, &region, "vouch-session").await?;
     let creds = &result.credentials;
     Ok(CredentialProcessOutput {

--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -271,7 +271,7 @@ pub(crate) fn resolve_management_role(
 /// and uses it for both the cache key and credential exchange.
 pub(crate) async fn get_aws_credentials(server: &str, role_arn: &str) -> Result<serde_json::Value> {
     let vouch_config = crate::config::Config::load()?;
-    let management_role = resolve_management_role(&vouch_config)?;
+    let management_role = resolve_management_role(&vouch_config)?.filter(|m| m != role_arn);
     let cache_key = if let Some(ref mgmt_role) = management_role {
         format!("aws:chain:{mgmt_role}:{role_arn}")
     } else {

--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -126,13 +126,16 @@ pub(crate) struct StsExchangeResult {
 ///
 /// The STS session name is always the user's email address (for CloudTrail
 /// visibility). Falls back to `fallback_label` if email is unavailable.
+/// Sets `SourceIdentity` and `TransitiveTagKeys` for audit trails through chains.
 pub(crate) async fn exchange_for_sts_credentials(
     server: &str,
     role_arn: &str,
     region: &str,
     fallback_label: &str,
 ) -> Result<StsExchangeResult> {
-    use crate::integrations::aws::sts::{assume_role_with_web_identity, parse_role_arn};
+    use crate::integrations::aws::sts::{
+        WebIdentityRequest, assume_role_with_web_identity, parse_role_arn,
+    };
 
     let arn = parse_role_arn(role_arn)?;
     let domain_suffix = arn.partition.dns_suffix();
@@ -155,15 +158,18 @@ pub(crate) async fn exchange_for_sts_credentials(
 
     let email = get_user_email(server).await;
     let session = email.as_deref().unwrap_or(fallback_label);
-    let credentials = assume_role_with_web_identity(
-        &http_client,
+    let transitive_keys: Vec<&str> = tags.iter().map(|(k, _)| k.as_str()).collect();
+    let credentials = assume_role_with_web_identity(WebIdentityRequest {
+        http_client: &http_client,
         role_arn,
-        session,
-        id_token,
+        role_session_name: session,
+        web_identity_token: id_token,
         region,
         domain_suffix,
-        &tags,
-    )
+        tags: &tags,
+        source_identity: Some(session),
+        transitive_tag_keys: &transitive_keys,
+    })
     .await
     .context("failed to assume AWS role")?;
 
@@ -174,6 +180,24 @@ pub(crate) async fn exchange_for_sts_credentials(
     })
 }
 
+/// Resolve the management role ARN for the active SSO session.
+///
+/// Looks up the first SSO session from `~/.aws/config`, then checks
+/// `~/.vouch/config.json` for a matching entry in `aws.sso_sessions`.
+/// Returns `None` if no chaining config is found (direct auth is used).
+fn resolve_management_role(vouch_config: &crate::config::Config) -> Result<Option<String>> {
+    let aws_config = crate::integrations::aws::config::AwsConfig::load()?;
+    let sso_session = aws_config.find_sso_session(None);
+    let session_name = sso_session.as_ref().map(|s| s.name.as_str());
+
+    let mgmt_role = vouch_config
+        .aws()
+        .and_then(|a| session_name.and_then(|name| a.sso_sessions.get(name)))
+        .map(|s| s.management_role.clone());
+
+    Ok(mgmt_role)
+}
+
 /// Run the AWS credential command.
 ///
 /// Uses a cache-first strategy via [`super::cache::get_or_fetch`]:
@@ -181,7 +205,12 @@ pub(crate) async fn exchange_for_sts_credentials(
 /// 2. Fetch fresh OIDC token from Vouch server, call STS, cache the result
 /// 3. On network error, fall back to cached credentials (if any)
 pub(crate) async fn run(server: &str, role_arn: &str) -> Result<()> {
-    let cache_key = format!("aws:{role_arn}");
+    let vouch_config = crate::config::Config::load()?;
+    let cache_key = if let Some(mgmt_role) = resolve_management_role(&vouch_config)? {
+        format!("aws:chain:{mgmt_role}:{role_arn}")
+    } else {
+        format!("aws:{role_arn}")
+    };
 
     let data = super::cache::get_or_fetch(&cache_key, "AWS credentials", || async {
         let output = fetch_and_assume(server, role_arn).await?;
@@ -196,23 +225,62 @@ pub(crate) async fn run(server: &str, role_arn: &str) -> Result<()> {
 }
 
 /// Fetch an OIDC token from the Vouch server and exchange it for STS credentials.
+///
+/// If `aws.management_role` is configured and the target role differs from the
+/// management role, chains through the management role (AssumeRoleWithWebIdentity →
+/// AssumeRole). Otherwise uses direct AssumeRoleWithWebIdentity.
 pub(crate) async fn fetch_and_assume(
     server: &str,
     role_arn: &str,
 ) -> Result<CredentialProcessOutput> {
     use crate::integrations::aws;
+    use crate::integrations::aws::sts::{assume_role, parse_role_arn};
 
     let profile_name = aws::resolve_profile(None).unwrap_or_default();
     let region = match aws::resolve_region(None, &profile_name) {
         Ok(r) => r,
         Err(_) => {
-            let arn = crate::integrations::aws::sts::parse_role_arn(role_arn)?;
+            let arn = parse_role_arn(role_arn)?;
             let default = arn.partition.default_sts_region();
             tracing::debug!("no region configured, defaulting to {default} for STS");
             default.to_string()
         }
     };
 
+    let vouch_config = crate::config::Config::load()?;
+    let management_role = resolve_management_role(&vouch_config)?;
+
+    if let Some(mgmt_role_arn) = management_role.filter(|m| m != role_arn) {
+        // Target differs from management role: chain management → target
+        let mgmt_result =
+            exchange_for_sts_credentials(server, &mgmt_role_arn, &region, "vouch-session")
+                .await
+                .context("failed to assume management role")?;
+
+        // Derive a session name from the email for CloudTrail visibility
+        let email = crate::session::get_user_email(server).await;
+        let session_name = email.as_deref().unwrap_or("vouch-session");
+
+        let chained_creds = assume_role(
+            &mgmt_result.http_client,
+            role_arn,
+            session_name,
+            &region,
+            &mgmt_result.credentials,
+        )
+        .await
+        .context("failed to assume target role via chaining")?;
+
+        return Ok(CredentialProcessOutput {
+            version: 1,
+            access_key_id: chained_creds.access_key_id.clone(),
+            secret_access_key: chained_creds.secret_access_key.clone(),
+            session_token: chained_creds.session_token.clone(),
+            expiration: chained_creds.expiration.to_string(),
+        });
+    }
+
+    // Direct AssumeRoleWithWebIdentity (no chaining needed)
     let result = exchange_for_sts_credentials(server, role_arn, &region, "vouch-session").await?;
     let creds = &result.credentials;
     Ok(CredentialProcessOutput {

--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -124,22 +124,36 @@ pub(crate) struct StsExchangeResult {
 /// Handles the full flow: OIDC token fetch → JWT decode for session tags →
 /// role ARN validation → `AssumeRoleWithWebIdentity`.
 ///
-/// If a management role is configured (via vouch config) and differs from
-/// `role_arn`, automatically chains: AssumeRoleWithWebIdentity into the
-/// management role, then AssumeRole into the target role. All callers get
-/// chaining transparently with no code changes.
+/// When `management_role` is `Some` and differs from `role_arn`, chains
+/// through the management role: `AssumeRoleWithWebIdentity` into the
+/// management role, then `AssumeRole` into the target.
 ///
-/// The STS session name is always the user's email address (for CloudTrail
-/// visibility). Falls back to `fallback_label` if email is unavailable.
-/// Sets `SourceIdentity` and `TransitiveTagKeys` for audit trails through chains.
+/// External callers (EKS, RDS, etc.) pass `None` — the management role
+/// is resolved internally from vouch config so they get chaining for
+/// free. `get_aws_credentials` pre-resolves it to avoid a double config
+/// load.
 pub(crate) async fn exchange_for_sts_credentials(
     server: &str,
     role_arn: &str,
     region: &str,
     fallback_label: &str,
+    management_role: Option<&str>,
 ) -> Result<StsExchangeResult> {
     use crate::integrations::aws::sts::{
         WebIdentityRequest, assume_role, assume_role_with_web_identity, parse_role_arn,
+    };
+
+    // If caller didn't pre-resolve, resolve now from config
+    let resolved;
+    let mgmt = match management_role {
+        Some(m) => Some(m),
+        None => {
+            resolved = crate::config::Config::load()
+                .ok()
+                .and_then(|c| resolve_management_role(&c).ok())
+                .flatten();
+            resolved.as_deref()
+        }
     };
 
     let arn = parse_role_arn(role_arn)?;
@@ -164,19 +178,15 @@ pub(crate) async fn exchange_for_sts_credentials(
     let email = get_user_email(server).await;
     let session = email.as_deref().unwrap_or(fallback_label);
 
-    // Check if management role chaining is configured
-    let vouch_config = crate::config::Config::load()?;
-    let management_role = resolve_management_role(&vouch_config)?;
-
-    if let Some(mgmt_role_arn) = management_role.filter(|m| m != role_arn) {
+    if let Some(mgmt_role_arn) = mgmt.filter(|m| *m != role_arn) {
         // Chain: AssumeRoleWithWebIdentity into management role, then AssumeRole into target
-        let mgmt_arn = parse_role_arn(&mgmt_role_arn)?;
+        let mgmt_arn = parse_role_arn(mgmt_role_arn)?;
         let mgmt_domain_suffix = mgmt_arn.partition.dns_suffix();
         let transitive_keys: Vec<&str> = tags.iter().map(|(k, _)| k.as_str()).collect();
 
         let mgmt_credentials = assume_role_with_web_identity(WebIdentityRequest {
             http_client: &http_client,
-            role_arn: &mgmt_role_arn,
+            role_arn: mgmt_role_arn,
             role_session_name: session,
             web_identity_token: id_token,
             region,
@@ -256,11 +266,9 @@ pub(crate) fn resolve_management_role(
 
 /// Get cached AWS credentials, fetching fresh ones if needed.
 ///
-/// This is the shared entry point for all code paths that need AWS
-/// STS credentials: `vouch credential aws`, `vouch credential codecommit`,
-/// and `vouch exec`. It handles:
-/// 1. Cache key generation (includes chain path when chaining is configured)
-/// 2. Cache-first fetch via the vouch agent
+/// Shared entry point for `vouch credential aws`, `vouch credential
+/// codecommit`, and `vouch exec`. Resolves the management role once
+/// and uses it for both the cache key and credential exchange.
 pub(crate) async fn get_aws_credentials(server: &str, role_arn: &str) -> Result<serde_json::Value> {
     let vouch_config = crate::config::Config::load()?;
     let management_role = resolve_management_role(&vouch_config)?;
@@ -270,8 +278,9 @@ pub(crate) async fn get_aws_credentials(server: &str, role_arn: &str) -> Result<
         format!("aws:{role_arn}")
     };
 
+    let mgmt = management_role;
     super::cache::get_or_fetch(&cache_key, "AWS credentials", || async move {
-        let output = fetch_and_assume(server, role_arn).await?;
+        let output = fetch_and_assume(server, role_arn, mgmt.as_deref()).await?;
         let expires_at = output.expiration.clone();
         Ok((output.to_json(), expires_at))
     })
@@ -288,14 +297,14 @@ pub(crate) async fn run(server: &str, role_arn: &str) -> Result<()> {
     Ok(())
 }
 
-/// Fetch an OIDC token from the Vouch server and exchange it for STS credentials.
+/// Fetch an OIDC token and exchange it for STS credentials.
 ///
-/// Resolves the AWS region, calls `exchange_for_sts_credentials` (which
-/// handles management role chaining internally), and wraps the result in
-/// `CredentialProcessOutput`.
-pub(crate) async fn fetch_and_assume(
+/// Resolves the AWS region, then calls `exchange_for_sts_credentials`
+/// with the pre-resolved management role.
+async fn fetch_and_assume(
     server: &str,
     role_arn: &str,
+    mgmt_role: Option<&str>,
 ) -> Result<CredentialProcessOutput> {
     use crate::integrations::aws;
     use crate::integrations::aws::sts::parse_role_arn;
@@ -311,7 +320,8 @@ pub(crate) async fn fetch_and_assume(
         }
     };
 
-    let result = exchange_for_sts_credentials(server, role_arn, &region, "vouch-session").await?;
+    let result =
+        exchange_for_sts_credentials(server, role_arn, &region, "vouch-session", mgmt_role).await?;
     let creds = &result.credentials;
     Ok(CredentialProcessOutput {
         version: 1,

--- a/crates/vouch-cli/src/commands/credential/codeartifact.rs
+++ b/crates/vouch-cli/src/commands/credential/codeartifact.rs
@@ -180,7 +180,7 @@ async fn fetch_token(
     })?;
 
     let result =
-        exchange_for_sts_credentials(server, &role_arn, region, "vouch-codeartifact").await?;
+        exchange_for_sts_credentials(server, &role_arn, region, "vouch-codeartifact", None).await?;
 
     let registry = CodeArtifactRegistry {
         domain: domain.to_string(),

--- a/crates/vouch-cli/src/commands/credential/codecommit.rs
+++ b/crates/vouch-cli/src/commands/credential/codecommit.rs
@@ -142,14 +142,7 @@ async fn get_sts_credentials() -> Result<StsCredentials> {
         )
     })?;
 
-    let cache_key = format!("aws:{role_arn}");
-
-    let data = super::cache::get_or_fetch(&cache_key, "AWS credentials", || async {
-        let output = super::aws::fetch_and_assume(&server, &role_arn).await?;
-        let expires_at = output.expiration.clone();
-        Ok((output.to_json(), expires_at))
-    })
-    .await?;
+    let data = super::aws::get_aws_credentials(&server, &role_arn).await?;
 
     // Extract STS credentials from the cached JSON
     let access_key_id = data

--- a/crates/vouch-cli/src/commands/credential/docker.rs
+++ b/crates/vouch-cli/src/commands/credential/docker.rs
@@ -216,7 +216,8 @@ async fn get_ecr_credential(
         )
     })?;
 
-    let result = exchange_for_sts_credentials(server, &role_arn, region, "vouch-docker").await?;
+    let result =
+        exchange_for_sts_credentials(server, &role_arn, region, "vouch-docker", None).await?;
 
     // Call ECR GetAuthorizationToken
     let ecr_token = get_ecr_authorization_token(

--- a/crates/vouch-cli/src/commands/credential/eks.rs
+++ b/crates/vouch-cli/src/commands/credential/eks.rs
@@ -68,7 +68,7 @@ async fn generate_eks_token(
     region: &str,
     role_arn: &str,
 ) -> Result<String> {
-    let result = exchange_for_sts_credentials(server, role_arn, region, "vouch-eks").await?;
+    let result = exchange_for_sts_credentials(server, role_arn, region, "vouch-eks", None).await?;
 
     // Build presigned STS GetCallerIdentity URL with cluster ID
     let sts_endpoint = format!("https://sts.{region}.{}", result.domain_suffix);

--- a/crates/vouch-cli/src/commands/credential/rds.rs
+++ b/crates/vouch-cli/src/commands/credential/rds.rs
@@ -92,7 +92,7 @@ async fn generate_rds_token(
     region: &str,
     role_arn: &str,
 ) -> Result<String> {
-    let result = exchange_for_sts_credentials(server, role_arn, region, "vouch-rds").await?;
+    let result = exchange_for_sts_credentials(server, role_arn, region, "vouch-rds", None).await?;
 
     // Build presigned URL for RDS IAM auth
     let endpoint = format!("https://{hostname}:{port}");

--- a/crates/vouch-cli/src/commands/credential/redshift.rs
+++ b/crates/vouch-cli/src/commands/credential/redshift.rs
@@ -98,7 +98,8 @@ pub(crate) async fn fetch_redshift_credentials(
     region: &str,
     role_arn: &str,
 ) -> Result<crate::integrations::aws::redshift::RedshiftCredentials> {
-    let result = exchange_for_sts_credentials(server, role_arn, region, "vouch-redshift").await?;
+    let result =
+        exchange_for_sts_credentials(server, role_arn, region, "vouch-redshift", None).await?;
 
     match target {
         RedshiftTarget::Cluster {

--- a/crates/vouch-cli/src/commands/exec.rs
+++ b/crates/vouch-cli/src/commands/exec.rs
@@ -65,14 +65,7 @@ pub(crate) async fn fetch_aws_credentials(
     server: &str,
     role_arn: &str,
 ) -> Result<AwsEnvCredentials> {
-    let cache_key = format!("aws:{role_arn}");
-
-    let data = cache::get_or_fetch(&cache_key, "AWS credentials", || async {
-        let output = super::credential::aws::fetch_and_assume(server, role_arn).await?;
-        let expires_at = output.expiration.clone();
-        Ok((output.to_json(), expires_at))
-    })
-    .await?;
+    let data = super::credential::aws::get_aws_credentials(server, role_arn).await?;
 
     let access_key_id = data
         .get("AccessKeyId")

--- a/crates/vouch-cli/src/commands/mod.rs
+++ b/crates/vouch-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! CLI command implementations.
 
+pub(crate) mod aws;
 pub(crate) mod completions;
 pub(crate) mod credential;
 pub(crate) mod diag;

--- a/crates/vouch-cli/src/commands/setup/aws.rs
+++ b/crates/vouch-cli/src/commands/setup/aws.rs
@@ -9,13 +9,62 @@ use std::path::PathBuf;
 use crate::integrations::aws::{AwsConfig, AwsProfile};
 use crate::utils::ensure_secure_dir;
 
-/// Run the AWS setup command.
+/// Sanitize an account name into a valid AWS CLI profile name segment.
+///
+/// Converts to lowercase, replaces non-alphanumeric-non-hyphen chars with `-`,
+/// and deduplicates consecutive hyphens.
+fn sanitize_profile_name(name: &str) -> String {
+    let lower = name.to_lowercase();
+    let replaced: String = lower
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+
+    // Collapse consecutive hyphens
+    let mut result = String::with_capacity(replaced.len());
+    let mut prev_hyphen = false;
+    for c in replaced.chars() {
+        if c == '-' {
+            if !prev_hyphen {
+                result.push(c);
+            }
+            prev_hyphen = true;
+        } else {
+            result.push(c);
+            prev_hyphen = false;
+        }
+    }
+    result.trim_matches('-').to_string()
+}
+
+/// Run the AWS setup command with an explicit role ARN.
 ///
 /// Automatically adds a vouch profile to ~/.aws/config with smart naming:
 /// - If `--profile` is given, uses that name (exits early if it already exists).
 /// - Otherwise, checks existing vouch profiles for a role match (exits early if found),
 ///   then picks the next available name: "vouch", "vouch-2", "vouch-3", etc.
-pub(crate) async fn run(profile: Option<&str>, role_arn: &str, region: Option<&str>) -> Result<()> {
+pub(crate) async fn run(
+    profile: Option<&str>,
+    role_arn: Option<&str>,
+    region: Option<&str>,
+    discover: bool,
+) -> Result<()> {
+    if discover {
+        return run_discover(profile, region).await;
+    }
+
+    let role_arn = role_arn.ok_or_else(|| {
+        crate::exit_code::CliError::ConfigError(
+            "Either --role or --discover is required".to_string(),
+        )
+    })?;
+
     let vouch_path = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("vouch"));
 
     let config_path = AwsConfig::default_path()?;
@@ -89,4 +138,143 @@ pub(crate) async fn run(profile: Option<&str>, role_arn: &str, region: Option<&s
     );
 
     Ok(())
+}
+
+/// Discover AWS accounts/roles via SSO and create profiles automatically.
+async fn run_discover(profile_prefix: Option<&str>, region: Option<&str>) -> Result<()> {
+    use crate::integrations::aws::config::AwsConfig as AwsCliConfig;
+    use crate::integrations::aws::sso::{SsoConfig, load_cached_token};
+    use crate::integrations::aws::sso_portal::{list_account_roles, list_accounts};
+    use vouch_common::aws::Partition;
+
+    let vouch_config = crate::config::Config::load()?;
+    let aws_cli_config = AwsCliConfig::load()?;
+
+    let session = aws_cli_config.find_sso_session(None).ok_or_else(|| {
+        crate::exit_code::CliError::ConfigError(
+            "No SSO session found in ~/.aws/config. Run 'aws configure sso' first.".to_string(),
+        )
+    })?;
+    let member_role_name = vouch_config
+        .aws()
+        .and_then(|a| a.sso_sessions.get(&session.name))
+        .map(|s| s.member_role_name.clone())
+        .unwrap_or_else(|| "VouchAccess".to_string());
+
+    let sso_region = session.region.clone();
+    let sso_config = SsoConfig::from_session(&session);
+
+    let token = load_cached_token(&sso_config).ok_or_else(|| {
+        crate::exit_code::CliError::NotAuthenticated {
+            reason: "SSO session expired or missing. Run 'vouch aws login' first.".to_string(),
+        }
+    })?;
+    let bearer = token.token();
+
+    let http_client =
+        vouch_common::http::credential_client(&format!("vouch-cli/{}", env!("CARGO_PKG_VERSION")))
+            .context("failed to create HTTP client")?;
+
+    let accounts = list_accounts(&http_client, &sso_region, &bearer)
+        .await
+        .context("failed to list SSO accounts")?;
+
+    let vouch_path = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("vouch"));
+
+    let config_path = AwsConfig::default_path()?;
+    let aws_dir = dirs::home_dir()
+        .context("could not determine home directory")?
+        .join(".aws");
+    ensure_secure_dir(&aws_dir)?;
+
+    let mut config =
+        AwsConfig::load_from(config_path.clone()).unwrap_or_else(|_| AwsConfig::empty(config_path));
+
+    let mut created_count: u32 = 0;
+    let mut skipped_count: u32 = 0;
+
+    for account in &accounts {
+        let roles = list_account_roles(&http_client, &sso_region, &bearer, &account.account_id)
+            .await
+            .with_context(|| format!("failed to list roles for account {}", account.account_id))?;
+
+        let has_vouch_role = roles.iter().any(|r| r.role_name == member_role_name);
+        if !has_vouch_role {
+            continue;
+        }
+
+        let partition = Partition::from_region(&sso_region);
+        let role_arn = format!(
+            "arn:{}:iam::{}:role/{}",
+            partition.as_str(),
+            account.account_id,
+            member_role_name
+        );
+
+        let safe_name = sanitize_profile_name(&account.account_name);
+        let profile_name = match profile_prefix {
+            Some(prefix) => format!("{prefix}-{safe_name}"),
+            None => format!("vouch-{safe_name}"),
+        };
+
+        if config.profile_exists(&profile_name) {
+            println!("Skipped [{profile_name}] — already exists");
+            skipped_count += 1;
+            continue;
+        }
+
+        config.set_profile(&AwsProfile {
+            name: profile_name.clone(),
+            credential_process: Some(format!(
+                "{} credential aws --role {role_arn}",
+                vouch_path.display()
+            )),
+            region: region.map(str::to_string),
+            output: Some("json".to_string()),
+        });
+
+        println!("Added profile [{profile_name}] → {role_arn}");
+        created_count += 1;
+    }
+
+    if created_count > 0 {
+        config.save()?;
+    }
+
+    println!();
+    println!("{created_count} profile(s) created, {skipped_count} skipped");
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitize_profile_name_basic() {
+        assert_eq!(sanitize_profile_name("Production"), "production");
+    }
+
+    #[test]
+    fn test_sanitize_profile_name_spaces() {
+        assert_eq!(sanitize_profile_name("My Account"), "my-account");
+    }
+
+    #[test]
+    fn test_sanitize_profile_name_special_chars() {
+        assert_eq!(sanitize_profile_name("Prod (US-East)"), "prod-us-east");
+        assert_eq!(sanitize_profile_name("Dev/Staging"), "dev-staging");
+    }
+
+    #[test]
+    fn test_sanitize_profile_name_dedup_hyphens() {
+        assert_eq!(sanitize_profile_name("prod--staging"), "prod-staging");
+        assert_eq!(sanitize_profile_name("a   b"), "a-b");
+    }
+
+    #[test]
+    fn test_sanitize_profile_name_leading_trailing_hyphen() {
+        assert_eq!(sanitize_profile_name("-my-account-"), "my-account");
+    }
 }

--- a/crates/vouch-cli/src/commands/setup/aws.rs
+++ b/crates/vouch-cli/src/commands/setup/aws.rs
@@ -282,4 +282,14 @@ mod tests {
     fn test_sanitize_profile_name_leading_trailing_hyphen() {
         assert_eq!(sanitize_profile_name("-my-account-"), "my-account");
     }
+
+    #[test]
+    fn test_sanitize_profile_name_empty() {
+        assert_eq!(sanitize_profile_name(""), "");
+    }
+
+    #[test]
+    fn test_sanitize_profile_name_all_special_chars() {
+        assert_eq!(sanitize_profile_name("!!!@@@###"), "");
+    }
 }

--- a/crates/vouch-cli/src/commands/setup/aws.rs
+++ b/crates/vouch-cli/src/commands/setup/aws.rs
@@ -212,9 +212,14 @@ async fn run_discover(profile_prefix: Option<&str>, region: Option<&str>) -> Res
         );
 
         let safe_name = sanitize_profile_name(&account.account_name);
+        let name_part = if safe_name.is_empty() {
+            account.account_id.clone()
+        } else {
+            safe_name
+        };
         let profile_name = match profile_prefix {
-            Some(prefix) => format!("{prefix}-{safe_name}"),
-            None => format!("vouch-{safe_name}"),
+            Some(prefix) => format!("{prefix}-{name_part}"),
+            None => format!("vouch-{name_part}"),
         };
 
         if config.profile_exists(&profile_name) {

--- a/crates/vouch-cli/src/commands/setup/eks.rs
+++ b/crates/vouch-cli/src/commands/setup/eks.rs
@@ -49,7 +49,8 @@ async fn describe_cluster(
     region: &str,
     role_arn: &str,
 ) -> Result<(String, String)> {
-    let result = exchange_for_sts_credentials(server, role_arn, region, "vouch-eks-setup").await?;
+    let result =
+        exchange_for_sts_credentials(server, role_arn, region, "vouch-eks-setup", None).await?;
 
     // Call EKS DescribeCluster REST API
     let endpoint = format!("https://eks.{region}.{}", result.domain_suffix);

--- a/crates/vouch-cli/src/commands/setup/mod.rs
+++ b/crates/vouch-cli/src/commands/setup/mod.rs
@@ -23,12 +23,15 @@ pub(crate) enum SetupCommands {
         /// AWS profile name to configure. Defaults to "vouch" if not specified.
         #[arg(long)]
         profile: Option<String>,
-        /// AWS IAM role ARN to assume.
-        #[arg(long)]
-        role: String,
+        /// AWS IAM role ARN to assume. Required unless --discover is set.
+        #[arg(long, required_unless_present = "discover")]
+        role: Option<String>,
         /// AWS region to set in the profile.
         #[arg(long)]
         region: Option<String>,
+        /// Discover accounts and roles via SSO and generate profiles automatically.
+        #[arg(long, conflicts_with = "role")]
+        discover: bool,
     },
     /// Configure SSH to use Vouch certificates.
     Ssh {

--- a/crates/vouch-cli/src/config.rs
+++ b/crates/vouch-cli/src/config.rs
@@ -12,6 +12,32 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
 
+/// AWS multi-account configuration in ~/.vouch/config.json.
+///
+/// Keyed by SSO session name (matching `[sso-session <name>]` in `~/.aws/config`).
+/// SSO connection details (start URL, region, scopes) are read from `~/.aws/config`
+/// — only role chaining config lives here.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct AwsMultiAccountConfig {
+    /// Per-SSO-session role chaining configuration, keyed by session name.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub sso_sessions: BTreeMap<String, SsoSessionConfig>,
+}
+
+/// Per-SSO-session configuration for role chaining.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct SsoSessionConfig {
+    /// Management account role ARN (Vouch OIDC trust deployed here).
+    pub management_role: String,
+    /// Role name to assume in member accounts.
+    #[serde(default = "default_member_role_name")]
+    pub member_role_name: String,
+}
+
+fn default_member_role_name() -> String {
+    "VouchAccess".to_string()
+}
+
 /// CLI configuration stored in ~/.vouch/config.json
 ///
 /// Per-server state (token, client_id, registration, DPoP key) is
@@ -27,6 +53,8 @@ pub(crate) struct Config {
     servers: BTreeMap<String, ServerConfig>,
     /// Global CodeArtifact profile configuration.
     codeartifact: Option<CodeArtifactConfig>,
+    /// AWS multi-account configuration (role chaining + SSO discovery).
+    aws: Option<AwsMultiAccountConfig>,
 }
 
 /// Per-server configuration state.
@@ -90,6 +118,9 @@ struct ConfigFile {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     codeartifact: Option<CodeArtifactConfig>,
 
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    aws: Option<AwsMultiAccountConfig>,
+
     // Legacy flat fields — read for migration, never written back.
     #[serde(default, skip_serializing)]
     server_url: Option<String>,
@@ -134,6 +165,7 @@ impl std::fmt::Debug for ConfigFile {
             .field("current_server", &self.current_server)
             .field("servers", &"[...]")
             .field("codeartifact", &self.codeartifact)
+            .field("aws", &self.aws)
             .finish()
     }
 }
@@ -144,6 +176,7 @@ impl std::fmt::Debug for Config {
             .field("current_server", &self.current_server)
             .field("servers", &self.servers.keys().collect::<Vec<_>>())
             .field("codeartifact", &self.codeartifact)
+            .field("aws", &self.aws)
             .finish()
     }
 }
@@ -363,6 +396,22 @@ impl Config {
         ca.profiles.insert(name.to_string(), profile);
     }
 
+    // =====================================================================
+    // AWS multi-account (global, not per-server)
+    // =====================================================================
+
+    /// Get the AWS multi-account configuration.
+    #[must_use]
+    pub(crate) fn aws(&self) -> Option<&AwsMultiAccountConfig> {
+        self.aws.as_ref()
+    }
+
+    /// Set the AWS multi-account configuration (in memory only, call `save()` to persist).
+    #[allow(dead_code)]
+    pub(crate) fn set_aws(&mut self, config: AwsMultiAccountConfig) {
+        self.aws = Some(config);
+    }
+
     /// Get the path to the config file.
     fn config_path() -> Result<PathBuf> {
         let home = dirs::home_dir().context("could not determine home directory")?;
@@ -492,6 +541,7 @@ impl From<ConfigFile> for Config {
             current_server,
             servers,
             codeartifact: file.codeartifact.take(),
+            aws: file.aws.take(),
         }
     }
 }
@@ -525,6 +575,7 @@ impl From<&Config> for ConfigFile {
             current_server: config.current_server.clone(),
             servers,
             codeartifact: config.codeartifact.clone(),
+            aws: config.aws.clone(),
             // Legacy fields are never written.
             server_url: None,
             token: None,

--- a/crates/vouch-cli/src/config.rs
+++ b/crates/vouch-cli/src/config.rs
@@ -1082,6 +1082,117 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // AwsMultiAccountConfig round-trip serialization
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn test_aws_multi_account_config_round_trip() {
+        let json = r#"{
+            "current_server": "us.vouch.sh",
+            "servers": {
+                "us.vouch.sh": {
+                    "server_url": "https://us.vouch.sh",
+                    "token": "test-token"
+                }
+            },
+            "aws": {
+                "sso_sessions": {
+                    "smoketurner": {
+                        "management_role": "arn:aws:iam::111:role/VouchManagement",
+                        "member_role_name": "VouchAccess"
+                    }
+                }
+            }
+        }"#;
+
+        let file: ConfigFile = serde_json::from_str(json).unwrap();
+        let config = Config::from(file);
+
+        let aws = config.aws().expect("aws config should exist");
+        assert_eq!(aws.sso_sessions.len(), 1);
+
+        let session = aws
+            .sso_sessions
+            .get("smoketurner")
+            .expect("smoketurner session");
+        assert_eq!(
+            session.management_role,
+            "arn:aws:iam::111:role/VouchManagement"
+        );
+        assert_eq!(session.member_role_name, "VouchAccess");
+
+        // Round-trip through JSON
+        let file2 = ConfigFile::from(&config);
+        let json2 = serde_json::to_string_pretty(&file2).unwrap();
+        let file3: ConfigFile = serde_json::from_str(&json2).unwrap();
+        let config2 = Config::from(file3);
+
+        let aws2 = config2.aws().expect("aws config should survive round-trip");
+        let session2 = aws2
+            .sso_sessions
+            .get("smoketurner")
+            .expect("smoketurner session");
+        assert_eq!(
+            session2.management_role,
+            "arn:aws:iam::111:role/VouchManagement"
+        );
+        assert_eq!(session2.member_role_name, "VouchAccess");
+    }
+
+    #[test]
+    fn test_aws_member_role_name_default_when_omitted() {
+        let json = r#"{
+            "aws": {
+                "sso_sessions": {
+                    "my-session": {
+                        "management_role": "arn:aws:iam::123456789012:role/Mgmt"
+                    }
+                }
+            }
+        }"#;
+
+        let file: ConfigFile = serde_json::from_str(json).unwrap();
+        let config = Config::from(file);
+
+        let aws = config.aws().expect("aws config should exist");
+        let session = aws.sso_sessions.get("my-session").expect("session");
+        assert_eq!(session.member_role_name, "VouchAccess");
+    }
+
+    #[test]
+    fn test_aws_empty_sso_sessions_serializes_correctly() {
+        let mut config = Config::default();
+        config.set_aws(AwsMultiAccountConfig {
+            sso_sessions: BTreeMap::new(),
+        });
+
+        let file = ConfigFile::from(&config);
+        let json = serde_json::to_string(&file).unwrap();
+
+        // Empty sso_sessions map is skipped due to skip_serializing_if
+        assert!(!json.contains("sso_sessions"));
+    }
+
+    #[test]
+    fn test_config_without_aws_section_loads_fine() {
+        let json = r#"{
+            "current_server": "us.vouch.sh",
+            "servers": {
+                "us.vouch.sh": {
+                    "server_url": "https://us.vouch.sh",
+                    "token": "test-token"
+                }
+            }
+        }"#;
+
+        let file: ConfigFile = serde_json::from_str(json).unwrap();
+        let config = Config::from(file);
+
+        assert!(config.aws().is_none());
+        assert_eq!(config.server_url(), Some("https://us.vouch.sh"));
+    }
+
+    // -----------------------------------------------------------------
     // Stale registration detection
     // -----------------------------------------------------------------
 

--- a/crates/vouch-cli/src/integrations/aws/config.rs
+++ b/crates/vouch-cli/src/integrations/aws/config.rs
@@ -212,6 +212,60 @@ impl AwsConfig {
     }
 }
 
+/// An SSO session from a `[sso-session <name>]` block in `~/.aws/config`.
+#[derive(Debug, Clone)]
+pub(crate) struct SsoSession {
+    /// Session name (e.g., "smoketurner").
+    pub name: String,
+    /// SSO start URL.
+    pub start_url: String,
+    /// SSO region.
+    pub region: String,
+    /// OAuth scopes (default: `["sso:account:access"]`).
+    pub scopes: Vec<String>,
+}
+
+impl AwsConfig {
+    /// Find an SSO session by name, or return the first one found if `name` is `None`.
+    #[must_use]
+    pub(crate) fn find_sso_session(&self, name: Option<&str>) -> Option<SsoSession> {
+        self.find_all_sso_sessions()
+            .into_iter()
+            .find(|s| name.is_none_or(|target| s.name == target))
+    }
+
+    /// Return all `[sso-session]` blocks from `~/.aws/config`, in file order.
+    #[must_use]
+    pub(crate) fn find_all_sso_sessions(&self) -> Vec<SsoSession> {
+        let mut sessions = Vec::new();
+        for (section_name, props) in &self.ini {
+            let Some(section_str) = section_name else {
+                continue;
+            };
+            let Some(session_name) = section_str.strip_prefix("sso-session ") else {
+                continue;
+            };
+            let Some(start_url) = props.get("sso_start_url") else {
+                continue;
+            };
+            let Some(region) = props.get("sso_region") else {
+                continue;
+            };
+            let scopes = props
+                .get("sso_registration_scopes")
+                .map(|s| s.split(',').map(|s| s.trim().to_string()).collect())
+                .unwrap_or_else(|| vec!["sso:account:access".to_string()]);
+            sessions.push(SsoSession {
+                name: session_name.to_string(),
+                start_url: start_url.to_string(),
+                region: region.to_string(),
+                scopes,
+            });
+        }
+        sessions
+    }
+}
+
 /// Extract the AWS role ARN from a credential_process command.
 ///
 /// Looks for `--role <arn>` in the command string.
@@ -732,5 +786,84 @@ credential_process = vouch credential aws --role arn:aws:iam::222:role/Staging
         let config = AwsConfig::load_from(file.path().to_path_buf()).unwrap();
 
         assert_eq!(config.next_vouch_profile_name(), "vouch-3");
+    }
+
+    #[test]
+    fn test_find_sso_session_by_name() {
+        let content = r#"
+[sso-session smoketurner]
+sso_start_url = https://smoketurner.awsapps.com/start
+sso_region = us-east-1
+sso_registration_scopes = sso:account:access
+
+[sso-session other]
+sso_start_url = https://other.awsapps.com/start
+sso_region = eu-west-1
+"#;
+        let file = create_temp_config(content);
+        let config = AwsConfig::load_from(file.path().to_path_buf()).unwrap();
+
+        let session = config.find_sso_session(Some("smoketurner")).unwrap();
+        assert_eq!(session.name, "smoketurner");
+        assert_eq!(session.start_url, "https://smoketurner.awsapps.com/start");
+        assert_eq!(session.region, "us-east-1");
+        assert_eq!(session.scopes, vec!["sso:account:access"]);
+    }
+
+    #[test]
+    fn test_find_sso_session_first_when_no_name() {
+        let content = r#"
+[sso-session only-session]
+sso_start_url = https://example.awsapps.com/start
+sso_region = us-west-2
+"#;
+        let file = create_temp_config(content);
+        let config = AwsConfig::load_from(file.path().to_path_buf()).unwrap();
+
+        // Without a name, returns the first session found
+        let session = config.find_sso_session(None).unwrap();
+        assert_eq!(session.name, "only-session");
+        assert_eq!(session.region, "us-west-2");
+    }
+
+    #[test]
+    fn test_find_sso_session_not_found() {
+        let content = r#"
+[profile vouch]
+credential_process = vouch credential aws --role arn:aws:iam::111:role/Prod
+"#;
+        let file = create_temp_config(content);
+        let config = AwsConfig::load_from(file.path().to_path_buf()).unwrap();
+
+        assert!(config.find_sso_session(Some("nonexistent")).is_none());
+        assert!(config.find_sso_session(None).is_none());
+    }
+
+    #[test]
+    fn test_find_sso_session_default_scopes() {
+        // When sso_registration_scopes is absent, default to "sso:account:access"
+        let content = r#"
+[sso-session my-session]
+sso_start_url = https://example.awsapps.com/start
+sso_region = us-east-1
+"#;
+        let file = create_temp_config(content);
+        let config = AwsConfig::load_from(file.path().to_path_buf()).unwrap();
+
+        let session = config.find_sso_session(None).unwrap();
+        assert_eq!(session.scopes, vec!["sso:account:access"]);
+    }
+
+    #[test]
+    fn test_find_sso_session_skips_wrong_name() {
+        let content = r#"
+[sso-session dev]
+sso_start_url = https://dev.awsapps.com/start
+sso_region = us-east-1
+"#;
+        let file = create_temp_config(content);
+        let config = AwsConfig::load_from(file.path().to_path_buf()).unwrap();
+
+        assert!(config.find_sso_session(Some("prod")).is_none());
     }
 }

--- a/crates/vouch-cli/src/integrations/aws/mod.rs
+++ b/crates/vouch-cli/src/integrations/aws/mod.rs
@@ -9,6 +9,8 @@ pub(crate) mod codecommit;
 pub(crate) mod config;
 pub(crate) mod redshift;
 pub(crate) mod sigv4;
+pub(crate) mod sso;
+pub(crate) mod sso_portal;
 pub(crate) mod sts;
 
 // Re-export commonly used types

--- a/crates/vouch-cli/src/integrations/aws/sso.rs
+++ b/crates/vouch-cli/src/integrations/aws/sso.rs
@@ -53,9 +53,9 @@ pub(crate) struct SsoClientRegistration {
     pub client_secret: String,
     /// ISO 8601 expiry timestamp (e.g. `"2026-07-09T01:54:45Z"`).
     pub expires_at: String,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     pub scopes: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     pub grant_types: Vec<String>,
 }
 
@@ -360,8 +360,8 @@ fn save_registration(
 ) -> Result<()> {
     crate::utils::ensure_secure_dir(cache_dir)?;
     let path = cache_dir.join(format!("{key}.json"));
-    let content = serde_json::to_vec_pretty(reg).context("failed to serialize registration")?;
-    crate::utils::atomic_write_secure(&path, &content)
+    let content = serialize_python_compat(reg).context("failed to serialize registration")?;
+    crate::utils::atomic_write_secure(&path, content.as_bytes())
         .context("failed to write SSO client registration cache")
 }
 
@@ -371,9 +371,56 @@ pub(crate) fn save_access_token(config: &SsoConfig, token: &SsoAccessToken) -> R
     crate::utils::ensure_secure_dir(&cache_dir)?;
     let key = token_cache_key(config);
     let path = cache_dir.join(format!("{key}.json"));
-    let content = serde_json::to_vec_pretty(token).context("failed to serialize access token")?;
-    crate::utils::atomic_write_secure(&path, &content)
+    let content = serialize_python_compat(token).context("failed to serialize access token")?;
+    crate::utils::atomic_write_secure(&path, content.as_bytes())
         .context("failed to write SSO access token cache")
+}
+
+/// Serialize a value to JSON with Python-compatible separators.
+///
+/// Python's `json.dumps()` uses `(', ', ': ')` as default separators,
+/// producing `{"key": "value", ...}`. Rust's `serde_json::to_string()`
+/// uses compact `{"key":"value",...}`. This function matches Python's
+/// format while preserving struct field order (serde serializes fields
+/// in declaration order).
+fn serialize_python_compat<T: Serialize>(value: &T) -> Result<String> {
+    // Serialize to compact JSON first (preserves struct field order),
+    // then add spaces to match Python's default separators.
+    let compact = serde_json::to_string(value).context("failed to serialize to JSON")?;
+    // Post-process: add space after every `:` and `,` that's part of
+    // JSON structure (not inside string values).
+    Ok(add_python_json_spacing(&compact))
+}
+
+/// Add Python-compatible spacing to compact JSON.
+///
+/// Inserts a space after `:` and `,` that appear at the JSON structure
+/// level (not inside quoted strings).
+fn add_python_json_spacing(compact: &str) -> String {
+    let mut result = String::with_capacity(compact.len() * 2);
+    let mut in_string = false;
+    let mut escape_next = false;
+
+    for ch in compact.chars() {
+        if escape_next {
+            result.push(ch);
+            escape_next = false;
+            continue;
+        }
+        if ch == '\\' && in_string {
+            result.push(ch);
+            escape_next = true;
+            continue;
+        }
+        if ch == '"' {
+            in_string = !in_string;
+        }
+        result.push(ch);
+        if !in_string && (ch == ':' || ch == ',') {
+            result.push(' ');
+        }
+    }
+    result
 }
 
 /// Register a new SSO OIDC client (or return cached registration).
@@ -425,10 +472,6 @@ pub(crate) async fn register_client(
         client_secret: String,
         /// Epoch seconds from the API; converted to ISO 8601 for the cache file.
         client_secret_expires_at: i64,
-        #[serde(default)]
-        scopes: Vec<String>,
-        #[serde(default)]
-        grant_types: Vec<String>,
     }
 
     let resp: RegisterResponse = response
@@ -439,12 +482,17 @@ pub(crate) async fn register_client(
     let expires_at = jiff::Timestamp::from_second(resp.client_secret_expires_at)
         .context("invalid clientSecretExpiresAt from SSO OIDC RegisterClient")?;
 
+    // scopes and grantTypes are not returned by the API — botocore
+    // populates them from the request parameters before caching.
     let reg = SsoClientRegistration {
         client_id: resp.client_id,
         client_secret: resp.client_secret,
         expires_at: format_sso_timestamp(expires_at),
-        scopes: resp.scopes,
-        grant_types: resp.grant_types,
+        scopes: config.scopes.clone(),
+        grant_types: vec![
+            "authorization_code".to_string(),
+            "refresh_token".to_string(),
+        ],
     };
 
     save_registration(&cache_dir, &cache_key, &reg)?;

--- a/crates/vouch-cli/src/integrations/aws/sso.rs
+++ b/crates/vouch-cli/src/integrations/aws/sso.rs
@@ -253,7 +253,11 @@ fn python_json_value(v: &serde_json::Value) -> String {
             // Sort keys to match Python's sort_keys=True.
             let mut pairs: Vec<String> = obj
                 .iter()
-                .map(|(k, val)| format!("\"{k}\": {}", python_json_value(val)))
+                .map(|(k, val)| {
+                    let escaped_key =
+                        serde_json::to_string(k).unwrap_or_else(|_| format!("\"{k}\""));
+                    format!("{escaped_key}: {}", python_json_value(val))
+                })
                 .collect();
             pairs.sort();
             format!("{{{}}}", pairs.join(", "))

--- a/crates/vouch-cli/src/integrations/aws/sso.rs
+++ b/crates/vouch-cli/src/integrations/aws/sso.rs
@@ -1,0 +1,1026 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! AWS IAM Identity Center (SSO) OIDC device authorization flow.
+//!
+//! Implements the OAuth 2.0 Device Authorization Grant against AWS SSO OIDC
+//! endpoints for obtaining SSO access tokens. Cached files are botocore-compatible
+//! so existing AWS CLI sessions are reused.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use vouch_common::aws::Partition;
+
+/// SSO OIDC configuration for the device authorization flow.
+pub(crate) struct SsoConfig {
+    /// SSO start URL (e.g., "https://my-sso.awsapps.com/start").
+    pub start_url: String,
+    /// SSO region (e.g., "us-east-1").
+    pub region: String,
+    /// OAuth scopes (default: ["sso:account:access"]).
+    pub scopes: Vec<String>,
+    /// SSO session name from `[sso-session <name>]` in `~/.aws/config`.
+    ///
+    /// When present, the token cache key is `SHA1(session_name)` (modern AWS CLI behavior).
+    /// When absent, falls back to `SHA1(start_url)` (legacy behavior).
+    pub session_name: Option<String>,
+}
+
+impl SsoConfig {
+    /// Create from an `SsoSession` parsed from `~/.aws/config`.
+    pub(crate) fn from_session(session: &crate::integrations::aws::config::SsoSession) -> Self {
+        Self {
+            start_url: session.start_url.clone(),
+            region: session.region.clone(),
+            scopes: session.scopes.clone(),
+            session_name: Some(session.name.clone()),
+        }
+    }
+}
+
+/// Cached SSO OIDC client registration (~90 day lifetime).
+///
+/// Stored in `~/.aws/sso/cache/{sha1}.json` with botocore-compatible format.
+/// Note: `region` and `tool` are only used for the cache key hash — they are
+/// NOT stored in the file itself.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SsoClientRegistration {
+    pub client_id: String,
+    pub client_secret: String,
+    /// ISO 8601 expiry timestamp (e.g. `"2026-07-09T01:54:45Z"`).
+    pub expires_at: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub scopes: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub grant_types: Vec<String>,
+}
+
+impl SsoClientRegistration {
+    /// Check whether this registration has expired.
+    #[must_use]
+    pub(crate) fn is_expired(&self) -> bool {
+        match parse_sso_timestamp(&self.expires_at) {
+            Ok(ts) => ts <= jiff::Timestamp::now(),
+            Err(_) => true,
+        }
+    }
+}
+
+impl std::fmt::Debug for SsoClientRegistration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SsoClientRegistration")
+            .field("client_id", &self.client_id)
+            .field("client_secret", &"[REDACTED]")
+            .field("expires_at", &self.expires_at)
+            .finish()
+    }
+}
+
+/// Serialize a `SecretString` as a plain string (required for on-disk cache format).
+fn serialize_secret<S: Serializer>(s: &SecretString, ser: S) -> Result<S::Ok, S::Error> {
+    ser.serialize_str(s.expose_secret())
+}
+
+/// Deserialize a plain string into a `SecretString`.
+fn deserialize_secret<'de, D: Deserializer<'de>>(de: D) -> Result<SecretString, D::Error> {
+    let s = String::deserialize(de)?;
+    Ok(SecretString::from(s))
+}
+
+/// Cached SSO access token (~8 hour lifetime).
+///
+/// Stored in `~/.aws/sso/cache/{sha1}.json` with botocore-compatible format.
+/// Cache key is `SHA1(session_name)` for `[sso-session]` configs, or
+/// `SHA1(start_url)` for legacy configs without a named session.
+/// Unknown fields are silently ignored so future botocore additions round-trip safely.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SsoAccessToken {
+    pub start_url: String,
+    pub region: String,
+    /// Access token — stored as plain string on disk but held as `SecretString` in memory.
+    #[serde(
+        serialize_with = "serialize_secret",
+        deserialize_with = "deserialize_secret"
+    )]
+    pub access_token: SecretString,
+    /// ISO 8601 expiry of the access token (e.g. `"2026-04-10T02:54:49Z"`).
+    pub expires_at: String,
+    pub client_id: String,
+    pub client_secret: String,
+    /// ISO 8601 expiry of the client registration.
+    pub registration_expires_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_token: Option<String>,
+}
+
+impl std::fmt::Debug for SsoAccessToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SsoAccessToken")
+            .field("start_url", &self.start_url)
+            .field("region", &self.region)
+            .field("access_token", &"[REDACTED]")
+            .field("expires_at", &self.expires_at)
+            .field("client_id", &self.client_id)
+            .field("client_secret", &"[REDACTED]")
+            .field("registration_expires_at", &self.registration_expires_at)
+            .field(
+                "refresh_token",
+                &self.refresh_token.as_ref().map(|_| "[REDACTED]"),
+            )
+            .finish()
+    }
+}
+
+impl SsoAccessToken {
+    /// Check whether the access token has expired.
+    ///
+    /// Handles three botocore timestamp variants:
+    /// - `"2024-01-15T18:30:45Z"` (standard ISO 8601)
+    /// - `"2024-01-15T18:30:45UTC"` (botocore legacy)
+    /// - `"2024-01-15T18:30:45+00:00"` (AWS CLI v2.15+)
+    #[must_use]
+    pub(crate) fn is_expired(&self) -> bool {
+        match parse_sso_timestamp(&self.expires_at) {
+            Ok(ts) => ts <= jiff::Timestamp::now(),
+            Err(_) => true,
+        }
+    }
+
+    /// Return the access token as a `SecretString`.
+    pub(crate) fn token(&self) -> SecretString {
+        self.access_token.clone()
+    }
+}
+
+/// Parse an SSO timestamp, handling three format variants:
+/// `"...Z"`, `"...UTC"`, and `"...+00:00"`.
+///
+/// Also handles microseconds: `"2024-01-15T18:30:45.123456UTC"`.
+pub(crate) fn parse_sso_timestamp(s: &str) -> Result<jiff::Timestamp> {
+    // Try standard ISO 8601 first (handles Z and +00:00)
+    if let Ok(ts) = s.parse::<jiff::Timestamp>() {
+        return Ok(ts);
+    }
+
+    // Strip trailing "UTC" suffix and retry
+    if let Some(stripped) = s.strip_suffix("UTC") {
+        // Handle optional microseconds: strip them and parse without
+        let normalized = if let Some(dot_pos) = stripped.rfind('.') {
+            // Check if the fractional part is all digits
+            let frac = stripped.get(dot_pos + 1..).unwrap_or("");
+            if frac.chars().all(|c| c.is_ascii_digit()) {
+                // Remove fractional seconds — jiff handles "...T18:30:45" directly
+                stripped.get(..dot_pos).unwrap_or(stripped).to_string()
+            } else {
+                stripped.to_string()
+            }
+        } else {
+            stripped.to_string()
+        };
+
+        let with_z = format!("{normalized}Z");
+        return with_z
+            .parse::<jiff::Timestamp>()
+            .with_context(|| format!("failed to parse SSO timestamp: {s}"));
+    }
+
+    Err(anyhow::anyhow!("unrecognized SSO timestamp format: {s}"))
+}
+
+/// Format a timestamp as ISO 8601 with `Z` suffix (botocore-compatible).
+fn format_sso_timestamp(ts: jiff::Timestamp) -> String {
+    let dt = ts.to_zoned(jiff::tz::TimeZone::UTC);
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        dt.year(),
+        dt.month(),
+        dt.day(),
+        dt.hour(),
+        dt.minute(),
+        dt.second()
+    )
+}
+
+/// SSO OIDC device authorization response.
+pub(crate) struct DeviceAuth {
+    /// Code to display to the user.
+    pub user_code: String,
+    /// URL for the user to open (without code, for display or fallback).
+    #[allow(dead_code)]
+    pub verification_uri: String,
+    /// URL with code pre-filled (for `open::that()`).
+    pub verification_uri_complete: String,
+    /// Device code for polling.
+    device_code: String,
+    /// Polling interval in seconds.
+    interval: u64,
+    /// How long this auth is valid (seconds).
+    expires_in: u64,
+}
+
+/// Error response from SSO OIDC endpoints.
+#[derive(Deserialize)]
+struct SsoOidcError {
+    error: String,
+    #[serde(rename = "error_description")]
+    _description: Option<String>,
+}
+
+/// Serialize a JSON value using Python-compatible separators, recursively.
+///
+/// Python's `json.dumps(obj, sort_keys=True)` uses `(', ', ': ')` as separators
+/// at every level. This produces `{"key": "value"}` and `["a", "b"]` rather than
+/// `{"key":"value"}` and `["a","b"]`. The difference produces different SHA-1 hashes.
+fn python_json_value(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::Null => "null".to_string(),
+        serde_json::Value::Bool(b) => if *b { "true" } else { "false" }.to_string(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::String(s) => {
+            // Use serde_json's string escaping rather than reimplementing it.
+            serde_json::to_string(v).unwrap_or_else(|_| format!("\"{s}\""))
+        }
+        serde_json::Value::Array(arr) => {
+            let items: Vec<String> = arr.iter().map(python_json_value).collect();
+            format!("[{}]", items.join(", "))
+        }
+        serde_json::Value::Object(obj) => {
+            // Sort keys to match Python's sort_keys=True.
+            let mut pairs: Vec<String> = obj
+                .iter()
+                .map(|(k, val)| format!("\"{k}\": {}", python_json_value(val)))
+                .collect();
+            pairs.sort();
+            format!("{{{}}}", pairs.join(", "))
+        }
+    }
+}
+
+/// Serialize a sorted `BTreeMap<&str, Value>` using Python-compatible separators.
+///
+/// Matches `json.dumps(obj, sort_keys=True)` exactly, including spaces inside arrays.
+fn python_json_dumps(map: &BTreeMap<&str, serde_json::Value>) -> String {
+    let pairs: Vec<String> = map
+        .iter()
+        .map(|(k, v)| format!("\"{k}\": {}", python_json_value(v)))
+        .collect();
+    format!("{{{}}}", pairs.join(", "))
+}
+
+/// Compute the botocore-compatible SHA-1 hex cache key for client registration.
+///
+/// Matches `hashlib.sha1(json.dumps(obj, sort_keys=True).encode()).hexdigest()` in Python.
+/// The JSON uses Python's default separators `(', ', ': ')`.
+/// The `session_name` field is `null` for legacy configs or the session name string
+/// for `[sso-session]` configs.
+pub(crate) fn registration_cache_key(config: &SsoConfig) -> String {
+    let mut obj: BTreeMap<&str, serde_json::Value> = BTreeMap::new();
+    obj.insert("region", serde_json::json!(config.region));
+    obj.insert("scopes", serde_json::json!(config.scopes));
+    obj.insert(
+        "session_name",
+        match &config.session_name {
+            Some(name) => serde_json::json!(name),
+            None => serde_json::Value::Null,
+        },
+    );
+    obj.insert("startUrl", serde_json::json!(config.start_url));
+    obj.insert("tool", serde_json::json!("botocore"));
+
+    let json_str = python_json_dumps(&obj);
+    sha1_hex(json_str.as_bytes())
+}
+
+/// Compute the SHA-1 hex cache key for access tokens.
+///
+/// - With `[sso-session]`: `SHA1(session_name)` — e.g. `SHA1("smoketurner")`
+/// - Legacy: `SHA1(start_url)`
+fn token_cache_key(config: &SsoConfig) -> String {
+    let input = config.session_name.as_deref().unwrap_or(&config.start_url);
+    sha1_hex(input.as_bytes())
+}
+
+/// Compute SHA-1 hex digest of bytes.
+fn sha1_hex(data: &[u8]) -> String {
+    use aws_lc_rs::digest::{SHA1_FOR_LEGACY_USE_ONLY, digest};
+    hex::encode(digest(&SHA1_FOR_LEGACY_USE_ONLY, data).as_ref())
+}
+
+/// Return the path to the SSO cache directory (`~/.aws/sso/cache/`).
+fn sso_cache_dir() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("could not determine home directory")?;
+    Ok(home.join(".aws").join("sso").join("cache"))
+}
+
+/// Load a cached SSO access token if present and not expired.
+pub(crate) fn load_cached_token(config: &SsoConfig) -> Option<SsoAccessToken> {
+    let cache_dir = sso_cache_dir().ok()?;
+    let key = token_cache_key(config);
+    let path = cache_dir.join(format!("{key}.json"));
+
+    let content = std::fs::read_to_string(&path).ok()?;
+    let token: SsoAccessToken = serde_json::from_str(&content).ok()?;
+
+    if token.is_expired() {
+        return None;
+    }
+
+    // Verify this token matches our SSO config
+    if token.start_url != config.start_url {
+        return None;
+    }
+
+    Some(token)
+}
+
+/// Load a cached SSO client registration if present and not expired.
+fn load_cached_registration(
+    cache_dir: &std::path::Path,
+    key: &str,
+) -> Option<SsoClientRegistration> {
+    let path = cache_dir.join(format!("{key}.json"));
+    let content = std::fs::read_to_string(&path).ok()?;
+    let reg: SsoClientRegistration = serde_json::from_str(&content).ok()?;
+    if reg.is_expired() {
+        return None;
+    }
+    Some(reg)
+}
+
+/// Save an SSO client registration to cache with 0600 permissions.
+fn save_registration(
+    cache_dir: &std::path::Path,
+    key: &str,
+    reg: &SsoClientRegistration,
+) -> Result<()> {
+    crate::utils::ensure_secure_dir(cache_dir)?;
+    let path = cache_dir.join(format!("{key}.json"));
+    let content = serde_json::to_vec_pretty(reg).context("failed to serialize registration")?;
+    crate::utils::atomic_write_secure(&path, &content)
+        .context("failed to write SSO client registration cache")
+}
+
+/// Save an SSO access token to cache with 0600 permissions.
+pub(crate) fn save_access_token(config: &SsoConfig, token: &SsoAccessToken) -> Result<()> {
+    let cache_dir = sso_cache_dir()?;
+    crate::utils::ensure_secure_dir(&cache_dir)?;
+    let key = token_cache_key(config);
+    let path = cache_dir.join(format!("{key}.json"));
+    let content = serde_json::to_vec_pretty(token).context("failed to serialize access token")?;
+    crate::utils::atomic_write_secure(&path, &content)
+        .context("failed to write SSO access token cache")
+}
+
+/// Register a new SSO OIDC client (or return cached registration).
+pub(crate) async fn register_client(
+    http_client: &reqwest::Client,
+    config: &SsoConfig,
+) -> Result<SsoClientRegistration> {
+    let cache_dir = sso_cache_dir()?;
+    let cache_key = registration_cache_key(config);
+
+    if let Some(cached) = load_cached_registration(&cache_dir, &cache_key) {
+        tracing::debug!("reusing cached SSO client registration");
+        return Ok(cached);
+    }
+
+    let partition = Partition::from_region(&config.region);
+    let oidc_endpoint = partition.sso_oidc_endpoint(&config.region);
+    let url = format!("{oidc_endpoint}/client/register");
+
+    let body = serde_json::json!({
+        "clientName": "vouch-cli",
+        "clientType": "public",
+        "scopes": config.scopes,
+    });
+
+    let response = http_client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .context("failed to register SSO OIDC client")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(crate::exit_code::CliError::NetworkError(format!(
+            "SSO OIDC client registration failed {status}: {text}"
+        ))
+        .into());
+    }
+
+    // The AWS SSO OIDC RegisterClient API returns `clientSecretExpiresAt` as
+    // an integer (Unix epoch seconds). We convert it to an ISO 8601 string
+    // for the cache file (botocore-compatible format).
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct RegisterResponse {
+        client_id: String,
+        client_secret: String,
+        /// Epoch seconds from the API; converted to ISO 8601 for the cache file.
+        client_secret_expires_at: i64,
+        #[serde(default)]
+        scopes: Vec<String>,
+        #[serde(default)]
+        grant_types: Vec<String>,
+    }
+
+    let resp: RegisterResponse = response
+        .json()
+        .await
+        .context("failed to parse SSO client registration response")?;
+
+    let expires_at = jiff::Timestamp::from_second(resp.client_secret_expires_at)
+        .context("invalid clientSecretExpiresAt from SSO OIDC RegisterClient")?;
+
+    let reg = SsoClientRegistration {
+        client_id: resp.client_id,
+        client_secret: resp.client_secret,
+        expires_at: format_sso_timestamp(expires_at),
+        scopes: resp.scopes,
+        grant_types: resp.grant_types,
+    };
+
+    save_registration(&cache_dir, &cache_key, &reg)?;
+    Ok(reg)
+}
+
+/// Start the device authorization flow.
+pub(crate) async fn start_device_authorization(
+    http_client: &reqwest::Client,
+    config: &SsoConfig,
+    registration: &SsoClientRegistration,
+) -> Result<DeviceAuth> {
+    let partition = Partition::from_region(&config.region);
+    let oidc_endpoint = partition.sso_oidc_endpoint(&config.region);
+    let url = format!("{oidc_endpoint}/device_authorization");
+
+    let body = serde_json::json!({
+        "clientId": registration.client_id,
+        "clientSecret": registration.client_secret,
+        "startUrl": config.start_url,
+    });
+
+    let response = http_client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .context("failed to start SSO device authorization")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(crate::exit_code::CliError::NetworkError(format!(
+            "SSO device authorization failed {status}: {text}"
+        ))
+        .into());
+    }
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct DeviceAuthResponse {
+        device_code: String,
+        user_code: String,
+        verification_uri: String,
+        verification_uri_complete: String,
+        #[serde(default = "default_interval")]
+        interval: u64,
+        expires_in: u64,
+    }
+
+    fn default_interval() -> u64 {
+        5
+    }
+
+    let resp: DeviceAuthResponse = response
+        .json()
+        .await
+        .context("failed to parse SSO device authorization response")?;
+
+    Ok(DeviceAuth {
+        user_code: resp.user_code,
+        verification_uri: resp.verification_uri,
+        verification_uri_complete: resp.verification_uri_complete,
+        device_code: resp.device_code,
+        interval: resp.interval,
+        expires_in: resp.expires_in,
+    })
+}
+
+/// Poll for an SSO access token after the user completes authorization.
+///
+/// Returns the token when the user has authorized, or an error if:
+/// - The user declined (`access_denied`)
+/// - The authorization expired (`expired_token`)
+/// - The device code expired
+pub(crate) async fn poll_for_token(
+    http_client: &reqwest::Client,
+    config: &SsoConfig,
+    registration: &SsoClientRegistration,
+    device_auth: &DeviceAuth,
+) -> Result<SsoAccessToken> {
+    let partition = Partition::from_region(&config.region);
+    let oidc_endpoint = partition.sso_oidc_endpoint(&config.region);
+    let url = format!("{oidc_endpoint}/token");
+
+    let mut interval_secs = device_auth.interval;
+    let deadline = jiff::Timestamp::now()
+        .checked_add(jiff::SignedDuration::from_secs(
+            i64::try_from(device_auth.expires_in).unwrap_or(i64::MAX),
+        ))
+        .context("SSO device auth expiry overflow")?;
+
+    // Safety cap: never loop more than 100 times regardless of expires_in
+    let max_iterations: u32 = 100;
+    let mut iteration: u32 = 0;
+
+    loop {
+        if jiff::Timestamp::now() >= deadline {
+            return Err(crate::exit_code::CliError::NetworkError(
+                "SSO device authorization timed out. Run 'vouch aws login' again.".to_string(),
+            )
+            .into());
+        }
+
+        if iteration >= max_iterations {
+            return Err(crate::exit_code::CliError::NetworkError(
+                "SSO device authorization polling limit reached.".to_string(),
+            )
+            .into());
+        }
+        iteration += 1;
+
+        tokio::time::sleep(Duration::from_secs(interval_secs)).await;
+
+        let body = serde_json::json!({
+            "clientId": registration.client_id,
+            "clientSecret": registration.client_secret,
+            "deviceCode": device_auth.device_code,
+            "grantType": "urn:ietf:params:oauth:grant-type:device_code",
+        });
+
+        let response = http_client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .context("failed to poll SSO token endpoint")?;
+
+        if response.status().is_success() {
+            #[derive(Deserialize)]
+            #[serde(rename_all = "camelCase")]
+            struct TokenResponse {
+                access_token: String,
+                expires_in: u64,
+                #[serde(default)]
+                refresh_token: Option<String>,
+            }
+
+            let resp: TokenResponse = response
+                .json()
+                .await
+                .context("failed to parse SSO token response")?;
+
+            let expires_at = jiff::Timestamp::now()
+                .checked_add(jiff::SignedDuration::from_secs(
+                    i64::try_from(resp.expires_in).unwrap_or(i64::MAX),
+                ))
+                .context("SSO token expiry overflow")?;
+
+            return Ok(SsoAccessToken {
+                start_url: config.start_url.clone(),
+                region: config.region.clone(),
+                access_token: SecretString::from(resp.access_token),
+                expires_at: format_sso_timestamp(expires_at),
+                client_id: registration.client_id.clone(),
+                client_secret: registration.client_secret.clone(),
+                registration_expires_at: registration.expires_at.clone(),
+                refresh_token: resp.refresh_token,
+            });
+        }
+
+        let status = response.status();
+        let body_text = response.text().await.unwrap_or_default();
+
+        // Parse the error to decide whether to retry or fail
+        let oidc_err: Option<SsoOidcError> = serde_json::from_str(&body_text).ok();
+        let error_code = oidc_err.as_ref().map(|e| e.error.as_str()).unwrap_or("");
+
+        match error_code {
+            "authorization_pending" => {
+                // Normal: user hasn't authorized yet — keep polling
+                tracing::debug!("SSO authorization pending, polling again in {interval_secs}s");
+            }
+            "slow_down" => {
+                // Server requesting slower polling
+                interval_secs += 5;
+                tracing::debug!("SSO slow_down: increasing interval to {interval_secs}s");
+            }
+            "access_denied" => {
+                return Err(crate::exit_code::CliError::PermissionDenied(
+                    "SSO authorization was denied.".to_string(),
+                )
+                .into());
+            }
+            "expired_token" => {
+                return Err(crate::exit_code::CliError::NetworkError(
+                    "SSO device code expired. Run 'vouch aws login' again.".to_string(),
+                )
+                .into());
+            }
+            _ => {
+                return Err(crate::exit_code::CliError::NetworkError(format!(
+                    "SSO token request failed {status}: {body_text}"
+                ))
+                .into());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::integrations::aws::config::SsoSession;
+
+    fn make_session(name: &str, start_url: &str, region: &str) -> SsoSession {
+        SsoSession {
+            name: name.to_string(),
+            start_url: start_url.to_string(),
+            region: region.to_string(),
+            scopes: vec!["sso:account:access".to_string()],
+        }
+    }
+
+    #[test]
+    fn test_registration_cache_key_deterministic() {
+        let session = make_session(
+            "my-session",
+            "https://my-sso.awsapps.com/start",
+            "us-east-1",
+        );
+        let config = SsoConfig::from_session(&session);
+
+        // Key must be stable across calls
+        let key1 = registration_cache_key(&config);
+        let key2 = registration_cache_key(&config);
+        assert_eq!(key1, key2);
+
+        // Key is a 40-char hex string (SHA-1)
+        assert_eq!(key1.len(), 40);
+        assert!(key1.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn test_registration_cache_key_differs_with_different_session_names() {
+        let session_a = make_session("session-a", "https://my-sso.awsapps.com/start", "us-east-1");
+        let session_b = make_session("session-b", "https://my-sso.awsapps.com/start", "us-east-1");
+        let config_a = SsoConfig::from_session(&session_a);
+        let config_b = SsoConfig::from_session(&session_b);
+        // Different session names → different keys
+        assert_ne!(
+            registration_cache_key(&config_a),
+            registration_cache_key(&config_b)
+        );
+    }
+
+    #[test]
+    fn test_token_cache_key_uses_session_name() {
+        let session = make_session(
+            "my-session",
+            "https://my-sso.awsapps.com/start",
+            "us-east-1",
+        );
+        let config = SsoConfig::from_session(&session);
+        let key = token_cache_key(&config);
+        assert_eq!(key, sha1_hex("my-session".as_bytes()));
+        assert_eq!(key.len(), 40);
+    }
+
+    #[test]
+    fn test_token_cache_key_smoketurner() {
+        // Verified: SHA1("smoketurner") = c31a222de1424e1a089c046fba783f6e4fb5954c
+        // This matches the user's real cache filename.
+        let session = make_session(
+            "smoketurner",
+            "https://smoketurner.awsapps.com/start",
+            "us-east-1",
+        );
+        let config = SsoConfig::from_session(&session);
+        let key = token_cache_key(&config);
+        assert_eq!(key, "c31a222de1424e1a089c046fba783f6e4fb5954c");
+    }
+
+    #[test]
+    fn test_token_cache_key_legacy_uses_start_url() {
+        // Legacy configs without a named [sso-session] use SHA1(start_url).
+        // Verified: SHA1("https://my-sso.awsapps.com/start") matches botocore.
+        let config = SsoConfig {
+            start_url: "https://my-sso.awsapps.com/start".to_string(),
+            region: "us-east-1".to_string(),
+            scopes: vec!["sso:account:access".to_string()],
+            session_name: None,
+        };
+        let key = token_cache_key(&config);
+        // Key must be SHA1 of the start URL, not the session name
+        assert_eq!(key, sha1_hex("https://my-sso.awsapps.com/start".as_bytes()));
+        assert_eq!(key.len(), 40);
+        assert!(key.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn test_token_cache_key_session_name_differs_from_start_url() {
+        // The key with a session name must differ from the key computed from the start_url.
+        let session = make_session(
+            "my-session",
+            "https://my-sso.awsapps.com/start",
+            "us-east-1",
+        );
+        let named_config = SsoConfig::from_session(&session);
+        let legacy_config = SsoConfig {
+            start_url: "https://my-sso.awsapps.com/start".to_string(),
+            region: "us-east-1".to_string(),
+            scopes: vec!["sso:account:access".to_string()],
+            session_name: None,
+        };
+        assert_ne!(
+            token_cache_key(&named_config),
+            token_cache_key(&legacy_config)
+        );
+    }
+
+    #[test]
+    fn test_python_json_dumps_single_scope() {
+        // Verify exact string output matches Python's json.dumps(obj, sort_keys=True)
+        let mut map = BTreeMap::new();
+        map.insert("region", serde_json::json!("us-east-1"));
+        map.insert("scopes", serde_json::json!(["sso:account:access"]));
+        map.insert("session_name", serde_json::json!("test"));
+        map.insert("startUrl", serde_json::json!("https://example.com/start"));
+        map.insert("tool", serde_json::json!("botocore"));
+
+        let out = python_json_dumps(&map);
+        assert_eq!(
+            out,
+            r#"{"region": "us-east-1", "scopes": ["sso:account:access"], "session_name": "test", "startUrl": "https://example.com/start", "tool": "botocore"}"#
+        );
+    }
+
+    #[test]
+    fn test_python_json_dumps_multi_scope() {
+        // Array items must also be separated with ", " to match Python
+        let mut map = BTreeMap::new();
+        map.insert("region", serde_json::json!("us-east-1"));
+        map.insert(
+            "scopes",
+            serde_json::json!(["sso:account:access", "sso:other:scope"]),
+        );
+        map.insert("session_name", serde_json::json!("multi"));
+        map.insert(
+            "startUrl",
+            serde_json::json!("https://example.awsapps.com/start"),
+        );
+        map.insert("tool", serde_json::json!("botocore"));
+
+        let out = python_json_dumps(&map);
+        assert_eq!(
+            out,
+            r#"{"region": "us-east-1", "scopes": ["sso:account:access", "sso:other:scope"], "session_name": "multi", "startUrl": "https://example.awsapps.com/start", "tool": "botocore"}"#
+        );
+    }
+
+    #[test]
+    fn test_registration_cache_key_multi_scope_golden() {
+        // Golden hash for multi-scope config — verified with Python:
+        // => "fffb192c213db6b8fee8752d8e12719f96a5f063"
+        let session = SsoSession {
+            name: "multi".to_string(),
+            start_url: "https://example.awsapps.com/start".to_string(),
+            region: "us-east-1".to_string(),
+            scopes: vec![
+                "sso:account:access".to_string(),
+                "sso:other:scope".to_string(),
+            ],
+        };
+        let config = SsoConfig::from_session(&session);
+        assert_eq!(
+            registration_cache_key(&config),
+            "fffb192c213db6b8fee8752d8e12719f96a5f063"
+        );
+    }
+
+    #[test]
+    fn test_registration_cache_key_smoketurner_golden() {
+        // Golden hash — verified with Python:
+        // import json, hashlib
+        // obj = {"region": "us-east-1", "scopes": ["sso:account:access"],
+        //        "session_name": "smoketurner",
+        //        "startUrl": "https://smoketurner.awsapps.com/start", "tool": "botocore"}
+        // hashlib.sha1(json.dumps(obj, sort_keys=True).encode()).hexdigest()
+        // => "a43c9cf4c32647e1c549c23ec7ac0ec48676a793"
+        let session = make_session(
+            "smoketurner",
+            "https://smoketurner.awsapps.com/start",
+            "us-east-1",
+        );
+        let config = SsoConfig::from_session(&session);
+        assert_eq!(
+            registration_cache_key(&config),
+            "a43c9cf4c32647e1c549c23ec7ac0ec48676a793"
+        );
+    }
+
+    #[test]
+    fn test_registration_cache_key_null_session_name_golden() {
+        // Golden hash for legacy configs (no [sso-session]) — verified with Python:
+        // obj = {"region": "us-east-1", "scopes": ["sso:account:access"],
+        //        "session_name": null,
+        //        "startUrl": "https://my-sso.awsapps.com/start", "tool": "botocore"}
+        // hashlib.sha1(json.dumps(obj, sort_keys=True).encode()).hexdigest()
+        // => "86c5f58554531cd1231f5471537186f468344753"
+        let config = SsoConfig {
+            start_url: "https://my-sso.awsapps.com/start".to_string(),
+            region: "us-east-1".to_string(),
+            scopes: vec!["sso:account:access".to_string()],
+            session_name: None,
+        };
+        assert_eq!(
+            registration_cache_key(&config),
+            "86c5f58554531cd1231f5471537186f468344753"
+        );
+    }
+
+    #[test]
+    fn test_client_registration_deserialization_real_format() {
+        // Real botocore cache file format (verified against ~/.aws/sso/cache/*.json)
+        let json = r#"{
+            "clientId": "cBP-1Sc6dal96A6SKmYmoHVzLWVhc3QtMQ",
+            "clientSecret": "eyJraWQi...(JWT)...",
+            "expiresAt": "2026-07-09T01:54:45Z",
+            "scopes": ["sso:account:access"],
+            "grantTypes": ["authorization_code", "refresh_token"]
+        }"#;
+        let reg: SsoClientRegistration = serde_json::from_str(json).expect("valid JSON");
+        assert_eq!(reg.client_id, "cBP-1Sc6dal96A6SKmYmoHVzLWVhc3QtMQ");
+        assert_eq!(reg.expires_at, "2026-07-09T01:54:45Z");
+        assert_eq!(reg.scopes, vec!["sso:account:access"]);
+        assert_eq!(reg.grant_types, vec!["authorization_code", "refresh_token"]);
+        assert!(!reg.is_expired());
+    }
+
+    #[test]
+    fn test_client_registration_deserialization_missing_optional_fields() {
+        // Older botocore versions may omit grantTypes
+        let json = r#"{
+            "clientId": "abc123",
+            "clientSecret": "secret",
+            "expiresAt": "2024-01-01T00:00:00Z"
+        }"#;
+        let reg: SsoClientRegistration = serde_json::from_str(json).expect("valid JSON");
+        assert!(reg.scopes.is_empty());
+        assert!(reg.grant_types.is_empty());
+        assert!(reg.is_expired());
+    }
+
+    #[test]
+    fn test_parse_sso_timestamp_utc_suffix() {
+        let ts = parse_sso_timestamp("2024-01-15T18:30:45UTC").unwrap();
+        let expected = "2024-01-15T18:30:45Z".parse::<jiff::Timestamp>().unwrap();
+        assert_eq!(ts, expected);
+    }
+
+    #[test]
+    fn test_parse_sso_timestamp_z_suffix() {
+        let ts = parse_sso_timestamp("2024-01-15T18:30:45Z").unwrap();
+        let expected = "2024-01-15T18:30:45Z".parse::<jiff::Timestamp>().unwrap();
+        assert_eq!(ts, expected);
+    }
+
+    #[test]
+    fn test_parse_sso_timestamp_plus_offset() {
+        let ts = parse_sso_timestamp("2024-01-15T18:30:45+00:00").unwrap();
+        let expected = "2024-01-15T18:30:45Z".parse::<jiff::Timestamp>().unwrap();
+        assert_eq!(ts, expected);
+    }
+
+    #[test]
+    fn test_parse_sso_timestamp_microseconds_utc() {
+        // botocore may write microseconds before UTC suffix
+        let ts = parse_sso_timestamp("2024-01-15T18:30:45.123456UTC").unwrap();
+        // Should parse to the second (microseconds stripped)
+        let expected = "2024-01-15T18:30:45Z".parse::<jiff::Timestamp>().unwrap();
+        assert_eq!(ts, expected);
+    }
+
+    #[test]
+    fn test_parse_sso_timestamp_invalid() {
+        assert!(parse_sso_timestamp("not-a-timestamp").is_err());
+        assert!(parse_sso_timestamp("").is_err());
+    }
+
+    #[test]
+    fn test_format_sso_timestamp_z_suffix() {
+        let ts = "2024-01-15T18:30:45Z".parse::<jiff::Timestamp>().unwrap();
+        let formatted = format_sso_timestamp(ts);
+        assert_eq!(formatted, "2024-01-15T18:30:45Z");
+    }
+
+    #[test]
+    fn test_format_sso_timestamp_round_trip() {
+        let ts = "2024-06-20T12:00:00Z".parse::<jiff::Timestamp>().unwrap();
+        let formatted = format_sso_timestamp(ts);
+        let reparsed = parse_sso_timestamp(&formatted).unwrap();
+        assert_eq!(ts, reparsed);
+    }
+
+    fn make_token(expires_at: String) -> SsoAccessToken {
+        SsoAccessToken {
+            start_url: "https://example.com/start".to_string(),
+            region: "us-east-1".to_string(),
+            access_token: SecretString::from("tok".to_string()),
+            expires_at,
+            client_id: "client-id".to_string(),
+            client_secret: "client-secret".to_string(),
+            registration_expires_at: "2026-07-09T01:54:45Z".to_string(),
+            refresh_token: None,
+        }
+    }
+
+    #[test]
+    fn test_access_token_is_expired() {
+        let past = format_sso_timestamp(
+            jiff::Timestamp::now()
+                .checked_sub(jiff::SignedDuration::from_secs(3600))
+                .unwrap(),
+        );
+        assert!(make_token(past).is_expired());
+    }
+
+    #[test]
+    fn test_access_token_not_expired() {
+        let future = format_sso_timestamp(
+            jiff::Timestamp::now()
+                .checked_add(jiff::SignedDuration::from_secs(3600))
+                .unwrap(),
+        );
+        assert!(!make_token(future).is_expired());
+    }
+
+    #[test]
+    fn test_access_token_invalid_expires_at_treated_as_expired() {
+        assert!(make_token("invalid".to_string()).is_expired());
+    }
+
+    #[test]
+    fn test_access_token_deserialization_real_format() {
+        // Real botocore cache file format (verified against ~/.aws/sso/cache/*.json).
+        // Uses a clearly-past expiresAt to avoid time-sensitivity in CI.
+        let json = r#"{
+            "startUrl": "https://smoketurner.awsapps.com/start",
+            "region": "us-east-1",
+            "accessToken": "aoaAAAAA...(long token)...",
+            "expiresAt": "2024-01-01T00:00:00Z",
+            "clientId": "cBP-1Sc6dal96A6SKmYmoHVzLWVhc3QtMQ",
+            "clientSecret": "eyJraWQi...(JWT)...",
+            "registrationExpiresAt": "2026-07-09T01:54:45Z",
+            "refreshToken": "aorAAAAA...(long token)..."
+        }"#;
+        let token: SsoAccessToken = serde_json::from_str(json).expect("valid JSON");
+        assert_eq!(token.start_url, "https://smoketurner.awsapps.com/start");
+        assert_eq!(token.region, "us-east-1");
+        assert_eq!(
+            token.access_token.expose_secret(),
+            "aoaAAAAA...(long token)..."
+        );
+        assert_eq!(token.expires_at, "2024-01-01T00:00:00Z");
+        assert_eq!(token.client_id, "cBP-1Sc6dal96A6SKmYmoHVzLWVhc3QtMQ");
+        assert_eq!(token.registration_expires_at, "2026-07-09T01:54:45Z");
+        assert!(token.refresh_token.is_some());
+        assert!(token.is_expired());
+    }
+
+    #[test]
+    fn test_access_token_deserialization_without_refresh_token() {
+        // Older botocore versions may omit refreshToken
+        let json = r#"{
+            "startUrl": "https://example.awsapps.com/start",
+            "region": "us-east-1",
+            "accessToken": "tok",
+            "expiresAt": "2099-01-01T00:00:00Z",
+            "clientId": "client-id",
+            "clientSecret": "secret",
+            "registrationExpiresAt": "2099-06-01T00:00:00Z"
+        }"#;
+        let token: SsoAccessToken = serde_json::from_str(json).expect("valid JSON");
+        assert!(token.refresh_token.is_none());
+        assert!(!token.is_expired());
+    }
+}

--- a/crates/vouch-cli/src/integrations/aws/sso.rs
+++ b/crates/vouch-cli/src/integrations/aws/sso.rs
@@ -1056,6 +1056,27 @@ mod tests {
     }
 
     #[test]
+    fn test_add_python_json_spacing_with_colons_in_strings() {
+        let input = r#"{"url":"https://a.com/b","note":"a,b:c"}"#;
+        let expected = r#"{"url": "https://a.com/b", "note": "a,b:c"}"#;
+        assert_eq!(add_python_json_spacing(input), expected);
+    }
+
+    #[test]
+    fn test_add_python_json_spacing_nested_array() {
+        let input = r#"{"scopes":["sso:account:access"]}"#;
+        let expected = r#"{"scopes": ["sso:account:access"]}"#;
+        assert_eq!(add_python_json_spacing(input), expected);
+    }
+
+    #[test]
+    fn test_add_python_json_spacing_escaped_quotes() {
+        let input = r#"{"key":"value with \"quotes\""}"#;
+        let expected = r#"{"key": "value with \"quotes\""}"#;
+        assert_eq!(add_python_json_spacing(input), expected);
+    }
+
+    #[test]
     fn test_access_token_deserialization_without_refresh_token() {
         // Older botocore versions may omit refreshToken
         let json = r#"{

--- a/crates/vouch-cli/src/integrations/aws/sso_portal.rs
+++ b/crates/vouch-cli/src/integrations/aws/sso_portal.rs
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! AWS SSO Portal API for listing accounts and roles.
+//!
+//! Uses Bearer token auth via the `x-amz-sso_bearer_token` header (not
+//! standard `Authorization: Bearer` — this is what the AWS SDK uses).
+
+use anyhow::{Context, Result};
+use secrecy::{ExposeSecret, SecretString};
+use serde::Deserialize;
+use vouch_common::aws::Partition;
+
+/// An AWS account the user has access to via SSO.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SsoAccount {
+    pub account_id: String,
+    pub account_name: String,
+    pub email_address: String,
+}
+
+/// A role available to the user in a specific SSO-assigned account.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SsoRole {
+    pub role_name: String,
+    #[allow(dead_code)]
+    pub account_id: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ListAccountsResponse {
+    account_list: Vec<SsoAccount>,
+    next_token: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ListAccountRolesResponse {
+    role_list: Vec<SsoRole>,
+    next_token: Option<String>,
+}
+
+/// List all AWS accounts assigned to the user via SSO.
+///
+/// Paginates automatically with a 100-page safety cap (~10,000 accounts max).
+pub(crate) async fn list_accounts(
+    http_client: &reqwest::Client,
+    region: &str,
+    access_token: &SecretString,
+) -> Result<Vec<SsoAccount>> {
+    let partition = Partition::from_region(region);
+    let base_url = partition.sso_portal_endpoint(region);
+    let url = format!("{base_url}/assignment/accounts");
+
+    let mut accounts = Vec::new();
+    let mut next_token: Option<String> = None;
+    let max_pages: u32 = 100;
+
+    for page in 0..max_pages {
+        let mut request = http_client
+            .get(&url)
+            .header("x-amz-sso_bearer_token", access_token.expose_secret())
+            .query(&[("max_result", "100")]);
+
+        if let Some(ref token) = next_token {
+            request = request.query(&[("next_token", token.as_str())]);
+        }
+
+        let response = request
+            .send()
+            .await
+            .context("failed to call SSO Portal list accounts")?;
+
+        if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+            return Err(crate::exit_code::CliError::NotAuthenticated {
+                reason: "SSO token is invalid or expired. Run 'vouch aws login' first.".to_string(),
+            }
+            .into());
+        }
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            return Err(crate::exit_code::CliError::NetworkError(format!(
+                "SSO Portal list accounts failed {status}: {text}"
+            ))
+            .into());
+        }
+
+        let resp: ListAccountsResponse = response
+            .json()
+            .await
+            .context("failed to parse SSO Portal accounts response")?;
+
+        accounts.extend(resp.account_list);
+
+        match resp.next_token {
+            Some(token) if !token.is_empty() => {
+                next_token = Some(token);
+            }
+            _ => break,
+        }
+
+        if page == max_pages - 1 {
+            tracing::warn!(
+                "SSO account list reached {max_pages}-page safety cap; results may be incomplete"
+            );
+        }
+    }
+
+    Ok(accounts)
+}
+
+/// List roles available to the user in a specific SSO-assigned account.
+///
+/// Paginates automatically with a 100-page safety cap.
+pub(crate) async fn list_account_roles(
+    http_client: &reqwest::Client,
+    region: &str,
+    access_token: &SecretString,
+    account_id: &str,
+) -> Result<Vec<SsoRole>> {
+    let partition = Partition::from_region(region);
+    let base_url = partition.sso_portal_endpoint(region);
+    let url = format!("{base_url}/assignment/roles");
+
+    let mut roles = Vec::new();
+    let mut next_token: Option<String> = None;
+    let max_pages: u32 = 100;
+
+    for page in 0..max_pages {
+        let mut request = http_client
+            .get(&url)
+            .header("x-amz-sso_bearer_token", access_token.expose_secret())
+            .query(&[("account_id", account_id), ("max_result", "100")]);
+
+        if let Some(ref token) = next_token {
+            request = request.query(&[("next_token", token.as_str())]);
+        }
+
+        let response = request
+            .send()
+            .await
+            .context("failed to call SSO Portal list roles")?;
+
+        if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+            return Err(crate::exit_code::CliError::NotAuthenticated {
+                reason: "SSO token is invalid or expired. Run 'vouch aws login' first.".to_string(),
+            }
+            .into());
+        }
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            return Err(crate::exit_code::CliError::NetworkError(format!(
+                "SSO Portal list roles failed {status}: {text}"
+            ))
+            .into());
+        }
+
+        let resp: ListAccountRolesResponse = response
+            .json()
+            .await
+            .context("failed to parse SSO Portal roles response")?;
+
+        roles.extend(resp.role_list);
+
+        match resp.next_token {
+            Some(token) if !token.is_empty() => {
+                next_token = Some(token);
+            }
+            _ => break,
+        }
+
+        if page == max_pages - 1 {
+            tracing::warn!(
+                "SSO roles list for account {account_id} reached {max_pages}-page safety cap"
+            );
+        }
+    }
+
+    Ok(roles)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_list_accounts_response_deserialization() {
+        let json = r#"{
+            "accountList": [
+                {
+                    "accountId": "111111111111",
+                    "accountName": "Production",
+                    "emailAddress": "prod@example.com"
+                },
+                {
+                    "accountId": "222222222222",
+                    "accountName": "Staging",
+                    "emailAddress": "staging@example.com"
+                }
+            ],
+            "nextToken": null
+        }"#;
+
+        let resp: ListAccountsResponse = serde_json::from_str(json).expect("valid JSON");
+        assert_eq!(resp.account_list.len(), 2);
+        assert_eq!(resp.account_list[0].account_id, "111111111111");
+        assert_eq!(resp.account_list[0].account_name, "Production");
+        assert_eq!(resp.account_list[1].account_id, "222222222222");
+        assert!(resp.next_token.is_none());
+    }
+
+    #[test]
+    fn test_list_accounts_response_with_pagination() {
+        let json = r#"{
+            "accountList": [
+                {
+                    "accountId": "111111111111",
+                    "accountName": "Production",
+                    "emailAddress": "prod@example.com"
+                }
+            ],
+            "nextToken": "abc123"
+        }"#;
+
+        let resp: ListAccountsResponse = serde_json::from_str(json).expect("valid JSON");
+        assert_eq!(resp.account_list.len(), 1);
+        assert_eq!(resp.next_token.as_deref(), Some("abc123"));
+    }
+
+    #[test]
+    fn test_list_account_roles_response_deserialization() {
+        let json = r#"{
+            "roleList": [
+                {
+                    "roleName": "AdministratorAccess",
+                    "accountId": "111111111111"
+                },
+                {
+                    "roleName": "ViewOnlyAccess",
+                    "accountId": "111111111111"
+                }
+            ],
+            "nextToken": null
+        }"#;
+
+        let resp: ListAccountRolesResponse = serde_json::from_str(json).expect("valid JSON");
+        assert_eq!(resp.role_list.len(), 2);
+        assert_eq!(resp.role_list[0].role_name, "AdministratorAccess");
+        assert_eq!(resp.role_list[1].role_name, "ViewOnlyAccess");
+        assert!(resp.next_token.is_none());
+    }
+
+    #[test]
+    fn test_list_account_roles_with_pagination() {
+        let json = r#"{
+            "roleList": [
+                {
+                    "roleName": "VouchAccess",
+                    "accountId": "333333333333"
+                }
+            ],
+            "nextToken": "page2token"
+        }"#;
+
+        let resp: ListAccountRolesResponse = serde_json::from_str(json).expect("valid JSON");
+        assert_eq!(resp.role_list.len(), 1);
+        assert_eq!(resp.next_token.as_deref(), Some("page2token"));
+    }
+
+    #[test]
+    fn test_sso_account_fields() {
+        let json = r#"{
+            "accountId": "123456789012",
+            "accountName": "My Account",
+            "emailAddress": "admin@example.com"
+        }"#;
+        let account: SsoAccount = serde_json::from_str(json).expect("valid JSON");
+        assert_eq!(account.account_id, "123456789012");
+        assert_eq!(account.account_name, "My Account");
+        assert_eq!(account.email_address, "admin@example.com");
+    }
+
+    #[test]
+    fn test_sso_role_fields() {
+        let json = r#"{
+            "roleName": "ReadOnly",
+            "accountId": "987654321098"
+        }"#;
+        let role: SsoRole = serde_json::from_str(json).expect("valid JSON");
+        assert_eq!(role.role_name, "ReadOnly");
+        assert_eq!(role.account_id, "987654321098");
+    }
+}

--- a/crates/vouch-cli/src/integrations/aws/sts.rs
+++ b/crates/vouch-cli/src/integrations/aws/sts.rs
@@ -55,28 +55,33 @@ impl std::fmt::Debug for StsCredentials {
     }
 }
 
+/// Parameters for `AssumeRoleWithWebIdentity`.
+///
+/// Bundles the required and optional parameters to stay within the
+/// project's 5-positional-parameter limit.
+pub(crate) struct WebIdentityRequest<'a> {
+    pub http_client: &'a reqwest::Client,
+    pub role_arn: &'a str,
+    pub role_session_name: &'a str,
+    pub web_identity_token: &'a str,
+    pub region: &'a str,
+    pub domain_suffix: &'a str,
+    pub tags: &'a [(String, String)],
+    /// Optional `SourceIdentity` for CloudTrail audit trails (propagates through role chains).
+    pub source_identity: Option<&'a str>,
+    /// Tags to propagate through role chains via `TransitiveTagKeys`.
+    pub transitive_tag_keys: &'a [&'a str],
+}
+
 /// Call AWS STS `AssumeRoleWithWebIdentity`.
 ///
 /// Uses regional STS endpoints to support all AWS partitions
 /// (commercial, China, GovCloud, EU Sovereign Cloud).
-///
-/// # Arguments
-/// * `role_arn` - The ARN of the role to assume
-/// * `role_session_name` - An identifier for the assumed role session
-/// * `web_identity_token` - The OIDC ID token from Vouch
-/// * `region` - AWS region (e.g., "us-east-1", "cn-north-1")
-/// * `domain_suffix` - AWS domain suffix (e.g., "amazonaws.com")
 pub(crate) async fn assume_role_with_web_identity(
-    http_client: &reqwest::Client,
-    role_arn: &str,
-    role_session_name: &str,
-    web_identity_token: &str,
-    region: &str,
-    domain_suffix: &str,
-    tags: &[(String, String)],
+    req: WebIdentityRequest<'_>,
 ) -> Result<StsCredentials> {
     // Use regional STS endpoint for the appropriate partition
-    let sts_url = format!("https://sts.{region}.{domain_suffix}/");
+    let sts_url = format!("https://sts.{}.{}/", req.region, req.domain_suffix);
 
     let mut form_params: Vec<(String, String)> = vec![
         (
@@ -84,18 +89,33 @@ pub(crate) async fn assume_role_with_web_identity(
             "AssumeRoleWithWebIdentity".to_string(),
         ),
         ("Version".to_string(), "2011-06-15".to_string()),
-        ("RoleArn".to_string(), role_arn.to_string()),
-        ("RoleSessionName".to_string(), role_session_name.to_string()),
+        ("RoleArn".to_string(), req.role_arn.to_string()),
+        (
+            "RoleSessionName".to_string(),
+            req.role_session_name.to_string(),
+        ),
         (
             "WebIdentityToken".to_string(),
-            web_identity_token.to_string(),
+            req.web_identity_token.to_string(),
         ),
     ];
 
     // Add session tags using AWS Tags.member.N format (1-based indexing)
-    append_tag_form_params(&mut form_params, tags);
+    append_tag_form_params(&mut form_params, req.tags);
 
-    let response = http_client
+    // Set SourceIdentity for audit trails (propagates immutably through role chains)
+    if let Some(identity) = req.source_identity {
+        form_params.push(("SourceIdentity".to_string(), identity.to_string()));
+    }
+
+    // Mark tags as transitive so they propagate through AssumeRole chains
+    for (i, key) in req.transitive_tag_keys.iter().enumerate() {
+        let n = i + 1;
+        form_params.push((format!("TransitiveTagKeys.member.{n}"), (*key).to_string()));
+    }
+
+    let response = req
+        .http_client
         .post(&sts_url)
         .form(&form_params)
         .send()
@@ -115,6 +135,43 @@ pub(crate) async fn assume_role_with_web_identity(
         .text()
         .await
         .context("failed to read STS response")?;
+
+    parse_sts_xml_response(&body)
+}
+
+/// Call AWS STS `AssumeRole` using SigV4-signed form POST.
+///
+/// Used for role chaining: assumes a target role using credentials
+/// from a prior `AssumeRoleWithWebIdentity` call.
+pub(crate) async fn assume_role(
+    http_client: &reqwest::Client,
+    role_arn: &str,
+    role_session_name: &str,
+    region: &str,
+    source_creds: &StsCredentials,
+) -> Result<StsCredentials> {
+    use crate::integrations::aws::sigv4::sign_and_send_form_post;
+    use vouch_common::aws::Partition;
+
+    let partition = Partition::from_region(region);
+    let domain_suffix = partition.dns_suffix();
+    let endpoint = format!("https://sts.{region}.{domain_suffix}/");
+
+    // Bind owned values to variables first — sign_and_send_form_post takes &[(&str, &str)]
+    // so all values must outlive the params slice. This pattern mirrors redshift.rs.
+    let duration_str = "3600".to_string();
+
+    let params: &[(&str, &str)] = &[
+        ("Action", "AssumeRole"),
+        ("Version", "2011-06-15"),
+        ("RoleArn", role_arn),
+        ("RoleSessionName", role_session_name),
+        ("DurationSeconds", &duration_str),
+    ];
+
+    let body = sign_and_send_form_post(http_client, &endpoint, "sts", region, source_creds, params)
+        .await
+        .context("failed to call AWS STS AssumeRole")?;
 
     parse_sts_xml_response(&body)
 }

--- a/crates/vouch-cli/src/integrations/aws/sts.rs
+++ b/crates/vouch-cli/src/integrations/aws/sts.rs
@@ -374,6 +374,92 @@ mod tests {
     }
 
     #[test]
+    fn test_source_identity_included_in_form_params() {
+        // Build the same form_params as assume_role_with_web_identity does,
+        // then verify SourceIdentity is appended when source_identity is Some.
+        let mut form_params: Vec<(String, String)> = vec![
+            (
+                "Action".to_string(),
+                "AssumeRoleWithWebIdentity".to_string(),
+            ),
+            ("Version".to_string(), "2011-06-15".to_string()),
+            (
+                "RoleArn".to_string(),
+                "arn:aws:iam::123:role/Test".to_string(),
+            ),
+            ("RoleSessionName".to_string(), "test-session".to_string()),
+            ("WebIdentityToken".to_string(), "token".to_string()),
+        ];
+
+        let source_identity: Option<&str> = Some("user@example.com");
+        if let Some(identity) = source_identity {
+            form_params.push(("SourceIdentity".to_string(), identity.to_string()));
+        }
+
+        let found = form_params
+            .iter()
+            .any(|(k, v)| k == "SourceIdentity" && v == "user@example.com");
+        assert!(found, "SourceIdentity param should be present");
+    }
+
+    #[test]
+    fn test_source_identity_absent_when_none() {
+        let mut form_params: Vec<(String, String)> = vec![(
+            "Action".to_string(),
+            "AssumeRoleWithWebIdentity".to_string(),
+        )];
+
+        let source_identity: Option<&str> = None;
+        if let Some(identity) = source_identity {
+            form_params.push(("SourceIdentity".to_string(), identity.to_string()));
+        }
+
+        let found = form_params.iter().any(|(k, _)| k == "SourceIdentity");
+        assert!(!found, "SourceIdentity param should be absent when None");
+    }
+
+    #[test]
+    fn test_transitive_tag_keys_format() {
+        // Verify the TransitiveTagKeys.member.N format used in assume_role_with_web_identity.
+        let transitive_tag_keys: &[&str] = &["email", "domain"];
+        let mut form_params: Vec<(String, String)> = Vec::new();
+
+        for (i, key) in transitive_tag_keys.iter().enumerate() {
+            let n = i + 1;
+            form_params.push((format!("TransitiveTagKeys.member.{n}"), (*key).to_string()));
+        }
+
+        assert_eq!(form_params.len(), 2);
+        assert_eq!(
+            form_params[0],
+            (
+                "TransitiveTagKeys.member.1".to_string(),
+                "email".to_string()
+            )
+        );
+        assert_eq!(
+            form_params[1],
+            (
+                "TransitiveTagKeys.member.2".to_string(),
+                "domain".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_transitive_tag_keys_empty() {
+        let transitive_tag_keys: &[&str] = &[];
+        let mut form_params: Vec<(String, String)> = Vec::new();
+
+        for (i, key) in transitive_tag_keys.iter().enumerate() {
+            let n = i + 1;
+            form_params.push((format!("TransitiveTagKeys.member.{n}"), (*key).to_string()));
+        }
+
+        assert!(form_params.is_empty());
+    }
+
+    #[test]
     fn test_append_tag_form_params_multiple_tags() {
         let mut params = vec![(
             "Action".to_string(),

--- a/crates/vouch-cli/src/main.rs
+++ b/crates/vouch-cli/src/main.rs
@@ -376,6 +376,11 @@ enum Commands {
         #[command(subcommand)]
         command: SetupCommands,
     },
+    /// AWS Identity Center commands for multi-account management.
+    Aws {
+        #[command(subcommand)]
+        command: AwsCommands,
+    },
     /// Generate shell completions.
     Completions(commands::completions::CompletionsArgs),
     /// Check your Vouch environment for common issues.
@@ -403,7 +408,8 @@ impl Commands {
     fn uses_server(&self) -> bool {
         !matches!(
             self,
-            Commands::Completions(_)
+            Commands::Aws { .. }
+                | Commands::Completions(_)
                 | Commands::Diag(_)
                 | Commands::Logout
                 | Commands::Init { .. }
@@ -412,6 +418,7 @@ impl Commands {
     }
 }
 
+use commands::aws::AwsCommands;
 use commands::credential::CredentialCommands;
 use commands::keys::KeysCommands;
 use commands::setup::SetupCommands;
@@ -636,7 +643,16 @@ async fn run() -> Result<()> {
                 profile,
                 role,
                 region,
-            } => commands::setup::aws::run(profile.as_deref(), &role, region.as_deref()).await,
+                discover,
+            } => {
+                commands::setup::aws::run(
+                    profile.as_deref(),
+                    role.as_deref(),
+                    region.as_deref(),
+                    discover,
+                )
+                .await
+            }
             SetupCommands::Ssh { hosts } => {
                 commands::setup::ssh::run(server, hosts.as_deref()).await
             }
@@ -719,6 +735,11 @@ async fn run() -> Result<()> {
                 )
                 .await
             }
+        },
+        Commands::Aws { command } => match command {
+            AwsCommands::Login(args) => commands::aws::login::run(args).await,
+            AwsCommands::Accounts(args) => commands::aws::accounts::run(args).await,
+            AwsCommands::Roles(args) => commands::aws::roles::run(args).await,
         },
         Commands::Completions(args) => {
             let mut cmd = Cli::command();

--- a/crates/vouch-common/src/aws.rs
+++ b/crates/vouch-common/src/aws.rs
@@ -486,6 +486,38 @@ mod tests {
     // =========================================================================
 
     #[test]
+    fn test_sso_oidc_endpoint_commercial() {
+        assert_eq!(
+            Partition::Aws.sso_oidc_endpoint("us-east-1"),
+            "https://oidc.us-east-1.amazonaws.com"
+        );
+    }
+
+    #[test]
+    fn test_sso_oidc_endpoint_china() {
+        assert_eq!(
+            Partition::AwsCn.sso_oidc_endpoint("cn-north-1"),
+            "https://oidc.cn-north-1.amazonaws.com.cn"
+        );
+    }
+
+    #[test]
+    fn test_sso_portal_endpoint_commercial() {
+        assert_eq!(
+            Partition::Aws.sso_portal_endpoint("us-east-1"),
+            "https://portal.sso.us-east-1.amazonaws.com"
+        );
+    }
+
+    #[test]
+    fn test_sso_portal_endpoint_govcloud() {
+        assert_eq!(
+            Partition::AwsUsGov.sso_portal_endpoint("us-gov-west-1"),
+            "https://portal.sso.us-gov-west-1.amazonaws.com"
+        );
+    }
+
+    #[test]
     fn test_dns_suffix() {
         assert_eq!(Partition::Aws.dns_suffix(), "amazonaws.com");
         assert_eq!(Partition::AwsCn.dns_suffix(), "amazonaws.com.cn");

--- a/crates/vouch-common/src/aws.rs
+++ b/crates/vouch-common/src/aws.rs
@@ -93,6 +93,43 @@ impl Partition {
         }
     }
 
+    /// Infer the AWS partition from a region string.
+    ///
+    /// Checks longer prefixes before shorter ones to avoid false matches
+    /// (e.g., `us-isob-` before `us-iso-`).
+    #[must_use]
+    pub fn from_region(region: &str) -> Self {
+        if region.starts_with("cn-") {
+            Self::AwsCn
+        } else if region.starts_with("us-gov-") {
+            Self::AwsUsGov
+        } else if region.starts_with("us-isob-") {
+            Self::AwsIsoB
+        } else if region.starts_with("us-isof-") {
+            Self::AwsIsoF
+        } else if region.starts_with("us-iso-") {
+            Self::AwsIso
+        } else if region.starts_with("eu-isoe-") {
+            Self::AwsIsoE
+        } else if region.starts_with("eusc-") {
+            Self::AwsEusc
+        } else {
+            Self::Aws
+        }
+    }
+
+    /// SSO OIDC endpoint for this partition.
+    #[must_use]
+    pub fn sso_oidc_endpoint(self, region: &str) -> String {
+        format!("https://oidc.{}.{}", region, self.dns_suffix())
+    }
+
+    /// SSO Portal endpoint for this partition.
+    #[must_use]
+    pub fn sso_portal_endpoint(self, region: &str) -> String {
+        format!("https://portal.sso.{}.{}", region, self.dns_suffix())
+    }
+
     /// DNS suffix for this partition's AWS endpoints.
     #[must_use]
     pub fn dns_suffix(self) -> &'static str {
@@ -397,6 +434,53 @@ mod tests {
         for p in &partitions {
             assert_eq!(Partition::parse(p.as_str()).unwrap(), *p);
         }
+    }
+
+    // =========================================================================
+    // from_region tests
+    // =========================================================================
+
+    #[test]
+    fn test_from_region_commercial() {
+        assert_eq!(Partition::from_region("us-east-1"), Partition::Aws);
+        assert_eq!(Partition::from_region("eu-west-1"), Partition::Aws);
+        assert_eq!(Partition::from_region("ap-southeast-2"), Partition::Aws);
+    }
+
+    #[test]
+    fn test_from_region_china() {
+        assert_eq!(Partition::from_region("cn-north-1"), Partition::AwsCn);
+        assert_eq!(Partition::from_region("cn-northwest-1"), Partition::AwsCn);
+    }
+
+    #[test]
+    fn test_from_region_govcloud() {
+        assert_eq!(Partition::from_region("us-gov-west-1"), Partition::AwsUsGov);
+        assert_eq!(Partition::from_region("us-gov-east-1"), Partition::AwsUsGov);
+    }
+
+    #[test]
+    fn test_from_region_iso_prefix_ordering() {
+        // us-isob- must be checked before us-iso- to avoid false match
+        assert_eq!(Partition::from_region("us-isob-east-1"), Partition::AwsIsoB);
+        assert_eq!(
+            Partition::from_region("us-isof-south-1"),
+            Partition::AwsIsoF
+        );
+        assert_eq!(Partition::from_region("us-iso-east-1"), Partition::AwsIso);
+        assert_eq!(Partition::from_region("us-iso-west-1"), Partition::AwsIso);
+        assert_eq!(Partition::from_region("eu-isoe-west-1"), Partition::AwsIsoE);
+    }
+
+    #[test]
+    fn test_from_region_eusc() {
+        assert_eq!(Partition::from_region("eusc-de-east-1"), Partition::AwsEusc);
+    }
+
+    #[test]
+    fn test_from_region_unknown_defaults_commercial() {
+        assert_eq!(Partition::from_region("unknown-region-1"), Partition::Aws);
+        assert_eq!(Partition::from_region(""), Partition::Aws);
     }
 
     // =========================================================================

--- a/crates/vouch-server/src/services/oidc/claims.rs
+++ b/crates/vouch-server/src/services/oidc/claims.rs
@@ -49,6 +49,26 @@ pub struct OidcIdTokenClaims {
     /// Can be used in AWS IAM trust policy conditions to restrict access by domain.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hd: Option<String>,
+    /// AWS STS source identity for role chaining audit trails.
+    ///
+    /// When present in the OIDC token, AWS STS extracts this as the
+    /// `SourceIdentity` during `AssumeRoleWithWebIdentity`. The value
+    /// persists immutably through role chains and appears in CloudTrail,
+    /// enabling end-to-end user attribution across chained role
+    /// assumptions.
+    ///
+    /// Uses the AWS-defined claim namespace per:
+    /// <https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_control-access_monitor.html#id_credentials_temp_control-access_monitor-assume-role-web-id>
+    ///
+    /// Only set for AWS tokens (via `for_aws()`), not Kubernetes or
+    /// other providers. This is a provider-defined claim permitted by
+    /// OIDC Core Section 5.1.2 (additional claims using
+    /// collision-resistant names).
+    #[serde(
+        rename = "https://aws.amazon.com/source_identity",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub source_identity: Option<String>,
 }
 
 /// Errors from building OIDC ID token claims.
@@ -67,6 +87,7 @@ pub struct OidcIdTokenClaimsBuilder {
     email: Option<String>,
     hardware_aaguid: Option<String>,
     hd: Option<String>,
+    source_identity: Option<String>,
     valid_for_seconds: u64,
 }
 
@@ -81,6 +102,7 @@ impl OidcIdTokenClaimsBuilder {
             email: None,
             hardware_aaguid: None,
             hd: None,
+            source_identity: None,
             valid_for_seconds: 28800, // 8 hours default
         }
     }
@@ -89,6 +111,8 @@ impl OidcIdTokenClaimsBuilder {
     ///
     /// AWS uses the issuer URL as the audience (AWS matches against the OIDC provider).
     /// The subject and email are both set to the user's email.
+    /// Includes `https://aws.amazon.com/source_identity` claim set to the
+    /// user's email for role chaining audit trails.
     #[must_use]
     pub fn for_aws(issuer: &str, email: &str) -> Self {
         Self::new()
@@ -96,6 +120,7 @@ impl OidcIdTokenClaimsBuilder {
             .subject(email)
             .audience(issuer) // AWS uses issuer as audience
             .email(email)
+            .source_identity(email)
     }
 
     /// Create a builder pre-configured for Kubernetes.
@@ -157,6 +182,16 @@ impl OidcIdTokenClaimsBuilder {
         self
     }
 
+    /// Set the AWS STS source identity for role chaining.
+    ///
+    /// Only relevant for AWS tokens. The value appears in CloudTrail
+    /// and persists immutably through role chains.
+    #[must_use]
+    pub fn source_identity(mut self, identity: &str) -> Self {
+        self.source_identity = Some(identity.to_string());
+        self
+    }
+
     /// Set the token validity period in seconds.
     #[must_use]
     pub fn valid_for_seconds(mut self, seconds: u64) -> Self {
@@ -195,6 +230,7 @@ impl OidcIdTokenClaimsBuilder {
             hardware_verified: true,
             hardware_aaguid: self.hardware_aaguid,
             hd: self.hd,
+            source_identity: self.source_identity,
         })
     }
 }

--- a/crates/vouch-server/src/services/oidc/discovery.rs
+++ b/crates/vouch-server/src/services/oidc/discovery.rs
@@ -59,6 +59,9 @@ pub struct OidcDiscoveryDocument {
     pub introspection_endpoint_auth_methods_supported: Vec<TokenEndpointAuthMethod>,
     /// OIDC Discovery 1.0 Section 3: RECOMMENDED. Supported Claim Names.
     pub claims_supported: Vec<String>,
+    /// OIDC Discovery 1.0 Section 3: OPTIONAL. Whether the server supports
+    /// the `claims` request parameter (OIDC Core Section 5.5).
+    pub claims_parameter_supported: bool,
     /// RFC 7636 Section 6.2: Supported PKCE code challenge methods.
     pub code_challenge_methods_supported: Vec<String>,
     /// RFC 9449 Section 5.1: Supported DPoP JWS signing algorithms.
@@ -239,6 +242,7 @@ pub fn build_discovery_document(state: &Arc<AppState>) -> OidcDiscoveryDocument 
             "amr".to_string(),
             "acr".to_string(),
         ],
+        claims_parameter_supported: false,
         code_challenge_methods_supported: vec!["S256".to_string()],
         // RS256 excluded per FAPI 2.0 Section 5.2.2.
         dpop_signing_alg_values_supported: Some(vec![


### PR DESCRIPTION
## Summary
- Add `vouch aws login/accounts/roles` commands for AWS IAM Identity Center (SSO) discovery
- Add role chaining support: management role → member role via `AssumeRole` with `SourceIdentity` and `TransitiveTagKeys` for end-to-end identity tracking
- Add `vouch setup aws --discover` for automatic `~/.aws/config` profile generation from SSO assignments
- SSO session config read from `~/.aws/config` `[sso-session]` blocks (no duplication in vouch config)
- Botocore-compatible cache at `~/.aws/sso/cache/` with correct SHA-1 hash keys and Python-compatible JSON separators
- Implicit chaining: `vouch credential aws --role <member-role>` auto-chains when management role is configured
- 1-hour chained sessions are transparent — credential cache auto-refreshes without YubiKey tap

## New Commands
- `vouch aws login [--sso-session <name>]` — SSO OIDC device authorization flow
- `vouch aws accounts [--sso-session <name>] [--json]` — list SSO-assigned accounts
- `vouch aws roles [--sso-session <name>] [--account <id>] [--json]` — list SSO-assigned roles
- `vouch setup aws --discover` — generate AWS CLI profiles from SSO assignments

## Config
```json
{
  "aws": {
    "sso_sessions": {
      "my-sso": {
        "management_role": "arn:aws:iam::111111111111:role/VouchManagement",
        "member_role_name": "VouchAccess"
      }
    }
  }
}
```

## Test plan
- [x] 516 unit tests pass (`cargo test --package vouch-cli`)
- [x] Clippy clean (`cargo clippy --all-targets -- -D warnings`)
- [x] Golden SHA-1 hash tests verified against Python/botocore
- [x] Real botocore cache file format deserialization tests
- [ ] Manual test with real AWS Identity Center
- [ ] Test `vouch aws login` → `vouch aws accounts` → `vouch aws roles` flow
- [ ] Test `vouch credential aws --role <member>` with chaining
- [ ] Test `vouch setup aws --discover` profile generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes AWS credential issuance (STS calls, caching keys, and role chaining) and adds new OIDC claim behavior in the server, which can impact authentication/authorization and audit trails.
> 
> **Overview**
> Adds new `vouch aws` subcommands (`login`, `accounts`, `roles`) that authenticate via AWS IAM Identity Center device flow and query the SSO Portal API using botocore-compatible token/client caches.
> 
> Extends AWS credential issuance to optionally *chain roles* (management `AssumeRoleWithWebIdentity` → target `AssumeRole`), updates caching to distinguish chained vs direct credentials, and refactors callers (`exec`, `codecommit`, etc.) to reuse the shared `get_aws_credentials` path.
> 
> Enhances setup with `vouch setup aws --discover` to generate per-account AWS CLI profiles from SSO assignments, introduces new global CLI config for per-SSO-session chaining (`aws.sso_sessions`), and updates common AWS partition utilities with `from_region` plus SSO endpoint helpers; the server now includes the AWS `source_identity` claim for AWS-issued OIDC tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49aef15fef9dab7b5626407237a6bd2696242fe0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->