### PR TITLE
Extract email from AWS ID token to eliminate redundant /v1/auth/status call

### DIFF
--- a/crates/vouch-cli/src/commands/aws/console.rs
+++ b/crates/vouch-cli/src/commands/aws/console.rs
@@ -61,11 +61,7 @@ pub(crate) async fn run(server: &str, args: ConsoleArgs) -> Result<()> {
     //    SecretAccessKey/SessionToken as SecretString until
     //    serialization.
     let result = crate::commands::credential::aws::exchange_for_sts_credentials(
-        server,
-        &role_arn,
-        &region,
-        "vouch-console",
-        None,
+        server, &role_arn, &region, None,
     )
     .await
     .context("failed to get AWS credentials")?;

--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -7,8 +7,10 @@ use anyhow::{Context, Result};
 use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
 use crate::client::VouchClient;
-use crate::session::get_user_email;
 
 /// AWS credential process output format.
 /// See: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html
@@ -65,6 +67,26 @@ impl std::fmt::Debug for OidcTokenResponse {
             .field("id_token", &"[REDACTED]")
             .finish()
     }
+}
+
+/// Minimal JWT claims for extracting the email field.
+#[derive(Deserialize)]
+struct JwtEmailClaims {
+    email: Option<String>,
+}
+
+/// Extract the email from a JWT's payload without signature verification.
+///
+/// The token was just received over TLS from our server, so cryptographic
+/// verification is unnecessary. Returns `None` on any decode or parse failure.
+fn extract_email_from_jwt(token: &str) -> Option<String> {
+    let payload = token.split('.').nth(1)?;
+    let decoded = URL_SAFE_NO_PAD.decode(payload).ok()?;
+    let claims: JwtEmailClaims = serde_json::from_slice(&decoded).ok()?;
+    // AWS RoleSessionName max is 64 chars; filter empty strings so the
+    // fallback kicks in rather than sending an empty value to STS.
+    let email = claims.email.filter(|e| !e.is_empty())?;
+    Some(email.chars().take(64).collect())
 }
 
 /// Result of the OIDC → STS credential exchange.
@@ -177,7 +199,6 @@ pub(crate) async fn exchange_for_sts_credentials(
     server: &str,
     role_arn: &str,
     region: &str,
-    session_name: &str,
     management_role: Option<&str>,
 ) -> Result<StsExchangeResult> {
     use crate::integrations::aws::sts::{
@@ -234,8 +255,8 @@ pub(crate) async fn exchange_for_sts_credentials(
         vouch_common::http::credential_client(&format!("vouch-cli/{}", env!("CARGO_PKG_VERSION")))
             .context("failed to create HTTP client")?;
 
-    let email = get_user_email(server).await;
-    let session = email.as_deref().unwrap_or(session_name);
+    let email = extract_email_from_jwt(id_token);
+    let session = email.as_deref().unwrap_or("vouch");
 
     let all_policies: &[&str] = agent_policies;
 
@@ -393,8 +414,7 @@ async fn fetch_and_assume(
 ) -> Result<CredentialProcessOutput> {
     let region = crate::integrations::aws::resolve_region_with_fallback(role_arn)?;
 
-    let result =
-        exchange_for_sts_credentials(server, role_arn, &region, "vouch-session", mgmt_role).await?;
+    let result = exchange_for_sts_credentials(server, role_arn, &region, mgmt_role).await?;
     let creds = &result.credentials;
     Ok(CredentialProcessOutput {
         version: 1,
@@ -439,6 +459,60 @@ mod tests {
 
         // Must have exactly 5 fields — no extra fields allowed
         assert_eq!(json.as_object().unwrap().len(), 5);
+    }
+
+    #[test]
+    fn test_extract_email_from_jwt() {
+        let payload = serde_json::json!({
+            "sub": "user@example.com",
+            "email": "user@example.com",
+            "iss": "https://vouch.example.com"
+        });
+        let encoded = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&payload).unwrap());
+        let token = format!("eyJhbGciOiJFUzI1NiJ9.{encoded}.fake-sig");
+
+        assert_eq!(
+            extract_email_from_jwt(&token),
+            Some("user@example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_email_from_jwt_missing_email() {
+        let payload = serde_json::json!({"sub": "user"});
+        let encoded = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&payload).unwrap());
+        let token = format!("eyJhbGciOiJFUzI1NiJ9.{encoded}.fake");
+
+        assert_eq!(extract_email_from_jwt(&token), None);
+    }
+
+    #[test]
+    fn test_extract_email_from_jwt_invalid_token() {
+        assert_eq!(extract_email_from_jwt("not-a-jwt"), None);
+        assert_eq!(extract_email_from_jwt(""), None);
+        assert_eq!(extract_email_from_jwt("a.!!!.c"), None);
+    }
+
+    #[test]
+    fn test_extract_email_from_jwt_empty_email() {
+        let payload = serde_json::json!({"email": ""});
+        let encoded = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&payload).unwrap());
+        let token = format!("eyJhbGciOiJFUzI1NiJ9.{encoded}.fake");
+
+        assert_eq!(extract_email_from_jwt(&token), None);
+    }
+
+    #[test]
+    fn test_extract_email_from_jwt_truncates_to_64_chars() {
+        // 72-char email — must be truncated to 64 for AWS RoleSessionName limit
+        let long_email = "a".repeat(60) + "@example.com"; // 72 chars
+        let payload = serde_json::json!({"email": long_email});
+        let encoded = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&payload).unwrap());
+        let token = format!("eyJhbGciOiJFUzI1NiJ9.{encoded}.fake");
+
+        let result = extract_email_from_jwt(&token).unwrap();
+        assert_eq!(result.len(), 64);
+        assert_eq!(result, long_email.chars().take(64).collect::<String>());
     }
 
     /// Verify the cached credential JSON can be round-tripped through the

