### PR TITLE
docs: link OpenID badge to FAPI 2.0 OP Security Profile certification

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Prove you're here.**
 
-<a href="https://openid.net/certification/"><img src="https://vouch.sh/img/openid-certified.png" alt="OpenID Certified" width="200"></a>
+<a href="https://openid.net/certification/certified-fapi-2-0-op-security-profile-final-message-signing-final/"><img src="https://vouch.sh/img/openid-certified.png" alt="OpenID Certified" width="200"></a>
 
 Hardware-backed authentication that issues short-lived credentials only after a human touches a YubiKey. One touch, one PIN, one 8-hour session — then SSH, AWS, Kubernetes, and more just work.
 


### PR DESCRIPTION
Point the README's "OpenID Certified" badge directly at the FAPI 2.0 OP
Security Profile (Final, Message Signing — Final) certification page
instead of the generic certification index.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; updates a README hyperlink with no impact on runtime behavior.
> 
> **Overview**
> Updates the README’s **OpenID Certified** badge link to point directly to the project’s *FAPI 2.0 OP Security Profile (Final, Message Signing — Final)* certification page instead of the generic OpenID certification index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cf8802e52f54e9477cd7044c0afcbccb8c7dc1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->