### PR TITLE
signing improvements

### DIFF
--- a/crates/vouch-cli/src/main.rs
+++ b/crates/vouch-cli/src/main.rs
@@ -472,12 +472,15 @@ async fn run() -> Result<()> {
 
     style::init(cli.color);
 
-    // Initialize logging: --verbose → debug, else RUST_LOG env → default warn
-    let filter = if cli.verbose {
-        EnvFilter::new("debug")
-    } else {
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"))
-    };
+    // Initialize logging: RUST_LOG env wins if set (so trace/per-target filters
+    // work for debugging); otherwise --verbose → debug, default warn.
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        if cli.verbose {
+            EnvFilter::new("debug")
+        } else {
+            EnvFilter::new("warn")
+        }
+    });
     tracing_subscriber::fmt().with_env_filter(filter).init();
 
     // Load config and resolve server URL

--- a/crates/vouch-httpsig/Cargo.toml
+++ b/crates/vouch-httpsig/Cargo.toml
@@ -10,7 +10,7 @@ workspace = true
 
 [features]
 default = []
-axum = ["dep:axum", "dep:tracing"]
+axum = ["dep:axum"]
 
 [dependencies]
 aws-lc-rs = { workspace = true, features = ["aws-lc-sys"] }
@@ -19,7 +19,7 @@ base64 = { workspace = true, features = ["std"] }
 http = { workspace = true, features = ["std"] }
 jiff = { workspace = true, features = ["std"] }
 thiserror = { workspace = true }
-tracing = { workspace = true, features = ["std"], optional = true }
+tracing = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 proptest = { workspace = true, features = ["std"] }

--- a/crates/vouch-httpsig/src/component.rs
+++ b/crates/vouch-httpsig/src/component.rs
@@ -625,6 +625,14 @@ fn extract_authority<T>(req: &http::Request<T>) -> Result<String, HttpSigError> 
     // path must too — otherwise the signer (URI path) and verifier (Host
     // fallback path) disagree on the authority component and signature
     // verification fails.
+    //
+    // Stripping is scheme-aware to match the URI-derived path: `:443` is only
+    // a default port for `https`, `:80` only for `http`. When the URI has no
+    // scheme (origin-form HTTP/1.1), we default to `https` to mirror path A's
+    // `unwrap_or("https")` behavior — this is correct for the dominant
+    // deployment (HTTPS on 443). Non-standard combinations (HTTPS on 80, HTTP
+    // on 443) rely on the scheme being available via `req.uri().scheme_str()`
+    // — typically only present for absolute-form or HTTP/2 requests.
     let host_header = req
         .headers()
         .get(http::header::HOST)
@@ -633,12 +641,19 @@ fn extract_authority<T>(req: &http::Request<T>) -> Result<String, HttpSigError> 
             HttpSigError::MissingComponent("URI has no authority and no Host header".into())
         })?;
 
+    let scheme = req.uri().scheme_str().unwrap_or("https");
     let normalized = host_header.trim().to_ascii_lowercase();
-    let stripped = normalized
-        .strip_suffix(":443")
-        .or_else(|| normalized.strip_suffix(":80"))
-        .map(str::to_string)
-        .unwrap_or(normalized);
+    let stripped = match scheme {
+        "https" => normalized
+            .strip_suffix(":443")
+            .map(str::to_string)
+            .unwrap_or(normalized),
+        "http" => normalized
+            .strip_suffix(":80")
+            .map(str::to_string)
+            .unwrap_or(normalized),
+        _ => normalized,
+    };
     Ok(stripped)
 }
 
