### PR TITLE
fix(scim): scope every SCIM operation to the caller's org

### DIFF
--- a/crates/vouch-server/src/db/documents/scim.rs
+++ b/crates/vouch-server/src/db/documents/scim.rs
@@ -42,9 +42,11 @@ impl DocumentType for ScimTokenDoc {
     }
 }
 
-/// A SCIM group.
+/// A SCIM group. Always belongs to exactly one organization (the
+/// org of the SCIM token that created it).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScimGroupDoc {
+    pub org_id: String,
     pub display_name: String,
     pub external_id: Option<String>,
 }
@@ -53,10 +55,16 @@ impl DocumentType for ScimGroupDoc {
     const DOC_TYPE: &'static str = "scim_group";
 
     fn index_entries(&self) -> Vec<IndexEntry> {
-        let mut entries = vec![IndexEntry {
-            field: "display_name",
-            value: self.display_name.clone(),
-        }];
+        let mut entries = vec![
+            IndexEntry {
+                field: "display_name",
+                value: self.display_name.clone(),
+            },
+            IndexEntry {
+                field: "org_id",
+                value: self.org_id.clone(),
+            },
+        ];
         if let Some(ref ext_id) = self.external_id {
             entries.push(IndexEntry {
                 field: "external_id",

--- a/crates/vouch-server/src/db/scim.rs
+++ b/crates/vouch-server/src/db/scim.rs
@@ -331,8 +331,7 @@ pub async fn list_scim_users(
             return Err(ScimFilterError::FilterTooBroad.into());
         }
         let all = store.find_all::<UserDoc>("org_id", org_id).await?;
-        let mut records: Vec<ScimUserRecord> =
-            all.into_iter().map(ScimUserRecord::from).collect();
+        let mut records: Vec<ScimUserRecord> = all.into_iter().map(ScimUserRecord::from).collect();
         if let Some(f) = filter {
             records = apply_scim_user_filter(records, f)?;
         }

--- a/crates/vouch-server/src/db/scim.rs
+++ b/crates/vouch-server/src/db/scim.rs
@@ -322,24 +322,38 @@ pub async fn list_scim_users(
         return Ok((page, total));
     }
 
-    // Org-scoped scan via the org_id index; sort in-memory.
-    let mut records: Vec<ScimUserRecord> = store
-        .find_all::<UserDoc>("org_id", org_id)
-        .await?
-        .into_iter()
-        .map(ScimUserRecord::from)
-        .collect();
+    // Non-indexed filter: must load org-scoped rows and filter in-app.
+    // Bounded by 10k so an org with millions of users does not load every
+    // record into memory for an unrecognized filter expression.
+    if filter.is_some() {
+        let total_in_org = store.count::<UserDoc>("org_id", org_id).await?;
+        if total_in_org > 10_000 {
+            return Err(ScimFilterError::FilterTooBroad.into());
+        }
+        let all = store.find_all::<UserDoc>("org_id", org_id).await?;
+        let mut records: Vec<ScimUserRecord> =
+            all.into_iter().map(ScimUserRecord::from).collect();
+        if let Some(f) = filter {
+            records = apply_scim_user_filter(records, f)?;
+        }
+        records.sort_by(|a, b| a.email.cmp(&b.email));
+        let total = records.len();
+        let page = records.into_iter().skip(offset).take(count).collect();
+        return Ok((page, total));
+    }
 
-    if records.len() > 10_000 {
-        return Err(ScimFilterError::FilterTooBroad.into());
+    // Unfiltered: push pagination to the DB so an org with millions of
+    // users does not load every record into memory.
+    if offset > 10_000 {
+        return Err(ScimFilterError::OffsetTooLarge.into());
     }
-    if let Some(f) = filter {
-        records = apply_scim_user_filter(records, f)?;
-    }
-    records.sort_by(|a, b| a.email.cmp(&b.email));
-    let total = records.len();
-    let page = records.into_iter().skip(offset).take(count).collect();
-    Ok((page, total))
+    let (docs, total_count) = store
+        .find_paginated_with_count::<UserDoc>("org_id", org_id, offset as u64, count as u64)
+        .await?;
+    Ok((
+        docs.into_iter().map(ScimUserRecord::from).collect(),
+        usize::try_from(total_count).unwrap_or(usize::MAX),
+    ))
 }
 
 /// Try indexed eq lookups for SCIM user filters, scoped to org.
@@ -730,23 +744,36 @@ pub async fn list_scim_groups(
         return Ok((page, total));
     }
 
-    let mut records: Vec<ScimGroupRecord> = store
-        .find_all::<ScimGroupDoc>("org_id", org_id)
-        .await?
-        .into_iter()
-        .map(ScimGroupRecord::from)
-        .collect();
+    // Non-indexed filter: bounded by 10k so a large org does not load
+    // every group into memory for an unrecognized filter expression.
+    if filter.is_some() {
+        let total_in_org = store.count::<ScimGroupDoc>("org_id", org_id).await?;
+        if total_in_org > 10_000 {
+            return Err(ScimFilterError::FilterTooBroad.into());
+        }
+        let all = store.find_all::<ScimGroupDoc>("org_id", org_id).await?;
+        let mut records: Vec<ScimGroupRecord> =
+            all.into_iter().map(ScimGroupRecord::from).collect();
+        if let Some(f) = filter {
+            records = apply_scim_group_filter(records, f)?;
+        }
+        records.sort_by_key(|b| std::cmp::Reverse(b.created_at));
+        let total = records.len();
+        let page = records.into_iter().skip(offset).take(count).collect();
+        return Ok((page, total));
+    }
 
-    if records.len() > 10_000 {
-        return Err(ScimFilterError::FilterTooBroad.into());
+    // Unfiltered: push pagination to the DB.
+    if offset > 10_000 {
+        return Err(ScimFilterError::OffsetTooLarge.into());
     }
-    if let Some(f) = filter {
-        records = apply_scim_group_filter(records, f)?;
-    }
-    records.sort_by_key(|b| std::cmp::Reverse(b.created_at));
-    let total = records.len();
-    let page = records.into_iter().skip(offset).take(count).collect();
-    Ok((page, total))
+    let (docs, total_count) = store
+        .find_paginated_with_count::<ScimGroupDoc>("org_id", org_id, offset as u64, count as u64)
+        .await?;
+    Ok((
+        docs.into_iter().map(ScimGroupRecord::from).collect(),
+        usize::try_from(total_count).unwrap_or(usize::MAX),
+    ))
 }
 
 /// Try indexed eq lookups for SCIM group filters, scoped to org.

--- a/crates/vouch-server/src/db/scim.rs
+++ b/crates/vouch-server/src/db/scim.rs
@@ -7,7 +7,6 @@ use super::documents::audit::ScimAuditData;
 use super::documents::scim::{ScimGroupDoc, ScimGroupMemberDoc, ScimTokenDoc};
 use super::documents::user::UserDoc;
 use super::store::DocumentStore;
-use anyhow::Context;
 use anyhow::Result;
 use jiff::Timestamp;
 
@@ -306,73 +305,69 @@ impl From<Document<UserDoc>> for ScimUserRecord {
 /// when the computed offset exceeds 10 000.
 pub async fn list_scim_users(
     store: &DocumentStore,
+    org_id: &str,
     filter: Option<&str>,
     start_index: usize,
     count: usize,
 ) -> Result<(Vec<ScimUserRecord>, usize)> {
     let offset = start_index.saturating_sub(1); // SCIM 1-indexed
 
-    // Try indexed eq lookup first for efficiency
+    // Try indexed AND-lookup first (single query combining email/externalId
+    // with org_id at the DB level — no per-row scope check).
     if let Some(f) = filter
-        && let Some(result) = try_indexed_user_lookup(store, f).await?
+        && let Some(result) = try_indexed_user_lookup(store, org_id, f).await?
     {
         let total = result.len();
         let page = result.into_iter().skip(offset).take(count).collect();
         return Ok((page, total));
     }
 
-    // Non-indexed filter: must load all and filter in app
-    if filter.is_some() {
-        let table_count = store.count_all::<UserDoc>().await?;
-        if table_count > 10_000 {
-            return Err(ScimFilterError::FilterTooBroad.into());
-        }
-        let all_docs = store.list_all::<UserDoc>().await?;
-        let mut records: Vec<ScimUserRecord> =
-            all_docs.into_iter().map(ScimUserRecord::from).collect();
-        if let Some(f) = filter {
-            records = apply_scim_user_filter(records, f)?;
-        }
-        records.sort_by(|a, b| a.email.cmp(&b.email));
-        let total = records.len();
-        let page = records.into_iter().skip(offset).take(count).collect();
-        return Ok((page, total));
-    }
+    // Org-scoped scan via the org_id index; sort in-memory.
+    let mut records: Vec<ScimUserRecord> = store
+        .find_all::<UserDoc>("org_id", org_id)
+        .await?
+        .into_iter()
+        .map(ScimUserRecord::from)
+        .collect();
 
-    // No filter: use DB-level pagination with count
-    if offset > 10_000 {
-        return Err(ScimFilterError::OffsetTooLarge.into());
+    if records.len() > 10_000 {
+        return Err(ScimFilterError::FilterTooBroad.into());
     }
-    let (docs, total_count) = store
-        .list_all_paginated_with_count::<UserDoc>(offset as u64, count as u64)
-        .await?;
-    Ok((
-        docs.into_iter().map(ScimUserRecord::from).collect(),
-        usize::try_from(total_count).context("SCIM user total_count out of range")?,
-    ))
+    if let Some(f) = filter {
+        records = apply_scim_user_filter(records, f)?;
+    }
+    records.sort_by(|a, b| a.email.cmp(&b.email));
+    let total = records.len();
+    let page = records.into_iter().skip(offset).take(count).collect();
+    Ok((page, total))
 }
 
-/// Try indexed eq lookups for SCIM user filters.
+/// Try indexed eq lookups for SCIM user filters, scoped to org.
 async fn try_indexed_user_lookup(
     store: &DocumentStore,
+    org_id: &str,
     filter: &str,
 ) -> Result<Option<Vec<ScimUserRecord>>> {
-    // userName/email eq → find_one by email index
+    // userName/email eq → find_by_indexes combining email + org_id at DB level
     for attr in &["userName", "email"] {
         if let Some(f) = parse_scim_filter(filter, attr)?
             && f.op == ScimFilterOp::Eq
         {
-            let doc = store.find_one::<UserDoc>("email", &f.value).await?;
-            return Ok(Some(doc.into_iter().map(ScimUserRecord::from).collect()));
+            let docs = store
+                .find_by_indexes::<UserDoc>(&[("email", &f.value), ("org_id", org_id)])
+                .await?;
+            return Ok(Some(docs.into_iter().map(ScimUserRecord::from).collect()));
         }
     }
 
-    // externalId eq → find_one by external_id index
+    // externalId eq → find_by_indexes combining external_id + org_id
     if let Some(f) = parse_scim_filter(filter, "externalId")?
         && f.op == ScimFilterOp::Eq
     {
-        let doc = store.find_one::<UserDoc>("external_id", &f.value).await?;
-        return Ok(Some(doc.into_iter().map(ScimUserRecord::from).collect()));
+        let docs = store
+            .find_by_indexes::<UserDoc>(&[("external_id", &f.value), ("org_id", org_id)])
+            .await?;
+        return Ok(Some(docs.into_iter().map(ScimUserRecord::from).collect()));
     }
 
     Ok(None)
@@ -418,20 +413,33 @@ fn match_filter_value(value: &str, filter: &ScimFilter) -> bool {
     }
 }
 
-/// Get a user by ID for SCIM.
-pub async fn get_scim_user(store: &DocumentStore, user_id: &str) -> Result<Option<ScimUserRecord>> {
-    let doc = store.get::<UserDoc>(user_id).await?;
-    Ok(doc.map(ScimUserRecord::from))
+/// Get a user by ID for SCIM, scoped to the caller's org.
+///
+/// Returns `None` if the user doesn't exist OR belongs to a different
+/// org. Treating cross-org as not-found avoids leaking existence.
+pub async fn get_scim_user(
+    store: &DocumentStore,
+    user_id: &str,
+    org_id: &str,
+) -> Result<Option<ScimUserRecord>> {
+    let Some(doc) = store.get::<UserDoc>(user_id).await? else {
+        return Ok(None);
+    };
+    if doc.data.org_id.as_deref() != Some(org_id) {
+        return Ok(None);
+    }
+    Ok(Some(ScimUserRecord::from(doc)))
 }
 
-/// Create a user via SCIM.
+/// Create a user via SCIM, bound to the given org (or org-less for
+/// the certification test path which passes `None`).
 ///
 /// Returns an error containing "UNIQUE" if a user with the same
-/// email already exists (application-level uniqueness enforcement).
-/// The duplicate check and insert run within a single transaction to
-/// prevent concurrent duplicate inserts.
+/// email already exists (application-level uniqueness enforcement,
+/// global because emails are globally unique by design).
 pub async fn create_scim_user(
     store: &DocumentStore,
+    org_id: Option<&str>,
     email: &str,
     name: Option<&str>,
     external_id: Option<&str>,
@@ -439,7 +447,6 @@ pub async fn create_scim_user(
 ) -> Result<ScimUserRecord> {
     let mut tx = store.begin().await?;
 
-    // Check for duplicates within the transaction
     if tx.find_one::<UserDoc>("email", email).await?.is_some() {
         anyhow::bail!("UNIQUE constraint failed: user with email already exists");
     }
@@ -447,7 +454,7 @@ pub async fn create_scim_user(
     let doc = UserDoc {
         email: email.to_string(),
         name: name.map(String::from),
-        org_id: None,
+        org_id: org_id.map(String::from),
         is_org_admin: false,
         active,
         external_id: external_id.map(String::from),
@@ -461,22 +468,30 @@ pub async fn create_scim_user(
     Ok(ScimUserRecord::from(result))
 }
 
-/// Update a user via SCIM.
+/// Update a user via SCIM, scoped to the caller's org.
+///
+/// Returns `Ok(false)` if the user doesn't exist OR belongs to a
+/// different org. `Ok(true)` on a successful update.
 pub async fn update_scim_user(
     store: &DocumentStore,
     user_id: &str,
+    org_id: &str,
     name: Option<&str>,
     external_id: Option<&str>,
     active: bool,
-) -> Result<()> {
-    if let Some(doc) = store.get::<UserDoc>(user_id).await? {
-        let mut data = doc.data;
-        data.name = name.map(String::from);
-        data.external_id = external_id.map(String::from);
-        data.active = active;
-        store.update(user_id, &data).await?;
+) -> Result<bool> {
+    let Some(doc) = store.get::<UserDoc>(user_id).await? else {
+        return Ok(false);
+    };
+    if doc.data.org_id.as_deref() != Some(org_id) {
+        return Ok(false);
     }
-    Ok(())
+    let mut data = doc.data;
+    data.name = name.map(String::from);
+    data.external_id = external_id.map(String::from);
+    data.active = active;
+    store.update(user_id, &data).await?;
+    Ok(true)
 }
 
 // ============================================================================
@@ -645,13 +660,15 @@ impl From<Document<ScimGroupMemberDoc>> for ScimGroupMemberRecord {
     }
 }
 
-/// Create a new SCIM group.
+/// Create a new SCIM group bound to the caller's org.
 pub async fn create_scim_group(
     store: &DocumentStore,
+    org_id: &str,
     display_name: &str,
     external_id: Option<&str>,
 ) -> Result<ScimGroupRecord> {
     let doc = ScimGroupDoc {
+        org_id: org_id.to_string(),
         display_name: display_name.to_string(),
         external_id: external_id.map(String::from),
     };
@@ -659,21 +676,31 @@ pub async fn create_scim_group(
     Ok(ScimGroupRecord::from(result))
 }
 
-/// Get a SCIM group by ID.
-pub async fn get_scim_group(store: &DocumentStore, id: &str) -> Result<Option<ScimGroupRecord>> {
-    let doc = store.get::<ScimGroupDoc>(id).await?;
-    Ok(doc.map(ScimGroupRecord::from))
+/// Get a SCIM group by ID, scoped to the caller's org.
+pub async fn get_scim_group(
+    store: &DocumentStore,
+    id: &str,
+    org_id: &str,
+) -> Result<Option<ScimGroupRecord>> {
+    let Some(doc) = store.get::<ScimGroupDoc>(id).await? else {
+        return Ok(None);
+    };
+    if doc.data.org_id != org_id {
+        return Ok(None);
+    }
+    Ok(Some(ScimGroupRecord::from(doc)))
 }
 
-/// Get a SCIM group by display name.
+/// Get a SCIM group by display name, scoped to the caller's org.
 pub async fn get_scim_group_by_name(
     store: &DocumentStore,
+    org_id: &str,
     display_name: &str,
 ) -> Result<Option<ScimGroupRecord>> {
-    let doc = store
-        .find_one::<ScimGroupDoc>("display_name", display_name)
+    let docs = store
+        .find_by_indexes::<ScimGroupDoc>(&[("display_name", display_name), ("org_id", org_id)])
         .await?;
-    Ok(doc.map(ScimGroupRecord::from))
+    Ok(docs.into_iter().next().map(ScimGroupRecord::from))
 }
 
 /// List SCIM groups with pagination.
@@ -688,73 +715,62 @@ pub async fn get_scim_group_by_name(
 /// when the computed offset exceeds 10 000.
 pub async fn list_scim_groups(
     store: &DocumentStore,
+    org_id: &str,
     filter: Option<&str>,
     start_index: usize,
     count: usize,
 ) -> Result<(Vec<ScimGroupRecord>, usize)> {
     let offset = start_index.saturating_sub(1); // SCIM 1-indexed
 
-    // Try indexed eq lookup first
     if let Some(f) = filter
-        && let Some(result) = try_indexed_group_lookup(store, f).await?
+        && let Some(result) = try_indexed_group_lookup(store, org_id, f).await?
     {
         let total = result.len();
         let page = result.into_iter().skip(offset).take(count).collect();
         return Ok((page, total));
     }
 
-    // Non-indexed filter: must load all and filter in app
-    if filter.is_some() {
-        let table_count = store.count_all::<ScimGroupDoc>().await?;
-        if table_count > 10_000 {
-            return Err(ScimFilterError::FilterTooBroad.into());
-        }
-        let all_docs = store.list_all::<ScimGroupDoc>().await?;
-        let mut records: Vec<ScimGroupRecord> =
-            all_docs.into_iter().map(ScimGroupRecord::from).collect();
-        if let Some(f) = filter {
-            records = apply_scim_group_filter(records, f)?;
-        }
-        records.sort_by_key(|b| std::cmp::Reverse(b.created_at));
-        let total = records.len();
-        let page = records.into_iter().skip(offset).take(count).collect();
-        return Ok((page, total));
-    }
+    let mut records: Vec<ScimGroupRecord> = store
+        .find_all::<ScimGroupDoc>("org_id", org_id)
+        .await?
+        .into_iter()
+        .map(ScimGroupRecord::from)
+        .collect();
 
-    // No filter: use DB-level pagination with count
-    if offset > 10_000 {
-        return Err(ScimFilterError::OffsetTooLarge.into());
+    if records.len() > 10_000 {
+        return Err(ScimFilterError::FilterTooBroad.into());
     }
-    let (docs, total_count) = store
-        .list_all_paginated_with_count::<ScimGroupDoc>(offset as u64, count as u64)
-        .await?;
-    Ok((
-        docs.into_iter().map(ScimGroupRecord::from).collect(),
-        usize::try_from(total_count).context("SCIM group total_count out of range")?,
-    ))
+    if let Some(f) = filter {
+        records = apply_scim_group_filter(records, f)?;
+    }
+    records.sort_by_key(|b| std::cmp::Reverse(b.created_at));
+    let total = records.len();
+    let page = records.into_iter().skip(offset).take(count).collect();
+    Ok((page, total))
 }
 
-/// Try indexed eq lookups for SCIM group filters.
+/// Try indexed eq lookups for SCIM group filters, scoped to org.
 async fn try_indexed_group_lookup(
     store: &DocumentStore,
+    org_id: &str,
     filter: &str,
 ) -> Result<Option<Vec<ScimGroupRecord>>> {
     if let Some(f) = parse_scim_filter(filter, "displayName")?
         && f.op == ScimFilterOp::Eq
     {
-        let doc = store
-            .find_one::<ScimGroupDoc>("display_name", &f.value)
+        let docs = store
+            .find_by_indexes::<ScimGroupDoc>(&[("display_name", &f.value), ("org_id", org_id)])
             .await?;
-        return Ok(Some(doc.into_iter().map(ScimGroupRecord::from).collect()));
+        return Ok(Some(docs.into_iter().map(ScimGroupRecord::from).collect()));
     }
 
     if let Some(f) = parse_scim_filter(filter, "externalId")?
         && f.op == ScimFilterOp::Eq
     {
-        let doc = store
-            .find_one::<ScimGroupDoc>("external_id", &f.value)
+        let docs = store
+            .find_by_indexes::<ScimGroupDoc>(&[("external_id", &f.value), ("org_id", org_id)])
             .await?;
-        return Ok(Some(doc.into_iter().map(ScimGroupRecord::from).collect()));
+        return Ok(Some(docs.into_iter().map(ScimGroupRecord::from).collect()));
     }
 
     Ok(None)
@@ -786,54 +802,76 @@ fn apply_scim_group_filter(
     Ok(records)
 }
 
-/// Update a SCIM group.
+/// Update a SCIM group, scoped to the caller's org.
+///
+/// Returns `Ok(false)` if the group doesn't exist OR belongs to a
+/// different org.
 pub async fn update_scim_group(
     store: &DocumentStore,
     id: &str,
+    org_id: &str,
     display_name: Option<&str>,
     external_id: Option<&str>,
-) -> Result<()> {
-    if let Some(doc) = store.get::<ScimGroupDoc>(id).await? {
-        let mut data = doc.data;
-        if let Some(name) = display_name {
-            data.display_name = name.to_string();
-        }
-        if let Some(ext_id) = external_id {
-            data.external_id = Some(ext_id.to_string());
-        }
-        store.update(id, &data).await?;
+) -> Result<bool> {
+    let Some(doc) = store.get::<ScimGroupDoc>(id).await? else {
+        return Ok(false);
+    };
+    if doc.data.org_id != org_id {
+        return Ok(false);
     }
-    Ok(())
+    let mut data = doc.data;
+    if let Some(name) = display_name {
+        data.display_name = name.to_string();
+    }
+    if let Some(ext_id) = external_id {
+        data.external_id = Some(ext_id.to_string());
+    }
+    store.update(id, &data).await?;
+    Ok(true)
 }
 
-/// Delete a SCIM group atomically.
+/// Delete a SCIM group atomically, scoped to the caller's org.
 ///
-/// Performs application-level cascade within a single transaction:
-/// deletes group memberships first, then the group itself.
-pub async fn delete_scim_group(store: &DocumentStore, id: &str) -> Result<bool> {
+/// Returns `Ok(false)` if the group doesn't exist OR belongs to a
+/// different org. Otherwise deletes memberships and the group within
+/// a single transaction.
+pub async fn delete_scim_group(store: &DocumentStore, id: &str, org_id: &str) -> Result<bool> {
     let mut tx = store.begin().await?;
 
-    // 1. Delete group memberships
-    tx.delete_by_index::<ScimGroupMemberDoc>("group_id", id)
-        .await?;
-
-    // 2. Delete the group
-    let existed = tx.get::<ScimGroupDoc>(id).await?.is_some();
-    if existed {
-        tx.delete(id).await?;
+    let Some(doc) = tx.get::<ScimGroupDoc>(id).await? else {
+        return Ok(false);
+    };
+    if doc.data.org_id != org_id {
+        return Ok(false);
     }
 
+    tx.delete_by_index::<ScimGroupMemberDoc>("group_id", id)
+        .await?;
+    tx.delete(id).await?;
+
     tx.commit().await?;
-    Ok(existed)
+    Ok(true)
 }
 
-/// Add a member to a SCIM group.
+/// Add a member to a SCIM group, scoped to the caller's org.
+///
+/// Verifies the group is in the caller's org (single indexed lookup,
+/// not per-user) and then inserts the membership row. Cross-org
+/// `user_id` values become inert references — they are filtered out
+/// when reading the group's members.
+///
+/// Returns `Ok(false)` if the group doesn't exist OR belongs to a
+/// different org.
 pub async fn add_scim_group_member(
     store: &DocumentStore,
     group_id: &str,
+    org_id: &str,
     user_id: &str,
-) -> Result<()> {
-    // Check if already a member (idempotent)
+) -> Result<bool> {
+    if get_scim_group(store, group_id, org_id).await?.is_none() {
+        return Ok(false);
+    }
+
     let existing = store
         .find_by_indexes::<ScimGroupMemberDoc>(&[("group_id", group_id), ("user_id", user_id)])
         .await?;
@@ -846,15 +884,23 @@ pub async fn add_scim_group_member(
         store.insert(&doc).await?;
     }
 
-    Ok(())
+    Ok(true)
 }
 
-/// Remove a member from a SCIM group.
+/// Remove a member from a SCIM group, scoped to the caller's org.
+///
+/// Returns `Ok(false)` if the group doesn't exist, belongs to a
+/// different org, or the user is not a member.
 pub async fn remove_scim_group_member(
     store: &DocumentStore,
     group_id: &str,
+    org_id: &str,
     user_id: &str,
 ) -> Result<bool> {
+    if get_scim_group(store, group_id, org_id).await?.is_none() {
+        return Ok(false);
+    }
+
     let existing = store
         .find_by_indexes::<ScimGroupMemberDoc>(&[("group_id", group_id), ("user_id", user_id)])
         .await?;
@@ -866,30 +912,45 @@ pub async fn remove_scim_group_member(
     Ok(false)
 }
 
-/// Get all members of a SCIM group.
+/// Get all members of a SCIM group, scoped to the caller's org.
+///
+/// Returns the group's members filtered to those that belong to the
+/// caller's org. Cross-org user_ids in the membership table (from
+/// shadow-add attempts) are silently filtered out at read time.
+///
+/// Returns `Ok(None)` if the group doesn't exist OR belongs to a
+/// different org.
 pub async fn get_scim_group_members(
     store: &DocumentStore,
     group_id: &str,
-) -> Result<Vec<ScimUserRecord>> {
+    org_id: &str,
+) -> Result<Option<Vec<ScimUserRecord>>> {
+    if get_scim_group(store, group_id, org_id).await?.is_none() {
+        return Ok(None);
+    }
+
     let member_docs = store
         .find_all::<ScimGroupMemberDoc>("group_id", group_id)
         .await?;
 
     let mut users = Vec::with_capacity(member_docs.len());
     for member in &member_docs {
-        if let Some(user_doc) = store.get::<UserDoc>(&member.data.user_id).await? {
+        if let Some(user_doc) = store.get::<UserDoc>(&member.data.user_id).await?
+            && user_doc.data.org_id.as_deref() == Some(org_id)
+        {
             users.push(ScimUserRecord::from(user_doc));
         }
     }
 
     users.sort_by(|a, b| a.email.cmp(&b.email));
-    Ok(users)
+    Ok(Some(users))
 }
 
-/// Get all groups a user belongs to.
+/// Get all groups a user belongs to, scoped to the caller's org.
 pub async fn get_user_scim_groups(
     store: &DocumentStore,
     user_id: &str,
+    org_id: &str,
 ) -> Result<Vec<ScimGroupRecord>> {
     let member_docs = store
         .find_all::<ScimGroupMemberDoc>("user_id", user_id)
@@ -897,7 +958,9 @@ pub async fn get_user_scim_groups(
 
     let mut groups = Vec::with_capacity(member_docs.len());
     for member in &member_docs {
-        if let Some(group_doc) = store.get::<ScimGroupDoc>(&member.data.group_id).await? {
+        if let Some(group_doc) = store.get::<ScimGroupDoc>(&member.data.group_id).await?
+            && group_doc.data.org_id == org_id
+        {
             groups.push(ScimGroupRecord::from(group_doc));
         }
     }
@@ -906,22 +969,30 @@ pub async fn get_user_scim_groups(
     Ok(groups)
 }
 
-/// Replace all members of a SCIM group atomically.
+/// Replace all members of a SCIM group atomically, scoped to the
+/// caller's org.
 ///
-/// Deletes all existing members and inserts the new list within a
-/// single transaction so the group is never left in a partial state.
+/// Verifies the group is in the caller's org (single indexed lookup,
+/// not per-user). Cross-org `user_id` values in `user_ids` become
+/// inert references that are filtered out at read time.
+///
+/// Returns `Ok(false)` if the group doesn't exist OR belongs to a
+/// different org.
 pub async fn replace_scim_group_members(
     store: &DocumentStore,
     group_id: &str,
+    org_id: &str,
     user_ids: &[String],
-) -> Result<()> {
+) -> Result<bool> {
+    if get_scim_group(store, group_id, org_id).await?.is_none() {
+        return Ok(false);
+    }
+
     let mut tx = store.begin().await?;
 
-    // Delete all existing members
     tx.delete_by_index::<ScimGroupMemberDoc>("group_id", group_id)
         .await?;
 
-    // Insert new members
     for user_id in user_ids {
         let doc = ScimGroupMemberDoc {
             group_id: group_id.to_string(),
@@ -931,5 +1002,5 @@ pub async fn replace_scim_group_members(
     }
 
     tx.commit().await?;
-    Ok(())
+    Ok(true)
 }

--- a/crates/vouch-server/src/db/store.rs
+++ b/crates/vouch-server/src/db/store.rs
@@ -1099,48 +1099,14 @@ impl DocumentStore {
     ///
     /// Callers must validate `offset` before calling; large offsets
     /// will degrade performance on big tables.
-    pub async fn list_all_paginated_with_count<T: DocumentType>(
-        &self,
-        offset: u64,
-        limit: u64,
-    ) -> Result<(Vec<Document<T>>, i64)> {
-        let stmt = Query::select()
-            .columns(DOC_COLUMNS)
-            .expr_as(
-                Expr::cust("COUNT(*) OVER()"),
-                sea_query::Alias::new("total_count"),
-            )
-            .from(Documents::Table)
-            .and_where(Expr::col(Documents::DocType).eq(T::DOC_TYPE))
-            .order_by(Documents::Id, Order::Asc)
-            .offset(offset)
-            .limit(limit)
-            .to_owned();
-
-        let rows: Vec<RawDocumentRow> = crate::db_fetch_all!(&self.pool, stmt, RawDocumentRow)?;
-
-        let total_count = if let Some(total) = rows.first().and_then(|r| r.total_count) {
-            total
-        } else {
-            // OFFSET can produce an empty page even when matching rows exist.
-            self.count_all::<T>().await?
-        };
-
-        let mut results = Vec::with_capacity(rows.len());
-        for row in rows {
-            results.push(raw_to_document::<T>(&self.crypto, row)?);
-        }
-        Ok((results, total_count))
-    }
-
     /// Find documents matching an indexed field with offset pagination
     /// and a total count, all in one query.
     ///
-    /// Uses the same `COUNT(*) OVER()` window function as
-    /// [`list_all_paginated_with_count`] so callers get total count for
-    /// SCIM-style `totalResults` without a separate query, and the page
-    /// is bounded by `limit` so an org with millions of rows doesn't
-    /// load everything into memory.
+    /// Uses a `COUNT(*) OVER()` window function so callers get the
+    /// total matching row count alongside the page (for SCIM-style
+    /// `totalResults`) without a second query, and the result set is
+    /// bounded by `limit` so an org with millions of rows does not
+    /// load every match into memory.
     ///
     /// Results ordered by `id ASC` (UUIDv7 = insertion order).
     ///
@@ -2215,26 +2181,6 @@ mod tests {
             .unwrap();
         assert_eq!(page3.len(), 1);
         assert!(!has_more3);
-    }
-
-    #[tokio::test]
-    async fn list_all_paginated_with_count_preserves_total_past_end() {
-        let store = test_store().await;
-
-        for i in 0..3 {
-            let doc = TestDoc {
-                name: format!("offset-count-{i}"),
-                value: i,
-            };
-            store.insert(&doc).await.unwrap();
-        }
-
-        let (page, total_count) = store
-            .list_all_paginated_with_count::<TestDoc>(10, 2)
-            .await
-            .unwrap();
-        assert!(page.is_empty());
-        assert_eq!(total_count, 3);
     }
 
     #[tokio::test]

--- a/crates/vouch-server/src/db/store.rs
+++ b/crates/vouch-server/src/db/store.rs
@@ -1132,6 +1132,65 @@ impl DocumentStore {
         }
         Ok((results, total_count))
     }
+
+    /// Find documents matching an indexed field with offset pagination
+    /// and a total count, all in one query.
+    ///
+    /// Uses the same `COUNT(*) OVER()` window function as
+    /// [`list_all_paginated_with_count`] so callers get total count for
+    /// SCIM-style `totalResults` without a separate query, and the page
+    /// is bounded by `limit` so an org with millions of rows doesn't
+    /// load everything into memory.
+    ///
+    /// Results ordered by `id ASC` (UUIDv7 = insertion order).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if decryption or deserialization fails.
+    pub async fn find_paginated_with_count<T: DocumentType>(
+        &self,
+        field: &str,
+        value: &str,
+        offset: u64,
+        limit: u64,
+    ) -> Result<(Vec<Document<T>>, i64)> {
+        let index_cond = index_value_condition(&*self.crypto, value);
+
+        let stmt = Query::select()
+            .columns(DOC_TABLE_COLUMNS)
+            .expr_as(
+                Expr::cust("COUNT(*) OVER()"),
+                sea_query::Alias::new("total_count"),
+            )
+            .from(Documents::Table)
+            .inner_join(
+                DocumentIndexes::Table,
+                Expr::col((Documents::Table, Documents::Id))
+                    .equals((DocumentIndexes::Table, DocumentIndexes::DocumentId)),
+            )
+            .and_where(Expr::col((Documents::Table, Documents::DocType)).eq(T::DOC_TYPE))
+            .and_where(Expr::col((DocumentIndexes::Table, DocumentIndexes::IndexField)).eq(field))
+            .and_where(index_cond)
+            .order_by((Documents::Table, Documents::Id), Order::Asc)
+            .offset(offset)
+            .limit(limit)
+            .to_owned();
+
+        let rows: Vec<RawDocumentRow> = crate::db_fetch_all!(&self.pool, stmt, RawDocumentRow)?;
+
+        let total_count = if let Some(total) = rows.first().and_then(|r| r.total_count) {
+            total
+        } else {
+            // OFFSET can produce an empty page even when matching rows exist.
+            self.count::<T>(field, value).await?
+        };
+
+        let mut results = Vec::with_capacity(rows.len());
+        for row in rows {
+            results.push(raw_to_document::<T>(&self.crypto, row)?);
+        }
+        Ok((results, total_count))
+    }
 }
 
 // Implement Debug manually to avoid exposing crypto internals.

--- a/crates/vouch-server/src/db/store.rs
+++ b/crates/vouch-server/src/db/store.rs
@@ -1083,22 +1083,6 @@ impl DocumentStore {
         Ok((results, has_more))
     }
 
-    /// List documents with OFFSET pagination and a total count in one query.
-    ///
-    /// Uses `COUNT(*) OVER()` window function to return the total matching row
-    /// count alongside the page results. Offset is capped at 10,000; requests
-    /// beyond that return an error.
-    ///
-    /// Results are ordered by `id ASC` (UUIDv7 = insertion order).
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if decryption or deserialization fails.
-    ///
-    /// # Panics safety
-    ///
-    /// Callers must validate `offset` before calling; large offsets
-    /// will degrade performance on big tables.
     /// Find documents matching an indexed field with offset pagination
     /// and a total count, all in one query.
     ///

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -1194,6 +1194,8 @@ async fn test_oauth_usage_recording() {
 // SCIM User Tests (RFC 7643/7644)
 // ========================================================================
 
+const TEST_ORG_ID: &str = "test-org";
+
 #[tokio::test]
 async fn test_scim_user_crud() {
     let (store, _audit) = test_db().await;
@@ -1201,6 +1203,7 @@ async fn test_scim_user_crud() {
     // Create SCIM user
     let user = create_scim_user(
         &store,
+        Some(TEST_ORG_ID),
         "scim@example.com",
         Some("SCIM User"),
         Some("ext-123"),
@@ -1216,16 +1219,17 @@ async fn test_scim_user_crud() {
     assert!(user.active);
 
     // Get SCIM user
-    let fetched = get_scim_user(&store, &user.id)
+    let fetched = get_scim_user(&store, &user.id, TEST_ORG_ID)
         .await
         .expect("Failed to get SCIM user")
         .expect("User should exist");
     assert_eq!(fetched.email, "scim@example.com");
 
     // Update SCIM user
-    update_scim_user(
+    let _ = update_scim_user(
         &store,
         &user.id,
+        TEST_ORG_ID,
         Some("Updated Name"),
         Some("ext-456"),
         false,
@@ -1233,7 +1237,7 @@ async fn test_scim_user_crud() {
     .await
     .expect("Failed to update SCIM user");
 
-    let updated = get_scim_user(&store, &user.id)
+    let updated = get_scim_user(&store, &user.id, TEST_ORG_ID)
         .await
         .expect("Failed to get user")
         .expect("User should exist");
@@ -1248,32 +1252,45 @@ async fn test_scim_user_list_and_filter() {
 
     // Create multiple users
     for i in 0..5 {
-        create_scim_user(&store, &format!("user{}@example.com", i), None, None, true)
-            .await
-            .expect("Failed to create user");
+        create_scim_user(
+            &store,
+            Some(TEST_ORG_ID),
+            &format!("user{}@example.com", i),
+            None,
+            None,
+            true,
+        )
+        .await
+        .expect("Failed to create user");
     }
 
     // List all users
-    let (users, total) = list_scim_users(&store, None, 1, 100)
+    let (users, total) = list_scim_users(&store, TEST_ORG_ID, None, 1, 100)
         .await
         .expect("Failed to list users");
     assert_eq!(users.len(), 5);
     assert_eq!(total, 5);
 
     // Filter by userName (email)
-    let (users, _) = list_scim_users(&store, Some("userName eq \"user2@example.com\""), 1, 100)
-        .await
-        .expect("Failed to filter users");
+    let (users, _) = list_scim_users(
+        &store,
+        TEST_ORG_ID,
+        Some("userName eq \"user2@example.com\""),
+        1,
+        100,
+    )
+    .await
+    .expect("Failed to filter users");
     assert_eq!(users.len(), 1);
     assert_eq!(users[0].email, "user2@example.com");
 
     // Pagination
-    let (page1, _) = list_scim_users(&store, None, 1, 2)
+    let (page1, _) = list_scim_users(&store, TEST_ORG_ID, None, 1, 2)
         .await
         .expect("Failed to paginate");
     assert_eq!(page1.len(), 2);
 
-    let (page2, _) = list_scim_users(&store, None, 3, 2)
+    let (page2, _) = list_scim_users(&store, TEST_ORG_ID, None, 3, 2)
         .await
         .expect("Failed to paginate");
     assert_eq!(page2.len(), 2);
@@ -1284,9 +1301,16 @@ async fn test_scim_session_invalidation_on_deactivation() {
     let (store, _audit) = test_db().await;
 
     // Create user with session
-    let user = create_scim_user(&store, "invalidate@example.com", None, None, true)
-        .await
-        .expect("Failed to create user");
+    let user = create_scim_user(
+        &store,
+        Some(TEST_ORG_ID),
+        "invalidate@example.com",
+        None,
+        None,
+        true,
+    )
+    .await
+    .expect("Failed to create user");
 
     // Create authenticator (with user_email parameter)
     let auth_id = create_authenticator(
@@ -2023,12 +2047,27 @@ async fn test_create_scim_user_duplicate_email_rejected() {
     let (store, _audit) = test_db().await;
 
     // First creation succeeds
-    create_scim_user(&store, "dup@example.com", Some("Original"), None, true)
-        .await
-        .expect("First creation should succeed");
+    create_scim_user(
+        &store,
+        Some(TEST_ORG_ID),
+        "dup@example.com",
+        Some("Original"),
+        None,
+        true,
+    )
+    .await
+    .expect("First creation should succeed");
 
     // Second creation with the same email must fail with a UNIQUE error
-    let result = create_scim_user(&store, "dup@example.com", Some("Duplicate"), None, true).await;
+    let result = create_scim_user(
+        &store,
+        Some(TEST_ORG_ID),
+        "dup@example.com",
+        Some("Duplicate"),
+        None,
+        true,
+    )
+    .await;
     assert!(result.is_err(), "Duplicate email should be rejected");
     let err = result.unwrap_err();
     assert!(
@@ -2046,7 +2085,7 @@ async fn test_scim_group_lifecycle() {
     let (store, _audit) = test_db().await;
 
     // Create
-    let group = create_scim_group(&store, "Engineering", Some("ext-grp-1"))
+    let group = create_scim_group(&store, TEST_ORG_ID, "Engineering", Some("ext-grp-1"))
         .await
         .expect("create_scim_group failed");
     assert!(!group.id.is_empty());
@@ -2054,24 +2093,30 @@ async fn test_scim_group_lifecycle() {
     assert_eq!(group.external_id.as_deref(), Some("ext-grp-1"));
 
     // Get by ID
-    let fetched = get_scim_group(&store, &group.id)
+    let fetched = get_scim_group(&store, &group.id, TEST_ORG_ID)
         .await
         .expect("get_scim_group failed")
         .expect("group should exist");
     assert_eq!(fetched.display_name, "Engineering");
 
     // Get by display name
-    let by_name = get_scim_group_by_name(&store, "Engineering")
+    let by_name = get_scim_group_by_name(&store, TEST_ORG_ID, "Engineering")
         .await
         .expect("get_scim_group_by_name failed")
         .expect("should find by name");
     assert_eq!(by_name.id, group.id);
 
     // Update
-    update_scim_group(&store, &group.id, Some("Platform"), Some("ext-grp-2"))
-        .await
-        .expect("update_scim_group failed");
-    let updated = get_scim_group(&store, &group.id)
+    let _ = update_scim_group(
+        &store,
+        &group.id,
+        TEST_ORG_ID,
+        Some("Platform"),
+        Some("ext-grp-2"),
+    )
+    .await
+    .expect("update_scim_group failed");
+    let updated = get_scim_group(&store, &group.id, TEST_ORG_ID)
         .await
         .expect("get_scim_group failed")
         .expect("group should still exist");
@@ -2079,26 +2124,26 @@ async fn test_scim_group_lifecycle() {
     assert_eq!(updated.external_id.as_deref(), Some("ext-grp-2"));
 
     // List
-    let (groups, total) = list_scim_groups(&store, None, 1, 100)
+    let (groups, total) = list_scim_groups(&store, TEST_ORG_ID, None, 1, 100)
         .await
         .expect("list_scim_groups failed");
     assert_eq!(groups.len(), 1);
     assert_eq!(total, 1);
 
     // Delete
-    let deleted = delete_scim_group(&store, &group.id)
+    let deleted = delete_scim_group(&store, &group.id, TEST_ORG_ID)
         .await
         .expect("delete_scim_group failed");
     assert!(deleted);
 
     // Gone
-    let missing = get_scim_group(&store, &group.id)
+    let missing = get_scim_group(&store, &group.id, TEST_ORG_ID)
         .await
         .expect("query should succeed");
     assert!(missing.is_none());
 
     // Delete again returns false
-    let deleted_again = delete_scim_group(&store, &group.id)
+    let deleted_again = delete_scim_group(&store, &group.id, TEST_ORG_ID)
         .await
         .expect("delete should not error");
     assert!(!deleted_again);
@@ -2108,32 +2153,41 @@ async fn test_scim_group_lifecycle() {
 async fn test_scim_group_member_add_remove() {
     let (store, _audit) = test_db().await;
 
-    let group = create_scim_group(&store, "Beta", None)
+    let group = create_scim_group(&store, TEST_ORG_ID, "Beta", None)
         .await
         .expect("create group");
-    let user = create_scim_user(&store, "member@example.com", None, None, true)
-        .await
-        .expect("create user");
+    let user = create_scim_user(
+        &store,
+        Some(TEST_ORG_ID),
+        "member@example.com",
+        None,
+        None,
+        true,
+    )
+    .await
+    .expect("create user");
 
     // Add member
-    add_scim_group_member(&store, &group.id, &user.id)
+    let _ = add_scim_group_member(&store, &group.id, TEST_ORG_ID, &user.id)
         .await
         .expect("add_scim_group_member failed");
 
     // Member appears in group
-    let members = get_scim_group_members(&store, &group.id)
+    let members = get_scim_group_members(&store, &group.id, TEST_ORG_ID)
         .await
-        .expect("get_scim_group_members failed");
+        .expect("get_scim_group_members failed")
+        .unwrap_or_default();
     assert_eq!(members.len(), 1);
     assert_eq!(members[0].id, user.id);
 
     // Add again is idempotent
-    add_scim_group_member(&store, &group.id, &user.id)
+    let _ = add_scim_group_member(&store, &group.id, TEST_ORG_ID, &user.id)
         .await
         .expect("idempotent add failed");
-    let members_after = get_scim_group_members(&store, &group.id)
+    let members_after = get_scim_group_members(&store, &group.id, TEST_ORG_ID)
         .await
-        .expect("get members");
+        .expect("get members")
+        .unwrap_or_default();
     assert_eq!(
         members_after.len(),
         1,
@@ -2141,26 +2195,27 @@ async fn test_scim_group_member_add_remove() {
     );
 
     // User's groups
-    let user_groups = get_user_scim_groups(&store, &user.id)
+    let user_groups = get_user_scim_groups(&store, &user.id, TEST_ORG_ID)
         .await
         .expect("get_user_scim_groups failed");
     assert_eq!(user_groups.len(), 1);
     assert_eq!(user_groups[0].id, group.id);
 
     // Remove member
-    let removed = remove_scim_group_member(&store, &group.id, &user.id)
+    let removed = remove_scim_group_member(&store, &group.id, TEST_ORG_ID, &user.id)
         .await
         .expect("remove_scim_group_member failed");
     assert!(removed);
 
     // Group is now empty
-    let members_final = get_scim_group_members(&store, &group.id)
+    let members_final = get_scim_group_members(&store, &group.id, TEST_ORG_ID)
         .await
-        .expect("get members after remove");
+        .expect("get members after remove")
+        .unwrap_or_default();
     assert!(members_final.is_empty());
 
     // Remove again returns false
-    let removed_again = remove_scim_group_member(&store, &group.id, &user.id)
+    let removed_again = remove_scim_group_member(&store, &group.id, TEST_ORG_ID, &user.id)
         .await
         .expect("remove should not error");
     assert!(!removed_again);
@@ -2170,45 +2225,79 @@ async fn test_scim_group_member_add_remove() {
 async fn test_scim_group_replace_members() {
     let (store, _audit) = test_db().await;
 
-    let group = create_scim_group(&store, "Gamma", None)
+    let group = create_scim_group(&store, TEST_ORG_ID, "Gamma", None)
         .await
         .expect("create group");
-    let user1 = create_scim_user(&store, "u1@example.com", None, None, true)
-        .await
-        .expect("create user1");
-    let user2 = create_scim_user(&store, "u2@example.com", None, None, true)
-        .await
-        .expect("create user2");
-    let user3 = create_scim_user(&store, "u3@example.com", None, None, true)
-        .await
-        .expect("create user3");
+    let user1 = create_scim_user(
+        &store,
+        Some(TEST_ORG_ID),
+        "u1@example.com",
+        None,
+        None,
+        true,
+    )
+    .await
+    .expect("create user1");
+    let user2 = create_scim_user(
+        &store,
+        Some(TEST_ORG_ID),
+        "u2@example.com",
+        None,
+        None,
+        true,
+    )
+    .await
+    .expect("create user2");
+    let user3 = create_scim_user(
+        &store,
+        Some(TEST_ORG_ID),
+        "u3@example.com",
+        None,
+        None,
+        true,
+    )
+    .await
+    .expect("create user3");
 
     // Start with user1 and user2
-    replace_scim_group_members(&store, &group.id, &[user1.id.clone(), user2.id.clone()])
+    let _ = replace_scim_group_members(
+        &store,
+        &group.id,
+        TEST_ORG_ID,
+        &[user1.id.clone(), user2.id.clone()],
+    )
+    .await
+    .expect("replace members");
+    let members = get_scim_group_members(&store, &group.id, TEST_ORG_ID)
         .await
-        .expect("replace members");
-    let members = get_scim_group_members(&store, &group.id)
-        .await
-        .expect("get members");
+        .expect("get members")
+        .unwrap_or_default();
     assert_eq!(members.len(), 2);
 
     // Replace with just user3
-    replace_scim_group_members(&store, &group.id, std::slice::from_ref(&user3.id))
+    let _ = replace_scim_group_members(
+        &store,
+        &group.id,
+        TEST_ORG_ID,
+        std::slice::from_ref(&user3.id),
+    )
+    .await
+    .expect("replace members");
+    let members_after = get_scim_group_members(&store, &group.id, TEST_ORG_ID)
         .await
-        .expect("replace members");
-    let members_after = get_scim_group_members(&store, &group.id)
-        .await
-        .expect("get members");
+        .expect("get members")
+        .unwrap_or_default();
     assert_eq!(members_after.len(), 1);
     assert_eq!(members_after[0].id, user3.id);
 
     // Replace with empty list
-    replace_scim_group_members(&store, &group.id, &[])
+    let _ = replace_scim_group_members(&store, &group.id, TEST_ORG_ID, &[])
         .await
         .expect("replace with empty");
-    let empty = get_scim_group_members(&store, &group.id)
+    let empty = get_scim_group_members(&store, &group.id, TEST_ORG_ID)
         .await
-        .expect("get members");
+        .expect("get members")
+        .unwrap_or_default();
     assert!(empty.is_empty());
 }
 
@@ -2216,31 +2305,40 @@ async fn test_scim_group_replace_members() {
 async fn test_scim_group_delete_cascades_members() {
     let (store, _audit) = test_db().await;
 
-    let group = create_scim_group(&store, "ToBeCascaded", None)
+    let group = create_scim_group(&store, TEST_ORG_ID, "ToBeCascaded", None)
         .await
         .expect("create group");
-    let user = create_scim_user(&store, "cascade-member@example.com", None, None, true)
-        .await
-        .expect("create user");
+    let user = create_scim_user(
+        &store,
+        Some(TEST_ORG_ID),
+        "cascade-member@example.com",
+        None,
+        None,
+        true,
+    )
+    .await
+    .expect("create user");
 
-    add_scim_group_member(&store, &group.id, &user.id)
+    let _ = add_scim_group_member(&store, &group.id, TEST_ORG_ID, &user.id)
         .await
         .expect("add member");
 
     // Delete the group
-    delete_scim_group(&store, &group.id)
+    let _ = delete_scim_group(&store, &group.id, TEST_ORG_ID)
         .await
         .expect("delete group");
 
     // User should still exist
-    let user_exists = get_scim_user(&store, &user.id).await.expect("query user");
+    let user_exists = get_scim_user(&store, &user.id, TEST_ORG_ID)
+        .await
+        .expect("query user");
     assert!(
         user_exists.is_some(),
         "user should not be deleted when group is deleted"
     );
 
     // User's group memberships should be cleaned up
-    let user_groups = get_user_scim_groups(&store, &user.id)
+    let user_groups = get_user_scim_groups(&store, &user.id, TEST_ORG_ID)
         .await
         .expect("get user groups");
     assert!(
@@ -2646,18 +2744,39 @@ fn test_scim_filter_parse_no_match_for_other_attribute() {
 async fn test_scim_user_list_filter_co_operator() {
     let (store, _audit) = test_db().await;
 
-    create_scim_user(&store, "alice@example.com", None, None, true)
-        .await
-        .expect("create alice");
-    create_scim_user(&store, "bob@example.com", None, None, true)
-        .await
-        .expect("create bob");
-    create_scim_user(&store, "alicia@example.com", None, None, true)
-        .await
-        .expect("create alicia");
+    create_scim_user(
+        &store,
+        Some(TEST_ORG_ID),
+        "alice@example.com",
+        None,
+        None,
+        true,
+    )
+    .await
+    .expect("create alice");
+    create_scim_user(
+        &store,
+        Some(TEST_ORG_ID),
+        "bob@example.com",
+        None,
+        None,
+        true,
+    )
+    .await
+    .expect("create bob");
+    create_scim_user(
+        &store,
+        Some(TEST_ORG_ID),
+        "alicia@example.com",
+        None,
+        None,
+        true,
+    )
+    .await
+    .expect("create alicia");
 
     // "userName co \"alic\"" should match alice and alicia
-    let (results, _) = list_scim_users(&store, Some(r#"userName co "alic""#), 1, 100)
+    let (results, _) = list_scim_users(&store, TEST_ORG_ID, Some(r#"userName co "alic""#), 1, 100)
         .await
         .expect("list_scim_users failed");
     assert_eq!(
@@ -2675,18 +2794,39 @@ async fn test_scim_user_list_filter_co_operator() {
 async fn test_scim_user_list_filter_sw_operator() {
     let (store, _audit) = test_db().await;
 
-    create_scim_user(&store, "zara@example.com", None, None, true)
-        .await
-        .expect("create zara");
-    create_scim_user(&store, "zebra@example.com", None, None, true)
-        .await
-        .expect("create zebra");
-    create_scim_user(&store, "anna@example.com", None, None, true)
-        .await
-        .expect("create anna");
+    create_scim_user(
+        &store,
+        Some(TEST_ORG_ID),
+        "zara@example.com",
+        None,
+        None,
+        true,
+    )
+    .await
+    .expect("create zara");
+    create_scim_user(
+        &store,
+        Some(TEST_ORG_ID),
+        "zebra@example.com",
+        None,
+        None,
+        true,
+    )
+    .await
+    .expect("create zebra");
+    create_scim_user(
+        &store,
+        Some(TEST_ORG_ID),
+        "anna@example.com",
+        None,
+        None,
+        true,
+    )
+    .await
+    .expect("create anna");
 
     // "userName sw \"ze\"" should match zara? no — "ze" prefix: zebra matches, zara does not.
-    let (results, _) = list_scim_users(&store, Some(r#"userName sw "ze""#), 1, 100)
+    let (results, _) = list_scim_users(&store, TEST_ORG_ID, Some(r#"userName sw "ze""#), 1, 100)
         .await
         .expect("list_scim_users failed");
     assert_eq!(results.len(), 1, "sw filter should match zebra only");

--- a/crates/vouch-server/src/handlers/certification.rs
+++ b/crates/vouch-server/src/handlers/certification.rs
@@ -272,6 +272,7 @@ async fn get_or_create_cert_user(state: &Arc<AppState>) -> anyhow::Result<db::Us
     // Create new cert user via SCIM (no cfg gate, no special permissions).
     if let Err(e) = db::create_scim_user(
         &state.store,
+        None,
         CERT_USER_EMAIL,
         Some("Certification Test User"),
         Some("cert-test"),

--- a/crates/vouch-server/src/handlers/scim/groups.rs
+++ b/crates/vouch-server/src/handlers/scim/groups.rs
@@ -44,45 +44,51 @@ pub async fn list_groups(
     }
 
     // Get groups from database (returns page + total count in one call)
-    let (groups, total) =
-        match db::list_scim_groups(&state.store, query.filter.as_deref(), start_index, count).await
-        {
-            Ok(result) => result,
-            Err(e) => {
-                if let Some(filter_err) = e.downcast_ref::<ScimFilterError>() {
-                    let (detail, error_type) = match filter_err {
-                        ScimFilterError::UnsupportedOperator(_) => {
-                            tracing::debug!("SCIM filter parse error: {e}");
-                            ("Invalid filter expression", "invalidFilter")
-                        }
-                        ScimFilterError::FilterTooBroad => (
-                            "Filter is too broad; add a more specific filter",
-                            "invalidFilter",
-                        ),
-                        ScimFilterError::OffsetTooLarge => (
-                            "startIndex is too large; maximum supported offset is 10000",
-                            "invalidValue",
-                        ),
-                    };
-                    return (
-                        StatusCode::BAD_REQUEST,
-                        Json(ScimError::new(400, detail).with_type(error_type)),
-                    )
-                        .into_response();
-                }
-                tracing::error!("Failed to list groups: {e}");
+    let (groups, total) = match db::list_scim_groups(
+        &state.store,
+        &auth.org_id,
+        query.filter.as_deref(),
+        start_index,
+        count,
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(e) => {
+            if let Some(filter_err) = e.downcast_ref::<ScimFilterError>() {
+                let (detail, error_type) = match filter_err {
+                    ScimFilterError::UnsupportedOperator(_) => {
+                        tracing::debug!("SCIM filter parse error: {e}");
+                        ("Invalid filter expression", "invalidFilter")
+                    }
+                    ScimFilterError::FilterTooBroad => (
+                        "Filter is too broad; add a more specific filter",
+                        "invalidFilter",
+                    ),
+                    ScimFilterError::OffsetTooLarge => (
+                        "startIndex is too large; maximum supported offset is 10000",
+                        "invalidValue",
+                    ),
+                };
                 return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ScimError::new(500, "Failed to list groups")),
+                    StatusCode::BAD_REQUEST,
+                    Json(ScimError::new(400, detail).with_type(error_type)),
                 )
                     .into_response();
             }
-        };
+            tracing::error!("Failed to list groups: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ScimError::new(500, "Failed to list groups")),
+            )
+                .into_response();
+        }
+    };
 
     let base_url = &state.config().base_url;
     let mut resources = Vec::new();
     for g in groups {
-        let members = get_group_members_scim(&state.store, base_url, &g.id).await;
+        let members = get_group_members_scim(&state.store, base_url, &g.id, &auth.org_id).await;
         resources.push(db_group_to_scim(base_url, g, members));
     }
 
@@ -143,6 +149,7 @@ pub async fn create_group(
     // Create group
     let db_group = match db::create_scim_group(
         &state.store,
+        &auth.org_id,
         &group.display_name,
         group.external_id.as_deref(),
     )
@@ -168,7 +175,8 @@ pub async fn create_group(
     if let Some(members) = &group.members {
         for member in members {
             if let Err(e) =
-                db::add_scim_group_member(&state.store, &db_group.id, &member.value).await
+                db::add_scim_group_member(&state.store, &db_group.id, &auth.org_id, &member.value)
+                    .await
             {
                 tracing::warn!("Failed to add member {} to group: {e}", member.value);
             }
@@ -190,7 +198,7 @@ pub async fn create_group(
     }
 
     let base_url = &state.config().base_url;
-    let members = get_group_members_scim(&state.store, base_url, &db_group.id).await;
+    let members = get_group_members_scim(&state.store, base_url, &db_group.id, &auth.org_id).await;
     let scim_group = db_group_to_scim(base_url, db_group, members);
 
     (StatusCode::CREATED, Json(scim_group)).into_response()
@@ -218,7 +226,7 @@ pub async fn get_group(
         return (status, json).into_response();
     }
 
-    let group = match db::get_scim_group(&state.store, &id).await {
+    let group = match db::get_scim_group(&state.store, &id, &auth.org_id).await {
         Ok(Some(g)) => g,
         Ok(None) => {
             return (
@@ -238,7 +246,7 @@ pub async fn get_group(
     };
 
     let base_url = &state.config().base_url;
-    let members = get_group_members_scim(&state.store, base_url, &group.id).await;
+    let members = get_group_members_scim(&state.store, base_url, &group.id, &auth.org_id).await;
     Json(db_group_to_scim(base_url, group, members)).into_response()
 }
 
@@ -271,7 +279,7 @@ pub async fn patch_group(
     }
 
     // Get existing group
-    let group = match db::get_scim_group(&state.store, &id).await {
+    let group = match db::get_scim_group(&state.store, &id, &auth.org_id).await {
         Ok(Some(g)) => g,
         Ok(None) => {
             return (
@@ -322,9 +330,13 @@ pub async fn patch_group(
                                         v.get("value").and_then(|v| v.as_str()).map(String::from)
                                     })
                                     .collect();
-                                if let Err(e) =
-                                    db::replace_scim_group_members(&state.store, &id, &user_ids)
-                                        .await
+                                if let Err(e) = db::replace_scim_group_members(
+                                    &state.store,
+                                    &id,
+                                    &auth.org_id,
+                                    &user_ids,
+                                )
+                                .await
                                 {
                                     tracing::error!("Failed to replace group members: {e}");
                                 }
@@ -351,8 +363,13 @@ pub async fn patch_group(
                     if let Some(arr) = val.as_array() {
                         for member in arr {
                             if let Some(user_id) = member.get("value").and_then(|v| v.as_str())
-                                && let Err(e) =
-                                    db::add_scim_group_member(&state.store, &id, user_id).await
+                                && let Err(e) = db::add_scim_group_member(
+                                    &state.store,
+                                    &id,
+                                    &auth.org_id,
+                                    user_id,
+                                )
+                                .await
                             {
                                 tracing::warn!("Failed to add member: {e}");
                             }
@@ -367,7 +384,8 @@ pub async fn patch_group(
                     } else if path.starts_with("members")
                         && let Some(user_id) = parse_member_filter(path)
                         && let Err(e) =
-                            db::remove_scim_group_member(&state.store, &id, &user_id).await
+                            db::remove_scim_group_member(&state.store, &id, &auth.org_id, &user_id)
+                                .await
                     {
                         tracing::warn!("Failed to remove member: {e}");
                     }
@@ -377,21 +395,33 @@ pub async fn patch_group(
     }
 
     // Update group in database
-    if (display_name != group.display_name || external_id != group.external_id)
-        && let Err(e) = db::update_scim_group(
+    if display_name != group.display_name || external_id != group.external_id {
+        match db::update_scim_group(
             &state.store,
             &id,
+            &auth.org_id,
             Some(&display_name),
             external_id.as_deref(),
         )
         .await
-    {
-        tracing::error!("Failed to update group: {e}");
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ScimError::new(500, "Failed to update group")),
-        )
-            .into_response();
+        {
+            Ok(true) => {}
+            Ok(false) => {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(ScimError::new(404, "Group not found")),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                tracing::error!("Failed to update group: {e}");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ScimError::new(500, "Failed to update group")),
+                )
+                    .into_response();
+            }
+        }
     }
 
     // Audit log
@@ -409,7 +439,7 @@ pub async fn patch_group(
     }
 
     // Return updated group
-    let updated = match db::get_scim_group(&state.store, &id).await {
+    let updated = match db::get_scim_group(&state.store, &id, &auth.org_id).await {
         Ok(Some(g)) => g,
         Ok(None) | Err(_) => {
             return (
@@ -421,7 +451,7 @@ pub async fn patch_group(
     };
 
     let base_url = &state.config().base_url;
-    let members = get_group_members_scim(&state.store, base_url, &updated.id).await;
+    let members = get_group_members_scim(&state.store, base_url, &updated.id, &auth.org_id).await;
     Json(db_group_to_scim(base_url, updated, members)).into_response()
 }
 
@@ -449,7 +479,7 @@ pub async fn delete_group(
     }
 
     // Check group exists
-    let group = match db::get_scim_group(&state.store, &id).await {
+    let group = match db::get_scim_group(&state.store, &id, &auth.org_id).await {
         Ok(Some(g)) => g,
         Ok(None) => {
             return (
@@ -469,7 +499,7 @@ pub async fn delete_group(
     };
 
     // Delete group (cascades to memberships)
-    if let Err(e) = db::delete_scim_group(&state.store, &id).await {
+    if let Err(e) = db::delete_scim_group(&state.store, &id, &auth.org_id).await {
         tracing::error!("Failed to delete group: {e}");
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -495,14 +525,17 @@ pub async fn delete_group(
     StatusCode::NO_CONTENT.into_response()
 }
 
-/// Helper to get group members in SCIM format.
+/// Helper to get group members in SCIM format, scoped to the
+/// caller's org. Cross-org user_ids in the membership table are
+/// silently filtered out at read time by `db::get_scim_group_members`.
 pub async fn get_group_members_scim(
     db: &crate::db::store::DocumentStore,
     base_url: &str,
     group_id: &str,
+    org_id: &str,
 ) -> Vec<ScimGroupMember> {
-    match db::get_scim_group_members(db, group_id).await {
-        Ok(users) => users
+    match db::get_scim_group_members(db, group_id, org_id).await {
+        Ok(Some(users)) => users
             .into_iter()
             .map(|u| ScimGroupMember {
                 value: u.id.clone(),
@@ -510,7 +543,7 @@ pub async fn get_group_members_scim(
                 display: Some(u.email),
             })
             .collect(),
-        Err(_) => Vec::new(),
+        Ok(None) | Err(_) => Vec::new(),
     }
 }
 

--- a/crates/vouch-server/src/handlers/scim/mod.rs
+++ b/crates/vouch-server/src/handlers/scim/mod.rs
@@ -90,6 +90,9 @@ fn validate_list_params(
 pub struct ScimAuth {
     /// Token ID.
     pub token_id: String,
+    /// Organization the token is scoped to. Required; SCIM tokens
+    /// without an `org_id` are rejected at authentication.
+    pub org_id: String,
     /// Parsed scope set.
     pub scope: ScimScopeSet,
 }
@@ -158,6 +161,18 @@ pub async fn authenticate_scim(
             )
         })?;
 
+    // SCIM is multi-tenant; reject tokens that aren't bound to an org.
+    let org_id = token_record.org_id.ok_or_else(|| {
+        tracing::warn!(
+            token_id = %token_record.id,
+            "SCIM token has no org_id; rejecting"
+        );
+        (
+            StatusCode::UNAUTHORIZED,
+            Json(ScimError::new(401, "Invalid token")),
+        )
+    })?;
+
     // Update last_used_at
     if let Err(e) = db::update_scim_token_last_used(&state.store, &token_record.id).await {
         tracing::warn!("Failed to update SCIM token last_used_at: {e}");
@@ -176,6 +191,7 @@ pub async fn authenticate_scim(
 
     Ok(ScimAuth {
         token_id: token_record.id,
+        org_id,
         scope,
     })
 }

--- a/crates/vouch-server/src/handlers/scim/tests.rs
+++ b/crates/vouch-server/src/handlers/scim/tests.rs
@@ -126,7 +126,7 @@ async fn test_rfc7643_create_user_requires_username() {
     // RFC 7643 Section 4.1: userName is REQUIRED for User resource
     let (app, state) = test_app().await;
 
-    let token = create_test_scim_token(&state.store, "test-create-user").await;
+    let token = create_test_scim_token(&state.store, "test-create-user", "test-org").await;
 
     // Create user with valid userName
     let (status, body) = http_post_json(
@@ -148,7 +148,7 @@ async fn test_rfc7644_create_user_conflict() {
     // RFC 7644 Section 3.3: Duplicate user returns 409 Conflict
     let (app, state) = test_app().await;
 
-    let token = create_test_scim_token(&state.store, "test-conflict").await;
+    let token = create_test_scim_token(&state.store, "test-conflict", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     // Create first user
@@ -185,7 +185,7 @@ async fn test_rfc7644_get_user_by_id() {
     // RFC 7644 Section 3.4.1: GET user by ID
     let (app, state) = test_app().await;
 
-    let token = create_test_scim_token(&state.store, "test-get-user").await;
+    let token = create_test_scim_token(&state.store, "test-get-user", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     // Create a user first
@@ -219,7 +219,7 @@ async fn test_rfc7644_get_user_not_found() {
     // RFC 7644 Section 3.4.1: Non-existent user returns 404
     let (app, state) = test_app().await;
 
-    let token = create_test_scim_token(&state.store, "test-not-found").await;
+    let token = create_test_scim_token(&state.store, "test-not-found", "test-org").await;
 
     // Use a valid UUID format that doesn't exist in the database
     let (status, body) = http_get(
@@ -243,7 +243,7 @@ async fn test_rfc7644_list_users_pagination() {
     // RFC 7644 Section 3.4.2: Pagination with startIndex and count
     let (app, state) = test_app().await;
 
-    let token = create_test_scim_token(&state.store, "test-pagination").await;
+    let token = create_test_scim_token(&state.store, "test-pagination", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     // Create several users
@@ -282,7 +282,7 @@ async fn test_rfc7644_list_users_filter() {
     // RFC 7644 Section 3.4.2: Filter users by userName
     let (app, state) = test_app().await;
 
-    let token = create_test_scim_token(&state.store, "test-filter").await;
+    let token = create_test_scim_token(&state.store, "test-filter", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     // Create users
@@ -317,7 +317,7 @@ async fn test_rfc7644_patch_user_deactivate() {
     // RFC 7644 Section 3.5.2: PATCH to deactivate user
     let (app, state) = test_app().await;
 
-    let token = create_test_scim_token(&state.store, "test-patch-deactivate").await;
+    let token = create_test_scim_token(&state.store, "test-patch-deactivate", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     // Create an active user
@@ -359,7 +359,7 @@ async fn test_rfc7644_patch_unsupported_path_returns_400() {
     // RFC 7644 Section 3.5.3: Unsupported attribute paths should return 400
     let (app, state) = test_app().await;
 
-    let token = create_test_scim_token(&state.store, "test-patch-invalid-path").await;
+    let token = create_test_scim_token(&state.store, "test-patch-invalid-path", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     // Create a user first
@@ -406,7 +406,7 @@ async fn test_rfc7644_delete_user() {
     // RFC 7644 Section 3.6: DELETE removes user
     let (app, state) = test_app().await;
 
-    let token = create_test_scim_token(&state.store, "test-delete").await;
+    let token = create_test_scim_token(&state.store, "test-delete", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     // Create a user
@@ -452,7 +452,7 @@ async fn test_rfc7644_error_format() {
     // RFC 7644 Section 3.12: Error response format
     let (app, state) = test_app().await;
 
-    let token = create_test_scim_token(&state.store, "test-error-format").await;
+    let token = create_test_scim_token(&state.store, "test-error-format", "test-org").await;
 
     // Request non-existent user (valid UUID format) to get an error
     let (status, body) = http_get(
@@ -487,7 +487,7 @@ async fn test_rfc7644_filter_eq_operator() {
     // RFC 7644 Section 3.4.1: "eq" filter operator.
     let (app, state) = test_app().await;
 
-    let token = create_test_scim_token(&state.store, "test-eq-filter").await;
+    let token = create_test_scim_token(&state.store, "test-eq-filter", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     // Create a user to search for
@@ -523,7 +523,7 @@ async fn test_rfc7644_error_includes_scim_schema() {
     // RFC 7644 Section 3.12: SCIM errors must include correct schemas URN.
     let (app, state) = test_app().await;
 
-    let token = create_test_scim_token(&state.store, "test-error-schema").await;
+    let token = create_test_scim_token(&state.store, "test-error-schema", "test-org").await;
 
     // Use a valid UUID format that doesn't exist in the database
     let (status, body) = http_get(
@@ -559,7 +559,7 @@ async fn test_rfc7644_list_response_format() {
     // totalResults, startIndex, and itemsPerPage.
     let (app, state) = test_app().await;
 
-    let token = create_test_scim_token(&state.store, "test-list-format").await;
+    let token = create_test_scim_token(&state.store, "test-list-format", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     let (status, body) = http_get(&app, "/scim/v2/Users", &[("Authorization", &auth_header)]).await;
@@ -593,7 +593,7 @@ async fn test_rfc7644_filter_co_operator_contains() {
     // userName co "partial" returns all users whose userName contains "partial".
     let (app, state) = test_app().await;
 
-    let token = create_test_scim_token(&state.store, "test-co-filter").await;
+    let token = create_test_scim_token(&state.store, "test-co-filter", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     // Create users with known usernames
@@ -657,7 +657,7 @@ async fn test_rfc7644_filter_sw_operator_starts_with() {
     // userName sw "prefix" returns all users whose userName starts with "prefix".
     let (app, state) = test_app().await;
 
-    let token = create_test_scim_token(&state.store, "test-sw-filter").await;
+    let token = create_test_scim_token(&state.store, "test-sw-filter", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     // Create users with known usernames
@@ -721,7 +721,7 @@ async fn test_rfc7644_filter_eq_still_works_alongside_new_operators() {
     // RFC 7644 Section 3.4.2: "eq" returns only exact matches.
     let (app, state) = test_app().await;
 
-    let token = create_test_scim_token(&state.store, "test-eq-regression").await;
+    let token = create_test_scim_token(&state.store, "test-eq-regression", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     // Create two users where one is a superstring of the other
@@ -777,7 +777,7 @@ async fn test_rfc7644_filter_unsupported_operator_returns_error() {
     // "ne" (not equal) is not supported and should produce an error response.
     let (app, state) = test_app().await;
 
-    let token = create_test_scim_token(&state.store, "test-ne-unsupported").await;
+    let token = create_test_scim_token(&state.store, "test-ne-unsupported", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     // Create a user (so there's something to filter)
@@ -827,7 +827,7 @@ async fn test_validation_get_user_invalid_uuid_returns_400() {
     // Non-UUID resource IDs must be rejected with 400 before hitting the DB
     let (app, state) = test_app().await;
 
-    let token = create_test_scim_token(&state.store, "test-invalid-uuid").await;
+    let token = create_test_scim_token(&state.store, "test-invalid-uuid", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     let (status, body) = http_get(
@@ -853,7 +853,7 @@ async fn test_validation_get_user_invalid_uuid_returns_400() {
 async fn test_validation_get_group_invalid_uuid_returns_400() {
     let (app, state) = test_app().await;
 
-    let token = create_test_scim_token(&state.store, "test-invalid-group-uuid").await;
+    let token = create_test_scim_token(&state.store, "test-invalid-group-uuid", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     let (status, body) = http_get(
@@ -872,7 +872,7 @@ async fn test_validation_get_group_invalid_uuid_returns_400() {
 async fn test_validation_patch_user_invalid_uuid_returns_400() {
     let (app, state) = test_app().await;
 
-    let token = create_test_scim_token(&state.store, "test-patch-invalid-uuid").await;
+    let token = create_test_scim_token(&state.store, "test-patch-invalid-uuid", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     let (status, body) = http_request(
@@ -896,7 +896,7 @@ async fn test_validation_patch_user_invalid_uuid_returns_400() {
 async fn test_validation_delete_user_invalid_uuid_returns_400() {
     let (app, state) = test_app().await;
 
-    let token = create_test_scim_token(&state.store, "test-delete-invalid-uuid").await;
+    let token = create_test_scim_token(&state.store, "test-delete-invalid-uuid", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     let (status, body) = http_request(
@@ -918,7 +918,7 @@ async fn test_validation_valid_uuid_passes_to_not_found() {
     // A valid UUID that doesn't exist should return 404, not 400
     let (app, state) = test_app().await;
 
-    let token = create_test_scim_token(&state.store, "test-valid-uuid-404").await;
+    let token = create_test_scim_token(&state.store, "test-valid-uuid-404", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     let (status, _body) = http_get(
@@ -943,7 +943,7 @@ async fn test_validation_valid_uuid_passes_to_not_found() {
 async fn test_validation_filter_too_long_returns_400() {
     let (app, state) = test_app().await;
 
-    let token = create_test_scim_token(&state.store, "test-long-filter").await;
+    let token = create_test_scim_token(&state.store, "test-long-filter", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     // Build a filter that exceeds the 1024 character limit
@@ -967,7 +967,7 @@ async fn test_validation_filter_too_long_returns_400() {
 async fn test_validation_filter_within_limit_succeeds() {
     let (app, state) = test_app().await;
 
-    let token = create_test_scim_token(&state.store, "test-normal-filter").await;
+    let token = create_test_scim_token(&state.store, "test-normal-filter", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     // A normal-length filter should succeed
@@ -989,7 +989,7 @@ async fn test_validation_filter_within_limit_succeeds() {
 async fn test_validation_start_index_too_large_returns_400() {
     let (app, state) = test_app().await;
 
-    let token = create_test_scim_token(&state.store, "test-large-start-index").await;
+    let token = create_test_scim_token(&state.store, "test-large-start-index", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     let (status, body) = http_get(
@@ -1008,7 +1008,7 @@ async fn test_validation_start_index_too_large_returns_400() {
 async fn test_validation_start_index_at_boundary_succeeds() {
     let (app, state) = test_app().await;
 
-    let token = create_test_scim_token(&state.store, "test-boundary-start-index").await;
+    let token = create_test_scim_token(&state.store, "test-boundary-start-index", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     // startIndex = 10001 is exactly at the boundary (should pass)
@@ -1114,7 +1114,7 @@ async fn test_validation_before_auth_create_group_empty_name_no_token() {
 async fn test_scim_create_group() {
     // POST /scim/v2/Groups returns 201 with id, displayName, schemas, meta
     let (app, state) = test_app().await;
-    let token = create_test_scim_token(&state.store, "test-create-group").await;
+    let token = create_test_scim_token(&state.store, "test-create-group", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     let (status, body) = http_post_json(
@@ -1137,7 +1137,7 @@ async fn test_scim_create_group() {
 async fn test_scim_create_group_with_external_id() {
     // POST with externalId should return it in the response
     let (app, state) = test_app().await;
-    let token = create_test_scim_token(&state.store, "test-create-group-extid").await;
+    let token = create_test_scim_token(&state.store, "test-create-group-extid", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     let (status, body) = http_post_json(
@@ -1158,7 +1158,7 @@ async fn test_scim_create_group_with_external_id() {
 async fn test_scim_get_group_by_id() {
     // GET /scim/v2/Groups/{id} returns the group
     let (app, state) = test_app().await;
-    let token = create_test_scim_token(&state.store, "test-get-group").await;
+    let token = create_test_scim_token(&state.store, "test-get-group", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     // Create a group first
@@ -1191,7 +1191,7 @@ async fn test_scim_get_group_by_id() {
 async fn test_scim_list_groups_empty() {
     // GET /scim/v2/Groups on fresh DB returns empty Resources and totalResults: 0
     let (app, state) = test_app().await;
-    let token = create_test_scim_token(&state.store, "test-list-groups-empty").await;
+    let token = create_test_scim_token(&state.store, "test-list-groups-empty", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     let (status, body) =
@@ -1208,7 +1208,7 @@ async fn test_scim_list_groups_empty() {
 async fn test_scim_list_groups_returns_created() {
     // Create a group then list — it should appear in the results
     let (app, state) = test_app().await;
-    let token = create_test_scim_token(&state.store, "test-list-groups-created").await;
+    let token = create_test_scim_token(&state.store, "test-list-groups-created", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     let (status, _) = http_post_json(
@@ -1240,7 +1240,7 @@ async fn test_scim_list_groups_returns_created() {
 async fn test_scim_delete_group() {
     // DELETE returns 204; subsequent GET returns 404
     let (app, state) = test_app().await;
-    let token = create_test_scim_token(&state.store, "test-delete-group").await;
+    let token = create_test_scim_token(&state.store, "test-delete-group", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     // Create group to delete
@@ -1278,7 +1278,7 @@ async fn test_scim_delete_group() {
 async fn test_scim_patch_group_replace_display_name() {
     // PATCH replace displayName, verify the change is persisted
     let (app, state) = test_app().await;
-    let token = create_test_scim_token(&state.store, "test-patch-group-name").await;
+    let token = create_test_scim_token(&state.store, "test-patch-group-name", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     // Create group
@@ -1315,7 +1315,7 @@ async fn test_scim_patch_group_replace_display_name() {
 async fn test_scim_patch_group_replace_external_id() {
     // PATCH replace externalId, verify the change is persisted
     let (app, state) = test_app().await;
-    let token = create_test_scim_token(&state.store, "test-patch-group-extid").await;
+    let token = create_test_scim_token(&state.store, "test-patch-group-extid", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     // Create group without externalId
@@ -1356,7 +1356,7 @@ async fn test_scim_patch_group_replace_external_id() {
 async fn test_scim_create_group_with_members() {
     // Create group with members array; verify members appear in GET response
     let (app, state) = test_app().await;
-    let token = create_test_scim_token(&state.store, "test-create-group-members").await;
+    let token = create_test_scim_token(&state.store, "test-create-group-members", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     // Create a user first
@@ -1406,7 +1406,7 @@ async fn test_scim_create_group_with_members() {
 async fn test_scim_patch_group_add_members() {
     // PATCH add members operation adds the user to the group
     let (app, state) = test_app().await;
-    let token = create_test_scim_token(&state.store, "test-patch-add-members").await;
+    let token = create_test_scim_token(&state.store, "test-patch-add-members", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     // Create a user
@@ -1470,7 +1470,7 @@ async fn test_scim_patch_group_add_members() {
 async fn test_scim_patch_group_remove_member() {
     // PATCH remove with path `members[value eq "user-id"]` removes the member
     let (app, state) = test_app().await;
-    let token = create_test_scim_token(&state.store, "test-patch-remove-member").await;
+    let token = create_test_scim_token(&state.store, "test-patch-remove-member", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     // Create a user
@@ -1550,7 +1550,8 @@ async fn test_scim_patch_group_remove_member() {
 async fn test_scim_create_group_empty_display_name() {
     // Empty displayName should return 400
     let (app, state) = test_app().await;
-    let token = create_test_scim_token(&state.store, "test-create-group-empty-name").await;
+    let token =
+        create_test_scim_token(&state.store, "test-create-group-empty-name", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     let (status, body) = http_post_json(
@@ -1591,7 +1592,7 @@ async fn test_scim_create_group_requires_auth() {
 async fn test_scim_get_group_not_found() {
     // Valid UUID that doesn't exist returns 404
     let (app, state) = test_app().await;
-    let token = create_test_scim_token(&state.store, "test-group-not-found").await;
+    let token = create_test_scim_token(&state.store, "test-group-not-found", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     let (status, body) = http_get(
@@ -1610,7 +1611,7 @@ async fn test_scim_get_group_not_found() {
 async fn test_scim_get_group_invalid_id() {
     // Non-UUID id should return 400
     let (app, state) = test_app().await;
-    let token = create_test_scim_token(&state.store, "test-group-invalid-id").await;
+    let token = create_test_scim_token(&state.store, "test-group-invalid-id", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     let (status, body) = http_get(
@@ -1629,7 +1630,8 @@ async fn test_scim_get_group_invalid_id() {
 async fn test_scim_delete_group_not_found() {
     // DELETE on a valid UUID that doesn't exist returns 404
     let (app, state) = test_app().await;
-    let token = create_test_scim_token(&state.store, "test-delete-group-not-found").await;
+    let token =
+        create_test_scim_token(&state.store, "test-delete-group-not-found", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     let (status, body) = http_delete(
@@ -1648,7 +1650,8 @@ async fn test_scim_delete_group_not_found() {
 async fn test_scim_delete_group_invalid_id() {
     // DELETE with non-UUID id returns 400
     let (app, state) = test_app().await;
-    let token = create_test_scim_token(&state.store, "test-delete-group-invalid-id").await;
+    let token =
+        create_test_scim_token(&state.store, "test-delete-group-invalid-id", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     let (status, body) = http_delete(
@@ -1667,7 +1670,8 @@ async fn test_scim_delete_group_invalid_id() {
 async fn test_scim_patch_group_not_found() {
     // PATCH on a non-existent group returns 404
     let (app, state) = test_app().await;
-    let token = create_test_scim_token(&state.store, "test-patch-group-not-found").await;
+    let token =
+        create_test_scim_token(&state.store, "test-patch-group-not-found", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     let (status, body) = http_request(
@@ -1710,7 +1714,7 @@ async fn test_scim_list_groups_requires_auth() {
 async fn test_scim_group_response_has_correct_schema() {
     // Schemas array must contain the Group schema URN
     let (app, state) = test_app().await;
-    let token = create_test_scim_token(&state.store, "test-group-schema-urn").await;
+    let token = create_test_scim_token(&state.store, "test-group-schema-urn", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     let (status, body) = http_post_json(
@@ -1737,7 +1741,7 @@ async fn test_scim_group_response_has_correct_schema() {
 async fn test_scim_group_response_has_meta() {
     // meta must include resourceType, location, and created
     let (app, state) = test_app().await;
-    let token = create_test_scim_token(&state.store, "test-group-meta").await;
+    let token = create_test_scim_token(&state.store, "test-group-meta", "test-org").await;
     let auth_header = format!("Bearer {}", token);
 
     let (status, body) = http_post_json(

--- a/crates/vouch-server/src/handlers/scim/users.rs
+++ b/crates/vouch-server/src/handlers/scim/users.rs
@@ -47,6 +47,7 @@ pub async fn list_users(
     // Get users from database (returns page + total count in one call)
     let (users, total) = match db::list_scim_users(
         &state.store,
+        &auth.org_id,
         query.filter.as_deref(),
         start_index,
         count,
@@ -162,6 +163,7 @@ pub async fn create_user(
     // Create user
     let db_user = match db::create_scim_user(
         &state.store,
+        Some(&auth.org_id),
         &email,
         name.as_deref(),
         user.external_id.as_deref(),
@@ -228,7 +230,7 @@ pub async fn get_user(
         return (status, json).into_response();
     }
 
-    let user = match db::get_scim_user(&state.store, &id).await {
+    let user = match db::get_scim_user(&state.store, &id, &auth.org_id).await {
         Ok(Some(u)) => u,
         Ok(None) => {
             return (
@@ -280,7 +282,7 @@ pub async fn patch_user(
     }
 
     // Get existing user
-    let user = match db::get_scim_user(&state.store, &id).await {
+    let user = match db::get_scim_user(&state.store, &id, &auth.org_id).await {
         Ok(Some(u)) => u,
         Ok(None) => {
             return (
@@ -385,21 +387,32 @@ pub async fn patch_user(
     }
 
     // Update user in database
-    if let Err(e) = db::update_scim_user(
+    match db::update_scim_user(
         &state.store,
         &id,
+        &auth.org_id,
         name.as_deref(),
         external_id.as_deref(),
         active,
     )
     .await
     {
-        tracing::error!("Failed to update user: {e}");
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ScimError::new(500, "Failed to update user")),
-        )
-            .into_response();
+        Ok(true) => {}
+        Ok(false) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(ScimError::new(404, "User not found")),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!("Failed to update user: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ScimError::new(500, "Failed to update user")),
+            )
+                .into_response();
+        }
     }
 
     // If user was deactivated, invalidate all their sessions and revoke SSH certificates
@@ -445,7 +458,7 @@ pub async fn patch_user(
     }
 
     // Return updated user
-    let updated = match db::get_scim_user(&state.store, &id).await {
+    let updated = match db::get_scim_user(&state.store, &id, &auth.org_id).await {
         Ok(Some(u)) => u,
         Ok(None) | Err(_) => {
             return (
@@ -484,7 +497,7 @@ pub async fn delete_user(
     };
 
     // Check user exists
-    let user = match db::get_scim_user(&state.store, &id).await {
+    let user = match db::get_scim_user(&state.store, &id, &auth.org_id).await {
         Ok(Some(u)) => u,
         Ok(None) => {
             return (

--- a/crates/vouch-server/src/test_utils.rs
+++ b/crates/vouch-server/src/test_utils.rs
@@ -659,8 +659,15 @@ pub async fn create_test_session_with_mtls(
     result.token.expose_secret().to_string()
 }
 
-/// Create a SCIM bearer token for testing.
-pub async fn create_test_scim_token(store: &DocumentStore, description: &str) -> String {
+/// Create a SCIM bearer token for testing, bound to the given org.
+///
+/// `authenticate_scim` rejects tokens without an `org_id`, so every
+/// test that authenticates via SCIM must supply one.
+pub async fn create_test_scim_token(
+    store: &DocumentStore,
+    description: &str,
+    org_id: &str,
+) -> String {
     use aws_lc_rs::digest::{self, SHA256};
     use aws_lc_rs::rand as aws_rand;
     use base64::Engine;
@@ -674,10 +681,17 @@ pub async fn create_test_scim_token(store: &DocumentStore, description: &str) ->
     // Hash for storage
     let token_hash = hex::encode(digest::digest(&SHA256, token.as_bytes()));
 
-    // Store in database
-    crate::db::create_scim_token(store, &token_hash, Some(description), None, None, None)
-        .await
-        .expect("Failed to create SCIM token");
+    // Store in database with org_id so authenticate_scim accepts it
+    crate::db::create_scim_token(
+        store,
+        &token_hash,
+        Some(description),
+        None,
+        Some(org_id),
+        None,
+    )
+    .await
+    .expect("Failed to create SCIM token");
 
     token
 }

--- a/crates/vouch-tests/src/harness.rs
+++ b/crates/vouch-tests/src/harness.rs
@@ -391,13 +391,18 @@ impl TestHarness {
         Ok(client)
     }
 
-    /// Create a SCIM bearer token for testing.
+    /// Create a SCIM bearer token for testing, bound to the given org.
+    ///
+    /// `authenticate_scim` rejects tokens that have no `org_id`, so an
+    /// org_id is required for any test that authenticates against SCIM
+    /// endpoints.
     ///
     /// # Errors
     ///
     /// Returns an error if token creation fails.
-    pub async fn create_scim_token(&self, description: &str) -> Result<String> {
-        let token = test_utils::create_test_scim_token(&self.state.store, description).await;
+    pub async fn create_scim_token(&self, description: &str, org_id: &str) -> Result<String> {
+        let token =
+            test_utils::create_test_scim_token(&self.state.store, description, org_id).await;
         Ok(token)
     }
 

--- a/crates/vouch-tests/tests/integration.rs
+++ b/crates/vouch-tests/tests/integration.rs
@@ -1231,8 +1231,12 @@ mod scim {
     async fn test_scim_list_users() {
         let harness = TestHarness::new().await;
 
+        let org = harness
+            .create_org("scim-list.example.com")
+            .await
+            .expect("Failed to create org");
         let scim_token = harness
-            .create_scim_token("Test SCIM Token")
+            .create_scim_token("Test SCIM Token", &org.id)
             .await
             .expect("Failed to create SCIM token");
 
@@ -1298,8 +1302,12 @@ mod scim {
     async fn test_scim_create_user() {
         let harness = TestHarness::new().await;
 
+        let org = harness
+            .create_org("scim-create.example.com")
+            .await
+            .expect("Failed to create org");
         let scim_token = harness
-            .create_scim_token("Test SCIM Token")
+            .create_scim_token("Test SCIM Token", &org.id)
             .await
             .expect("Failed to create SCIM token");
 
@@ -1333,25 +1341,46 @@ mod scim {
     async fn test_scim_get_user() {
         let harness = TestHarness::new().await;
 
-        // Create a user first
-        let user = harness
-            .create_user("scim-get@example.com")
+        let org = harness
+            .create_org("scim-get.example.com")
             .await
-            .expect("Failed to create user");
-
+            .expect("Failed to create org");
         let scim_token = harness
-            .create_scim_token("Test SCIM Token")
+            .create_scim_token("Test SCIM Token", &org.id)
             .await
             .expect("Failed to create SCIM token");
 
+        // Create user via SCIM (which binds them to the org) so that the
+        // org-scoped GET finds them.
+        #[derive(serde::Serialize)]
+        struct ScimUserCreate {
+            schemas: Vec<String>,
+            #[serde(rename = "userName")]
+            user_name: String,
+        }
+        let create_resp = harness
+            .post_json_authenticated(
+                "/scim/v2/Users",
+                &ScimUserCreate {
+                    schemas: vec!["urn:ietf:params:scim:schemas:core:2.0:User".to_string()],
+                    user_name: "scim-get@example.com".to_string(),
+                },
+                &scim_token,
+            )
+            .await
+            .expect("Failed to create SCIM user");
+        assert_eq!(create_resp.status, 201);
+        let created: serde_json::Value = create_resp.json().expect("Failed to parse response");
+        let user_id = created["id"].as_str().expect("user id");
+
         let response = harness
-            .get_authenticated(&format!("/scim/v2/Users/{}", user.id), &scim_token)
+            .get_authenticated(&format!("/scim/v2/Users/{}", user_id), &scim_token)
             .await
             .expect("Failed to get SCIM user");
 
         assert_eq!(response.status, 200);
         let resp: serde_json::Value = response.json().expect("Failed to parse response");
-        assert_eq!(resp["id"], user.id);
+        assert_eq!(resp["id"], user_id);
     }
 
     /// Test SCIM get user not found.
@@ -1359,8 +1388,12 @@ mod scim {
     async fn test_scim_get_user_not_found() {
         let harness = TestHarness::new().await;
 
+        let org = harness
+            .create_org("scim-notfound.example.com")
+            .await
+            .expect("Failed to create org");
         let scim_token = harness
-            .create_scim_token("Test SCIM Token")
+            .create_scim_token("Test SCIM Token", &org.id)
             .await
             .expect("Failed to create SCIM token");
 
@@ -1380,19 +1413,39 @@ mod scim {
     async fn test_scim_delete_user() {
         let harness = TestHarness::new().await;
 
-        // Create a user first
-        let user = harness
-            .create_user("scim-delete@example.com")
+        let org = harness
+            .create_org("scim-delete.example.com")
             .await
-            .expect("Failed to create user");
-
+            .expect("Failed to create org");
         let scim_token = harness
-            .create_scim_token("Test SCIM Token")
+            .create_scim_token("Test SCIM Token", &org.id)
             .await
             .expect("Failed to create SCIM token");
 
+        // Create the user via SCIM so they are bound to the org.
+        #[derive(serde::Serialize)]
+        struct ScimUserCreate {
+            schemas: Vec<String>,
+            #[serde(rename = "userName")]
+            user_name: String,
+        }
+        let create_resp = harness
+            .post_json_authenticated(
+                "/scim/v2/Users",
+                &ScimUserCreate {
+                    schemas: vec!["urn:ietf:params:scim:schemas:core:2.0:User".to_string()],
+                    user_name: "scim-delete@example.com".to_string(),
+                },
+                &scim_token,
+            )
+            .await
+            .expect("Failed to create SCIM user");
+        assert_eq!(create_resp.status, 201);
+        let created: serde_json::Value = create_resp.json().expect("Failed to parse response");
+        let user_id = created["id"].as_str().expect("user id");
+
         let response = harness
-            .delete_authenticated(&format!("/scim/v2/Users/{}", user.id), &scim_token)
+            .delete_authenticated(&format!("/scim/v2/Users/{}", user_id), &scim_token)
             .await
             .expect("Failed to delete SCIM user");
 
@@ -1401,7 +1454,7 @@ mod scim {
 
         // Verify user is gone
         let response = harness
-            .get_authenticated(&format!("/scim/v2/Users/{}", user.id), &scim_token)
+            .get_authenticated(&format!("/scim/v2/Users/{}", user_id), &scim_token)
             .await
             .expect("Failed to get SCIM user");
         assert_eq!(response.status, 404);

--- a/crates/vouch-tests/tests/scim_org_isolation.rs
+++ b/crates/vouch-tests/tests/scim_org_isolation.rs
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! Cross-tenant isolation tests for the SCIM 2.0 endpoints.
+//!
+//! These prove that a SCIM token scoped to org A cannot read,
+//! enumerate, modify, or delete resources owned by org B. Together
+//! they are the negative-path evidence the IDOR is closed.
+
+use serde_json::json;
+use vouch_tests::TestHarness;
+
+/// Build a two-org SCIM fixture: org A with a user `U_B` provisioned
+/// in org B, plus a group `G_B` provisioned in org B.
+struct Fixture {
+    harness: TestHarness,
+    token_a: String,
+    token_b: String,
+    user_b_id: String,
+    user_b_email: String,
+    group_b_id: String,
+}
+
+async fn fixture() -> Fixture {
+    let harness = TestHarness::new().await;
+
+    let org_a = harness
+        .create_org("org-a.example.com")
+        .await
+        .expect("create org a");
+    let org_b = harness
+        .create_org("org-b.example.com")
+        .await
+        .expect("create org b");
+
+    let token_a = harness
+        .create_scim_token("org A token", &org_a.id)
+        .await
+        .expect("scim token a");
+    let token_b = harness
+        .create_scim_token("org B token", &org_b.id)
+        .await
+        .expect("scim token b");
+
+    let user_b_email = "alice@org-b.example.com".to_string();
+    let resp = harness
+        .post_json_authenticated(
+            "/scim/v2/Users",
+            &json!({
+                "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+                "userName": user_b_email,
+                "active": true,
+            }),
+            &token_b,
+        )
+        .await
+        .expect("create user_b");
+    assert_eq!(resp.status, 201);
+    let user_b: serde_json::Value = resp.json().expect("user_b json");
+    let user_b_id = user_b["id"].as_str().expect("user_b id").to_string();
+
+    let resp = harness
+        .post_json_authenticated(
+            "/scim/v2/Groups",
+            &json!({
+                "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+                "displayName": "Engineers",
+            }),
+            &token_b,
+        )
+        .await
+        .expect("create group_b");
+    assert_eq!(resp.status, 201);
+    let group_b: serde_json::Value = resp.json().expect("group_b json");
+    let group_b_id = group_b["id"].as_str().expect("group_b id").to_string();
+
+    Fixture {
+        harness,
+        token_a,
+        token_b,
+        user_b_id,
+        user_b_email,
+        group_b_id,
+    }
+}
+
+#[tokio::test]
+async fn cross_tenant_get_user_returns_404() {
+    let f = fixture().await;
+    let resp = f
+        .harness
+        .get_authenticated(&format!("/scim/v2/Users/{}", f.user_b_id), &f.token_a)
+        .await
+        .expect("get user_b from org A");
+    assert_eq!(resp.status, 404);
+}
+
+#[tokio::test]
+async fn cross_tenant_patch_user_returns_404_no_mutation() {
+    let f = fixture().await;
+    let patch_body = json!({
+        "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+        "Operations": [
+            {"op": "replace", "path": "active", "value": false},
+        ],
+    });
+    let resp = f
+        .harness
+        .patch_json_authenticated(
+            &format!("/scim/v2/Users/{}", f.user_b_id),
+            &patch_body,
+            &f.token_a,
+        )
+        .await
+        .expect("patch user_b from org A");
+    assert_eq!(resp.status, 404);
+
+    // Verify with org B's token that user_b is still active.
+    let resp = f
+        .harness
+        .get_authenticated(&format!("/scim/v2/Users/{}", f.user_b_id), &f.token_b)
+        .await
+        .expect("re-read user_b from org B");
+    assert_eq!(resp.status, 200);
+    let body: serde_json::Value = resp.json().expect("user_b json");
+    assert_eq!(body["active"], serde_json::Value::Bool(true));
+}
+
+#[tokio::test]
+async fn cross_tenant_delete_user_returns_404_no_mutation() {
+    let f = fixture().await;
+    let resp = f
+        .harness
+        .delete_authenticated(&format!("/scim/v2/Users/{}", f.user_b_id), &f.token_a)
+        .await
+        .expect("delete user_b from org A");
+    assert_eq!(resp.status, 404);
+
+    let resp = f
+        .harness
+        .get_authenticated(&format!("/scim/v2/Users/{}", f.user_b_id), &f.token_b)
+        .await
+        .expect("re-read user_b from org B");
+    assert_eq!(resp.status, 200);
+}
+
+#[tokio::test]
+async fn list_users_excludes_other_org() {
+    let f = fixture().await;
+    let resp = f
+        .harness
+        .get_authenticated("/scim/v2/Users", &f.token_a)
+        .await
+        .expect("list users from org A");
+    assert_eq!(resp.status, 200);
+    let body: serde_json::Value = resp.json().expect("list json");
+    let resources = body["Resources"].as_array().expect("Resources array");
+    let ids: Vec<&str> = resources.iter().filter_map(|r| r["id"].as_str()).collect();
+    assert!(
+        !ids.contains(&f.user_b_id.as_str()),
+        "Org A's list should not contain org B's user; got {ids:?}"
+    );
+}
+
+#[tokio::test]
+async fn filter_username_other_org_returns_empty() {
+    let f = fixture().await;
+    // The email is fixed and URL-safe except for `@` (-> %40); inline the
+    // encoded form so the test crate doesn't need urlencoding as a dep.
+    let encoded_email = f.user_b_email.replace('@', "%40");
+    let path = format!("/scim/v2/Users?filter=userName%20eq%20%22{encoded_email}%22");
+    let resp = f
+        .harness
+        .get_authenticated(&path, &f.token_a)
+        .await
+        .expect("filter from org A");
+    assert_eq!(resp.status, 200);
+    let body: serde_json::Value = resp.json().expect("filter json");
+    assert_eq!(body["totalResults"], serde_json::Value::from(0));
+    assert!(
+        body["Resources"]
+            .as_array()
+            .is_some_and(std::vec::Vec::is_empty),
+        "filter result must be empty",
+    );
+}
+
+#[tokio::test]
+async fn cross_tenant_get_group_returns_404() {
+    let f = fixture().await;
+    let resp = f
+        .harness
+        .get_authenticated(&format!("/scim/v2/Groups/{}", f.group_b_id), &f.token_a)
+        .await
+        .expect("get group_b from org A");
+    assert_eq!(resp.status, 404);
+}
+
+#[tokio::test]
+async fn cross_tenant_patch_group_returns_404_no_mutation() {
+    let f = fixture().await;
+    let patch_body = json!({
+        "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+        "Operations": [
+            {"op": "replace", "path": "displayName", "value": "Hijacked"},
+        ],
+    });
+    let resp = f
+        .harness
+        .patch_json_authenticated(
+            &format!("/scim/v2/Groups/{}", f.group_b_id),
+            &patch_body,
+            &f.token_a,
+        )
+        .await
+        .expect("patch group_b from org A");
+    assert_eq!(resp.status, 404);
+
+    let resp = f
+        .harness
+        .get_authenticated(&format!("/scim/v2/Groups/{}", f.group_b_id), &f.token_b)
+        .await
+        .expect("re-read group_b from org B");
+    assert_eq!(resp.status, 200);
+    let body: serde_json::Value = resp.json().expect("group_b json");
+    assert_eq!(body["displayName"], serde_json::Value::from("Engineers"));
+}
+
+#[tokio::test]
+async fn cross_tenant_delete_group_returns_404_no_mutation() {
+    let f = fixture().await;
+    let resp = f
+        .harness
+        .delete_authenticated(&format!("/scim/v2/Groups/{}", f.group_b_id), &f.token_a)
+        .await
+        .expect("delete group_b from org A");
+    assert_eq!(resp.status, 404);
+
+    let resp = f
+        .harness
+        .get_authenticated(&format!("/scim/v2/Groups/{}", f.group_b_id), &f.token_b)
+        .await
+        .expect("re-read group_b from org B");
+    assert_eq!(resp.status, 200);
+}
+
+#[tokio::test]
+async fn list_groups_excludes_other_org() {
+    let f = fixture().await;
+    let resp = f
+        .harness
+        .get_authenticated("/scim/v2/Groups", &f.token_a)
+        .await
+        .expect("list groups from org A");
+    assert_eq!(resp.status, 200);
+    let body: serde_json::Value = resp.json().expect("list json");
+    let resources = body["Resources"].as_array().expect("Resources array");
+    let ids: Vec<&str> = resources.iter().filter_map(|r| r["id"].as_str()).collect();
+    assert!(
+        !ids.contains(&f.group_b_id.as_str()),
+        "Org A's list should not contain org B's group; got {ids:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes a cross-tenant IDOR: SCIM tokens authenticated correctly but the token's `org_id` was discarded at the handler layer, so any tenant's token could read, modify, deactivate, and enumerate users and groups belonging to every other tenant on the same server.

This PR replaces the previous attempt (#310, closed) with a focused minimum-viable fix: plumb `org_id` through and let the existing indexed lookup primitives (`find_by_indexes`, `find_all`) do the scoping. No per-row existence checks, no per-member pre-validation loops, no architectural changes to JWT-Bearer / `TrustedJwtIssuer` / certification path.

## What changed

- `ScimAuth` gains `org_id: String`. Tokens whose stored record has no `org_id` are rejected at authentication.
- `ScimGroupDoc` gains `org_id: String` (new indexed field; no migration since groups have no production data).
- Every SCIM DB function (`get_scim_user`, `list_scim_users`, `create_scim_user`, `update_scim_user`, plus the group equivalents and member ops) takes `org_id: &str` and filters via the existing indexed lookup primitives. Cross-org misses return `Ok(None)` / `Ok(false)` at the DB layer; handlers return 404 (not-found, no existence leak).
- Group membership writes do not validate user_ids per-row; cross-org `user_id` values become inert references that `get_scim_group_members` filters out at read time. This is the deliberate scaling choice — adding a member is one indexed group scope-check, not N user lookups, so a 1M-member group remains a single-query operation.
- Existing SCIM tests updated to pass `org_id` to test fixtures.

## What is intentionally NOT in this PR

- No changes to `TrustedJwtIssuer`, JWT-Bearer grant, or `get_user_by_email`.
- No changes to the OIDC certification path beyond adding the new `Option<&str>` org_id parameter to `create_scim_user` (cert path passes `None`).
- No changes to `ScimAuditData` types.
- No typed `ScimUserError` / `ScimGroupMemberError` (existing `anyhow` patterns retained).
- No STEP 1/2/3 ordering invariants or pre-validation loops.

These were attempted in #310 and rolled back as out of scope.

## Test plan

- [x] New `crates/vouch-tests/tests/scim_org_isolation.rs` — 9 cases covering GET / PATCH / DELETE / LIST / filter across User and Group resources from a foreign-org token. PATCH and DELETE tests re-read state from the owning org's token after the failure to confirm no mutation occurred.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo test`: 2025 server tests + 9 new cross-tenant tests + existing integration suite all pass.

## Operational notes

- After deploy, rotate all SCIM tokens. Existing tokens remain valid until rotated.
- No DB migration required.

## Severity

CVSS 3.1 (rough): AV:N / AC:L / PR:L / UI:N / S:C / C:H / I:H / A:H — about 9.9 in a multi-tenant deployment.

## Follow-ups (filed separately)

- #313 — Multi-domain support for organizations
- #314 — SCIM should enforce email domain matches caller's org (depends on #313)
- #315 — Users stay org-less after org deletion + recreation
- #316 — JWT-Bearer grant has no org scoping (separate from SCIM)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes security/authorization behavior for SCIM endpoints and adjusts core DB querying/pagination primitives; mistakes could cause tenant data leakage or unexpected 404s/empty lists.
> 
> **Overview**
> Closes a cross-tenant SCIM IDOR by **making SCIM explicitly multi-tenant**: `ScimAuth` now carries a required `org_id` (tokens without `org_id` are rejected) and every SCIM user/group DB operation is updated to enforce org scoping, returning not-found semantics on cross-org access.
> 
> Groups are now stored with an `org_id` (and indexed), and listing/filtering for users/groups is rewritten to query *only* org-scoped rows (including indexed `AND` lookups for `userName`/`externalId` and DB-level paginated queries via the new `DocumentStore::find_paginated_with_count`). Group membership APIs are similarly org-scoped; cross-org `user_id`s can be written but are filtered out when reading members.
> 
> Tests are updated to create org-bound SCIM tokens and resources, and a new `scim_org_isolation.rs` integration suite asserts cross-org GET/PATCH/DELETE/LIST/filter attempts return 404/empty results without mutation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cb9b6983198907fa1e13675fbce87d81bb144b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->