### PR TITLE
Audit allow attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ mem_forget = "deny"
 module_name_repetitions = "allow"
 similar_names = "allow"
 
-allow_attributes = "deny"
 allow_attributes_without_reason = "deny"
 # pedantic = { level = "warn", priority = -1 }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,8 @@ mem_forget = "deny"
 module_name_repetitions = "allow"
 similar_names = "allow"
 
-# Deferred — requires migrating ~330 #[allow] to #[expect] with per-attr verification
-# allow_attributes = "deny"
+allow_attributes = "deny"
+allow_attributes_without_reason = "deny"
 # pedantic = { level = "warn", priority = -1 }
 
 [workspace.dependencies]

--- a/crates/vouch-agent/src/audit.rs
+++ b/crates/vouch-agent/src/audit.rs
@@ -127,7 +127,7 @@ fn write_event(record: &AuditRecord) -> std::io::Result<()> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use super::*;
 

--- a/crates/vouch-agent/src/audit.rs
+++ b/crates/vouch-agent/src/audit.rs
@@ -127,7 +127,10 @@ fn write_event(record: &AuditRecord) -> std::io::Result<()> {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-agent/src/config.rs
+++ b/crates/vouch-agent/src/config.rs
@@ -114,7 +114,10 @@ pub(crate) fn read_config() -> Result<Option<VouchConfig>> {
 }
 
 #[cfg(test)]
-#[expect(clippy::expect_used, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-agent/src/config.rs
+++ b/crates/vouch-agent/src/config.rs
@@ -114,7 +114,7 @@ pub(crate) fn read_config() -> Result<Option<VouchConfig>> {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used)]
+#[expect(clippy::expect_used, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use super::*;
 

