### PR TITLE
fix FAPI 2.0 regression

### DIFF
--- a/crates/vouch-server/src/handlers/oidc/authorize.rs
+++ b/crates/vouch-server/src/handlers/oidc/authorize.rs
@@ -331,15 +331,7 @@ async fn check_session_and_authorize(
                     )
                     .await;
             }
-            store_pending_and_redirect(
-                state,
-                validated,
-                &resolved.client,
-                resolved.response_mode,
-                None,
-                par_to_consume,
-            )
-            .await
+            store_pending_and_redirect(state, validated, resolved.response_mode, None).await
         }
     }
 }
@@ -1241,50 +1233,13 @@ fn resolve_redirect_uri(
 async fn store_pending_and_redirect(
     state: &Arc<AppState>,
     validated: crate::services::oidc::authorization::ValidatedAuthRequest,
-    oauth_client: &OAuthClient,
     response_mode: ResponseMode,
     prompt_override: Option<Prompt>,
-    par_to_consume: Option<(&str, &str)>,
 ) -> Response {
-    // RFC 9126: Consume PAR immediately to enforce single-use semantics.
+    // FAPI 2.0 Section 5.3.2.2 Note 3: Do NOT consume the PAR here.
+    // The request_uri must remain valid until authorization completes (code issued).
     // The pending auth record takes over as the single-use artifact for the
-    // remainder of the flow. Consuming now avoids PAR TTL expiry issues
-    // (PAR lives 60s but user auth takes minutes).
-    if let Some((request_uri, client_id)) = par_to_consume {
-        match db::consume_pushed_authorization_request(&state.store, request_uri, client_id).await {
-            Ok(true) => {} // successfully consumed
-            Ok(false) => {
-                tracing::warn!(
-                    request_uri,
-                    client_id,
-                    "PAR replay detected during pending auth creation"
-                );
-                return oauth_error_response(
-                    state,
-                    oauth_client,
-                    validated.redirect_uri(),
-                    "invalid_request_uri",
-                    "The request_uri has already been used or is invalid",
-                    validated.state(),
-                    response_mode,
-                )
-                .await;
-            }
-            Err(e) => {
-                tracing::error!("Failed to consume PAR: {e}");
-                return oauth_error_response(
-                    state,
-                    oauth_client,
-                    validated.redirect_uri(),
-                    "server_error",
-                    "Failed to process pushed authorization request",
-                    validated.state(),
-                    response_mode,
-                )
-                .await;
-            }
-        }
-    }
+    // remainder of the flow. The PAR expires naturally after its TTL (60s).
 
     let scope_str = validated.scope().to_space_separated();
     let max_age_i64 = validated.max_age().and_then(|v| i64::try_from(v).ok());
@@ -1417,15 +1372,8 @@ async fn authorize_authenticated_user(
 
     // Step 4: Re-auth needed — store pending request and redirect to login.
     if needs_reauth {
-        return store_pending_and_redirect(
-            state,
-            validated,
-            oauth_client,
-            response_mode,
-            Some(Prompt::Login),
-            par_to_consume,
-        )
-        .await;
+        return store_pending_and_redirect(state, validated, response_mode, Some(Prompt::Login))
+            .await;
     }
 
     // Steps 5-8: ACR + resource + PAR consumption + code issuance.

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
@@ -997,10 +997,11 @@ async fn test_rfc9126_consume_par_with_stale_version_returns_false() {
 // ========================================================================
 
 #[tokio::test]
-async fn test_rfc9126_par_consumed_when_no_session() {
-    // RFC 9126 Section 2.3: request_uri MUST be consumed on first use even
-    // when the user has no existing session and must authenticate first.
-    // The PAR should be consumed immediately when creating the pending auth.
+async fn test_rfc9126_par_not_consumed_when_no_session() {
+    // FAPI 2.0 Section 5.3.2.2 Note 3: request_uri must remain valid until
+    // authorization completes (code issued). When the user has no session and
+    // must authenticate first, the PAR should NOT be consumed — the pending
+    // auth record becomes the single-use artifact for the remainder of the flow.
     use crate::db::documents::par::PushedAuthorizationRequestDoc;
 
     let (app, state) = test_app().await;
@@ -1036,7 +1037,7 @@ async fn test_rfc9126_par_consumed_when_no_session() {
         "Should redirect to /login?pending_auth=..., got: {location_str}"
     );
 
-    // Verify PAR is consumed in DB
+    // Verify PAR is NOT consumed — it remains valid for reuse until code issuance.
     let doc = state
         .store
         .find_one::<PushedAuthorizationRequestDoc>("request_uri", &request_uri)
@@ -1044,15 +1045,15 @@ async fn test_rfc9126_par_consumed_when_no_session() {
         .unwrap()
         .expect("PAR doc should still exist");
     assert!(
-        doc.data.consumed_at.is_some(),
-        "PAR should be marked as consumed after pending auth creation"
+        doc.data.consumed_at.is_none(),
+        "PAR should NOT be consumed when redirecting to login (FAPI 2.0 reuse allowed)"
     );
 }
 
 #[tokio::test]
-async fn test_rfc9126_par_replay_rejected_after_login_redirect() {
-    // RFC 9126 Section 2.3: After a PAR is consumed during the login-required
-    // path, replaying the same request_uri must fail.
+async fn test_rfc9126_par_reuse_succeeds_before_auth_completion() {
+    // FAPI 2.0 Section 5.3.2.2 Note 3: request_uri can be reused before
+    // authorization completes. Both uses should succeed (redirect to login).
     let (app, state) = test_app().await;
 
     let user = create_test_user(&state.store, "par-replay-login@example.com").await;
@@ -1060,7 +1061,7 @@ async fn test_rfc9126_par_replay_rejected_after_login_redirect() {
 
     let request_uri = create_par_request(&app, &client).await;
 
-    // First use without session — triggers login redirect + PAR consumption
+    // First use without session — triggers login redirect
     let response1 = http_get_full(
         &app,
         &format!(
@@ -1076,7 +1077,7 @@ async fn test_rfc9126_par_replay_rejected_after_login_redirect() {
         "First use should redirect to login"
     );
 
-    // Second use of same request_uri — should fail (PAR already consumed)
+    // Second use of same request_uri — should also succeed (PAR not consumed yet)
     let response2 = http_get_full(
         &app,
         &format!(
@@ -1088,34 +1089,31 @@ async fn test_rfc9126_par_replay_rejected_after_login_redirect() {
     )
     .await;
 
-    // The PAR lookup should fail because it's consumed — error page shown
-    assert_eq!(
-        response2.status,
-        StatusCode::OK,
-        "Second use should return error page, got: {}",
+    assert!(
+        response2.status == StatusCode::FOUND || response2.status == StatusCode::SEE_OTHER,
+        "Second use should also redirect to login (reuse allowed before auth completes), got: {}",
         response2.status
     );
+    let location = response2
+        .headers
+        .get("location")
+        .expect("redirect location");
+    let location_str = location.to_str().unwrap();
     assert!(
-        response2.body.contains("expired")
-            || response2.body.contains("Invalid")
-            || response2.body.contains("error"),
-        "Response should indicate the request_uri was already consumed"
+        location_str.starts_with("/login?pending_auth="),
+        "Second use should also redirect to /login?pending_auth=..., got: {location_str}"
     );
 }
 
 // ========================================================================
-// RFC 9126 Section 2.3 — PAR Consumed on Re-auth Path (Issue #270)
+// FAPI 2.0 Section 5.3.2.2 — PAR Reuse on Re-auth Path
 // ========================================================================
 
 #[tokio::test]
-async fn test_rfc9126_par_consumed_when_reauth_required() {
-    // RFC 9126 Section 2.3: request_uri MUST be consumed even when the user
-    // has an existing session but re-authentication is required.
-    //
-    // The PAR flow uses ReauthPolicy::Always, so any authenticated user
-    // without prompt=none triggers the re-auth path (call site 2 of the fix).
-    // This exercises authorize_authenticated_user → needs_reauth=true →
-    // store_pending_and_redirect(par_to_consume=Some(...)).
+async fn test_rfc9126_par_not_consumed_when_reauth_required() {
+    // FAPI 2.0 Section 5.3.2.2 Note 3: request_uri must remain valid until
+    // authorization completes. When re-auth is required, the PAR should NOT
+    // be consumed — the pending auth record is the single-use artifact.
     use crate::db::documents::par::PushedAuthorizationRequestDoc;
 
     let (app, state) = test_app().await;
@@ -1154,7 +1152,7 @@ async fn test_rfc9126_par_consumed_when_reauth_required() {
         "Should redirect to /login?pending_auth=..., got: {location_str}"
     );
 
-    // Verify PAR is consumed in DB — the fix ensures consumption at re-auth path too.
+    // Verify PAR is NOT consumed — it remains valid for reuse until code issuance.
     let doc = state
         .store
         .find_one::<PushedAuthorizationRequestDoc>("request_uri", &request_uri)
@@ -1162,15 +1160,15 @@ async fn test_rfc9126_par_consumed_when_reauth_required() {
         .unwrap()
         .expect("PAR doc should still exist");
     assert!(
-        doc.data.consumed_at.is_some(),
-        "PAR should be marked as consumed after re-auth redirect (call site 2 of fix)"
+        doc.data.consumed_at.is_none(),
+        "PAR should NOT be consumed when redirecting to re-auth (FAPI 2.0 reuse allowed)"
     );
 }
 
 #[tokio::test]
-async fn test_rfc9126_par_replay_rejected_after_reauth_redirect() {
-    // RFC 9126 Section 2.3: After a PAR is consumed during the re-auth path,
-    // replaying the same request_uri must fail — even though the user has a session.
+async fn test_rfc9126_par_reuse_succeeds_after_reauth_redirect() {
+    // FAPI 2.0 Section 5.3.2.2 Note 3: request_uri can be reused before
+    // authorization completes, even on the re-auth path.
     let (app, state) = test_app().await;
 
     let user = create_test_user(&state.store, "par-reauth-replay@example.com").await;
@@ -1180,7 +1178,7 @@ async fn test_rfc9126_par_replay_rejected_after_reauth_redirect() {
 
     let request_uri = create_par_request(&app, &client).await;
 
-    // First use with session — triggers re-auth redirect + PAR consumption.
+    // First use with session — triggers re-auth redirect.
     let response1 = http_get_full(
         &app,
         &format!(
@@ -1197,7 +1195,7 @@ async fn test_rfc9126_par_replay_rejected_after_reauth_redirect() {
         response1.status
     );
 
-    // Second use of same request_uri — PAR is already consumed, must fail.
+    // Second use of same request_uri — should also succeed (PAR not consumed).
     let response2 = http_get_full(
         &app,
         &format!(
@@ -1209,28 +1207,27 @@ async fn test_rfc9126_par_replay_rejected_after_reauth_redirect() {
     )
     .await;
 
-    // The PAR lookup returns consumed/expired — error page shown.
-    assert_eq!(
-        response2.status,
-        StatusCode::OK,
-        "Second use of request_uri after re-auth redirect should return error page, got: {}",
+    assert!(
+        response2.status == StatusCode::FOUND || response2.status == StatusCode::SEE_OTHER,
+        "Second use should also redirect to login (reuse allowed), got: {}",
         response2.status
     );
+    let location = response2
+        .headers
+        .get("location")
+        .expect("redirect location");
+    let location_str = location.to_str().unwrap();
     assert!(
-        response2.body.contains("expired")
-            || response2.body.contains("Invalid")
-            || response2.body.contains("error"),
-        "Response should indicate the request_uri was already consumed: {}",
-        response2.body
+        location_str.starts_with("/login?pending_auth="),
+        "Second use should also redirect to /login?pending_auth=..., got: {location_str}"
     );
 }
 
 #[tokio::test]
-async fn test_rfc9126_par_already_consumed_returns_error_redirect_not_login() {
-    // When store_pending_and_redirect is called with par_to_consume but the PAR
-    // is already consumed (Ok(false)), the response must be an OAuth error redirect
-    // (invalid_request_uri) — NOT a login redirect. This verifies the Ok(false) branch
-    // in store_pending_and_redirect.
+async fn test_rfc9126_par_already_consumed_returns_error_not_login() {
+    // When the PAR has already been consumed (e.g., code was issued in a prior
+    // flow), lookup_par detects consumed_at and returns an error page instead
+    // of proceeding with authorization.
     use crate::db::documents::par::PushedAuthorizationRequestDoc;
 
     let (app, state) = test_app().await;


### PR DESCRIPTION
## Summary

  Root cause: Commit 64e5994 ("Fix consume PAR #278") consumed the PAR request_uri too early — in store_pending_and_redirect when the user needs to log in. This
   prevented request_uri reuse before auth completion, violating FAPI 2.0 Section 5.3.2.2 Note 3.

  Issue #270 context: The original issue correctly identified that PAR wasn't consumed in the pending auth path, but the recommended fix was to persist PAR
  identifiers in the pending auth record and consume at code issuance. PR #278 took a shortcut by consuming immediately, which broke the conformance test.

  The fix:
  - Removed PAR consumption from store_pending_and_redirect (authorize.rs)
  - The pending auth record serves as the single-use artifact for the flow
  - PAR is still consumed at code issuance (in issue_code_after_reauth_check) for the authenticated path
  - The 60-second PAR TTL provides natural expiry protection
  - Updated 4 unit tests to assert FAPI 2.0 compliant behavior (request_uri reuse succeeds)

  Files changed (in ../vouch):
  - crates/vouch-server/src/handlers/oidc/authorize.rs — removed early consumption
  - crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs — updated tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when PAR `request_uri` is consumed in the authorization flow, which affects replay protection and FAPI/OIDC conformance behavior. Risk is mitigated by existing single-use enforcement at code issuance and updated unit tests covering the login/reauth redirect paths.
> 
> **Overview**
> Aligns PAR behavior with **FAPI 2.0** by **stopping early consumption of `request_uri`** when the user is redirected to login/re-auth; the pending auth record now acts as the single-use artifact until completion.
> 
> Updates PAR conformance tests to expect `request_uri` **remains unconsumed** and **can be reused** prior to authorization completion (both no-session and re-auth paths), while still treating already-consumed PARs as errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 277970a77873100e71cbfd6cae5a898b37839d3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->