### PR TITLE
better unique violation checks

### DIFF
--- a/crates/vouch-server/src/db/dpop.rs
+++ b/crates/vouch-server/src/db/dpop.rs
@@ -108,11 +108,7 @@ pub async fn check_and_store_dpop_jti(
     match store.insert_with_id(&id, &doc).await {
         Ok(_) => Ok(true),
         Err(e) => {
-            let err_str = e.to_string();
-            if err_str.contains("UNIQUE")
-                || err_str.contains("duplicate key")
-                || err_str.contains("PRIMARY KEY")
-            {
+            if super::pool::is_unique_violation(&e) {
                 Ok(false)
             } else {
                 Err(e)

--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -852,8 +852,7 @@ pub async fn store_jwt_assertion_jti(
     match store.insert_with_id(&id, &doc).await {
         Ok(_) => Ok(true),
         Err(e) => {
-            let err_str = e.to_string();
-            if err_str.contains("UNIQUE") || err_str.contains("duplicate key") {
+            if super::pool::is_unique_violation(&e) {
                 Ok(false)
             } else {
                 Err(e)

--- a/crates/vouch-server/src/db/pool.rs
+++ b/crates/vouch-server/src/db/pool.rs
@@ -787,6 +787,20 @@ pub(crate) fn is_retryable_db_error(err: &anyhow::Error) -> bool {
     false
 }
 
+/// Check whether an error is a unique/primary-key constraint violation.
+///
+/// Downcasts through `anyhow::Error` → `sqlx::Error::Database` and
+/// inspects the structured error kind. Covers both UNIQUE and PRIMARY KEY
+/// constraints across SQLite, PostgreSQL, and Aurora DSQL.
+pub(crate) fn is_unique_violation(err: &anyhow::Error) -> bool {
+    if let Some(sqlx_err) = err.downcast_ref::<sqlx::Error>()
+        && let sqlx::Error::Database(db_err) = sqlx_err
+    {
+        return db_err.is_unique_violation();
+    }
+    false
+}
+
 /// Compute a jittered exponential backoff duration for the given attempt.
 ///
 /// Base delay doubles each attempt (~100ms, ~200ms, ~400ms) with ±25% jitter.
@@ -884,6 +898,12 @@ mod tests {
     fn test_is_retryable_db_error_non_db() {
         let err = anyhow::anyhow!("some random error");
         assert!(!is_retryable_db_error(&err));
+    }
+
+    #[test]
+    fn test_is_unique_violation_non_db() {
+        let err = anyhow::anyhow!("some random error");
+        assert!(!is_unique_violation(&err));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #271

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small refactor to error classification for insert collisions, with behavior unchanged except for more reliable detection across DB backends.
> 
> **Overview**
> Improves replay-prevention insert handling for DPoP and JWT-assertion JTIs by replacing string-matching of database error messages with a structured unique/primary-key constraint check.
> 
> Adds `pool::is_unique_violation()` (with a basic unit test) and uses it to consistently treat duplicate JTI inserts as a non-error (`Ok(false)`) across SQLite/Postgres/Aurora DSQL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a731a0c2dc0b03ad1580d7387404439e221814f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->