### PR TITLE
Properly store DPoP JTI

### DIFF
--- a/crates/vouch-server/src/db/documents/dpop.rs
+++ b/crates/vouch-server/src/db/documents/dpop.rs
@@ -39,10 +39,9 @@ impl DocumentType for DpopJtiDoc {
     const DOC_TYPE: &'static str = "dpop_jti";
 
     fn index_entries(&self) -> Vec<IndexEntry> {
-        vec![IndexEntry {
-            field: "jti",
-            value: self.jti.clone(),
-        }]
+        // No index needed — replay detection uses deterministic document IDs
+        // (PRIMARY KEY collision), not index lookups.
+        Vec::new()
     }
 
     fn expires_at(&self) -> Option<Timestamp> {

--- a/crates/vouch-server/src/db/dpop.rs
+++ b/crates/vouch-server/src/db/dpop.rs
@@ -10,6 +10,23 @@ use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use jiff::{Timestamp, ToSpan};
 
+/// Maximum JTI length.
+const MAX_JTI_LENGTH: usize = 256;
+
+/// Derive a deterministic document ID from a DPoP JTI.
+///
+/// DPoP JTIs are globally unique (RFC 9449 Section 11.1), unlike JWT
+/// assertion JTIs which are scoped per-client. The domain separator
+/// `"dpop_jti\0"` prevents cross-type ID collisions.
+fn deterministic_dpop_jti_id(jti: &str) -> String {
+    use aws_lc_rs::digest::{self, SHA256};
+
+    let mut ctx = digest::Context::new(&SHA256);
+    ctx.update(b"dpop_jti\0");
+    ctx.update(jti.as_bytes());
+    hex::encode(ctx.finish().as_ref())
+}
+
 /// Generate a random URL-safe string.
 fn generate_random_string(len: usize) -> Result<String> {
     let mut bytes = vec![0u8; len];
@@ -57,33 +74,38 @@ pub async fn validate_and_consume_dpop_nonce(store: &DocumentStore, nonce: &str)
     Ok(true)
 }
 
-/// Check if JTI exists (replay) and store it.
+/// Check if JTI exists (replay) and store it atomically.
 /// Returns `true` if new, `false` if replay.
 ///
-/// Uses the JTI as the document ID for uniqueness.
+/// Uses a deterministic document ID derived from the JTI so that
+/// concurrent inserts collide on the PRIMARY KEY constraint,
+/// preventing TOCTOU races.
 pub async fn check_and_store_dpop_jti(
     store: &DocumentStore,
     jti: &str,
     validity_seconds: i64,
 ) -> Result<bool> {
+    if jti.is_empty() {
+        return Err(anyhow::anyhow!("DPoP JTI must not be empty"));
+    }
+    if jti.len() > MAX_JTI_LENGTH {
+        return Err(anyhow::anyhow!(
+            "DPoP JTI exceeds maximum length ({MAX_JTI_LENGTH})"
+        ));
+    }
+
     let now = Timestamp::now();
     let expires_at = now
         .checked_add(validity_seconds.seconds())
         .context("DPoP JTI expiry timestamp overflow")?;
 
-    // Check if JTI already exists by looking up the index
-    let existing = store.find_one::<DpopJtiDoc>("jti", jti).await?;
-    if existing.is_some() {
-        return Ok(false);
-    }
-
+    let id = deterministic_dpop_jti_id(jti);
     let doc = DpopJtiDoc {
         jti: jti.to_string(),
         expires_at,
     };
 
-    // Insert — if a race causes a duplicate, treat as replay
-    match store.insert(&doc).await {
+    match store.insert_with_id(&id, &doc).await {
         Ok(_) => Ok(true),
         Err(e) => {
             let err_str = e.to_string();

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -2456,6 +2456,122 @@ async fn test_delete_expired_jwt_assertion_jtis() {
 }
 
 // ========================================================================
+// DPoP JTI replay prevention
+// ========================================================================
+
+#[tokio::test]
+async fn test_dpop_jti_replay_prevention() {
+    let (store, _audit) = test_db().await;
+
+    // First use returns true
+    let stored = check_and_store_dpop_jti(&store, "dpop-jti-1", 600)
+        .await
+        .expect("first store should not error");
+    assert!(stored, "First use of a JTI should be accepted");
+
+    // Replay returns false
+    let replayed = check_and_store_dpop_jti(&store, "dpop-jti-1", 600)
+        .await
+        .expect("replay check should not error");
+    assert!(!replayed, "Replay of same JTI should be rejected");
+
+    // Different JTI succeeds
+    let different = check_and_store_dpop_jti(&store, "dpop-jti-2", 600)
+        .await
+        .expect("different JTI should not error");
+    assert!(different, "Different JTI should be accepted");
+}
+
+#[tokio::test]
+async fn test_dpop_jti_empty() {
+    let (store, _audit) = test_db().await;
+
+    let result = check_and_store_dpop_jti(&store, "", 600).await;
+    assert!(result.is_err(), "Empty JTI must return an error");
+}
+
+#[tokio::test]
+async fn test_dpop_jti_too_long() {
+    let (store, _audit) = test_db().await;
+
+    let long_jti = "x".repeat(257);
+    let result = check_and_store_dpop_jti(&store, &long_jti, 600).await;
+    assert!(
+        result.is_err(),
+        "JTI exceeding max length must return an error"
+    );
+}
+
+#[tokio::test]
+async fn test_dpop_jti_at_max_length() {
+    let (store, _audit) = test_db().await;
+
+    let max_jti = "d".repeat(256);
+    let stored = check_and_store_dpop_jti(&store, &max_jti, 600)
+        .await
+        .expect("256-char JTI should not error");
+    assert!(stored, "JTI at max length should be accepted");
+
+    let replayed = check_and_store_dpop_jti(&store, &max_jti, 600)
+        .await
+        .expect("replay check should not error");
+    assert!(!replayed, "Replay of max-length JTI should be rejected");
+}
+
+#[tokio::test]
+async fn test_dpop_jti_concurrent_insert_rejects_duplicates() {
+    let (store, _audit) = test_db().await;
+    let store = Arc::new(store);
+
+    let num_tasks = 20;
+    let mut handles = Vec::with_capacity(num_tasks);
+
+    for _ in 0..num_tasks {
+        let s = Arc::clone(&store);
+        handles.push(tokio::spawn(async move {
+            check_and_store_dpop_jti(&s, "same-jti", 600).await
+        }));
+    }
+
+    let mut successes = 0u32;
+    for handle in handles {
+        let result = handle.await.expect("task should not panic");
+        if let Ok(true) = result {
+            successes += 1;
+        }
+    }
+
+    assert_eq!(
+        successes, 1,
+        "Exactly one concurrent insert should succeed, got {successes}"
+    );
+}
+
+#[tokio::test]
+async fn test_delete_expired_dpop_jtis() {
+    let (store, _audit) = test_db().await;
+
+    // Insert one with past expiry (validity_seconds=0 won't work since
+    // it computes from now; instead insert directly with short validity
+    // and rely on the fact that we can test cleanup.)
+    check_and_store_dpop_jti(&store, "valid-dpop-jti", 3600)
+        .await
+        .expect("insert valid");
+
+    // Cleanup should not delete the valid one
+    let deleted = delete_expired_dpop_jtis(&store, "")
+        .await
+        .expect("delete_expired should not error");
+    assert_eq!(deleted, 0, "No expired JTIs to delete");
+
+    // The valid one should still block replay
+    let still_blocked = check_and_store_dpop_jti(&store, "valid-dpop-jti", 3600)
+        .await
+        .expect("check");
+    assert!(!still_blocked, "Valid JTI should still block replay");
+}
+
+// ========================================================================
 // SCIM filter parsing — co / sw operators and error path
 // ========================================================================
 


### PR DESCRIPTION
Fixes #256

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches DPoP replay-prevention logic (security-sensitive) and changes how JTIs are keyed/stored, which could affect duplicate detection or cleanup behavior if the ID derivation is wrong.
> 
> **Overview**
> DPoP JTI replay prevention now stores entries using a deterministic SHA-256–derived document ID (with a domain separator) and inserts via `insert_with_id`, so concurrent requests race on the PRIMARY KEY instead of a non-atomic index lookup.
> 
> This removes the `jti` index from `DpopJtiDoc`, adds basic JTI validation (non-empty, max 256 chars), and introduces targeted tests covering replay behavior, boundary conditions, and concurrent insertion semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 637fcd7d1d514f74278acb78ca45e81a911a70b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->