### PR TITLE
Check active user

### DIFF
--- a/crates/vouch-server/src/handlers/applications/api.rs
+++ b/crates/vouch-server/src/handlers/applications/api.rs
@@ -548,38 +548,28 @@ pub async fn update_application_api(
         .and_then(|s| s.parse::<AccessScope>().ok());
 
     // Get user to check active status and org membership
-    let user = if access_scope == Some(AccessScope::Organization) {
-        let u = db::get_user_by_id(&state.store, &token.sub)
-            .await
-            .map_err(|e| {
-                tracing::error!("Failed to get user for scope validation: {e}");
-                ServiceError::api(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "db_error",
-                    "Internal database error",
-                )
-            })?
-            .ok_or_else(|| {
-                ServiceError::api(StatusCode::NOT_FOUND, "not_found", "User not found")
-            })?;
+    let user = db::get_user_by_id(&state.store, &token.sub)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get user: {e}");
+            ServiceError::api(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "db_error",
+                "Internal database error",
+            )
+        })?
+        .ok_or_else(|| ServiceError::api(StatusCode::NOT_FOUND, "not_found", "User not found"))?;
 
-        if !u.active {
-            return Err(ServiceError::api(
-                StatusCode::UNAUTHORIZED,
-                "unauthorized",
-                "User account is deactivated",
-            ));
-        }
-
-        Some(u)
-    } else {
-        None
-    };
+    if !user.active {
+        return Err(ServiceError::api(
+            StatusCode::UNAUTHORIZED,
+            "unauthorized",
+            "User account is deactivated",
+        ));
+    }
 
     // Validate: Organization scope requires user to have an org
