### PR TITLE
Publish vouch to winget on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1084,6 +1084,22 @@ jobs:
             --repo "${REPOSITORY}" \
             --draft=false
 
+  winget:
+    name: Publish to winget
+    runs-on: ubuntu-latest
+    needs: publish-release
+    permissions:
+      contents: read
+
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
+        with:
+          identifier: SmokeTurner.Vouch
+          installers-regex: '\.zip$'
+          token: ${{ secrets.WINGET_TOKEN }}
+          fork-user: vouch-sh
+          max-versions-to-keep: 5
+
   homebrew:
     name: Update Homebrew Tap
     runs-on: ubuntu-latest
@@ -1328,6 +1344,12 @@ jobs:
 
             ```bash
             brew services start vouch
+            ```
+
+            ### winget (Windows)
+
+            ```pwsh
+            winget install SmokeTurner.Vouch
             ```
 
             ### APT Repository (Debian/Ubuntu)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1096,6 +1096,7 @@ jobs:
         with:
           identifier: SmokeTurner.Vouch
           installers-regex: '\.zip$'
+          release-tag: ${{ github.event.inputs.tag || github.ref_name }}
           token: ${{ secrets.WINGET_TOKEN }}
           fork-user: vouch-bot
           max-versions-to-keep: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1097,7 +1097,7 @@ jobs:
           identifier: SmokeTurner.Vouch
           installers-regex: '\.zip$'
           token: ${{ secrets.WINGET_TOKEN }}
-          fork-user: vouch-sh
+          fork-user: vouch-bot
           max-versions-to-keep: 5
 
   homebrew:


### PR DESCRIPTION
## Summary

- Add `winget` job after `publish-release` using `vedantmgoyal9/winget-releaser@v2` (pinned to SHA `4ffc7888bff…`)
- Run in parallel with `homebrew` and `release-notes`; an upstream PR failure won't block release notes
- Add a `winget install SmokeTurner.Vouch` snippet to the release-notes body

`PackageIdentifier` is `SmokeTurner.Vouch`, matching the Authenticode Subject CN (`Smoke Turner, LLC`) on the signed Windows binaries from #324. The v1 seed manifest is filed at microsoft/winget-pkgs#366735 and must merge upstream before the next release runs the new job. The existing `installers-regex: '\.zip$'` override is required because the action's default pattern only matches `.exe|.msi|.msix|.appx`.

`WINGET_TOKEN` is a classic PAT (public_repo) on a dedicated `vouch-bot` account with access scoped to `vouch-sh/winget-pkgs` only.

Closes #325

## Test plan

- [ ] Wait for microsoft/winget-pkgs#366735 to merge upstream
- [ ] Cut a tagged release; confirm the `winget` job opens a follow-up PR on microsoft/winget-pkgs
- [ ] On a clean Windows host: \`winget install SmokeTurner.Vouch\` succeeds with no SmartScreen prompt; \`vouch --version\` works on PATH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI-only change, but it introduces a new publishing path that relies on the `WINGET_TOKEN` secret and an external action to create PRs upstream, so misconfiguration could break releases or leak/overuse credentials.
> 
> **Overview**
> Automates Windows distribution by adding a new `winget` job to the release workflow that runs after `publish-release` and uses `vedantmgoyal9/winget-releaser@v2` (pinned) to open/update the Winget package for `SmokeTurner.Vouch` from the release’s `.zip` installers.
> 
> Updates the release-notes template to include a **Winget (Windows)** install snippet (`winget install SmokeTurner.Vouch`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5a330f27f4fb2e14c6e3e4c9edcf8fd82047a4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->