### PR TITLE
Support role paths

### DIFF
--- a/crates/vouch-cli/src/commands/setup/aws.rs
+++ b/crates/vouch-cli/src/commands/setup/aws.rs
@@ -9,19 +9,6 @@ use std::path::PathBuf;
 use crate::integrations::aws::{AwsConfig, AwsProfile};
 use crate::utils::ensure_secure_dir;
 
-/// Build the assumable member-account role ARN.
-///
-/// `role_path` must already be in canonical form (starts and ends with `/`,
-/// or is just `/`); see [`crate::config::normalize_member_role_path`].
-fn build_member_role_arn(
-    partition: &str,
-    account_id: &str,
-    role_path: &str,
-    role_name: &str,
-) -> String {
-    format!("arn:{partition}:iam::{account_id}:role{role_path}{role_name}")
-}
-
 /// Sanitize an account name into a valid AWS CLI profile name segment.
 ///
 /// Converts to lowercase, replaces non-alphanumeric-non-hyphen chars with `-`,
@@ -170,20 +157,9 @@ async fn run_discover(profile_prefix: Option<&str>, region: Option<&str>) -> Res
     })?;
     let session_cfg = vouch_config
         .aws()
-        .and_then(|a| a.sso_sessions.get(&session.name));
-    let member_role_name =
-        session_cfg.map_or_else(|| "VouchAccess".to_string(), |s| s.member_role_name.clone());
-    let member_role_path = match session_cfg {
-        Some(s) => {
-            crate::config::normalize_member_role_path(&s.member_role_path).with_context(|| {
-                format!(
-                    "invalid member_role_path for SSO session {:?}",
-                    session.name
-                )
-            })?
-        }
-        None => "/".to_string(),
-    };
+        .and_then(|a| a.sso_sessions.get(&session.name))
+        .cloned()
+        .unwrap_or_default();
 
     let sso_region = session.region.clone();
     let sso_config = SsoConfig::from_session(&session);
@@ -222,18 +198,15 @@ async fn run_discover(profile_prefix: Option<&str>, region: Option<&str>) -> Res
             .await
             .with_context(|| format!("failed to list roles for account {}", account.account_id))?;
 
-        let has_vouch_role = roles.iter().any(|r| r.role_name == member_role_name);
+        let has_vouch_role = roles
+            .iter()
+            .any(|r| r.role_name == session_cfg.member_role_name);
         if !has_vouch_role {
             continue;
         }
 
         let partition = Partition::from_region(&sso_region);
-        let role_arn = build_member_role_arn(
-            partition.as_str(),
-            &account.account_id,
-            &member_role_path,
-            &member_role_name,
-        );
+        let role_arn = session_cfg.role_arn_in(partition.as_str(), &account.account_id);
 
         let safe_name = sanitize_profile_name(&account.account_name);
         let name_part = if safe_name.is_empty() {
@@ -314,29 +287,5 @@ mod tests {
     #[test]
     fn test_sanitize_profile_name_all_special_chars() {
         assert_eq!(sanitize_profile_name("!!!@@@###"), "");
-    }
-
-    #[test]
-    fn test_build_member_role_arn_no_path() {
-        assert_eq!(
-            build_member_role_arn("aws", "123456789012", "/", "VouchAccess"),
-            "arn:aws:iam::123456789012:role/VouchAccess",
-        );
-    }
-
-    #[test]
-    fn test_build_member_role_arn_with_path() {
-        assert_eq!(
-            build_member_role_arn("aws", "123456789012", "/teams/sec/", "VouchAccess"),
-            "arn:aws:iam::123456789012:role/teams/sec/VouchAccess",
-        );
-    }
-
-    #[test]
-    fn test_build_member_role_arn_partition_govcloud() {
-        assert_eq!(
-            build_member_role_arn("aws-us-gov", "123", "/teams/", "VouchAccess"),
-            "arn:aws-us-gov:iam::123:role/teams/VouchAccess",
-        );
     }
 }

--- a/crates/vouch-cli/src/commands/setup/aws.rs
+++ b/crates/vouch-cli/src/commands/setup/aws.rs
@@ -9,6 +9,19 @@ use std::path::PathBuf;
 use crate::integrations::aws::{AwsConfig, AwsProfile};
 use crate::utils::ensure_secure_dir;
 
+/// Build the assumable member-account role ARN.
+///
+/// `role_path` must already be in canonical form (starts and ends with `/`,
+/// or is just `/`); see [`crate::config::normalize_member_role_path`].
+fn build_member_role_arn(
+    partition: &str,
+    account_id: &str,
+    role_path: &str,
+    role_name: &str,
+) -> String {
+    format!("arn:{partition}:iam::{account_id}:role{role_path}{role_name}")
+}
+
 /// Sanitize an account name into a valid AWS CLI profile name segment.
 ///
 /// Converts to lowercase, replaces non-alphanumeric-non-hyphen chars with `-`,
@@ -155,10 +168,22 @@ async fn run_discover(profile_prefix: Option<&str>, region: Option<&str>) -> Res
             "No SSO session found in ~/.aws/config. Run 'aws configure sso' first.".to_string(),
         )
     })?;
