### PR TITLE
Change default server

### DIFF
--- a/crates/vouch-cli/src/main.rs
+++ b/crates/vouch-cli/src/main.rs
@@ -480,7 +480,7 @@ async fn run() -> Result<()> {
     let server_raw = cli
         .server
         .or_else(|| config.server_url().map(String::from))
-        .unwrap_or_else(|| "http://localhost:3000".to_string());
+        .unwrap_or_else(|| "https://us.vouch.sh".to_string());
 
     // Validate and normalize URL for commands that contact the server.
     // Offline commands (completions, init, logout, diag) skip validation


### PR DESCRIPTION
Fixes #328

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CLI’s implicit server target, so users without `--server` or config may now contact the hosted `https://us.vouch.sh` instead of a local instance, which can affect environments that relied on the previous localhost default.
> 
> **Overview**
> Updates the CLI’s server URL resolution so that when neither `--server` nor config provides a server, it now defaults to `https://us.vouch.sh` instead of `http://localhost:3000`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e207e7850090e8223654115c8064bd8d4004b3dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->