### PR TITLE
fix: reject deactivated users in FIDO2 grant and token issuance flows

### DIFF
--- a/crates/vouch-server/src/handlers/session.rs
+++ b/crates/vouch-server/src/handlers/session.rs
@@ -359,6 +359,14 @@ pub async fn extract_user_with_org(
             ServiceError::api(StatusCode::UNAUTHORIZED, "unauthorized", "User not found")
         })?;
 
+    if !user.active {
+        return Err(ServiceError::api(
+            StatusCode::UNAUTHORIZED,
+            "unauthorized",
+            "User account is deactivated",
+        ));
+    }
+
     let org_id = user.org_id.clone().ok_or_else(|| {
         ServiceError::api(
             StatusCode::FORBIDDEN,

--- a/crates/vouch-server/src/services/auth.rs
+++ b/crates/vouch-server/src/services/auth.rs
@@ -144,6 +144,10 @@ pub(crate) async fn lookup_and_verify_authenticator(
         return Err(ServiceError::Forbidden("user_mismatch"));
     }
 
+    if !user.active {
+        return Err(ServiceError::Forbidden("user_deactivated"));
+    }
+
     Ok(AuthenticatorLookupResult {
         authenticator,
         user,

--- a/crates/vouch-server/src/services/oidc/token.rs
+++ b/crates/vouch-server/src/services/oidc/token.rs
@@ -201,6 +201,21 @@ pub async fn exchange_authorization_code(
     // Decode and validate the authorization code
     let auth_code = decode_authorization_code(state, params.code, params.client_id).await?;
 
+    // Reject deactivated users before issuing tokens
+    let user = db::get_user_by_id(&state.store, &auth_code.user_id)
+        .await
+        .map_err(|e| ServiceError::Internal(e.to_string()))?
+        .ok_or(ServiceError::oauth(
+            OAuthErrorCode::InvalidGrant,
+            "User not found",
+        ))?;
+    if !user.active {
+        return Err(ServiceError::oauth(
+            OAuthErrorCode::InvalidGrant,
+            "User account is deactivated",
+        ));
+    }
+
     // RFC 6749 Section 10.5: Enforce single-use authorization codes.
     let code_hash = hash_token(params.code);
     enforce_single_use_code(state, &code_hash, &auth_code).await?;


### PR DESCRIPTION
Deactivated users could bypass lockout by completing FIDO2 assertion
to obtain new OAuth tokens, because lookup_and_verify_authenticator
did not check user.active. Add active-status checks at three layers:
authentication (auth.rs), authorization code exchange (token.rs),
and resource access (session.rs).

Closes #245

https://claude.ai/code/session_01MQngustDcshoKd6PdcnWaH