--- a/crates/vouch-agent/src/daemon.rs
+++ b/crates/vouch-agent/src/daemon.rs
@@ -80,7 +80,10 @@ pub fn is_running() -> Result<bool> {
 
 /// Check if a process with the given PID is running.
 #[cfg(unix)]
-#[expect(unsafe_code, reason = "libc::kill(pid, 0) probe; safety documented inline")]
+#[expect(
+    unsafe_code,
+    reason = "libc::kill(pid, 0) probe; safety documented inline"
+)]
 fn is_process_running(pid: i32) -> bool {
     // Send signal 0 to check if process exists
     // SAFETY: kill(pid, 0) is a standard Unix API to check if a process exists
@@ -144,7 +147,10 @@ pub fn remove_pid_file() -> Result<()> {
 /// Returns `Ok(DaemonizeResult::Child)` in the daemon process,
 /// `Ok(DaemonizeResult::Parent)` in parent processes (caller should exit with code 0).
 #[cfg(unix)]
-#[expect(unsafe_code, reason = "POSIX double-fork daemonization; safety documented inline")]
+#[expect(
+    unsafe_code,
+    reason = "POSIX double-fork daemonization; safety documented inline"
+)]
 pub fn daemonize() -> Result<DaemonizeResult> {
     use std::os::unix::io::AsRawFd;
 

--- a/crates/vouch-agent/src/daemon.rs
+++ b/crates/vouch-agent/src/daemon.rs
@@ -80,7 +80,7 @@ pub fn is_running() -> Result<bool> {
 
 /// Check if a process with the given PID is running.
 #[cfg(unix)]
-#[allow(unsafe_code)]
+#[expect(unsafe_code, reason = "libc::kill(pid, 0) probe; safety documented inline")]
 fn is_process_running(pid: i32) -> bool {
     // Send signal 0 to check if process exists
     // SAFETY: kill(pid, 0) is a standard Unix API to check if a process exists
@@ -144,7 +144,7 @@ pub fn remove_pid_file() -> Result<()> {
 /// Returns `Ok(DaemonizeResult::Child)` in the daemon process,
 /// `Ok(DaemonizeResult::Parent)` in parent processes (caller should exit with code 0).
 #[cfg(unix)]
-#[allow(unsafe_code)]
+#[expect(unsafe_code, reason = "POSIX double-fork daemonization; safety documented inline")]
 pub fn daemonize() -> Result<DaemonizeResult> {
     use std::os::unix::io::AsRawFd;
 

--- a/crates/vouch-agent/src/error.rs
+++ b/crates/vouch-agent/src/error.rs
@@ -44,7 +44,7 @@ pub enum AgentError {
 pub type Result<T> = std::result::Result<T, AgentError>;
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use super::*;
 

--- a/crates/vouch-agent/src/error.rs
+++ b/crates/vouch-agent/src/error.rs
@@ -44,7 +44,10 @@ pub enum AgentError {
 pub type Result<T> = std::result::Result<T, AgentError>;
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-agent/src/main.rs
+++ b/crates/vouch-agent/src/main.rs
@@ -236,7 +236,10 @@ async fn run_agent_server(enable_ssh_agent: bool) -> ExitCode {
 }
 
 /// Stop a running agent.
-#[expect(unsafe_code, reason = "libc::kill sends SIGTERM to a PID we own; safety documented inline")]
+#[expect(
+    unsafe_code,
+    reason = "libc::kill sends SIGTERM to a PID we own; safety documented inline"
+)]
 fn stop_agent() -> ExitCode {
     // Read PID file
     let pid_path = match daemon::pid_file_path() {

--- a/crates/vouch-agent/src/main.rs
+++ b/crates/vouch-agent/src/main.rs
@@ -236,7 +236,7 @@ async fn run_agent_server(enable_ssh_agent: bool) -> ExitCode {
 }
 
 /// Stop a running agent.
-#[allow(unsafe_code)]
+#[expect(unsafe_code, reason = "libc::kill sends SIGTERM to a PID we own; safety documented inline")]
 fn stop_agent() -> ExitCode {
     // Read PID file
     let pid_path = match daemon::pid_file_path() {

--- a/crates/vouch-agent/src/protocol.rs
+++ b/crates/vouch-agent/src/protocol.rs
@@ -246,7 +246,11 @@ pub struct GetCachedCredentialParams {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-agent/src/server.rs
+++ b/crates/vouch-agent/src/server.rs
@@ -136,7 +136,7 @@ impl AgentServer {
 /// method" (→ `method_not_found`) from "malformed JSON" (→ `parse_error`).
 #[derive(serde::Deserialize)]
 struct RawRequest {
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "deserialized for JSON-RPC 2.0 conformance, value not consumed")]
     jsonrpc: String,
     id: u64,
     method: String,

--- a/crates/vouch-agent/src/server.rs
+++ b/crates/vouch-agent/src/server.rs
@@ -136,7 +136,10 @@ impl AgentServer {
 /// method" (→ `method_not_found`) from "malformed JSON" (→ `parse_error`).
 #[derive(serde::Deserialize)]
 struct RawRequest {
-    #[expect(dead_code, reason = "deserialized for JSON-RPC 2.0 conformance, value not consumed")]
+    #[expect(
+        dead_code,
+        reason = "deserialized for JSON-RPC 2.0 conformance, value not consumed"
+    )]
     jsonrpc: String,
     id: u64,
     method: String,

--- a/crates/vouch-agent/src/socket.rs
+++ b/crates/vouch-agent/src/socket.rs
@@ -104,7 +104,7 @@ pub(crate) fn set_socket_permissions(path: &Path) -> Result<()> {
 }
 
 /// Get the current process's real UID.
-#[allow(unsafe_code)]
+#[expect(unsafe_code, reason = "libc::getuid is always safe with no side effects")]
 pub(crate) fn current_uid() -> u32 {
     // SAFETY: getuid() is always safe — it reads the process's real UID
     // with no side effects.

--- a/crates/vouch-agent/src/socket.rs
+++ b/crates/vouch-agent/src/socket.rs
@@ -104,7 +104,10 @@ pub(crate) fn set_socket_permissions(path: &Path) -> Result<()> {
 }
 
 /// Get the current process's real UID.
-#[expect(unsafe_code, reason = "libc::getuid is always safe with no side effects")]
+#[expect(
+    unsafe_code,
+    reason = "libc::getuid is always safe with no side effects"
+)]
 pub(crate) fn current_uid() -> u32 {
     // SAFETY: getuid() is always safe — it reads the process's real UID
     // with no side effects.

--- a/crates/vouch-agent/src/ssh_agent/credentials.rs
+++ b/crates/vouch-agent/src/ssh_agent/credentials.rs
@@ -193,7 +193,10 @@ pub(super) fn parse_openssh_public_key(openssh: &str) -> Result<Vec<u8>> {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-agent/src/ssh_agent/credentials.rs
+++ b/crates/vouch-agent/src/ssh_agent/credentials.rs
@@ -193,7 +193,7 @@ pub(super) fn parse_openssh_public_key(openssh: &str) -> Result<Vec<u8>> {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use super::*;
 

--- a/crates/vouch-agent/src/ssh_agent/mod.rs
+++ b/crates/vouch-agent/src/ssh_agent/mod.rs
@@ -47,7 +47,7 @@ pub fn ssh_agent_socket_path() -> Result<PathBuf> {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use super::*;
 

--- a/crates/vouch-agent/src/ssh_agent/mod.rs
+++ b/crates/vouch-agent/src/ssh_agent/mod.rs
@@ -47,7 +47,10 @@ pub fn ssh_agent_socket_path() -> Result<PathBuf> {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-agent/src/ssh_agent/protocol.rs
+++ b/crates/vouch-agent/src/ssh_agent/protocol.rs
@@ -145,7 +145,11 @@ pub(super) fn sign_data(private_key: &PrivateKey, data: &[u8]) -> Result<Vec<u8>
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-agent/src/ssh_agent/state.rs
+++ b/crates/vouch-agent/src/ssh_agent/state.rs
@@ -165,7 +165,6 @@ impl SshAgentState {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-agent/src/state.rs
+++ b/crates/vouch-agent/src/state.rs
@@ -348,7 +348,10 @@ impl AgentState {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-agent/src/state.rs
+++ b/crates/vouch-agent/src/state.rs
@@ -65,7 +65,11 @@ impl Session {
     }
 
     /// Get seconds until expiration (0 if already expired).
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "duration since now is non-negative and bounded by session lifetime (< 24h, fits u64)"
+    )]
     pub fn expires_in_seconds(&self) -> u64 {
         let now = Timestamp::now();
         if now >= self.expires_at {
@@ -276,7 +280,6 @@ impl AgentState {
     ///
     /// Rejects keys longer than 256 bytes and caps the cache at 128 entries,
     /// evicting the oldest expired entry (or the oldest entry) when full.
-    #[allow(clippy::map_entry)] // Entry API not viable: eviction needs map access between check and insert
     pub async fn cache_credential(&self, credential_type: String, credential: CachedCredential) {
         if credential_type.len() > MAX_CREDENTIAL_TYPE_LEN {
             warn!(
@@ -345,7 +348,7 @@ impl AgentState {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
+#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use super::*;
 

--- a/crates/vouch-agent/src/wire.rs
+++ b/crates/vouch-agent/src/wire.rs
@@ -103,7 +103,11 @@ pub fn encode_bytes(data: &[u8]) -> Result<Vec<u8>> {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use std::io::Cursor;

--- a/crates/vouch-cli/src/client.rs
+++ b/crates/vouch-cli/src/client.rs
@@ -127,7 +127,10 @@ impl<H: HttpClient> VouchClient<H> {
     /// Create a client with a custom HTTP implementation.
     ///
     /// Used for testing with `TestHttpClient`.
-    #[allow(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "constructor used by TestHttpClient in test contexts"
+    )]
     pub(crate) fn with_http(http: H, base_url: &str) -> Self {
         Self {
             http,
@@ -705,12 +708,11 @@ impl ServerErrorKind {
 }
 
 #[cfg(test)]
-#[allow(
+#[expect(
     clippy::unwrap_used,
-    clippy::expect_used,
     clippy::indexing_slicing,
-    clippy::panic,
-    clippy::string_slice
+    clippy::string_slice,
+    reason = "test code: panic on assertion failure is acceptable"
 )]
 mod tests {
     use super::*;

--- a/crates/vouch-cli/src/commands/aws/console.rs
+++ b/crates/vouch-cli/src/commands/aws/console.rs
@@ -126,7 +126,10 @@ pub(crate) async fn run(server: &str, args: ConsoleArgs) -> Result<()> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -450,7 +450,11 @@ async fn fetch_and_assume(
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/commands/credential/cargo.rs
+++ b/crates/vouch-cli/src/commands/credential/cargo.rs
@@ -49,7 +49,10 @@ struct CredentialRequest {
     action: Action,
     /// Additional command-line arguments (after `--`).
     #[serde(default)]
-    #[allow(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "deserialized from cargo credential protocol; not consumed"
+    )]
     args: Vec<String>,
 }
 
@@ -63,7 +66,10 @@ struct RegistryInfo {
     name: Option<String>,
     /// Headers from HTTP 401 response (if any).
     #[serde(default)]
-    #[allow(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "deserialized from cargo credential protocol; not consumed"
+    )]
     headers: Vec<String>,
 }
 
@@ -85,7 +91,10 @@ enum Action {
 /// Operation details for "get" action.
 #[derive(Debug, Deserialize)]
 #[serde(tag = "operation", rename_all = "kebab-case")]
-#[allow(dead_code)]
+#[expect(
+    dead_code,
+    reason = "enum variants deserialized from cargo credential protocol"
+)]
 enum Operation {
     /// Reading from registry (cargo fetch, build, etc).
     Read,
@@ -111,11 +120,9 @@ enum Operation {
 struct LoginOptions {
     /// Token provided by user (if any).
     /// We don't use this - vouch manages its own authentication.
-    #[allow(dead_code)]
     token: Option<SecretString>,
     /// URL for browser-based login (if any).
     #[serde(rename = "login-url")]
-    #[allow(dead_code)]
     login_url: Option<String>,
 }
 
@@ -145,7 +152,10 @@ enum CredentialResponse {
     },
     /// Successful login response.
     /// We don't use this - vouch doesn't support cargo login.
-    #[allow(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "variant declared for protocol completeness; vouch rejects cargo login"
+    )]
     Login,
     /// Successful logout response.
     Logout,
@@ -173,7 +183,10 @@ impl std::fmt::Debug for CredentialResponse {
 /// Cache control for tokens.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "kebab-case")]
-#[allow(dead_code)]
+#[expect(
+    dead_code,
+    reason = "variants serialized as part of cargo credential protocol"
+)]
 enum CacheControl {
     /// Never cache the token.
     Never,
@@ -406,7 +419,11 @@ fn parse_jwt_expiration(token: &str) -> Option<i64> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::panic)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::panic,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/commands/credential/codeartifact.rs
+++ b/crates/vouch-cli/src/commands/credential/codeartifact.rs
@@ -196,7 +196,10 @@ async fn fetch_token(
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     /// Verify the CodeArtifact cache JSON round-trips correctly.
     ///

--- a/crates/vouch-cli/src/commands/credential/codecommit.rs
+++ b/crates/vouch-cli/src/commands/credential/codecommit.rs
@@ -271,7 +271,6 @@ fn exec_git_remote_http(remote_name: &str, signed_url: &str) -> Result<()> {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/commands/credential/docker.rs
+++ b/crates/vouch-cli/src/commands/credential/docker.rs
@@ -341,7 +341,12 @@ async fn get_ghcr_credential(server: &str, token: &SecretString) -> Result<Docke
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/commands/credential/eks.rs
+++ b/crates/vouch-cli/src/commands/credential/eks.rs
@@ -107,7 +107,10 @@ fn build_exec_credential(token: &str) -> Result<serde_json::Value> {
 /// The lifetime matches the presigned STS URL validity minus a safety
 /// margin, so cached tokens are never served after the URL expires.
 fn expiration_rfc3339() -> Result<String> {
-    #[allow(clippy::cast_possible_wrap)]
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "EKS_TOKEN_EXPIRES_SECONDS is bounded to <2^63 by AWS EKS token TTL"
+    )]
     let ttl_seconds = EKS_TOKEN_EXPIRES_SECONDS as i64 - EKS_EXPIRY_MARGIN_SECONDS;
     let expires = jiff::Timestamp::now()
         .checked_add(jiff::SignedDuration::from_secs(ttl_seconds))
@@ -116,7 +119,12 @@ fn expiration_rfc3339() -> Result<String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/commands/credential/git_protocol.rs
+++ b/crates/vouch-cli/src/commands/credential/git_protocol.rs
@@ -63,7 +63,10 @@ pub(crate) fn write_credential_output(
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/commands/credential/kubernetes.rs
+++ b/crates/vouch-cli/src/commands/credential/kubernetes.rs
@@ -71,7 +71,12 @@ fn expiration_rfc3339(expires_in: u64) -> Result<String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/commands/credential/pip.rs
+++ b/crates/vouch-cli/src/commands/credential/pip.rs
@@ -74,7 +74,10 @@ async fn handle_get(url: &str) -> Result<()> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/commands/credential/rds.rs
+++ b/crates/vouch-cli/src/commands/credential/rds.rs
@@ -137,7 +137,10 @@ fn rds_cache_expiry() -> Result<String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/commands/credential/redshift.rs
+++ b/crates/vouch-cli/src/commands/credential/redshift.rs
@@ -155,7 +155,12 @@ pub(crate) fn resolve_target<'a>(
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+#[expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/commands/credential/ssh.rs
+++ b/crates/vouch-cli/src/commands/credential/ssh.rs
@@ -406,7 +406,10 @@ pub(crate) async fn run(server: &str, key_path: Option<&str>, force: bool) -> Re
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use ssh_key::certificate::Builder;

--- a/crates/vouch-cli/src/commands/diag.rs
+++ b/crates/vouch-cli/src/commands/diag.rs
@@ -7,12 +7,13 @@
 // This is a diagnostic/debug command that intentionally does low-level byte manipulation
 // and uses direct indexing for parsing binary data structures. The lints below are
 // suppressed because this is debugging code, not production code.
-#![allow(
+#![expect(
     clippy::indexing_slicing,
     clippy::unwrap_used,
     clippy::unwrap_in_result,
     clippy::expect_used,
-    clippy::needless_borrows_for_generic_args
+    clippy::needless_borrows_for_generic_args,
+    reason = "debugging command for diagnostics output, not production code paths"
 )]
 
 use anyhow::{Context, Result, bail};

--- a/crates/vouch-cli/src/commands/exec.rs
+++ b/crates/vouch-cli/src/commands/exec.rs
@@ -388,7 +388,10 @@ async fn inject_redshift_credentials(
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use crate::commands::credential::aws::CredentialProcessOutput;

--- a/crates/vouch-cli/src/commands/login.rs
+++ b/crates/vouch-cli/src/commands/login.rs
@@ -632,11 +632,10 @@ fn format_expiry(expires_at: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(
+#[expect(
     clippy::unwrap_used,
     clippy::expect_used,
-    clippy::indexing_slicing,
-    clippy::panic
+    reason = "test code: panic on assertion failure is acceptable"
 )]
 mod tests {
     use super::*;

--- a/crates/vouch-cli/src/commands/setup/aws.rs
+++ b/crates/vouch-cli/src/commands/setup/aws.rs
@@ -252,7 +252,6 @@ async fn run_discover(profile_prefix: Option<&str>, region: Option<&str>) -> Res
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/commands/setup/codeartifact.rs
+++ b/crates/vouch-cli/src/commands/setup/codeartifact.rs
@@ -755,7 +755,10 @@ fn build_npmrc_pnpm_content(
 }
 
 #[cfg(test)]
-#[allow(clippy::indexing_slicing)]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use clap::ValueEnum;

--- a/crates/vouch-cli/src/commands/setup/eks.rs
+++ b/crates/vouch-cli/src/commands/setup/eks.rs
@@ -210,7 +210,10 @@ pub(crate) async fn run(
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/commands/setup/kubeconfig.rs
+++ b/crates/vouch-cli/src/commands/setup/kubeconfig.rs
@@ -139,7 +139,11 @@ pub(crate) fn save_kubeconfig(path: &std::path::Path, config: &Kubeconfig) -> Re
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::indexing_slicing, clippy::unwrap_used)]
+#[expect(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/commands/setup/ssh.rs
+++ b/crates/vouch-cli/src/commands/setup/ssh.rs
@@ -284,7 +284,10 @@ fn add_trusted_ca_to_known_hosts(ca_path: &std::path::Path, host_patterns: &str)
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/commands/setup/ssm.rs
+++ b/crates/vouch-cli/src/commands/setup/ssm.rs
@@ -250,7 +250,6 @@ pub(crate) async fn run(
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/commands/status.rs
+++ b/crates/vouch-cli/src/commands/status.rs
@@ -338,7 +338,6 @@ async fn print_all_integrations(server: &str) {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/config.rs
+++ b/crates/vouch-cli/src/config.rs
@@ -407,7 +407,10 @@ impl Config {
     }
 
     /// Set the AWS multi-account configuration (in memory only, call `save()` to persist).
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "API exposed for callers; lint fires inconsistently across compilation targets"
+    )]
     pub(crate) fn set_aws(&mut self, config: AwsMultiAccountConfig) {
         self.aws = Some(config);
     }
@@ -443,7 +446,6 @@ impl Config {
 
     /// Get the DPoP key ID for the stored client keypair.
     #[must_use]
-    #[allow(dead_code)]
     pub(crate) fn dpop_key_id(&self) -> Option<&str> {
         self.current().and_then(|s| s.dpop_key_id.as_deref())
     }
@@ -609,7 +611,11 @@ impl From<&ServerConfig> for ServerConfigFile {
 // =========================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/exit_code.rs
+++ b/crates/vouch-cli/src/exit_code.rs
@@ -50,7 +50,10 @@ pub(crate) enum CliError {
     },
 
     /// Hardware security key not found or timed out.
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "variant for future error categorisation; lint fires inconsistently across compilation targets"
+    )]
     #[error("{0}")]
     HardwareNotFound(String),
 
@@ -199,7 +202,6 @@ fn classify_message(msg: &str) -> ExitCode {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/fapi/client_assertion.rs
+++ b/crates/vouch-cli/src/fapi/client_assertion.rs
@@ -105,11 +105,11 @@ impl ClientAssertionBuilder {
 }
 
 #[cfg(test)]
-#[allow(
+#[expect(
     clippy::unwrap_used,
     clippy::expect_used,
     clippy::indexing_slicing,
-    clippy::get_unwrap
+    reason = "test code: panic on assertion failure is acceptable"
 )]
 mod tests {
     use super::*;

--- a/crates/vouch-cli/src/fapi/dpop.rs
+++ b/crates/vouch-cli/src/fapi/dpop.rs
@@ -182,11 +182,11 @@ fn strip_query_and_fragment(raw_url: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(
+#[expect(
     clippy::unwrap_used,
     clippy::expect_used,
     clippy::indexing_slicing,
-    clippy::get_unwrap
+    reason = "test code: panic on assertion failure is acceptable"
 )]
 mod tests {
     use super::*;

--- a/crates/vouch-cli/src/fapi/error.rs
+++ b/crates/vouch-cli/src/fapi/error.rs
@@ -40,7 +40,10 @@ pub enum FapiError {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/fapi/interaction.rs
+++ b/crates/vouch-cli/src/fapi/interaction.rs
@@ -101,7 +101,6 @@ impl Default for FapiInteraction {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/fapi/key.rs
+++ b/crates/vouch-cli/src/fapi/key.rs
@@ -359,7 +359,11 @@ fn compute_thumbprint(x: &str, y: &str) -> Result<String, FapiError> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use tempfile::tempdir;

--- a/crates/vouch-cli/src/fido2.rs
+++ b/crates/vouch-cli/src/fido2.rs
@@ -64,7 +64,10 @@ struct SuppressStdout {
 }
 
 #[cfg(unix)]
-#[allow(unsafe_code)]
+#[expect(
+    unsafe_code,
+    reason = "POSIX dup/dup2 for stdout suppression; safety documented inline"
+)]
 impl SuppressStdout {
     fn new() -> Option<Self> {
         use std::os::unix::io::AsRawFd;
@@ -94,7 +97,10 @@ impl SuppressStdout {
 }
 
 #[cfg(unix)]
-#[allow(unsafe_code)]
+#[expect(
+    unsafe_code,
+    reason = "POSIX dup2 to restore stdout on drop; safety documented inline"
+)]
 impl Drop for SuppressStdout {
     fn drop(&mut self) {
         use std::os::unix::io::AsRawFd;
@@ -264,7 +270,7 @@ impl YubiKey {
     /// Discover and connect to a `YubiKey`.
     ///
     /// Returns immediately if a device is found, or an error if not.
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "used by binary target, not the library")]
     pub(crate) fn discover() -> Result<Self> {
         let cfg = LibCfg::init();
         let device = FidoKeyHidFactory::create(&cfg)
@@ -360,7 +366,7 @@ impl YubiKey {
     /// Get the number of PIN retry attempts remaining.
     ///
     /// Returns the count of attempts before the PIN is blocked.
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "used by binary target, not the library")]
     pub(crate) fn pin_retries(&self) -> Result<i32> {
         self.device
             .get_pin_retries()
@@ -388,7 +394,7 @@ impl YubiKey {
     }
 
     /// Change the PIN on a `YubiKey`.
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "used by binary target, not the library")]
     pub(crate) fn change_pin(&self, current_pin: &str, new_pin: &str) -> Result<()> {
         self.device
             .change_pin(current_pin, new_pin)
@@ -402,7 +408,10 @@ impl YubiKey {
     /// `exclude_credentials` is a list of credential IDs already registered
     /// for this user. If the `YubiKey` holds any of them, it returns
     /// `CTAP2_ERR_CREDENTIAL_EXCLUDED` (0x19) instead of creating a duplicate.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "FIDO2 makeCredential parameters per CTAP2 spec"
+    )]
     pub(crate) fn register(
         &self,
         rp_id: &str,
@@ -520,7 +529,10 @@ impl YubiKey {
 /// Prompt for `YubiKey` PIN securely (no echo).
 ///
 /// Returns the PIN wrapped in `SecretString` for memory protection.
-#[allow(dead_code)] // Used by binary target, not the library
+#[allow(
+    dead_code,
+    reason = "used by binary target; lint fires inconsistently across compilation targets"
+)]
 fn prompt_pin() -> Result<SecretString> {
     eprint!("YubiKey PIN: ");
     let pin = rpassword::read_password().context("failed to read PIN")?;
@@ -611,7 +623,10 @@ fn translate_fido2_error(err: anyhow::Error, operation: &str) -> anyhow::Error {
 /// - Maximum 63 characters (FIDO2 limit)
 ///
 /// Returns the PIN wrapped in `SecretString` for memory protection.
-#[allow(dead_code)] // Used by binary target, not the library
+#[allow(
+    dead_code,
+    reason = "used by binary target; lint fires inconsistently across compilation targets"
+)]
 fn prompt_new_pin() -> Result<SecretString> {
     use std::io::{Write, stderr};
 
@@ -647,7 +662,10 @@ fn prompt_new_pin() -> Result<SecretString> {
 /// Check if a PIN is set on the YubiKey, and if not, guide the user through setup.
 ///
 /// Returns the PIN wrapped in `SecretString` (either existing or newly set).
-#[allow(dead_code)] // Used by binary target, not the library
+#[allow(
+    dead_code,
+    reason = "used by binary target; lint fires inconsistently across compilation targets"
+)]
 pub(crate) fn ensure_pin_configured(key: &YubiKey) -> Result<SecretString> {
     if key.is_pin_set()? {
         // PIN is already set, just prompt for it
@@ -710,14 +728,20 @@ impl ClientData {
 /// Trait for abstracting FIDO2 device operations.
 ///
 /// This trait enables testing FIDO2 flows without physical hardware.
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "trait used by tests and feature-gated test-utils consumers; lint fires inconsistently across compilation targets"
+)]
 pub trait FidoDevice: Send {
     /// Perform FIDO2 registration (makeCredential).
     ///
     /// Creates a new credential on the device.
     /// `exclude_credentials` prevents duplicate registration when the device
     /// already holds one of the listed credentials.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "FIDO2 makeCredential parameters per CTAP2 spec"
+    )]
     fn register(
         &self,
         rp_id: &str,
@@ -778,7 +802,10 @@ impl FidoDevice for YubiKey {
 /// This implementation uses Ed25519 keys to generate real cryptographic
 /// signatures that can be verified by the server's COSE verifier.
 #[cfg(any(test, feature = "test-utils"))]
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "test/test-utils helper; lint fires inconsistently across compilation targets"
+)]
 fn sha256(data: &[u8]) -> Vec<u8> {
     aws_lc_rs::digest::digest(&aws_lc_rs::digest::SHA256, data)
         .as_ref()
@@ -786,7 +813,10 @@ fn sha256(data: &[u8]) -> Vec<u8> {
 }
 
 #[cfg(feature = "test-utils")]
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "fields populated for feature-gated test-utils consumers; lint fires inconsistently"
+)]
 pub struct MockFidoDevice {
     /// The signing key (Ed25519 private key).
     signing_key: ed25519_dalek::SigningKey,
@@ -799,7 +829,10 @@ pub struct MockFidoDevice {
 }
 
 #[cfg(feature = "test-utils")]
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "constructors and helpers invoked by feature-gated test consumers; lint fires inconsistently"
+)]
 impl MockFidoDevice {
     /// Create a new mock FIDO2 device with random keys.
     #[must_use]
@@ -930,7 +963,10 @@ impl FidoDevice for MockFidoDevice {
         // Build attested credential data
         // AAGUID (16 bytes) + credential ID length (2 bytes) + credential ID + public key
         let aaguid = [0u8; 16]; // Zeros for mock device
-        #[allow(clippy::cast_possible_truncation)]
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "credential_id length is bounded to ≤u16::MAX by FIDO2 attestation format"
+        )]
         let cred_id_len = (self.credential_id.len() as u16).to_be_bytes();
 
         let mut auth_data = Vec::new();
@@ -991,7 +1027,11 @@ impl FidoDevice for MockFidoDevice {
 
 /// Build a COSE OKP (Octet Key Pair) key for Ed25519.
 #[cfg(any(test, feature = "test-utils"))]
-#[allow(dead_code, clippy::expect_used)]
+#[allow(
+    dead_code,
+    clippy::expect_used,
+    reason = "test/test-utils helper; .expect on infallible CBOR construction; lint fires inconsistently"
+)]
 fn build_cose_okp_key(public_key: &[u8; 32]) -> Vec<u8> {
     use ciborium::Value;
 
@@ -1016,7 +1056,10 @@ fn build_cose_okp_key(public_key: &[u8; 32]) -> Vec<u8> {
 
 /// Build a "none" attestation object for testing.
 #[cfg(any(test, feature = "test-utils"))]
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "test/test-utils helper; lint fires inconsistently across compilation targets"
+)]
 fn build_none_attestation_object(auth_data: &[u8]) -> Result<Vec<u8>> {
     use ciborium::Value;
 
@@ -1037,7 +1080,6 @@ fn build_none_attestation_object(auth_data: &[u8]) -> Result<Vec<u8>> {
 
 #[cfg(test)]
 mod tests {
-    #[allow(unused_imports)]
     use super::*;
 
     #[tokio::test]

--- a/crates/vouch-cli/src/http.rs
+++ b/crates/vouch-cli/src/http.rs
@@ -651,7 +651,10 @@ mod test_utils {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/integrations/aws/codeartifact.rs
+++ b/crates/vouch-cli/src/integrations/aws/codeartifact.rs
@@ -164,7 +164,10 @@ pub(crate) async fn get_authorization_token(
     let ca_response: GetAuthorizationTokenResponse =
         serde_json::from_str(&response_body).context("failed to parse CodeArtifact response")?;
 
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "CodeArtifact expiration is a Unix timestamp (seconds), well below i64::MAX"
+    )]
     let expiration = ca_response.expiration as i64;
 
     Ok(CodeArtifactToken {
@@ -174,7 +177,10 @@ pub(crate) async fn get_authorization_token(
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/integrations/aws/codecommit.rs
+++ b/crates/vouch-cli/src/integrations/aws/codecommit.rs
@@ -248,11 +248,11 @@ fn codecommit_domain_for_region(region: &str) -> &'static str {
 }
 
 #[cfg(test)]
-#[allow(
+#[expect(
     clippy::expect_used,
     clippy::unwrap_used,
-    clippy::indexing_slicing,
-    clippy::string_slice
+    clippy::string_slice,
+    reason = "test code: panic on assertion failure is acceptable"
 )]
 mod tests {
     use super::*;

--- a/crates/vouch-cli/src/integrations/aws/config.rs
+++ b/crates/vouch-cli/src/integrations/aws/config.rs
@@ -66,7 +66,6 @@ impl AwsConfig {
 
     /// Get a profile by name.
     #[must_use]
-    #[allow(dead_code)] // Used in tests and useful for future features
     pub(crate) fn get_profile(&self, name: &str) -> Option<AwsProfile> {
         let section_name = Self::profile_to_section(name);
         let section = self.ini.section(Some(section_name.as_str()))?;
@@ -284,7 +283,11 @@ pub(crate) fn extract_role_from_credential_process(credential_process: &str) -> 
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
+#[expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/integrations/aws/mod.rs
+++ b/crates/vouch-cli/src/integrations/aws/mod.rs
@@ -214,7 +214,11 @@ fn check_aws_status() -> AwsStatus {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
+#[expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use std::io::Write;

--- a/crates/vouch-cli/src/integrations/aws/redshift.rs
+++ b/crates/vouch-cli/src/integrations/aws/redshift.rs
@@ -183,7 +183,10 @@ fn parse_serverless_json_response(json: &str) -> Result<RedshiftCredentials> {
         .and_then(|v| v.as_f64())
         .context("missing expiration in Redshift Serverless response")?;
 
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Redshift expiration is a Unix timestamp (seconds), well below i64::MAX"
+    )]
     let expiration_secs = expiration_ts as i64;
     let expiration = jiff::Timestamp::from_second(expiration_secs)
         .context("invalid expiration timestamp in Redshift Serverless response")?
@@ -197,7 +200,10 @@ fn parse_serverless_json_response(json: &str) -> Result<RedshiftCredentials> {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/integrations/aws/sigv4.rs
+++ b/crates/vouch-cli/src/integrations/aws/sigv4.rs
@@ -178,7 +178,10 @@ pub(crate) async fn sign_and_send_json_rpc(
 /// * `service` - AWS service name for signing (e.g., `eks`, `codeartifact`)
 /// * `region` - AWS region
 /// * `creds` - Temporary AWS credentials from STS
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "AWS SigV4 REST request requires all listed parameters"
+)]
 pub(crate) async fn sign_and_send_rest(
     http_client: &reqwest::Client,
     method: reqwest::Method,
@@ -523,11 +526,11 @@ fn truncate_error_body(body: &str, max_len: usize) -> &str {
 }
 
 #[cfg(test)]
-#[allow(
+#[expect(
     clippy::expect_used,
     clippy::unwrap_used,
-    clippy::indexing_slicing,
-    clippy::string_slice
+    clippy::string_slice,
+    reason = "test code: panic on assertion failure is acceptable"
 )]
 mod tests {
     use super::*;

--- a/crates/vouch-cli/src/integrations/aws/sso.rs
+++ b/crates/vouch-cli/src/integrations/aws/sso.rs
@@ -211,7 +211,10 @@ pub(crate) struct DeviceAuth {
     /// Code to display to the user.
     pub user_code: String,
     /// URL for the user to open (without code, for display or fallback).
-    #[allow(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "deserialized from AWS SSO OIDC response; UI uses verification_uri_complete"
+    )]
     pub verification_uri: String,
     /// URL with code pre-filled (for `open::that()`).
     pub verification_uri_complete: String,
@@ -651,7 +654,11 @@ pub(crate) async fn poll_for_token(
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
+#[expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use crate::integrations::aws::config::SsoSession;

--- a/crates/vouch-cli/src/integrations/aws/sso_portal.rs
+++ b/crates/vouch-cli/src/integrations/aws/sso_portal.rs
@@ -23,7 +23,10 @@ pub(crate) struct SsoAccount {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct SsoRole {
     pub role_name: String,
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "deserialized from AWS SSO portal listing; lint fires inconsistently across compilation targets"
+    )]
     pub account_id: String,
 }
 
@@ -185,7 +188,11 @@ pub(crate) async fn list_account_roles(
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/integrations/aws/sts.rs
+++ b/crates/vouch-cli/src/integrations/aws/sts.rs
@@ -248,7 +248,11 @@ fn parse_sts_xml_response(xml: &str) -> Result<StsCredentials> {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use vouch_common::aws::Partition;

--- a/crates/vouch-cli/src/integrations/cargo/config.rs
+++ b/crates/vouch-cli/src/integrations/cargo/config.rs
@@ -227,7 +227,11 @@ impl CargoConfig {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
+#[expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/integrations/cargo/mod.rs
+++ b/crates/vouch-cli/src/integrations/cargo/mod.rs
@@ -79,7 +79,12 @@ impl IntegrationCheck for CargoIntegration {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+#[expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use std::io::Write;

--- a/crates/vouch-cli/src/integrations/eks.rs
+++ b/crates/vouch-cli/src/integrations/eks.rs
@@ -143,7 +143,12 @@ fn is_vouch_eks_exec(exec: &EksExecConfig) -> bool {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/integrations/ssm.rs
+++ b/crates/vouch-cli/src/integrations/ssm.rs
@@ -120,7 +120,6 @@ pub(crate) fn extract_flag_value(line: &str, flag: &str) -> Option<String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/main.rs
+++ b/crates/vouch-cli/src/main.rs
@@ -16,7 +16,10 @@ mod client;
 mod commands;
 mod config;
 mod exit_code;
-#[allow(unreachable_pub)] // Items are pub for lib.rs re-exports used by vouch-tests
+#[expect(
+    unreachable_pub,
+    reason = "items pub for lib.rs re-exports used by vouch-tests"
+)]
 mod fido2;
 mod integrations;
 mod server_url;

--- a/crates/vouch-cli/src/posture/common.rs
+++ b/crates/vouch-cli/src/posture/common.rs
@@ -16,7 +16,10 @@ pub(super) fn detect(posture: &mut DevicePosture) {
 #[cfg(unix)]
 fn detect_elevated() -> bool {
     // SAFETY: geteuid() is always safe to call.
-    #[allow(unsafe_code)]
+    #[expect(
+        unsafe_code,
+        reason = "libc::geteuid is always safe with no side effects"
+    )]
     unsafe {
         libc::geteuid() == 0
     }
@@ -114,12 +117,6 @@ pub(super) fn run_command(program: &str, args: &[&str]) -> Option<String> {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::indexing_slicing,
-    clippy::panic
-)]
 mod tests {
     #[cfg(target_os = "linux")]
     use super::parse_ppid_from_proc_stat;

--- a/crates/vouch-cli/src/posture/linux.rs
+++ b/crates/vouch-cli/src/posture/linux.rs
@@ -354,7 +354,8 @@ fn unquote(s: &str) -> String {
     clippy::unwrap_used,
     clippy::expect_used,
     clippy::indexing_slicing,
-    clippy::panic
+    clippy::panic,
+    reason = "test code: panic on assertion failure is acceptable"
 )]
 mod tests {
     use super::*;

--- a/crates/vouch-cli/src/server_url.rs
+++ b/crates/vouch-cli/src/server_url.rs
@@ -98,7 +98,10 @@ pub(crate) enum ServerUrlError {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/utils.rs
+++ b/crates/vouch-cli/src/utils.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Shared utility functions for the CLI.
 
-#![allow(dead_code)]
+#![allow(
+    dead_code,
+    reason = "shared utilities used selectively across binary and test targets"
+)]
 
 use anyhow::{Context, Result};
 use std::fs;
@@ -149,7 +152,14 @@ pub(crate) fn is_vouch_symlink(path: &Path) -> bool {
 pub(crate) fn create_symlink_with_fallback(
     vouch_path: &Path,
     symlink_path: &Path,
-    #[allow(unused_variables)] windows_batch_content: &str,
+    #[cfg_attr(
+        not(target_os = "windows"),
+        expect(
+            unused_variables,
+            reason = "parameter consumed only under cfg(windows)"
+        )
+    )]
+    windows_batch_content: &str,
 ) -> Result<()> {
     // Ensure parent directory exists
     if let Some(parent) = symlink_path.parent()
@@ -222,7 +232,10 @@ pub(crate) fn create_symlink_with_fallback(
 /// This is the only `unsafe` call in the CLI crate. `flock` is a well-defined
 /// POSIX API and the file descriptor is guaranteed valid by the borrow of `File`.
 #[cfg(unix)]
-#[allow(unsafe_code)]
+#[expect(
+    unsafe_code,
+    reason = "POSIX flock; safety documented inline above call site"
+)]
 pub(crate) fn flock_exclusive(file: &fs::File) -> Result<(), std::io::Error> {
     use std::os::unix::io::{AsFd, AsRawFd};
     let ret = unsafe { libc::flock(file.as_fd().as_raw_fd(), libc::LOCK_EX) };
@@ -233,7 +246,10 @@ pub(crate) fn flock_exclusive(file: &fs::File) -> Result<(), std::io::Error> {
 }
 
 #[cfg(test)]
-#[allow(clippy::panic_in_result_fn)]
+#[expect(
+    clippy::panic_in_result_fn,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-common/src/aaguid.rs
+++ b/crates/vouch-common/src/aaguid.rs
@@ -517,7 +517,11 @@ pub fn extract_public_key_from_attestation(attestation: &[u8]) -> Option<Vec<u8>
 }
 
 #[cfg(test)]
-#[allow(clippy::indexing_slicing, clippy::unwrap_used)]
+#[expect(
+    clippy::indexing_slicing,
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-common/src/api_tests.rs
+++ b/crates/vouch-common/src/api_tests.rs
@@ -5,7 +5,10 @@
 //! and deserialize correctly with the typed encoding wrappers.
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use crate::api::*;
     use uuid::Uuid;

--- a/crates/vouch-common/src/api_tests.rs
+++ b/crates/vouch-common/src/api_tests.rs
@@ -5,12 +5,7 @@
 //! and deserialize correctly with the typed encoding wrappers.
 
 #[cfg(test)]
-#[allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::panic,
-    clippy::indexing_slicing
-)]
+#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use crate::api::*;
     use uuid::Uuid;

--- a/crates/vouch-common/src/aws.rs
+++ b/crates/vouch-common/src/aws.rs
@@ -316,7 +316,10 @@ pub fn expiration_from_secs(expires_in: u64) -> Result<jiff::Timestamp, jiff::Er
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-common/src/aws.rs
+++ b/crates/vouch-common/src/aws.rs
@@ -316,7 +316,7 @@ pub fn expiration_from_secs(expires_in: u64) -> Result<jiff::Timestamp, jiff::Er
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use super::*;
 

--- a/crates/vouch-common/src/cookie.rs
+++ b/crates/vouch-common/src/cookie.rs
@@ -199,7 +199,7 @@ pub fn is_cookie_expired(cookie: &SessionCookie) -> bool {
 }
 
 #[cfg(test)]
-#[expect(clippy::panic)]
+#[expect(clippy::panic, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use super::*;
 

--- a/crates/vouch-common/src/cookie.rs
+++ b/crates/vouch-common/src/cookie.rs
@@ -199,7 +199,10 @@ pub fn is_cookie_expired(cookie: &SessionCookie) -> bool {
 }
 
 #[cfg(test)]
-#[expect(clippy::panic, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::panic,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-common/src/encoding.rs
+++ b/crates/vouch-common/src/encoding.rs
@@ -366,7 +366,7 @@ impl<T, E: Encoding> std::fmt::LowerHex for Encoded<T, E> {
 // ============================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use super::*;
 

--- a/crates/vouch-common/src/encoding.rs
+++ b/crates/vouch-common/src/encoding.rs
@@ -366,7 +366,10 @@ impl<T, E: Encoding> std::fmt::LowerHex for Encoded<T, E> {
 // ============================================================================
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-common/src/encoding_tests.rs
+++ b/crates/vouch-common/src/encoding_tests.rs
@@ -5,7 +5,10 @@
 //! with serde_json before we introduce new encoding types.
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use crate::encoding::{Base64Url, ConvertEncoding, Encoded, Raw};
     use serde::{Deserialize, Serialize};

--- a/crates/vouch-common/src/encoding_tests.rs
+++ b/crates/vouch-common/src/encoding_tests.rs
@@ -5,7 +5,7 @@
 //! with serde_json before we introduce new encoding types.
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use crate::encoding::{Base64Url, ConvertEncoding, Encoded, Raw};
     use serde::{Deserialize, Serialize};

--- a/crates/vouch-common/src/fido2_types.rs
+++ b/crates/vouch-common/src/fido2_types.rs
@@ -162,7 +162,10 @@ pub type Base64UrlCredentialId = CredentialId<Base64Url>;
 // ============================================================================
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use crate::encoding::ConvertEncoding;

--- a/crates/vouch-common/src/fido2_types.rs
+++ b/crates/vouch-common/src/fido2_types.rs
@@ -162,7 +162,7 @@ pub type Base64UrlCredentialId = CredentialId<Base64Url>;
 // ============================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use super::*;
     use crate::encoding::ConvertEncoding;

--- a/crates/vouch-common/src/fixtures.rs
+++ b/crates/vouch-common/src/fixtures.rs
@@ -133,7 +133,10 @@ impl Fido2Fixture {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-common/src/fixtures.rs
+++ b/crates/vouch-common/src/fixtures.rs
@@ -133,7 +133,7 @@ impl Fido2Fixture {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use super::*;
 

--- a/crates/vouch-common/src/posture.rs
+++ b/crates/vouch-common/src/posture.rs
@@ -427,11 +427,10 @@ impl DevicePosture {
 }
 
 #[cfg(test)]
-#[allow(
+#[expect(
     clippy::unwrap_used,
-    clippy::expect_used,
     clippy::indexing_slicing,
-    clippy::panic
+    reason = "test code: panic on assertion failure is acceptable"
 )]
 mod tests {
     use super::*;

--- a/crates/vouch-httpsig/src/algorithm/ecdsa_p256.rs
+++ b/crates/vouch-httpsig/src/algorithm/ecdsa_p256.rs
@@ -127,7 +127,10 @@ impl VerifyingAlgorithm for EcdsaP256Verifier {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-httpsig/src/algorithm/ecdsa_p256.rs
+++ b/crates/vouch-httpsig/src/algorithm/ecdsa_p256.rs
@@ -127,7 +127,7 @@ impl VerifyingAlgorithm for EcdsaP256Verifier {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use super::*;
 

--- a/crates/vouch-httpsig/src/algorithm/ecdsa_p384.rs
+++ b/crates/vouch-httpsig/src/algorithm/ecdsa_p384.rs
@@ -127,7 +127,7 @@ impl VerifyingAlgorithm for EcdsaP384Verifier {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use super::*;
 

--- a/crates/vouch-httpsig/src/algorithm/ecdsa_p384.rs
+++ b/crates/vouch-httpsig/src/algorithm/ecdsa_p384.rs
@@ -127,7 +127,10 @@ impl VerifyingAlgorithm for EcdsaP384Verifier {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-httpsig/src/algorithm/ed25519.rs
+++ b/crates/vouch-httpsig/src/algorithm/ed25519.rs
@@ -120,7 +120,7 @@ impl VerifyingAlgorithm for Ed25519Verifier {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use super::*;
 

--- a/crates/vouch-httpsig/src/algorithm/ed25519.rs
+++ b/crates/vouch-httpsig/src/algorithm/ed25519.rs
@@ -120,7 +120,10 @@ impl VerifyingAlgorithm for Ed25519Verifier {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-httpsig/src/algorithm/hmac_sha256.rs
+++ b/crates/vouch-httpsig/src/algorithm/hmac_sha256.rs
@@ -61,7 +61,10 @@ impl VerifyingAlgorithm for HmacSha256Key {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-httpsig/src/algorithm/hmac_sha256.rs
+++ b/crates/vouch-httpsig/src/algorithm/hmac_sha256.rs
@@ -61,7 +61,7 @@ impl VerifyingAlgorithm for HmacSha256Key {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use super::*;
 

--- a/crates/vouch-httpsig/src/algorithm/rsa_pss_sha512.rs
+++ b/crates/vouch-httpsig/src/algorithm/rsa_pss_sha512.rs
@@ -117,7 +117,10 @@ impl VerifyingAlgorithm for RsaPssSha512Verifier {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-httpsig/src/algorithm/rsa_pss_sha512.rs
+++ b/crates/vouch-httpsig/src/algorithm/rsa_pss_sha512.rs
@@ -117,7 +117,7 @@ impl VerifyingAlgorithm for RsaPssSha512Verifier {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use super::*;
 

--- a/crates/vouch-httpsig/src/algorithm/rsa_v15_sha256.rs
+++ b/crates/vouch-httpsig/src/algorithm/rsa_v15_sha256.rs
@@ -117,7 +117,7 @@ impl VerifyingAlgorithm for RsaV15Sha256Verifier {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use super::*;
 

--- a/crates/vouch-httpsig/src/algorithm/rsa_v15_sha256.rs
+++ b/crates/vouch-httpsig/src/algorithm/rsa_v15_sha256.rs
@@ -117,7 +117,10 @@ impl VerifyingAlgorithm for RsaV15Sha256Verifier {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-httpsig/src/component.rs
+++ b/crates/vouch-httpsig/src/component.rs
@@ -679,12 +679,7 @@ fn hex_val(c: u8) -> Option<u8> {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::indexing_slicing,
-    clippy::panic
-)]
+#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use super::*;
 

--- a/crates/vouch-httpsig/src/component.rs
+++ b/crates/vouch-httpsig/src/component.rs
@@ -679,7 +679,10 @@ fn hex_val(c: u8) -> Option<u8> {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-httpsig/src/digest.rs
+++ b/crates/vouch-httpsig/src/digest.rs
@@ -125,7 +125,10 @@ pub fn verify_content_digest(header_value: &str, body: &[u8]) -> Result<(), Http
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-httpsig/src/digest.rs
+++ b/crates/vouch-httpsig/src/digest.rs
@@ -125,7 +125,7 @@ pub fn verify_content_digest(header_value: &str, body: &[u8]) -> Result<(), Http
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use super::*;
 

--- a/crates/vouch-httpsig/src/middleware.rs
+++ b/crates/vouch-httpsig/src/middleware.rs
@@ -235,7 +235,10 @@ fn extract_keyid_from_header(header_value: &str, label: &str) -> Option<String> 
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use crate::algorithm::ecdsa_p256::EcdsaP256Signer;

--- a/crates/vouch-httpsig/src/middleware.rs
+++ b/crates/vouch-httpsig/src/middleware.rs
@@ -235,7 +235,7 @@ fn extract_keyid_from_header(header_value: &str, label: &str) -> Option<String> 
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use super::*;
     use crate::algorithm::ecdsa_p256::EcdsaP256Signer;

--- a/crates/vouch-httpsig/src/sfv/parse.rs
+++ b/crates/vouch-httpsig/src/sfv/parse.rs
@@ -554,11 +554,11 @@ pub fn parse_item(input: &str) -> Result<SfvItem, HttpSigError> {
 }
 
 #[cfg(test)]
-#[allow(
+#[expect(
     clippy::unwrap_used,
-    clippy::expect_used,
     clippy::indexing_slicing,
-    clippy::panic
+    clippy::panic,
+    reason = "test code: panic on assertion failure is acceptable"
 )]
 mod tests {
     use super::*;

--- a/crates/vouch-httpsig/src/sfv/serialize.rs
+++ b/crates/vouch-httpsig/src/sfv/serialize.rs
@@ -143,7 +143,7 @@ fn serialize_params(params: &SfvParams, out: &mut String) {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use super::*;
     use crate::sfv::parse;

--- a/crates/vouch-httpsig/src/sfv/serialize.rs
+++ b/crates/vouch-httpsig/src/sfv/serialize.rs
@@ -143,7 +143,10 @@ fn serialize_params(params: &SfvParams, out: &mut String) {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use crate::sfv::parse;

--- a/crates/vouch-httpsig/src/sign.rs
+++ b/crates/vouch-httpsig/src/sign.rs
@@ -241,12 +241,7 @@ fn build_signature_dict(label: &str, signature: &[u8]) -> String {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::indexing_slicing,
-    clippy::panic
-)]
+#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use super::*;
     use crate::algorithm::hmac_sha256::HmacSha256Key;

--- a/crates/vouch-httpsig/src/sign.rs
+++ b/crates/vouch-httpsig/src/sign.rs
@@ -241,7 +241,10 @@ fn build_signature_dict(label: &str, signature: &[u8]) -> String {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use crate::algorithm::hmac_sha256::HmacSha256Key;

--- a/crates/vouch-httpsig/src/signature_base.rs
+++ b/crates/vouch-httpsig/src/signature_base.rs
@@ -90,12 +90,7 @@ pub fn build_response_base_with_params_str<T, U>(
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::indexing_slicing,
-    clippy::panic
-)]
+#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use super::*;
     use crate::component::ComponentIdentifier;

--- a/crates/vouch-httpsig/src/signature_base.rs
+++ b/crates/vouch-httpsig/src/signature_base.rs
@@ -90,7 +90,10 @@ pub fn build_response_base_with_params_str<T, U>(
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use crate::component::ComponentIdentifier;

--- a/crates/vouch-httpsig/src/signature_params.rs
+++ b/crates/vouch-httpsig/src/signature_params.rs
@@ -133,7 +133,7 @@ fn extract_integer_param(params: &SfvParams, key: &str) -> Option<i64> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use super::*;
     use crate::sfv::parse::parse_inner_list;

--- a/crates/vouch-httpsig/src/signature_params.rs
+++ b/crates/vouch-httpsig/src/signature_params.rs
@@ -133,7 +133,10 @@ fn extract_integer_param(params: &SfvParams, key: &str) -> Option<i64> {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use crate::sfv::parse::parse_inner_list;

--- a/crates/vouch-httpsig/src/verify.rs
+++ b/crates/vouch-httpsig/src/verify.rs
@@ -249,7 +249,10 @@ fn validate_timestamps(params: &SignatureParams, max_age: Option<i64>) -> Result
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use crate::algorithm::SigningAlgorithm;

--- a/crates/vouch-httpsig/src/verify.rs
+++ b/crates/vouch-httpsig/src/verify.rs
@@ -249,12 +249,7 @@ fn validate_timestamps(params: &SignatureParams, max_age: Option<i64>) -> Result
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::indexing_slicing,
-    clippy::panic
-)]
+#[expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
 mod tests {
     use super::*;
     use crate::algorithm::SigningAlgorithm;

--- a/crates/vouch-httpsig/tests/rfc9421_vectors.rs
+++ b/crates/vouch-httpsig/tests/rfc9421_vectors.rs
@@ -4,11 +4,10 @@
 //! These tests verify signature base construction and signature verification
 //! against the exact examples from RFC 9421 Appendix B.
 
-#![allow(
+#![expect(
     clippy::unwrap_used,
-    clippy::expect_used,
     clippy::indexing_slicing,
-    clippy::panic
+    reason = "test code: panic on assertion failure is acceptable"
 )]
 
 use base64::Engine;

--- a/crates/vouch-httpsig/tests/sfv_proptest.rs
+++ b/crates/vouch-httpsig/tests/sfv_proptest.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Property-based tests for the SFV parser/serializer roundtrip.
 
-#![expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
+#![expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 
 use proptest::prelude::*;
 

--- a/crates/vouch-httpsig/tests/sfv_proptest.rs
+++ b/crates/vouch-httpsig/tests/sfv_proptest.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Property-based tests for the SFV parser/serializer roundtrip.
 
-#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![expect(clippy::unwrap_used, reason = "test code: panic on assertion failure is acceptable")]
 
 use proptest::prelude::*;
 

--- a/crates/vouch-server/src/config.rs
+++ b/crates/vouch-server/src/config.rs
@@ -824,7 +824,10 @@ pub fn resolve_dsql_endpoints(endpoints: &HashMap<String, String>) -> Result<Str
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use crate::test_utils::test_config;
     use secrecy::SecretString;

--- a/crates/vouch-server/src/crypto/attestation_chain.rs
+++ b/crates/vouch-server/src/crypto/attestation_chain.rs
@@ -173,7 +173,10 @@ pub fn validate_attestation_chain(
 // Pinned root CAs parsed once at first use. These are compile-time-embedded
 // PEM constants — a parse failure means the binary is broken, so expect is
 // the correct response (fail loudly on startup, not silently at runtime).
-#[allow(clippy::expect_used)]
+#[expect(
+    clippy::expect_used,
+    reason = "embedded PEM is a build-time constant; .expect surfaces invalid build"
+)]
 static PINNED_ROOTS: LazyLock<Vec<Certificate>> = LazyLock::new(|| {
     vec![
         Certificate::from_pem(YUBICO_FIDO_CA_1_PEM)
@@ -315,7 +318,10 @@ fn format_aaguid(bytes: &[u8]) -> String {
 // ============================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/crypto/ber.rs
+++ b/crates/vouch-server/src/crypto/ber.rs
@@ -319,7 +319,10 @@ impl<'a> DerParser<'a> {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+    #![expect(
+        clippy::unwrap_used,
+        reason = "test code: panic on assertion failure is acceptable"
+    )]
     use super::*;
 
     // ====================================================================

--- a/crates/vouch-server/src/crypto/cose.rs
+++ b/crates/vouch-server/src/crypto/cose.rs
@@ -97,7 +97,11 @@ pub fn cose_key_to_cbor(key: &COSEKey) -> Result<Vec<u8>, CoseError> {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
+#[expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use webauthn_rs::prelude::{COSEAlgorithm, COSEEC2Key, COSEKey, COSEKeyType, ECDSACurve};

--- a/crates/vouch-server/src/crypto/document_crypto.rs
+++ b/crates/vouch-server/src/crypto/document_crypto.rs
@@ -273,7 +273,10 @@ pub(crate) fn p384_hpke_keys_from_private_key_der(
 // ============================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/crypto/hash.rs
+++ b/crates/vouch-server/src/crypto/hash.rs
@@ -42,7 +42,10 @@ pub fn generate_challenge() -> Result<Vec<u8>, aws_lc_rs::error::Unspecified> {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/crypto/jwt.rs
+++ b/crates/vouch-server/src/crypto/jwt.rs
@@ -454,7 +454,11 @@ pub(crate) fn decode_state_token<T: DeserializeOwned>(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use crate::services::auth::AccessTokenClaims;

--- a/crates/vouch-server/src/crypto/kms_signer.rs
+++ b/crates/vouch-server/src/crypto/kms_signer.rs
@@ -643,7 +643,12 @@ impl KmsSignerRsa3072 {
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/crypto/pem.rs
+++ b/crates/vouch-server/src/crypto/pem.rs
@@ -49,7 +49,10 @@ pub(crate) fn decode_base64_pem(content: &str) -> Result<String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/crypto/ssh_ca.rs
+++ b/crates/vouch-server/src/crypto/ssh_ca.rs
@@ -360,7 +360,10 @@ pub struct SignedCertificate {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/crypto/tpm_decrypt.rs
+++ b/crates/vouch-server/src/crypto/tpm_decrypt.rs
@@ -436,7 +436,10 @@ fn aes_256_cbc_decrypt(key: &[u8], iv: &[u8], ciphertext: &[u8]) -> Result<Zeroi
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+    #![expect(
+        clippy::unwrap_used,
+        reason = "test code: panic on assertion failure is acceptable"
+    )]
     use super::*;
 
     #[test]

--- a/crates/vouch-server/src/crypto/webauthn_verify.rs
+++ b/crates/vouch-server/src/crypto/webauthn_verify.rs
@@ -176,7 +176,7 @@ struct ClientData {
     challenge: String,
     origin: String,
     #[serde(rename = "crossOrigin", default)]
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "reserved for serde DTO conformance / future use")]
     cross_origin: Option<bool>,
 }
 
@@ -195,7 +195,10 @@ struct ClientData {
 /// * `expected_origin` - The expected origin URL
 /// * `stored_counter` - The previously stored counter value
 /// * `require_user_verification` - Whether to require UV flag
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "WebAuthn assertion verification requires all per-RFC parameters"
+)]
 pub fn verify_assertion(
     authenticator_data: &[u8],
     client_data_json: &[u8],
@@ -237,7 +240,10 @@ pub fn verify_assertion(
 /// * `stored_counter` - The previously stored counter value
 /// * `require_user_verification` - Whether to require UV flag
 /// * `verifier` - The COSE verifier to use for signature verification
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "WebAuthn assertion verification requires all per-RFC parameters"
+)]
 pub fn verify_assertion_with_verifier<V: CoseVerifier>(
     authenticator_data: &[u8],
     client_data_json: &[u8],
@@ -367,7 +373,10 @@ pub fn verify_assertion_with_verifier<V: CoseVerifier>(
 /// - `ClientDataJson<Raw>` for client data JSON
 /// - `Signature<Raw>` for the signature
 /// - `CoseKey<Raw>` for the public key
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "WebAuthn assertion verification requires all per-RFC parameters"
+)]
 pub fn verify_assertion_typed(
     authenticator_data: &AuthData<Raw>,
     client_data_json: &ClientDataJson<Raw>,
@@ -395,7 +404,10 @@ pub fn verify_assertion_typed(
 /// Verify a WebAuthn assertion with a custom COSE verifier using typed parameters.
 ///
 /// This is a type-safe wrapper around [`verify_assertion_with_verifier`].
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "WebAuthn assertion verification requires all per-RFC parameters"
+)]
 pub fn verify_assertion_typed_with_verifier<V: CoseVerifier>(
     authenticator_data: &AuthData<Raw>,
     client_data_json: &ClientDataJson<Raw>,
@@ -451,7 +463,6 @@ pub struct RegistrationVerificationResult {
 /// 5. For `fmt="none"`: accept (no attestation statement)
 ///
 /// Returns the server-verified credential ID, public key, and AAGUID.
-#[allow(clippy::too_many_arguments)]
 pub fn verify_registration(
     attestation_object: &[u8],
     client_data_json: &[u8],
@@ -474,7 +485,6 @@ pub fn verify_registration(
 /// Verify a WebAuthn registration with a custom COSE verifier.
 ///
 /// This is the testable version of [`verify_registration`].
-#[allow(clippy::too_many_arguments)]
 pub fn verify_registration_with_verifier<V: CoseVerifier>(
     attestation_object: &[u8],
     client_data_json: &[u8],
@@ -1088,7 +1098,11 @@ fn verify_eddsa(
 }
 
 #[cfg(test)]
-#[allow(clippy::indexing_slicing, clippy::unwrap_used)]
+#[expect(
+    clippy::indexing_slicing,
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use aws_lc_rs::digest::{self, SHA256};
@@ -1118,7 +1132,7 @@ mod tests {
     }
 
     /// Create a minimal valid ES256 COSE key
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "reserved for serde DTO conformance / future use")]
     fn make_es256_cose_key(x: &[u8], y: &[u8]) -> Vec<u8> {
         let mut buf = Vec::new();
         let key = ciborium::Value::Map(vec![
@@ -1173,7 +1187,7 @@ mod tests {
     }
 
     /// Create a minimal valid RS256 COSE key
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "reserved for serde DTO conformance / future use")]
     fn make_rs256_cose_key(n: &[u8], e: &[u8]) -> Vec<u8> {
         let mut buf = Vec::new();
         let key = ciborium::Value::Map(vec![

--- a/crates/vouch-server/src/db/audit.rs
+++ b/crates/vouch-server/src/db/audit.rs
@@ -305,11 +305,11 @@ fn raw_to_audit_event(row: RawAuditRow) -> AuditEvent {
 // ============================================================================
 
 #[cfg(test)]
-#[allow(
+#[expect(
     clippy::unwrap_used,
-    clippy::expect_used,
     clippy::unreachable,
-    clippy::indexing_slicing
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
 )]
 mod tests {
     use super::*;

--- a/crates/vouch-server/src/db/authenticators.rs
+++ b/crates/vouch-server/src/db/authenticators.rs
@@ -72,7 +72,10 @@ pub struct AuthenticatorWithUser {
 /// Create a new authenticator.
 ///
 /// `user_email` is denormalized into the document to eliminate JOINs.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "authenticator record requires all denormalized fields"
+)]
 pub async fn create_authenticator(
     store: &DocumentStore,
     user_id: &str,

--- a/crates/vouch-server/src/db/config.rs
+++ b/crates/vouch-server/src/db/config.rs
@@ -128,7 +128,10 @@ pub async fn delete_old_auth_events(audit: &AuditStore, before: jiff::Timestamp)
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use crate::handlers::extractors::ClientInfo;

--- a/crates/vouch-server/src/db/credentials.rs
+++ b/crates/vouch-server/src/db/credentials.rs
@@ -14,7 +14,10 @@ use jiff::Timestamp;
 // ============================================================
 
 /// Insert a token exchange audit record.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "token-exchange audit row requires all RFC 8693 fields"
+)]
 pub async fn insert_token_exchange(
     store: &DocumentStore,
     subject_user_id: &str,
@@ -45,7 +48,6 @@ pub async fn delete_old_token_exchanges(store: &DocumentStore) -> Result<u64> {
 
 /// Token exchange audit record.
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct TokenExchangeRecord {
     pub id: String,
     pub subject_user_id: String,
@@ -75,7 +77,6 @@ impl From<Document<TokenExchangeDoc>> for TokenExchangeRecord {
 }
 
 /// Get token exchange records for a user.
-#[allow(dead_code)]
 pub async fn get_token_exchanges_for_user(
     store: &DocumentStore,
     user_id: &str,
@@ -93,7 +94,6 @@ pub async fn get_token_exchanges_for_user(
 
 /// Delegation policy record.
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct DelegationPolicy {
     pub id: String,
     pub name: String,
@@ -174,7 +174,6 @@ pub async fn get_delegation_policies(store: &DocumentStore) -> Result<Vec<Delega
 }
 
 /// Update a delegation policy's enabled status.
-#[allow(dead_code)]
 pub async fn set_delegation_policy_enabled(
     store: &DocumentStore,
     id: &str,
@@ -190,7 +189,6 @@ pub async fn set_delegation_policy_enabled(
 }
 
 /// Delete a delegation policy.
-#[allow(dead_code)]
 pub async fn delete_delegation_policy(store: &DocumentStore, id: &str) -> Result<bool> {
     store.delete(id).await?;
     Ok(true)
@@ -206,13 +204,10 @@ pub struct EnrollmentSession {
     pub id: String,
     pub user_id: String,
     pub user_email: String,
-    #[allow(dead_code)]
     pub session_token_hash: String,
     pub device_auth_id: Option<String>,
     pub expires_at: Timestamp,
-    #[allow(dead_code)]
     pub created_at: Timestamp,
-    #[allow(dead_code)]
     pub last_used_at: Option<Timestamp>,
 }
 
@@ -274,14 +269,10 @@ pub async fn delete_expired_enrollment_sessions(store: &DocumentStore) -> Result
 /// Record of an issued SSH certificate.
 #[derive(Debug)]
 pub struct IssuedSshCertificate {
-    #[allow(dead_code)]
     pub id: String,
     pub serial: String,
-    #[allow(dead_code)]
     pub user_id: String,
-    #[allow(dead_code)]
     pub user_email: String,
-    #[allow(dead_code)]
     pub principals: Vec<String>,
     pub expires_at: Timestamp,
 }
@@ -347,18 +338,12 @@ pub async fn delete_expired_ssh_issued_certs(store: &DocumentStore) -> Result<u6
 /// Revoked SSH certificate record.
 #[derive(Debug)]
 pub struct RevokedSshCertificate {
-    #[allow(dead_code)]
     pub id: String,
     pub serial: String,
-    #[allow(dead_code)]
     pub user_id: String,
-    #[allow(dead_code)]
     pub reason: Option<String>,
-    #[allow(dead_code)]
     pub revoked_at: Timestamp,
-    #[allow(dead_code)]
     pub expires_at: Timestamp,
-    #[allow(dead_code)]
     pub revoked_by: Option<String>,
 }
 
@@ -460,11 +445,11 @@ pub async fn delete_expired_ssh_revocations(store: &DocumentStore) -> Result<u64
 // ============================================================
 
 #[cfg(test)]
-#[allow(
+#[expect(
     clippy::expect_used,
-    clippy::unwrap_used,
     clippy::indexing_slicing,
-    clippy::panic
+    clippy::panic,
+    reason = "test code: panic on assertion failure is acceptable"
 )]
 mod tests {
     use super::*;

--- a/crates/vouch-server/src/db/device_auth.rs
+++ b/crates/vouch-server/src/db/device_auth.rs
@@ -121,7 +121,10 @@ pub async fn get_device_auth_by_user_code(
 }
 
 /// Get a device auth request by ID.
-#[allow(dead_code)] // Used in db/tests.rs
+#[allow(
+    dead_code,
+    reason = "API exposed for callers; lint fires inconsistently across compilation targets"
+)]
 pub(crate) async fn get_device_auth_by_id(
     store: &DocumentStore,
     id: &str,
@@ -180,7 +183,6 @@ pub async fn authorize_device_auth(
 ///
 /// The read and status update execute within a single transaction so
 /// concurrent denial attempts are serialized correctly.
-#[allow(dead_code)]
 pub async fn deny_device_auth(store: &DocumentStore, id: &str) -> Result<()> {
     if id.is_empty() {
         bail!("deny_device_auth called with empty id");

--- a/crates/vouch-server/src/db/documents/audit.rs
+++ b/crates/vouch-server/src/db/documents/audit.rs
@@ -60,7 +60,10 @@ pub struct GitHubCredentialAuditData {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/db/documents/github.rs
+++ b/crates/vouch-server/src/db/documents/github.rs
@@ -63,7 +63,10 @@ impl DocumentType for GitHubInstallationDoc {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use serde_json::json;

--- a/crates/vouch-server/src/db/documents/oauth.rs
+++ b/crates/vouch-server/src/db/documents/oauth.rs
@@ -562,7 +562,11 @@ impl DocumentType for DelegationPolicyDoc {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::{
         AccessScope, JwsAlgorithm, OAuthClientType, OAuthDocumentParseError,

--- a/crates/vouch-server/src/db/dsql.rs
+++ b/crates/vouch-server/src/db/dsql.rs
@@ -360,7 +360,10 @@ fn extract_service_id_from_vpc_endpoint(host: &str) -> Option<String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/db/github.rs
+++ b/crates/vouch-server/src/db/github.rs
@@ -50,7 +50,10 @@ impl From<Document<GitHubInstallationDoc>> for GitHubInstallation {
 }
 
 /// Create a new GitHub App installation for an organization.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "GitHub installation record requires all webhook fields"
+)]
 pub async fn create_github_installation(
     store: &DocumentStore,
     org_id: &str,

--- a/crates/vouch-server/src/db/jwt_issuer.rs
+++ b/crates/vouch-server/src/db/jwt_issuer.rs
@@ -52,7 +52,10 @@ impl From<Document<TrustedJwtIssuerDoc>> for TrustedJwtIssuer {
 }
 
 /// Create a new trusted JWT issuer.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "JWT issuer record requires all configuration fields"
+)]
 pub async fn create_trusted_jwt_issuer(
     store: &DocumentStore,
     issuer: &str,
@@ -100,7 +103,10 @@ pub async fn list_trusted_jwt_issuers(store: &DocumentStore) -> Result<Vec<Trust
 }
 
 /// Update a trusted JWT issuer.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "JWT issuer record requires all configuration fields"
+)]
 pub async fn update_trusted_jwt_issuer(
     store: &DocumentStore,
     id: &str,

--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -352,7 +352,6 @@ pub async fn update_oauth_client_last_used(store: &DocumentStore, id: &str) -> R
 
 /// OAuth client secret record.
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct OAuthClientSecret {
     pub id: String,
     pub oauth_client_id: String,
@@ -907,7 +906,11 @@ pub async fn validate_oauth_client_credentials(
 // ============================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/db/pool.rs
+++ b/crates/vouch-server/src/db/pool.rs
@@ -120,7 +120,10 @@ impl Pool {
     /// Panics if the in-memory pool creation fails (should never happen).
     #[cfg(any(test, feature = "test-utils"))]
     #[must_use]
-    #[allow(clippy::expect_used)]
+    #[expect(
+        clippy::expect_used,
+        reason = "test-only constructor; .expect surfaces broken in-memory sqlite setup"
+    )]
     pub fn new_test() -> Self {
         // Create a synchronous in-memory pool
         // Note: This is intentionally synchronous for test setup convenience
@@ -817,7 +820,10 @@ pub(crate) fn retry_backoff(attempt: u32) -> Duration {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/db/scim.rs
+++ b/crates/vouch-server/src/db/scim.rs
@@ -114,7 +114,6 @@ impl Default for ScimScopeSet {
 
 /// SCIM token record.
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct ScimToken {
     pub id: String,
     pub token_hash: String,
@@ -176,7 +175,6 @@ pub async fn update_scim_token_last_used(store: &DocumentStore, token_id: &str) 
 }
 
 /// Create a new SCIM token.
-#[allow(dead_code)]
 pub async fn create_scim_token(
     store: &DocumentStore,
     token_hash: &str,
@@ -204,7 +202,6 @@ pub async fn create_scim_token(
 /// Returns `Ok(true)` if a token was deleted, `Ok(false)` if no
 /// matching token was found for the given org (prevents cross-org
 /// deletion).
-#[allow(dead_code)]
 pub async fn delete_scim_token(
     store: &DocumentStore,
     token_id: &str,
@@ -224,7 +221,6 @@ pub async fn delete_scim_token(
 }
 
 /// List SCIM tokens, optionally filtered by organization.
-#[allow(dead_code)]
 pub async fn list_scim_tokens(
     store: &DocumentStore,
     org_id: Option<&str>,
@@ -632,7 +628,6 @@ impl From<Document<ScimGroupDoc>> for ScimGroupRecord {
 
 /// SCIM Group member record.
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct ScimGroupMemberRecord {
     pub group_id: String,
     pub user_id: String,
@@ -670,7 +665,6 @@ pub async fn get_scim_group(store: &DocumentStore, id: &str) -> Result<Option<Sc
 }
 
 /// Get a SCIM group by display name.
-#[allow(dead_code)]
 pub async fn get_scim_group_by_name(
     store: &DocumentStore,
     display_name: &str,
@@ -892,7 +886,6 @@ pub async fn get_scim_group_members(
 }
 
 /// Get all groups a user belongs to.
-#[allow(dead_code)]
 pub async fn get_user_scim_groups(
     store: &DocumentStore,
     user_id: &str,

--- a/crates/vouch-server/src/db/sessions.rs
+++ b/crates/vouch-server/src/db/sessions.rs
@@ -50,7 +50,10 @@ impl From<Document<SessionDoc>> for Session {
 /// `authenticator_id` is optional for OIDC-authenticated users who haven't
 /// registered a security key yet.
 /// `user_email` is denormalized into the session document.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "session record requires all denormalized client/user fields"
+)]
 pub async fn create_session(
     store: &DocumentStore,
     user_id: &str,
@@ -155,7 +158,10 @@ impl SessionCache {
     /// * `ttl_secs` — time-to-live per entry in seconds (e.g. 30)
     #[must_use]
     pub fn new(max_capacity: u64, ttl_secs: u64) -> Self {
-        #[allow(clippy::cast_possible_truncation)]
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "min(u32::MAX) bounds the value to fit usize on 32-bit and larger targets"
+        )]
         let cap = max_capacity.min(u32::MAX as u64) as usize;
         Self {
             entries: Mutex::new(HashMap::with_capacity(cap)),

--- a/crates/vouch-server/src/db/store.rs
+++ b/crates/vouch-server/src/db/store.rs
@@ -118,7 +118,7 @@ fn build_index_insert(
 #[derive(sqlx::FromRow)]
 struct RawDocumentRow {
     id: String,
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "reserved for serde DTO conformance / future use")]
     doc_type: String,
     schema_version: i32,
     encapped_key: Option<String>,
@@ -193,7 +193,10 @@ fn raw_to_document<T: DocumentType>(
 
     let json_bytes = crypto.open(T::DOC_TYPE.as_bytes(), row.id.as_bytes(), &encrypted_doc)?;
 
-    #[allow(clippy::cast_sign_loss)]
+    #[expect(
+        clippy::cast_sign_loss,
+        reason = "schema_version stored as i64 but always non-negative by invariant"
+    )]
     let version = row.schema_version as u32;
     let typed_data = if version < T::CURRENT_VERSION {
         let value: serde_json::Value =
@@ -1571,11 +1574,11 @@ impl std::fmt::Debug for StoreTransaction<'_> {
 // ============================================================================
 
 #[cfg(test)]
-#[allow(
+#[expect(
     clippy::unwrap_used,
-    clippy::expect_used,
     clippy::unreachable,
-    clippy::indexing_slicing
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
 )]
 mod tests {
     use super::*;

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Database module tests.
 
-#![allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#![expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 
 use std::sync::Arc;
 

--- a/crates/vouch-server/src/geo.rs
+++ b/crates/vouch-server/src/geo.rs
@@ -127,7 +127,10 @@ pub fn country_flag(code: &str) -> Option<String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/handlers/admin/audit.rs
+++ b/crates/vouch-server/src/handlers/admin/audit.rs
@@ -216,7 +216,10 @@ impl GeoFields {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use crate::test_utils::*;

--- a/crates/vouch-server/src/handlers/admin/members.rs
+++ b/crates/vouch-server/src/handlers/admin/members.rs
@@ -513,7 +513,12 @@ pub async fn remove_member(
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use axum::http::StatusCode;
 

--- a/crates/vouch-server/src/handlers/admin/policies.rs
+++ b/crates/vouch-server/src/handlers/admin/policies.rs
@@ -642,7 +642,11 @@ pub async fn validate_cel_api(
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use crate::test_utils::*;
     use axum::http::StatusCode;

--- a/crates/vouch-server/src/handlers/admin/scim_tokens.rs
+++ b/crates/vouch-server/src/handlers/admin/scim_tokens.rs
@@ -461,7 +461,12 @@ pub async fn admin_revoke_scim_token(
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use axum::http::StatusCode;
     use secrecy::ExposeSecret;

--- a/crates/vouch-server/src/handlers/applications/api.rs
+++ b/crates/vouch-server/src/handlers/applications/api.rs
@@ -417,8 +417,10 @@ pub async fn get_application_api(
 
 /// Update an application (API).
 /// PATCH /api/v1/applications/:id
-// Axum handlers require all extractors as parameters; argument count is inherent to the framework.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "axum handler signature: extractors are positional parameters"
+)]
 pub async fn update_application_api(
     method: Method,
     uri: OriginalUri,
@@ -785,8 +787,10 @@ pub async fn delete_application_api(
 
 /// Add a new client secret (API).
 /// POST /api/v1/applications/:id/secrets
-// Axum handlers require all extractors as parameters; argument count is inherent to the framework.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "axum handler signature: extractors are positional parameters"
+)]
 pub async fn add_secret_api(
     method: Method,
     uri: OriginalUri,
@@ -1196,7 +1200,12 @@ pub async fn revoke_tokens_api(
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use axum::http::StatusCode;
 

--- a/crates/vouch-server/src/handlers/applications/mod.rs
+++ b/crates/vouch-server/src/handlers/applications/mod.rs
@@ -55,7 +55,10 @@ const SECRET_LENGTH: usize = 32;
 ///
 /// # Panics
 /// Panics if the system RNG fails.
-#[allow(clippy::expect_used)]
+#[expect(
+    clippy::expect_used,
+    reason = ".expect on aws_rand::fill is acceptable: RNG failure is fatal at startup"
+)]
 pub(crate) fn generate_client_secret() -> String {
     let mut bytes = [0u8; SECRET_LENGTH];
     aws_rand::fill(&mut bytes).expect("RNG failure");

--- a/crates/vouch-server/src/handlers/applications/types.rs
+++ b/crates/vouch-server/src/handlers/applications/types.rs
@@ -86,7 +86,6 @@ impl From<OAuthClient> for ApplicationInfo {
 /// Application create page template.
 #[derive(Template)]
 #[template(path = "applications/create.html")]
-#[allow(dead_code)]
 pub struct ApplicationCreateTemplate {
     /// Authentication context for header display.
     pub auth: AuthContext,
@@ -97,7 +96,6 @@ pub struct ApplicationCreateTemplate {
 /// Application created success page (shows credentials once).
 #[derive(Template)]
 #[template(path = "applications/created.html")]
-#[allow(dead_code)]
 pub struct ApplicationCreatedTemplate {
     pub name: String,
     pub client_id: String,
@@ -111,7 +109,6 @@ pub struct ApplicationCreatedTemplate {
 /// Application detail page template.
 #[derive(Template)]
 #[template(path = "applications/detail.html")]
-#[allow(dead_code)]
 pub struct ApplicationDetailTemplate {
     pub app: ApplicationInfo,
     pub secrets_count: usize,
@@ -130,7 +127,6 @@ pub struct UsageStat {
 /// Secret added success page (shows new secret once).
 #[derive(Template)]
 #[template(path = "applications/secret_added.html")]
-#[allow(dead_code)]
 pub struct SecretAddedTemplate {
     pub app_id: String,
     pub name: String,

--- a/crates/vouch-server/src/handlers/applications/web.rs
+++ b/crates/vouch-server/src/handlers/applications/web.rs
@@ -949,7 +949,6 @@ pub async fn delete_secret_form(
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use axum::http::StatusCode;
 

--- a/crates/vouch-server/src/handlers/auth.rs
+++ b/crates/vouch-server/src/handlers/auth.rs
@@ -178,7 +178,11 @@ pub async fn logout(
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use crate::test_utils::*;
     use axum::http::StatusCode;

--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -369,7 +369,10 @@ pub async fn browser_login_start(
 /// 5. Credential ID byte length validation
 /// 6. Client data JSON structure validation (type, origin)
 /// 7. Database operations (authenticator lookup, signature verification)
-#[allow(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "FAPI 2.0 browser login orchestrates assertion verification and session issuance"
+)]
 pub async fn browser_login_complete(
     State(state): State<Arc<AppState>>,
     client_info: ClientInfo,
@@ -752,7 +755,10 @@ pub(crate) fn validate_origin(
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::expect_used, clippy::unwrap_used)]
+    #![expect(
+        clippy::expect_used,
+        reason = "test code: panic on assertion failure is acceptable"
+    )]
     use super::*;
 
     #[tokio::test]

--- a/crates/vouch-server/src/handlers/certification.rs
+++ b/crates/vouch-server/src/handlers/certification.rs
@@ -341,7 +341,10 @@ async fn get_or_create_cert_authenticator(
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::expect_used, clippy::unwrap_used)]
+    #![expect(
+        clippy::expect_used,
+        reason = "test code: panic on assertion failure is acceptable"
+    )]
     use super::*;
     use crate::handlers::browser_login::hmac_sha256_base64url;
     use crate::handlers::oidc::build_authorization_success_redirect_url;

--- a/crates/vouch-server/src/handlers/credentials.rs
+++ b/crates/vouch-server/src/handlers/credentials.rs
@@ -664,8 +664,10 @@ pub async fn get_github_status(
 /// Returns a short-lived GitHub installation access token that can be used
 /// with Git operations. The token is scoped to the user's organization's
 /// GitHub installation with minimal permissions (contents:write, metadata:read).
-// Axum handlers require all extractors as parameters; argument count is inherent to the framework.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "axum handler signature: extractors are positional parameters"
+)]
 pub async fn get_github_token(
     method: Method,
     uri: OriginalUri,
@@ -908,7 +910,12 @@ pub async fn get_github_token(
 // ============================================================================
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use crate::test_utils::*;
     use axum::http::StatusCode;

--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -71,7 +71,6 @@ fn hash_device_code(code: &str) -> String {
 ///
 /// RFC 8628 Section 3.1: The client makes a request using
 /// "application/x-www-form-urlencoded" format.
-#[allow(clippy::unused_async)]
 pub async fn device_code(
     State(state): State<Arc<AppState>>,
     axum::Form(req): axum::Form<DeviceCodeRequest>,
@@ -165,7 +164,6 @@ pub async fn device_code(
 /// - `expired_token` — the device code has expired
 /// - `access_denied` — the user denied the authorization request
 /// - A successful token response when the user has authorized
-#[allow(clippy::unused_async)]
 pub async fn device_token(
     State(state): State<Arc<AppState>>,
     Json(req): Json<DeviceTokenRequest>,
@@ -361,7 +359,12 @@ pub async fn device_token(
 // ============================================================================
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use crate::test_utils::*;

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -125,13 +125,13 @@ pub struct OidcCallbackParams {
 #[derive(Debug, Deserialize)]
 struct OidcTokenResponse {
     id_token: String,
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "reserved for serde DTO conformance / future use")]
     access_token: String,
 }
 
 /// Client data JSON structure from `WebAuthn` response.
 #[derive(Deserialize)]
-#[allow(dead_code)]
+#[expect(dead_code, reason = "reserved for serde DTO conformance / future use")]
 struct ClientData {
     challenge: String,
     origin: String,
@@ -179,14 +179,12 @@ impl BrowserRegistrationState {
 
 /// Show device code entry page.
 /// GET /device
-#[allow(clippy::unused_async)]
 pub async fn device_verify_page() -> impl IntoResponse {
     DeviceVerifyTemplate { error: None }
 }
 
 /// Handle device code submission.
 /// POST /device
-#[allow(clippy::unused_async)]
 pub async fn device_verify_submit(
     State(state): State<Arc<AppState>>,
     Form(form): Form<UserCodeForm>,
@@ -345,7 +343,10 @@ pub async fn device_verify_submit(
 
 /// Handle OIDC callback.
 /// GET /oauth/callback
-#[allow(clippy::unused_async, clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "axum handler; OIDC callback orchestrates IdP exchange and enrollment"
+)]
 pub async fn oidc_callback(
     State(state): State<Arc<AppState>>,
     Query(params): Query<OidcCallbackParams>,
@@ -528,7 +529,6 @@ pub async fn oidc_callback(
     complete_enrollment_after_identity(&state, &stored_state, &oidc_state, identity).await
 }
 
-#[allow(clippy::too_many_lines)]
 pub(crate) async fn complete_enrollment_after_identity(
     state: &Arc<AppState>,
     stored_state: &db::OidcState,
@@ -752,7 +752,6 @@ pub async fn enroll_keys_page(State(state): State<Arc<AppState>>, jar: CookieJar
 /// Start browser-based `WebAuthn` registration.
 /// POST /enroll/webauthn/start
 /// Authentication is via session cookie (set by oidc_callback).
-#[allow(clippy::unused_async)]
 pub async fn browser_register_start(
     State(state): State<Arc<AppState>>,
     jar: CookieJar,
@@ -952,7 +951,10 @@ const MAX_CREDENTIAL_ID_BYTES: usize = 1023;
 /// 6. Hardware attestation validation (reject software passkeys)
 /// 7. WebAuthn cryptographic verification
 /// 8. Database operations (duplicate check, store, authorize)
-#[allow(clippy::unused_async, clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "axum handler; FIDO2 registration completion: attestation, db, session"
+)]
 pub async fn browser_register_complete(
     State(state): State<Arc<AppState>>,
     client_info: ClientInfo,
@@ -1432,7 +1434,6 @@ pub async fn direct_enroll_start(State(state): State<Arc<AppState>>) -> Response
 }
 
 /// Check if a device auth request is for direct enrollment.
-#[allow(dead_code)]
 pub fn is_direct_enrollment(device_auth: &db::DeviceAuthRequest) -> bool {
     device_auth.user_code.starts_with(DIRECT_ENROLL_PREFIX)
 }
@@ -1463,7 +1464,10 @@ fn is_valid_user_code_format(code: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+    #![expect(
+        clippy::expect_used,
+        reason = "test code: panic on assertion failure is acceptable"
+    )]
 
     use super::*;
     use crate::test_utils::{http_post_json, test_app};

--- a/crates/vouch-server/src/handlers/extractors.rs
+++ b/crates/vouch-server/src/handlers/extractors.rs
@@ -258,7 +258,10 @@ impl FromRequestParts<Arc<AppState>> for OptionalClientCert {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use axum::http::HeaderValue;

--- a/crates/vouch-server/src/handlers/github.rs
+++ b/crates/vouch-server/src/handlers/github.rs
@@ -184,7 +184,7 @@ pub struct GitHubCallbackParams {
     /// State token for CSRF protection.
     state: Option<String>,
     /// Setup action (only present during installation).
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "reserved for serde DTO conformance / future use")]
     setup_action: Option<String>,
     /// OAuth authorization code (present for OAuth callbacks).
     code: Option<String>,
@@ -198,7 +198,7 @@ pub struct GitHubConnectParams {
     /// State token for CSRF protection.
     state: Option<String>,
     /// Setup action (only present during installation).
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "reserved for serde DTO conformance / future use")]
     setup_action: Option<String>,
 }
 
@@ -665,7 +665,10 @@ pub async fn github_success_page(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use crate::crypto::jwt::{JwtType, StateTokenSigner};

--- a/crates/vouch-server/src/handlers/keys.rs
+++ b/crates/vouch-server/src/handlers/keys.rs
@@ -313,8 +313,10 @@ pub async fn list_keys(
 }
 
 /// Rename a registered key.
-// Axum handlers require all extractors as parameters; argument count is inherent to the framework.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "axum handler signature: extractors are positional parameters"
+)]
 pub async fn rename_key(
     method: Method,
     uri: OriginalUri,
@@ -404,7 +406,11 @@ pub async fn delete_key(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use crate::crypto::jwt::{JwtType, StateTokenSigner};

--- a/crates/vouch-server/src/handlers/oidc/authorize.rs
+++ b/crates/vouch-server/src/handlers/oidc/authorize.rs
@@ -157,8 +157,10 @@ impl ResolvedClient {
     /// Used for JAR and request_uri_fetch flows, where the client must be
     /// loaded before JWT verification. The client has already been through
     /// `lookup_and_check_active`.
-    // Response is 128 bytes but this is intentional — we return HTTP responses.
-    #[allow(clippy::result_large_err)]
+    #[expect(
+        clippy::result_large_err,
+        reason = "Err is an HTTP Response; size is acceptable in error path"
+    )]
     fn from_validated_client(
         client: OAuthClient,
         redirect_uri: String,
@@ -1062,7 +1064,6 @@ async fn handle_pending_auth(state: &Arc<AppState>, pending_id: &str, jar: &Cook
 // ---------------------------------------------------------------------------
 
 /// Complete the pending auth flow: check access, check max_age, issue code.
-#[allow(clippy::too_many_arguments)]
 async fn complete_pending_auth(
     state: &Arc<AppState>,
     resolved: &ResolvedClient,
@@ -1219,8 +1220,10 @@ async fn lookup_and_check_active(
 /// Resolve the redirect_uri from the request parameter or the client's single registered URI.
 ///
 /// Returns `Err(Response)` with an error page when the URI cannot be determined.
-// Response is 128 bytes but this is intentional — we return HTTP responses.
-#[allow(clippy::result_large_err)]
+#[expect(
+    clippy::result_large_err,
+    reason = "Err is an HTTP Response; size is acceptable in error path"
+)]
 fn resolve_redirect_uri(
     redirect_uri_param: Option<&str>,
     client: &OAuthClient,
@@ -1356,7 +1359,10 @@ enum ReauthPolicy {
 /// Called after session validation confirms the user is authenticated. Checks
 /// client access, applies the re-auth policy, validates ACR and resource, optionally
 /// consumes a PAR record, and issues the authorization code.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "OAuth authorization for authenticated user requires full validated request context"
+)]
 async fn authorize_authenticated_user(
     state: &Arc<AppState>,
     validated: ValidatedAuthRequest,
@@ -1442,7 +1448,10 @@ async fn authorize_authenticated_user(
 /// Validate ACR, resource, consume PAR if needed, and issue the authorization code.
 ///
 /// Called after access and re-auth checks have passed in `authorize_authenticated_user`.
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "issuing authorization code requires full validated request context"
+)]
 async fn issue_code_after_reauth_check(
     state: &Arc<AppState>,
     validated: ValidatedAuthRequest,

--- a/crates/vouch-server/src/handlers/oidc/client_auth.rs
+++ b/crates/vouch-server/src/handlers/oidc/client_auth.rs
@@ -95,7 +95,10 @@ pub(crate) fn extract_client_credentials(
 ///
 /// Handles mutual exclusion: a request MUST NOT use more than one client
 /// authentication method (e.g., Basic auth header + client_assertion = error).
-#[allow(clippy::result_large_err)]
+#[expect(
+    clippy::result_large_err,
+    reason = "Err is an HTTP Response; size is acceptable in error path"
+)]
 pub(crate) fn extract_client_auth<T: ClientAuthFields>(
     headers: &HeaderMap,
     params: &T,

--- a/crates/vouch-server/src/handlers/oidc/tests/mod.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/mod.rs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Tests for OIDC handlers — organized by RFC/specification.
 
-#![allow(
+#![expect(
     clippy::expect_used,
     clippy::unwrap_used,
     clippy::indexing_slicing,
-    clippy::string_slice
+    clippy::string_slice,
+    reason = "test code: panic on assertion failure is acceptable"
 )]
 
 mod helpers;

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -1169,7 +1169,6 @@ fn token_error_response(error: &str, description: &str) -> Response {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::OAuthGrantType;
 

--- a/crates/vouch-server/src/handlers/registration.rs
+++ b/crates/vouch-server/src/handlers/registration.rs
@@ -144,7 +144,11 @@ fn has_x5c_in_attestation(attestation: &[u8]) -> bool {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use ciborium::Value;

--- a/crates/vouch-server/src/handlers/saml.rs
+++ b/crates/vouch-server/src/handlers/saml.rs
@@ -43,7 +43,6 @@ pub struct SamlAcsForm {
 
 /// Return SP metadata XML.
 /// GET /saml/metadata
-#[allow(clippy::unused_async)]
 pub async fn metadata(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let config = state.config();
     let sp_entity_id = config
@@ -63,7 +62,6 @@ pub async fn metadata(State(state): State<Arc<AppState>>) -> impl IntoResponse {
 ///
 /// Receives the IdP's SAML Response, validates it, and completes the
 /// enrollment flow identically to `oidc_callback()`.
-#[allow(clippy::too_many_lines)]
 pub async fn acs(State(state): State<Arc<AppState>>, Form(form): Form<SamlAcsForm>) -> Response {
     // Step 1: RelayState is required — it's our CSRF/state token.
     let relay_state = match form.relay_state {
@@ -166,7 +164,6 @@ pub async fn acs(State(state): State<Arc<AppState>>, Form(form): Form<SamlAcsFor
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used)]
     use crate::test_utils::{http_get_full, http_post_form, test_app};
     use axum::http::StatusCode;
 

--- a/crates/vouch-server/src/handlers/scim/groups.rs
+++ b/crates/vouch-server/src/handlers/scim/groups.rs
@@ -246,7 +246,10 @@ pub async fn get_group(
 ///
 /// Modifies a Group resource using SCIM PATCH operations (add, replace, remove).
 /// Supports member management via the `members` path.
-#[allow(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "SCIM PATCH operation handles add/remove/replace across all group fields"
+)]
 pub async fn patch_group(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,

--- a/crates/vouch-server/src/handlers/scim/tests.rs
+++ b/crates/vouch-server/src/handlers/scim/tests.rs
@@ -1,5 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-#![allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#![expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 
 use super::*;
 use crate::test_utils::*;

--- a/crates/vouch-server/src/handlers/scim/types.rs
+++ b/crates/vouch-server/src/handlers/scim/types.rs
@@ -104,7 +104,6 @@ pub struct ScimMeta {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ScimPatchRequest {
-    #[allow(dead_code)]
     pub schemas: Vec<String>,
     #[serde(rename = "Operations")]
     pub operations: Vec<ScimPatchOp>,

--- a/crates/vouch-server/src/handlers/scim/users.rs
+++ b/crates/vouch-server/src/handlers/scim/users.rs
@@ -256,7 +256,10 @@ pub async fn get_user(
 ///
 /// Modifies a User resource using SCIM PATCH operations (add, replace, remove).
 /// Deactivating a user invalidates all sessions and revokes SSH certificates.
-#[allow(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "SCIM PATCH operation handles add/remove/replace across all user fields"
+)]
 pub async fn patch_user(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,

--- a/crates/vouch-server/src/handlers/session.rs
+++ b/crates/vouch-server/src/handlers/session.rs
@@ -509,7 +509,10 @@ pub async fn get_auth_context(state: &AppState, jar: &CookieJar) -> AuthContext 
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use axum::http::StatusCode;
 

--- a/crates/vouch-server/src/infra/cleanup.rs
+++ b/crates/vouch-server/src/infra/cleanup.rs
@@ -223,7 +223,10 @@ pub async fn run_cleanup(
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/infra/httpsig.rs
+++ b/crates/vouch-server/src/infra/httpsig.rs
@@ -131,11 +131,10 @@ fn jwk_to_p256_public_key(jwk: &serde_json::Value) -> Option<Vec<u8>> {
 }
 
 #[cfg(test)]
-#[allow(
+#[expect(
     clippy::unwrap_used,
-    clippy::expect_used,
     clippy::indexing_slicing,
-    clippy::panic
+    reason = "test code: panic on assertion failure is acceptable"
 )]
 mod tests {
     use super::*;

--- a/crates/vouch-server/src/infra/mtls_listener.rs
+++ b/crates/vouch-server/src/infra/mtls_listener.rs
@@ -265,7 +265,10 @@ impl rustls::server::danger::ClientCertVerifier for AcceptAnyClientCert {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/infra/rate_limit.rs
+++ b/crates/vouch-server/src/infra/rate_limit.rs
@@ -61,7 +61,6 @@ impl KeyExtractor for TrustedProxyKeyExtractor {
         "TrustedProxyKeyExtractor"
     }
 
-    #[allow(clippy::indexing_slicing)]
     fn extract<T>(
         &self,
         req: &http::Request<T>,

--- a/crates/vouch-server/src/infra/resource_metadata.rs
+++ b/crates/vouch-server/src/infra/resource_metadata.rs
@@ -181,7 +181,10 @@ fn sanitize_for_quoted_string(value: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/infra/router.rs
+++ b/crates/vouch-server/src/infra/router.rs
@@ -70,7 +70,10 @@ fn build_date() -> String {
 
 /// Print an ASCII banner at server startup.
 pub fn print_startup_banner() {
-    #[allow(clippy::print_stdout)]
+    #[expect(
+        clippy::print_stdout,
+        reason = "intentional banner output to stdout on server startup"
+    )]
     {
         println!(
             r"

--- a/crates/vouch-server/src/infra/s3_config.rs
+++ b/crates/vouch-server/src/infra/s3_config.rs
@@ -882,7 +882,11 @@ impl ServerConfig {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    #![expect(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        reason = "test code: panic on assertion failure is acceptable"
+    )]
     use super::*;
 
     #[test]

--- a/crates/vouch-server/src/infra/security_headers.rs
+++ b/crates/vouch-server/src/infra/security_headers.rs
@@ -140,7 +140,10 @@ pub fn apply_security_layers(
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use crate::test_utils::*;
 

--- a/crates/vouch-server/src/infra/tls.rs
+++ b/crates/vouch-server/src/infra/tls.rs
@@ -207,7 +207,6 @@ fn validate_pem(pem_bytes: &[u8], expected_type: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used)]
     use super::*;
 
     #[test]

--- a/crates/vouch-server/src/lib.rs
+++ b/crates/vouch-server/src/lib.rs
@@ -168,7 +168,10 @@ fn is_valid_host(hostname: &str, rp_id: &str) -> bool {
 #[cfg(test)]
 mod redirect_tests {
     // Tests are allowed to use unwrap/expect for convenience
-    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    #![expect(
+        clippy::unwrap_used,
+        reason = "test code: panic on assertion failure is acceptable"
+    )]
 
     use super::*;
     use crate::services::oidc::OidcSigningKey;

--- a/crates/vouch-server/src/main.rs
+++ b/crates/vouch-server/src/main.rs
@@ -35,7 +35,10 @@ struct Cli {
 }
 
 #[derive(clap::Subcommand)]
-#[allow(clippy::large_enum_variant)]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "clap::Subcommand variants vary in payload size by command"
+)]
 enum Commands {
     /// Start the identity server.
     Serve(config::Args),

--- a/crates/vouch-server/src/services/auth.rs
+++ b/crates/vouch-server/src/services/auth.rs
@@ -592,7 +592,12 @@ pub(crate) fn decode_token(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use crate::test_utils::{TEST_ISSUER, make_test_access_token, make_test_oidc_key};

--- a/crates/vouch-server/src/services/error.rs
+++ b/crates/vouch-server/src/services/error.rs
@@ -516,7 +516,11 @@ impl IntoResponse for ServiceError {
 pub(crate) type ServiceResult<T> = Result<T, ServiceError>;
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/services/idp/mod.rs
+++ b/crates/vouch-server/src/services/idp/mod.rs
@@ -266,7 +266,10 @@ impl UpstreamIdp {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used)]
+    #![expect(
+        clippy::unwrap_used,
+        reason = "test code: panic on assertion failure is acceptable"
+    )]
 
     use super::*;
     use crate::test_utils::test_config;

--- a/crates/vouch-server/src/services/idp/oidc.rs
+++ b/crates/vouch-server/src/services/idp/oidc.rs
@@ -282,7 +282,12 @@ fn is_localhost(url: &Url) -> bool {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+    #![expect(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        reason = "test code: panic on assertion failure is acceptable"
+    )]
 
     use super::*;
 

--- a/crates/vouch-server/src/services/idp/saml/authn_request.rs
+++ b/crates/vouch-server/src/services/idp/saml/authn_request.rs
@@ -215,7 +215,11 @@ fn xml_escape_attr(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    #![expect(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        reason = "test code: panic on assertion failure is acceptable"
+    )]
     use super::*;
     use crate::services::idp::saml::{IdpMetadata, SamlProvider};
     use flate2::read::DeflateDecoder;

--- a/crates/vouch-server/src/services/idp/saml/c14n.rs
+++ b/crates/vouch-server/src/services/idp/saml/c14n.rs
@@ -408,7 +408,11 @@ pub(crate) fn escape_attribute(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    #![expect(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        reason = "test code: panic on assertion failure is acceptable"
+    )]
     use super::*;
 
     fn c14n(xml: &str, xpath: &str, inclusive_prefixes: &[&str]) -> String {

--- a/crates/vouch-server/src/services/idp/saml/metadata.rs
+++ b/crates/vouch-server/src/services/idp/saml/metadata.rs
@@ -243,7 +243,10 @@ fn xml_escape_attr(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used)]
+    #![expect(
+        clippy::unwrap_used,
+        reason = "test code: panic on assertion failure is acceptable"
+    )]
     use super::*;
 
     // =========================================================================

--- a/crates/vouch-server/src/services/idp/saml/response.rs
+++ b/crates/vouch-server/src/services/idp/saml/response.rs
@@ -48,10 +48,10 @@ pub(crate) struct SamlAssertion {
     /// Domain extracted from email or configured domain attribute.
     pub domain: Option<String>,
     /// Display name extracted from configured name attribute, if available.
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "reserved for serde DTO conformance / future use")]
     pub name: Option<String>,
     /// Session expiry time from `<AuthnStatement SessionNotOnOrAfter>`.
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "reserved for serde DTO conformance / future use")]
     pub session_not_on_or_after: Option<Timestamp>,
 }
 
@@ -663,11 +663,11 @@ fn parse_saml_timestamp(s: &str) -> Result<Timestamp, ResponseError> {
 
 #[cfg(test)]
 mod tests {
-    #![allow(
+    #![expect(
         clippy::unwrap_used,
         clippy::expect_used,
-        clippy::too_many_lines,
-        clippy::string_slice
+        clippy::string_slice,
+        reason = "test code: panic on assertion failure is acceptable"
     )]
     use super::*;
 
@@ -1365,7 +1365,10 @@ mod tests {
     /// - After insertion: text(`\n  `) + Issuer + Signature(excluded) + text(`\n  `) + Subject
     ///
     /// Both produce the same canonical bytes.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "test helper builds SAML response with all signed-element parameters"
+    )]
     fn build_signed_saml_response(
         key_pair: &aws_lc_rs::rsa::KeyPair,
         email: &str,

--- a/crates/vouch-server/src/services/idp/saml/signature.rs
+++ b/crates/vouch-server/src/services/idp/saml/signature.rs
@@ -162,8 +162,10 @@ pub(crate) fn verify_xml_signature(
         )));
     }
 
-    // Safety: we verified ref_uri starts with '#' (ASCII, single byte), so [1..] is safe
-    #[allow(clippy::string_slice)]
+    #[expect(
+        clippy::string_slice,
+        reason = "ref_uri is verified to start with '#' (ASCII, single byte); slice at [1..] is safe"
+    )]
     let element_id = &ref_uri[1..];
     if element_id.is_empty() {
         return Err(SignatureError::InvalidReference(
@@ -593,7 +595,10 @@ fn try_verify_with_cert(
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used)]
+    #![expect(
+        clippy::unwrap_used,
+        reason = "test code: panic on assertion failure is acceptable"
+    )]
     use super::*;
 
     // =========================================================================

--- a/crates/vouch-server/src/services/integrations/aws.rs
+++ b/crates/vouch-server/src/services/integrations/aws.rs
@@ -85,7 +85,10 @@ pub struct AwsTokenResult {
 /// * `authenticator_id` - The authenticator ID from the session (for AAGUID lookup)
 /// * `hd` - The user's organization domain (Google Workspace hosted domain)
 /// * `source` - AI coding agent identifier (e.g., "claude-code", "cursor")
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "AWS STS AssumeRoleWithWebIdentity issuance requires full session context"
+)]
 pub async fn issue_aws_token(
     store: &DocumentStore,
     base_url: &str,
@@ -172,11 +175,10 @@ async fn get_authenticator(
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::unwrap_used,
+#[expect(
     clippy::expect_used,
     clippy::indexing_slicing,
-    clippy::panic
+    reason = "test code: panic on assertion failure is acceptable"
 )]
 mod tests {
     use super::*;

--- a/crates/vouch-server/src/services/integrations/github/app.rs
+++ b/crates/vouch-server/src/services/integrations/github/app.rs
@@ -73,7 +73,6 @@ impl RsaPrivateKeyDer {
     }
 
     /// Convert PEM to DER bytes.
-    #[cfg_attr(test, allow(dead_code))]
     pub(crate) fn pem_to_der(pem_content: &str) -> Result<Vec<u8>> {
         let lines: Vec<&str> = pem_content.lines().collect();
         let mut base64_content = String::new();
@@ -412,7 +411,6 @@ pub fn minimal_git_permissions() -> HashMap<String, String> {
 #[derive(Debug, Deserialize)]
 pub struct UserInstallationsResponse {
     /// Total count of installations the user has access to.
-    #[allow(dead_code)]
     pub total_count: u32,
     /// List of installations.
     pub installations: Vec<InstallationDetails>,
@@ -525,18 +523,14 @@ pub struct GitHubOAuthTokenResponse {
     /// Access token for API calls.
     pub access_token: String,
     /// Token type (usually "bearer").
-    #[allow(dead_code)]
     pub token_type: String,
     /// Granted scopes (space-separated).
-    #[allow(dead_code)]
     pub scope: Option<String>,
     /// Refresh token for getting new access tokens.
     pub refresh_token: Option<String>,
     /// Access token expiration in seconds (8 hours for GitHub Apps).
-    #[allow(dead_code)]
     pub expires_in: Option<u64>,
     /// Refresh token expiration in seconds (6 months for GitHub Apps).
-    #[allow(dead_code)]
     pub refresh_token_expires_in: Option<u64>,
 }
 
@@ -666,7 +660,10 @@ pub async fn refresh_oauth_token(
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 
@@ -752,7 +749,10 @@ eyYRskrWOAtu0DuWJARLn74r5B4ze8s4DvUdPe781neRB1hMbXte6g==
     }
 
     #[test]
-    #[allow(clippy::unreachable)]
+    #[expect(
+        clippy::unreachable,
+        reason = "test code: unreachable! after let-else-Err proof"
+    )]
     fn test_rsa_key_rejects_pkcs8_pem() {
         // Verify that PKCS#8 PEM format is rejected with a helpful error
         let pkcs8_pem = "-----BEGIN PRIVATE KEY-----\nMIIEvg...\n-----END PRIVATE KEY-----";

--- a/crates/vouch-server/src/services/integrations/github/webhooks.rs
+++ b/crates/vouch-server/src/services/integrations/github/webhooks.rs
@@ -25,13 +25,11 @@ pub enum InstallationEvent {
         installation: WebhookInstallation,
         #[serde(default)]
         repositories: Vec<WebhookRepository>,
-        #[allow(dead_code)]
         sender: Option<WebhookSender>,
     },
     Deleted {
         installation: WebhookInstallation,
         #[serde(default)]
-        #[allow(dead_code)]
         repositories: Vec<WebhookRepository>,
     },
     Suspend {
@@ -79,21 +77,17 @@ pub struct WebhookInstallation {
 pub struct WebhookAccount {
     pub login: String,
     #[serde(rename = "type")]
-    #[allow(dead_code)]
     pub account_type: String,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct WebhookRepository {
     pub name: String,
-    #[allow(dead_code)]
     pub full_name: String,
-    #[allow(dead_code)]
     pub private: bool,
 }
 
 #[derive(Debug, Deserialize)]
-#[allow(dead_code)]
 pub struct WebhookSender {
     pub login: String,
 }
@@ -342,7 +336,11 @@ impl GitHubService<'_> {
 // ============================================================================
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/services/keys.rs
+++ b/crates/vouch-server/src/services/keys.rs
@@ -222,7 +222,10 @@ pub(crate) async fn delete_key(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/services/oidc/authorization.rs
+++ b/crates/vouch-server/src/services/oidc/authorization.rs
@@ -828,7 +828,10 @@ pub fn check_client_access(client: &OAuthClient, user: &User) -> ServiceResult<(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use crate::db::{FapiProfile, JwsAlgorithm, OAuthClientType, TokenEndpointAuthMethod};

--- a/crates/vouch-server/src/services/oidc/authorization_details.rs
+++ b/crates/vouch-server/src/services/oidc/authorization_details.rs
@@ -218,7 +218,11 @@ fn validate_no_control_chars(value: &serde_json::Value) -> bool {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/services/oidc/claims.rs
+++ b/crates/vouch-server/src/services/oidc/claims.rs
@@ -284,7 +284,11 @@ impl Default for OidcIdTokenClaimsBuilder {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/services/oidc/client_credentials.rs
+++ b/crates/vouch-server/src/services/oidc/client_credentials.rs
@@ -101,7 +101,10 @@ pub async fn exchange_client_credentials(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use crate::services::oidc::OAuthScope;

--- a/crates/vouch-server/src/services/oidc/discovery.rs
+++ b/crates/vouch-server/src/services/oidc/discovery.rs
@@ -19,7 +19,10 @@ use std::sync::Arc;
 /// All fields defined in OpenID Provider Metadata:
 /// <https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata>
 #[derive(Debug, Serialize)]
-#[allow(clippy::struct_excessive_bools)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "OIDC discovery document has many boolean capability flags by spec"
+)]
 pub struct OidcDiscoveryDocument {
     /// OIDC Discovery 1.0 Section 3: REQUIRED. Issuer Identifier (must match tokens).
     pub issuer: String,

--- a/crates/vouch-server/src/services/oidc/dpop.rs
+++ b/crates/vouch-server/src/services/oidc/dpop.rs
@@ -151,7 +151,6 @@ pub use super::claims::CnfClaim;
 #[derive(Debug, Clone)]
 pub enum DpopError {
     /// Missing DPoP header.
-    #[allow(dead_code)]
     MissingProof,
     /// Invalid proof format.
     InvalidFormat(String),
@@ -201,7 +200,6 @@ pub struct ValidatedDpopProof {
     /// JWK thumbprint of the sender's key.
     pub jkt: String,
     /// The public key from the proof.
-    #[allow(dead_code)]
     pub jwk: DpopJwk,
     /// Unique identifier from the proof.
     pub jti: String,
@@ -382,8 +380,11 @@ pub fn validate_dpop_claims(
 ///
 /// RFC 9449 Section 4.2: The `htu` claim should contain the HTTP target URI
 /// without query and fragment components.
-#[allow(clippy::string_slice)]
 /// Normalize a URI by stripping query and fragment for comparison.
+#[expect(
+    clippy::string_slice,
+    reason = "byte offsets come from str::find on ASCII chars; always at valid char boundary"
+)]
 pub fn normalize_uri(uri: &str) -> String {
     // Find the first occurrence of either '?' or '#' to handle all orderings
     // Safety: both `find('?')` and `find('#')` return byte offsets of ASCII
@@ -566,7 +567,11 @@ pub async fn validate_dpop_at_resource(
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/services/oidc/exchange.rs
+++ b/crates/vouch-server/src/services/oidc/exchange.rs
@@ -88,7 +88,10 @@ pub struct TokenExchangeResult {
 ///
 /// # Errors
 /// Returns `ServiceError` for invalid requests.
-#[allow(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "RFC 8693 token exchange: validate all params, resolve subject, issue tokens"
+)]
 pub async fn exchange_token(
     state: &Arc<AppState>,
     params: TokenExchangeParams<'_>,

--- a/crates/vouch-server/src/services/oidc/fapi.rs
+++ b/crates/vouch-server/src/services/oidc/fapi.rs
@@ -260,7 +260,6 @@ pub fn auth_code_lifetime_seconds(client: &OAuthClient) -> i64 {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::db::{AccessScope, FapiProfile, JwsAlgorithm, OAuthClientType};

--- a/crates/vouch-server/src/services/oidc/fido2_grant.rs
+++ b/crates/vouch-server/src/services/oidc/fido2_grant.rs
@@ -106,7 +106,10 @@ pub struct Fido2AssertionResult {
 /// - Invalid FIDO2 assertion
 /// - Unknown authenticator
 /// - User mismatch
-#[allow(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "FIDO2 grant: parse assertion, verify, bind tokens, audit"
+)]
 pub async fn exchange_fido2_assertion(
     state: &Arc<AppState>,
     params: Fido2AssertionParams<'_>,
@@ -336,7 +339,6 @@ pub async fn exchange_fido2_assertion(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     // NOTE(mtls-threading): `Fido2AssertionParams::mtls_cert_thumbprint` is a
     // plain `Option<&str>` threaded from the handler through to

--- a/crates/vouch-server/src/services/oidc/introspection.rs
+++ b/crates/vouch-server/src/services/oidc/introspection.rs
@@ -327,7 +327,11 @@ pub async fn revoke_token(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/services/oidc/jar.rs
+++ b/crates/vouch-server/src/services/oidc/jar.rs
@@ -51,7 +51,7 @@ struct RequestObjectClaims {
     nbf: Option<i64>,
     /// JWT ID (optional).
     #[serde(default)]
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "reserved for serde DTO conformance / future use")]
     jti: Option<String>,
 
     // OAuth authorization request parameters
@@ -110,11 +110,11 @@ pub struct QueryParamHints<'a> {
 #[derive(Debug, Deserialize)]
 struct RequestObjectHeader {
     /// Algorithm used for signing.
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "reserved for serde DTO conformance / future use")]
     pub alg: String,
     /// Key ID (optional).
     #[serde(default)]
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "reserved for serde DTO conformance / future use")]
     pub kid: Option<String>,
     /// Type header — must be "oauth-authz-req+jwt" for Request Objects.
     #[serde(default)]
@@ -611,7 +611,12 @@ pub async fn validate_request_object(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use crate::services::oidc::jwt_bearer::SUPPORTED_ALGORITHMS;

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
@@ -258,7 +258,11 @@ pub async fn authenticate_client_jwt(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use crate::config::ServerConfig;

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/grant.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/grant.rs
@@ -251,7 +251,10 @@ fn compute_granted_scope(requested: Option<&str>, allowed: Option<&str>) -> Opti
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::compute_granted_scope;
     use crate::services::oidc::OAuthScope;

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/jwks.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/jwks.rs
@@ -520,7 +520,12 @@ fn build_decoding_key_from_jwk(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/validate.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/validate.rs
@@ -289,7 +289,12 @@ pub fn map_algorithm(alg: &str) -> ServiceResult<jsonwebtoken::Algorithm> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/services/oidc/keys.rs
+++ b/crates/vouch-server/src/services/oidc/keys.rs
@@ -831,7 +831,11 @@ async fn sign_jwt_rsa_with_kms<T: Serialize>(
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use serde::{Deserialize, Serialize};

--- a/crates/vouch-server/src/services/oidc/mtls.rs
+++ b/crates/vouch-server/src/services/oidc/mtls.rs
@@ -234,7 +234,11 @@ pub(crate) fn verify_self_signed_tls_client_auth(
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
+#[expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/services/oidc/protected_resource.rs
+++ b/crates/vouch-server/src/services/oidc/protected_resource.rs
@@ -116,7 +116,6 @@ pub const PROTECTED_RESOURCE_PREFIXES: &[&str] = &[
 /// fields and `null` values as equivalent but discourages emitting
 /// explicit `null`s.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-#[allow(clippy::struct_excessive_bools)]
 pub struct ProtectedResourceMetadata {
     /// RFC 9728 §2: REQUIRED. Resource identifier URL. Per §4, the
     /// returned value MUST be byte-identical to the resource

--- a/crates/vouch-server/src/services/oidc/registration.rs
+++ b/crates/vouch-server/src/services/oidc/registration.rs
@@ -1523,7 +1523,12 @@ async fn verify_software_statement_jwt(
 // ============================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/services/oidc/resource.rs
+++ b/crates/vouch-server/src/services/oidc/resource.rs
@@ -76,7 +76,10 @@ impl std::fmt::Display for ResourceUri {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/services/oidc/scope.rs
+++ b/crates/vouch-server/src/services/oidc/scope.rs
@@ -156,7 +156,10 @@ impl fmt::Display for ScopeSet {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/services/oidc/token.rs
+++ b/crates/vouch-server/src/services/oidc/token.rs
@@ -1014,7 +1014,11 @@ pub async fn validate_session_token(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-server/src/services/posture.rs
+++ b/crates/vouch-server/src/services/posture.rs
@@ -685,7 +685,10 @@ fn extract_device_posture(ad_value: Option<&serde_json::Value>) -> ServiceResult
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
     use vouch_common::posture::{EdrAgent, MdmAgent, OperatingSystem, PostureTypeTag};

--- a/crates/vouch-server/src/test_utils.rs
+++ b/crates/vouch-server/src/test_utils.rs
@@ -4,7 +4,10 @@
 //! This module provides shared test infrastructure for handler tests.
 
 // Tests are allowed to use expect/unwrap on failures
-#![allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+#![expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 
 use arc_swap::ArcSwap;
 use axum::{


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily lint-annotation churn with minimal runtime impact, but touches many files and could break builds if any `#[expect]`/`cfg_attr` annotations are mis-specified on certain targets.
> 
> **Overview**
> **Enforces stricter lint hygiene** by enabling Clippy’s `allow_attributes_without_reason = "deny"` at the workspace level.
> 
> Updates widespread lint suppressions (tests, unsafe blocks, long/arg-heavy handlers, serde DTO fields, etc.) to use `#[expect(..., reason = "...")]` (or reasoned `#[allow]` where appropriate), documenting why each suppression is intentional.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29e5bba349d2cf3e19b3f9e02f2a7b2cd1d84f62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->