### PR TITLE
Fix CSP for Chrome/Edge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5702,7 +5702,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vouch-agent"
-version = "2026.4.7"
+version = "2026.4.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5728,7 +5728,7 @@ dependencies = [
 
 [[package]]
 name = "vouch-cli"
-version = "2026.4.7"
+version = "2026.4.8"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -5782,7 +5782,7 @@ dependencies = [
 
 [[package]]
 name = "vouch-common"
-version = "2026.4.7"
+version = "2026.4.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "vouch-httpsig"
-version = "2026.4.7"
+version = "2026.4.8"
 dependencies = [
  "aws-lc-rs",
  "axum",
@@ -5818,7 +5818,7 @@ dependencies = [
 
 [[package]]
 name = "vouch-server"
-version = "2026.4.7"
+version = "2026.4.8"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -5900,7 +5900,7 @@ dependencies = [
 
 [[package]]
 name = "vouch-tests"
-version = "2026.4.7"
+version = "2026.4.8"
 dependencies = [
  "anyhow",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "2026.4.7"
+version = "2026.4.8"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 rust-version = "1.95.0"

--- a/crates/vouch-server/src/infra/csp.rs
+++ b/crates/vouch-server/src/infra/csp.rs
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! Content-Security-Policy source-expression types.
+//!
+//! `CspOrigin` represents a CSP source expression of the form
+//! `scheme://host[:port]` for use in directives like `form-action`. It is the
+//! only way the CSP middleware accepts an origin, preventing arbitrary
+//! `String`s (paths, javascript: URLs, etc.) from being inserted into a CSP
+//! header by mistake.
+
+use std::fmt;
+
+/// A CSP source expression of the form `scheme://host[:port]`.
+///
+/// Constructed only via [`CspOrigin::from_url`] or [`CspOrigin::parse`], which
+/// reject non-http(s) schemes and hostless URLs. The default port for the
+/// scheme is omitted; non-default ports are preserved. IPv6 hosts are
+/// bracketed; internationalized hostnames are punycode-encoded.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CspOrigin(String);
+
+impl CspOrigin {
+    /// Build from an already-parsed URL (e.g. an OIDC `authorization_endpoint`).
+    ///
+    /// Returns `None` for non-http(s) schemes or URLs without a host. Logs a
+    /// `tracing::warn!` for the rejection so misconfiguration is visible.
+    #[must_use]
+    pub fn from_url(url: &url::Url) -> Option<Self> {
+        let scheme = url.scheme();
+        if scheme != "https" && scheme != "http" {
+            tracing::warn!(
+                url = %url,
+                scheme = %scheme,
+                "URL scheme not allowed for CSP origin; expected http(s)"
+            );
+            return None;
+        }
+        let Some(host) = url.host_str() else {
+            tracing::warn!(url = %url, "URL has no host; cannot form CSP origin");
+            return None;
+        };
+        Some(match url.port() {
+            Some(port) => Self(format!("{scheme}://{host}:{port}")),
+            None => Self(format!("{scheme}://{host}")),
+        })
+    }
+
+    /// Parse a raw URL string (e.g. a SAML SSO URL from IdP metadata).
+    ///
+    /// Returns `None` for parse failures, non-http(s) schemes, or hostless
+    /// URLs. Logs a `tracing::warn!` for rejection.
+    #[must_use]
+    pub fn parse(raw: &str) -> Option<Self> {
+        match url::Url::parse(raw) {
+            Ok(url) => Self::from_url(&url),
+            Err(err) => {
+                tracing::warn!(
+                    url = %raw,
+                    error = %err,
+                    "Failed to parse URL for CSP origin"
+                );
+                None
+            }
+        }
+    }
+
+    /// Borrow the formatted origin string.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for CspOrigin {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
+mod tests {
+    use super::*;
+
+    fn parse_url(s: &str) -> url::Url {
+        url::Url::parse(s).expect("test URL parses")
+    }
+
+    #[test]
+    fn from_url_https_default_port() {
+        let url = parse_url("https://accounts.google.com/o/oauth2/v2/auth");
+        let origin = CspOrigin::from_url(&url).expect("origin");
+        assert_eq!(origin.as_str(), "https://accounts.google.com");
+    }
+
+    #[test]
+    fn from_url_https_explicit_default_port_is_normalized() {
+        // url crate normalizes default-port URLs by stripping the port.
+        let url = parse_url("https://accounts.google.com:443/o/oauth2/v2/auth");
+        let origin = CspOrigin::from_url(&url).expect("origin");
+        assert_eq!(origin.as_str(), "https://accounts.google.com");
+    }
+
+    #[test]
+    fn from_url_https_custom_port() {
+        let url = parse_url("https://idp.example.com:8443/realms/x/protocol/openid-connect/auth");
+        let origin = CspOrigin::from_url(&url).expect("origin");
+        assert_eq!(origin.as_str(), "https://idp.example.com:8443");
+    }
+
+    #[test]
+    fn from_url_http_localhost_with_port() {
+        let url = parse_url("http://localhost:8080/oauth2/auth");
+        let origin = CspOrigin::from_url(&url).expect("origin");
+        assert_eq!(origin.as_str(), "http://localhost:8080");
+    }
+
+    #[test]
+    fn from_url_ipv6_bracketed() {
+        let url = parse_url("https://[::1]:8443/auth");
+        let origin = CspOrigin::from_url(&url).expect("origin");
+        assert_eq!(origin.as_str(), "https://[::1]:8443");
+    }
+
+    #[test]
+    fn from_url_idn_punycode() {
+        // Cyrillic domain → punycode.
+        let url = parse_url("https://приклад.укр/auth");
+        let origin = CspOrigin::from_url(&url).expect("origin");
+        assert!(
+            origin.as_str().starts_with("https://xn--"),
+            "expected punycode-encoded host, got: {}",
+            origin.as_str()
+        );
+    }
+
+    #[test]
+    fn from_url_rejects_file_scheme() {
+        let url = parse_url("file:///etc/passwd");
+        assert!(CspOrigin::from_url(&url).is_none());
+    }
+
+    #[test]
+    fn from_url_rejects_javascript_scheme() {
+        let url = parse_url("javascript:alert(1)");
+        assert!(CspOrigin::from_url(&url).is_none());
+    }
+
+    #[test]
+    fn from_url_rejects_ftp_scheme() {
+        // Scheme allowlist must be positive (http | https), not just a
+        // blocklist of obviously dangerous schemes. ftp:// is a host-bearing
+        // URL that would otherwise pass the host_str() guard.
+        let url = parse_url("ftp://files.example.com/pub/");
+        assert!(CspOrigin::from_url(&url).is_none());
+    }
+
+    #[test]
+    fn from_url_rejects_ws_scheme() {
+        let url = parse_url("ws://socket.example.com/");
+        assert!(CspOrigin::from_url(&url).is_none());
+    }
+
+    #[test]
+    fn parse_handles_invalid_urls() {
+        assert!(CspOrigin::parse("not a url").is_none());
+        assert!(CspOrigin::parse("").is_none());
+    }
+
+    #[test]
+    fn parse_round_trips_valid_url() {
+        let origin = CspOrigin::parse("https://idp.example.com/sso/post").expect("origin");
+        assert_eq!(origin.as_str(), "https://idp.example.com");
+    }
+
+    #[test]
+    fn display_matches_as_str() {
+        let origin = CspOrigin::parse("https://idp.example.com:8443/sso").expect("origin");
+        assert_eq!(format!("{origin}"), origin.as_str());
+    }
+}

--- a/crates/vouch-server/src/infra/mod.rs
+++ b/crates/vouch-server/src/infra/mod.rs
@@ -6,6 +6,7 @@
 //! They are not part of the business logic or HTTP handler layers.
 
 pub mod cleanup;
+pub mod csp;
 pub mod generate_document_key;
 pub mod httpsig;
 pub mod metrics;

--- a/crates/vouch-server/src/infra/router.rs
+++ b/crates/vouch-server/src/infra/router.rs
@@ -162,7 +162,8 @@ pub fn build_app(state: Arc<AppState>, config: &config::ServerConfig) -> anyhow:
             .merge(metrics_route)
             .merge(certification_route),
         config,
-    )
+        state.upstream_idp.as_ref(),
+    )?
     .layer(axum::middleware::from_fn(metrics_middleware))
     // Global request timeout: 30 seconds.
     .layer(TimeoutLayer::with_status_code(

--- a/crates/vouch-server/src/infra/security_headers.rs
+++ b/crates/vouch-server/src/infra/security_headers.rs
@@ -13,7 +13,7 @@ use axum::{
 use tower_http::cors::CorsLayer;
 use tower_http::set_header::SetResponseHeaderLayer;
 
-use crate::{AppState, config};
+use crate::{AppState, config, services::idp::UpstreamIdp};
 
 /// Build permissive CORS layer for API endpoints (OIDC, SCIM, v1, api).
 ///
@@ -81,10 +81,24 @@ pub fn build_ui_cors_layer(config: &config::ServerConfig) -> CorsLayer {
 ///
 /// Sets X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy,
 /// Cross-Origin-Opener-Policy, Content-Security-Policy, and HSTS (when TLS is configured).
+///
+/// `idp` extends the CSP `form-action` source list with the configured upstream
+/// IdP's origin(s). Chromium-based browsers enforce `form-action` through
+/// redirects (CSP3 §6.4.1.1), so without this widening the `POST /device`
+/// flow's 303 redirect to the IdP would be blocked.
+///
+/// # Errors
+///
+/// Returns an error if the constructed CSP `HeaderValue` cannot be built. This
+/// is unreachable in practice -- origins from `CspOrigin` are ASCII-only -- but
+/// `Result` propagation ensures any future bug fails server startup loudly
+/// rather than silently producing a CSP without IdP origins.
 pub fn apply_security_layers(
     router: Router<Arc<AppState>>,
     config: &config::ServerConfig,
-) -> Router<Arc<AppState>> {
+    idp: Option<&UpstreamIdp>,
+) -> anyhow::Result<Router<Arc<AppState>>> {
+    let csp = build_csp_header(idp)?;
     let router = router
         .layer(SetResponseHeaderLayer::if_not_present(
             header::CACHE_CONTROL,
@@ -104,9 +118,7 @@ pub fn apply_security_layers(
         ))
         .layer(SetResponseHeaderLayer::overriding(
             HeaderName::from_static("permissions-policy"),
-            HeaderValue::from_static(
-                "camera=(), microphone=(), geolocation=(), payment=()",
-            ),
+            HeaderValue::from_static("camera=(), microphone=(), geolocation=(), payment=()"),
         ))
         .layer(SetResponseHeaderLayer::overriding(
             HeaderName::from_static("cross-origin-opener-policy"),
@@ -114,9 +126,7 @@ pub fn apply_security_layers(
         ))
         .layer(SetResponseHeaderLayer::overriding(
             HeaderName::from_static("content-security-policy"),
-            HeaderValue::from_static(
-                "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
-            ),
+            csp,
         ))
         .layer(SetResponseHeaderLayer::overriding(
             HeaderName::from_static("x-dns-prefetch-control"),
@@ -129,19 +139,46 @@ pub fn apply_security_layers(
 
     // HSTS only when TLS is configured.
     // `preload` enables submission to browser HSTS preload lists per RFC 6797 / FAPI 2.0.
-    if config.tls_configured() {
+    let router = if config.tls_configured() {
         router.layer(SetResponseHeaderLayer::overriding(
             header::STRICT_TRANSPORT_SECURITY,
             HeaderValue::from_static("max-age=63072000; includeSubDomains; preload"),
         ))
     } else {
         router
+    };
+
+    Ok(router)
+}
+
+/// Build the `Content-Security-Policy` header value.
+///
+/// Extends `form-action 'self'` with the configured upstream IdP's origin(s),
+/// if any. The remaining directives are static.
+fn build_csp_header(idp: Option<&UpstreamIdp>) -> anyhow::Result<HeaderValue> {
+    let origins: Vec<crate::infra::csp::CspOrigin> = idp
+        .map(UpstreamIdp::form_action_origins)
+        .unwrap_or_default();
+    let mut form_action = String::from("form-action 'self'");
+    for origin in &origins {
+        form_action.push(' ');
+        form_action.push_str(origin.as_str());
     }
+    let csp = format!(
+        "default-src 'self'; script-src 'self'; style-src 'self'; \
+         img-src 'self'; font-src 'self'; connect-src 'self'; \
+         frame-ancestors 'none'; base-uri 'self'; {form_action}"
+    );
+    HeaderValue::from_str(&csp).map_err(|e| {
+        anyhow::anyhow!("failed to build Content-Security-Policy header from {csp:?}: {e}")
+    })
 }
 
 #[cfg(test)]
 #[expect(
     clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::string_slice,
     reason = "test code: panic on assertion failure is acceptable"
 )]
 mod tests {
@@ -151,7 +188,7 @@ mod tests {
     async fn test_x_frame_options_header() {
         let state = test_app_state().await;
         let config = state.config();
-        let router = apply_security_layers_to_test_router(state.clone(), &config);
+        let router = apply_security_layers_to_test_router(state.clone(), &config, None);
 
         let resp = http_get_full(&router, "/health", &[]).await;
         assert_eq!(resp.headers.get("x-frame-options").unwrap(), "DENY");
@@ -161,7 +198,7 @@ mod tests {
     async fn test_x_content_type_options_header() {
         let state = test_app_state().await;
         let config = state.config();
-        let router = apply_security_layers_to_test_router(state.clone(), &config);
+        let router = apply_security_layers_to_test_router(state.clone(), &config, None);
 
         let resp = http_get_full(&router, "/health", &[]).await;
         assert_eq!(
@@ -174,7 +211,7 @@ mod tests {
     async fn test_content_security_policy_header() {
         let state = test_app_state().await;
         let config = state.config();
-        let router = apply_security_layers_to_test_router(state.clone(), &config);
+        let router = apply_security_layers_to_test_router(state.clone(), &config, None);
 
         let resp = http_get_full(&router, "/health", &[]).await;
         let csp = resp
@@ -185,13 +222,178 @@ mod tests {
             .unwrap();
         assert!(csp.contains("default-src 'self'"));
         assert!(csp.contains("frame-ancestors 'none'"));
+        // form-action must be present and -- because no IdP is configured --
+        // contain only 'self'. The character following 'self' must be `;` or
+        // end-of-string; any other character would indicate a stray source.
+        let needle = "form-action 'self'";
+        let idx = csp.find(needle).expect("form-action 'self' present");
+        let next = csp[idx + needle.len()..].chars().next();
+        assert!(
+            matches!(next, None | Some(';')),
+            "form-action 'self' must end the directive when no IdP is configured; \
+             next char was {next:?}; full CSP: {csp}"
+        );
+    }
+
+    /// Regression guard: with no IdP configured, the CSP header is byte-
+    /// identical to the previous static value. Catches accidental trailing
+    /// whitespace or empty source tokens introduced by future refactors.
+    #[tokio::test]
+    async fn test_csp_form_action_no_idp_byte_identical() {
+        let state = test_app_state().await;
+        let config = state.config();
+        let router = apply_security_layers_to_test_router(state.clone(), &config, None);
+
+        let resp = http_get_full(&router, "/health", &[]).await;
+        let csp = resp
+            .headers
+            .get("content-security-policy")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(
+            csp,
+            "default-src 'self'; script-src 'self'; style-src 'self'; \
+             img-src 'self'; font-src 'self'; connect-src 'self'; \
+             frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+        );
+    }
+
+    fn make_oidc_idp(auth_endpoint: &str) -> crate::services::idp::UpstreamIdp {
+        crate::services::idp::UpstreamIdp::Oidc(Box::new(
+            crate::services::idp::oidc::OidcProvider {
+                issuer: "https://accounts.google.com".to_string(),
+                authorization_endpoint: url::Url::parse(auth_endpoint).unwrap(),
+                token_endpoint: url::Url::parse("https://oauth2.googleapis.com/token").unwrap(),
+                jwks_uri: url::Url::parse("https://www.googleapis.com/oauth2/v3/certs").unwrap(),
+            },
+        ))
+    }
+
+    fn make_saml_idp(
+        sso_post: Option<&str>,
+        sso_redirect: Option<&str>,
+    ) -> crate::services::idp::UpstreamIdp {
+        crate::services::idp::UpstreamIdp::Saml(crate::services::idp::saml::SamlProvider {
+            idp_metadata: crate::services::idp::saml::IdpMetadata {
+                entity_id: "https://idp.example.com/saml".to_string(),
+                sso_post_url: sso_post.map(str::to_string),
+                sso_redirect_url: sso_redirect.map(str::to_string),
+                signing_certificates: vec![],
+            },
+            sp_entity_id: "https://vouch.example.com".to_string(),
+            acs_url: "https://vouch.example.com/saml/acs".to_string(),
+            email_attribute: None,
+            domain_attribute: None,
+        })
+    }
+
+    /// Extract the `form-action` directive's full value from a CSP string.
+    ///
+    /// The CSP is `directive value; directive value; ...`. This pulls out
+    /// the substring between `form-action ` and the next `;` (or end of
+    /// string), enabling an exact-equality assertion that catches mutations
+    /// the loose `.contains()` would miss (e.g. tab vs space, missing
+    /// origin, extra whitespace).
+    fn extract_form_action(csp: &str) -> &str {
+        csp.split(';')
+            .map(str::trim)
+            .find(|d| d.starts_with("form-action"))
+            .expect("form-action directive present in CSP")
+    }
+
+    #[tokio::test]
+    async fn test_csp_form_action_includes_oidc_origin() {
+        let state = test_app_state().await;
+        let config = state.config();
+        let idp = make_oidc_idp("https://accounts.google.com/o/oauth2/v2/auth");
+        let router = apply_security_layers_to_test_router(state.clone(), &config, Some(&idp));
+
+        let resp = http_get_full(&router, "/health", &[]).await;
+        let csp = resp
+            .headers
+            .get("content-security-policy")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(
+            extract_form_action(csp),
+            "form-action 'self' https://accounts.google.com"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_csp_form_action_oidc_custom_port() {
+        let state = test_app_state().await;
+        let config = state.config();
+        let idp = make_oidc_idp("https://idp.example.com:8443/auth");
+        let router = apply_security_layers_to_test_router(state.clone(), &config, Some(&idp));
+
+        let resp = http_get_full(&router, "/health", &[]).await;
+        let csp = resp
+            .headers
+            .get("content-security-policy")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(
+            extract_form_action(csp),
+            "form-action 'self' https://idp.example.com:8443"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_csp_form_action_includes_saml_post_origin() {
+        let state = test_app_state().await;
+        let config = state.config();
+        let idp = make_saml_idp(Some("https://idp.example.com/sso/post"), None);
+        let router = apply_security_layers_to_test_router(state.clone(), &config, Some(&idp));
+
+        let resp = http_get_full(&router, "/health", &[]).await;
+        let csp = resp
+            .headers
+            .get("content-security-policy")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(
+            extract_form_action(csp),
+            "form-action 'self' https://idp.example.com"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_csp_form_action_saml_two_distinct_hosts() {
+        let state = test_app_state().await;
+        let config = state.config();
+        let idp = make_saml_idp(
+            Some("https://idp-a.example.com/sso/post"),
+            Some("https://idp-b.example.com/sso/redirect"),
+        );
+        let router = apply_security_layers_to_test_router(state.clone(), &config, Some(&idp));
+
+        let resp = http_get_full(&router, "/health", &[]).await;
+        let csp = resp
+            .headers
+            .get("content-security-policy")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(
+            csp.contains("https://idp-a.example.com"),
+            "missing idp-a origin; got: {csp}"
+        );
+        assert!(
+            csp.contains("https://idp-b.example.com"),
+            "missing idp-b origin; got: {csp}"
+        );
     }
 
     #[tokio::test]
     async fn test_referrer_policy_header() {
         let state = test_app_state().await;
         let config = state.config();
-        let router = apply_security_layers_to_test_router(state.clone(), &config);
+        let router = apply_security_layers_to_test_router(state.clone(), &config, None);
 
         let resp = http_get_full(&router, "/health", &[]).await;
         assert_eq!(
@@ -204,7 +406,7 @@ mod tests {
     async fn test_permissions_policy_header() {
         let state = test_app_state().await;
         let config = state.config();
-        let router = apply_security_layers_to_test_router(state.clone(), &config);
+        let router = apply_security_layers_to_test_router(state.clone(), &config, None);
 
         let resp = http_get_full(&router, "/health", &[]).await;
         let pp = resp
@@ -221,7 +423,7 @@ mod tests {
     async fn test_cross_origin_opener_policy_header() {
         let state = test_app_state().await;
         let config = state.config();
-        let router = apply_security_layers_to_test_router(state.clone(), &config);
+        let router = apply_security_layers_to_test_router(state.clone(), &config, None);
 
         let resp = http_get_full(&router, "/health", &[]).await;
         assert_eq!(
@@ -231,15 +433,21 @@ mod tests {
     }
 
     /// Build a minimal router with security headers for testing.
+    ///
+    /// `idp` is forwarded to `apply_security_layers` to widen the CSP
+    /// `form-action` directive when an upstream IdP is configured.
     fn apply_security_layers_to_test_router(
         state: std::sync::Arc<crate::AppState>,
         config: &crate::config::ServerConfig,
+        idp: Option<&crate::services::idp::UpstreamIdp>,
     ) -> axum::Router {
         use axum::routing::get;
 
         let router: axum::Router<std::sync::Arc<crate::AppState>> =
             axum::Router::new().route("/health", get(|| async { "ok" }));
 
-        super::apply_security_layers(router, config).with_state(state)
+        super::apply_security_layers(router, config, idp)
+            .expect("apply_security_layers builds CSP for test router")
+            .with_state(state)
     }
 }

--- a/crates/vouch-server/src/services/idp/mod.rs
+++ b/crates/vouch-server/src/services/idp/mod.rs
@@ -262,12 +262,29 @@ impl UpstreamIdp {
             Self::Saml(s) => IdpBrand::from_entity_id(s.entity_id()),
         }
     }
+
+    /// Origins the browser must be allowed to redirect to or POST to during
+    /// upstream sign-in handoff.
+    ///
+    /// Used by the CSP middleware to widen `form-action` so Chromium-based
+    /// browsers don't block the 303 redirect (OIDC) or auto-submitting
+    /// SAML POST form. Returns deduplicated origins; an empty `Vec` when
+    /// the IdP exposes no http(s) endpoints (in practice unreachable, but
+    /// expressed in the type).
+    #[must_use]
+    pub fn form_action_origins(&self) -> Vec<crate::infra::csp::CspOrigin> {
+        match self {
+            Self::Oidc(p) => p.form_action_origin().into_iter().collect(),
+            Self::Saml(s) => s.form_action_origins(),
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     #![expect(
         clippy::unwrap_used,
+        clippy::indexing_slicing,
         reason = "test code: panic on assertion failure is acceptable"
     )]
 
@@ -733,5 +750,94 @@ mod tests {
             extract_email_domain("https://accounts.google.com", None, "user@gmail.com"),
             None,
         );
+    }
+
+    // =========================================================================
+    // form_action_origins tests
+    // =========================================================================
+
+    fn make_saml_provider(
+        sso_post_url: Option<&str>,
+        sso_redirect_url: Option<&str>,
+    ) -> saml::SamlProvider {
+        saml::SamlProvider {
+            idp_metadata: saml::IdpMetadata {
+                entity_id: "https://idp.example.com/saml".to_string(),
+                sso_post_url: sso_post_url.map(str::to_string),
+                sso_redirect_url: sso_redirect_url.map(str::to_string),
+                signing_certificates: vec![],
+            },
+            sp_entity_id: "https://vouch.example.com".to_string(),
+            acs_url: "https://vouch.example.com/saml/acs".to_string(),
+            email_attribute: None,
+            domain_attribute: None,
+        }
+    }
+
+    #[test]
+    fn form_action_origins_oidc_single() {
+        let provider = make_oidc_provider("https://accounts.google.com/o/oauth2/v2/auth");
+        let idp = UpstreamIdp::Oidc(Box::new(provider));
+        let origins = idp.form_action_origins();
+        assert_eq!(origins.len(), 1);
+        assert_eq!(origins[0].as_str(), "https://accounts.google.com");
+    }
+
+    #[test]
+    fn form_action_origins_oidc_custom_port() {
+        let provider = make_oidc_provider(
+            "https://idp.example.com:8443/realms/x/protocol/openid-connect/auth",
+        );
+        let idp = UpstreamIdp::Oidc(Box::new(provider));
+        let origins = idp.form_action_origins();
+        assert_eq!(origins.len(), 1);
+        assert_eq!(origins[0].as_str(), "https://idp.example.com:8443");
+    }
+
+    #[test]
+    fn form_action_origins_saml_post_only() {
+        let provider = make_saml_provider(Some("https://idp.example.com/sso/post"), None);
+        let idp = UpstreamIdp::Saml(provider);
+        let origins = idp.form_action_origins();
+        assert_eq!(origins.len(), 1);
+        assert_eq!(origins[0].as_str(), "https://idp.example.com");
+    }
+
+    #[test]
+    fn form_action_origins_saml_redirect_only() {
+        let provider = make_saml_provider(None, Some("https://idp.example.com/sso/redirect"));
+        let idp = UpstreamIdp::Saml(provider);
+        let origins = idp.form_action_origins();
+        assert_eq!(origins.len(), 1);
+        assert_eq!(origins[0].as_str(), "https://idp.example.com");
+    }
+
+    #[test]
+    fn form_action_origins_saml_dedup_same_host() {
+        let provider = make_saml_provider(
+            Some("https://idp.example.com/sso/post"),
+            Some("https://idp.example.com/sso/redirect"),
+        );
+        let idp = UpstreamIdp::Saml(provider);
+        let origins = idp.form_action_origins();
+        assert_eq!(origins.len(), 1, "duplicate origins should be collapsed");
+        assert_eq!(origins[0].as_str(), "https://idp.example.com");
+    }
+
+    #[test]
+    fn form_action_origins_saml_two_distinct_hosts() {
+        let provider = make_saml_provider(
+            Some("https://idp-a.example.com/sso/post"),
+            Some("https://idp-b.example.com/sso/redirect"),
+        );
+        let idp = UpstreamIdp::Saml(provider);
+        let origins = idp.form_action_origins();
+        let serialized: Vec<&str> = origins
+            .iter()
+            .map(crate::infra::csp::CspOrigin::as_str)
+            .collect();
+        assert_eq!(origins.len(), 2);
+        assert!(serialized.contains(&"https://idp-a.example.com"));
+        assert!(serialized.contains(&"https://idp-b.example.com"));
     }
 }

--- a/crates/vouch-server/src/services/idp/oidc.rs
+++ b/crates/vouch-server/src/services/idp/oidc.rs
@@ -22,6 +22,18 @@ pub struct OidcProvider {
     pub jwks_uri: Url,
 }
 
+impl OidcProvider {
+    /// CSP `form-action` origin for the authorization endpoint.
+    ///
+    /// Returns `None` if the endpoint URL has no host or a non-http(s) scheme;
+    /// in practice this never happens because `fetch_discovery` rejects such
+    /// inputs, but the type expresses the invariant.
+    #[must_use]
+    pub fn form_action_origin(&self) -> Option<crate::infra::csp::CspOrigin> {
+        crate::infra::csp::CspOrigin::from_url(&self.authorization_endpoint)
+    }
+}
+
 #[derive(Deserialize)]
 struct DiscoveryDocument {
     issuer: String,

--- a/crates/vouch-server/src/services/idp/saml/mod.rs
+++ b/crates/vouch-server/src/services/idp/saml/mod.rs
@@ -38,4 +38,29 @@ impl SamlProvider {
     pub fn entity_id(&self) -> &str {
         &self.idp_metadata.entity_id
     }
+
+    /// CSP `form-action` origins for SAML SSO URLs.
+    ///
+    /// Returns the origins of `sso_post_url` and `sso_redirect_url` (whichever
+    /// are configured), deduplicated. Used to widen `form-action` so the
+    /// auto-submitting POST form (HTTP-POST binding) and 303 redirect
+    /// (HTTP-Redirect binding) are not blocked by Chromium-based browsers.
+    #[must_use]
+    pub fn form_action_origins(&self) -> Vec<crate::infra::csp::CspOrigin> {
+        let mut origins: Vec<crate::infra::csp::CspOrigin> = Vec::new();
+        let mut push = |raw: &str| {
+            if let Some(origin) = crate::infra::csp::CspOrigin::parse(raw)
+                && !origins.iter().any(|existing| existing == &origin)
+            {
+                origins.push(origin);
+            }
+        };
+        if let Some(url) = self.idp_metadata.sso_post_url.as_deref() {
+            push(url);
+        }
+        if let Some(url) = self.idp_metadata.sso_redirect_url.as_deref() {
+            push(url);
+        }
+        origins
+    }
 }

--- a/crates/vouch-server/static/js/saml-autosubmit.js
+++ b/crates/vouch-server/static/js/saml-autosubmit.js
@@ -1,0 +1,5 @@
+// Auto-submit the SAML AuthnRequest form to the upstream IdP.
+// Loaded by templates/saml_post_form.html via <script defer> so it runs
+// after the form is parsed. Inline event handlers (e.g. body onload) are
+// blocked by Content-Security-Policy script-src 'self'.
+document.forms[0].submit();

--- a/crates/vouch-server/templates/saml_post_form.html
+++ b/crates/vouch-server/templates/saml_post_form.html
@@ -4,12 +4,13 @@
   <meta charset="utf-8">
   <title>Redirecting...</title>
 </head>
-<body onload="document.forms[0].submit()">
+<body>
   <noscript><p>Redirecting to identity provider. If you are not redirected, click the button below.</p></noscript>
   <form method="post" action="{{ action_url }}">
     <input type="hidden" name="SAMLRequest" value="{{ saml_request }}">
     <input type="hidden" name="RelayState" value="{{ relay_state }}">
     <noscript><button type="submit">Continue</button></noscript>
   </form>
+  <script src="/static/js/saml-autosubmit.js" defer></script>
 </body>
 </html>

--- a/crates/vouch-tests/tests/proptest.rs
+++ b/crates/vouch-tests/tests/proptest.rs
@@ -1159,4 +1159,33 @@ proptest! {
 
         let _ = validate_attestation_chain(&[cert_data], Some(&aaguid));
     }
+
+    // =========================================================================
+    // CSP origin: arbitrary input must never produce an injection-prone string
+    // =========================================================================
+
+    /// `CspOrigin::parse` either rejects the input or produces a string with
+    /// no CSP-meaningful characters. The CSP `form-action` directive
+    /// concatenates origins separated by spaces; if any produced origin
+    /// contained `;`, `'`, or whitespace, the resulting header would be
+    /// malformed or could be exploited to inject an unrelated directive.
+    ///
+    /// `parse` internally calls `from_url`, so this also covers the OIDC
+    /// (already-parsed `url::Url`) path.
+    #[test]
+    fn prop_csp_origin_never_contains_injection_chars(raw in "\\PC*") {
+        use vouch_server::infra::csp::CspOrigin;
+
+        if let Some(origin) = CspOrigin::parse(&raw) {
+            let s = origin.as_str();
+            prop_assert!(!s.contains(';'), "semicolon in origin: {s}");
+            prop_assert!(!s.contains('\''), "single-quote in origin: {s}");
+            prop_assert!(!s.contains('"'), "double-quote in origin: {s}");
+            prop_assert!(
+                !s.chars().any(char::is_whitespace),
+                "whitespace in origin: {s}"
+            );
+            prop_assert!(s.is_ascii(), "non-ASCII in origin: {s}");
+        }
+    }
 }


### PR DESCRIPTION
Fixes #329

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global `Content-Security-Policy` generation to include upstream IdP origins, which can affect browser auth/enrollment flows if miscomputed. Risk is mitigated by strict origin parsing/allowlisting plus unit and property-based tests guarding against CSP injection and regressions.
> 
> **Overview**
> Fixes Chromium-based browsers blocking upstream sign-in handoff by making CSP dynamic: `security_headers::apply_security_layers` now builds the `Content-Security-Policy` header at startup and extends `form-action 'self'` with the configured upstream IdP origin(s) (OIDC auth endpoint and/or SAML SSO URLs).
> 
> Adds a new typed `CspOrigin` helper to safely derive `scheme://host[:port]` from URLs (http/https only) and wires IdP helpers (`UpstreamIdp::form_action_origins`, `OidcProvider::form_action_origin`, `SamlProvider::form_action_origins`) into CSP construction, with expanded unit tests and a proptest to prevent header-injection characters.
> 
> Updates SAML POST auto-submit to comply with CSP by removing the inline `onload` handler and loading a new `/static/js/saml-autosubmit.js` script instead, and bumps workspace/package versions to `2026.4.8`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 575e174631f27a13ea7ea31a48e9f8ae11bb7294. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->