### PR TITLE
more lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,9 @@ rc_buffer = "deny"
 # Style: prefer .map_or(default, f) over .map(f).unwrap_or(default)
 map_unwrap_or = "deny"
 
+# Silent drops of #[must_use] (mostly Result) hide real failures
+let_underscore_must_use = "deny"
+
 module_name_repetitions = "allow"
 similar_names = "allow"
 

--- a/crates/vouch-agent/src/audit.rs
+++ b/crates/vouch-agent/src/audit.rs
@@ -103,7 +103,8 @@ fn write_event(record: &AuditRecord) -> std::io::Result<()> {
         && metadata.len() > MAX_LOG_SIZE
     {
         let rotated = dir.join("audit.log.1");
-        let _ = std::fs::rename(&log_path, &rotated);
+        // Best-effort rotation; failure is non-fatal and is shadowed by the next write.
+        let _rotated = std::fs::rename(&log_path, &rotated);
     }
 
     let mut file = std::fs::OpenOptions::new()
@@ -115,7 +116,8 @@ fn write_event(record: &AuditRecord) -> std::io::Result<()> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(&log_path, std::fs::Permissions::from_mode(0o600));
+        // Best-effort tightening; if it fails the log still gets written.
+        let _chmod = std::fs::set_permissions(&log_path, std::fs::Permissions::from_mode(0o600));
     }
 
     let json = serde_json::to_string(record)

--- a/crates/vouch-agent/src/daemon.rs
+++ b/crates/vouch-agent/src/daemon.rs
@@ -62,8 +62,8 @@ pub fn is_running() -> Result<bool> {
     let pid: i32 = match contents.trim().parse() {
         Ok(p) => p,
         Err(_) => {
-            // Invalid PID file, remove it
-            let _ = fs::remove_file(&pid_path);
+            // Invalid PID file, remove it (best-effort cleanup).
+            let _removed = fs::remove_file(&pid_path);
             return Ok(false);
         }
     };
@@ -72,8 +72,8 @@ pub fn is_running() -> Result<bool> {
     if is_process_running(pid) {
         Ok(true)
     } else {
-        // Stale PID file, remove it
-        let _ = fs::remove_file(&pid_path);
+        // Stale PID file, remove it (best-effort cleanup).
+        let _removed = fs::remove_file(&pid_path);
         Ok(false)
     }
 }
@@ -182,8 +182,8 @@ pub fn daemonize() -> Result<DaemonizeResult> {
         return Ok(DaemonizeResult::Parent);
     }
 
-    // Change working directory to root
-    let _ = std::env::set_current_dir("/");
+    // Change working directory to root (best-effort; non-fatal if it fails).
+    let _chdir = std::env::set_current_dir("/");
 
     // Close standard file descriptors and redirect to /dev/null or log file
     let log_path = log_file_path()?;

--- a/crates/vouch-agent/src/main.rs
+++ b/crates/vouch-agent/src/main.rs
@@ -213,8 +213,8 @@ async fn run_agent_server(enable_ssh_agent: bool) -> ExitCode {
                     warn!("Failed to listen for Ctrl+C: {e}");
                 }
             }
-            // Signal SSH agent to stop accepting new connections
-            let _ = shutdown_tx.send(true);
+            // Signal SSH agent to stop accepting new connections; receiver may already be gone.
+            let _signaled = shutdown_tx.send(true);
             ExitCode::SUCCESS
         }
         Some(()) = async {
@@ -224,8 +224,8 @@ async fn run_agent_server(enable_ssh_agent: bool) -> ExitCode {
             }
         } => {
             info!("Received SIGTERM, shutting down...");
-            // Signal SSH agent to stop accepting new connections
-            let _ = shutdown_tx.send(true);
+            // Signal SSH agent to stop accepting new connections; receiver may already be gone.
+            let _signaled = shutdown_tx.send(true);
             ExitCode::SUCCESS
         }
     };
@@ -267,7 +267,8 @@ fn stop_agent() -> ExitCode {
         Ok(p) => p,
         Err(_) => {
             eprintln!("Invalid PID in file");
-            let _ = std::fs::remove_file(&pid_path);
+            // Best-effort cleanup of the stale PID file.
+            let _removed = std::fs::remove_file(&pid_path);
             return ExitCode::FAILURE;
         }
     };