-    if access_scope == Some(AccessScope::Organization)
-        && user.as_ref().is_some_and(|u| u.org_id.is_none())
-    {
+    if access_scope == Some(AccessScope::Organization) && user.org_id.is_none() {
         return Err(ServiceError::api(
             StatusCode::BAD_REQUEST,
             "invalid_access_scope",
@@ -589,7 +579,7 @@ pub async fn update_application_api(
 
     // Set org_id only for organization-scoped apps
     let org_id = if access_scope == Some(AccessScope::Organization) {
-        user.as_ref().and_then(|u| u.org_id.as_deref())
+        user.org_id.as_deref()
     } else {
         None
     };
@@ -2245,7 +2235,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_update_application_rejects_deactivated_user_on_org_scope() {
+    async fn test_update_application_rejects_deactivated_user() {
         let (app, state) = test_app().await;
         let user = create_test_user(&state.store, "deactivated-update@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
@@ -2261,7 +2251,7 @@ mod tests {
             &app,
             "PATCH",
             &format!("/api/v1/applications/{}", client.app_id),
-            Some(r#"{"access_scope": "organization"}"#.to_string()),
+            Some(r#"{"name": "Renamed App"}"#.to_string()),
             &[
                 ("Content-Type", "application/json"),
                 ("Authorization", &auth),

--- a/crates/vouch-server/src/handlers/applications/api.rs
+++ b/crates/vouch-server/src/handlers/applications/api.rs
@@ -240,6 +240,14 @@ pub async fn create_application_api(
         })?
         .ok_or_else(|| ServiceError::api(StatusCode::NOT_FOUND, "not_found", "User not found"))?;
 
+    if !user.active {
+        return Err(ServiceError::api(
+            StatusCode::UNAUTHORIZED,
+            "unauthorized",
+            "User account is deactivated",
+        ));
+    }
+
     // Validate: Organization scope requires user to have an org
     if access_scope == AccessScope::Organization && user.org_id.is_none() {
         return Err(ServiceError::api(
@@ -539,23 +547,31 @@ pub async fn update_application_api(
         .as_ref()
         .and_then(|s| s.parse::<AccessScope>().ok());
 
-    // Get user to check org membership if changing to organization scope
+    // Get user to check active status and org membership
     let user = if access_scope == Some(AccessScope::Organization) {
-        Some(
-            db::get_user_by_id(&state.store, &token.sub)
-                .await
-                .map_err(|e| {
-                    tracing::error!("Failed to get user for scope validation: {e}");
-                    ServiceError::api(
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        "db_error",
-                        "Internal database error",
-                    )
-                })?
-                .ok_or_else(|| {
-                    ServiceError::api(StatusCode::NOT_FOUND, "not_found", "User not found")
-                })?,
-        )
+        let u = db::get_user_by_id(&state.store, &token.sub)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to get user for scope validation: {e}");
+                ServiceError::api(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "db_error",
+                    "Internal database error",
+                )
+            })?
+            .ok_or_else(|| {
+                ServiceError::api(StatusCode::NOT_FOUND, "not_found", "User not found")
+            })?;
+
+        if !u.active {
+            return Err(ServiceError::api(
+                StatusCode::UNAUTHORIZED,
+                "unauthorized",
+                "User account is deactivated",
+            ));
+        }
+
+        Some(u)
     } else {
         None
     };
@@ -2069,6 +2085,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_create_application_rejects_deactivated_user() {
+        let (app, state) = test_app().await;
+        let user = create_test_user(&state.store, "deactivated-create@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let auth = bearer(&token);
+
+        crate::db::update_user_active_status(&state.store, &user.id, false)
+            .await
+            .expect("deactivate user");
+
+        let (status, body) = http_post_json(
+            &app,
+            "/api/v1/applications",
+            r#"{"name":"Test App","application_type":"web","redirect_uris":["https://example.com/cb"]}"#,
+            &[("Authorization", &auth)],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+        assert_eq!(error["code"], "unauthorized");
+        assert_eq!(error["message"], "User account is deactivated");
+    }
+
+    #[tokio::test]
     async fn test_create_application_rejects_empty_name() {
         let (app, state) = test_app().await;
         let user = create_test_user(&state.store, "create-emptyname@example.com").await;
@@ -2200,6 +2242,37 @@ mod tests {
         assert_eq!(status, StatusCode::OK, "body: {resp_body}");
         let json: serde_json::Value = serde_json::from_str(&resp_body).expect("valid json");
         assert_eq!(json["name"].as_str().unwrap(), "Renamed App");
+    }
+
+    #[tokio::test]
+    async fn test_update_application_rejects_deactivated_user_on_org_scope() {
+        let (app, state) = test_app().await;
+        let user = create_test_user(&state.store, "deactivated-update@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let auth = bearer(&token);
+        let client = create_test_oauth_client(&state.store, &user.id).await;
+
+        crate::db::update_user_active_status(&state.store, &user.id, false)
+            .await
+            .expect("deactivate user");
+
+        let (status, body) = http_request(
+            &app,
+            "PATCH",
+            &format!("/api/v1/applications/{}", client.app_id),
+            Some(r#"{"access_scope": "organization"}"#.to_string()),
+            &[
+                ("Content-Type", "application/json"),
+                ("Authorization", &auth),
+            ],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+        assert_eq!(error["code"], "unauthorized");
+        assert_eq!(error["message"], "User account is deactivated");
     }
 
     // ========================================================================

--- a/crates/vouch-server/src/handlers/keys.rs
+++ b/crates/vouch-server/src/handlers/keys.rs
@@ -111,6 +111,14 @@ pub async fn register_start(
             ServiceError::api(StatusCode::NOT_FOUND, "user_not_found", "User not found")
         })?;
 
+    if !user.active {
+        return Err(ServiceError::api(
+            StatusCode::UNAUTHORIZED,
+            "unauthorized",
+            "User account is deactivated",
+        ));
+    }
+
     tracing::info!(
         "Registration start for authenticated user: {} (adding key: {})",
         redact_email(&user.email),
@@ -588,6 +596,31 @@ mod tests {
             http_post_json(&app, "/v1/keys/register/start", r#"{"name":"My Key"}"#, &[]).await;
 
         assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_register_start_rejects_deactivated_user() {
+        let (app, state) = test_app().await;
+        let user = create_test_user(&state.store, "deactivated-register@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+
+        crate::db::update_user_active_status(&state.store, &user.id, false)
+            .await
+            .expect("deactivate user");
+
+        let (status, body) = http_post_json(
+            &app,
+            "/v1/keys/register/start",
+            r#"{"name":"My Key"}"#,
+            &[("Authorization", &format!("Bearer {token}"))],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+        assert_eq!(error["code"], "unauthorized");
+        assert_eq!(error["message"], "User account is deactivated");
     }
 
     // ========================================================================

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7523.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7523.rs
@@ -1135,3 +1135,67 @@ async fn test_non_fapi_client_accepts_token_endpoint_audience() {
         "Non-FAPI client with aud=token_endpoint_url must pass client auth (status={status}): {resp_body}"
     );
 }
+
+#[tokio::test]
+async fn test_rfc7523_jwt_bearer_grant_deactivated_user_rejected() {
+    // GH#275: Deactivated user cannot obtain tokens via JWT bearer grant.
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "deactivated-bearer@example.com").await;
+
+    let (pkcs8_bytes, jwk) = generate_es256_signing_key();
+
+    let issuer_url = "https://deactivated-issuer.example.com";
+    let issuer = db::create_trusted_jwt_issuer(
+        &state.store,
+        issuer_url,
+        "Deactivated Test Issuer",
+        None,
+        "https://deactivated-issuer.example.com/.well-known/jwks.json",
+        Some("email"),
+        Some("openid email"),
+        Some(3600),
+    )
+    .await
+    .expect("Failed to create trusted issuer");
+
+    let jwks_value = serde_json::json!({
+        "keys": [jwk]
+    });
+    db::update_issuer_jwks_cache(&state.store, &issuer.id, &jwks_value)
+        .await
+        .expect("Failed to update JWKS cache");
+
+    // Build JWT assertion
+    let now = jiff::Timestamp::now().as_second();
+    let header = serde_json::json!({
+        "alg": "ES256",
+        "typ": "JWT",
+        "kid": "test-key-1"
+    });
+    let claims = serde_json::json!({
+        "iss": issuer_url,
+        "sub": user.email,
+        "aud": state.config().base_url,
+        "iat": now,
+        "exp": now + 60,
+        "jti": uuid::Uuid::now_v7().to_string()
+    });
+    let assertion = sign_jwt_assertion(&pkcs8_bytes, &header, &claims);
+
+    // Deactivate the user after building the assertion
+    crate::db::update_user_active_status(&state.store, &user.id, false)
+        .await
+        .expect("deactivate user");
+
+    let body = format!(
+        "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer\
+         &assertion={assertion}&scope=openid email"
+    );
+
+    let (status, resp_body) = http_post_form(&app, "/oauth/token", &body, &[]).await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let error: serde_json::Value = serde_json::from_str(&resp_body).expect("Valid JSON");
+    assert_eq!(error["error"], "invalid_grant");
+}

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc8693.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc8693.rs
@@ -673,3 +673,36 @@ async fn test_rfc8693_invalid_actor_token_type() {
         "Invalid actor_token_type should be rejected, got {status}: {body}"
     );
 }
+
+#[tokio::test]
+async fn test_rfc8693_deactivated_subject_user_rejected() {
+    // GH#275: Deactivated user cannot exchange tokens.
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "deactivated-exchange@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+    let auth_header = client.basic_auth_header();
+
+    // Deactivate the user after creating the session
+    crate::db::update_user_active_status(&state.store, &user.id, false)
+        .await
+        .expect("deactivate user");
+
+    let (status, body) = http_post_form(
+        &app,
+        "/oauth/token",
+        &format!(
+            "grant_type=urn:ietf:params:oauth:grant-type:token-exchange\
+             &subject_token={token}\
+             &subject_token_type=urn:ietf:params:oauth:token-type:access_token"
+        ),
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(error["error"], "invalid_grant");
+}

--- a/crates/vouch-server/src/services/oidc/exchange.rs
+++ b/crates/vouch-server/src/services/oidc/exchange.rs
@@ -150,6 +150,14 @@ pub async fn exchange_token(
         .ok_or_else(|| {
             ServiceError::oauth(OAuthErrorCode::InvalidGrant, "Subject token user not found")
         })?;
+
+    if !subject_user.active {
+        return Err(ServiceError::oauth(
+            OAuthErrorCode::InvalidGrant,
+            "User account is deactivated",
+        ));
+    }
+
     let subject_email = &subject_user.email;
 
     // Handle actor token if present (for delegation chains)

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/grant.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/grant.rs
@@ -153,6 +153,20 @@ pub async fn exchange_jwt_bearer_grant(
         ServiceError::oauth(OAuthErrorCode::InvalidGrant, "User not found")
     })?;
 
+    // 8b. Reject deactivated users
+    if !user.active {
+        tracing::warn!(
+            target: "security",
+            user_id = %user.id,
+            issuer = %issuer.issuer,
+            "JWT bearer grant rejected: user account is deactivated"
+        );
+        return Err(ServiceError::oauth(
+            OAuthErrorCode::InvalidGrant,
+            "User account is deactivated",
+        ));
+    }
+
     // 9. Check JTI for replay (RFC 7523 Section 3)
     //    Deterministic document ID derived from (jti, issuer) ensures the
     //    PRIMARY KEY constraint prevents concurrent duplicate inserts.


### PR DESCRIPTION
Fixes #275

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication/authorization behavior in token issuance and exchange paths (RFC 7523/8693) and multiple authenticated APIs, which is security-critical and could break existing clients if status codes/errors are relied upon.
> 
> **Overview**
> **Deactivated accounts are now consistently blocked from performing authenticated actions.** API handlers for application create/update and key registration start now fetch the user record and return `401` (`code: unauthorized`, message *"User account is deactivated"*) when `user.active` is false.
> 
> **OAuth token flows now also enforce `user.active`.** Token exchange (`RFC 8693`) and JWT bearer grant (`RFC 7523`) reject deactivated subject users with `invalid_grant`, and new integration tests cover these scenarios to prevent regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ba1922ec864411353de99b73eaaf1e125a10f26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->