### PR TITLE
Deterministic JTI

### DIFF
--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -806,7 +806,30 @@ pub async fn update_oauth_client_registration(
 /// Maximum JTI length.
 const MAX_JTI_LENGTH: usize = 256;
 
+/// Derive a deterministic document ID from (jti, client_id).
+///
+/// Two concurrent inserts for the same JTI+client_id produce the same
+/// document ID, so the second INSERT fails on the `documents` PRIMARY KEY
+/// constraint. This eliminates the TOCTOU race without requiring elevated
+/// transaction isolation or advisory locks.
+fn deterministic_jti_id(jti: &str, client_id: &str) -> String {
+    use aws_lc_rs::digest::{self, SHA256};
+
+    let mut ctx = digest::Context::new(&SHA256);
+    ctx.update(b"jwt_assertion_jti\0");
+    ctx.update(client_id.as_bytes());
+    ctx.update(b"\0");
+    ctx.update(jti.as_bytes());
+    hex::encode(ctx.finish().as_ref())
+}
+
 /// Store a JWT assertion JTI for replay prevention.
+///
+/// Returns `true` if the JTI was stored (first use), `false` if it
+/// already exists (replay). Uses a deterministic document ID derived
+/// from (jti, client_id) so that concurrent inserts collide on the
+/// PRIMARY KEY constraint, preventing TOCTOU races regardless of
+/// transaction isolation level or database backend.
 pub async fn store_jwt_assertion_jti(
     store: &DocumentStore,
     jti: &str,
@@ -819,21 +842,14 @@ pub async fn store_jwt_assertion_jti(
         ));
     }
 
-    // Check for existing JTI+client_id combination
-    let existing = store
-        .find_by_indexes::<JwtAssertionJtiDoc>(&[("jti", jti), ("client_id", client_id)])
-        .await?;
-    if !existing.is_empty() {
-        return Ok(false);
-    }
-
+    let id = deterministic_jti_id(jti, client_id);
     let doc = JwtAssertionJtiDoc {
         jti: jti.to_string(),
         client_id: client_id.to_string(),
         expires_at,
     };
 
-    match store.insert(&doc).await {
+    match store.insert_with_id(&id, &doc).await {
         Ok(_) => Ok(true),
         Err(e) => {
             let err_str = e.to_string();

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -2039,6 +2039,69 @@ async fn test_store_jwt_assertion_jti_too_long() {
 }
 
 #[tokio::test]
+async fn test_store_jwt_assertion_jti_at_max_length() {
+    let (store, _audit) = test_db().await;
+
+    // Exactly MAX_JTI_LENGTH (256) must be accepted
+    let max_jti = "j".repeat(256);
+    let stored = store_jwt_assertion_jti(
+        &store,
+        &max_jti,
+        "client-1",
+        "2099-01-01T00:00:00Z".parse().unwrap(),
+    )
+    .await
+    .expect("256-char JTI should not error");
+    assert!(stored, "JTI at max length should be accepted");
+
+    // Replay still detected
+    let replayed = store_jwt_assertion_jti(
+        &store,
+        &max_jti,
+        "client-1",
+        "2099-01-01T00:00:00Z".parse().unwrap(),
+    )
+    .await
+    .expect("replay check should not error");
+    assert!(!replayed, "Replay of max-length JTI should be rejected");
+}
+
+#[tokio::test]
+async fn test_store_jwt_assertion_jti_client_isolation() {
+    let (store, _audit) = test_db().await;
+
+    let expires: jiff::Timestamp = "2099-01-01T00:00:00Z".parse().unwrap();
+
+    // Three independent (jti, client_id) pairs must all succeed
+    let a = store_jwt_assertion_jti(&store, "jti-xyz", "client-A", expires)
+        .await
+        .expect("pair A should not error");
+    let b = store_jwt_assertion_jti(&store, "jti-xyz", "client-B", expires)
+        .await
+        .expect("pair B should not error");
+    let c = store_jwt_assertion_jti(&store, "jti-pqr", "client-A", expires)
+        .await
+        .expect("pair C should not error");
+    assert!(a, "First pair should be accepted");
+    assert!(b, "Same JTI, different client should be accepted");
+    assert!(c, "Different JTI, same client should be accepted");
+
+    // Each pair replays to false independently
+    let a2 = store_jwt_assertion_jti(&store, "jti-xyz", "client-A", expires)
+        .await
+        .expect("replay A");
+    let b2 = store_jwt_assertion_jti(&store, "jti-xyz", "client-B", expires)
+        .await
+        .expect("replay B");
+    let c2 = store_jwt_assertion_jti(&store, "jti-pqr", "client-A", expires)
+        .await
+        .expect("replay C");
+    assert!(!a2, "Replay of pair A should be rejected");
+    assert!(!b2, "Replay of pair B should be rejected");
+    assert!(!c2, "Replay of pair C should be rejected");
+}
+
+#[tokio::test]
 async fn test_delete_expired_jwt_assertion_jtis() {
     let (store, _audit) = test_db().await;
 

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/grant.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/grant.rs
@@ -154,7 +154,8 @@ pub async fn exchange_jwt_bearer_grant(
     })?;
 
     // 9. Check JTI for replay (RFC 7523 Section 3)
-    //    Atomic insert with UNIQUE(jti, client_id) prevents TOCTOU races.
+    //    Deterministic document ID derived from (jti, issuer) ensures the
+    //    PRIMARY KEY constraint prevents concurrent duplicate inserts.
     if let Some(ref jti) = validated.claims.jti {
         let max_lifetime = i64::from(issuer.max_token_lifetime_seconds);
         let expires_at = Timestamp::now()


### PR DESCRIPTION
Fixes #250

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the JWT bearer replay-prevention write path by switching JTI storage to deterministic IDs and relying on primary-key collisions; mistakes could allow replays or cause false positives during token exchange.
> 
> **Overview**
> **Eliminates a race in JWT bearer JTI replay prevention.** `store_jwt_assertion_jti` now derives a deterministic document ID from `(jti, client_id)` (SHA-256) and inserts via `insert_with_id`, removing the prior read-then-insert check so concurrent requests reliably collide on the `documents` primary key.
> 
> Adds tests covering the max-length JTI boundary and independence across `(jti, client_id)` pairs, and updates JWT bearer grant comments to reflect the new replay-protection mechanism.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5410fc2fbecf8020077238b63953c2bb5789dd18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->