### PR TITLE
Fix deactivated users

### DIFF
--- a/crates/vouch-server/src/handlers/credentials.rs
+++ b/crates/vouch-server/src/handlers/credentials.rs
@@ -60,6 +60,29 @@ pub async fn issue_ssh_certificate(
     )
     .await?;
 
+    // Reject deactivated users (defense-in-depth for SCIM deactivation)
+    let user = db::get_user_by_id(&state.store, &token.sub)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get user by ID: {e}");
+            ServiceError::api(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "db_error",
+                "Internal database error",
+            )
+        })?
+        .ok_or_else(|| {
+            ServiceError::api(StatusCode::NOT_FOUND, "user_not_found", "User not found")
+        })?;
+
+    if !user.active {
+        return Err(ServiceError::api(
+            StatusCode::UNAUTHORIZED,
+            "unauthorized",
+            "User account is deactivated",
+        ));
+    }
+
     // Certificate validity matches session duration
     let valid_seconds = state.config().session_hours * 3600;
 
@@ -330,6 +353,14 @@ pub async fn get_aws_token(
             ServiceError::api(StatusCode::NOT_FOUND, "user_not_found", "User not found")
         })?;
 
+    if !user.active {
+        return Err(ServiceError::api(
+            StatusCode::UNAUTHORIZED,
+            "unauthorized",
+            "User account is deactivated",
+        ));
+    }
+
     let user_email = token.email.clone().unwrap_or_else(|| user.email.clone());
 
     // Get user's organization domain (hd claim) if they belong to an org
@@ -449,6 +480,14 @@ pub async fn get_kubernetes_token(
         .ok_or_else(|| {
             ServiceError::api(StatusCode::NOT_FOUND, "user_not_found", "User not found")
         })?;
+
+    if !user.active {
+        return Err(ServiceError::api(
+            StatusCode::UNAUTHORIZED,
+            "unauthorized",
+            "User account is deactivated",
+        ));
+    }
 
     let user_email = token.email.clone().unwrap_or_else(|| user.email.clone());
     let audience = query
@@ -572,6 +611,14 @@ pub async fn get_github_status(
             ServiceError::api(StatusCode::NOT_FOUND, "user_not_found", "User not found")
         })?;
 
+    if !user.active {
+        return Err(ServiceError::api(
+            StatusCode::UNAUTHORIZED,
+            "unauthorized",
+            "User account is deactivated",
+        ));
+    }
+
     // Check if GitHub App is configured
     let configured = state.github_app.is_some();
 
@@ -658,6 +705,14 @@ pub async fn get_github_token(
         .ok_or_else(|| {
             ServiceError::api(StatusCode::NOT_FOUND, "user_not_found", "User not found")
         })?;
+
+    if !user.active {
+        return Err(ServiceError::api(
+            StatusCode::UNAUTHORIZED,
+            "unauthorized",
+            "User account is deactivated",
+        ));
+    }
 
     // Verify user has an organization
     let org_id = user.org_id.as_ref().ok_or_else(|| {
@@ -1327,5 +1382,85 @@ mod tests {
         assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
         let error: serde_json::Value = serde_json::from_str(&resp_body).expect("Valid JSON");
         assert_eq!(error["code"], "github_not_configured");
+    }
+
+    // ========================================================================
+    // Deactivated User Credential Denial Tests (Issue #252)
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_deactivated_user_cannot_get_aws_token() {
+        let (app, state) = test_app().await;
+
+        let user = create_test_user(&state.store, "deactivated-aws@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+
+        // Deactivate the user
+        crate::db::update_user_active_status(&state.store, &user.id, false)
+            .await
+            .expect("deactivate user");
+
+        let (status, body) = http_get(
+            &app,
+            "/v1/credentials/aws/token",
+            &[("Authorization", &format!("Bearer {token}"))],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+        assert_eq!(error["code"], "unauthorized");
+        assert_eq!(error["message"], "User account is deactivated");
+    }
+
+    #[tokio::test]
+    async fn test_deactivated_user_cannot_get_k8s_token() {
+        let (app, state) = test_app().await;
+
+        let user = create_test_user(&state.store, "deactivated-k8s@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+
+        crate::db::update_user_active_status(&state.store, &user.id, false)
+            .await
+            .expect("deactivate user");
+
+        let (status, body) = http_get(
+            &app,
+            "/v1/credentials/kubernetes/token",
+            &[("Authorization", &format!("Bearer {token}"))],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+        assert_eq!(error["code"], "unauthorized");
+        assert_eq!(error["message"], "User account is deactivated");
+    }
+
+    #[tokio::test]
+    async fn test_deactivated_user_cannot_get_github_status() {
+        let (app, state) = test_app().await;
+
+        let user = create_test_user(&state.store, "deactivated-gh@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+
+        crate::db::update_user_active_status(&state.store, &user.id, false)
+            .await
+            .expect("deactivate user");
+
+        let (status, body) = http_get(
+            &app,
+            "/v1/credentials/github/status",
+            &[("Authorization", &format!("Bearer {token}"))],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+        assert_eq!(error["code"], "unauthorized");
+        assert_eq!(error["message"], "User account is deactivated");
     }
 }


### PR DESCRIPTION
Fixes #252

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential-issuance/authz paths (SSH/AWS/Kubernetes/GitHub) and could inadvertently block access if `active` state handling is wrong, but the change is small and covered by tests.
> 
> **Overview**
> Prevents **deactivated users** from obtaining credentials by adding an `active` user check (returning `401 unauthorized` with "User account is deactivated") across the credential handlers, including SSH certificate issuance and AWS/Kubernetes/GitHub endpoints.
> 
> Adds integration tests to ensure deactivated accounts cannot retrieve AWS tokens, Kubernetes tokens, or GitHub status (Issue #252).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52889c1caa0c35a9130734dd116fb33f916a4230. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->