### PR TITLE
upload windows binary for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,13 @@ jobs:
       - name: Build # zizmor: ignore[template-injection] — static matrix values
         if: runner.os != 'Linux'
         run: cargo build --release --target ${{ matrix.target }} ${{ matrix.packages }}
+      - name: Upload Windows binary
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vouch-${{ matrix.name }}-${{ github.sha }}
+          path: target/${{ matrix.target }}/release/vouch.exe
+          retention-days: 7
 
   dependency-review:
     name: Dependency Review


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: workflow-only change that uploads Windows build outputs; primary impact is CI artifact storage/availability rather than runtime behavior.
> 
> **Overview**
> **CI now publishes Windows build outputs as artifacts.** After non-Linux builds complete, the `build` job uploads `target/.../release/vouch.exe` on Windows runners using `actions/upload-artifact`, naming it `vouch-${{ matrix.name }}-${{ github.sha }}` with a 7‑day retention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dc118862b9d9b036dbb862e5f42d682247d5b5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->