### PR TITLE
Return error if chain not verified

### DIFF
--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -1162,6 +1162,20 @@ pub async fn browser_register_complete(
                 );
             }
             Err(e) => {
+                if state.config().require_attestation_cert {
+                    tracing::warn!(
+                        "Browser enrollment: x5c chain validation \
+                         failed (fatal, require_attestation_cert=true): {e}"
+                    );
+                    return Err(ServiceError::api(
+                        StatusCode::BAD_REQUEST,
+                        "attestation_chain_invalid",
+                        "Attestation certificate chain could not be \
+                         verified against trusted roots. Only genuine \
+                         hardware authenticators with valid attestation \
+                         chains are accepted.",
+                    ));
+                }
                 tracing::warn!(
                     "Browser enrollment: x5c chain validation \
                      failed (non-fatal): {e}"


### PR DESCRIPTION
Fixes #251

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens enrollment validation by turning previously non-fatal attestation chain failures into hard errors when `require_attestation_cert` is enabled, which could block registrations if roots/certs are misconfigured or chains are incomplete.
> 
> **Overview**
> Browser WebAuthn enrollment now **returns a `400` API error** (`attestation_chain_invalid`) when x5c attestation certificate chain validation fails *and* `require_attestation_cert` is set, instead of only logging a warning and proceeding.
> 
> When `require_attestation_cert` is false, the failure remains non-fatal and enrollment continues with `attestation_verified` unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac4bb02d56f26258fa330e1558ad3870fdaeb91d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->