### PR TITLE
Track certificate issuance

### DIFF
--- a/crates/vouch-server/src/db/credentials.rs
+++ b/crates/vouch-server/src/db/credentials.rs
@@ -432,6 +432,7 @@ pub async fn revoke_all_ssh_certificates_for_user(
     }
 
     let now = Timestamp::now();
+    let mut tx = store.begin().await?;
     let mut count: u64 = 0;
     for cert in &issued {
         let doc = SshRevokedCertDoc {
@@ -442,9 +443,10 @@ pub async fn revoke_all_ssh_certificates_for_user(
             expires_at: cert.expires_at,
             revoked_by: revoked_by.map(String::from),
         };
-        store.insert(&doc).await?;
+        tx.insert(&doc).await?;
         count += 1;
     }
+    tx.commit().await?;
     Ok(count)
 }
 

--- a/crates/vouch-server/src/db/credentials.rs
+++ b/crates/vouch-server/src/db/credentials.rs
@@ -3,7 +3,7 @@
 //! token exchange, cloud integrations).
 
 use super::document_type::{Document, DocumentType};
-use super::documents::credential::{EnrollmentSessionDoc, SshRevokedCertDoc};
+use super::documents::credential::{EnrollmentSessionDoc, SshIssuedCertDoc, SshRevokedCertDoc};
 use super::documents::oauth::{DelegationPolicyDoc, TokenExchangeDoc};
 use super::store::DocumentStore;
 use anyhow::Result;
@@ -268,6 +268,79 @@ pub async fn delete_expired_enrollment_sessions(store: &DocumentStore) -> Result
 }
 
 // ============================================================
+// SSH Issued Certificate Tracking
+// ============================================================
+
+/// Record of an issued SSH certificate.
+#[derive(Debug)]
+pub struct IssuedSshCertificate {
+    #[allow(dead_code)]
+    pub id: String,
+    pub serial: String,
+    #[allow(dead_code)]
+    pub user_id: String,
+    #[allow(dead_code)]
+    pub user_email: String,
+    #[allow(dead_code)]
+    pub principals: Vec<String>,
+    pub expires_at: Timestamp,
+}
+
+impl From<Document<SshIssuedCertDoc>> for IssuedSshCertificate {
+    fn from(doc: Document<SshIssuedCertDoc>) -> Self {
+        Self {
+            id: doc.id,
+            serial: doc.data.serial,
+            user_id: doc.data.user_id,
+            user_email: doc.data.user_email,
+            principals: doc.data.principals,
+            expires_at: doc.data.expires_at,
+        }
+    }
+}
+
+/// Record an SSH certificate issuance for revocation tracking.
+pub async fn record_ssh_certificate_issuance(
+    store: &DocumentStore,
+    serial: u64,
+    user_id: &str,
+    user_email: &str,
+    principals: &[String],
+    expires_at: Timestamp,
+) -> Result<String> {
+    let doc = SshIssuedCertDoc {
+        serial: serial.to_string(),
+        user_id: user_id.to_string(),
+        user_email: user_email.to_string(),
+        principals: principals.to_vec(),
+        expires_at,
+    };
+    let result = store.insert(&doc).await?;
+    Ok(result.id)
+}
+
+/// Get all non-expired issued SSH certificates for a user.
+pub async fn get_issued_ssh_certificates_for_user(
+    store: &DocumentStore,
+    user_id: &str,
+) -> Result<Vec<IssuedSshCertificate>> {
+    let docs = store
+        .find_all::<SshIssuedCertDoc>("user_id", user_id)
+        .await?;
+    let now = Timestamp::now();
+    Ok(docs
+        .into_iter()
+        .filter(|d| d.data.expires_at > now)
+        .map(IssuedSshCertificate::from)
+        .collect())
+}
+
+/// Delete expired SSH issued certificate records.
+pub async fn delete_expired_ssh_issued_certs(store: &DocumentStore) -> Result<u64> {
+    store.delete_expired(SshIssuedCertDoc::DOC_TYPE).await
+}
+
+// ============================================================
 // SSH Certificate Revocation
 // ============================================================
 