-    let member_role_name = vouch_config
+    let session_cfg = vouch_config
         .aws()
-        .and_then(|a| a.sso_sessions.get(&session.name))
-        .map_or_else(|| "VouchAccess".to_string(), |s| s.member_role_name.clone());
+        .and_then(|a| a.sso_sessions.get(&session.name));
+    let member_role_name =
+        session_cfg.map_or_else(|| "VouchAccess".to_string(), |s| s.member_role_name.clone());
+    let member_role_path = match session_cfg {
+        Some(s) => {
+            crate::config::normalize_member_role_path(&s.member_role_path).with_context(|| {
+                format!(
+                    "invalid member_role_path for SSO session {:?}",
+                    session.name
+                )
+            })?
+        }
+        None => "/".to_string(),
+    };
 
     let sso_region = session.region.clone();
     let sso_config = SsoConfig::from_session(&session);
@@ -203,11 +228,11 @@ async fn run_discover(profile_prefix: Option<&str>, region: Option<&str>) -> Res
         }
 
         let partition = Partition::from_region(&sso_region);
-        let role_arn = format!(
-            "arn:{}:iam::{}:role/{}",
+        let role_arn = build_member_role_arn(
             partition.as_str(),
-            account.account_id,
-            member_role_name
+            &account.account_id,
+            &member_role_path,
+            &member_role_name,
         );
 
         let safe_name = sanitize_profile_name(&account.account_name);
@@ -289,5 +314,29 @@ mod tests {
     #[test]
     fn test_sanitize_profile_name_all_special_chars() {
         assert_eq!(sanitize_profile_name("!!!@@@###"), "");
+    }
+
+    #[test]
+    fn test_build_member_role_arn_no_path() {
+        assert_eq!(
+            build_member_role_arn("aws", "123456789012", "/", "VouchAccess"),
+            "arn:aws:iam::123456789012:role/VouchAccess",
+        );
+    }
+
+    #[test]
+    fn test_build_member_role_arn_with_path() {
+        assert_eq!(
+            build_member_role_arn("aws", "123456789012", "/teams/sec/", "VouchAccess"),
+            "arn:aws:iam::123456789012:role/teams/sec/VouchAccess",
+        );
+    }
+
+    #[test]
+    fn test_build_member_role_arn_partition_govcloud() {
+        assert_eq!(
+            build_member_role_arn("aws-us-gov", "123", "/teams/", "VouchAccess"),
+            "arn:aws-us-gov:iam::123:role/teams/VouchAccess",
+        );
     }
 }

--- a/crates/vouch-cli/src/config.rs
+++ b/crates/vouch-cli/src/config.rs
@@ -32,10 +32,51 @@ pub(crate) struct SsoSessionConfig {
     /// Role name to assume in member accounts.
     #[serde(default = "default_member_role_name")]
     pub member_role_name: String,
+    /// IAM Path of the member-account role. Canonical form starts and ends
+    /// with `/` (e.g. `/teams/sec/`). `/` means no path. Use
+    /// [`normalize_member_role_path`] to coerce user input.
+    #[serde(default = "default_member_role_path")]
+    pub member_role_path: String,
 }
 
 fn default_member_role_name() -> String {
     "VouchAccess".to_string()
+}
+
+fn default_member_role_path() -> String {
+    "/".to_string()
+}
+
+/// Normalize an IAM Path string so it starts and ends with `/`.
+///
+/// Accepts forms like `""`, `"/"`, `"teams/sec"`, `"/teams/sec"`,
+/// `"teams/sec/"`, `"/teams/sec/"` and returns `/teams/sec/` (or `/` for
+/// the empty/root case). Rejects whitespace and embedded ARN fragments.
+pub(crate) fn normalize_member_role_path(raw: &str) -> Result<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed == "/" {
+        return Ok("/".to_string());
+    }
+    if trimmed.chars().any(char::is_whitespace) {
+        anyhow::bail!("member_role_path must not contain whitespace: {raw:?}");
+    }
+    if trimmed.contains("//") {
+        anyhow::bail!("member_role_path must not contain empty segments: {raw:?}");
+    }
+    if trimmed.contains(':') || trimmed.contains("arn:") {
+        anyhow::bail!("member_role_path must be a path, not an ARN: {raw:?}");
+    }
+    let with_leading = if trimmed.starts_with('/') {
+        trimmed.to_string()
+    } else {
+        format!("/{trimmed}")
+    };
+    let canonical = if with_leading.ends_with('/') {
+        with_leading
+    } else {
+        format!("{with_leading}/")
+    };
+    Ok(canonical)
 }
 
 /// CLI configuration stored in ~/.vouch/config.json
