### PR TITLE
Fix authenticator reuse

### DIFF
--- a/crates/vouch-server/src/handlers/oidc/tests/rfc6749_token.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc6749_token.rs
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! RFC 6749 — Token endpoint basics and error format tests.
+//!
+//! GH#272 regression tests are also housed here: an authorization code whose
+//! authenticator has been deleted must return `invalid_grant` at the token
+//! endpoint instead of issuing a token.
 
 use super::helpers::*;
 
@@ -284,5 +288,80 @@ async fn test_rfc6749_token_response_no_error_field_on_success() {
     assert!(
         response.get("error_description").is_none(),
         "RFC 6749 §5.1: Successful response must NOT contain 'error_description'"
+    );
+}
+
+// ========================================================================
+// GH#272 — Revoked authenticator blocks code exchange
+// ========================================================================
+
+/// Regression test for GH#272: an authorization code that embeds an
+/// `authenticator_id` for an authenticator that has since been
+/// deleted/revoked must return `invalid_grant` at the token endpoint.
+///
+/// Before the fix, `exchange_authorization_code` looked up the user and
+/// enforced single-use but never verified that the authenticator still
+/// existed.  An attacker (or a stale code in flight) could therefore redeem
+/// a code issued for a revoked key and receive a live access token.
+#[tokio::test]
+async fn test_token_exchange_rejects_revoked_authenticator() {
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "revoked-auth@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+
+    let scope_set = ScopeSet::parse("openid email");
+    let code = issue_authorization_code(
+        &state,
+        AuthorizationCodeParams {
+            client_id: &client.client_id,
+            redirect_uri: "https://example.com/callback",
+            user_id: &user.id,
+            email: &user.email,
+            authenticator_id: &auth_id,
+            aaguid: None,
+            scope: &scope_set,
+            nonce: None,
+            code_challenge: None,
+            code_challenge_method: None,
+            resource: None,
+            acr_values: None,
+            dpop_jkt: None,
+            auth_code_lifetime_seconds:
+                crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
+            authorization_details: None,
+            auth_time: None,
+        },
+    )
+    .await
+    .expect("Failed to issue authorization code");
+
+    // Revoke the authenticator between code issuance and code exchange.
+    db::delete_authenticator(&state.store, &auth_id)
+        .await
+        .expect("Failed to delete authenticator");
+
+    let auth_header = client.basic_auth_header();
+    let (status, body) = http_post_form(
+        &app,
+        "/oauth/token",
+        &format!(
+            "grant_type=authorization_code&code={}&redirect_uri=https://example.com/callback",
+            code
+        ),
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "Revoked authenticator must return 400, got: {body}"
+    );
+    let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(
+        error["error"], "invalid_grant",
+        "Revoked authenticator must return invalid_grant, got: {body}"
     );
 }

--- a/crates/vouch-server/src/services/oidc/token.rs
+++ b/crates/vouch-server/src/services/oidc/token.rs
@@ -216,6 +216,15 @@ pub async fn exchange_authorization_code(
         ));
     }
 
+    // Reject tokens for revoked/deleted authenticators (GH#272)
+    let _authenticator = db::get_authenticator_by_id(&state.store, &auth_code.authenticator_id)
+        .await
+        .map_err(|e| ServiceError::Internal(e.to_string()))?
+        .ok_or(ServiceError::oauth(
+            OAuthErrorCode::InvalidGrant,
+            "Authenticator not found",
+        ))?;
+
     // RFC 6749 Section 10.5: Enforce single-use authorization codes.
     let code_hash = hash_token(params.code);
     enforce_single_use_code(state, &code_hash, &auth_code).await?;

--- a/crates/vouch-server/src/services/oidc/token.rs
+++ b/crates/vouch-server/src/services/oidc/token.rs
@@ -201,6 +201,12 @@ pub async fn exchange_authorization_code(
     // Decode and validate the authorization code
     let auth_code = decode_authorization_code(state, params.code, params.client_id).await?;
 
+    // RFC 6749 Section 10.5: Enforce single-use authorization codes.
+    // This MUST happen before any other validation to ensure codes are always
+    // consumed, enabling replay detection regardless of subsequent check outcomes.
+    let code_hash = hash_token(params.code);
+    enforce_single_use_code(state, &code_hash, &auth_code).await?;
+
     // Reject deactivated users before issuing tokens
     let user = db::get_user_by_id(&state.store, &auth_code.user_id)
         .await
@@ -224,10 +230,6 @@ pub async fn exchange_authorization_code(
             OAuthErrorCode::InvalidGrant,
             "Authenticator not found",
         ))?;
-
-    // RFC 6749 Section 10.5: Enforce single-use authorization codes.
-    let code_hash = hash_token(params.code);
-    enforce_single_use_code(state, &code_hash, &auth_code).await?;
 
     // RFC 6749 Section 4.1.3: Authenticate the client (if credentials provided)
     let authenticated_client =


### PR DESCRIPTION
Fixes #272

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the token issuance path by reordering/adding validation during `exchange_authorization_code`, which could change error behavior for some edge cases. Scope is small and covered by a new regression test, but it is security-sensitive code.
> 
> **Overview**
> Prevents exchanging an authorization code into tokens when the `authenticator_id` embedded in the code has since been deleted/revoked, returning `invalid_grant` instead (fix for GH#272).
> 
> Also reorders validation in `exchange_authorization_code` so the single-use code consumption happens immediately after decoding, and adds a token-endpoint regression test that revokes the authenticator between code issuance and exchange.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6fe95baa44090c5d701bac4a4339f02e0194792. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->