@@ -285,7 +286,8 @@ fn stop_agent() -> ExitCode {
             // SAFETY: kill(pid, 0) checks if process exists
             if unsafe { libc::kill(pid, 0) } != 0 {
                 println!("Agent stopped");
-                let _ = daemon::remove_pid_file();
+                // Best-effort cleanup of the PID file.
+                let _removed = daemon::remove_pid_file();
             } else {
                 println!("Agent is shutting down...");
             }
@@ -295,7 +297,8 @@ fn stop_agent() -> ExitCode {
             // Remove stale PID file if process doesn't exist
             // SAFETY: kill(pid, 0) checks if process exists
             if unsafe { libc::kill(pid, 0) } != 0 {
-                let _ = daemon::remove_pid_file();
+                // Best-effort cleanup of the stale PID file.
+                let _removed = daemon::remove_pid_file();
             }
             ExitCode::FAILURE
         }

--- a/crates/vouch-agent/src/server.rs
+++ b/crates/vouch-agent/src/server.rs
@@ -455,7 +455,7 @@ async fn send_response(stream: &mut UnixStream, response: &Response) -> Result<(
 
 impl Drop for AgentServer {
     fn drop(&mut self) {
-        // Clean up socket on drop
-        let _ = crate::socket::remove_socket();
+        // Clean up socket on drop (best-effort; cannot return errors from Drop).
+        let _removed = crate::socket::remove_socket();
     }
 }

--- a/crates/vouch-cli/src/commands/credential/docker.rs
+++ b/crates/vouch-cli/src/commands/credential/docker.rs
@@ -86,7 +86,7 @@ pub(crate) async fn run(operation: &str) -> Result<()> {
         "store" | "erase" => {
             // These operations are no-ops for Vouch since we don't store credentials
             // Just consume stdin to avoid broken pipe
-            let _ = read_server_url();
+            let _consumed = read_server_url();
             Ok(())
         }
         "list" => {

--- a/crates/vouch-cli/src/commands/credential/ssh.rs
+++ b/crates/vouch-cli/src/commands/credential/ssh.rs
@@ -248,7 +248,8 @@ pub(crate) async fn auto_provision(
             // Store in agent with session linkage (Unix only)
             #[cfg(unix)]
             if let Ok(mut agent) = vouch_agent::AgentClient::connect().await {
-                let _ = agent
+                // Best-effort agent push; SSH cert is already on disk.
+                let _stored = agent
                     .store_ssh_credentials_with_session(
                         &result.key_path.to_string_lossy(),
                         &result.cert_path.to_string_lossy(),
@@ -318,7 +319,8 @@ pub(crate) async fn run(server: &str, key_path: Option<&str>, force: bool) -> Re
         if let Ok(mut agent_client) = vouch_agent::AgentClient::connect().await {
             let key_str = result.key_path.to_string_lossy().to_string();
             let cert_str = result.cert_path.to_string_lossy().to_string();
-            let _ = agent_client
+            // Best-effort agent push; SSH cert is already on disk.
+            let _stored = agent_client
                 .store_ssh_credentials(&key_str, &cert_str)
                 .await;
         }

--- a/crates/vouch-cli/src/commands/login.rs
+++ b/crates/vouch-cli/src/commands/login.rs
@@ -473,9 +473,10 @@ async fn ensure_client_registered(client: &VouchClient, fapi_key: &ClientKey) ->
                     .await
                     {
                         Ok(true) => {
-                            // Cache the verification timestamp.
+                            // Cache the verification timestamp; cache write
+                            // failures are non-fatal — next login revalidates.
                             let now = jiff::Timestamp::now().to_string();
-                            let _ = Config::modify(|cfg| {
+                            let _cached = Config::modify(|cfg| {
                                 cfg.set_server_url(&base_url);
                                 cfg.set_registration_verified_at(&now);
                             });

--- a/crates/vouch-cli/src/commands/setup/ssh.rs
+++ b/crates/vouch-cli/src/commands/setup/ssh.rs
@@ -251,7 +251,8 @@ fn add_trusted_ca_to_known_hosts(ca_path: &std::path::Path, host_patterns: &str)
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let _ = fs::set_permissions(&lock_path, fs::Permissions::from_mode(0o600));
+        // Best-effort tightening of lock file permissions.
+        let _chmod = fs::set_permissions(&lock_path, fs::Permissions::from_mode(0o600));
     }
 
     #[cfg(unix)]

--- a/crates/vouch-cli/src/config.rs
+++ b/crates/vouch-cli/src/config.rs
@@ -362,7 +362,9 @@ impl Config {
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let _ = std::fs::set_permissions(&lock_path, std::fs::Permissions::from_mode(0o600));
+            // Best-effort tightening of lock file permissions.
+            let _chmod =
+                std::fs::set_permissions(&lock_path, std::fs::Permissions::from_mode(0o600));
         }
 
         crate::utils::flock_exclusive(&lock_file).context("failed to acquire config file lock")?;

--- a/crates/vouch-cli/src/fido2.rs
+++ b/crates/vouch-cli/src/fido2.rs
@@ -179,7 +179,8 @@ where
 {
     let (tx, rx) = tokio::sync::oneshot::channel();
     std::thread::spawn(move || {
-        let _ = tx.send(f());
+        // Receiver dropping (caller cancelled) is fine; nothing to do.
+        let _sent = tx.send(f());
     });
     rx.await.context("FIDO2 thread panicked")?
 }
@@ -1166,12 +1167,12 @@ mod tests {
         assert_eq!(device.counter(), 0);
 
         // First authentication increments to 1
-        let _ = device.authenticate("example.com", &challenge, "1234");
+        let _auth = device.authenticate("example.com", &challenge, "1234");
         // Counter was read as 0 and incremented to 1 during auth
         assert_eq!(device.counter(), 1);
 
         // Second authentication increments to 2
-        let _ = device.authenticate("example.com", &challenge, "1234");
+        let _auth = device.authenticate("example.com", &challenge, "1234");
         assert_eq!(device.counter(), 2);
     }
 }

--- a/crates/vouch-cli/src/integrations/ssm.rs
+++ b/crates/vouch-cli/src/integrations/ssm.rs
@@ -32,7 +32,8 @@ pub(crate) fn is_plugin_available() -> bool {
         .spawn()
     {
         Ok(mut child) => {
-            let _ = child.wait();
+            // Best-effort cleanup of the spawned probe process.
+            let _waited = child.wait();
             true
         }
         Err(e) if e.kind() == ErrorKind::NotFound => false,

--- a/crates/vouch-cli/src/style.rs
+++ b/crates/vouch-cli/src/style.rs
@@ -31,7 +31,8 @@ pub(crate) fn init(choice: ColorChoice) {
             std::io::stdout().is_terminal() && std::env::var_os("NO_COLOR").is_none()
         }
     };
-    let _ = COLOR_ENABLED.set(enabled);
+    // OnceLock::set returning Err means it was already set, which is fine on repeat init.
+    let _set = COLOR_ENABLED.set(enabled);
 }
 
 /// Whether color is currently enabled.

--- a/crates/vouch-httpsig/src/sfv/serialize.rs
+++ b/crates/vouch-httpsig/src/sfv/serialize.rs
@@ -91,7 +91,8 @@ fn serialize_bare_item(item: &SfvBareItem, out: &mut String) {
     match item {
         SfvBareItem::Integer(v) => {
             use std::fmt::Write;
-            let _ = write!(out, "{v}");
+            // Writing to a String never fails; ignore the formal Result.
+            let _written = write!(out, "{v}");
         }
         SfvBareItem::Decimal(v) => {
             // RFC 8941 §4.1.5: serialize with up to 3 fractional digits,

--- a/crates/vouch-httpsig/tests/sfv_proptest.rs
+++ b/crates/vouch-httpsig/tests/sfv_proptest.rs
@@ -3,7 +3,8 @@
 
 #![expect(
     clippy::unwrap_used,
-    reason = "test code: panic on assertion failure is acceptable"
+    clippy::let_underscore_must_use,
+    reason = "test code: panic on assertion failure is acceptable; proptest fuzz harness intentionally discards parse results"
 )]
 
 use proptest::prelude::*;

--- a/crates/vouch-server/src/crypto/tpm_decrypt.rs
+++ b/crates/vouch-server/src/crypto/tpm_decrypt.rs
@@ -621,7 +621,7 @@ mod tests {
         // the binary should not be in PATH.
         // If it IS installed (unlikely on dev), the test still passes
         // since we only assert the function doesn't panic.
-        let _ = is_attest_binary_available();
+        let _checked = is_attest_binary_available();
     }
 
     /// End-to-end CMS EnvelopedData parsing + decryption with a hand-crafted structure.

--- a/crates/vouch-server/src/db/pool.rs
+++ b/crates/vouch-server/src/db/pool.rs
@@ -674,8 +674,9 @@ pub(crate) fn redact_database_url(url: &str) -> String {
     match url::Url::parse(url) {
         Ok(mut parsed) => {
             if parsed.password().is_some() {
-                // url::Url::set_password returns Result<(), ()>
-                let _ = parsed.set_password(Some("***"));
+                // url::Url::set_password returns Result<(), ()>; failure is impossible
+                // here because we just confirmed the URL is parsed.
+                let _set = parsed.set_password(Some("***"));
             }
             parsed.to_string()
         }

--- a/crates/vouch-server/src/handlers/admin/members.rs
+++ b/crates/vouch-server/src/handlers/admin/members.rs
@@ -156,7 +156,7 @@ pub async fn promote_member(
         "target_user_id": &*target_id,
         "admin_user_id": admin.id,
     });
-    let _ = state
+    if let Err(e) = state
         .audit
         .insert_event(
             "admin_promote",
@@ -164,7 +164,10 @@ pub async fn promote_member(
             Some(&target.email),
             &data.to_string(),
         )
-        .await;
+        .await
+    {
+        tracing::warn!(error = %e, "failed to write admin_promote audit event");
+    }
 
     tracing::info!(
         "Admin {} promoted {} to org admin",
@@ -213,7 +216,7 @@ pub async fn demote_member(
         "target_user_id": &*target_id,
         "admin_user_id": admin.id,
     });
-    let _ = state
+    if let Err(e) = state
         .audit
         .insert_event(
             "admin_demote",
@@ -221,7 +224,10 @@ pub async fn demote_member(
             Some(&target.email),
             &data.to_string(),
         )
-        .await;
+        .await
+    {
+        tracing::warn!(error = %e, "failed to write admin_demote audit event");
+    }
 
     tracing::info!(
         "Admin {} demoted {} from org admin",
@@ -290,7 +296,7 @@ pub async fn deactivate_member(
         "target_user_id": &*target_id,
         "admin_user_id": admin.id,
     });
-    let _ = state
+    if let Err(e) = state
         .audit
         .insert_event(
             "admin_deactivate",
@@ -298,7 +304,10 @@ pub async fn deactivate_member(
             Some(&target.email),
             &data.to_string(),
         )
-        .await;
+        .await
+    {
+        tracing::warn!(error = %e, "failed to write admin_deactivate audit event");
+    }
 
     tracing::info!("Admin {} deactivated user {}", admin.email, target.email);
 
@@ -334,7 +343,7 @@ pub async fn activate_member(
         "target_user_id": &*target_id,
         "admin_user_id": admin.id,
     });
-    let _ = state
+    if let Err(e) = state
         .audit
         .insert_event(
             "admin_activate",
@@ -342,7 +351,10 @@ pub async fn activate_member(
             Some(&target.email),
             &data.to_string(),
         )
-        .await;
+        .await
+    {
+        tracing::warn!(error = %e, "failed to write admin_activate audit event");
+    }
 
     tracing::info!("Admin {} reactivated user {}", admin.email, target.email);
 
@@ -414,7 +426,7 @@ pub async fn revoke_member_credentials(
         "admin_user_id": admin.id,
         "keys_revoked": key_count,
     });
-    let _ = state
+    if let Err(e) = state
         .audit
         .insert_event(
             "admin_revoke_credentials",
@@ -422,7 +434,10 @@ pub async fn revoke_member_credentials(
             Some(&target.email),
             &data.to_string(),
         )
-        .await;
+        .await
+    {
+        tracing::warn!(error = %e, "failed to write admin_revoke_credentials audit event");
+    }
 
     tracing::info!(
         "Admin {} revoked {} credentials for user {}",
@@ -493,7 +508,7 @@ pub async fn remove_member(
         "target_user_id": &*target_id,
         "admin_user_id": admin.id,
     });
-    let _ = state
+    if let Err(e) = state
         .audit
         .insert_event(
             "admin_remove_user",
@@ -501,7 +516,10 @@ pub async fn remove_member(
             Some(&target_email),
             &data.to_string(),
         )
-        .await;
+        .await
+    {
+        tracing::warn!(error = %e, "failed to write admin_remove_user audit event");
+    }
 
     tracing::info!(
         "Admin {} removed user {} from organization",

--- a/crates/vouch-server/src/handlers/admin/policies.rs
+++ b/crates/vouch-server/src/handlers/admin/policies.rs
@@ -197,7 +197,7 @@ pub async fn toggle_preconfigured_policy(
         "slug": &slug,
         "admin_user_id": admin.id,
     });
-    let _ = state
+    if let Err(e) = state
         .audit
         .insert_event(
             "admin_policy_toggle",
@@ -205,7 +205,10 @@ pub async fn toggle_preconfigured_policy(
             Some(&slug),
             &data.to_string(),
         )
-        .await;
+        .await
+    {
+        tracing::warn!(error = %e, "failed to write admin_policy_toggle audit event");
+    }
 
     tracing::info!(
         "Admin {} {} preconfigured policy '{}'",
@@ -309,7 +312,7 @@ pub async fn create_custom_policy(
         "admin_user_id": admin.id,
         "cel_expression_hash": cel_hash,
     });
-    let _ = state
+    if let Err(e) = state
         .audit
         .insert_event(
             "admin_policy_create",
@@ -317,7 +320,10 @@ pub async fn create_custom_policy(
             Some(&policy.name),
             &data.to_string(),
         )
-        .await;
+        .await
+    {
+        tracing::warn!(error = %e, "failed to write admin_policy_create audit event");
+    }
 
     tracing::info!(
         "Admin {} created custom policy '{}'",
@@ -397,7 +403,7 @@ pub async fn update_custom_policy(
         "admin_user_id": admin.id,
         "cel_expression_hash": cel_hash,
     });
-    let _ = state
+    if let Err(e) = state
         .audit
         .insert_event(
             "admin_policy_update",
@@ -405,7 +411,10 @@ pub async fn update_custom_policy(
             Some(&form.name),
             &data.to_string(),
         )
-        .await;
+        .await
+    {
+        tracing::warn!(error = %e, "failed to write admin_policy_update audit event");
+    }
 
     tracing::info!("Admin {} updated custom policy '{}'", admin.email, id);
 
@@ -443,7 +452,7 @@ pub async fn delete_custom_policy(
         "policy_id": &*id,
         "admin_user_id": admin.id,
     });
-    let _ = state
+    if let Err(e) = state
         .audit
         .insert_event(
             "admin_policy_delete",
@@ -451,7 +460,10 @@ pub async fn delete_custom_policy(
             Some(&*id),
             &data.to_string(),
         )
-        .await;
+        .await
+    {
+        tracing::warn!(error = %e, "failed to write admin_policy_delete audit event");
+    }
 
     tracing::info!("Admin {} deleted custom policy '{}'", admin.email, id);
 
@@ -539,7 +551,7 @@ pub async fn toggle_custom_policy(
         "admin_user_id": admin.id,
         "cel_expression_hash": cel_hash,
     });
-    let _ = state
+    if let Err(e) = state
         .audit
         .insert_event(
             "admin_policy_toggle",
@@ -547,7 +559,10 @@ pub async fn toggle_custom_policy(
             Some(&policy.name),
             &data.to_string(),
         )
-        .await;
+        .await
+    {
+        tracing::warn!(error = %e, "failed to write admin_policy_toggle audit event");
+    }
 
     tracing::info!(
         "Admin {} {} custom policy '{}'",

--- a/crates/vouch-server/src/handlers/admin/scim_tokens.rs
+++ b/crates/vouch-server/src/handlers/admin/scim_tokens.rs
@@ -121,7 +121,7 @@ pub async fn create_scim_token(
         "token_id": token_id,
         "admin_user_id": user.id,
     });
-    let _ = state
+    if let Err(e) = state
         .audit
         .insert_event(
             "admin_create_scim_token",
@@ -129,7 +129,10 @@ pub async fn create_scim_token(
             Some(&user.email),
             &data.to_string(),
         )
-        .await;
+        .await
+    {
+        tracing::warn!(error = %e, "failed to write admin_create_scim_token audit event");
+    }
 
     tracing::info!("Created SCIM token: {} for org: {}", token_id, org_id);
 
@@ -197,7 +200,7 @@ pub async fn delete_scim_token(
         "token_id": &*token_id,
         "admin_user_id": user.id,
     });
-    let _ = state
+    if let Err(e) = state
         .audit
         .insert_event(
             "admin_delete_scim_token",
@@ -205,7 +208,10 @@ pub async fn delete_scim_token(
             Some(&user.email),
             &data.to_string(),
         )
-        .await;
+        .await
+    {
+        tracing::warn!(error = %e, "failed to write admin_delete_scim_token audit event");
+    }
 
     tracing::info!("Deleted SCIM token: {}", token_id);
 
@@ -373,7 +379,7 @@ pub async fn admin_create_scim_token(
         "token_id": token_id,
         "admin_user_id": admin.id,
     });
-    let _ = state
+    if let Err(e) = state
         .audit
         .insert_event(
             "admin_create_scim_token",
@@ -381,7 +387,10 @@ pub async fn admin_create_scim_token(
             Some(&admin.email),
             &data.to_string(),
         )
-        .await;
+        .await
+    {
+        tracing::warn!(error = %e, "failed to write admin_create_scim_token audit event");
+    }
 
     tracing::info!(
         "Admin {} created SCIM token {} for org {}",
@@ -440,7 +449,7 @@ pub async fn admin_revoke_scim_token(
         "token_id": &*token_id,
         "admin_user_id": admin.id,
     });
-    let _ = state
+    if let Err(e) = state
         .audit
         .insert_event(
             "admin_revoke_scim_token",
@@ -448,7 +457,10 @@ pub async fn admin_revoke_scim_token(
             Some(&admin.email),
             &data.to_string(),
         )
-        .await;
+        .await
+    {
+        tracing::warn!(error = %e, "failed to write admin_revoke_scim_token audit event");
+    }
 
     tracing::info!(
         "Admin {} revoked SCIM token {} for org {}",

--- a/crates/vouch-server/src/infra/serve.rs
+++ b/crates/vouch-server/src/infra/serve.rs
@@ -196,12 +196,12 @@ pub async fn serve(components: ServerComponents, app: Router) -> Result<()> {
             .serve(app.into_make_service_with_connect_info::<std::net::SocketAddr>())
             .await?;
 
-        // Wait for HTTP redirect server to finish
-        let _ = http_handle.await;
+        // Wait for HTTP redirect server to finish; ignore JoinError on shutdown.
+        let _http = http_handle.await;
 
-        // Wait for mTLS listener to finish
+        // Wait for mTLS listener to finish; ignore JoinError on shutdown.
         if let Some(handle) = mtls_handle {
-            let _ = handle.await;
+            let _mtls = handle.await;
         }
     } else {
         // Start S3 config polling task if configured (no TLS)

--- a/crates/vouch-server/src/infra/telemetry.rs
+++ b/crates/vouch-server/src/infra/telemetry.rs
@@ -91,8 +91,9 @@ fn init_opentelemetry() -> Result<
 
     let tracer = provider.tracer("vouch-server");
 
-    // Store provider for shutdown
-    let _ = TRACER_PROVIDER.set(provider);
+    // Store provider for shutdown; OnceLock::set returning Err means it was already
+    // set, which is fine on repeat init.
+    let _set = TRACER_PROVIDER.set(provider);
 
     let layer = tracing_opentelemetry::OpenTelemetryLayer::new(tracer);
     Ok(Some(layer))

--- a/crates/vouch-server/src/services/idp/saml/authn_request.rs
+++ b/crates/vouch-server/src/services/idp/saml/authn_request.rs
@@ -133,7 +133,8 @@ fn generate_request_id() -> Result<String, AuthnRequestError> {
     aws_lc_rs::rand::fill(&mut bytes).map_err(|e| AuthnRequestError::RandomId(e.to_string()))?;
     let hex: String = bytes.iter().fold(String::with_capacity(32), |mut s, b| {
         use std::fmt::Write as _;
-        let _ = write!(s, "{b:02x}");
+        // Writing to a String never fails; ignore the formal Result.
+        let _written = write!(s, "{b:02x}");
         s
     });
     Ok(format!("_{hex}"))

--- a/crates/vouch-server/src/services/integrations/github/oauth.rs
+++ b/crates/vouch-server/src/services/integrations/github/oauth.rs
@@ -114,7 +114,9 @@ impl GitHubService<'_> {
             && let Ok(Some(user)) = db::get_user_by_id(self.store, user_id).await
             && let (Some(github_id), Some(github_login)) = (user.github_id, &user.github_login)
         {
-            let _ = db::update_user_github_identity(
+            // Best-effort refresh-token rotation; user session stays valid even if
+            // this DB write fails — the next refresh will retry.
+            let _updated = db::update_user_github_identity(
                 self.store,
                 user_id,
                 github_id,

--- a/crates/vouch-server/src/services/oidc/discovery.rs
+++ b/crates/vouch-server/src/services/oidc/discovery.rs
@@ -319,7 +319,9 @@ fn build_mtls_aliases(state: &Arc<AppState>, base_url: &str) -> Option<MtlsEndpo
 
     // Derive mTLS base URL by replacing the port with mtls_port.
     let mtls_base = if let Ok(mut url) = url::Url::parse(base_url) {
-        let _ = url.set_port(Some(config.mtls_port));
+        // url::Url::set_port returns Result<(), ()>; failure means non-special URL,
+        // already validated upstream.
+        let _set = url.set_port(Some(config.mtls_port));
         url.to_string().trim_end_matches('/').to_string()
     } else {
         tracing::warn!(

--- a/crates/vouch-server/src/services/oidc/token.rs
+++ b/crates/vouch-server/src/services/oidc/token.rs
@@ -889,7 +889,9 @@ pub async fn validate_dpop_if_present(
     if config.tls_configured()
         && let Ok(mut url) = url::Url::parse(&config.base_url)
     {
-        let _ = url.set_port(Some(config.mtls_port));
+        // url::Url::set_port returns Result<(), ()>; failure means non-special URL,
+        // already validated upstream.
+        let _set = url.set_port(Some(config.mtls_port));
         let mtls_uri = format!("{}{}", url.as_str().trim_end_matches('/'), uri);
         accepted_uris.push(mtls_uri);
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: primarily lint tightening and mechanical updates to explicitly ignore `Result`s; the only behavioral change is that admin audit-write failures now emit warnings instead of being silently swallowed.
> 
> **Overview**
> Adds workspace-wide Clippy `let_underscore_must_use = "deny"` to prevent silently dropping `#[must_use]` values (mostly `Result`).
> 
> Updates call sites across the agent, CLI, httpsig, and server to replace `let _ = ...` with named ignored bindings (e.g., `_chmod`, `_removed`, `_set`) and add clarifying comments about best-effort failures.
> 
> Improves server admin handlers to *log warnings* when `state.audit.insert_event(...)` fails (instead of silently ignoring the error) for actions like member promote/demote/activate/deactivate, credential revocation, policy changes, and SCIM token create/revoke/delete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3adf2f56927b1dbc9c9da269274b4dbf761e5a9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->