@@ -1105,7 +1146,8 @@ mod tests {
                 "sso_sessions": {
                     "smoketurner": {
                         "management_role": "arn:aws:iam::111:role/VouchManagement",
-                        "member_role_name": "VouchAccess"
+                        "member_role_name": "VouchAccess",
+                        "member_role_path": "/teams/sec/"
                     }
                 }
             }
@@ -1126,6 +1168,7 @@ mod tests {
             "arn:aws:iam::111:role/VouchManagement"
         );
         assert_eq!(session.member_role_name, "VouchAccess");
+        assert_eq!(session.member_role_path, "/teams/sec/");
 
         // Round-trip through JSON
         let file2 = ConfigFile::from(&config);
@@ -1143,6 +1186,7 @@ mod tests {
             "arn:aws:iam::111:role/VouchManagement"
         );
         assert_eq!(session2.member_role_name, "VouchAccess");
+        assert_eq!(session2.member_role_path, "/teams/sec/");
     }
 
     #[test]
@@ -1163,6 +1207,36 @@ mod tests {
         let aws = config.aws().expect("aws config should exist");
         let session = aws.sso_sessions.get("my-session").expect("session");
         assert_eq!(session.member_role_name, "VouchAccess");
+        assert_eq!(session.member_role_path, "/");
+    }
+
+    #[test]
+    fn test_normalize_member_role_path_canonical_forms() {
+        assert_eq!(normalize_member_role_path("").unwrap(), "/");
+        assert_eq!(normalize_member_role_path("/").unwrap(), "/");
+        assert_eq!(
+            normalize_member_role_path("teams/sec").unwrap(),
+            "/teams/sec/"
+        );
+        assert_eq!(
+            normalize_member_role_path("/teams/sec").unwrap(),
+            "/teams/sec/"
+        );
+        assert_eq!(
+            normalize_member_role_path("teams/sec/").unwrap(),
+            "/teams/sec/"
+        );
+        assert_eq!(
+            normalize_member_role_path("/teams/sec/").unwrap(),
+            "/teams/sec/"
+        );
+    }
+
+    #[test]
+    fn test_normalize_member_role_path_rejects_invalid() {
+        assert!(normalize_member_role_path("teams sec").is_err());
+        assert!(normalize_member_role_path("//teams//sec").is_err());
+        assert!(normalize_member_role_path("arn:aws:iam::1:role/foo").is_err());
     }
 
     #[test]

--- a/crates/vouch-cli/src/config.rs
+++ b/crates/vouch-cli/src/config.rs
@@ -32,11 +32,35 @@ pub(crate) struct SsoSessionConfig {
     /// Role name to assume in member accounts.
     #[serde(default = "default_member_role_name")]
     pub member_role_name: String,
-    /// IAM Path of the member-account role. Canonical form starts and ends
-    /// with `/` (e.g. `/teams/sec/`). `/` means no path. Use
-    /// [`normalize_member_role_path`] to coerce user input.
-    #[serde(default = "default_member_role_path")]
+    /// IAM Path of the member-account role, always canonical (starts and
+    /// ends with `/`, e.g. `/teams/sec/`; `/` means no path). User input is
+    /// normalized at deserialization via [`normalize_member_role_path`].
+    #[serde(
+        default = "default_member_role_path",
+        deserialize_with = "deserialize_member_role_path"
+    )]
     pub member_role_path: String,
