### PR TITLE
Fix minor README inaccuracies in shell integration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ eval "$(vouch env --type aws --role arn:aws:iam::ID:role/name)"
 
 ### Shell Completions
 ```bash
-# Bash
-vouch completions bash >> ~/.bashrc
+# Bash (requires the bash-completion package)
+vouch completions bash > ~/.local/share/bash-completion/completions/vouch
 
 # Zsh
 vouch completions zsh > "${fpath[1]}/_vouch"
@@ -180,7 +180,7 @@ vouch completions fish > ~/.config/fish/completions/vouch.fish
 
 ### Shell Integration
 
-Add session status to your shell prompt (sets `VOUCH_AUTHENTICATED` and `VOUCH_EXPIRES_IN`):
+Add session status to your shell prompt (sets `VOUCH_AUTHENTICATED`, `VOUCH_EMAIL`, and `VOUCH_EXPIRES_IN`):
 
 ```bash
 # Bash (add to ~/.bashrc)


### PR DESCRIPTION
Use the conventional bash-completion directory instead of appending the
full completion script to ~/.bashrc, and include VOUCH_EMAIL in the list
of environment variables the `vouch init` prompt hook exports (it has
been set by status.rs alongside VOUCH_AUTHENTICATED and VOUCH_EXPIRES_IN).

https://claude.ai/code/session_01TpHDmbMpJepTAhcq6t9YRA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime behavior is modified.
> 
> **Overview**
> Updates `README.md` shell docs to use the standard Bash completion install location (instead of appending to `~/.bashrc`) and clarifies that `vouch init` exposes `VOUCH_EMAIL` in addition to `VOUCH_AUTHENTICATED` and `VOUCH_EXPIRES_IN`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cddb116d151b7bb496ac73170eb368d4636c61c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->