--- a/crates/vouch-cli/src/commands/credential/codeartifact.rs
+++ b/crates/vouch-cli/src/commands/credential/codeartifact.rs
@@ -179,8 +179,7 @@ async fn fetch_token(
         )
     })?;
 
-    let result =
-        exchange_for_sts_credentials(server, &role_arn, region, "vouch-codeartifact", None).await?;
+    let result = exchange_for_sts_credentials(server, &role_arn, region, None).await?;
 
     let registry = CodeArtifactRegistry {
         domain: domain.to_string(),

--- a/crates/vouch-cli/src/commands/credential/docker.rs
+++ b/crates/vouch-cli/src/commands/credential/docker.rs
@@ -216,8 +216,7 @@ async fn get_ecr_credential(
         )
     })?;
 
-    let result =
-        exchange_for_sts_credentials(server, &role_arn, region, "vouch-docker", None).await?;
+    let result = exchange_for_sts_credentials(server, &role_arn, region, None).await?;
 
     // Call ECR GetAuthorizationToken
     let ecr_token = get_ecr_authorization_token(

--- a/crates/vouch-cli/src/commands/credential/eks.rs
+++ b/crates/vouch-cli/src/commands/credential/eks.rs
@@ -68,7 +68,7 @@ async fn generate_eks_token(
     region: &str,
     role_arn: &str,
 ) -> Result<String> {
-    let result = exchange_for_sts_credentials(server, role_arn, region, "vouch-eks", None).await?;
+    let result = exchange_for_sts_credentials(server, role_arn, region, None).await?;
 
     // Build presigned STS GetCallerIdentity URL with cluster ID
     let sts_endpoint = format!("https://sts.{region}.{}", result.domain_suffix);

--- a/crates/vouch-cli/src/commands/credential/rds.rs
+++ b/crates/vouch-cli/src/commands/credential/rds.rs
@@ -92,7 +92,7 @@ async fn generate_rds_token(
     region: &str,
     role_arn: &str,
 ) -> Result<String> {
-    let result = exchange_for_sts_credentials(server, role_arn, region, "vouch-rds", None).await?;
+    let result = exchange_for_sts_credentials(server, role_arn, region, None).await?;
 
     // Build presigned URL for RDS IAM auth
     let endpoint = format!("https://{hostname}:{port}");

--- a/crates/vouch-cli/src/commands/credential/redshift.rs
+++ b/crates/vouch-cli/src/commands/credential/redshift.rs
@@ -98,8 +98,7 @@ pub(crate) async fn fetch_redshift_credentials(
     region: &str,
     role_arn: &str,
 ) -> Result<crate::integrations::aws::redshift::RedshiftCredentials> {
-    let result =
-        exchange_for_sts_credentials(server, role_arn, region, "vouch-redshift", None).await?;
+    let result = exchange_for_sts_credentials(server, role_arn, region, None).await?;
 
     match target {
         RedshiftTarget::Cluster {

--- a/crates/vouch-cli/src/commands/setup/eks.rs
+++ b/crates/vouch-cli/src/commands/setup/eks.rs
@@ -49,8 +49,7 @@ async fn describe_cluster(
     region: &str,
     role_arn: &str,
 ) -> Result<(String, String)> {
-    let result =
-        exchange_for_sts_credentials(server, role_arn, region, "vouch-eks-setup", None).await?;
+    let result = exchange_for_sts_credentials(server, role_arn, region, None).await?;
 
     // Call EKS DescribeCluster REST API
     let endpoint = format!("https://eks.{region}.{}", result.domain_suffix);

--- a/crates/vouch-cli/src/session.rs
+++ b/crates/vouch-cli/src/session.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Session utilities for credential commands.
 
-use crate::client::VouchClient;
 use crate::config::Config;
 use anyhow::{Context, Result};
 use secrecy::SecretString;
@@ -210,30 +209,4 @@ pub(crate) async fn store_and_finalize(
     );
 
     Ok(agent_stored)
-}
-
-/// Get user email for AWS session name default.
-///
-/// Tries multiple sources in order:
-/// 1. Agent (Unix only) - most reliable, always up-to-date
-/// 2. Server status endpoint - fallback for edge cases
-pub(crate) async fn get_user_email(server: &str) -> Option<String> {
-    // 1. Try agent first (Unix only)
-    #[cfg(unix)]
-    if let Ok(mut agent) = vouch_agent::AgentClient::connect().await
-        && let Ok(session) = agent.get_session().await
-    {
-        return Some(session.user_email);
-    }
-
-    // 2. Try server status endpoint (fallback)
-    if let Ok(client) = VouchClient::new(server).await
-        && let Ok(status) = client
-            .get_authenticated::<vouch_common::SessionStatus>("/v1/auth/status")
-            .await
-    {
-        return status.email;
-    }
-
-    None
 }


### PR DESCRIPTION
The AWS credential flow previously made a second HTTP request to /v1/auth/status (with a second FAPI keychain load) just to resolve the user's email for the STS RoleSessionName. The email is already present in the AWS ID token JWT returned by /v1/credentials/aws/token.

Decode the JWT payload directly to extract it, removing the redundant network round-trip and keychain access. Also remove the now-unused session_name parameter from exchange_for_sts_credentials() and all 8 call sites, since the email always takes precedence.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how `RoleSessionName` is derived for all AWS credential flows and removes a network-based fallback; malformed/unexpected JWT payloads could alter session naming behavior but should not affect credential issuance.
> 
> **Overview**
> Removes the extra `/v1/auth/status` call during AWS credential exchange by **decoding the OIDC `id_token` JWT payload client-side** to extract the user `email` for the STS `RoleSessionName` (with empty/invalid handling and 64-char truncation).
> 
> Simplifies the AWS credential API by **dropping the `session_name` parameter** from `exchange_for_sts_credentials` and updating all callers (`aws console`, CodeArtifact, Docker/ECR, EKS, RDS, Redshift, and EKS setup) accordingly; deletes the now-unused `session::get_user_email` helper and adds focused unit tests for JWT email extraction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9006c8f0b54934f422b93f8b0ea1694cec1f6a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->