### PR TITLE
Check device auth status

### DIFF
--- a/crates/vouch-server/src/db/device_auth.rs
+++ b/crates/vouch-server/src/db/device_auth.rs
@@ -156,6 +156,15 @@ pub async fn authorize_device_auth(
         );
     };
 
+    if doc.data.status != DeviceAuthStatus::Pending {
+        bail!(
+            "authorize_device_auth: device auth request '{}' \
+             already has status '{:?}'",
+            id,
+            doc.data.status
+        );
+    }
+
     let mut data = doc.data;
     data.status = DeviceAuthStatus::Authorized;
     data.user_id = Some(user_id.to_string());
@@ -168,13 +177,40 @@ pub async fn authorize_device_auth(
 }
 
 /// Deny a device auth request.
+///
+/// The read and status update execute within a single transaction so
+/// concurrent denial attempts are serialized correctly.
 #[allow(dead_code)]
 pub async fn deny_device_auth(store: &DocumentStore, id: &str) -> Result<()> {
-    if let Some(doc) = store.get::<DeviceAuthRequestDoc>(id).await? {
-        let mut data = doc.data;
-        data.status = DeviceAuthStatus::Denied;
-        store.update(id, &data).await?;
+    if id.is_empty() {
+        bail!("deny_device_auth called with empty id");
     }
+
+    let mut tx = store.begin().await?;
+
+    let doc = tx.get::<DeviceAuthRequestDoc>(id).await?;
+    let Some(doc) = doc else {
+        bail!(
+            "deny_device_auth: no device auth request \
+             found with id '{}'",
+            id
+        );
+    };
+
+    if doc.data.status != DeviceAuthStatus::Pending {
+        bail!(
+            "deny_device_auth: device auth request '{}' \
+             already has status '{:?}'",
+            id,
+            doc.data.status
+        );
+    }
+
+    let mut data = doc.data;
+    data.status = DeviceAuthStatus::Denied;
+    tx.update(id, &data).await?;
+
+    tx.commit().await?;
     Ok(())
 }
 

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -526,6 +526,128 @@ async fn test_device_auth_request_doc_consumed_at_defaults_to_none() {
 }
 
 // ========================================================================
+// Device Auth Single-Use Semantics (GH#254)
+// ========================================================================
+
+#[tokio::test]
+async fn test_double_authorization_should_fail() {
+    let (store, _audit) = test_db().await;
+
+    let id = create_device_auth_request(
+        &store,
+        "dbl_auth_hash",
+        "DBLA-0001",
+        None,
+        "2099-12-31T23:59:59Z".parse().unwrap(),
+        5,
+    )
+    .await
+    .expect("create");
+
+    authorize_device_auth(&store, &id, "user_a", "a@example.com", "auth_a")
+        .await
+        .expect("first authorization should succeed");
+
+    let result = authorize_device_auth(&store, &id, "user_b", "b@example.com", "auth_b").await;
+    assert!(result.is_err(), "second authorization should fail");
+
+    // Original user must be preserved
+    let req = get_device_auth_by_id(&store, &id)
+        .await
+        .expect("get")
+        .expect("exists");
+    assert_eq!(req.status, DeviceAuthStatus::Authorized);
+    assert_eq!(req.user_id.as_deref(), Some("user_a"));
+}
+
+#[tokio::test]
+async fn test_authorize_after_deny_should_fail() {
+    let (store, _audit) = test_db().await;
+
+    let id = create_device_auth_request(
+        &store,
+        "deny_then_auth",
+        "DNYA-0001",
+        None,
+        "2099-12-31T23:59:59Z".parse().unwrap(),
+        5,
+    )
+    .await
+    .expect("create");
+
+    deny_device_auth(&store, &id).await.expect("deny succeeds");
+
+    let result = authorize_device_auth(&store, &id, "user_a", "a@example.com", "auth_a").await;
+    assert!(result.is_err(), "authorize after deny should fail");
+
+    let req = get_device_auth_by_id(&store, &id)
+        .await
+        .expect("get")
+        .expect("exists");
+    assert_eq!(req.status, DeviceAuthStatus::Denied);
+    assert!(req.user_id.is_none());
+}
+
+#[tokio::test]
+async fn test_deny_after_authorize_should_fail() {
+    let (store, _audit) = test_db().await;
+
+    let id = create_device_auth_request(
+        &store,
+        "auth_then_deny",
+        "ATDN-0001",
+        None,
+        "2099-12-31T23:59:59Z".parse().unwrap(),
+        5,
+    )
+    .await
+    .expect("create");
+
+    authorize_device_auth(&store, &id, "user_a", "a@example.com", "auth_a")
+        .await
+        .expect("authorize succeeds");
+
+    let result = deny_device_auth(&store, &id).await;
+    assert!(result.is_err(), "deny after authorize should fail");
+
+    let req = get_device_auth_by_id(&store, &id)
+        .await
+        .expect("get")
+        .expect("exists");
+    assert_eq!(req.status, DeviceAuthStatus::Authorized);
+    assert_eq!(req.user_id.as_deref(), Some("user_a"));
+}
+
+#[tokio::test]
+async fn test_double_deny_should_fail() {
+    let (store, _audit) = test_db().await;
+
+    let id = create_device_auth_request(
+        &store,
+        "dbl_deny_hash",
+        "DBLD-0001",
+        None,
+        "2099-12-31T23:59:59Z".parse().unwrap(),
+        5,
+    )
+    .await
+    .expect("create");
+
+    deny_device_auth(&store, &id)
+        .await
+        .expect("first deny should succeed");
+
+    let result = deny_device_auth(&store, &id).await;
+    assert!(result.is_err(), "second deny should fail");
+
+    let req = get_device_auth_by_id(&store, &id)
+        .await
+        .expect("get")
+        .expect("exists");
+    assert_eq!(req.status, DeviceAuthStatus::Denied);
+}
+
+// ========================================================================
 // OIDC State Tests
 // ========================================================================
 


### PR DESCRIPTION
Fixes #254

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes device authorization state transitions to hard-fail unless the request is still `Pending`, which can surface new errors in existing flows and affects an auth-related code path. Uses transactions to serialize concurrent updates, reducing race conditions but potentially altering behavior under contention.
> 
> **Overview**
> Enforces **single-use state transitions** for RFC 8628 device auth requests: `authorize_device_auth` and `deny_device_auth` now only succeed when the request status is `Pending`, otherwise they return an error and preserve the original user/status.
> 
> Both operations now run the read+update in a single DB transaction (and validate non-empty IDs) to serialize concurrent attempts. Adds regression tests covering double-authorize, double-deny, and authorize/deny ordering (GH#254).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9af2bbebe4a3e7e3fc9b6ba5f2de1eb5d509e786. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->