@@ -758,6 +773,7 @@ mod tests {
         // Some HTTP/1.1 clients emit Host with explicit :443. The URI-derived
         // path strips it; the Host fallback must too, or the signer's authority
         // ("example.com") will not match the verifier's ("example.com:443").
+        // With no URI scheme available, fallback defaults to "https".
         let req = make_request(
             "POST",
             "/v1/credentials/ssh",
@@ -768,17 +784,26 @@ mod tests {
     }
 
     #[test]
-    fn test_authority_host_header_strips_default_http_port() {
-        let req = make_request("POST", "/v1/foo", &[("host", "example.com:80")]);
+    fn test_authority_host_header_lowercase_and_strip() {
+        let req = make_request("POST", "/v1/foo", &[("host", "Example.COM:443")]);
         let cid = ComponentIdentifier::authority();
         assert_eq!(cid.resolve_from_request(&req).unwrap(), "example.com");
     }
 
     #[test]
-    fn test_authority_host_header_lowercase_and_strip() {
-        let req = make_request("POST", "/v1/foo", &[("host", "Example.COM:443")]);
+    fn test_authority_host_header_keeps_non_default_port() {
+        // Scheme defaults to "https" when URI has none; :80 is not the
+        // default port for https, so it must NOT be stripped.
+        let req = make_request("POST", "/v1/foo", &[("host", "example.com:80")]);
         let cid = ComponentIdentifier::authority();
-        assert_eq!(cid.resolve_from_request(&req).unwrap(), "example.com");
+        assert_eq!(cid.resolve_from_request(&req).unwrap(), "example.com:80");
+    }
+
+    #[test]
+    fn test_authority_host_header_keeps_arbitrary_port() {
+        let req = make_request("POST", "/v1/foo", &[("host", "example.com:8443")]);
+        let cid = ComponentIdentifier::authority();
+        assert_eq!(cid.resolve_from_request(&req).unwrap(), "example.com:8443");
     }
 
     #[test]

--- a/crates/vouch-httpsig/src/component.rs
+++ b/crates/vouch-httpsig/src/component.rs
@@ -619,9 +619,12 @@ fn extract_authority<T>(req: &http::Request<T>) -> Result<String, HttpSigError> 
     }
 
     // Fall back to Host header (HTTP/1.1 origin-form requests).
-    // The Host header includes the port when non-default (e.g., "localhost:3000"),
-    // so no separate default-port stripping is needed — the signer and Host header
-    // will agree on the representation.
+    // RFC 9421 §2.2.3 requires authority normalization: lowercase + strip
+    // default ports. Some HTTP/1.1 clients emit `Host: example.com:443` with
+    // an explicit default port; the URI-derived path above strips it, so this
+    // path must too — otherwise the signer (URI path) and verifier (Host
+    // fallback path) disagree on the authority component and signature
+    // verification fails.
     let host_header = req
         .headers()
         .get(http::header::HOST)
@@ -630,7 +633,13 @@ fn extract_authority<T>(req: &http::Request<T>) -> Result<String, HttpSigError> 
             HttpSigError::MissingComponent("URI has no authority and no Host header".into())
         })?;
 
-    Ok(host_header.trim().to_ascii_lowercase())
+    let normalized = host_header.trim().to_ascii_lowercase();
+    let stripped = normalized
+        .strip_suffix(":443")
+        .or_else(|| normalized.strip_suffix(":80"))
+        .map(str::to_string)
+        .unwrap_or(normalized);
+    Ok(stripped)
 }
 
 /// Extract the path from a request URI. Empty path becomes "/".
@@ -742,6 +751,52 @@ mod tests {
         let req = make_request("POST", "/v1/credentials/ssh", &[("host", "localhost:3000")]);
         let cid = ComponentIdentifier::authority();
         assert_eq!(cid.resolve_from_request(&req).unwrap(), "localhost:3000");
+    }
+
+    #[test]
+    fn test_authority_host_header_strips_default_https_port() {
+        // Some HTTP/1.1 clients emit Host with explicit :443. The URI-derived
+        // path strips it; the Host fallback must too, or the signer's authority
+        // ("example.com") will not match the verifier's ("example.com:443").
+        let req = make_request(
+            "POST",
+            "/v1/credentials/ssh",
+            &[("host", "example.com:443")],
+        );
+        let cid = ComponentIdentifier::authority();
+        assert_eq!(cid.resolve_from_request(&req).unwrap(), "example.com");
+    }
+
+    #[test]
+    fn test_authority_host_header_strips_default_http_port() {
+        let req = make_request("POST", "/v1/foo", &[("host", "example.com:80")]);
+        let cid = ComponentIdentifier::authority();
+        assert_eq!(cid.resolve_from_request(&req).unwrap(), "example.com");
+    }
+
+    #[test]
+    fn test_authority_host_header_lowercase_and_strip() {
+        let req = make_request("POST", "/v1/foo", &[("host", "Example.COM:443")]);
+        let cid = ComponentIdentifier::authority();
+        assert_eq!(cid.resolve_from_request(&req).unwrap(), "example.com");
+    }
+
+    #[test]
+    fn test_authority_uri_and_host_header_agree_on_default_port() {
+        // Cross-check: client signs via URI path with default port stripped,
+        // server verifies via Host header path with default port stripped.
+        // Both should produce the same authority string.
+        let client_req = make_request("POST", "https://dev.vouch.sh/v1/credentials/ssh", &[]);
+        let server_req = make_request(
+            "POST",
+            "/v1/credentials/ssh",
+            &[("host", "dev.vouch.sh:443")],
+        );
+        let cid = ComponentIdentifier::authority();
+        let client_authority = cid.resolve_from_request(&client_req).unwrap();
+        let server_authority = cid.resolve_from_request(&server_req).unwrap();
+        assert_eq!(client_authority, server_authority);
+        assert_eq!(client_authority, "dev.vouch.sh");
     }
 
     #[test]

