### PR TITLE
added "vouch aws console"

### DIFF
--- a/crates/vouch-cli/src/commands/aws/console.rs
+++ b/crates/vouch-cli/src/commands/aws/console.rs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! `vouch aws console` — open the AWS Management Console via federation.
+//!
+//! Uses the custom identity broker flow described in the AWS documentation:
+//! <https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html>
+
+use anyhow::{Context, Result};
+use secrecy::ExposeSecret;
+use serde::Deserialize;
+
+use crate::integrations::aws;
+
+/// Arguments for `vouch aws console`.
+#[derive(clap::Args)]
+pub(crate) struct ConsoleArgs {
+    /// AWS IAM role ARN to assume (auto-detected from ~/.aws/config
+    /// if not specified).
+    #[arg(long)]
+    pub role: Option<String>,
+}
+
+/// Response from the AWS federation `getSigninToken` action.
+#[derive(Deserialize)]
+struct SigninTokenResponse {
+    #[serde(rename = "SigninToken")]
+    signin_token: String,
+}
+
+/// Run `vouch aws console`.
+pub(crate) async fn run(args: ConsoleArgs) -> Result<()> {
+    // 1. Resolve role ARN
+    let role_arn = match args.role {
+        Some(r) => r,
+        None => aws::get_local_aws_role().ok_or_else(|| {
+            anyhow::anyhow!(
+                "AWS not configured. Run 'vouch setup aws --role \
+                 <role-arn>' first, or specify --role."
+            )
+        })?,
+    };
+
+    // 2. Determine partition and federation endpoints from role ARN
+    let partition =
+        vouch_common::aws::Partition::from_arn(&role_arn).context("invalid role ARN")?;
+    let federation_url = partition.federation_endpoint()?;
+    let console_url = partition.console_url()?;
+
+    // 3. Resolve region (for STS call)
+    let profile_name = aws::resolve_profile(None).unwrap_or_default();
+    let region = match aws::resolve_region(None, &profile_name) {
+        Ok(r) => r,
+        Err(_) => {
+            let default = partition.default_sts_region();
+            tracing::debug!("no region configured, defaulting to {default}");
+            default.to_string()
+        }
+    };
+
+    // 4. Resolve Vouch session and exchange for STS credentials.
+    //    Uses exchange_for_sts_credentials directly to keep
+    //    SecretAccessKey/SessionToken as SecretString until
+    //    serialization.
+    let session = crate::session::resolve_session().await?;
+    let server = &session.server_url;
+
+    let result = crate::commands::credential::aws::exchange_for_sts_credentials(
+        server,
+        &role_arn,
+        &region,
+        "vouch-console",
+        None,
+    )
+    .await
+    .context("failed to get AWS credentials")?;
+
+    let creds = &result.credentials;
+
+    // 5. Build federation session JSON — expose secrets only here
+    let session_encoded = serde_json::to_string(&serde_json::json!({
+        "sessionId": creds.access_key_id,
+        "sessionKey": creds.secret_access_key.expose_secret(),
+        "sessionToken": creds.session_token.expose_secret(),
+    }))
+    .context("failed to serialize session JSON")?;
+
+    // 6. POST to federation endpoint for a signin token
+    let resp = result
+        .http_client
+        .post(federation_url)
+        .form(&[
+            ("Action", "getSigninToken"),
+            ("SessionDuration", "3600"),
+            ("Session", &session_encoded),
+        ])
+        .send()
+        .await
+        .context("failed to request signin token")?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("federation getSigninToken failed ({status}): {body}");
+    }
+
+    let token_resp: SigninTokenResponse = resp
+        .json()
+        .await
+        .context("failed to parse signin token response")?;
+
+    // 7. Construct login URL using url::Url for safe encoding
+    let mut login_url =
+        url::Url::parse(federation_url).context("invalid federation endpoint URL")?;
+    login_url
+        .query_pairs_mut()
+        .append_pair("Action", "login")
+        .append_pair("Issuer", server)
+        .append_pair("Destination", console_url)
+        .append_pair("SigninToken", &token_resp.signin_token);
+
+    // 8. Open browser (print URL only as fallback)
+    let login_str = login_url.as_str();
+    match open::that(login_str) {
+        Ok(()) => {
+            println!("Opening AWS Console...");
+        }
+        Err(e) => {
+            tracing::debug!("failed to open browser: {e}");
+            println!("{login_str}");
+            eprintln!(
+                "Could not open browser automatically. \
+                 Open the URL above in your browser."
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_signin_token_response_deserialize() {
+        let json = r#"{"SigninToken": "abc123"}"#;
+        let resp: SigninTokenResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.signin_token, "abc123");
+    }
+
+    #[test]
+    fn test_login_url_construction() {
+        let mut login_url = url::Url::parse("https://signin.aws.amazon.com/federation").unwrap();
+        login_url
+            .query_pairs_mut()
+            .append_pair("Action", "login")
+            .append_pair("Issuer", "https://vouch.example.com")
+            .append_pair("Destination", "https://console.aws.amazon.com/")
+            .append_pair("SigninToken", "tok-123");
+
+        let s = login_url.as_str();
+        assert!(s.starts_with("https://signin.aws.amazon.com/federation?"));
+        assert!(s.contains("Action=login"));
+        assert!(s.contains("Issuer=https%3A%2F%2Fvouch.example.com"));
+        assert!(s.contains("Destination=https%3A%2F%2Fconsole.aws.amazon.com%2F"));
+        assert!(s.contains("SigninToken=tok-123"));
+    }
+}

--- a/crates/vouch-cli/src/commands/aws/console.rs
+++ b/crates/vouch-cli/src/commands/aws/console.rs
@@ -27,7 +27,7 @@ struct SigninTokenResponse {
 }
 
 /// Run `vouch aws console`.
-pub(crate) async fn run(args: ConsoleArgs) -> Result<()> {
+pub(crate) async fn run(server: &str, args: ConsoleArgs) -> Result<()> {
     // 1. Resolve role ARN
     let role_arn = match args.role {
         Some(r) => r,
@@ -56,13 +56,10 @@ pub(crate) async fn run(args: ConsoleArgs) -> Result<()> {
         }
     };
 
-    // 4. Resolve Vouch session and exchange for STS credentials.
+    // 4. Exchange Vouch session for STS credentials.
     //    Uses exchange_for_sts_credentials directly to keep
     //    SecretAccessKey/SessionToken as SecretString until
     //    serialization.
-    let session = crate::session::resolve_session().await?;
-    let server = &session.server_url;
-
     let result = crate::commands::credential::aws::exchange_for_sts_credentials(
         server,
         &role_arn,

--- a/crates/vouch-cli/src/commands/aws/mod.rs
+++ b/crates/vouch-cli/src/commands/aws/mod.rs
@@ -7,6 +7,7 @@ use clap::Subcommand;
 use crate::integrations::aws::config::{AwsConfig, SsoSession};
 
 pub(crate) mod accounts;
+pub(crate) mod console;
 pub(crate) mod login;
 pub(crate) mod roles;
 
@@ -19,6 +20,8 @@ pub(crate) enum AwsCommands {
     Accounts(accounts::AccountsArgs),
     /// List available roles across your AWS accounts.
     Roles(roles::RolesArgs),
+    /// Open the AWS Management Console in your browser.
+    Console(console::ConsoleArgs),
 }
 
 /// Resolve which SSO session to use.

--- a/crates/vouch-cli/src/main.rs
+++ b/crates/vouch-cli/src/main.rs
@@ -742,7 +742,7 @@ async fn run() -> Result<()> {
             AwsCommands::Login(args) => commands::aws::login::run(args).await,
             AwsCommands::Accounts(args) => commands::aws::accounts::run(args).await,
             AwsCommands::Roles(args) => commands::aws::roles::run(args).await,
-            AwsCommands::Console(args) => commands::aws::console::run(args).await,
+            AwsCommands::Console(args) => commands::aws::console::run(server, args).await,
         },
         Commands::Completions(args) => {
             let mut cmd = Cli::command();

--- a/crates/vouch-cli/src/main.rs
+++ b/crates/vouch-cli/src/main.rs
@@ -406,15 +406,17 @@ enum Commands {
 impl Commands {
     /// Whether this command contacts the server (and thus needs URL security checks).
     fn uses_server(&self) -> bool {
-        !matches!(
-            self,
-            Commands::Aws { .. }
-                | Commands::Completions(_)
-                | Commands::Diag(_)
-                | Commands::Logout
-                | Commands::Init { .. }
-                | Commands::Posture { .. }
-        )
+        match self {
+            Commands::Aws { command } => {
+                matches!(command, AwsCommands::Console(_))
+            }
+            Commands::Completions(_)
+            | Commands::Diag(_)
+            | Commands::Logout
+            | Commands::Init { .. }
+            | Commands::Posture { .. } => false,
+            _ => true,
+        }
     }
 }
 
@@ -740,6 +742,7 @@ async fn run() -> Result<()> {
             AwsCommands::Login(args) => commands::aws::login::run(args).await,
             AwsCommands::Accounts(args) => commands::aws::accounts::run(args).await,
             AwsCommands::Roles(args) => commands::aws::roles::run(args).await,
+            AwsCommands::Console(args) => commands::aws::console::run(args).await,
         },
         Commands::Completions(args) => {
             let mut cmd = Cli::command();

--- a/crates/vouch-common/src/aws.rs
+++ b/crates/vouch-common/src/aws.rs
@@ -130,6 +130,51 @@ impl Partition {
         format!("https://portal.sso.{}.{}", region, self.dns_suffix())
     }
 
+    /// AWS Console sign-in federation endpoint for this partition.
+    ///
+    /// Used to obtain a sign-in token and construct a console login URL.
+    /// See: <https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html>
+    ///
+    /// Note: China uses `amazonaws.cn` for console/signin portals, NOT
+    /// `amazonaws.com.cn` (which is the API endpoint DNS suffix from
+    /// [`dns_suffix`](Self::dns_suffix)).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for ISO partitions which do not support console
+    /// federation.
+    pub fn federation_endpoint(self) -> Result<&'static str, FederationError> {
+        match self {
+            Self::Aws => Ok("https://signin.aws.amazon.com/federation"),
+            // amazonaws.cn, not amazonaws.com.cn — see doc comment
+            Self::AwsCn => Ok("https://signin.amazonaws.cn/federation"),
+            Self::AwsUsGov => Ok("https://signin.amazonaws-us-gov.com/federation"),
+            Self::AwsEusc => Ok("https://signin.amazonaws-eusc.eu/federation"),
+            Self::AwsIso | Self::AwsIsoB | Self::AwsIsoE | Self::AwsIsoF => {
+                Err(FederationError(self))
+            }
+        }
+    }
+
+    /// AWS Management Console URL for this partition.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for ISO partitions which do not have a public
+    /// console URL.
+    pub fn console_url(self) -> Result<&'static str, FederationError> {
+        match self {
+            Self::Aws => Ok("https://console.aws.amazon.com/"),
+            // amazonaws.cn, not amazonaws.com.cn — see federation_endpoint doc
+            Self::AwsCn => Ok("https://console.amazonaws.cn/"),
+            Self::AwsUsGov => Ok("https://console.amazonaws-us-gov.com/"),
+            Self::AwsEusc => Ok("https://console.amazonaws-eusc.eu/"),
+            Self::AwsIso | Self::AwsIsoB | Self::AwsIsoE | Self::AwsIsoF => {
+                Err(FederationError(self))
+            }
+        }
+    }
+
     /// DNS suffix for this partition's AWS endpoints.
     #[must_use]
     pub fn dns_suffix(self) -> &'static str {
@@ -145,6 +190,12 @@ impl Partition {
     }
 }
 
+impl std::fmt::Display for Partition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Error returned when a partition string is not recognized.
 #[derive(Debug, thiserror::Error)]
 #[error(
@@ -153,6 +204,12 @@ impl Partition {
      aws-iso, aws-iso-b, aws-iso-e, aws-iso-f"
 )]
 pub struct PartitionError(String);
+
+/// Error returned when console federation is not supported for a
+/// partition.
+#[derive(Debug, thiserror::Error)]
+#[error("AWS Console federation is not supported for the '{0}' partition")]
+pub struct FederationError(Partition);
 
 /// Parsed AWS ARN (Amazon Resource Name).
 ///
@@ -527,5 +584,100 @@ mod tests {
         assert_eq!(Partition::AwsIsoB.dns_suffix(), "sc2s.sgov.gov");
         assert_eq!(Partition::AwsIsoE.dns_suffix(), "cloud.adc-e.uk");
         assert_eq!(Partition::AwsIsoF.dns_suffix(), "csp.hci.ic.gov");
+    }
+
+    // =========================================================================
+    // Federation endpoint tests
+    // =========================================================================
+
+    #[test]
+    fn test_federation_endpoint_commercial() {
+        assert_eq!(
+            Partition::Aws.federation_endpoint().unwrap(),
+            "https://signin.aws.amazon.com/federation"
+        );
+    }
+
+    #[test]
+    fn test_federation_endpoint_china() {
+        assert_eq!(
+            Partition::AwsCn.federation_endpoint().unwrap(),
+            "https://signin.amazonaws.cn/federation"
+        );
+    }
+
+    #[test]
+    fn test_federation_endpoint_govcloud() {
+        assert_eq!(
+            Partition::AwsUsGov.federation_endpoint().unwrap(),
+            "https://signin.amazonaws-us-gov.com/federation"
+        );
+    }
+
+    #[test]
+    fn test_federation_endpoint_eusc() {
+        assert_eq!(
+            Partition::AwsEusc.federation_endpoint().unwrap(),
+            "https://signin.amazonaws-eusc.eu/federation"
+        );
+    }
+
+    #[test]
+    fn test_federation_endpoint_iso_unsupported() {
+        assert!(Partition::AwsIso.federation_endpoint().is_err());
+        assert!(Partition::AwsIsoB.federation_endpoint().is_err());
+        assert!(Partition::AwsIsoE.federation_endpoint().is_err());
+        assert!(Partition::AwsIsoF.federation_endpoint().is_err());
+    }
+
+    // =========================================================================
+    // Console URL tests
+    // =========================================================================
+
+    #[test]
+    fn test_console_url_commercial() {
+        assert_eq!(
+            Partition::Aws.console_url().unwrap(),
+            "https://console.aws.amazon.com/"
+        );
+    }
+
+    #[test]
+    fn test_console_url_china() {
+        assert_eq!(
+            Partition::AwsCn.console_url().unwrap(),
+            "https://console.amazonaws.cn/"
+        );
+    }
+
+    #[test]
+    fn test_console_url_govcloud() {
+        assert_eq!(
+            Partition::AwsUsGov.console_url().unwrap(),
+            "https://console.amazonaws-us-gov.com/"
+        );
+    }
+
+    #[test]
+    fn test_console_url_eusc() {
+        assert_eq!(
+            Partition::AwsEusc.console_url().unwrap(),
+            "https://console.amazonaws-eusc.eu/"
+        );
+    }
+
+    #[test]
+    fn test_console_url_iso_unsupported() {
+        assert!(Partition::AwsIso.console_url().is_err());
+        assert!(Partition::AwsIsoB.console_url().is_err());
+        assert!(Partition::AwsIsoE.console_url().is_err());
+        assert!(Partition::AwsIsoF.console_url().is_err());
+    }
+
+    #[test]
+    fn test_partition_display() {
+        assert_eq!(Partition::Aws.to_string(), "aws");
+        assert_eq!(Partition::AwsCn.to_string(), "aws-cn");
+        assert_eq!(Partition::AwsUsGov.to_string(), "aws-us-gov");
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new flow that exchanges Vouch sessions for STS credentials and then calls AWS federation endpoints to open a console session; mistakes here could leak credentials via logs/URLs or break access in non-standard partitions.
> 
> **Overview**
> Adds a new `vouch aws console` subcommand that assumes an IAM role (auto-detected or `--role`), exchanges the Vouch session for STS credentials, requests an AWS federation `SigninToken`, and opens the resulting console login URL (printing it as a fallback).
> 
> Extends `vouch-common`’s AWS `Partition` with partition-specific federation/console endpoints (including China/GovCloud/EUSC) and explicit errors for ISO partitions, plus associated tests, and wires the new command into CLI dispatch and server-URL validation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fe75d86a3964add074dde55f83fbcd5335cdbc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->