### PR TITLE
Add session policy to limit role chaining

### DIFF
--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -239,8 +239,28 @@ pub(crate) async fn exchange_for_sts_credentials(
 
     let all_policies: &[&str] = agent_policies;
 
+    // Inline session policy for the management role hop when an agent is
+    // detected: restrict to only the STS actions needed for role chaining.
+    let mgmt_hop_policy = if agent_source.is_some() {
+        Some(serde_json::json!({
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": [
+                    "sts:AssumeRole",
+                    "sts:TagSession",
+                    "sts:SetSourceIdentity"
+                ],
+                "Resource": "*"
+            }]
+        }))
+    } else {
+        None
+    };
+
     if let Some(mgmt_role_arn) = mgmt.filter(|m| *m != role_arn) {
-        // Chain: AssumeRoleWithWebIdentity into management role, then AssumeRole into target
+        // Chain: AssumeRoleWithWebIdentity into management role, then AssumeRole into target.
+        // Management hop gets an inline STS-only policy; final hop gets ReadOnlyAccess.
         let mgmt_arn = parse_role_arn(mgmt_role_arn)?;
         let mgmt_domain_suffix = mgmt_arn.partition.dns_suffix();
 
@@ -251,7 +271,8 @@ pub(crate) async fn exchange_for_sts_credentials(
             web_identity_token: id_token,
             region,
             domain_suffix: mgmt_domain_suffix,
-            session_policy_names: all_policies,
+            session_policy_names: &[],
+            session_policy: mgmt_hop_policy.as_ref(),
         })
         .await
         .context("failed to assume management role")?;
@@ -263,6 +284,7 @@ pub(crate) async fn exchange_for_sts_credentials(
             region,
             &mgmt_credentials,
             all_policies,
+            None,
         )
         .await
         .context("failed to assume target role via chaining")?;
@@ -283,6 +305,7 @@ pub(crate) async fn exchange_for_sts_credentials(
         region,
         domain_suffix,
         session_policy_names: all_policies,
+        session_policy: None,
     })
     .await
     .context("failed to assume AWS role")?;

--- a/crates/vouch-cli/src/integrations/aws/sts.rs
+++ b/crates/vouch-cli/src/integrations/aws/sts.rs
@@ -77,6 +77,10 @@ pub(crate) struct WebIdentityRequest<'a> {
     /// (e.g., "ReadOnlyAccess" → `arn:{partition}:iam::aws:policy/ReadOnlyAccess`).
     /// Effective permissions = role policy ∩ session policy (intersection).
     pub session_policy_names: &'a [&'a str],
+    /// Optional inline session policy (AWS IAM policy document).
+    /// Applied in addition to managed policies. Effective permissions =
+    /// role policy ∩ managed policies ∩ inline policy.
+    pub session_policy: Option<&'a serde_json::Value>,
 }
 
 /// Call AWS STS `AssumeRoleWithWebIdentity`.
@@ -112,6 +116,13 @@ pub(crate) async fn assume_role_with_web_identity(
     for (i, policy_name) in req.session_policy_names.iter().enumerate() {
         let arn = format!("arn:{}:iam::aws:policy/{}", partition.as_str(), policy_name);
         form_params.push((format!("PolicyArns.member.{}.arn", i + 1), arn));
+    }
+
+    // Attach inline session policy if provided.
+    if let Some(policy) = req.session_policy {
+        let policy_json = serde_json::to_string(policy)
+            .map_err(|e| anyhow::anyhow!("failed to serialize session policy: {e}"))?;
+        form_params.push(("Policy".to_string(), policy_json));
     }
 
     let response = req
@@ -150,6 +161,7 @@ pub(crate) async fn assume_role(
     region: &str,
     source_creds: &StsCredentials,
     session_policy_names: &[&str],
+    session_policy: Option<&serde_json::Value>,
 ) -> Result<StsCredentials> {
     use crate::integrations::aws::sigv4::sign_and_send_form_post;
     use vouch_common::aws::Partition;
@@ -182,6 +194,14 @@ pub(crate) async fn assume_role(
         .collect();
     for (key, arn) in policy_keys.iter().zip(policy_arns.iter()) {
         params.push((key.as_str(), arn.as_str()));
+    }
+
+    // Attach inline session policy if provided.
+    let policy_json;
+    if let Some(policy) = session_policy {
+        policy_json = serde_json::to_string(policy)
+            .map_err(|e| anyhow::anyhow!("failed to serialize session policy: {e}"))?;
+        params.push(("Policy", &policy_json));
     }
 
     let body =


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches AWS STS credential exchange and session policy enforcement; mistakes could break role chaining or unintentionally change effective permissions for agent-detected sessions.
> 
> **Overview**
> When an AI coding agent is detected, the management-role hop in the chained AWS auth flow now uses an **inline STS-only session policy** (only `sts:AssumeRole`, `sts:TagSession`, `sts:SetSourceIdentity`) instead of inheriting the broader managed session policies.
> 
> Adds support for passing an optional inline session policy to both `AssumeRoleWithWebIdentity` and chained `AssumeRole` STS calls, serializing it into the `Policy` form parameter; direct (non-chained) flows remain unchanged aside from explicitly setting no inline policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29345aa2281128088ac1ab6139accc4c0ae48521. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->