### PR TITLE
Fix OIDC revoke

### DIFF
--- a/crates/vouch-server/src/handlers/oidc/introspect.rs
+++ b/crates/vouch-server/src/handlers/oidc/introspect.rs
@@ -11,7 +11,8 @@ use crate::services::oidc::introspection::{
     IntrospectionResult, introspect_token as svc_introspect, revoke_token as svc_revoke,
     wrap_introspection_jwt,
 };
-use crate::services::oidc::token::authenticate_client;
+use crate::services::oidc::jwt_bearer::commit_jti;
+use crate::services::oidc::token::ClientAuthError;
 use axum::{
     Json,
     extract::State,
@@ -22,9 +23,7 @@ use secrecy::SecretString;
 use serde::Deserialize;
 use std::sync::Arc;
 
-use super::client_auth::{
-    ClientAuthFields, authenticate_client_any, extract_client_auth, extract_client_credentials,
-};
+use super::client_auth::{ClientAuthFields, authenticate_client_any, extract_client_auth};
 
 /// Token revocation request (RFC 7009 Section 2.1).
 ///
@@ -73,8 +72,8 @@ impl ClientAuthFields for RevokeRequest {
 
 /// Token introspection request (RFC 7662 Section 2.1).
 ///
-/// Also accepts `client_id`/`client_secret` for `client_secret_post` authentication
-/// (RFC 6749 Section 2.3.1).
+/// Supports `client_secret_basic`, `client_secret_post`, and `private_key_jwt`
+/// (RFC 7523) client authentication methods.
 #[derive(Debug, Deserialize)]
 pub struct IntrospectRequest {
     /// RFC 7662 Section 2.1: The string value of the token.
@@ -89,6 +88,31 @@ pub struct IntrospectRequest {
     /// Wrapped in `SecretString` to prevent accidental logging and ensure zeroization on drop.
     #[serde(default)]
     client_secret: Option<SecretString>,
+    /// RFC 7521 Section 4.2: JWT assertion for `private_key_jwt` authentication.
+    #[serde(default)]
+    client_assertion: Option<String>,
+    /// RFC 7521 Section 4.2: Assertion type (must be
+    /// `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`).
+    #[serde(default)]
+    client_assertion_type: Option<String>,
+}
+
+impl ClientAuthFields for IntrospectRequest {
+    fn client_id(&self) -> Option<&str> {
+        self.client_id.as_deref()
+    }
+
+    fn client_secret(&self) -> Option<SecretString> {
+        self.client_secret.clone()
+    }
+
+    fn client_assertion(&self) -> Option<&str> {
+        self.client_assertion.as_deref()
+    }
+
+    fn client_assertion_type(&self) -> Option<&str> {
+        self.client_assertion_type.as_deref()
+    }
 }
 
 /// POST /oauth/revoke
@@ -109,8 +133,8 @@ pub async fn revoke(
         Err(response) => return response,
     };
 
-    let caller_client_id = match authenticate_client_any(&state, auth).await {
-        Ok(Some((_client, client_id, _jti))) => client_id,
+    let (caller_client_id, pending_jti) = match authenticate_client_any(&state, auth).await {
+        Ok(Some((_client, client_id, jti))) => (client_id, jti),
         Ok(None) => {
             // No credentials provided → 401
             return (StatusCode::UNAUTHORIZED, [("www-authenticate", "Basic")]).into_response();
@@ -126,6 +150,23 @@ pub async fn revoke(
         &caller_client_id,
     )
     .await;
+
+    // Commit JTI after revocation so clients can retry on failure.
+    if let Some(ref jti) = pending_jti {
+        match commit_jti(&state, jti).await {
+            Ok(()) => {}
+            Err(ClientAuthError::InvalidCredentials) => {
+                // JTI was already used — reject so the client generates a new assertion.
+                return StatusCode::UNAUTHORIZED.into_response();
+            }
+            Err(e) => {
+                // Transient DB error. Revocation already succeeded — return 200
+                // per RFC 7009 §2 and log for ops visibility.
+                tracing::warn!("JTI commit failed for revoke (revocation succeeded): {e:?}");
+            }
+        }
+    }
+
     // Always return 200 per RFC 7009 Section 2 (for valid clients)
     StatusCode::OK.into_response()
 }
@@ -133,7 +174,8 @@ pub async fn revoke(
 /// POST /oauth/introspect
 ///
 /// Introspect a token (RFC 7662).
-/// Requires client authentication via `Authorization: Basic` header or body credentials.
+/// Requires client authentication via `Authorization: Basic` header, body
+/// credentials, or `private_key_jwt` (RFC 7523).
 /// Returns token metadata if valid, or `{"active": false}` if invalid or auth fails.
 pub async fn introspect(
     State(state): State<Arc<AppState>>,
@@ -141,21 +183,19 @@ pub async fn introspect(
     axum::Form(params): axum::Form<IntrospectRequest>,
 ) -> Response {
     // RFC 7662 Section 2.1: The introspection endpoint MUST authenticate the caller.
-    // Supports both client_secret_basic (header) and client_secret_post (body).
-    let credentials =
-        extract_client_credentials(&headers, params.client_id.as_deref(), params.client_secret);
-    let authenticated_client = match credentials {
-        Some(creds) => match authenticate_client(&state, &creds).await {
-            Ok(c) => c.client,
-            Err(_) => {
-                // RFC 7662 §2.1: Invalid client credentials → 401
-                return (StatusCode::UNAUTHORIZED, [("www-authenticate", "Basic")]).into_response();
-            }
-        },
-        None => {
+    // Supports client_secret_basic, client_secret_post, and private_key_jwt.
+    let auth = match extract_client_auth(&headers, &params) {
+        Ok(auth) => auth,
+        Err(response) => return response,
+    };
+
+    let (authenticated_client, pending_jti) = match authenticate_client_any(&state, auth).await {
+        Ok(Some((client, _client_id, jti))) => (client.client, jti),
+        Ok(None) => {
             // No credentials provided → 401
             return (StatusCode::UNAUTHORIZED, [("www-authenticate", "Basic")]).into_response();
         }
+        Err(response) => return response,
     };
 
     let wants_jwt = authenticated_client
@@ -176,6 +216,23 @@ pub async fn introspect(
         Ok(r) => r,
         Err(_) => IntrospectionResult::inactive(),
     };
+
+    // Commit JTI after introspection so clients can retry on failure.
+    if let Some(ref jti) = pending_jti {
+        match commit_jti(&state, jti).await {
+            Ok(()) => {}
+            Err(ClientAuthError::InvalidCredentials) => {
+                // JTI was already used — reject so the client generates a new assertion.
+                return StatusCode::UNAUTHORIZED.into_response();
+            }
+            Err(e) => {
+                // Transient DB error. Introspection already succeeded — return the
+                // result per defense-in-depth: prefer denying replay over dropping
+                // a valid response. Log for ops visibility.
+                tracing::warn!("JTI commit failed for introspect (returning result anyway): {e:?}");
+            }
+        }
+    }
 
     if wants_jwt {
         // RFC 9701: Return a signed JWT with Content-Type: application/token-introspection+jwt

--- a/crates/vouch-server/src/handlers/oidc/tests/helpers.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/helpers.rs
@@ -98,6 +98,118 @@ pub(super) async fn issue_oauth_access_token_with_scope(
     (access_token, id_token)
 }
 
+// ========================================================================
+// JWT Client Authentication Helpers (shared across rfc7009, rfc7523, rfc7662)
+// ========================================================================
+
+pub(super) use aws_lc_rs::signature::{ECDSA_P256_SHA256_FIXED_SIGNING, EcdsaKeyPair};
+
+/// Generate an ES256 signing key pair. Returns (pkcs8_bytes, JWK public key).
+pub(super) fn generate_es256_signing_key() -> (Vec<u8>, serde_json::Value) {
+    use aws_lc_rs::signature::KeyPair;
+
+    let rng = aws_lc_rs::rand::SystemRandom::new();
+    let pkcs8 = EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &rng)
+        .expect("Failed to generate key");
+    let key_pair = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, pkcs8.as_ref())
+        .expect("Failed to parse key");
+
+    let pub_bytes = key_pair.public_key().as_ref();
+    let x = URL_SAFE_NO_PAD.encode(&pub_bytes[1..33]);
+    let y = URL_SAFE_NO_PAD.encode(&pub_bytes[33..65]);
+
+    let jwk = serde_json::json!({
+        "kty": "EC",
+        "crv": "P-256",
+        "x": x,
+        "y": y,
+        "use": "sig",
+        "alg": "ES256",
+        "kid": "test-key-1"
+    });
+
+    (pkcs8.as_ref().to_vec(), jwk)
+}
+
+/// Sign a JWT assertion with an ES256 key (pkcs8 bytes).
+pub(super) fn sign_jwt_assertion(
+    pkcs8_bytes: &[u8],
+    header: &serde_json::Value,
+    claims: &serde_json::Value,
+) -> String {
+    let key_pair = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, pkcs8_bytes)
+        .expect("Failed to parse key");
+
+    let header_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(header).unwrap());
+    let claims_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(claims).unwrap());
+    let signing_input = format!("{header_b64}.{claims_b64}");
+
+    let rng = aws_lc_rs::rand::SystemRandom::new();
+    let sig = key_pair
+        .sign(&rng, signing_input.as_bytes())
+        .expect("Failed to sign");
+    let sig_b64 = URL_SAFE_NO_PAD.encode(sig.as_ref());
+
+    format!("{header_b64}.{claims_b64}.{sig_b64}")
+}
+
+/// Create a test OAuth client configured for `private_key_jwt` auth with inline JWKS.
+/// Returns (TestOAuthClient, pkcs8_bytes) where pkcs8_bytes is the ES256 signing key.
+pub(super) async fn create_test_jwt_client(
+    store: &db::store::DocumentStore,
+    user_id: &str,
+) -> (TestOAuthClient, Vec<u8>) {
+    let (pkcs8_bytes, jwk) = generate_es256_signing_key();
+
+    let client = create_test_oauth_client(store, user_id).await;
+
+    let oauth_client = db::get_oauth_client_by_client_id(store, &client.client_id)
+        .await
+        .expect("DB error")
+        .expect("Client not found");
+
+    let jwks_value = serde_json::json!({
+        "keys": [jwk]
+    });
+    db::update_oauth_client_jwks(store, &oauth_client.id, &jwks_value)
+        .await
+        .expect("Failed to set JWKS");
+
+    db::update_oauth_client_auth_method(store, &oauth_client.id, "private_key_jwt")
+        .await
+        .expect("Failed to set auth method");
+
+    (client, pkcs8_bytes)
+}
+
+/// Build a JWT assertion for `private_key_jwt` client auth (RFC 7523 Section 2.2).
+pub(super) fn build_client_assertion(
+    client_id: &str,
+    audience: &str,
+    pkcs8_bytes: &[u8],
+    jti: Option<&str>,
+) -> String {
+    let now = jiff::Timestamp::now().as_second();
+    let header = serde_json::json!({
+        "alg": "ES256",
+        "typ": "JWT",
+        "kid": "test-key-1"
+    });
+    let mut claims = serde_json::json!({
+        "iss": client_id,
+        "sub": client_id,
+        "aud": audience,
+        "iat": now,
+        "exp": now + 60
+    });
+    if let Some(jti_val) = jti {
+        claims["jti"] = serde_json::json!(jti_val);
+    } else {
+        claims["jti"] = serde_json::json!(uuid::Uuid::now_v7().to_string());
+    }
+    sign_jwt_assertion(pkcs8_bytes, &header, &claims)
+}
+
 /// Decode a JWT payload (middle part) without signature verification.
 pub(super) fn decode_jwt_payload(token: &str) -> serde_json::Value {
     let parts: Vec<&str> = token.split('.').collect();

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7009.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7009.rs
@@ -441,3 +441,90 @@ async fn test_rfc7009_cross_client_revocation_blocked() {
         "Cross-client revocation must not revoke the token"
     );
 }
+
+// ========================================================================
+// RFC 7009 — Token Revocation with private_key_jwt (GH#274)
+// ========================================================================
+
+#[tokio::test]
+async fn test_rfc7009_revoke_with_private_key_jwt_succeeds() {
+    // RFC 7009 + RFC 7523: Revocation with private_key_jwt authentication.
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "revoke-jwt@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let (jwt_client, pkcs8_bytes) = create_test_jwt_client(&state.store, &user.id).await;
+
+    // Issue a token via a separate client_secret client (to have a token to revoke)
+    let secret_client = create_test_oauth_client(&state.store, &user.id).await;
+    let (token, _) = issue_oauth_access_token(&app, &state, &user, &auth_id, &secret_client).await;
+
+    // Revoke using private_key_jwt with aud=/oauth/revoke
+    let revoke_url = format!("{}/oauth/revoke", state.config().base_url);
+    let assertion = build_client_assertion(&jwt_client.client_id, &revoke_url, &pkcs8_bytes, None);
+
+    let body = format!(
+        "token={}&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={}",
+        token, assertion
+    );
+
+    let (status, _) = http_post_form(&app, "/oauth/revoke", &body, &[]).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "Revocation with private_key_jwt must return 200"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc7009_revoke_private_key_jwt_jti_replay_rejected() {
+    // GH#274: Replayed JWT assertion at /oauth/revoke must be rejected.
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "revoke-replay@example.com").await;
+    let (jwt_client, pkcs8_bytes) = create_test_jwt_client(&state.store, &user.id).await;
+
+    let revoke_url = format!("{}/oauth/revoke", state.config().base_url);
+    let fixed_jti = "revoke-replay-jti-001";
+
+    // First revocation with a fixed JTI — should return 200
+    let assertion1 = build_client_assertion(
+        &jwt_client.client_id,
+        &revoke_url,
+        &pkcs8_bytes,
+        Some(fixed_jti),
+    );
+    let body1 = format!(
+        "token=some_token\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={}",
+        assertion1
+    );
+    let (status1, _) = http_post_form(&app, "/oauth/revoke", &body1, &[]).await;
+    assert_eq!(
+        status1,
+        StatusCode::OK,
+        "First use of JTI at revoke must return 200"
+    );
+
+    // Second revocation with the SAME JTI — must be rejected (replay)
+    let assertion2 = build_client_assertion(
+        &jwt_client.client_id,
+        &revoke_url,
+        &pkcs8_bytes,
+        Some(fixed_jti),
+    );
+    let body2 = format!(
+        "token=some_other_token\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={}",
+        assertion2
+    );
+    let (status2, _) = http_post_form(&app, "/oauth/revoke", &body2, &[]).await;
+    assert_eq!(
+        status2,
+        StatusCode::UNAUTHORIZED,
+        "Replayed JTI at revoke must be rejected with 401"
+    );
+}

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7662.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7662.rs
@@ -481,3 +481,152 @@ async fn test_rfc7662_same_client_introspection_returns_active() {
         "Active introspection must include iat"
     );
 }
+
+// ========================================================================
+// RFC 7662 — Token Introspection with private_key_jwt (GH#274)
+// ========================================================================
+
+#[tokio::test]
+async fn test_rfc7662_introspect_with_private_key_jwt_succeeds() {
+    // RFC 7662 + RFC 7523: Introspection with private_key_jwt authentication.
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "introspect-jwt@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let (jwt_client, pkcs8_bytes) = create_test_jwt_client(&state.store, &user.id).await;
+
+    // Issue a token for the JWT client via auth code flow
+
+    let scope_set = ScopeSet::parse("openid email");
+    let code = issue_authorization_code(
+        &state,
+        AuthorizationCodeParams {
+            client_id: &jwt_client.client_id,
+            redirect_uri: "https://example.com/callback",
+            user_id: &user.id,
+            email: &user.email,
+            authenticator_id: &auth_id,
+            aaguid: None,
+            scope: &scope_set,
+            nonce: None,
+            code_challenge: None,
+            code_challenge_method: None,
+            resource: None,
+            acr_values: None,
+            dpop_jkt: None,
+            auth_code_lifetime_seconds:
+                crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
+            authorization_details: None,
+            auth_time: None,
+        },
+    )
+    .await
+    .expect("Failed to issue code");
+
+    // Exchange code using private_key_jwt
+    let token_url = format!("{}/oauth/token", state.config().base_url);
+    let assertion = build_client_assertion(&jwt_client.client_id, &token_url, &pkcs8_bytes, None);
+    let token_body = format!(
+        "grant_type=authorization_code&code={}&redirect_uri={}\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={}",
+        code,
+        urlencoding::encode("https://example.com/callback"),
+        assertion
+    );
+    let (status, resp_body) = http_post_form(&app, "/oauth/token", &token_body, &[]).await;
+    assert_eq!(status, StatusCode::OK, "Token exchange failed: {resp_body}");
+    let token_resp: serde_json::Value = serde_json::from_str(&resp_body).expect("Valid JSON");
+    let access_token = token_resp["access_token"].as_str().expect("access_token");
+
+    // Introspect using private_key_jwt with aud=/oauth/introspect
+    let introspect_url = format!("{}/oauth/introspect", state.config().base_url);
+    let intro_assertion =
+        build_client_assertion(&jwt_client.client_id, &introspect_url, &pkcs8_bytes, None);
+    let intro_body = format!(
+        "token={}&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={}",
+        access_token, intro_assertion
+    );
+    let (status, body) = http_post_form(&app, "/oauth/introspect", &intro_body, &[]).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "Introspection with private_key_jwt failed: {body}"
+    );
+    let result: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(
+        result["active"], true,
+        "Token should be active via private_key_jwt introspection"
+    );
+    assert!(result.get("sub").is_some(), "Active token must have sub");
+    assert!(result.get("exp").is_some(), "Active token must have exp");
+}
+
+#[tokio::test]
+async fn test_rfc7662_introspect_private_key_jwt_jti_replay_rejected() {
+    // GH#274: Replayed JWT assertion at /oauth/introspect must be rejected.
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "introspect-replay@example.com").await;
+    let (jwt_client, pkcs8_bytes) = create_test_jwt_client(&state.store, &user.id).await;
+
+    let introspect_url = format!("{}/oauth/introspect", state.config().base_url);
+    let fixed_jti = "introspect-replay-jti-001";
+
+    // First introspection with a fixed JTI — should return 200
+    let assertion1 = build_client_assertion(
+        &jwt_client.client_id,
+        &introspect_url,
+        &pkcs8_bytes,
+        Some(fixed_jti),
+    );
+    let body1 = format!(
+        "token=some_token\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={}",
+        assertion1
+    );
+    let (status1, _) = http_post_form(&app, "/oauth/introspect", &body1, &[]).await;
+    assert_eq!(
+        status1,
+        StatusCode::OK,
+        "First use of JTI at introspect must return 200"
+    );
+
+    // Second introspection with the SAME JTI — must be rejected (replay)
+    let assertion2 = build_client_assertion(
+        &jwt_client.client_id,
+        &introspect_url,
+        &pkcs8_bytes,
+        Some(fixed_jti),
+    );
+    let body2 = format!(
+        "token=another_token\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={}",
+        assertion2
+    );
+    let (status2, _) = http_post_form(&app, "/oauth/introspect", &body2, &[]).await;
+    assert_eq!(
+        status2,
+        StatusCode::UNAUTHORIZED,
+        "Replayed JTI at introspect must be rejected with 401"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc7662_introspect_private_key_jwt_invalid_assertion_rejected() {
+    // Invalid client assertion at /oauth/introspect must be rejected.
+    let (app, _state) = test_app().await;
+
+    let body = "token=some_token\
+        &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+        &client_assertion=invalid.jwt.value";
+
+    let (status, _) = http_post_form(&app, "/oauth/introspect", body, &[]).await;
+    assert!(
+        status == StatusCode::UNAUTHORIZED || status == StatusCode::BAD_REQUEST,
+        "Invalid JWT assertion at introspect must be rejected, got: {status}"
+    );
+}

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 /// Call [`commit_jti`] after the full request succeeds to prevent replay.
 /// If the request fails with a retryable error (e.g., `use_dpop_nonce`),
 /// drop this without committing so the client can retry.
+#[must_use = "JTI must be committed via commit_jti() after the request succeeds"]
 pub struct PendingJti {
     jti: Option<String>,
     client_id: String,
@@ -37,7 +38,7 @@ pub async fn commit_jti(
     };
     let expires_at = Timestamp::now()
         .checked_add(pending.max_lifetime.seconds())
-        .unwrap_or_else(|_| Timestamp::now());
+        .map_err(|e| ClientAuthError::DatabaseError(e.to_string()))?;
 
     let is_new = db::store_jwt_assertion_jti(&state.store, jti, &pending.client_id, expires_at)
         .await
@@ -180,6 +181,7 @@ pub async fn authenticate_client_jwt(
     let token_endpoint_url = format!("{base_url}/oauth/token");
     let revoke_endpoint_url = format!("{base_url}/oauth/revoke");
     let par_endpoint_url = format!("{base_url}/oauth/par");
+    let introspect_endpoint_url = format!("{base_url}/oauth/introspect");
 
     let allowed_audiences: Vec<&str> = if client.is_fapi() {
         vec![base_url]
@@ -188,6 +190,7 @@ pub async fn authenticate_client_jwt(
             &token_endpoint_url,
             &revoke_endpoint_url,
             &par_endpoint_url,
+            &introspect_endpoint_url,
             base_url,
         ]
     };


### PR DESCRIPTION
Fixes #274

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth client authentication for `/oauth/revoke` and `/oauth/introspect`, adding `private_key_jwt` support and new JTI commit/replay behavior that can affect client compatibility and security-critical flows.
> 
> **Overview**
> Updates `/oauth/revoke` and `/oauth/introspect` handlers to use the shared client-auth extraction path and **add `private_key_jwt` (RFC 7523) authentication** alongside `client_secret_basic`/`client_secret_post`.
> 
> Adds **post-success JTI commitment** for JWT assertions on both endpoints to prevent replay (401 on reused JTI, warn+continue on transient DB errors), and extends JWT assertion audience validation to accept `/oauth/introspect`.
> 
> Expands OIDC test coverage with reusable JWT-auth helpers plus new RFC 7009/7662 tests for `private_key_jwt` success, invalid assertions, and JTI replay rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77ebd56fd2a436a94bb532683d784d90ee85fc82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->