--- a/crates/vouch-httpsig/src/sign.rs
+++ b/crates/vouch-httpsig/src/sign.rs
@@ -157,6 +157,13 @@ impl SignatureBuilder {
         // Serialize the params once — used for both signature base and Signature-Input header
         let params_str = params.serialize();
         let base = build_request_base_with_params_str(req, &params, &params_str)?;
+        tracing::trace!(
+            label = %self.label,
+            keyid = ?signer.key_id(),
+            alg = %signer.algorithm_id(),
+            base = %String::from_utf8_lossy(&base),
+            "signing HTTP request"
+        );
         let signature = signer.sign(&base)?;
 
         append_signature_headers_with_params_str(
@@ -181,6 +188,13 @@ impl SignatureBuilder {
         let params = self.build_params(signer);
         let params_str = params.serialize();
         let base = build_response_base_with_params_str(resp, req, &params, &params_str)?;
+        tracing::trace!(
+            label = %self.label,
+            keyid = ?signer.key_id(),
+            alg = %signer.algorithm_id(),
+            base = %String::from_utf8_lossy(&base),
+            "signing HTTP response"
+        );
         let signature = signer.sign(&base)?;
 
         append_signature_headers_with_params_str(

--- a/crates/vouch-httpsig/src/verify.rs
+++ b/crates/vouch-httpsig/src/verify.rs
@@ -38,6 +38,13 @@ pub fn verify_request_signature<T>(
     validate_timestamps(&params, max_age)?;
 
     let base = build_request_base_with_params_str(req, &params, &params_str)?;
+    tracing::trace!(
+        label = %label,
+        keyid = ?params.keyid,
+        alg = ?params.alg,
+        base = %String::from_utf8_lossy(&base),
+        "verifying HTTP request signature"
+    );
     verifier.verify(&base, &signature_bytes)?;
 
     Ok(params)
@@ -61,6 +68,13 @@ pub fn verify_response_signature<T, U>(
     validate_timestamps(&params, max_age)?;
 
     let base = build_response_base_with_params_str(resp, req, &params, &params_str)?;
+    tracing::trace!(
+        label = %label,
+        keyid = ?params.keyid,
+        alg = ?params.alg,
+        base = %String::from_utf8_lossy(&base),
+        "verifying HTTP response signature"
+    );
     verifier.verify(&base, &signature_bytes)?;
 
     Ok(params)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches HTTP signature base construction/verification by changing `@authority` normalization for Host-header requests, which can affect interoperability and signature validation outcomes. Also changes logging behavior and dependency feature flags, with low runtime risk but potential impact on debugging and build configurations.
> 
> **Overview**
> Improves RFC 9421 HTTP signature interoperability by **normalizing `@authority` from the `Host` header** to lowercase and **strip default ports** (`:443` for https, `:80` for http) so HTTP/1.1 origin-form requests match URI-derived signing behavior; adds focused unit tests for these cases.
> 
> Adds `tracing::trace!` logs that emit the computed signature base during `sign_request`/`sign_response` and `verify_request_signature`/`verify_response_signature` to aid debugging.
> 
> Updates CLI logging init so `RUST_LOG` takes precedence over `--verbose`, and adjusts `vouch-httpsig` Cargo features/deps by making `tracing` non-optional and removing it from the `axum` feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc2605c66bc5077a1bf45c3fdcd20e8ca406a530. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->