### PR TITLE
Fix revocation

### DIFF
--- a/crates/vouch-server/src/handlers/oidc/introspect.rs
+++ b/crates/vouch-server/src/handlers/oidc/introspect.rs
@@ -109,20 +109,21 @@ pub async fn revoke(
         Err(response) => return response,
     };
 
-    match authenticate_client_any(&state, auth).await {
-        Ok(Some(_)) => {}
+    let caller_client_id = match authenticate_client_any(&state, auth).await {
+        Ok(Some((_client, client_id, _jti))) => client_id,
         Ok(None) => {
             // No credentials provided → 401
             return (StatusCode::UNAUTHORIZED, [("www-authenticate", "Basic")]).into_response();
         }
         Err(response) => return response,
-    }
+    };
 
     let _result = svc_revoke(
         &state,
         &params.token,
         params.token_type_hint.as_deref(),
         client_info,
+        &caller_client_id,
     )
     .await;
     // Always return 200 per RFC 7009 Section 2 (for valid clients)

--- a/crates/vouch-server/src/handlers/oidc/tests/auth_flows.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/auth_flows.rs
@@ -810,7 +810,7 @@ async fn test_token_revocation_vs_key_deletion() {
     let auth_b = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
-    let token_a1 = create_test_session(&state, &user.id, &user.email, &auth_a).await;
+    let (token_a1, _) = issue_oauth_access_token(&app, &state, &user, &auth_a, &client).await;
     let token_a2 = create_test_session(&state, &user.id, &user.email, &auth_a).await;
 
     // Revoke token_a1 — kills ALL sessions for the user

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7009.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7009.rs
@@ -12,11 +12,11 @@ async fn test_revoke_valid_token() {
     // RFC 7009 Section 2.1: Successful revocation returns 200 and invalidates the token
     let (app, state) = test_app().await;
 
-    // Create a test session and OAuth client for authentication
     let user = create_test_user(&state.store, "revoke@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
+
+    let (token, _) = issue_oauth_access_token(&app, &state, &user, &auth_id, &client).await;
     let auth_header = client.basic_auth_header();
 
     // Verify token works before revocation
@@ -72,11 +72,11 @@ async fn test_revoke_token_invalidates_session() {
     // After revocation, the token should not work
     let (app, state) = test_app().await;
 
-    // Create a test session and OAuth client for authentication
     let user = create_test_user(&state.store, "revoke-check@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
+
+    let (token, _) = issue_oauth_access_token(&app, &state, &user, &auth_id, &client).await;
     let auth_header = client.basic_auth_header();
 
     // Verify token works before revocation
@@ -393,5 +393,51 @@ async fn test_revoke_already_revoked_token_returns_200() {
         status,
         StatusCode::OK,
         "RFC 7009 §2.2: revoking an already-revoked token must still return 200"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc7009_cross_client_revocation_blocked() {
+    // RFC 7009 Section 2.1: Client B must NOT be able to revoke Client A's token.
+    // The server must verify the token was issued to the requesting client.
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "revoke-cross@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let client_a = create_test_oauth_client(&state.store, &user.id).await;
+    let client_b = create_test_oauth_client(&state.store, &user.id).await;
+
+    // Issue token for client A
+    let (token_a, _) = issue_oauth_access_token(&app, &state, &user, &auth_id, &client_a).await;
+
+    // Client B tries to revoke Client A's token — returns 200 but must NOT revoke
+    let auth_b = client_b.basic_auth_header();
+    let (status, _) = http_post_form(
+        &app,
+        "/oauth/revoke",
+        &format!("token={}", token_a),
+        &[("Authorization", &auth_b)],
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "RFC 7009: revocation always returns 200"
+    );
+
+    // Verify token is still active — cross-client revocation must be a no-op
+    let auth_a = client_a.basic_auth_header();
+    let (status, body) = http_post_form(
+        &app,
+        "/oauth/introspect",
+        &format!("token={}", token_a),
+        &[("Authorization", &auth_a)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let result: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(
+        result["active"], true,
+        "Cross-client revocation must not revoke the token"
     );
 }

--- a/crates/vouch-server/src/services/oidc/introspection.rs
+++ b/crates/vouch-server/src/services/oidc/introspection.rs
@@ -230,10 +230,22 @@ pub async fn revoke_token(
     token: &str,
     _token_type_hint: Option<&str>,
     client_info: crate::handlers::extractors::ClientInfo,
+    caller_client_id: &str,
 ) -> RevocationResult {
     // Try to decode to get email for audit logging
     let config = state.config();
     let decoded = decode_token(token, &state.oidc_key, &config.base_url);
+
+    // RFC 7009 Section 2.1: Verify the token was issued to the calling client.
+    // If not, return success but perform no revocation.
+    if let Some(DecodedToken::AccessToken(ref claims)) = decoded
+        && caller_client_id != claims.client_id
+    {
+        return RevocationResult {
+            revoked: false,
+            user_email: None,
+        };
+    }
 
     let sub = decoded.as_ref().map(|d| d.sub().to_string());
     let email = decoded.as_ref().and_then(|d| d.email().map(String::from));

--- a/crates/vouch-tests/tests/integration.rs
+++ b/crates/vouch-tests/tests/integration.rs
@@ -1440,16 +1440,21 @@ mod session {
     async fn test_logout_via_revoke_clears_session() {
         let harness = TestHarness::new().await;
 
-        let (user, _auth_id, token) = harness
+        let (user, auth_id, _raw_token) = harness
             .create_authenticated_user("logout@example.com")
             .await
             .expect("Failed to create authenticated user");
 
-        // RFC 7009 Section 2.1: Revocation requires client authentication
+        // RFC 7009 Section 2.1: Revocation requires client authentication.
+        // Token must be bound to the client for ownership check.
         let client = harness
             .create_oauth_client(&user.id)
             .await
             .expect("Failed to create OAuth client");
+        let token = harness
+            .create_session_for_client(&user.id, &user.email, &auth_id, &client.client_id)
+            .await
+            .expect("Failed to create client-bound session");
         let auth_header = client.basic_auth_header();
 
         // Verify token works


### PR DESCRIPTION
Fixes #248

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes token revocation semantics to be client-bound, which impacts logout/session invalidation behavior and could break clients relying on cross-client revocation. However it follows RFC 7009 and is covered by added tests.
> 
> **Overview**
> **Fixes RFC 7009 revocation ownership enforcement.** The `/oauth/revoke` handler now captures the authenticated caller’s `client_id` and passes it into `revoke_token`.
> 
> `revoke_token` now verifies the presented access token was issued to the calling client and, if not, returns success while performing **no** revocation (preventing cross-client token/session invalidation). Tests were updated to issue client-bound access tokens and a new regression test asserts cross-client revocation is a no-op while still returning `200`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81832f57c5cce61679b6484197f3ecf9e00092aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->