### PR TITLE
additional linting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,10 @@ get_unwrap = "deny"
 indexing_slicing = "deny"
 
 # String slicing can panic on non-UTF8 boundaries
-string_slice = "warn"
+string_slice = "deny"
+
+# Modulo by zero panics — use checked_rem or guard the divisor
+modulo_arithmetic = "deny"
 
 # Code hygiene
 dbg_macro = "deny"
@@ -45,6 +48,15 @@ dbg_macro = "deny"
 await_holding_lock = "deny"
 large_futures = "deny"
 mem_forget = "deny"
+
+# Use atomics (AtomicBool, AtomicU32, ...) instead of Mutex<bool/integer>
+mutex_atomic = "deny"
+
+# Rc<String>/Arc<Vec<T>> should be Rc<str>/Arc<[T]> (cheaper, sized)
+rc_buffer = "deny"
+
+# Style: prefer .map_or(default, f) over .map(f).unwrap_or(default)
+map_unwrap_or = "deny"
 
 module_name_repetitions = "allow"
 similar_names = "allow"

--- a/crates/vouch-cli/src/commands/credential/codeartifact.rs
+++ b/crates/vouch-cli/src/commands/credential/codeartifact.rs
@@ -140,8 +140,7 @@ pub(crate) async fn get_token(
     let data = cache::get_or_fetch(&cache_key, "CodeArtifact token", || async {
         let token = fetch_token(server, domain, domain_owner, region).await?;
         let expires_at = jiff::Timestamp::from_second(token.expiration)
-            .map(|ts| ts.to_string())
-            .unwrap_or_else(|_| cache::default_expiry());
+            .map_or_else(|_| cache::default_expiry(), |ts| ts.to_string());
         let data = serde_json::json!({
             "authorization_token": token.authorization_token.expose_secret(),
             "expiration": token.expiration,

--- a/crates/vouch-cli/src/commands/credential/ssh.rs
+++ b/crates/vouch-cli/src/commands/credential/ssh.rs
@@ -370,17 +370,19 @@ pub(crate) async fn run(server: &str, key_path: Option<&str>, force: bool) -> Re
                 println!("SSH credentials loaded into agent.");
                 println!(
                     "  SSH agent socket: {}",
-                    vouch_agent::ssh_agent_socket_path()
-                        .map(|p| p.display().to_string())
-                        .unwrap_or_else(|_| { "~/.vouch/ssh-agent.sock".to_string() })
+                    vouch_agent::ssh_agent_socket_path().map_or_else(
+                        |_| "~/.vouch/ssh-agent.sock".to_string(),
+                        |p| p.display().to_string()
+                    )
                 );
                 println!();
                 println!("To use the agent, set SSH_AUTH_SOCK:");
                 println!(
                     "  export SSH_AUTH_SOCK={}",
-                    vouch_agent::ssh_agent_socket_path()
-                        .map(|p| p.display().to_string())
-                        .unwrap_or_else(|_| { "~/.vouch/ssh-agent.sock".to_string() })
+                    vouch_agent::ssh_agent_socket_path().map_or_else(
+                        |_| "~/.vouch/ssh-agent.sock".to_string(),
+                        |p| p.display().to_string()
+                    )
                 );
             }
         } else {

--- a/crates/vouch-cli/src/commands/exec.rs
+++ b/crates/vouch-cli/src/commands/exec.rs
@@ -123,8 +123,7 @@ pub(crate) async fn fetch_github_token_cached(server: &str) -> Result<GitHubEnvT
             .get("expires_at")
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty())
-            .map(String::from)
-            .unwrap_or_else(cache::default_expiry);
+            .map_or_else(cache::default_expiry, String::from);
         Ok((response, expires_at))
     })
     .await?;

--- a/crates/vouch-cli/src/commands/keys.rs
+++ b/crates/vouch-cli/src/commands/keys.rs
@@ -285,7 +285,7 @@ pub(crate) async fn remove(server: &str, key_id: &str, force: bool) -> Result<()
     // Prompt for confirmation unless --force is used
     if !force {
         println!("You are about to remove the key '{key_name}' (ID: {key_id}).");
-        if key.map(|k| k.is_current_session).unwrap_or(false) {
+        if key.is_some_and(|k| k.is_current_session) {
             println!("WARNING: This is the key used for your current session.");
             println!("         Your session will be invalidated.");
         }

--- a/crates/vouch-cli/src/commands/setup/aws.rs
+++ b/crates/vouch-cli/src/commands/setup/aws.rs
@@ -158,8 +158,7 @@ async fn run_discover(profile_prefix: Option<&str>, region: Option<&str>) -> Res
     let member_role_name = vouch_config
         .aws()
         .and_then(|a| a.sso_sessions.get(&session.name))
-        .map(|s| s.member_role_name.clone())
-        .unwrap_or_else(|| "VouchAccess".to_string());
+        .map_or_else(|| "VouchAccess".to_string(), |s| s.member_role_name.clone());
 
     let sso_region = session.region.clone();
     let sso_config = SsoConfig::from_session(&session);

--- a/crates/vouch-cli/src/commands/setup/docker.rs
+++ b/crates/vouch-cli/src/commands/setup/docker.rs
@@ -161,8 +161,8 @@ fn print_example_config() {
 /// Check if Docker credential helper is configured.
 pub(crate) fn check_docker_config() -> DockerSetupStatus {
     // Check for symlink or batch file
-    let symlink_exists = crate::utils::vouch_helper_path("docker-credential-vouch")
-        .map(|p| {
+    let symlink_exists =
+        crate::utils::vouch_helper_path("docker-credential-vouch").is_ok_and(|p| {
             #[cfg(unix)]
             {
                 p.exists() || p.is_symlink()
@@ -172,8 +172,7 @@ pub(crate) fn check_docker_config() -> DockerSetupStatus {
                 // On Windows, check for the .bat file
                 p.with_extension("bat").exists()
             }
-        })
-        .unwrap_or(false);
+        });
 
     // Check Docker config
     let configured_registries = get_configured_registries().unwrap_or_default();

--- a/crates/vouch-cli/src/commands/setup/eks.rs
+++ b/crates/vouch-cli/src/commands/setup/eks.rs
@@ -104,9 +104,10 @@ pub(crate) async fn run(
     profile: Option<&str>,
     kubeconfig_path: Option<&str>,
 ) -> Result<()> {
-    let kubeconfig_path = kubeconfig_path.map(PathBuf::from).unwrap_or_else(|| {
-        default_kubeconfig_path().unwrap_or_else(|_| PathBuf::from("~/.kube/config"))
-    });
+    let kubeconfig_path = kubeconfig_path.map_or_else(
+        || default_kubeconfig_path().unwrap_or_else(|_| PathBuf::from("~/.kube/config")),
+        PathBuf::from,
+    );
 
     // Auto-discover profile, region, and role
     let profile_name = aws::resolve_profile(profile)?;

--- a/crates/vouch-cli/src/commands/setup/ssh.rs
+++ b/crates/vouch-cli/src/commands/setup/ssh.rs
@@ -133,9 +133,10 @@ fn configure_ssh_config(hosts: Option<&str>) -> Result<()> {
     let key_path = default_key_path()?;
     let cert_path = PathBuf::from(format!("{}-cert.pub", key_path.display()));
     #[cfg(unix)]
-    let agent_socket = vouch_agent::ssh_agent_socket_path()
-        .map(|p| p.display().to_string())
-        .unwrap_or_else(|_| "~/.vouch/ssh-agent.sock".to_string());
+    let agent_socket = vouch_agent::ssh_agent_socket_path().map_or_else(
+        |_| "~/.vouch/ssh-agent.sock".to_string(),
+        |p| p.display().to_string(),
+    );
     #[cfg(not(unix))]
     let agent_socket = "~/.vouch/ssh-agent.sock".to_string();
 

--- a/crates/vouch-cli/src/commands/setup/ssm.rs
+++ b/crates/vouch-cli/src/commands/setup/ssm.rs
@@ -115,8 +115,7 @@ fn strip_ssm_block(content: &str) -> String {
     let after_marker = from_marker.get(marker_offset..).unwrap_or("");
     let block_rest_len = after_marker
         .find("\n\n")
-        .map(|pos| marker_offset + pos + 1)
-        .unwrap_or(from_marker.len());
+        .map_or(from_marker.len(), |pos| marker_offset + pos + 1);
 
     let after = from_marker.get(block_rest_len..).unwrap_or("");
 

--- a/crates/vouch-cli/src/integrations/aws/config.rs
+++ b/crates/vouch-cli/src/integrations/aws/config.rs
@@ -250,10 +250,10 @@ impl AwsConfig {
             let Some(region) = props.get("sso_region") else {
                 continue;
             };
-            let scopes = props
-                .get("sso_registration_scopes")
-                .map(|s| s.split(',').map(|s| s.trim().to_string()).collect())
-                .unwrap_or_else(|| vec!["sso:account:access".to_string()]);
+            let scopes = props.get("sso_registration_scopes").map_or_else(
+                || vec!["sso:account:access".to_string()],
+                |s| s.split(',').map(|s| s.trim().to_string()).collect(),
+            );
             sessions.push(SsoSession {
                 name: session_name.to_string(),
                 start_url: start_url.to_string(),

--- a/crates/vouch-cli/src/integrations/aws/mod.rs
+++ b/crates/vouch-cli/src/integrations/aws/mod.rs
@@ -158,17 +158,16 @@ impl IntegrationCheck for AwsIntegration {
             };
         }
 
-        let summary = status
-            .profile_name
-            .as_ref()
-            .map(|p| {
+        let summary = status.profile_name.as_ref().map_or_else(
+            || "configured".to_string(),
+            |p| {
                 if p == "default" {
                     "default profile".to_string()
                 } else {
                     format!("profile: {p}")
                 }
-            })
-            .unwrap_or_else(|| "configured".to_string());
+            },
+        );
 
         let mut details = Vec::new();
         if let Some(role) = &status.role_arn {

--- a/crates/vouch-cli/src/integrations/aws/sso.rs
+++ b/crates/vouch-cli/src/integrations/aws/sso.rs
@@ -619,7 +619,7 @@ pub(crate) async fn poll_for_token(
 
         // Parse the error to decide whether to retry or fail
         let oidc_err: Option<SsoOidcError> = serde_json::from_str(&body_text).ok();
-        let error_code = oidc_err.as_ref().map(|e| e.error.as_str()).unwrap_or("");
+        let error_code = oidc_err.as_ref().map_or("", |e| e.error.as_str());
 
         match error_code {
             "authorization_pending" => {

--- a/crates/vouch-cli/src/integrations/github.rs
+++ b/crates/vouch-cli/src/integrations/github.rs
@@ -214,8 +214,7 @@ fn is_git_repo() -> bool {
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
+        .is_ok_and(|s| s.success())
 }
 
 /// Get all GitHub remotes from the current git repo.

--- a/crates/vouch-cli/src/posture/macos.rs
+++ b/crates/vouch-cli/src/posture/macos.rs
@@ -143,12 +143,7 @@ fn detect_firewall(posture: &mut DevicePosture) {
 fn detect_secure_boot(posture: &mut DevicePosture) {
     // SIP — separate from Secure Boot
     let sip_output = run_command("csrutil", &["status"]);
-    posture.sip_enabled = Some(
-        sip_output
-            .as_deref()
-            .map(|s| s.contains("enabled"))
-            .unwrap_or(false),
-    );
+    posture.sip_enabled = Some(sip_output.as_deref().is_some_and(|s| s.contains("enabled")));
 
     let is_arm = std::env::consts::ARCH == "aarch64";
 

--- a/crates/vouch-cli/src/session.rs
+++ b/crates/vouch-cli/src/session.rs
@@ -149,9 +149,10 @@ fn write_session_cookie_file(server: &str, token: &str, expires_at_ts: Option<ji
         Err(_) => "localhost".to_string(),
     };
 
-    let expires = expires_at_ts
-        .map(|ts| ts.as_second())
-        .unwrap_or_else(|| jiff::Timestamp::now().as_second() + 28_800);
+    let expires = expires_at_ts.map_or_else(
+        || jiff::Timestamp::now().as_second() + 28_800,
+        |ts| ts.as_second(),
+    );
 
     let cookie = SessionCookie::new(&domain, token, expires);
     if let Err(e) = write_cookie(&cookie) {

--- a/crates/vouch-cli/src/utils.rs
+++ b/crates/vouch-cli/src/utils.rs
@@ -133,12 +133,10 @@ pub(crate) fn vouch_helper_path(name: &str) -> Result<PathBuf> {
 ///
 /// Returns `true` if the path is a symlink whose target filename is `vouch`.
 pub(crate) fn is_vouch_symlink(path: &Path) -> bool {
-    std::fs::read_link(path)
-        .map(|target| {
-            let s = target.to_string_lossy();
-            s.ends_with("/vouch") || s.ends_with("\\vouch")
-        })
-        .unwrap_or(false)
+    std::fs::read_link(path).is_ok_and(|target| {
+        let s = target.to_string_lossy();
+        s.ends_with("/vouch") || s.ends_with("\\vouch")
+    })
 }
 
 /// Create a symlink (Unix) or batch file wrapper (Windows) pointing to the vouch binary.

--- a/crates/vouch-server/src/crypto/ssh_ca.rs
+++ b/crates/vouch-server/src/crypto/ssh_ca.rs
@@ -243,8 +243,7 @@ impl SshCa {
         // random bits makes collision probability negligible (~2^-64).
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_secs());
         let mut rand_bytes = [0u8; 8];
         aws_lc_rs::rand::fill(&mut rand_bytes)
             .map_err(|_| anyhow::anyhow!("Failed to generate random serial bytes"))?;

--- a/crates/vouch-server/src/handlers/admin/audit.rs
+++ b/crates/vouch-server/src/handlers/admin/audit.rs
@@ -133,8 +133,7 @@ pub async fn admin_audit_page(
             let created_at = e
                 .created_at
                 .parse::<Timestamp>()
-                .map(|ts| format_timestamp(&ts))
-                .unwrap_or_else(|_| e.created_at.clone());
+                .map_or_else(|_| e.created_at.clone(), |ts| format_timestamp(&ts));
             AuditRow {
                 id: e.id.clone(),
                 event_type: e.event_type.clone(),

--- a/crates/vouch-server/src/handlers/applications/api.rs
+++ b/crates/vouch-server/src/handlers/applications/api.rs
@@ -598,8 +598,7 @@ pub async fn update_application_api(
     let resource_uris = req
         .resource_uris
         .as_deref()
-        .map(|u| u.to_vec())
-        .unwrap_or_else(|| client.resource_uris.clone());
+        .map_or_else(|| client.resource_uris.clone(), <[String]>::to_vec);
 
     // Determine FAPI profile
     let is_fapi = req

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -881,8 +881,7 @@ pub async fn browser_register_start(
     let now = jiff::Timestamp::now();
     let reg_exp = now
         .checked_add(jiff::Span::new().minutes(5))
-        .map(|t| t.as_second())
-        .unwrap_or(now.as_second() + 300);
+        .map_or(now.as_second() + 300, |t| t.as_second());
     let reg_state = BrowserRegistrationState {
         device_auth_id,
         user_id,

--- a/crates/vouch-server/src/handlers/github.rs
+++ b/crates/vouch-server/src/handlers/github.rs
@@ -277,8 +277,7 @@ pub async fn github_webhook(
     let event_type = headers
         .get("x-github-event")
         .and_then(|h| h.to_str().ok())
-        .map(WebhookEvent::from)
-        .unwrap_or(WebhookEvent::Unknown);
+        .map_or(WebhookEvent::Unknown, WebhookEvent::from);
 
     service
         .handle_webhook_event(event_type, &body)

--- a/crates/vouch-server/src/handlers/keys.rs
+++ b/crates/vouch-server/src/handlers/keys.rs
@@ -147,8 +147,7 @@ pub async fn register_start(
     let now = Timestamp::now();
     let exp = now
         .checked_add(jiff::Span::new().minutes(5))
-        .map(|t| t.as_second())
-        .unwrap_or(now.as_second() + 300);
+        .map_or(now.as_second() + 300, |t| t.as_second());
     let reg_state = RegistrationState {
         user_id,
         user_name: user.email.clone(),

--- a/crates/vouch-server/src/handlers/oidc/fido2_challenge.rs
+++ b/crates/vouch-server/src/handlers/oidc/fido2_challenge.rs
@@ -71,8 +71,7 @@ pub async fn fido2_challenge(State(state): State<Arc<AppState>>) -> Response {
     let now = Timestamp::now();
     let exp = now
         .checked_add(jiff::Span::new().minutes(5))
-        .map(|t| t.as_second())
-        .unwrap_or(now.as_second() + 300);
+        .map_or(now.as_second() + 300, |t| t.as_second());
 
     let challenge_state = Fido2ChallengeState {
         challenge: challenge.clone(),

--- a/crates/vouch-server/src/handlers/oidc/tests/fido2_grant.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/fido2_grant.rs
@@ -855,7 +855,7 @@ fn build_client_assertion(
         "aud": audience,
         "iat": now,
         "exp": now + 60,
-        "jti": jti.map(str::to_string).unwrap_or_else(|| uuid::Uuid::now_v7().to_string())
+        "jti": jti.map_or_else(|| uuid::Uuid::now_v7().to_string(), str::to_string)
     });
 
     let header_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&header).unwrap());

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9207.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9207.rs
@@ -136,8 +136,7 @@ async fn test_rfc9207_authorize_response_includes_iss_parameter() {
     let after_iss = location.get(iss_start..).expect("iss_start in bounds");
     let iss_end = after_iss
         .find('&')
-        .map(|i| iss_start + i)
-        .unwrap_or(location.len());
+        .map_or(location.len(), |i| iss_start + i);
     let iss_encoded = location
         .get(iss_start..iss_end)
         .expect("iss range in bounds");

--- a/crates/vouch-server/src/handlers/scim/tests.rs
+++ b/crates/vouch-server/src/handlers/scim/tests.rs
@@ -1535,8 +1535,7 @@ async fn test_scim_patch_group_remove_member() {
     let has_member = group
         .get("members")
         .and_then(|m| m.as_array())
-        .map(|arr| arr.iter().any(|m| m["value"] == user_id))
-        .unwrap_or(false);
+        .is_some_and(|arr| arr.iter().any(|m| m["value"] == user_id));
     assert!(
         !has_member,
         "Removed member must not appear in GET response"

--- a/crates/vouch-server/src/handlers/scim/users.rs
+++ b/crates/vouch-server/src/handlers/scim/users.rs
@@ -142,8 +142,7 @@ pub async fn create_user(
             .iter()
             .find(|e| e.primary)
             .or_else(|| emails.first())
-            .map(|e| e.value.clone())
-            .unwrap_or_else(|| user.user_name.clone())
+            .map_or_else(|| user.user_name.clone(), |e| e.value.clone())
     } else {
         user.user_name.clone()
     };

--- a/crates/vouch-server/src/infra/rate_limit.rs
+++ b/crates/vouch-server/src/infra/rate_limit.rs
@@ -41,7 +41,7 @@ use crate::handlers::extractors::resolve_client_ip;
 /// trusted proxies are configured or the peer is not trusted.
 #[derive(Debug, Clone)]
 pub struct TrustedProxyKeyExtractor {
-    trusted_cidrs: Arc<Vec<IpNet>>,
+    trusted_cidrs: Arc<[IpNet]>,
 }
 
 impl TrustedProxyKeyExtractor {
@@ -49,7 +49,7 @@ impl TrustedProxyKeyExtractor {
     #[must_use]
     pub fn new(trusted_cidrs: Vec<IpNet>) -> Self {
         Self {
-            trusted_cidrs: Arc::new(trusted_cidrs),
+            trusted_cidrs: Arc::from(trusted_cidrs),
         }
     }
 }

--- a/crates/vouch-server/src/infra/router.rs
+++ b/crates/vouch-server/src/infra/router.rs
@@ -64,8 +64,10 @@ fn build_date() -> String {
         .and_then(|s| s.parse::<i64>().ok())
         .filter(|&ts| ts > 0)
         .and_then(|ts| jiff::Timestamp::from_second(ts).ok())
-        .map(|ts| ts.strftime("%Y-%m-%d").to_string())
-        .unwrap_or_else(|| "dev".to_string())
+        .map_or_else(
+            || "dev".to_string(),
+            |ts| ts.strftime("%Y-%m-%d").to_string(),
+        )
 }
 
 /// Print an ASCII banner at server startup.
@@ -776,8 +778,7 @@ async fn metrics_middleware(req: Request<axum::body::Body>, next: Next) -> impl 
     let path = req
         .extensions()
         .get::<MatchedPath>()
-        .map(|p| p.as_str().to_string())
-        .unwrap_or_else(|| req.uri().path().to_string());
+        .map_or_else(|| req.uri().path().to_string(), |p| p.as_str().to_string());
     let start = std::time::Instant::now();
 
     let response = next.run(req).await;

--- a/crates/vouch-server/src/services/idp/saml/c14n.rs
+++ b/crates/vouch-server/src/services/idp/saml/c14n.rs
@@ -123,8 +123,7 @@ fn canonicalize_node(
     let ancestor_default_ns = rendered_ns
         .iter()
         .find(|(p, _)| p.is_empty())
-        .map(|(_, u)| u.as_str())
-        .unwrap_or("");
+        .map_or("", |(_, u)| u.as_str());
 
     // Undeclare if: element has no default NS but ancestor rendered one,
     // AND we haven't already emitted xmlns="" (which would happen if this

--- a/crates/vouch-server/src/services/oidc/authorization.rs
+++ b/crates/vouch-server/src/services/oidc/authorization.rs
@@ -661,8 +661,7 @@ pub async fn issue_authorization_code(
     let lifetime_secs = params.auth_code_lifetime_seconds;
     let exp = now
         .checked_add(Span::new().seconds(lifetime_secs))
-        .map(|t| t.as_second())
-        .unwrap_or_else(|_| now.as_second() + lifetime_secs);
+        .map_or_else(|_| now.as_second() + lifetime_secs, |t| t.as_second());
 
     let auth_code = AuthorizationCode {
         iss: state.config().base_url.clone(),

--- a/crates/vouch-server/src/services/oidc/fido2_grant.rs
+++ b/crates/vouch-server/src/services/oidc/fido2_grant.rs
@@ -294,10 +294,7 @@ pub async fn exchange_fido2_assertion(
     }
 
     // 10. Create OAuth access token
-    let scope = params
-        .scope
-        .map(ScopeSet::parse)
-        .unwrap_or_else(ScopeSet::all);
+    let scope = params.scope.map_or_else(ScopeSet::all, ScopeSet::parse);
 
     let dpop_jkt = params.dpop_proof.as_ref().map(|p| p.jkt.as_str());
     let now = jiff::Timestamp::now().as_second();

--- a/crates/vouch-server/src/services/posture.rs
+++ b/crates/vouch-server/src/services/posture.rs
@@ -222,6 +222,10 @@ pub(crate) fn validate_cel_expression(expression: &str) -> ServiceResult<()> {
 /// Supports 1-3 components: "15" → 15_000_000, "15.3" → 15_003_000,
 /// "15.3.1" → 15_003_001. Use for correct version comparisons:
 /// `semver(posture.os_version) >= semver("14.0.0")`
+#[expect(
+    clippy::rc_buffer,
+    reason = "cel::IntoFunction trait extractor only supports Arc<String>, not Arc<str>"
+)]
 fn cel_semver(ftx: &FunctionContext, value: Arc<String>) -> Result<Value, ExecutionError> {
     let mut parts = value.splitn(4, '.');
     let parse = |s: &str, ftx: &FunctionContext| -> Result<i64, ExecutionError> {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily lint- and style-driven refactors (option/result combinators, `Arc` backing storage) with minimal behavioral impact; risk is limited to subtle changes in default/fallback branches if any logic was inadvertently reordered.
> 
> **Overview**
> **Tightens workspace Clippy linting** by promoting `string_slice` to `deny` and newly denying `modulo_arithmetic`, `mutex_atomic`, `rc_buffer`, and `map_unwrap_or`.
> 
> Updates CLI and server code to comply, mostly by replacing `.map(...).unwrap_or(_else)` patterns with `.map_or(_else)`, and using `is_ok_and`/`is_some_and` for more explicit fallbacks. Also switches rate-limit trusted CIDR storage from `Arc<Vec<IpNet>>` to `Arc<[IpNet]>` and adds a targeted lint exception where `Arc<String>` is required by a trait.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc76417d1794df0e3e0ef27345ed16df4c5641f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->