### PR TITLE
Sign Windows binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -425,17 +425,17 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
           TARGET: ${{ matrix.target }}
-          BINS: ${{ matrix.bins }}
         run: |
-          STAGING="vouch-v${VERSION}-${TARGET}"
+          ARCHIVE="vouch-v${VERSION}-${TARGET}.zip"
 
-          mkdir -p "${STAGING}"
-          for bin in ${BINS}; do
-            cp "target/${TARGET}/release/${bin}.exe" "${STAGING}/"
-          done
+          # Stage signed binary in CWD so it lands at the zip root (no versioned
+          # subdir). Users get vouch.exe directly on extract; winget can use a
+          # constant RelativeFilePath: vouch.exe across versions.
+          cp "target/${TARGET}/release/vouch.exe" vouch.exe
+          7z a "${ARCHIVE}" vouch.exe
+          rm vouch.exe
 
-          7z a "${STAGING}.zip" "${STAGING}"
-          sha256sum "${STAGING}.zip" > "${STAGING}.zip.sha256"
+          sha256sum "${ARCHIVE}" > "${ARCHIVE}.sha256"
 
       - name: Collect SBOM artifacts
         id: sbom

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -377,6 +377,19 @@ jobs:
 
           rm -rf notarize-staging "$NOTARIZE_ZIP"
 
+      - name: Code sign Windows binaries
+        if: runner.os == 'Windows'
+        uses: skeeto/aas-sign@79a311e72cc15dda726cee96094327a13d50df1c # v1.0.0
+        with:
+          version: v1.0.0
+          endpoint: ${{ secrets.TRUSTED_SIGNING_ENDPOINT }}
+          account: ${{ secrets.TRUSTED_SIGNING_ACCOUNT }}
+          profile: ${{ secrets.CERTIFICATE_PROFILE }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          files: |
+            target/${{ matrix.target }}/release/vouch.exe
+
       - name: Create archive (tar.gz)
         if: matrix.archive-ext == 'tar.gz'
         shell: bash


### PR DESCRIPTION
Fixes #300

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release pipeline to introduce Windows code signing and alters the structure/naming of Windows zip artifacts, which can break downstream installers (e.g., winget) or release automation if misconfigured.
> 
> **Overview**
> Adds a Windows code-signing step to the `Release` workflow using `skeeto/aas-sign`, configured via Trusted Signing/Azure secrets, to sign `vouch.exe` during CLI builds.
> 
> Updates Windows `.zip` packaging to ship `vouch.exe` at the archive root (no versioned subdirectory) and regenerates SHA256 files for the new archive name/layout to support stable `RelativeFilePath` usage (e.g., winget).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 635671c5796d6ada3d862ea9316f7ec08ed5da95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->