+}
+
+impl Default for SsoSessionConfig {
+    fn default() -> Self {
+        Self {
+            management_role: String::new(),
+            member_role_name: default_member_role_name(),
+            member_role_path: default_member_role_path(),
+        }
+    }
+}
+
+impl SsoSessionConfig {
+    /// Build the assumable member-account role ARN for the given account.
+    pub(crate) fn role_arn_in(&self, partition: &str, account_id: &str) -> String {
+        format!(
+            "arn:{partition}:iam::{account_id}:role{path}{name}",
+            path = self.member_role_path,
+            name = self.member_role_name,
+        )
+    }
 }
 
 fn default_member_role_name() -> String {
@@ -45,6 +69,14 @@ fn default_member_role_name() -> String {
 
 fn default_member_role_path() -> String {
     "/".to_string()
+}
+
+fn deserialize_member_role_path<'de, D>(deserializer: D) -> std::result::Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = String::deserialize(deserializer)?;
+    normalize_member_role_path(&raw).map_err(serde::de::Error::custom)
 }
 
 /// Normalize an IAM Path string so it starts and ends with `/`.
@@ -1237,6 +1269,84 @@ mod tests {
         assert!(normalize_member_role_path("teams sec").is_err());
         assert!(normalize_member_role_path("//teams//sec").is_err());
         assert!(normalize_member_role_path("arn:aws:iam::1:role/foo").is_err());
+    }
+
+    #[test]
+    fn test_sso_session_config_default() {
+        let cfg = SsoSessionConfig::default();
+        assert_eq!(cfg.management_role, "");
+        assert_eq!(cfg.member_role_name, "VouchAccess");
+        assert_eq!(cfg.member_role_path, "/");
+    }
+
+    #[test]
+    fn test_role_arn_in_no_path() {
+        let cfg = SsoSessionConfig::default();
+        assert_eq!(
+            cfg.role_arn_in("aws", "123456789012"),
+            "arn:aws:iam::123456789012:role/VouchAccess"
+        );
+    }
+
+    #[test]
+    fn test_role_arn_in_with_path() {
+        let cfg = SsoSessionConfig {
+            member_role_path: "/teams/sec/".to_string(),
+            ..SsoSessionConfig::default()
+        };
+        assert_eq!(
+            cfg.role_arn_in("aws", "123456789012"),
+            "arn:aws:iam::123456789012:role/teams/sec/VouchAccess"
+        );
+    }
+
+    #[test]
+    fn test_role_arn_in_partition_govcloud() {
+        let cfg = SsoSessionConfig {
+            member_role_path: "/teams/".to_string(),
+            ..SsoSessionConfig::default()
+        };
+        assert_eq!(
+            cfg.role_arn_in("aws-us-gov", "123"),
+            "arn:aws-us-gov:iam::123:role/teams/VouchAccess"
+        );
+    }
+
+    #[test]
+    fn test_member_role_path_normalized_on_deserialize() {
+        let json = r#"{
+            "aws": {
+                "sso_sessions": {
+                    "my-session": {
+                        "management_role": "arn:aws:iam::1:role/Mgmt",
+                        "member_role_path": "teams/sec"
+                    }
+                }
+            }
+        }"#;
+
+        let file: ConfigFile = serde_json::from_str(json).unwrap();
+        let config = Config::from(file);
+        let aws = config.aws().expect("aws config should exist");
+        let session = aws.sso_sessions.get("my-session").expect("session");
+        assert_eq!(session.member_role_path, "/teams/sec/");
+    }
+
+    #[test]
+    fn test_member_role_path_invalid_rejected_on_deserialize() {
+        let json = r#"{
+            "aws": {
+                "sso_sessions": {
+                    "my-session": {
+                        "management_role": "arn:aws:iam::1:role/Mgmt",
+                        "member_role_path": "arn:aws:iam::1:role/foo"
+                    }
+                }
+            }
+        }"#;
+
+        let result: std::result::Result<ConfigFile, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "ARN-shaped paths must be rejected");
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new persisted config field that changes how member-account role ARNs are constructed during AWS profile discovery, which could break existing setups if misconfigured. Validation and defaults reduce risk, but it touches AWS credential/profile generation paths.
> 
> **Overview**
> Adds support for IAM *role paths* in AWS multi-account SSO configuration by introducing `member_role_path` on `SsoSessionConfig`, with normalization/validation during deserialization and defaults for backward compatibility.
> 
> Updates `vouch aws setup --discover` to use the full session config (including role path) when checking for available roles and when generating member-account `role_arn`s via `SsoSessionConfig::role_arn_in`. Expands config round-trip and parsing tests to cover normalization, invalid inputs, and ARN construction across partitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bb8a4c80a9ef9197b861388109f08bc35d2b4a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->