### PR TITLE
more lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,11 @@ repository = "https://github.com/vouch-sh/vouch"
 [workspace.lints.rust]
 unsafe_code = "deny"
 unreachable_pub = "warn"
+non_ascii_idents = "deny"
+trivial_casts = "warn"
+trivial_numeric_casts = "warn"
+unused_lifetimes = "warn"
+single_use_lifetimes = "warn"
 
 [workspace.lints.clippy]
 # Panic-prevention lints
@@ -40,6 +45,12 @@ string_slice = "deny"
 
 # Modulo by zero panics — use checked_rem or guard the divisor
 modulo_arithmetic = "deny"
+
+# Integer division panics on /0 — pair with modulo_arithmetic
+integer_division = "deny"
+
+# Time/Duration subtraction panics on negative result — use checked_sub or saturating_sub
+unchecked_time_subtraction = "deny"
 
 # Code hygiene
 dbg_macro = "deny"

--- a/crates/vouch-agent/src/expiry_monitor.rs
+++ b/crates/vouch-agent/src/expiry_monitor.rs
@@ -60,7 +60,8 @@ pub async fn run(state: Arc<AgentState>) {
         for &threshold in WARN_THRESHOLDS_SECS {
             if remaining_secs <= threshold && !fired_thresholds.contains(&threshold) {
                 fired_thresholds.push(threshold);
-                let mins = threshold / 60;
+                // 60 is non-zero; unwrap_or arm is unreachable.
+                let mins = threshold.checked_div(60).unwrap_or(0);
                 let message = format!(
                     "Your Vouch session expires in {} minute{}.",
                     mins,

--- a/crates/vouch-agent/src/recovery.rs
+++ b/crates/vouch-agent/src/recovery.rs
@@ -108,8 +108,9 @@ async fn try_recover_inner(
     // Store server URL in SSH agent state (enables lazy loading)
     ssh_state.set_server_url(server_url).await;
 
-    let hours = expires_in / 3600;
-    let minutes = (expires_in % 3600) / 60;
+    // 3600 and 60 are non-zero; unwrap_or arms are unreachable.
+    let hours = expires_in.checked_div(3600).unwrap_or(0);
+    let minutes = (expires_in % 3600).checked_div(60).unwrap_or(0);
     info!("Session recovered for {email} (expires in {hours}h {minutes}m)");
 
     Ok(true)

--- a/crates/vouch-cli/src/client.rs
+++ b/crates/vouch-cli/src/client.rs
@@ -593,7 +593,8 @@ fn backoff_with_jitter(attempt: u32) -> std::time::Duration {
 
     let exp_ms = BASE_MS.saturating_mul(1_u64.checked_shl(attempt).unwrap_or(u64::MAX));
     let capped_ms = exp_ms.min(CAP_MS);
-    let half_ms = capped_ms / 2;
+    // 2 is non-zero; unwrap_or arm is unreachable.
+    let half_ms = capped_ms.checked_div(2).unwrap_or(0);
 
     let jitter_ms = random_u64_in_range(half_ms);
 
@@ -607,7 +608,8 @@ fn random_u64_in_range(max: u64) -> u64 {
     }
     let mut buf = [0u8; 8];
     if aws_lc_rs::rand::fill(&mut buf).is_err() {
-        return max / 2; // deterministic fallback
+        // 2 is non-zero; unwrap_or arm is unreachable.
+        return max.checked_div(2).unwrap_or(0); // deterministic fallback
     }
     u64::from_le_bytes(buf) % (max + 1)
 }

--- a/crates/vouch-cli/src/commands/credential/ssh.rs
+++ b/crates/vouch-cli/src/commands/credential/ssh.rs
@@ -107,8 +107,9 @@ pub(crate) struct SshProvisionResult {
 
 /// Format seconds as a human-readable "Xh Ym" duration string.
 fn format_duration(secs: u64) -> String {
-    let hours = secs / 3600;
-    let minutes = (secs % 3600) / 60;
+    // 3600 and 60 are non-zero; unwrap_or arms are unreachable.
+    let hours = secs.checked_div(3600).unwrap_or(0);
+    let minutes = (secs % 3600).checked_div(60).unwrap_or(0);
     format!("{hours}h {minutes}m")
 }
 

--- a/crates/vouch-cli/src/commands/doctor.rs
+++ b/crates/vouch-cli/src/commands/doctor.rs
@@ -270,8 +270,11 @@ async fn check_session() -> CheckResult {
         return match client.get_session().await {
             Ok(session) => {
                 if session.expires_in_seconds > 0 {
-                    let hours = session.expires_in_seconds / 3600;
-                    let mins = (session.expires_in_seconds % 3600) / 60;
+                    // 3600 and 60 are non-zero; unwrap_or arms are unreachable.
+                    let hours = session.expires_in_seconds.checked_div(3600).unwrap_or(0);
+                    let mins = (session.expires_in_seconds % 3600)
+                        .checked_div(60)
+                        .unwrap_or(0);
                     CheckResult::pass(
                         "session",
                         format!(

--- a/crates/vouch-cli/src/commands/login.rs
+++ b/crates/vouch-cli/src/commands/login.rs
@@ -625,7 +625,8 @@ fn format_expiry(expires_at: &str) -> String {
     };
 
     let secs = ts.duration_since(jiff::Timestamp::now()).as_secs().max(0);
-    let remaining = jiff::SignedDuration::from_mins(secs / 60);
+    // 60 is non-zero; unwrap_or arm is unreachable.
+    let remaining = jiff::SignedDuration::from_mins(secs.checked_div(60).unwrap_or(0));
     let local = ts.to_zoned(jiff::tz::TimeZone::system());
     let datetime = local.strftime("%Y-%m-%d %H:%M %Z");
 

--- a/crates/vouch-cli/src/commands/posture.rs
+++ b/crates/vouch-cli/src/commands/posture.rs
@@ -123,9 +123,10 @@ fn print_text(p: &vouch_common::posture::DevicePosture) {
 
     // System uptime
     if let Some(secs) = p.uptime_secs {
-        let days = secs / 86400;
-        let hours = (secs % 86400) / 3600;
-        let mins = (secs % 3600) / 60;
+        // 86400, 3600, 60 are non-zero; unwrap_or arms are unreachable.
+        let days = secs.checked_div(86400).unwrap_or(0);
+        let hours = (secs % 86400).checked_div(3600).unwrap_or(0);
+        let mins = (secs % 3600).checked_div(60).unwrap_or(0);
         println!("  Uptime:          {days}d {hours}h {mins}m");
     }
 

--- a/crates/vouch-cli/src/commands/status.rs
+++ b/crates/vouch-cli/src/commands/status.rs
@@ -277,8 +277,9 @@ fn print_agent_session(server: &str, session: &SessionInfo) {
 ///
 /// Returns `"in Xh Ym"` or `"in Ym"` depending on whether hours > 0.
 pub(crate) fn format_remaining_time(expires_in: u64) -> String {
-    let remaining_mins = expires_in / 60;
-    let hours = remaining_mins / 60;
+    // 60 is non-zero; unwrap_or arms are unreachable.
+    let remaining_mins = expires_in.checked_div(60).unwrap_or(0);
+    let hours = remaining_mins.checked_div(60).unwrap_or(0);
     let mins = remaining_mins % 60;
 
     if hours > 0 {

--- a/crates/vouch-cli/src/integrations/ssh.rs
+++ b/crates/vouch-cli/src/integrations/ssh.rs
@@ -88,7 +88,9 @@ impl IntegrationCheck for SshIntegration {
         }
 
         let remaining_secs = valid_before_i64 - now_unix;
-        let remaining = jiff::SignedDuration::from_mins(remaining_secs / 60);
+        // 60 is non-zero; unwrap_or arm is unreachable.
+        let remaining =
+            jiff::SignedDuration::from_mins(remaining_secs.checked_div(60).unwrap_or(0));
 
         let principals: Vec<String> = cert
             .valid_principals()

--- a/crates/vouch-server/src/db/pool.rs
+++ b/crates/vouch-server/src/db/pool.rs
@@ -811,7 +811,8 @@ pub(crate) fn is_unique_violation(err: &anyhow::Error) -> bool {
 pub(crate) fn retry_backoff(attempt: u32) -> Duration {
     let base_ms = 100u64.saturating_mul(1u64 << attempt);
     // ±25% jitter using simple xorshift on timestamp
-    let jitter_range = base_ms / 4;
+    // 4 is non-zero; unwrap_or arm is unreachable.
+    let jitter_range = base_ms.checked_div(4).unwrap_or(0);
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()

--- a/crates/vouch-server/src/db/store.rs
+++ b/crates/vouch-server/src/db/store.rs
@@ -1083,7 +1083,7 @@ pub struct StoreTransaction<'a> {
     crypto: &'a Arc<dyn DocumentCrypto>,
 }
 
-impl<'a> StoreTransaction<'a> {
+impl StoreTransaction<'_> {
     /// Commit the transaction.
     ///
     /// # Errors

--- a/crates/vouch-server/src/infra/cleanup.rs
+++ b/crates/vouch-server/src/infra/cleanup.rs
@@ -75,7 +75,8 @@ pub fn start_cleanup_task(
     tokio::spawn(async move {
         let base_secs = interval_minutes * 60;
         // Jitter of up to 20% of the base interval
-        let max_jitter_secs = base_secs / 5;
+        // 5 is non-zero; unwrap_or arm is unreachable.
+        let max_jitter_secs = base_secs.checked_div(5).unwrap_or(0);
 
         // Initial delay with jitter so instances started simultaneously don't
         // all fire their first cleanup at the same time.

--- a/crates/vouch-server/src/infra/httpsig.rs
+++ b/crates/vouch-server/src/infra/httpsig.rs
@@ -68,7 +68,8 @@ impl KeyResolver for OAuthClientKeyResolver {
                 if kid == keyid {
                     let public_key = jwk_to_p256_public_key(jwk)?;
                     let verifier = EcdsaP256Verifier::new(&public_key, &keyid);
-                    return Some(Arc::new(verifier) as Arc<dyn VerifyingAlgorithm>);
+                    let arc: Arc<dyn VerifyingAlgorithm> = Arc::new(verifier);
+                    return Some(arc);
                 }
             }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily lint/config tightening plus mechanical refactors from `/` to `checked_div` to satisfy new panic-prevention rules; runtime behavior should be unchanged, with low risk aside from potential new warnings/CI failures from stricter linting.
> 
> **Overview**
> Tightens workspace linting by adding additional Rust and Clippy rules (notably `integer_division` and `unchecked_time_subtraction`) to further enforce panic-free, hygiene-focused code.
> 
> Updates multiple CLI/agent/server call sites to replace direct integer division used in time/backoff formatting and jitter calculations with `checked_div(...).unwrap_or(0)` so the codebase complies with the new lint requirements. Also includes a small cleanup in server code to simplify an `Arc<dyn VerifyingAlgorithm>` return and to elide an unused lifetime parameter in `StoreTransaction`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e621d50ab8b9eac74d5df6b1ce33d2401ae1633c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->