@@ -304,7 +377,6 @@ impl From<Document<SshRevokedCertDoc>> for RevokedSshCertificate {
 }
 
 /// Revoke an SSH certificate.
-#[allow(dead_code)]
 pub async fn revoke_ssh_certificate(
     store: &DocumentStore,
     serial: &str,
@@ -346,31 +418,396 @@ pub async fn get_revoked_ssh_certificates(
         .collect())
 }
 
-/// Revoke all SSH certificates for a user.
+/// Revoke all SSH certificates for a user by looking up issued certs
+/// and inserting a revocation record for each real serial.
 pub async fn revoke_all_ssh_certificates_for_user(
     store: &DocumentStore,
     user_id: &str,
     reason: Option<&str>,
     revoked_by: Option<&str>,
 ) -> Result<u64> {
-    let now = Timestamp::now();
-    let expires_at = jiff::Timestamp::now()
-        .checked_add(jiff::Span::new().years(1))
-        .map_err(|_| anyhow::anyhow!("Time calculation overflow"))?;
+    let issued = get_issued_ssh_certificates_for_user(store, user_id).await?;
+    if issued.is_empty() {
+        return Ok(0);
+    }
 
-    let doc = SshRevokedCertDoc {
-        serial: format!("user:{user_id}"),
-        user_id: user_id.to_string(),
-        reason: reason.map(String::from),
-        revoked_at: now,
-        expires_at,
-        revoked_by: revoked_by.map(String::from),
-    };
-    store.insert(&doc).await?;
-    Ok(1)
+    let now = Timestamp::now();
+    let mut count: u64 = 0;
+    for cert in &issued {
+        let doc = SshRevokedCertDoc {
+            serial: cert.serial.clone(),
+            user_id: user_id.to_string(),
+            reason: reason.map(String::from),
+            revoked_at: now,
+            expires_at: cert.expires_at,
+            revoked_by: revoked_by.map(String::from),
+        };
+        store.insert(&doc).await?;
+        count += 1;
+    }
+    Ok(count)
 }
 
 /// Delete expired SSH certificate revocations.
 pub async fn delete_expired_ssh_revocations(store: &DocumentStore) -> Result<u64> {
     store.delete_expired(SshRevokedCertDoc::DOC_TYPE).await
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::panic
+)]
+mod tests {
+    use super::*;
+    use crate::crypto::document_crypto::PlaintextDocumentCrypto;
+    use crate::db::pool::Pool;
+    use crate::db::store::DocumentStore;
+    use std::sync::Arc;
+
+    /// Create an in-memory test store with SQLite migrations applied.
+    async fn test_store() -> DocumentStore {
+        let pool = Pool::connect("sqlite::memory:", &crate::db::pool::PoolConfig::default())
+            .await
+            .expect("connect");
+        match &pool {
+            Pool::Sqlite(p) => sqlx::migrate!("./migrations/sqlite")
+                .run(p)
+                .await
+                .expect("migrate"),
+            Pool::Postgres(_) => panic!("unexpected pool type in unit tests"),
+        }
+        let crypto: Arc<dyn crate::crypto::document_crypto::DocumentCrypto> =
+            Arc::new(PlaintextDocumentCrypto);
+        DocumentStore::new(pool, crypto)
+    }
+
+    /// Helper: insert an issued SSH certificate and return its serial as a string.
+    async fn insert_issued(store: &DocumentStore, user_id: &str, serial: u64) -> String {
+        let expires_at = Timestamp::now()
+            .checked_add(jiff::Span::new().hours(8))
+            .expect("future timestamp");
+        record_ssh_certificate_issuance(
+            store,
+            serial,
+            user_id,
+            "user@example.com",
+            &["user".to_string()],
+            expires_at,
+        )
+        .await
+        .expect("record issuance");
+        serial.to_string()
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // record_ssh_certificate_issuance
+    // ────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_record_ssh_certificate_issuance_stores_correct_serial() {
+        let store = test_store().await;
+        let serial: u64 = 9_876_543_210;
+        let stored_serial = insert_issued(&store, "user-1", serial).await;
+
+        assert_eq!(stored_serial, serial.to_string());
+
+        // Verify the record is retrievable.
+        let certs = get_issued_ssh_certificates_for_user(&store, "user-1")
+            .await
+            .expect("get issued");
+        assert_eq!(certs.len(), 1);
+        assert_eq!(certs[0].serial, serial.to_string());
+    }
+
+    #[tokio::test]
+    async fn test_record_ssh_certificate_issuance_serial_is_numeric_string() {
+        // The core invariant: serials must be stored as decimal u64 strings,
+        // never as synthetic "user:{id}" values or any non-numeric form.
+        let store = test_store().await;
+        let serial: u64 = 12_345;
+        insert_issued(&store, "user-numeric", serial).await;
+
+        let certs = get_issued_ssh_certificates_for_user(&store, "user-numeric")
+            .await
+            .expect("get issued");
+
+        let stored = &certs[0].serial;
+        assert!(
+            stored.parse::<u64>().is_ok(),
+            "stored serial '{stored}' must parse as u64"
+        );
+        assert_eq!(stored, "12345");
+    }
+
+    #[tokio::test]
+    async fn test_record_ssh_certificate_issuance_max_u64() {
+        let store = test_store().await;
+        let serial = u64::MAX;
+        insert_issued(&store, "user-max", serial).await;
+
+        let certs = get_issued_ssh_certificates_for_user(&store, "user-max")
+            .await
+            .expect("get issued");
+        assert_eq!(certs[0].serial, u64::MAX.to_string());
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // get_issued_ssh_certificates_for_user
+    // ────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_get_issued_ssh_certificates_filters_expired() {
+        let store = test_store().await;
+
+        // Insert one expired cert (in the past)
+        let expired_at = Timestamp::now()
+            .checked_sub(jiff::Span::new().hours(1))
+            .expect("past timestamp");
+        record_ssh_certificate_issuance(
+            &store,
+            1001,
+            "user-exp",
+            "user@example.com",
+            &["user".to_string()],
+            expired_at,
+        )
+        .await
+        .expect("record expired");
+
+        // Insert one valid cert (in the future)
+        insert_issued(&store, "user-exp", 1002).await;
+
+        let certs = get_issued_ssh_certificates_for_user(&store, "user-exp")
+            .await
+            .expect("get issued");
+
+        // Only the valid cert should be returned.
+        assert_eq!(certs.len(), 1, "only non-expired cert should be returned");
+        assert_eq!(certs[0].serial, "1002");
+    }
+
+    #[tokio::test]
+    async fn test_get_issued_ssh_certificates_returns_empty_for_unknown_user() {
+        let store = test_store().await;
+
+        let certs = get_issued_ssh_certificates_for_user(&store, "nonexistent-user")
+            .await
+            .expect("get issued");
+
+        assert!(certs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_issued_ssh_certificates_multiple_certs() {
+        let store = test_store().await;
+
+        let serials = [111_u64, 222, 333];
+        for &s in &serials {
+            insert_issued(&store, "user-multi", s).await;
+        }
+
+        let certs = get_issued_ssh_certificates_for_user(&store, "user-multi")
+            .await
+            .expect("get issued");
+
+        assert_eq!(certs.len(), 3);
+        let mut returned: Vec<u64> = certs
+            .iter()
+            .map(|c| c.serial.parse::<u64>().expect("numeric serial"))
+            .collect();
+        returned.sort_unstable();
+        assert_eq!(returned, vec![111, 222, 333]);
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // revoke_all_ssh_certificates_for_user — core security property
+    // ────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_revoke_all_creates_revocations_with_real_numeric_serials() {
+        // SECURITY: This test verifies the fix for GH#249.
+        // Prior to the fix, revoke_all_ssh_certificates_for_user inserted a
+        // synthetic "user:{user_id}" serial that could never match the real u64
+        // serial stored in the SSH certificate.  The fix must look up issued
+        // certificate records and revoke each real serial.
+        let store = test_store().await;
+
+        let serial_a: u64 = 5_000_000;
+        let serial_b: u64 = 9_999_999;
+        insert_issued(&store, "user-revoke", serial_a).await;
+        insert_issued(&store, "user-revoke", serial_b).await;
+
+        let count = revoke_all_ssh_certificates_for_user(&store, "user-revoke", None, None)
+            .await
+            .expect("revoke all");
+
+        assert_eq!(count, 2, "should have revoked exactly 2 certs");
+
+        // Each revocation record must carry a real numeric serial.
+        let revoked = get_revoked_ssh_certificates(&store)
+            .await
+            .expect("get revoked");
+
+        let mut revoked_serials: Vec<u64> = revoked
+            .iter()
+            .filter(|r| r.user_id == "user-revoke")
+            .map(|r| r.serial.parse::<u64>().expect("serial must be numeric u64"))
+            .collect();
+        revoked_serials.sort_unstable();
+
+        assert_eq!(
+            revoked_serials,
+            vec![serial_a, serial_b],
+            "revoked serials must exactly match the issued serials"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_revoke_all_returns_zero_when_no_issued_certs() {
+        let store = test_store().await;
+
+        let count = revoke_all_ssh_certificates_for_user(&store, "user-none", None, None)
+            .await
+            .expect("revoke all");
+
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_revoke_all_does_not_revoke_expired_certs() {
+        // Expired certs are filtered by get_issued_ssh_certificates_for_user
+        // and must not generate revocation records (they have already expired).
+        let store = test_store().await;
+
+        let expired_at = Timestamp::now()
+            .checked_sub(jiff::Span::new().hours(1))
+            .expect("past");
+        record_ssh_certificate_issuance(
+            &store,
+            7001,
+            "user-exp-revoke",
+            "user@example.com",
+            &["user".to_string()],
+            expired_at,
+        )
+        .await
+        .expect("record expired");
+
+        let count = revoke_all_ssh_certificates_for_user(&store, "user-exp-revoke", None, None)
+            .await
+            .expect("revoke all");
+
+        assert_eq!(count, 0, "expired certs should not generate revocations");
+    }
+
+    #[tokio::test]
+    async fn test_revoke_all_propagates_reason_and_revoked_by() {
+        let store = test_store().await;
+        insert_issued(&store, "user-meta", 42).await;
+
+        revoke_all_ssh_certificates_for_user(
+            &store,
+            "user-meta",
+            Some("scim_deprovisioning"),
+            Some("admin@example.com"),
+        )
+        .await
+        .expect("revoke all");
+
+        let revoked = get_revoked_ssh_certificates(&store)
+            .await
+            .expect("get revoked");
+
+        let record = revoked
+            .iter()
+            .find(|r| r.user_id == "user-meta")
+            .expect("revocation record must exist");
+
+        assert_eq!(record.reason.as_deref(), Some("scim_deprovisioning"));
+        assert_eq!(record.revoked_by.as_deref(), Some("admin@example.com"));
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // Revoked serial appears in KRL (is_ssh_certificate_revoked)
+    // ────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_revoked_serial_is_detected_by_krl_check() {
+        // After revoke_all, each real serial must be visible through
+        // is_ssh_certificate_revoked (the check used by SSH servers).
+        let store = test_store().await;
+        let serial: u64 = 1_234_567_890;
+        insert_issued(&store, "user-krl", serial).await;
+
+        revoke_all_ssh_certificates_for_user(&store, "user-krl", None, None)
+            .await
+            .expect("revoke all");
+
+        let is_revoked = is_ssh_certificate_revoked(&store, &serial.to_string())
+            .await
+            .expect("check revocation");
+
+        assert!(
+            is_revoked,
+            "serial {serial} must be reported as revoked after revoke_all"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_non_revoked_serial_is_not_in_krl() {
+        let store = test_store().await;
+
+        let is_revoked = is_ssh_certificate_revoked(&store, "99999999")
+            .await
+            .expect("check revocation");
+
+        assert!(!is_revoked);
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // delete_expired_ssh_issued_certs
+    // ────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_delete_expired_ssh_issued_certs_removes_expired() {
+        let store = test_store().await;
+
+        // Insert expired cert
+        let expired_at = Timestamp::now()
+            .checked_sub(jiff::Span::new().hours(1))
+            .expect("past");
+        record_ssh_certificate_issuance(
+            &store,
+            8001,
+            "user-cleanup",
+            "user@example.com",
+            &["user".to_string()],
+            expired_at,
+        )
+        .await
+        .expect("record expired");
+
+        // Insert valid cert
+        insert_issued(&store, "user-cleanup", 8002).await;
+
+        let deleted = delete_expired_ssh_issued_certs(&store)
+            .await
+            .expect("delete expired");
+
+        assert_eq!(deleted, 1, "only the expired cert record should be removed");
+
+        // Valid cert is still there
+        let remaining = get_issued_ssh_certificates_for_user(&store, "user-cleanup")
+            .await
+            .expect("get issued");
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].serial, "8002");
+    }
 }

--- a/crates/vouch-server/src/db/documents/credential.rs
+++ b/crates/vouch-server/src/db/documents/credential.rs
@@ -37,6 +37,37 @@ impl DocumentType for EnrollmentSessionDoc {
     }
 }
 
+/// A record of an issued SSH certificate (for revocation tracking).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SshIssuedCertDoc {
+    pub serial: String,
+    pub user_id: String,
+    pub user_email: String,
+    pub principals: Vec<String>,
+    pub expires_at: Timestamp,
+}
+
+impl DocumentType for SshIssuedCertDoc {
+    const DOC_TYPE: &'static str = "ssh_issued_cert";
+
+    fn index_entries(&self) -> Vec<IndexEntry> {
+        vec![
+            IndexEntry {
+                field: "serial",
+                value: self.serial.clone(),
+            },
+            IndexEntry {
+                field: "user_id",
+                value: self.user_id.clone(),
+            },
+        ]
+    }
+
+    fn expires_at(&self) -> Option<Timestamp> {
+        Some(self.expires_at)
+    }
+}
+
 /// A revoked SSH certificate.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SshRevokedCertDoc {

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -147,11 +147,13 @@ pub use dpop::{
 
 // Re-export credentials types and functions
 pub use credentials::{
-    DelegationPolicy, EnrollmentSession, RevokedSshCertificate, TokenExchangeRecord,
-    check_delegation_policy, create_enrollment_session, delete_delegation_policy,
-    delete_expired_enrollment_sessions, delete_expired_ssh_revocations, delete_old_token_exchanges,
-    get_delegation_policies, get_enrollment_session_by_token_hash, get_revoked_ssh_certificates,
-    get_token_exchanges_for_user, insert_token_exchange, is_ssh_certificate_revoked,
+    DelegationPolicy, EnrollmentSession, IssuedSshCertificate, RevokedSshCertificate,
+    TokenExchangeRecord, check_delegation_policy, create_enrollment_session,
+    delete_delegation_policy, delete_expired_enrollment_sessions, delete_expired_ssh_issued_certs,
+    delete_expired_ssh_revocations, delete_old_token_exchanges, get_delegation_policies,
+    get_enrollment_session_by_token_hash, get_issued_ssh_certificates_for_user,
+    get_revoked_ssh_certificates, get_token_exchanges_for_user, insert_token_exchange,
+    is_ssh_certificate_revoked, record_ssh_certificate_issuance,
     revoke_all_ssh_certificates_for_user, revoke_ssh_certificate, set_delegation_policy_enabled,
 };
 

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -1371,6 +1371,58 @@ async fn test_user_cascade_delete() {
     assert!(get_user_by_id(&store, &user_id).await.unwrap().is_none());
 }
 
+/// Regression test for GH#249 / PR#262: SSH revocation records must
+/// survive user deletion so they remain visible in the KRL.
+#[tokio::test]
+async fn test_user_delete_preserves_ssh_revocations() {
+    let (store, _audit) = test_db().await;
+
+    let (user_id, _) = upsert_user(&store, "revoke-preserve@example.com", None)
+        .await
+        .expect("Failed to create user");
+
+    let serial: u64 = 4_242_424;
+    let expires_at: jiff::Timestamp = "2099-12-31T23:59:59Z".parse().unwrap();
+
+    record_ssh_certificate_issuance(
+        &store,
+        serial,
+        &user_id,
+        "revoke-preserve@example.com",
+        &["revoke-preserve@example.com".to_string()],
+        expires_at,
+    )
+    .await
+    .expect("Failed to record issued SSH certificate");
+
+    revoke_all_ssh_certificates_for_user(
+        &store,
+        &user_id,
+        Some("User deleted by admin"),
+        Some("admin-user-id"),
+    )
+    .await
+    .expect("Failed to revoke SSH certificates");
+
+    delete_user(&store, &user_id).await.expect("delete failed");
+
+    // User should be gone
+    assert!(
+        get_user_by_id(&store, &user_id)
+            .await
+            .expect("query failed")
+            .is_none()
+    );
+
+    // Revocation record must persist after user deletion
+    assert!(
+        is_ssh_certificate_revoked(&store, &serial.to_string())
+            .await
+            .expect("revocation check failed"),
+        "revoked serial must remain after deleting the user"
+    );
+}
+
 #[tokio::test]
 async fn test_oauth_client_cascade_delete() {
     let (store, audit) = test_db().await;

--- a/crates/vouch-server/src/db/users.rs
+++ b/crates/vouch-server/src/db/users.rs
@@ -116,13 +116,17 @@ pub async fn get_user_by_id(store: &DocumentStore, user_id: &str) -> Result<Opti
 /// 1. Delete sessions
 /// 2. Delete enrollment sessions
 /// 3. Delete authenticators (and their related device_auth refs)
-/// 4. Delete SSH revoked certificates
+/// 4. Delete SSH issued certificate records
 /// 5. Delete token exchanges
 /// 6. Unlink OAuth clients (set user_id to None)
 /// 7. Delete the user
+///
+/// Note: SSH revocation records (`SshRevokedCertDoc`) are intentionally
+/// NOT deleted — they must outlive the user so SSH servers can still
+/// check the KRL. They expire naturally via `expires_at`.
 pub async fn delete_user(store: &DocumentStore, user_id: &str) -> Result<bool> {
     use super::documents::authenticator::AuthenticatorDoc;
-    use super::documents::credential::{EnrollmentSessionDoc, SshIssuedCertDoc, SshRevokedCertDoc};
+    use super::documents::credential::{EnrollmentSessionDoc, SshIssuedCertDoc};
     use super::documents::device_auth::DeviceAuthRequestDoc;
     use super::documents::oauth::OAuthClientDoc;
     use super::documents::oauth::TokenExchangeDoc;
@@ -149,11 +153,7 @@ pub async fn delete_user(store: &DocumentStore, user_id: &str) -> Result<bool> {
     tx.delete_by_index::<AuthenticatorDoc>("user_id", user_id)
         .await?;
 
-    // 4. Delete SSH revoked certificates
-    tx.delete_by_index::<SshRevokedCertDoc>("user_id", user_id)
-        .await?;
-
-    // 4b. Delete SSH issued certificate records
+    // 4. Delete SSH issued certificate records
     tx.delete_by_index::<SshIssuedCertDoc>("user_id", user_id)
         .await?;
 

--- a/crates/vouch-server/src/db/users.rs
+++ b/crates/vouch-server/src/db/users.rs
@@ -122,7 +122,7 @@ pub async fn get_user_by_id(store: &DocumentStore, user_id: &str) -> Result<Opti
 /// 7. Delete the user
 pub async fn delete_user(store: &DocumentStore, user_id: &str) -> Result<bool> {
     use super::documents::authenticator::AuthenticatorDoc;
-    use super::documents::credential::{EnrollmentSessionDoc, SshRevokedCertDoc};
+    use super::documents::credential::{EnrollmentSessionDoc, SshIssuedCertDoc, SshRevokedCertDoc};
     use super::documents::device_auth::DeviceAuthRequestDoc;
     use super::documents::oauth::OAuthClientDoc;
     use super::documents::oauth::TokenExchangeDoc;
@@ -151,6 +151,10 @@ pub async fn delete_user(store: &DocumentStore, user_id: &str) -> Result<bool> {
 
     // 4. Delete SSH revoked certificates
     tx.delete_by_index::<SshRevokedCertDoc>("user_id", user_id)
+        .await?;
+
+    // 4b. Delete SSH issued certificate records
+    tx.delete_by_index::<SshIssuedCertDoc>("user_id", user_id)
         .await?;
 
     // 5. Delete token exchanges

--- a/crates/vouch-server/src/handlers/admin/members.rs
+++ b/crates/vouch-server/src/handlers/admin/members.rs
@@ -434,18 +434,24 @@ pub async fn remove_member(
 
     let target_email = target.email.clone();
 
-    // Revoke SSH certificates before deleting (delete_user cascades
-    // and removes the issued cert records, so revoke first).
-    if let Err(e) = db::revoke_all_ssh_certificates_for_user(
+    // Revoke SSH certificates before deleting. If revocation fails,
+    // abort — delete_user would destroy the issued cert records,
+    // making the certs permanently unrevocable.
+    db::revoke_all_ssh_certificates_for_user(
         &state.store,
         &target_id,
         Some("User removed by admin"),
         Some(&admin.id),
     )
     .await
-    {
+    .map_err(|e| {
         tracing::error!("Failed to revoke SSH certificates for removed user: {e}");
-    }
+        ServiceError::api(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "revocation_failed",
+            "Failed to revoke SSH certificates",
+        )
+    })?;
 
     db::delete_user(&state.store, &target_id).await?;
 

--- a/crates/vouch-server/src/handlers/admin/members.rs
+++ b/crates/vouch-server/src/handlers/admin/members.rs
@@ -434,6 +434,19 @@ pub async fn remove_member(
 
     let target_email = target.email.clone();
 
+    // Revoke SSH certificates before deleting (delete_user cascades
+    // and removes the issued cert records, so revoke first).
+    if let Err(e) = db::revoke_all_ssh_certificates_for_user(
+        &state.store,
+        &target_id,
+        Some("User removed by admin"),
+        Some(&admin.id),
+    )
+    .await
+    {
+        tracing::error!("Failed to revoke SSH certificates for removed user: {e}");
+    }
+
     db::delete_user(&state.store, &target_id).await?;
 
     let data = serde_json::json!({

--- a/crates/vouch-server/src/handlers/credentials.rs
+++ b/crates/vouch-server/src/handlers/credentials.rs
@@ -102,7 +102,13 @@ pub async fn issue_ssh_certificate(
 
     // Record issuance for revocation tracking. If this fails, do NOT
     // return the certificate — an untracked cert cannot be revoked.
-    let valid_secs_i64 = i64::try_from(valid_seconds).unwrap_or(i64::MAX);
+    let valid_secs_i64 = i64::try_from(valid_seconds).map_err(|_| {
+        ServiceError::api(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "time_error",
+            "Session duration overflow",
+        )
+    })?;
     let cert_expires_at = Timestamp::now()
         .checked_add(jiff::Span::new().seconds(valid_secs_i64))
         .map_err(|_| {

--- a/crates/vouch-server/src/handlers/credentials.rs
+++ b/crates/vouch-server/src/handlers/credentials.rs
@@ -49,8 +49,8 @@ pub async fn issue_ssh_certificate(
         ));
     }
 
-    // Validate token and get user email
-    let (_token, user_email) = extract_resource_token_with_email(
+    // Validate token and get user email + user_id
+    let (token, user_email) = extract_resource_token_with_email(
         &state,
         &headers,
         &jar,
@@ -97,6 +97,40 @@ pub async fn issue_ssh_certificate(
             StatusCode::BAD_REQUEST,
             "signing_failed",
             "Failed to sign certificate",
+        )
+    })?;
+
+    // Record issuance for revocation tracking. If this fails, do NOT
+    // return the certificate — an untracked cert cannot be revoked.
+    let valid_secs_i64 = i64::try_from(valid_seconds).unwrap_or(i64::MAX);
+    let cert_expires_at = Timestamp::now()
+        .checked_add(jiff::Span::new().seconds(valid_secs_i64))
+        .map_err(|_| {
+            ServiceError::api(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "time_error",
+                "Failed to compute certificate expiry",
+            )
+        })?;
+
+    db::record_ssh_certificate_issuance(
+        &state.store,
+        signed.serial,
+        &token.sub,
+        &user_email,
+        &signed.principals,
+        cert_expires_at,
+    )
+    .await
+    .map_err(|e| {
+        tracing::error!(
+            "Failed to record SSH certificate issuance for {}: {e}",
+            redact_email(&user_email),
+        );
+        ServiceError::api(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "recording_failed",
+            "Failed to record certificate issuance",
         )
     })?;
 

--- a/crates/vouch-server/src/handlers/scim/users.rs
+++ b/crates/vouch-server/src/handlers/scim/users.rs
@@ -513,7 +513,9 @@ pub async fn delete_user(
         state.session_cache.invalidate_for_user(&id);
     }
 
-    // Revoke all SSH certificates for this user
+    // Revoke SSH certificates before deleting. If revocation fails,
+    // abort — delete_user would destroy the issued cert records,
+    // making the certs permanently unrevocable.
     if let Err(e) = db::revoke_all_ssh_certificates_for_user(
         &state.store,
         &id,
@@ -523,6 +525,11 @@ pub async fn delete_user(
     .await
     {
         tracing::error!("Failed to revoke SSH certificates for deleted user: {e}");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ScimError::new(500, "Failed to revoke SSH certificates")),
+        )
+            .into_response();
     }
 
     // Delete user (cascades to authenticators)

--- a/crates/vouch-server/src/infra/cleanup.rs
+++ b/crates/vouch-server/src/infra/cleanup.rs
@@ -213,6 +213,12 @@ pub async fn run_cleanup(
         "expired SSH certificate revocations"
     );
 
+    // Clean up expired SSH issued certificate records
+    cleanup_and_log!(
+        db::delete_expired_ssh_issued_certs(store),
+        "expired SSH issued certificate records"
+    );
+
     tracing::debug!("Background cleanup tasks complete");
 }
 


### PR DESCRIPTION
Fixes #249

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SSH certificate issuance/revocation and user-deletion flows, which are security-sensitive and could affect whether certificates are properly revocable or issuance succeeds under DB failure conditions.
> 
> **Overview**
> **Adds SSH certificate issuance tracking to fix broken “revoke all” behavior.** A new `SshIssuedCertDoc` store is introduced, certificates issued by `POST /v1/credentials/ssh` are now recorded (and issuance fails if tracking can’t be persisted), and background cleanup deletes expired issuance records.
> 
> **Revocation semantics are corrected and hardened.** `revoke_all_ssh_certificates_for_user` now revokes each *real* non-expired cert serial by looking up issued cert records (transactionally) instead of inserting a synthetic `user:{id}` serial, and user deletion no longer removes `SshRevokedCertDoc` so KRL checks continue to work after a user is deleted; admin/SCIM delete paths now revoke first and abort deletion on revocation failure. Extensive regression tests cover these invariants (GH#249).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00c2d14ec91b0a6277d1d1df8411ecd1e83740de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->