### PR TITLE
arithmetic linting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,34 @@ integer_division = "deny"
 # Time/Duration subtraction panics on negative result — use checked_sub or saturating_sub
 unchecked_time_subtraction = "deny"
 
+# Float equality is unreliable — use abs(a - b) < epsilon
+float_cmp = "deny"
+float_cmp_const = "deny"
+
+# Lossy float literals (e.g. 16_777_217f32) silently lose precision
+lossy_float_literal = "deny"
+
+# 0.0 / 0.0 is NaN, almost always a bug
+zero_divided_by_zero = "deny"
+
+# `From` impls must be infallible — fallible conversions belong in `TryFrom`
+fallible_impl_from = "deny"
+
+# Recursive Display/Debug impls cause stack-overflow panics
+recursive_format_impl = "deny"
+
+# Stack-overflow risk
+large_stack_arrays = "deny"
+large_stack_frames = "deny"
+
+# Infinite iteration / hangs
+infinite_iter = "deny"
+
+# Undefined behavior (belt-and-braces alongside unsafe_code = "deny")
+mem_replace_with_uninit = "deny"
+uninit_assumed_init = "deny"
+uninit_vec = "deny"
+
 # Code hygiene
 dbg_macro = "deny"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,10 @@ modulo_arithmetic = "deny"
 # Integer division panics on /0 — pair with modulo_arithmetic
 integer_division = "deny"
 
+# `+`, `-`, `*` panic in debug on overflow and wrap silently in release.
+# Use checked_*/saturating_*/wrapping_* explicitly to declare intent.
+arithmetic_side_effects = "deny"
+
 # Time/Duration subtraction panics on negative result — use checked_sub or saturating_sub
 unchecked_time_subtraction = "deny"
 

