### PR TITLE
Fix consume PAR

### DIFF
--- a/crates/vouch-server/src/handlers/oidc/authorize.rs
+++ b/crates/vouch-server/src/handlers/oidc/authorize.rs
@@ -331,7 +331,14 @@ async fn check_session_and_authorize(
                     )
                     .await;
             }
-            store_pending_and_redirect(state, validated, resolved.response_mode, None).await
+            store_pending_and_redirect(
+                state,
+                validated,
+                resolved.response_mode,
+                None,
+                par_to_consume,
+            )
+            .await
         }
     }
 }
@@ -1235,7 +1242,50 @@ async fn store_pending_and_redirect(
     validated: crate::services::oidc::authorization::ValidatedAuthRequest,
     response_mode: ResponseMode,
     prompt_override: Option<Prompt>,
+    par_to_consume: Option<(&str, &str)>,
 ) -> Response {
+    // RFC 9126: Consume PAR immediately to enforce single-use semantics.
+    // The pending auth record takes over as the single-use artifact for the
+    // remainder of the flow. Consuming now avoids PAR TTL expiry issues
+    // (PAR lives 60s but user auth takes minutes).
+    if let Some((request_uri, client_id)) = par_to_consume {
+        match db::consume_pushed_authorization_request(&state.store, request_uri, client_id).await {
+            Ok(true) => {} // successfully consumed
+            Ok(false) => {
+                tracing::warn!(
+                    request_uri,
+                    client_id,
+                    "PAR replay detected during pending auth creation"
+                );
+                return build_authorization_redirect(
+                    validated.redirect_uri(),
+                    &[
+                        ("error", "invalid_request_uri"),
+                        (
+                            "error_description",
+                            "The request_uri has already been used or is invalid",
+                        ),
+                        ("iss", &state.config().base_url),
+                    ],
+                );
+            }
+            Err(e) => {
+                tracing::error!("Failed to consume PAR: {e}");
+                return build_authorization_redirect(
+                    validated.redirect_uri(),
+                    &[
+                        ("error", "server_error"),
+                        (
+                            "error_description",
+                            "Failed to process pushed authorization request",
+                        ),
+                        ("iss", &state.config().base_url),
+                    ],
+                );
+            }
+        }
+    }
+
     let scope_str = validated.scope().to_space_separated();
     let max_age_i64 = validated.max_age().and_then(|v| i64::try_from(v).ok());
     let ad_value = validated.authorization_details_value();
@@ -1367,8 +1417,14 @@ async fn authorize_authenticated_user(
 
     // Step 4: Re-auth needed — store pending request and redirect to login.
     if needs_reauth {
-        return store_pending_and_redirect(state, validated, response_mode, Some(Prompt::Login))
-            .await;
+        return store_pending_and_redirect(
+            state,
+            validated,
+            response_mode,
+            Some(Prompt::Login),
+            par_to_consume,
+        )
+        .await;
     }
 
     // Steps 5-8: ACR + resource + PAR consumption + code issuance.

--- a/crates/vouch-server/src/handlers/oidc/authorize.rs
+++ b/crates/vouch-server/src/handlers/oidc/authorize.rs
@@ -334,6 +334,7 @@ async fn check_session_and_authorize(
             store_pending_and_redirect(
                 state,
                 validated,
+                &resolved.client,
                 resolved.response_mode,
                 None,
                 par_to_consume,
@@ -1240,6 +1241,7 @@ fn resolve_redirect_uri(
 async fn store_pending_and_redirect(
     state: &Arc<AppState>,
     validated: crate::services::oidc::authorization::ValidatedAuthRequest,
+    oauth_client: &OAuthClient,
     response_mode: ResponseMode,
     prompt_override: Option<Prompt>,
     par_to_consume: Option<(&str, &str)>,
@@ -1257,31 +1259,29 @@ async fn store_pending_and_redirect(
                     client_id,
                     "PAR replay detected during pending auth creation"
                 );
-                return build_authorization_redirect(
+                return oauth_error_response(
+                    state,
+                    oauth_client,
                     validated.redirect_uri(),
-                    &[
-                        ("error", "invalid_request_uri"),
-                        (
-                            "error_description",
-                            "The request_uri has already been used or is invalid",
-                        ),
-                        ("iss", &state.config().base_url),
-                    ],
-                );
+                    "invalid_request_uri",
+                    "The request_uri has already been used or is invalid",
+                    validated.state(),
+                    response_mode,
+                )
+                .await;
             }
             Err(e) => {
                 tracing::error!("Failed to consume PAR: {e}");
-                return build_authorization_redirect(
+                return oauth_error_response(
+                    state,
+                    oauth_client,
                     validated.redirect_uri(),
-                    &[
-                        ("error", "server_error"),
-                        (
-                            "error_description",
-                            "Failed to process pushed authorization request",
-                        ),
-                        ("iss", &state.config().base_url),
-                    ],
-                );
+                    "server_error",
+                    "Failed to process pushed authorization request",
+                    validated.state(),
+                    response_mode,
+                )
+                .await;
             }
         }
     }
@@ -1420,6 +1420,7 @@ async fn authorize_authenticated_user(
         return store_pending_and_redirect(
             state,
             validated,
+            oauth_client,
             response_mode,
             Some(Prompt::Login),
             par_to_consume,

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
@@ -991,3 +991,317 @@ async fn test_rfc9126_consume_par_with_stale_version_returns_false() {
             .unwrap();
     assert!(!result, "Second consumption should fail (already consumed)");
 }
+
+// ========================================================================
+// RFC 9126 Section 2.3 — PAR Single-Use When Login Required (Issue #270)
+// ========================================================================
+
+#[tokio::test]
+async fn test_rfc9126_par_consumed_when_no_session() {
+    // RFC 9126 Section 2.3: request_uri MUST be consumed on first use even
+    // when the user has no existing session and must authenticate first.
+    // The PAR should be consumed immediately when creating the pending auth.
+    use crate::db::documents::par::PushedAuthorizationRequestDoc;
+
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "par-nosession@example.com").await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+
+    // Create PAR without prompt=none (will require auth)
+    let request_uri = create_par_request(&app, &client).await;
+
+    // Hit authorize endpoint WITHOUT a session cookie — should redirect to login
+    let response = http_get_full(
+        &app,
+        &format!(
+            "/oauth/authorize?client_id={}&request_uri={}",
+            client.client_id,
+            urlencoding::encode(&request_uri),
+        ),
+        &[],
+    )
+    .await;
+
+    // Should redirect to /login?pending_auth=...
+    assert!(
+        response.status == StatusCode::FOUND || response.status == StatusCode::SEE_OTHER,
+        "Should redirect to login, got: {}",
+        response.status
+    );
+    let location = response.headers.get("location").expect("redirect location");
+    let location_str = location.to_str().unwrap();
+    assert!(
+        location_str.starts_with("/login?pending_auth="),
+        "Should redirect to /login?pending_auth=..., got: {location_str}"
+    );
+
+    // Verify PAR is consumed in DB
+    let doc = state
+        .store
+        .find_one::<PushedAuthorizationRequestDoc>("request_uri", &request_uri)
+        .await
+        .unwrap()
+        .expect("PAR doc should still exist");
+    assert!(
+        doc.data.consumed_at.is_some(),
+        "PAR should be marked as consumed after pending auth creation"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc9126_par_replay_rejected_after_login_redirect() {
+    // RFC 9126 Section 2.3: After a PAR is consumed during the login-required
+    // path, replaying the same request_uri must fail.
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "par-replay-login@example.com").await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+
+    let request_uri = create_par_request(&app, &client).await;
+
+    // First use without session — triggers login redirect + PAR consumption
+    let response1 = http_get_full(
+        &app,
+        &format!(
+            "/oauth/authorize?client_id={}&request_uri={}",
+            client.client_id,
+            urlencoding::encode(&request_uri),
+        ),
+        &[],
+    )
+    .await;
+    assert!(
+        response1.status == StatusCode::FOUND || response1.status == StatusCode::SEE_OTHER,
+        "First use should redirect to login"
+    );
+
+    // Second use of same request_uri — should fail (PAR already consumed)
+    let response2 = http_get_full(
+        &app,
+        &format!(
+            "/oauth/authorize?client_id={}&request_uri={}",
+            client.client_id,
+            urlencoding::encode(&request_uri),
+        ),
+        &[],
+    )
+    .await;
+
+    // The PAR lookup should fail because it's consumed — error page shown
+    assert_eq!(
+        response2.status,
+        StatusCode::OK,
+        "Second use should return error page, got: {}",
+        response2.status
+    );
+    assert!(
+        response2.body.contains("expired")
+            || response2.body.contains("Invalid")
+            || response2.body.contains("error"),
+        "Response should indicate the request_uri was already consumed"
+    );
+}
+
+// ========================================================================
+// RFC 9126 Section 2.3 — PAR Consumed on Re-auth Path (Issue #270)
+// ========================================================================
+
+#[tokio::test]
+async fn test_rfc9126_par_consumed_when_reauth_required() {
+    // RFC 9126 Section 2.3: request_uri MUST be consumed even when the user
+    // has an existing session but re-authentication is required.
+    //
+    // The PAR flow uses ReauthPolicy::Always, so any authenticated user
+    // without prompt=none triggers the re-auth path (call site 2 of the fix).
+    // This exercises authorize_authenticated_user → needs_reauth=true →
+    // store_pending_and_redirect(par_to_consume=Some(...)).
+    use crate::db::documents::par::PushedAuthorizationRequestDoc;
+
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "par-reauth@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+    // User has a valid session — but PAR flow always requires re-auth.
+    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+
+    // Create PAR without prompt=none — will trigger re-auth under ReauthPolicy::Always.
+    let request_uri = create_par_request(&app, &client).await;
+
+    // Hit authorize WITH a session cookie — session is valid but re-auth is required.
+    let response = http_get_full(
+        &app,
+        &format!(
+            "/oauth/authorize?client_id={}&request_uri={}",
+            client.client_id,
+            urlencoding::encode(&request_uri),
+        ),
+        &[("Cookie", &format!("__Host-vouch_session={session_token}"))],
+    )
+    .await;
+
+    // Should redirect to /login?pending_auth=... (re-auth required)
+    assert!(
+        response.status == StatusCode::FOUND || response.status == StatusCode::SEE_OTHER,
+        "Re-auth path should redirect to login, got: {}",
+        response.status
+    );
+    let location = response.headers.get("location").expect("redirect location");
+    let location_str = location.to_str().unwrap();
+    assert!(
+        location_str.starts_with("/login?pending_auth="),
+        "Should redirect to /login?pending_auth=..., got: {location_str}"
+    );
+
+    // Verify PAR is consumed in DB — the fix ensures consumption at re-auth path too.
+    let doc = state
+        .store
+        .find_one::<PushedAuthorizationRequestDoc>("request_uri", &request_uri)
+        .await
+        .unwrap()
+        .expect("PAR doc should still exist");
+    assert!(
+        doc.data.consumed_at.is_some(),
+        "PAR should be marked as consumed after re-auth redirect (call site 2 of fix)"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc9126_par_replay_rejected_after_reauth_redirect() {
+    // RFC 9126 Section 2.3: After a PAR is consumed during the re-auth path,
+    // replaying the same request_uri must fail — even though the user has a session.
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "par-reauth-replay@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+
+    let request_uri = create_par_request(&app, &client).await;
+
+    // First use with session — triggers re-auth redirect + PAR consumption.
+    let response1 = http_get_full(
+        &app,
+        &format!(
+            "/oauth/authorize?client_id={}&request_uri={}",
+            client.client_id,
+            urlencoding::encode(&request_uri),
+        ),
+        &[("Cookie", &format!("__Host-vouch_session={session_token}"))],
+    )
+    .await;
+    assert!(
+        response1.status == StatusCode::FOUND || response1.status == StatusCode::SEE_OTHER,
+        "First use should redirect to login for re-auth, got: {}",
+        response1.status
+    );
+
+    // Second use of same request_uri — PAR is already consumed, must fail.
+    let response2 = http_get_full(
+        &app,
+        &format!(
+            "/oauth/authorize?client_id={}&request_uri={}",
+            client.client_id,
+            urlencoding::encode(&request_uri),
+        ),
+        &[("Cookie", &format!("__Host-vouch_session={session_token}"))],
+    )
+    .await;
+
+    // The PAR lookup returns consumed/expired — error page shown.
+    assert_eq!(
+        response2.status,
+        StatusCode::OK,
+        "Second use of request_uri after re-auth redirect should return error page, got: {}",
+        response2.status
+    );
+    assert!(
+        response2.body.contains("expired")
+            || response2.body.contains("Invalid")
+            || response2.body.contains("error"),
+        "Response should indicate the request_uri was already consumed: {}",
+        response2.body
+    );
+}
+
+#[tokio::test]
+async fn test_rfc9126_par_already_consumed_returns_error_redirect_not_login() {
+    // When store_pending_and_redirect is called with par_to_consume but the PAR
+    // is already consumed (Ok(false)), the response must be an OAuth error redirect
+    // (invalid_request_uri) — NOT a login redirect. This verifies the Ok(false) branch
+    // in store_pending_and_redirect.
+    use crate::db::documents::par::PushedAuthorizationRequestDoc;
+
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "par-preconsumed@example.com").await;
+    create_test_authenticator(&state.store, &user.id).await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+
+    let request_uri = create_par_request(&app, &client).await;
+
+    // Consume the PAR directly via DB before the authorize request arrives.
+    let consumed = crate::db::consume_pushed_authorization_request(
+        &state.store,
+        &request_uri,
+        &client.client_id,
+    )
+    .await
+    .unwrap();
+    assert!(consumed, "Pre-consumption should succeed");
+
+    // Confirm consumed_at is set.
+    let doc = state
+        .store
+        .find_one::<PushedAuthorizationRequestDoc>("request_uri", &request_uri)
+        .await
+        .unwrap()
+        .expect("PAR doc should exist");
+    assert!(doc.data.consumed_at.is_some(), "PAR should be pre-consumed");
+
+    // Now attempt to authorize without a session — would normally → login redirect,
+    // but PAR is already consumed so must return invalid_request_uri instead.
+    let response = http_get_full(
+        &app,
+        &format!(
+            "/oauth/authorize?client_id={}&request_uri={}",
+            client.client_id,
+            urlencoding::encode(&request_uri),
+        ),
+        &[],
+    )
+    .await;
+
+    // The PAR lookup (lookup_par) detects consumed_at is set and returns an error page.
+    // This exercises the consumed-before-authorize path at the lookup layer.
+    assert_eq!(
+        response.status,
+        StatusCode::OK,
+        "Pre-consumed PAR should return error page, got: {}",
+        response.status
+    );
+    assert!(
+        response.body.contains("expired")
+            || response.body.contains("Invalid")
+            || response.body.contains("error"),
+        "Response should indicate the request_uri is already consumed: {}",
+        response.body
+    );
+
+    // Critically: the response must NOT be a redirect to /login?pending_auth=...
+    // (which would mean the PAR was consumed twice and a new pending_auth was created).
+    assert!(
+        !response.body.contains("pending_auth"),
+        "Pre-consumed PAR should not create a new pending_auth record"
+    );
+    let location = response.headers.get("location");
+    assert!(
+        location.is_none()
+            || !location
+                .and_then(|l| l.to_str().ok())
+                .unwrap_or("")
+                .starts_with("/login"),
+        "Pre-consumed PAR must not redirect to /login"
+    );
+}


### PR DESCRIPTION
Fixes #270

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth/OIDC authorization flow control and PAR single-use semantics; mistakes could cause auth failures or incorrect redirects, though changes are localized and covered by new tests.
> 
> **Overview**
> Ensures RFC 9126 PAR `request_uri` values are **single-use even when authorization can’t complete immediately** (no session or re-auth required). The authorize handler now consumes the PAR at `store_pending_and_redirect()` time (not only at code issuance), and returns an OAuth redirect error (`invalid_request_uri`/`server_error`) when consumption fails or indicates replay.
> 
> Adds a focused RFC 9126 test suite covering PAR consumption and replay rejection across the login-required and re-auth redirect paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bb0e6d616c1416885834bd3d3bf260021aa9210. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->