--- a/crates/vouch-agent/src/client.rs
+++ b/crates/vouch-agent/src/client.rs
@@ -60,7 +60,7 @@ impl AgentClient {
         params: Option<serde_json::Value>,
     ) -> Result<Response> {
         let id = self.next_id;
-        self.next_id += 1;
+        self.next_id = self.next_id.wrapping_add(1);
 
         let request = Request {
             jsonrpc: JSONRPC_VERSION.to_string(),

--- a/crates/vouch-agent/src/lib.rs
+++ b/crates/vouch-agent/src/lib.rs
@@ -26,7 +26,6 @@
 //!     Ok(())
 //! }
 //! ```
-#![deny(clippy::arithmetic_side_effects)]
 
 pub mod audit;
 #[cfg(unix)]

--- a/crates/vouch-agent/src/lib.rs
+++ b/crates/vouch-agent/src/lib.rs
@@ -26,6 +26,7 @@
 //!     Ok(())
 //! }
 //! ```
+#![deny(clippy::arithmetic_side_effects)]
 
 pub mod audit;
 #[cfg(unix)]

--- a/crates/vouch-agent/src/ssh_agent/credentials.rs
+++ b/crates/vouch-agent/src/ssh_agent/credentials.rs
@@ -70,14 +70,15 @@ impl CertificateMetadata {
     pub fn is_expiring_soon(&self) -> bool {
         let now = Timestamp::now();
         let threshold =
-            Timestamp::from_second(now.as_second() + REFRESH_THRESHOLD_SECONDS).unwrap_or(now);
+            Timestamp::from_second(now.as_second().saturating_add(REFRESH_THRESHOLD_SECONDS))
+                .unwrap_or(now);
         self.expires_at < threshold
     }
 
     /// Get remaining validity in seconds.
     pub fn remaining_seconds(&self) -> i64 {
         let now = Timestamp::now();
-        self.expires_at.as_second() - now.as_second()
+        self.expires_at.as_second().saturating_sub(now.as_second())
     }
 }
 

--- a/crates/vouch-agent/src/ssh_agent/state.rs
+++ b/crates/vouch-agent/src/ssh_agent/state.rs
@@ -125,7 +125,7 @@ impl SshAgentState {
         match guard.last_refresh_at {
             Some(last) => {
                 let now = Timestamp::now();
-                let elapsed = now.as_second() - last.as_second();
+                let elapsed = now.as_second().saturating_sub(last.as_second());
                 elapsed >= MIN_REFRESH_INTERVAL_SECONDS
             }
             None => true,

--- a/crates/vouch-agent/src/state.rs
+++ b/crates/vouch-agent/src/state.rs
@@ -350,6 +350,7 @@ impl AgentState {
 #[cfg(test)]
 #[expect(
     clippy::unwrap_used,
+    clippy::arithmetic_side_effects,
     reason = "test code: panic on assertion failure is acceptable"
 )]
 mod tests {

--- a/crates/vouch-agent/src/transport.rs
+++ b/crates/vouch-agent/src/transport.rs
@@ -120,16 +120,18 @@ impl TestTransport {
         while filled < buf.len() {
             // If we have buffered data, use it first
             if self.read_pos < self.read_buffer.len() {
-                let available = self.read_buffer.len() - self.read_pos;
-                let needed = buf.len() - filled;
+                let available = self.read_buffer.len().saturating_sub(self.read_pos);
+                let needed = buf.len().saturating_sub(filled);
                 let to_copy = available.min(needed);
+                let dest_end = filled.saturating_add(to_copy);
+                let src_end = self.read_pos.saturating_add(to_copy);
 
-                if let Some(dest) = buf.get_mut(filled..filled + to_copy)
-                    && let Some(src) = self.read_buffer.get(self.read_pos..self.read_pos + to_copy)
+                if let Some(dest) = buf.get_mut(filled..dest_end)
+                    && let Some(src) = self.read_buffer.get(self.read_pos..src_end)
                 {
                     dest.copy_from_slice(src);
-                    self.read_pos += to_copy;
-                    filled += to_copy;
+                    self.read_pos = self.read_pos.saturating_add(to_copy);
+                    filled = filled.saturating_add(to_copy);
                 }
 
                 // Clear buffer if fully consumed

--- a/crates/vouch-agent/src/wire.rs
+++ b/crates/vouch-agent/src/wire.rs
@@ -55,15 +55,18 @@ pub async fn write_message<W: AsyncWrite + Unpin>(writer: &mut W, data: &[u8]) -
 
 /// Read a u32 from a buffer at the given offset (advances offset).
 pub fn read_u32(buf: &[u8], offset: &mut usize) -> Result<u32> {
-    if *offset + 4 > buf.len() {
+    let end = offset
+        .checked_add(4)
+        .ok_or_else(|| AgentError::Protocol("buffer underflow".to_string()))?;
+    if end > buf.len() {
         return Err(AgentError::Protocol("buffer underflow".to_string()));
     }
     let bytes: [u8; 4] = buf
-        .get(*offset..*offset + 4)
+        .get(*offset..end)
         .ok_or_else(|| AgentError::Protocol("buffer underflow".to_string()))?
         .try_into()
         .map_err(|_| AgentError::Protocol("buffer underflow".to_string()))?;
-    *offset += 4;
+    *offset = end;
     Ok(u32::from_be_bytes(bytes))
 }
 
@@ -82,7 +85,7 @@ pub fn encode_string(s: &str) -> Result<Vec<u8>> {
     let bytes = s.as_bytes();
     let len = u32::try_from(bytes.len())
         .map_err(|_| AgentError::Protocol("string too large for wire format".to_string()))?;
-    let mut buf = Vec::with_capacity(4 + bytes.len());
+    let mut buf = Vec::with_capacity(bytes.len().saturating_add(4));
     buf.extend_from_slice(&len.to_be_bytes());
     buf.extend_from_slice(bytes);
     Ok(buf)
@@ -96,7 +99,7 @@ pub fn encode_string(s: &str) -> Result<Vec<u8>> {
 pub fn encode_bytes(data: &[u8]) -> Result<Vec<u8>> {
     let len = u32::try_from(data.len())
         .map_err(|_| AgentError::Protocol("data too large for wire format".to_string()))?;
-    let mut buf = Vec::with_capacity(4 + data.len());
+    let mut buf = Vec::with_capacity(data.len().saturating_add(4));
     buf.extend_from_slice(&len.to_be_bytes());
     buf.extend_from_slice(data);
     Ok(buf)

--- a/crates/vouch-cli/src/client.rs
+++ b/crates/vouch-cli/src/client.rs
@@ -421,7 +421,7 @@ impl<H: HttpClient> VouchClient<H> {
             match retry_delay(&response, attempt) {
                 Some(wait) => {
                     tokio::time::sleep(wait).await;
-                    attempt += 1;
+                    attempt = attempt.saturating_add(1);
                 }
                 None => return Self::handle_response(response),
             }
@@ -562,7 +562,7 @@ fn retry_delay(response: &HttpResponse, attempt: u32) -> Option<std::time::Durat
             eprintln!(
                 "Rate limited by server, retrying in {secs}s \
                  (attempt {}/{MAX_RETRIES})...",
-                attempt + 1,
+                attempt.saturating_add(1),
             );
             Some(std::time::Duration::from_secs(secs))
         }
@@ -573,7 +573,7 @@ fn retry_delay(response: &HttpResponse, attempt: u32) -> Option<std::time::Durat
                  (attempt {}/{MAX_RETRIES})...",
                 response.status,
                 delay.as_secs_f64(),
-                attempt + 1,
+                attempt.saturating_add(1),
             );
             Some(delay)
         }
@@ -598,7 +598,7 @@ fn backoff_with_jitter(attempt: u32) -> std::time::Duration {
 
     let jitter_ms = random_u64_in_range(half_ms);
 
-    std::time::Duration::from_millis(half_ms + jitter_ms)
+    std::time::Duration::from_millis(half_ms.saturating_add(jitter_ms))
 }
 
 /// Return a random `u64` in `0..=max` using `aws-lc-rs` CSPRNG.
@@ -611,7 +611,12 @@ fn random_u64_in_range(max: u64) -> u64 {
         // 2 is non-zero; unwrap_or arm is unreachable.
         return max.checked_div(2).unwrap_or(0); // deterministic fallback
     }
-    u64::from_le_bytes(buf) % (max + 1)
+    let value = u64::from_le_bytes(buf);
+    match max.checked_add(1) {
+        // checked_rem returns None only if modulus is 0; checked_add(1) is non-zero.
+        Some(modulus) => value.checked_rem(modulus).unwrap_or(0),
+        None => value, // max == u64::MAX: full range
+    }
 }
 
 /// Classification of HTTP error responses from the server.

--- a/crates/vouch-cli/src/commands/credential/eks.rs
+++ b/crates/vouch-cli/src/commands/credential/eks.rs
@@ -111,7 +111,7 @@ fn expiration_rfc3339() -> Result<String> {
         clippy::cast_possible_wrap,
         reason = "EKS_TOKEN_EXPIRES_SECONDS is bounded to <2^63 by AWS EKS token TTL"
     )]
-    let ttl_seconds = EKS_TOKEN_EXPIRES_SECONDS as i64 - EKS_EXPIRY_MARGIN_SECONDS;
+    let ttl_seconds = (EKS_TOKEN_EXPIRES_SECONDS as i64).saturating_sub(EKS_EXPIRY_MARGIN_SECONDS);
     let expires = jiff::Timestamp::now()
         .checked_add(jiff::SignedDuration::from_secs(ttl_seconds))
         .context("failed to compute EKS token expiration")?;

--- a/crates/vouch-cli/src/commands/credential/ssh.rs
+++ b/crates/vouch-cli/src/commands/credential/ssh.rs
@@ -141,7 +141,7 @@ fn check_existing_certificate(key_path: &Path) -> Option<SshProvisionResult> {
         return None;
     }
 
-    let remaining_secs = valid_before_i64 - now_unix;
+    let remaining_secs = valid_before_i64.saturating_sub(now_unix);
     if remaining_secs <= vouch_common::SSH_CERT_REFRESH_THRESHOLD_SECS {
         tracing::debug!(
             remaining_secs,

--- a/crates/vouch-cli/src/commands/diag.rs
+++ b/crates/vouch-cli/src/commands/diag.rs
@@ -197,7 +197,7 @@ pub(crate) fn run(args: DiagArgs) -> Result<()> {
     }
 
     let cred_id_len = u16::from_be_bytes([auth_data[53], auth_data[54]]) as usize;
-    let cose_key_start = 55 + cred_id_len;
+    let cose_key_start = 55_usize.saturating_add(cred_id_len);
     let cose_key_bytes = &auth_data[cose_key_start..];
 
     out!(
@@ -360,7 +360,7 @@ pub(crate) fn run(args: DiagArgs) -> Result<()> {
     // Build the message: authenticator_data || SHA256(raw_challenge)
     // The library uses SHA256(challenge) directly, not SHA256(clientDataJSON)
     let challenge_hash = digest(&SHA256, &auth_challenge);
-    let mut message = Vec::with_capacity(assertion.auth_data.len() + 32);
+    let mut message = Vec::with_capacity(assertion.auth_data.len().saturating_add(32));
     message.extend_from_slice(&assertion.auth_data);
     message.extend_from_slice(challenge_hash.as_ref());
 
@@ -455,14 +455,14 @@ pub(crate) fn run(args: DiagArgs) -> Result<()> {
         out!("DER SEQUENCE length: {}", seq_len);
         if sig.len() >= 4 && sig[2] == 0x02 {
             let r_len = sig[3] as usize;
-            let r_start = 4;
-            let r_end = r_start + r_len;
+            let r_start = 4_usize;
+            let r_end = r_start.saturating_add(r_len);
             if sig.len() >= r_end {
                 out!("r ({} bytes): {}", r_len, hex::encode(&sig[r_start..r_end]));
-                if sig.len() > r_end + 1 && sig[r_end] == 0x02 {
-                    let s_len = sig[r_end + 1] as usize;
-                    let s_start = r_end + 2;
-                    let s_end = s_start + s_len;
+                if sig.len() > r_end.saturating_add(1) && sig[r_end] == 0x02 {
+                    let s_len = sig[r_end.saturating_add(1)] as usize;
+                    let s_start = r_end.saturating_add(2);
+                    let s_end = s_start.saturating_add(s_len);
                     if sig.len() >= s_end {
                         out!("s ({} bytes): {}", s_len, hex::encode(&sig[s_start..s_end]));
                     }

--- a/crates/vouch-cli/src/commands/enroll.rs
+++ b/crates/vouch-cli/src/commands/enroll.rs
@@ -243,7 +243,7 @@ async fn poll_for_token(
     let timeout = std::time::Duration::from_secs(device_response.expires_in);
     let start = std::time::Instant::now();
 
-    let mut dots = 0;
+    let mut dots: usize = 0;
     // Track server-provided DPoP nonce for RFC 9449 nonce binding
     let mut dpop_nonce: Option<String> = None;
 
@@ -262,9 +262,9 @@ async fn poll_for_token(
 
         // Show progress (only on interactive terminals)
         if stdout().is_terminal() {
-            dots = (dots + 1) % 4;
+            dots = dots.saturating_add(1) % 4;
             print!("\rWaiting for browser authorization{}", ".".repeat(dots));
-            print!("{}", " ".repeat(3 - dots));
+            print!("{}", " ".repeat(3_usize.saturating_sub(dots)));
             stdout().flush().ok();
         }
 

--- a/crates/vouch-cli/src/commands/setup/aws.rs
+++ b/crates/vouch-cli/src/commands/setup/aws.rs
@@ -221,7 +221,7 @@ async fn run_discover(profile_prefix: Option<&str>, region: Option<&str>) -> Res
 
         if config.profile_exists(&profile_name) {
             println!("Skipped [{profile_name}] — already exists");
-            skipped_count += 1;
+            skipped_count = skipped_count.saturating_add(1);
             continue;
         }
 
@@ -236,7 +236,7 @@ async fn run_discover(profile_prefix: Option<&str>, region: Option<&str>) -> Res
         });
 
         println!("Added profile [{profile_name}] → {role_arn}");
-        created_count += 1;
+        created_count = created_count.saturating_add(1);
     }
 
     if created_count > 0 {

--- a/crates/vouch-cli/src/commands/setup/ssm.rs
+++ b/crates/vouch-cli/src/commands/setup/ssm.rs
@@ -100,22 +100,23 @@ fn strip_ssm_block(content: &str) -> String {
     };
 
     // Walk backwards from the marker to consume the leading newline
-    let block_start = if start > 0 && content.as_bytes().get(start - 1) == Some(&b'\n') {
-        start - 1
-    } else {
-        start
-    };
+    let block_start =
+        if start > 0 && content.as_bytes().get(start.saturating_sub(1)) == Some(&b'\n') {
+            start.saturating_sub(1)
+        } else {
+            start
+        };
 
     // Split safely at ASCII boundaries (SSM_MARKER and newlines are ASCII)
     let (before, from_marker) = content.split_at(block_start);
 
     // Find the end of the block in the remaining content: look for a blank
     // line or treat everything as the block.
-    let marker_offset = start - block_start;
+    let marker_offset = start.saturating_sub(block_start);
     let after_marker = from_marker.get(marker_offset..).unwrap_or("");
-    let block_rest_len = after_marker
-        .find("\n\n")
-        .map_or(from_marker.len(), |pos| marker_offset + pos + 1);
+    let block_rest_len = after_marker.find("\n\n").map_or(from_marker.len(), |pos| {
+        marker_offset.saturating_add(pos).saturating_add(1)
+    });
 
     let after = from_marker.get(block_rest_len..).unwrap_or("");
 

--- a/crates/vouch-cli/src/exit_code.rs
+++ b/crates/vouch-cli/src/exit_code.rs
@@ -202,6 +202,10 @@ fn classify_message(msg: &str) -> ExitCode {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::arithmetic_side_effects,
+    reason = "test code: bounded loop over Debug string length"
+)]
 mod tests {
     use super::*;
 

--- a/crates/vouch-cli/src/fapi/client_assertion.rs
+++ b/crates/vouch-cli/src/fapi/client_assertion.rs
@@ -91,7 +91,7 @@ impl ClientAssertionBuilder {
             aud: self.audience,
             jti: uuid::Uuid::now_v7().to_string(),
             iat: now,
-            exp: now + 60,
+            exp: now.saturating_add(60),
         };
 
         let token = jsonwebtoken::encode(&header, &claims, &key.encoding_key())

--- a/crates/vouch-cli/src/fido2.rs
+++ b/crates/vouch-cli/src/fido2.rs
@@ -1009,7 +1009,7 @@ impl FidoDevice for MockFidoDevice {
         let auth_data = self.build_authenticator_data(rp_id, 0x05);
 
         // Build signed data: authenticator_data || SHA-256(client_data_json)
-        let mut signed_data = Vec::with_capacity(auth_data.len() + 32);
+        let mut signed_data = Vec::with_capacity(auth_data.len().saturating_add(32));
         signed_data.extend_from_slice(&auth_data);
         signed_data.extend_from_slice(&client_data_hash);
 

--- a/crates/vouch-cli/src/http.rs
+++ b/crates/vouch-cli/src/http.rs
@@ -447,18 +447,21 @@ pub fn parse_www_authenticate(header: &str) -> Option<StepUpChallenge> {
         let prefix = format!("{name}=\"");
         let mut search_from = 0;
         loop {
-            let start = header.get(search_from..)?.find(&prefix)? + search_from;
+            let start = header
+                .get(search_from..)?
+                .find(&prefix)?
+                .saturating_add(search_from);
             // Verify boundary: the character before the match must be a delimiter
             // (comma, space) or the start of the string.
             if start > 0 {
                 let prev = header.as_bytes().get(start.wrapping_sub(1)).copied()?;
                 if prev != b',' && prev != b' ' {
                     // Not a real parameter boundary — keep searching
-                    search_from = start + 1;
+                    search_from = start.saturating_add(1);
                     continue;
                 }
             }
-            let value_start = start + prefix.len();
+            let value_start = start.saturating_add(prefix.len());
             let rest = header.get(value_start..)?;
             let end = rest.find('"')?;
             return rest.get(..end).map(String::from);

--- a/crates/vouch-cli/src/integrations/aws/codeartifact.rs
+++ b/crates/vouch-cli/src/integrations/aws/codeartifact.rs
@@ -82,7 +82,7 @@ pub(crate) fn parse_codeartifact_url(url: &str) -> Option<CodeArtifactRegistry> 
     // The owner is the last segment after the final hyphen (since domain names can contain hyphens)
     let last_hyphen = domain_owner_part.rfind('-')?;
     let domain = domain_owner_part.get(..last_hyphen)?;
-    let domain_owner = domain_owner_part.get(last_hyphen + 1..)?;
+    let domain_owner = domain_owner_part.get(last_hyphen.saturating_add(1)..)?;
 
     if domain.is_empty() || domain_owner.is_empty() {
         return None;

--- a/crates/vouch-cli/src/integrations/aws/config.rs
+++ b/crates/vouch-cli/src/integrations/aws/config.rs
@@ -272,7 +272,9 @@ impl AwsConfig {
 pub(crate) fn extract_role_from_credential_process(credential_process: &str) -> Option<String> {
     // Find --role and extract the next token
     if let Some(role_start) = credential_process.find("--role") {
-        let after_flag = credential_process.get(role_start + 6..)?.trim_start();
+        let after_flag = credential_process
+            .get(role_start.saturating_add(6)..)?
+            .trim_start();
         // Role ARN is the next whitespace-delimited token
         let role_arn = after_flag.split_whitespace().next()?;
         if role_arn.starts_with("arn:aws") {

--- a/crates/vouch-cli/src/integrations/aws/sigv4.rs
+++ b/crates/vouch-cli/src/integrations/aws/sigv4.rs
@@ -520,7 +520,7 @@ fn truncate_error_body(body: &str, max_len: usize) -> &str {
     // Find the last char boundary at or before max_len
     let mut end = max_len;
     while !body.is_char_boundary(end) && end > 0 {
-        end -= 1;
+        end = end.saturating_sub(1);
     }
     body.get(..end).unwrap_or(body)
 }

--- a/crates/vouch-cli/src/integrations/aws/sso.rs
+++ b/crates/vouch-cli/src/integrations/aws/sso.rs
@@ -172,7 +172,7 @@ pub(crate) fn parse_sso_timestamp(s: &str) -> Result<jiff::Timestamp> {
         // Handle optional microseconds: strip them and parse without
         let normalized = if let Some(dot_pos) = stripped.rfind('.') {
             // Check if the fractional part is all digits
-            let frac = stripped.get(dot_pos + 1..).unwrap_or("");
+            let frac = stripped.get(dot_pos.saturating_add(1)..).unwrap_or("");
             if frac.chars().all(|c| c.is_ascii_digit()) {
                 // Remove fractional seconds — jiff handles "...T18:30:45" directly
                 stripped.get(..dot_pos).unwrap_or(stripped).to_string()
@@ -563,7 +563,7 @@ pub(crate) async fn poll_for_token(
             )
             .into());
         }
-        iteration += 1;
+        iteration = iteration.saturating_add(1);
 
         tokio::time::sleep(Duration::from_secs(interval_secs)).await;
 
@@ -628,7 +628,7 @@ pub(crate) async fn poll_for_token(
             }
             "slow_down" => {
                 // Server requesting slower polling
-                interval_secs += 5;
+                interval_secs = interval_secs.saturating_add(5);
                 tracing::debug!("SSO slow_down: increasing interval to {interval_secs}s");
             }
             "access_denied" => {

--- a/crates/vouch-cli/src/integrations/aws/sts.rs
+++ b/crates/vouch-cli/src/integrations/aws/sts.rs
@@ -115,7 +115,10 @@ pub(crate) async fn assume_role_with_web_identity(
     // Attach managed session policies (intersection model — only restricts).
     for (i, policy_name) in req.session_policy_names.iter().enumerate() {
         let arn = format!("arn:{}:iam::aws:policy/{}", partition.as_str(), policy_name);
-        form_params.push((format!("PolicyArns.member.{}.arn", i + 1), arn));
+        form_params.push((
+            format!("PolicyArns.member.{}.arn", i.saturating_add(1)),
+            arn,
+        ));
     }
 
     // Attach inline session policy if provided.
@@ -190,7 +193,7 @@ pub(crate) async fn assume_role(
 
     // Attach managed session policies (intersection model — only restricts).
     let policy_keys: Vec<String> = (0..policy_arns.len())
-        .map(|i| format!("PolicyArns.member.{}.arn", i + 1))
+        .map(|i| format!("PolicyArns.member.{}.arn", i.saturating_add(1)))
         .collect();
     for (key, arn) in policy_keys.iter().zip(policy_arns.iter()) {
         params.push((key.as_str(), arn.as_str()));

--- a/crates/vouch-cli/src/integrations/github.rs
+++ b/crates/vouch-cli/src/integrations/github.rs
@@ -286,7 +286,7 @@ fn parse_github_remote_url(url: &str) -> Option<(String, String)> {
     if url.contains("github") || url.contains("ghe.com") {
         // Try to extract path after the host (SSH format: git@host:path)
         if let Some(colon_pos) = url.rfind(':')
-            && let Some(path) = url.get(colon_pos + 1..)
+            && let Some(path) = url.get(colon_pos.saturating_add(1)..)
             && !path.starts_with("//")
         {
             return parse_owner_repo_path(path);

--- a/crates/vouch-cli/src/integrations/ssh.rs
+++ b/crates/vouch-cli/src/integrations/ssh.rs
@@ -87,7 +87,7 @@ impl IntegrationCheck for SshIntegration {
             };
         }
 
-        let remaining_secs = valid_before_i64 - now_unix;
+        let remaining_secs = valid_before_i64.saturating_sub(now_unix);
         // 60 is non-zero; unwrap_or arm is unreachable.
         let remaining =
             jiff::SignedDuration::from_mins(remaining_secs.checked_div(60).unwrap_or(0));

--- a/crates/vouch-cli/src/main.rs
+++ b/crates/vouch-cli/src/main.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Vouch CLI - Hardware-backed identity for developers.
-#![deny(clippy::arithmetic_side_effects)]
 
 // Avoid musl's default allocator due to lackluster performance
 // https://nickb.dev/blog/default-musl-allocator-considered-harmful-to-performance

--- a/crates/vouch-cli/src/main.rs
+++ b/crates/vouch-cli/src/main.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Vouch CLI - Hardware-backed identity for developers.
+#![deny(clippy::arithmetic_side_effects)]
 
 // Avoid musl's default allocator due to lackluster performance
 // https://nickb.dev/blog/default-musl-allocator-considered-harmful-to-performance
@@ -137,7 +138,7 @@ async fn check_pnpm_tokenhelper_invocation(argv0: &str) -> Result<bool> {
         let flag = |name: &str| {
             args.iter()
                 .position(|a| a == name)
-                .and_then(|i| args.get(i + 1))
+                .and_then(|i| args.get(i.saturating_add(1)))
         };
         let domain = flag("--domain");
         let domain_owner = flag("--domain-owner");

--- a/crates/vouch-cli/src/posture/common.rs
+++ b/crates/vouch-cli/src/posture/common.rs
@@ -43,7 +43,7 @@ fn detect_elevated() -> bool {
 #[cfg(target_os = "linux")]
 fn parse_ppid_from_proc_stat(stat: &str) -> Option<String> {
     let after_comm = stat.rfind(')')?;
-    let rest = stat.get(after_comm + 2..)?;
+    let rest = stat.get(after_comm.saturating_add(2)..)?;
     let mut fields = rest.split_whitespace();
     let _state = fields.next()?;
     let ppid = fields.next()?;

--- a/crates/vouch-cli/src/posture/linux.rs
+++ b/crates/vouch-cli/src/posture/linux.rs
@@ -156,7 +156,7 @@ fn detect_screen_lock_kde(posture: &mut DevicePosture) {
         posture.screen_lock_idle_timeout_secs = timeout_output
             .as_deref()
             .and_then(|s| s.trim().parse::<u64>().ok())
-            .map(|mins| mins * 60);
+            .map(|mins: u64| mins.saturating_mul(60));
     }
 }
 

--- a/crates/vouch-cli/src/session.rs
+++ b/crates/vouch-cli/src/session.rs
@@ -150,7 +150,7 @@ fn write_session_cookie_file(server: &str, token: &str, expires_at_ts: Option<ji
     };
 
     let expires = expires_at_ts.map_or_else(
-        || jiff::Timestamp::now().as_second() + 28_800,
+        || jiff::Timestamp::now().as_second().saturating_add(28_800),
         |ts| ts.as_second(),
     );
 

--- a/crates/vouch-common/src/aaguid.rs
+++ b/crates/vouch-common/src/aaguid.rs
@@ -489,7 +489,7 @@ pub fn extract_public_key_from_auth_data(auth_data: &[u8]) -> Option<Vec<u8>> {
     let cred_id_len = u16::from_be_bytes(cred_id_len_bytes) as usize;
 
     // Public key starts after credId
-    let public_key_offset = 55 + cred_id_len;
+    let public_key_offset = 55_usize.checked_add(cred_id_len)?;
 
     // The rest of auth_data is the COSE-encoded public key
     auth_data.get(public_key_offset..).map(|s| s.to_vec())

--- a/crates/vouch-common/src/lib.rs
+++ b/crates/vouch-common/src/lib.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Shared types for vouch CLI and server.
+#![deny(clippy::arithmetic_side_effects)]
 
 pub mod aaguid;
 pub(crate) mod api;

--- a/crates/vouch-common/src/lib.rs
+++ b/crates/vouch-common/src/lib.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Shared types for vouch CLI and server.
-#![deny(clippy::arithmetic_side_effects)]
 
 pub mod aaguid;
 pub(crate) mod api;

--- a/crates/vouch-httpsig/src/component.rs
+++ b/crates/vouch-httpsig/src/component.rs
@@ -654,16 +654,16 @@ fn url_decode(input: &str) -> String {
 
     while let Some(&c) = bytes.get(i) {
         if c == b'%' {
-            let hi = bytes.get(i + 1).copied().and_then(hex_val);
-            let lo = bytes.get(i + 2).copied().and_then(hex_val);
+            let hi = bytes.get(i.saturating_add(1)).copied().and_then(hex_val);
+            let lo = bytes.get(i.saturating_add(2)).copied().and_then(hex_val);
             if let (Some(h), Some(l)) = (hi, lo) {
                 result.push(char::from(h << 4 | l));
-                i += 3;
+                i = i.saturating_add(3);
                 continue;
             }
         }
         result.push(char::from(c));
-        i += 1;
+        i = i.saturating_add(1);
     }
 
     result
@@ -671,9 +671,9 @@ fn url_decode(input: &str) -> String {
 
 fn hex_val(c: u8) -> Option<u8> {
     match c {
-        b'0'..=b'9' => Some(c - b'0'),
-        b'a'..=b'f' => Some(c - b'a' + 10),
-        b'A'..=b'F' => Some(c - b'A' + 10),
+        b'0'..=b'9' => Some(c.wrapping_sub(b'0')),
+        b'a'..=b'f' => Some(c.wrapping_sub(b'a').wrapping_add(10)),
+        b'A'..=b'F' => Some(c.wrapping_sub(b'A').wrapping_add(10)),
         _ => None,
     }
 }

--- a/crates/vouch-httpsig/src/lib.rs
+++ b/crates/vouch-httpsig/src/lib.rs
@@ -13,7 +13,6 @@
 //! - `hmac-sha256` — HMAC with SHA-256
 //! - `rsa-pss-sha512` — RSASSA-PSS with SHA-512
 //! - `rsa-v1_5-sha256` — RSASSA-PKCS1-v1.5 with SHA-256
-#![deny(clippy::arithmetic_side_effects)]
 
 pub mod algorithm;
 pub mod component;

--- a/crates/vouch-httpsig/src/lib.rs
+++ b/crates/vouch-httpsig/src/lib.rs
@@ -13,6 +13,7 @@
 //! - `hmac-sha256` — HMAC with SHA-256
 //! - `rsa-pss-sha512` — RSASSA-PSS with SHA-512
 //! - `rsa-v1_5-sha256` — RSASSA-PKCS1-v1.5 with SHA-256
+#![deny(clippy::arithmetic_side_effects)]
 
 pub mod algorithm;
 pub mod component;

--- a/crates/vouch-httpsig/src/sfv/parse.rs
+++ b/crates/vouch-httpsig/src/sfv/parse.rs
@@ -30,7 +30,7 @@ impl<'a> Parser<'a> {
     }
 
     fn advance(&mut self) {
-        self.pos += 1;
+        self.pos = self.pos.saturating_add(1);
     }
 
     fn skip_sp(&mut self) {
@@ -245,7 +245,7 @@ impl<'a> Parser<'a> {
             self.advance();
         }
 
-        let frac_len = self.pos - frac_start;
+        let frac_len = self.pos.saturating_sub(frac_start);
         if frac_len == 0 || frac_len > 3 {
             return Err(HttpSigError::SfvParse(format!(
                 "decimal fractional part must be 1-3 digits, got {frac_len}"
@@ -260,10 +260,10 @@ impl<'a> Parser<'a> {
             .map_err(|e| HttpSigError::SfvParse(format!("decimal parse error: {e}")))?;
 
         // RFC 8941 §3.3.2: integer component up to 12 digits
-        let int_part_len = (frac_start - 1) - start; // -1 for the '.'
+        let int_part_len = frac_start.saturating_sub(1).saturating_sub(start); // -1 for the '.'
         let has_sign = self.input.get(start).is_some_and(|&b| b == b'-');
         let digit_len = if has_sign {
-            int_part_len - 1
+            int_part_len.saturating_sub(1)
         } else {
             int_part_len
         };

--- a/crates/vouch-httpsig/src/sign.rs
+++ b/crates/vouch-httpsig/src/sign.rs
@@ -125,7 +125,7 @@ impl SignatureBuilder {
         let base = self
             .created
             .unwrap_or_else(|| jiff::Timestamp::now().as_second());
-        self.expires = Some(base + seconds);
+        self.expires = Some(base.saturating_add(seconds));
         self
     }
 

--- a/crates/vouch-httpsig/src/verify.rs
+++ b/crates/vouch-httpsig/src/verify.rs
@@ -226,7 +226,7 @@ fn validate_timestamps(params: &SignatureParams, max_age: Option<i64>) -> Result
 
     // Reject future-dated signatures regardless of max_age
     if let Some(created) = params.created
-        && created > now + 60
+        && created > now.saturating_add(60)
     {
         return Err(HttpSigError::Expired(format!(
             "signature created in the future: {created} (now={now})"
@@ -238,7 +238,7 @@ fn validate_timestamps(params: &SignatureParams, max_age: Option<i64>) -> Result
         let created = params.created.ok_or_else(|| {
             HttpSigError::Expired("max_age enforced but signature has no created timestamp".into())
         })?;
-        if now - created > max_age {
+        if now.saturating_sub(created) > max_age {
             return Err(HttpSigError::Expired(format!(
                 "signature created at {created} exceeds max age {max_age}s (now={now})"
             )));

--- a/crates/vouch-server/src/crypto/attestation_chain.rs
+++ b/crates/vouch-server/src/crypto/attestation_chain.rs
@@ -107,7 +107,7 @@ pub fn validate_attestation_chain(
     // Verify the chain: each cert is signed by the next cert
     // (leaf at index 0, closest-to-root at last index)
     for i in 0..certs.len().saturating_sub(1) {
-        let issuer_idx = i + 1;
+        let issuer_idx = i.saturating_add(1);
         let subject = certs.get(i).ok_or(AttestationChainError::EmptyChain)?;
         let issuer = certs
             .get(issuer_idx)

--- a/crates/vouch-server/src/crypto/ber.rs
+++ b/crates/vouch-server/src/crypto/ber.rs
@@ -56,24 +56,28 @@ impl<'a> DerParser<'a> {
         }
 
         let tag = *self.data.get(self.pos).context("DER: missing tag byte")?;
-        self.pos += 1;
+        self.pos = self.pos.saturating_add(1);
 
         let length = self.read_length()?;
 
-        if self.pos + length > self.data.len() {
+        let value_end = self
+            .pos
+            .checked_add(length)
+            .context("DER: position overflow")?;
+        if value_end > self.data.len() {
             anyhow::bail!(
                 "DER: value length {} exceeds remaining data {} at position {}",
                 length,
-                self.data.len() - self.pos,
+                self.data.len().saturating_sub(self.pos),
                 self.pos
             );
         }
 
         let value = self
             .data
-            .get(self.pos..self.pos + length)
+            .get(self.pos..value_end)
             .context("DER: failed to read value bytes")?;
-        self.pos += length;
+        self.pos = value_end;
 
         Ok((tag, value))
     }
@@ -90,7 +94,7 @@ impl<'a> DerParser<'a> {
         }
 
         let tag = *self.data.get(self.pos).context("BER: missing tag byte")?;
-        self.pos += 1;
+        self.pos = self.pos.saturating_add(1);
 
         let first = *self
             .data
@@ -99,25 +103,29 @@ impl<'a> DerParser<'a> {
 
         if first == 0x80 {
             // Indefinite length: scan for end-of-contents (0x00 0x00)
-            self.pos += 1; // consume the 0x80 length byte
+            self.pos = self.pos.saturating_add(1); // consume the 0x80 length byte
             let content_start = self.pos;
 
             // Walk nested TLVs to find the matching EOC
             loop {
-                if self.pos + 1 >= self.data.len() {
+                if self.pos.saturating_add(1) >= self.data.len() {
                     anyhow::bail!(
                         "BER: unterminated indefinite length at position {content_start}"
                     );
                 }
                 let b0 = self.data.get(self.pos).copied().unwrap_or(1);
-                let b1 = self.data.get(self.pos + 1).copied().unwrap_or(1);
+                let b1 = self
+                    .data
+                    .get(self.pos.saturating_add(1))
+                    .copied()
+                    .unwrap_or(1);
                 if b0 == 0x00 && b1 == 0x00 {
                     // Found end-of-contents
                     let value = self
                         .data
                         .get(content_start..self.pos)
                         .context("BER: failed to extract indefinite content")?;
-                    self.pos += 2; // skip the EOC bytes
+                    self.pos = self.pos.saturating_add(2); // skip the EOC bytes
                     return Ok((tag, value));
                 }
                 // Skip one nested TLV element (start at depth 0)
@@ -127,20 +135,24 @@ impl<'a> DerParser<'a> {
             // Definite length -- delegate to normal read_length
             let length = self.read_length()?;
 
-            if self.pos + length > self.data.len() {
+            let value_end = self
+                .pos
+                .checked_add(length)
+                .context("BER: position overflow")?;
+            if value_end > self.data.len() {
                 anyhow::bail!(
                     "BER: value length {} exceeds remaining data {} at position {}",
                     length,
-                    self.data.len() - self.pos,
+                    self.data.len().saturating_sub(self.pos),
                     self.pos
                 );
             }
 
             let value = self
                 .data
-                .get(self.pos..self.pos + length)
+                .get(self.pos..value_end)
                 .context("BER: failed to read value bytes")?;
-            self.pos += length;
+            self.pos = value_end;
 
             Ok((tag, value))
         }
@@ -159,7 +171,7 @@ impl<'a> DerParser<'a> {
         }
 
         // Skip tag
-        self.pos += 1;
+        self.pos = self.pos.saturating_add(1);
 
         let first = *self
             .data
@@ -168,26 +180,34 @@ impl<'a> DerParser<'a> {
 
         if first == 0x80 {
             // Nested indefinite length -- recurse by scanning for EOC
-            self.pos += 1;
+            self.pos = self.pos.saturating_add(1);
             loop {
-                if self.pos + 1 >= self.data.len() {
+                if self.pos.saturating_add(1) >= self.data.len() {
                     anyhow::bail!("BER: unterminated nested indefinite length");
                 }
                 let b0 = self.data.get(self.pos).copied().unwrap_or(1);
-                let b1 = self.data.get(self.pos + 1).copied().unwrap_or(1);
+                let b1 = self
+                    .data
+                    .get(self.pos.saturating_add(1))
+                    .copied()
+                    .unwrap_or(1);
                 if b0 == 0x00 && b1 == 0x00 {
-                    self.pos += 2;
+                    self.pos = self.pos.saturating_add(2);
                     return Ok(());
                 }
-                self.skip_ber_element_bounded(depth + 1)?;
+                self.skip_ber_element_bounded(depth.saturating_add(1))?;
             }
         } else {
             // Definite length
             let length = self.read_length()?;
-            if self.pos + length > self.data.len() {
+            let new_pos = self
+                .pos
+                .checked_add(length)
+                .context("BER: position overflow in skip")?;
+            if new_pos > self.data.len() {
                 anyhow::bail!("BER: skip exceeds data bounds");
             }
-            self.pos += length;
+            self.pos = new_pos;
             Ok(())
         }
     }
@@ -198,7 +218,7 @@ impl<'a> DerParser<'a> {
             .data
             .get(self.pos)
             .context("DER: missing length byte")?;
-        self.pos += 1;
+        self.pos = self.pos.saturating_add(1);
 
         if first < 0x80 {
             // Short form
@@ -218,7 +238,7 @@ impl<'a> DerParser<'a> {
                     .data
                     .get(self.pos)
                     .context("DER: truncated length field")?;
-                self.pos += 1;
+                self.pos = self.pos.saturating_add(1);
                 length = length.checked_shl(8).context("DER: length overflow")? | (byte as usize);
             }
 

--- a/crates/vouch-server/src/crypto/webauthn_verify.rs
+++ b/crates/vouch-server/src/crypto/webauthn_verify.rs
@@ -344,7 +344,7 @@ pub fn verify_assertion_with_verifier<V: CoseVerifier>(
 
     // 7. Build signed data: authenticator_data || SHA-256(client_data_json)
     let client_data_hash = digest::digest(&SHA256, client_data_json);
-    let mut signed_data = Vec::with_capacity(authenticator_data.len() + 32);
+    let mut signed_data = Vec::with_capacity(authenticator_data.len().saturating_add(32));
     signed_data.extend_from_slice(authenticator_data);
     signed_data.extend_from_slice(client_data_hash.as_ref());
 
@@ -576,18 +576,21 @@ pub fn verify_registration_with_verifier<V: CoseVerifier>(
         .map_err(|_| VerifyError::InvalidAuthDataLength)?;
     let cred_id_len = u16::from_be_bytes(cred_id_len_bytes) as usize;
 
-    if attested_data.len() < 18 + cred_id_len {
+    let cose_key_start = 18_usize
+        .checked_add(cred_id_len)
+        .ok_or(VerifyError::InvalidAuthDataLength)?;
+    if attested_data.len() < cose_key_start {
         return Err(VerifyError::InvalidAuthDataLength);
     }
 
     let credential_id = attested_data
-        .get(18..18 + cred_id_len)
+        .get(18..cose_key_start)
         .ok_or(VerifyError::InvalidAuthDataLength)?
         .to_vec();
 
     // The COSE public key starts after the credential ID
     let cose_key_bytes = attested_data
-        .get(18 + cred_id_len..)
+        .get(cose_key_start..)
         .ok_or(VerifyError::InvalidAuthDataLength)?
         .to_vec();
 
@@ -740,7 +743,7 @@ fn verify_packed_attestation<V: CoseVerifier>(
 
         // Build signed data: authData || SHA-256(clientDataJSON)
         let client_data_hash = digest::digest(&SHA256, client_data_json);
-        let mut signed_data = Vec::with_capacity(auth_data_bytes.len() + 32);
+        let mut signed_data = Vec::with_capacity(auth_data_bytes.len().saturating_add(32));
         signed_data.extend_from_slice(auth_data_bytes);
         signed_data.extend_from_slice(client_data_hash.as_ref());
 
@@ -776,7 +779,7 @@ fn verify_packed_attestation<V: CoseVerifier>(
 
     // Build signed data: authData || SHA-256(clientDataJSON)
     let client_data_hash = digest::digest(&SHA256, client_data_json);
-    let mut signed_data = Vec::with_capacity(auth_data_bytes.len() + 32);
+    let mut signed_data = Vec::with_capacity(auth_data_bytes.len().saturating_add(32));
     signed_data.extend_from_slice(auth_data_bytes);
     signed_data.extend_from_slice(client_data_hash.as_ref());
 
@@ -1013,7 +1016,7 @@ fn verify_es256(
     let y = get_cose_bytes(map, -3)?;
 
     // Build uncompressed SEC1 point: 0x04 || x || y
-    let mut point = Vec::with_capacity(1 + x.len() + y.len());
+    let mut point = Vec::with_capacity(x.len().saturating_add(y.len()).saturating_add(1));
     point.push(0x04);
     point.extend_from_slice(&x);
     point.extend_from_slice(&y);

--- a/crates/vouch-server/src/db/audit.rs
+++ b/crates/vouch-server/src/db/audit.rs
@@ -239,7 +239,7 @@ impl AuditStore {
             email_domain: filter.email_domain.clone(),
             since: filter.since.clone(),
             before_id: filter.before_id.clone(),
-            limit: Some(page_size + 1),
+            limit: Some(page_size.saturating_add(1)),
         };
         let mut events = self.query_events(&f).await?;
         let has_more = events.len() as u64 > page_size;

--- a/crates/vouch-server/src/db/config.rs
+++ b/crates/vouch-server/src/db/config.rs
@@ -118,11 +118,12 @@ pub async fn insert_auth_event(
 pub async fn delete_old_auth_events(audit: &AuditStore, before: jiff::Timestamp) -> Result<u64> {
     let before_str = before.to_string();
     // Delete all auth event types.
-    let mut total = 0;
+    let mut total: u64 = 0;
     for event_type in AuthEventType::ALL {
-        total += audit
+        let deleted = audit
             .delete_old_events(event_type.as_str(), &before_str)
             .await?;
+        total = total.saturating_add(deleted);
     }
     Ok(total)
 }

--- a/crates/vouch-server/src/db/credentials.rs
+++ b/crates/vouch-server/src/db/credentials.rs
@@ -429,7 +429,7 @@ pub async fn revoke_all_ssh_certificates_for_user(
             revoked_by: revoked_by.map(String::from),
         };
         tx.insert(&doc).await?;
-        count += 1;
+        count = count.saturating_add(1);
     }
     tx.commit().await?;
     Ok(count)

--- a/crates/vouch-server/src/db/device_auth.rs
+++ b/crates/vouch-server/src/db/device_auth.rs
@@ -264,7 +264,7 @@ pub async fn update_device_auth_poll_time(
 
     // Check if polling too fast
     if let Some(last_poll) = doc.data.last_poll_at {
-        let elapsed = now.as_second() - last_poll.as_second();
+        let elapsed = now.as_second().saturating_sub(last_poll.as_second());
         if elapsed < i64::from(interval_seconds) {
             return Ok(false);
         }

--- a/crates/vouch-server/src/db/dsql.rs
+++ b/crates/vouch-server/src/db/dsql.rs
@@ -325,7 +325,7 @@ fn find_vpce_position(parts: &[&str]) -> Option<usize> {
     parts
         .iter()
         .position(|&p| p == "vpce")
-        .filter(|&i| parts.get(i + 1) == Some(&"amazonaws"))
+        .filter(|&i| parts.get(i.saturating_add(1)) == Some(&"amazonaws"))
 }
 
 /// Extract the AWS region from a VPC endpoint hostname.
@@ -339,7 +339,9 @@ fn extract_region_from_vpc_endpoint(host: &str) -> Option<String> {
     if vpce_idx == 0 {
         return None;
     }
-    parts.get(vpce_idx - 1).map(|s| (*s).to_string())
+    parts
+        .get(vpce_idx.saturating_sub(1))
+        .map(|s| (*s).to_string())
 }
 
 /// Extract the DSQL service ID from a VPC endpoint hostname.

--- a/crates/vouch-server/src/db/migrations.rs
+++ b/crates/vouch-server/src/db/migrations.rs
@@ -82,7 +82,7 @@ pub async fn run_dsql_migrations(pool: &PgPool) -> Result<MigrationResult> {
             "migration complete"
         );
 
-        newly_applied += 1;
+        newly_applied = newly_applied.saturating_add(1);
     }
 
     Ok((newly_applied, total))

--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -591,7 +591,8 @@ pub async fn get_oauth_usage_stats(
                 continue;
             };
             if data.oauth_client_id == oauth_client_id {
-                *stats.entry(audit_event_type.to_string()).or_default() += 1;
+                let entry: &mut i64 = stats.entry(audit_event_type.to_string()).or_default();
+                *entry = entry.saturating_add(1);
             }
         }
     }
@@ -605,11 +606,12 @@ pub async fn get_oauth_usage_stats(
 /// Delete old usage events (for retention policy).
 pub async fn delete_old_oauth_usage_events(audit: &AuditStore, before: Timestamp) -> Result<u64> {
     let before_str = before.to_string();
-    let mut total = 0;
+    let mut total: u64 = 0;
     for event_type in OAuthEventType::USAGE_EVENTS {
-        total += audit
+        let deleted = audit
             .delete_old_events(event_type.audit_event_type(), &before_str)
             .await?;
+        total = total.saturating_add(deleted);
     }
     Ok(total)
 }

--- a/crates/vouch-server/src/db/pool.rs
+++ b/crates/vouch-server/src/db/pool.rs
@@ -457,7 +457,7 @@ macro_rules! with_dsql_retry {
                         $crate::db::pool::retry_backoff(__attempt),
                     )
                     .await;
-                    __attempt += 1;
+                    __attempt = __attempt.saturating_add(1);
                 }
                 Err(e) => break Err(e),
             }
@@ -817,7 +817,12 @@ pub(crate) fn retry_backoff(attempt: u32) -> Duration {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .subsec_nanos();
-    let jitter = (u64::from(nanos) % (jitter_range * 2 + 1)).saturating_sub(jitter_range);
+    let modulus = jitter_range.saturating_mul(2).saturating_add(1);
+    // checked_rem returns None only if modulus is 0; saturating_add(1) is non-zero.
+    let jitter = u64::from(nanos)
+        .checked_rem(modulus)
+        .unwrap_or(0)
+        .saturating_sub(jitter_range);
     Duration::from_millis(base_ms.saturating_add(jitter))
 }
 

--- a/crates/vouch-server/src/db/posture_policies.rs
+++ b/crates/vouch-server/src/db/posture_policies.rs
@@ -227,5 +227,5 @@ pub async fn delete_custom_policy(store: &DocumentStore, id: &str, org_id: &str)
 pub async fn count_active_policies(store: &DocumentStore, org_id: &str) -> Result<usize> {
     let preconfigured_count = get_active_preconfigured_slugs(store, org_id).await?.len();
     let custom_active = get_active_custom_policies(store, org_id).await?.len();
-    Ok(preconfigured_count + custom_active)
+    Ok(preconfigured_count.saturating_add(custom_active))
 }

--- a/crates/vouch-server/src/db/scim.rs
+++ b/crates/vouch-server/src/db/scim.rs
@@ -549,7 +549,7 @@ pub(crate) fn parse_scim_filter(
     };
 
     let after_attr = filter_lower
-        .get(attr_pos + attr_lower.len()..)
+        .get(attr_pos.saturating_add(attr_lower.len())..)
         .unwrap_or("");
     let after_attr_trimmed = after_attr.trim_start();
 
@@ -576,7 +576,7 @@ pub(crate) fn parse_scim_filter(
     let pattern_lower = format!("{attr_lower} {op_word} ");
 
     if let Some(lower_pos) = filter_lower.find(&pattern_lower) {
-        let lower_end = lower_pos + pattern_lower.len();
+        let lower_end = lower_pos.saturating_add(pattern_lower.len());
 
         // Map byte offset in filter_lower back to the original filter
         // by counting characters up to that offset, then converting

--- a/crates/vouch-server/src/db/sessions.rs
+++ b/crates/vouch-server/src/db/sessions.rs
@@ -118,7 +118,7 @@ pub async fn delete_oauth_sessions_for_user(store: &DocumentStore, user_id: &str
     for session in &sessions {
         if session.data.session_type == SessionPurpose::OAuthAccessToken {
             store.delete(&session.id).await?;
-            count += 1;
+            count = count.saturating_add(1);
         }
     }
     Ok(count)

--- a/crates/vouch-server/src/db/store.rs
+++ b/crates/vouch-server/src/db/store.rs
@@ -536,7 +536,7 @@ impl DocumentStore {
         // Fetch one extra to detect whether there are more pages.
         let stmt = query
             .order_by((Documents::Table, Documents::Id), Order::Asc)
-            .limit(limit + 1)
+            .limit(limit.saturating_add(1))
             .to_owned();
 
         let rows: Vec<RawDocumentRow> = crate::db_fetch_all!(&self.pool, stmt, RawDocumentRow)?;
@@ -723,7 +723,10 @@ impl DocumentStore {
                         Expr::val(T::CURRENT_VERSION as i32),
                     )
                     .value(Documents::UpdatedAt, Expr::val(now_str.as_str()))
-                    .value(Documents::Version, Expr::val(expected_version + 1))
+                    .value(
+                        Documents::Version,
+                        Expr::val(expected_version.saturating_add(1)),
+                    )
                     .and_where(Expr::col(Documents::Id).eq(id))
                     .and_where(Expr::col(Documents::Version).eq(expected_version));
                 q.to_owned()
@@ -993,7 +996,7 @@ impl DocumentStore {
 
         let stmt = query
             .order_by(Documents::Id, Order::Asc)
-            .limit(limit + 1)
+            .limit(limit.saturating_add(1))
             .to_owned();
 
         let rows: Vec<RawDocumentRow> = crate::db_fetch_all!(&self.pool, stmt, RawDocumentRow)?;
@@ -1518,7 +1521,10 @@ impl StoreTransaction<'_> {
                     Expr::val(T::CURRENT_VERSION as i32),
                 )
                 .value(Documents::UpdatedAt, Expr::val(now_str.as_str()))
-                .value(Documents::Version, Expr::val(expected_version + 1))
+                .value(
+                    Documents::Version,
+                    Expr::val(expected_version.saturating_add(1)),
+                )
                 .and_where(Expr::col(Documents::Id).eq(id))
                 .and_where(Expr::col(Documents::Version).eq(expected_version));
             q.to_owned()

--- a/crates/vouch-server/src/geo.rs
+++ b/crates/vouch-server/src/geo.rs
@@ -121,8 +121,12 @@ pub fn country_flag(code: &str) -> Option<String> {
     if !a.is_ascii_alphabetic() || !b.is_ascii_alphabetic() {
         return None;
     }
-    let ri_a = char::from_u32(0x1F1E6_u32 + u32::from(a.to_ascii_uppercase() - b'A'))?;
-    let ri_b = char::from_u32(0x1F1E6_u32 + u32::from(b.to_ascii_uppercase() - b'A'))?;
+    let ri_a = char::from_u32(
+        0x1F1E6_u32.saturating_add(u32::from(a.to_ascii_uppercase().wrapping_sub(b'A'))),
+    )?;
+    let ri_b = char::from_u32(
+        0x1F1E6_u32.saturating_add(u32::from(b.to_ascii_uppercase().wrapping_sub(b'A'))),
+    )?;
     Some(format!("{ri_a}{ri_b}"))
 }
 

--- a/crates/vouch-server/src/handlers/admin/policies.rs
+++ b/crates/vouch-server/src/handlers/admin/policies.rs
@@ -171,7 +171,7 @@ pub async fn toggle_preconfigured_policy(
             .await
             .map_err(|e| ServiceError::Internal(format!("Failed to count policies: {e}")))?
             .len();
-        let total_active = active_slugs.len() + custom_active_count;
+        let total_active = active_slugs.len().saturating_add(custom_active_count);
 
         if total_active >= posture::MAX_ACTIVE_POLICIES {
             return Ok(Redirect::to(&format!(
@@ -513,7 +513,9 @@ pub async fn toggle_custom_policy(
             .map_err(|e| ServiceError::Internal(format!("Failed to count policies: {e}")))?
             .len();
         // Subtract 1 if this policy was already counted as active
-        let other_active = preconfigured_count + custom_active_count - usize::from(policy.active);
+        let other_active = preconfigured_count
+            .saturating_add(custom_active_count)
+            .saturating_sub(usize::from(policy.active));
 
         if other_active >= posture::MAX_ACTIVE_POLICIES {
             return Ok(Redirect::to(&format!(

--- a/crates/vouch-server/src/handlers/auth.rs
+++ b/crates/vouch-server/src/handlers/auth.rs
@@ -100,7 +100,7 @@ pub async fn status(
     // Calculate time remaining
     let now = Timestamp::now().as_second();
     let expires_in = if access_claims.exp > now {
-        u64::try_from(access_claims.exp - now).ok()
+        u64::try_from(access_claims.exp.saturating_sub(now)).ok()
     } else {
         None
     };

--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -691,7 +691,7 @@ pub async fn browser_login_complete(
 
     // Create session cookie
     let session_hours = i64::try_from(state.config().session_hours).unwrap_or(8);
-    let cookie = create_session_cookie(token.expose_secret(), session_hours * 3600);
+    let cookie = create_session_cookie(token.expose_secret(), session_hours.saturating_mul(3600));
 
     // Determine redirect URL
     let redirect_url = if let Some(pending_id) = auth_state.pending_auth {

--- a/crates/vouch-server/src/handlers/certification.rs
+++ b/crates/vouch-server/src/handlers/certification.rs
@@ -157,7 +157,10 @@ pub async fn complete_login(
     };
 
     let session_hours = i64::try_from(state.config().session_hours).unwrap_or(8);
-    let cookie = create_session_cookie(session_result.token.expose_secret(), session_hours * 3600);
+    let cookie = create_session_cookie(
+        session_result.token.expose_secret(),
+        session_hours.saturating_mul(3600),
+    );
 
     // ── 6. Redirect to authorize endpoint with pending_auth ──────────────
     // This mirrors the production browser login flow: after authentication,

--- a/crates/vouch-server/src/handlers/credentials.rs
+++ b/crates/vouch-server/src/handlers/credentials.rs
@@ -84,7 +84,7 @@ pub async fn issue_ssh_certificate(
     }
 
     // Certificate validity matches session duration
-    let valid_seconds = state.config().session_hours * 3600;
+    let valid_seconds = state.config().session_hours.saturating_mul(3600);
 
     // Sign the certificate on a blocking thread to avoid deadlocking
     // the tokio runtime. The ssh-key crate's sign path uses

--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -48,7 +48,10 @@ fn generate_user_code() -> Result<String, aws_lc_rs::error::Unspecified> {
     let chars: Vec<char> = bytes
         .iter()
         .map(|b| {
-            let idx = (*b as usize) % USER_CODE_ALPHABET.len();
+            // checked_rem returns None only if alphabet is empty; USER_CODE_ALPHABET is non-empty.
+            let idx = (*b as usize)
+                .checked_rem(USER_CODE_ALPHABET.len())
+                .unwrap_or(0);
             USER_CODE_ALPHABET.get(idx).copied().unwrap_or(b'X') as char
         })
         .collect();

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -696,7 +696,7 @@ pub(crate) async fn complete_enrollment_after_identity(
     tracing::debug!("Setting session cookie and redirecting to /enroll/keys");
 
     // Create session cookie and redirect to keys page
-    let cookie = create_session_cookie(token.expose_secret(), session_hours * 3600);
+    let cookie = create_session_cookie(token.expose_secret(), session_hours.saturating_mul(3600));
 
     Response::builder()
         .status(StatusCode::SEE_OTHER)
@@ -881,7 +881,7 @@ pub async fn browser_register_start(
     let now = jiff::Timestamp::now();
     let reg_exp = now
         .checked_add(jiff::Span::new().minutes(5))
-        .map_or(now.as_second() + 300, |t| t.as_second());
+        .map_or(now.as_second().saturating_add(300), |t| t.as_second());
     let reg_state = BrowserRegistrationState {
         device_auth_id,
         user_id,
@@ -1290,7 +1290,7 @@ pub async fn browser_register_complete(
     let token = session_result.token;
 
     // Return success template with session cookie
-    let cookie = create_session_cookie(token.expose_secret(), session_hours * 3600);
+    let cookie = create_session_cookie(token.expose_secret(), session_hours.saturating_mul(3600));
     let html = SuccessTemplate.render().map_err(|e| {
         tracing::error!("Template render error: {}", e);
         ServiceError::api(
@@ -1465,6 +1465,7 @@ fn is_valid_user_code_format(code: &str) -> bool {
 mod tests {
     #![expect(
         clippy::expect_used,
+        clippy::arithmetic_side_effects,
         reason = "test code: panic on assertion failure is acceptable"
     )]
 

--- a/crates/vouch-server/src/handlers/extractors.rs
+++ b/crates/vouch-server/src/handlers/extractors.rs
@@ -192,7 +192,7 @@ pub(crate) fn resolve_client_ip(
     let addrs: Vec<&str> = xff.split(',').map(str::trim).collect();
     let mut idx = addrs.len();
     while idx > 0 {
-        idx -= 1;
+        idx = idx.saturating_sub(1);
         let addr_str = addrs.get(idx).copied().unwrap_or("");
         if let Ok(addr) = addr_str.parse::<IpAddr>() {
             let addr = addr.to_canonical();

--- a/crates/vouch-server/src/handlers/github.rs
+++ b/crates/vouch-server/src/handlers/github.rs
@@ -145,7 +145,7 @@ impl GitHubStateToken {
             org_id: org_id.to_string(),
             user_id: user_id.to_string(),
             iat: now,
-            exp: now + 600, // 10 minutes
+            exp: now.saturating_add(600), // 10 minutes
             nonce,
             flow_type,
         })

--- a/crates/vouch-server/src/handlers/keys.rs
+++ b/crates/vouch-server/src/handlers/keys.rs
@@ -147,7 +147,7 @@ pub async fn register_start(
     let now = Timestamp::now();
     let exp = now
         .checked_add(jiff::Span::new().minutes(5))
-        .map_or(now.as_second() + 300, |t| t.as_second());
+        .map_or(now.as_second().saturating_add(300), |t| t.as_second());
     let reg_state = RegistrationState {
         user_id,
         user_name: user.email.clone(),

--- a/crates/vouch-server/src/handlers/oidc/fido2_challenge.rs
+++ b/crates/vouch-server/src/handlers/oidc/fido2_challenge.rs
@@ -71,7 +71,7 @@ pub async fn fido2_challenge(State(state): State<Arc<AppState>>) -> Response {
     let now = Timestamp::now();
     let exp = now
         .checked_add(jiff::Span::new().minutes(5))
-        .map_or(now.as_second() + 300, |t| t.as_second());
+        .map_or(now.as_second().saturating_add(300), |t| t.as_second());
 
     let challenge_state = Fido2ChallengeState {
         challenge: challenge.clone(),

--- a/crates/vouch-server/src/handlers/oidc/tests/mod.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/mod.rs
@@ -6,6 +6,7 @@
     clippy::unwrap_used,
     clippy::indexing_slicing,
     clippy::string_slice,
+    clippy::arithmetic_side_effects,
     reason = "test code: panic on assertion failure is acceptable"
 )]
 

--- a/crates/vouch-server/src/handlers/oidc/userinfo.rs
+++ b/crates/vouch-server/src/handlers/oidc/userinfo.rs
@@ -335,7 +335,7 @@ async fn build_signed_userinfo_response(
         sub: response_body.sub.clone(),
         aud,
         iat: now,
-        exp: now + 300,
+        exp: now.saturating_add(300),
         email: response_body.email.clone(),
         email_verified: response_body.email_verified,
     };

--- a/crates/vouch-server/src/handlers/scim/groups.rs
+++ b/crates/vouch-server/src/handlers/scim/groups.rs
@@ -543,7 +543,7 @@ pub fn db_group_to_scim(
 fn parse_member_filter(path: &str) -> Option<String> {
     // Simple parser for members[value eq "user-id"]
     if let Some(start) = path.find("value eq \"") {
-        let start_idx = start + 10;
+        let start_idx = start.saturating_add(10);
         if let Some(rest) = path.get(start_idx..)
             && let Some(end) = rest.find('"')
         {

--- a/crates/vouch-server/src/infra/cleanup.rs
+++ b/crates/vouch-server/src/infra/cleanup.rs
@@ -51,7 +51,10 @@ fn random_jitter(max_jitter_secs: u64) -> std::time::Duration {
     }
     let mut buf = [0u8; 8];
     if aws_rand::fill(&mut buf).is_ok() {
-        let value = u64::from_le_bytes(buf) % max_jitter_secs;
+        // checked_rem returns None only if max_jitter_secs is 0; guarded above.
+        let value = u64::from_le_bytes(buf)
+            .checked_rem(max_jitter_secs)
+            .unwrap_or(0);
         std::time::Duration::from_secs(value)
     } else {
         std::time::Duration::ZERO
@@ -73,7 +76,7 @@ pub fn start_cleanup_task(
     oauth_events_retention_days: i64,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
-        let base_secs = interval_minutes * 60;
+        let base_secs = interval_minutes.saturating_mul(60);
         // Jitter of up to 20% of the base interval
         // 5 is non-zero; unwrap_or arm is unreachable.
         let max_jitter_secs = base_secs.checked_div(5).unwrap_or(0);
@@ -81,7 +84,8 @@ pub fn start_cleanup_task(
         // Initial delay with jitter so instances started simultaneously don't
         // all fire their first cleanup at the same time.
         let initial_jitter = random_jitter(max_jitter_secs);
-        let initial_delay = std::time::Duration::from_secs(base_secs) + initial_jitter;
+        let initial_delay =
+            std::time::Duration::from_secs(base_secs).saturating_add(initial_jitter);
         tracing::debug!(
             "First cleanup in {}s (base {}s + jitter {}s)",
             initial_delay.as_secs(),
@@ -104,7 +108,7 @@ pub fn start_cleanup_task(
 
             // Sleep with jitter before the next run
             let jitter = random_jitter(max_jitter_secs);
-            let sleep_duration = std::time::Duration::from_secs(base_secs) + jitter;
+            let sleep_duration = std::time::Duration::from_secs(base_secs).saturating_add(jitter);
             tracing::debug!(
                 "Next cleanup in {}s (base {}s + jitter {}s)",
                 sleep_duration.as_secs(),

--- a/crates/vouch-server/src/infra/resource_metadata.rs
+++ b/crates/vouch-server/src/infra/resource_metadata.rs
@@ -146,22 +146,22 @@ fn has_resource_metadata_parameter(header: &str) -> bool {
     if needle.is_empty() || lower_bytes.len() < needle.len() {
         return false;
     }
-    let last_start = lower_bytes.len() - needle.len();
+    let last_start = lower_bytes.len().saturating_sub(needle.len());
     let mut i = 0usize;
     while i <= last_start {
-        if lower_bytes.get(i..i + needle.len()) == Some(needle) {
+        let end = i.saturating_add(needle.len());
+        if lower_bytes.get(i..end) == Some(needle) {
             let before_ok = i == 0
                 || matches!(
                     lower_bytes.get(i.saturating_sub(1)),
                     Some(b' ' | b',' | b'\t'),
                 );
-            let after_idx = i + needle.len();
-            let after_ok = matches!(lower_bytes.get(after_idx), Some(b'=') | None);
+            let after_ok = matches!(lower_bytes.get(end), Some(b'=') | None);
             if before_ok && after_ok {
                 return true;
             }
         }
-        i += 1;
+        i = i.saturating_add(1);
     }
     false
 }

--- a/crates/vouch-server/src/infra/startup.rs
+++ b/crates/vouch-server/src/infra/startup.rs
@@ -322,7 +322,7 @@ async fn connect_and_migrate(config: &config::ServerConfig) -> Result<Pool> {
             let after: i64 = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM _sqlx_migrations")
                 .fetch_one(pool)
                 .await?;
-            ((after - before) as usize, total)
+            (after.saturating_sub(before) as usize, total)
         }
         Pool::Postgres(pool) => {
             // Check if this is a DSQL endpoint
@@ -347,7 +347,7 @@ async fn connect_and_migrate(config: &config::ServerConfig) -> Result<Pool> {
                     sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM _sqlx_migrations")
                         .fetch_one(pool)
                         .await?;
-                ((after - before) as usize, total)
+                (after.saturating_sub(before) as usize, total)
             }
         }
     };

--- a/crates/vouch-server/src/services/auth.rs
+++ b/crates/vouch-server/src/services/auth.rs
@@ -292,10 +292,10 @@ impl ActorClaim {
     /// deeply nested (potentially malicious) actor chains.
     #[must_use]
     pub(crate) fn depth(&self) -> usize {
-        let mut depth = 1;
+        let mut depth: usize = 1;
         let mut current = &self.actor;
         while let Some(inner) = current {
-            depth += 1;
+            depth = depth.saturating_add(1);
             current = &inner.actor;
         }
         depth
@@ -498,7 +498,7 @@ pub(crate) async fn create_oauth_access_token(
     .await
     .map_err(|e| ServiceError::Internal(format!("Failed to store session: {e}")))?;
 
-    let expires_in = state.config().session_hours * 3600;
+    let expires_in = state.config().session_hours.saturating_mul(3600);
 
     Ok(CreateSessionResult {
         token: SecretString::from(token),

--- a/crates/vouch-server/src/services/idp/saml/c14n.rs
+++ b/crates/vouch-server/src/services/idp/saml/c14n.rs
@@ -287,7 +287,7 @@ fn find_prefix_for_uri<'a>(node: roxmltree::Node<'_, 'a>, uri: &str) -> Option<&
             }
         }
         current = n.parent();
-        depth += 1;
+        depth = depth.saturating_add(1);
     }
 
     if candidates.is_empty() {

--- a/crates/vouch-server/src/services/integrations/aws.rs
+++ b/crates/vouch-server/src/services/integrations/aws.rs
@@ -103,7 +103,7 @@ pub async fn issue_aws_token(
     let authenticator = get_authenticator(store, authenticator_id).await?;
 
     // Token validity matches session duration
-    let expires_in = session_hours * 3600;
+    let expires_in = session_hours.saturating_mul(3600);
 
     // Build AWS session tags for ABAC and CloudTrail attribution.
     // Tags are embedded in the JWT so AWS extracts them during

--- a/crates/vouch-server/src/services/integrations/github/app.rs
+++ b/crates/vouch-server/src/services/integrations/github/app.rs
@@ -230,7 +230,7 @@ impl GitHubApp {
                 tracing::info!(
                     "GitHub App private key validated: {} bytes, modulus {} bits",
                     private_key.as_bytes().len(),
-                    key_pair.public_modulus_len() * 8
+                    key_pair.public_modulus_len().saturating_mul(8)
                 );
             }
             Err(e) => {
@@ -259,9 +259,9 @@ impl GitHubApp {
     pub async fn generate_app_jwt(&self) -> Result<String> {
         let now = jiff::Timestamp::now();
         // GitHub recommends setting iat to 60 seconds in the past to account for clock drift
-        let iat = now.as_second() - 60;
+        let iat = now.as_second().saturating_sub(60);
         // JWT expires in 10 minutes (GitHub maximum)
-        let exp = now.as_second() + 600;
+        let exp = now.as_second().saturating_add(600);
 
         let claims = GitHubAppJwtClaims {
             iat,
@@ -429,7 +429,7 @@ pub async fn list_user_accessible_installations(
     user_token: &str,
 ) -> Result<Vec<InstallationDetails>> {
     let mut all_installations = Vec::new();
-    let mut page = 1;
+    let mut page: u32 = 1;
 
     loop {
         let response = http_client
@@ -464,7 +464,7 @@ pub async fn list_user_accessible_installations(
         if count < 100 {
             break;
         }
-        page += 1;
+        page = page.saturating_add(1);
     }
 
     Ok(all_installations)

--- a/crates/vouch-server/src/services/keys.rs
+++ b/crates/vouch-server/src/services/keys.rs
@@ -224,6 +224,7 @@ pub(crate) async fn delete_key(
 #[cfg(test)]
 #[expect(
     clippy::unwrap_used,
+    clippy::arithmetic_side_effects,
     reason = "test code: panic on assertion failure is acceptable"
 )]
 mod tests {

--- a/crates/vouch-server/src/services/oidc/authorization.rs
+++ b/crates/vouch-server/src/services/oidc/authorization.rs
@@ -661,7 +661,10 @@ pub async fn issue_authorization_code(
     let lifetime_secs = params.auth_code_lifetime_seconds;
     let exp = now
         .checked_add(Span::new().seconds(lifetime_secs))
-        .map_or_else(|_| now.as_second() + lifetime_secs, |t| t.as_second());
+        .map_or_else(
+            |_| now.as_second().saturating_add(lifetime_secs),
+            |t| t.as_second(),
+        );
 
     let auth_code = AuthorizationCode {
         iss: state.config().base_url.clone(),

--- a/crates/vouch-server/src/services/oidc/authorization_details.rs
+++ b/crates/vouch-server/src/services/oidc/authorization_details.rs
@@ -191,8 +191,12 @@ fn validate_depth(value: &serde_json::Value, max_depth: usize) -> bool {
         return !value.is_array() && !value.is_object();
     }
     match value {
-        serde_json::Value::Array(arr) => arr.iter().all(|v| validate_depth(v, max_depth - 1)),
-        serde_json::Value::Object(map) => map.values().all(|v| validate_depth(v, max_depth - 1)),
+        serde_json::Value::Array(arr) => arr
+            .iter()
+            .all(|v| validate_depth(v, max_depth.saturating_sub(1))),
+        serde_json::Value::Object(map) => map
+            .values()
+            .all(|v| validate_depth(v, max_depth.saturating_sub(1))),
         _ => true,
     }
 }

--- a/crates/vouch-server/src/services/oidc/claims.rs
+++ b/crates/vouch-server/src/services/oidc/claims.rs
@@ -247,7 +247,9 @@ impl OidcIdTokenClaimsBuilder {
     /// Returns an error if required fields (issuer, subject, audience) are missing.
     pub fn build(self) -> Result<OidcIdTokenClaims, ClaimsBuildError> {
         let now = jiff::Timestamp::now();
-        let exp = now.as_second() + i64::try_from(self.valid_for_seconds).unwrap_or(28800);
+        let exp = now
+            .as_second()
+            .saturating_add(i64::try_from(self.valid_for_seconds).unwrap_or(28800));
 
         Ok(OidcIdTokenClaims {
             iss: self

--- a/crates/vouch-server/src/services/oidc/dpop.rs
+++ b/crates/vouch-server/src/services/oidc/dpop.rs
@@ -334,7 +334,7 @@ pub fn validate_dpop_claims(
     }
 
     // Check timestamp (not too old, not in future)
-    let age = now - claims.iat;
+    let age = now.saturating_sub(claims.iat);
     if age < -60 {
         // Allow 60 seconds clock skew into future
         return Err(DpopError::Expired);

--- a/crates/vouch-server/src/services/oidc/exchange.rs
+++ b/crates/vouch-server/src/services/oidc/exchange.rs
@@ -285,7 +285,7 @@ pub async fn exchange_token(
     // Calculate expiration with policy TTL limit and subject token remaining TTL.
     // RFC 8693 Section 2.2: The exchanged token's lifetime should not exceed
     // the remaining lifetime of the subject token.
-    let default_expires_in = state.config().session_hours * 3600;
+    let default_expires_in = state.config().session_hours.saturating_mul(3600);
     let mut expires_in = match max_ttl_override {
         Some(max_ttl) => {
             let max_ttl_u64 = u64::try_from(max_ttl).map_err(|_| {

--- a/crates/vouch-server/src/services/oidc/jar.rs
+++ b/crates/vouch-server/src/services/oidc/jar.rs
@@ -411,7 +411,7 @@ pub async fn validate_request_object(
     let now = Timestamp::now().as_second();
 
     if let Some(exp) = claims.exp
-        && exp < now - clock_skew
+        && exp < now.saturating_sub(clock_skew)
     {
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidRequestObject,
@@ -420,14 +420,14 @@ pub async fn validate_request_object(
     }
 
     if let Some(nbf) = claims.nbf {
-        if nbf > now + clock_skew {
+        if nbf > now.saturating_add(clock_skew) {
             return Err(ServiceError::oauth(
                 OAuthErrorCode::InvalidRequestObject,
                 "Request Object is not yet valid (nbf claim)",
             ));
         }
         // FAPI 2.0: nbf must not be more than 60 minutes in the past.
-        if client.is_fapi() && nbf < now - 3600 - clock_skew {
+        if client.is_fapi() && nbf < now.saturating_sub(3600).saturating_sub(clock_skew) {
             return Err(ServiceError::oauth(
                 OAuthErrorCode::InvalidRequestObject,
                 "Request Object nbf is too far in the past (more than 60 minutes)",
@@ -436,7 +436,7 @@ pub async fn validate_request_object(
     }
 
     if let Some(iat) = claims.iat
-        && iat > now + clock_skew
+        && iat > now.saturating_add(clock_skew)
     {
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidRequestObject,
@@ -495,7 +495,7 @@ pub async fn validate_request_object(
         // FAPI 2.0 Message Signing: exp must not be more than 60 minutes
         // after nbf (prevents long-lived request objects).
         if let (Some(exp), Some(nbf)) = (claims.exp, claims.nbf) {
-            let window = exp - nbf;
+            let window = exp.saturating_sub(nbf);
             if window > 3600 {
                 return Err(ServiceError::oauth(
                     OAuthErrorCode::InvalidRequestObject,
@@ -615,6 +615,7 @@ pub async fn validate_request_object(
     clippy::unwrap_used,
     clippy::expect_used,
     clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
     reason = "test code: panic on assertion failure is acceptable"
 )]
 mod tests {

--- a/crates/vouch-server/src/services/oidc/jarm.rs
+++ b/crates/vouch-server/src/services/oidc/jarm.rs
@@ -69,7 +69,7 @@ pub async fn build_jarm_success_jwt(
     state_param: Option<&str>,
 ) -> Result<String> {
     let now = Timestamp::now().as_second();
-    let exp = now + JARM_JWT_LIFETIME_SECONDS;
+    let exp = now.saturating_add(JARM_JWT_LIFETIME_SECONDS);
     let issuer = state.config().base_url.clone();
 
     let claims = JarmSuccessClaims {
@@ -104,7 +104,7 @@ pub async fn build_jarm_error_jwt(
     state_param: Option<&str>,
 ) -> Result<String> {
     let now = Timestamp::now().as_second();
-    let exp = now + JARM_JWT_LIFETIME_SECONDS;
+    let exp = now.saturating_add(JARM_JWT_LIFETIME_SECONDS);
     let issuer = state.config().base_url.clone();
 
     let claims = JarmErrorClaims {

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/jwks.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/jwks.rs
@@ -131,7 +131,7 @@ async fn resolve_jwks_uri(
     if let (Some(cache), Some(cached_at)) = (cached_jwks, cached_at)
         && let Ok(ts) = cached_at.parse::<Timestamp>()
     {
-        let cache_age = Timestamp::now().as_second() - ts.as_second();
+        let cache_age = Timestamp::now().as_second().saturating_sub(ts.as_second());
         if cache_age < JWKS_CACHE_TTL_SECONDS {
             return parse_jwks_value(cache);
         }
@@ -151,7 +151,7 @@ async fn resolve_jwks_uri(
             if let (Some(cache), Some(cached_at)) = (cached_jwks, cached_at)
                 && let Ok(ts) = cached_at.parse::<Timestamp>()
             {
-                let stale_age = Timestamp::now().as_second() - ts.as_second();
+                let stale_age = Timestamp::now().as_second().saturating_sub(ts.as_second());
                 if stale_age < JWKS_STALE_MAX_AGE_SECONDS {
                     tracing::warn!("JWKS fetch failed, using stale cache: {e}");
                     return parse_jwks_value(cache);
@@ -176,7 +176,7 @@ async fn resolve_jwks_uri_for_issuer(
     if let (Some(cache), Some(cached_at)) = (cached_jwks, cached_at)
         && let Ok(ts) = cached_at.parse::<Timestamp>()
     {
-        let cache_age = Timestamp::now().as_second() - ts.as_second();
+        let cache_age = Timestamp::now().as_second().saturating_sub(ts.as_second());
         if cache_age < JWKS_CACHE_TTL_SECONDS {
             return parse_jwks_value(cache);
         }
@@ -195,7 +195,7 @@ async fn resolve_jwks_uri_for_issuer(
             if let (Some(cache), Some(cached_at)) = (cached_jwks, cached_at)
                 && let Ok(ts) = cached_at.parse::<Timestamp>()
             {
-                let stale_age = Timestamp::now().as_second() - ts.as_second();
+                let stale_age = Timestamp::now().as_second().saturating_sub(ts.as_second());
                 if stale_age < JWKS_STALE_MAX_AGE_SECONDS {
                     tracing::warn!("JWKS fetch failed, using stale cache: {e}");
                     return parse_jwks_value(cache);
@@ -392,7 +392,7 @@ pub async fn find_matching_key_with_refresh_client(
     if let Some(cached_at) = jwks_uri_cached_at
         && let Ok(ts) = cached_at.parse::<Timestamp>()
     {
-        let age = Timestamp::now().as_second() - ts.as_second();
+        let age = Timestamp::now().as_second().saturating_sub(ts.as_second());
         if age < JWKS_FORCE_REFRESH_MIN_INTERVAL_SECONDS {
             tracing::debug!(
                 "Skipping JWKS force-refresh for client {client_id}: refreshed {age}s ago"
@@ -437,7 +437,7 @@ pub async fn find_matching_key_with_refresh_issuer(
     if let Some(cached_at) = jwks_cached_at
         && let Ok(ts) = cached_at.parse::<Timestamp>()
     {
-        let age = Timestamp::now().as_second() - ts.as_second();
+        let age = Timestamp::now().as_second().saturating_sub(ts.as_second());
         if age < JWKS_FORCE_REFRESH_MIN_INTERVAL_SECONDS {
             tracing::debug!(
                 "Skipping JWKS force-refresh for issuer {issuer_id}: refreshed {age}s ago"

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/validate.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/validate.rs
@@ -186,7 +186,7 @@ pub fn validate_jwt_assertion(
     let now = Timestamp::now().as_second();
 
     // Validate expiration (RFC 7523 Section 3: MUST reject expired JWTs)
-    if claims.exp < now - CLOCK_SKEW_SECONDS {
+    if claims.exp < now.saturating_sub(CLOCK_SKEW_SECONDS) {
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidClient,
             "JWT assertion has expired",
@@ -195,7 +195,7 @@ pub fn validate_jwt_assertion(
 
     // Validate not-before if present
     if let Some(nbf) = claims.nbf
-        && nbf > now + CLOCK_SKEW_SECONDS
+        && nbf > now.saturating_add(CLOCK_SKEW_SECONDS)
     {
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidClient,
@@ -205,7 +205,7 @@ pub fn validate_jwt_assertion(
 
     // Validate iat if present
     if let Some(iat) = claims.iat
-        && iat > now + CLOCK_SKEW_SECONDS
+        && iat > now.saturating_add(CLOCK_SKEW_SECONDS)
     {
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidClient,
@@ -215,7 +215,7 @@ pub fn validate_jwt_assertion(
 
     // Validate max lifetime: exp - iat (or exp - now if no iat)
     let effective_iat = claims.iat.unwrap_or(now);
-    let lifetime = claims.exp - effective_iat;
+    let lifetime = claims.exp.saturating_sub(effective_iat);
     if lifetime > max_lifetime_seconds {
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidClient,
@@ -293,6 +293,7 @@ pub fn map_algorithm(alg: &str) -> ServiceResult<jsonwebtoken::Algorithm> {
     clippy::unwrap_used,
     clippy::expect_used,
     clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
     reason = "test code: panic on assertion failure is acceptable"
 )]
 mod tests {

--- a/crates/vouch-server/src/services/oidc/keys.rs
+++ b/crates/vouch-server/src/services/oidc/keys.rs
@@ -579,8 +579,10 @@ impl OidcRsaSigningKey {
         // but from_pem() accepts any PKCS#8 RSA key — reject undersized keys.
         // Use bit-counting (not byte length) to handle edge cases where
         // strip_leading_zeros may remove DER sign-padding bytes.
-        let key_bits =
-            n_bytes.len() * 8 - n_bytes.first().map_or(0, |b| b.leading_zeros() as usize);
+        let key_bits = n_bytes
+            .len()
+            .saturating_mul(8)
+            .saturating_sub(n_bytes.first().map_or(0, |b| b.leading_zeros() as usize));
         if key_bits < 3072 {
             bail!("RSA key must be at least 3072 bits, got {key_bits} bits");
         }

--- a/crates/vouch-server/src/services/oidc/protected_resource.rs
+++ b/crates/vouch-server/src/services/oidc/protected_resource.rs
@@ -249,7 +249,7 @@ pub fn classify_sub_path(raw_tail: &str) -> SubPathClassification {
         // `oauth/register/{client_id}` under the `oauth/register`
         // prefix). We require a `/` boundary to avoid
         // `oauth/registerX` matching `oauth/register`.
-        let mut bounded = String::with_capacity(prefix.len() + 1);
+        let mut bounded = String::with_capacity(prefix.len().saturating_add(1));
         bounded.push_str(prefix);
         bounded.push('/');
         if tail.starts_with(&bounded) {

--- a/crates/vouch-server/src/services/posture.rs
+++ b/crates/vouch-server/src/services/posture.rs
@@ -249,7 +249,12 @@ fn cel_semver(ftx: &FunctionContext, value: Arc<String>) -> Result<Value, Execut
     if parts.next().is_some() {
         return Err(ftx.error("expected 1-3 version components"));
     }
-    Ok(Value::Int(major * 1_000_000 + minor * 1_000 + patch))
+    Ok(Value::Int(
+        major
+            .saturating_mul(1_000_000)
+            .saturating_add(minor.saturating_mul(1_000))
+            .saturating_add(patch),
+    ))
 }
 
 /// Convert a `serde_json::Value` to a CEL `Value`.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Broad mechanical changes replace arithmetic with `saturating_*`/`wrapping_*`/`checked_*` across agent/CLI/server code, which reduces panic risk but can subtly change edge-case behavior in timeouts, pagination, and crypto parsing.
> 
> **Overview**
> Tightens workspace linting by **denying more Clippy panic/UB lints**, notably `arithmetic_side_effects`, and then updates affected code paths to use explicit `saturating_*`, `wrapping_*`, and `checked_*` arithmetic.
> 
> The refactor touches request IDs, timestamp/TTL math, retry/backoff counters, pagination limits, buffer/offset calculations, and various parsers/encoders (wire protocol, BER/DER, SFV, URL/header parsing), generally replacing `+/-/*/%` and index arithmetic with overflow-safe equivalents and adding a few targeted `#[expect]`s in tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93641b28b40119773e62a83948aa8a7f7b31845e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->