### PR TITLE
check clock skew

### DIFF
--- a/crates/vouch-cli/src/commands/doctor.rs
+++ b/crates/vouch-cli/src/commands/doctor.rs
@@ -89,15 +89,22 @@ pub(crate) async fn run(server: &str, quiet: bool, json: bool) -> Result<()> {
         checks.push(agent_result);
     }
 
-    // Check 3: Server reachable
+    // Check 3: Server reachable (and clock skew, derived from same response)
     if !suppress {
         print!("Server reachable ... ");
     }
-    let server_result = check_server(server).await;
+    let (server_result, clock_result) = check_server(server).await;
     if !suppress {
         print_result(&server_result);
     }
     checks.push(server_result);
+    if let Some(clock) = clock_result {
+        if !suppress {
+            print!("Clock in sync with server ... ");
+            print_result(&clock);
+        }
+        checks.push(clock);
+    }
 
     // Check 4: Session valid
     if !suppress {
@@ -279,24 +286,70 @@ async fn check_agent() -> CheckResult {
     }
 }
 
-/// Check if the server is reachable.
-async fn check_server(server: &str) -> CheckResult {
+/// Check if the server is reachable, and use the response's `Date` header
+/// to also report clock skew between the local system and the server.
+///
+/// Returns `(reachability_result, Some(clock_skew_result))` when the request
+/// completes (skew can be computed from the `Date` header), or
+/// `(reachability_result, None)` when the request never produced a response.
+async fn check_server(server: &str) -> (CheckResult, Option<CheckResult>) {
     let client = match VouchClient::unauthenticated(server) {
         Ok(c) => c,
-        Err(e) => return CheckResult::fail("server", format!("Invalid server URL: {e}")),
+        Err(e) => {
+            return (
+                CheckResult::fail("server", format!("Invalid server URL: {e}")),
+                None,
+            );
+        }
     };
 
     let url = format!("{}/health", client.base_url());
-    match client.raw_client().get(&url).send().await {
-        Ok(resp) if resp.status().is_success() => {
-            CheckResult::pass("server", format!("Server at {server} is reachable"))
+    let response = match client.raw_client().get(&url).send().await {
+        Ok(resp) => resp,
+        Err(e) => {
+            return (
+                CheckResult::fail("server", format!("Server unreachable: {e}")),
+                None,
+            );
         }
-        Ok(resp) => CheckResult::fail(
+    };
+
+    let clock_result = build_clock_skew_result(response.headers());
+
+    let server_result = if response.status().is_success() {
+        CheckResult::pass("server", format!("Server at {server} is reachable"))
+    } else {
+        CheckResult::fail(
             "server",
-            format!("Server returned status: {}", resp.status()),
-        ),
-        Err(e) => CheckResult::fail("server", format!("Server unreachable: {e}")),
+            format!("Server returned status: {}", response.status()),
+        )
+    };
+
+    (server_result, clock_result)
+}
+
+/// Build a `CheckResult` describing the clock skew between this client and
+/// the server, derived from the response's `Date` header. Returns `None` if
+/// the server response lacks a parseable `Date` header (rare — RFC 7231
+/// requires it on every response).
+fn build_clock_skew_result(headers: &reqwest::header::HeaderMap) -> Option<CheckResult> {
+    let (skew_secs, local_behind) = vouch_cli::http::compute_clock_skew(headers)?;
+    if skew_secs < vouch_cli::http::CLOCK_SKEW_THRESHOLD_SECS {
+        return Some(CheckResult::pass(
+            "clock_skew",
+            format!("System clock within {skew_secs}s of server"),
+        ));
     }
+    let direction = if local_behind { "behind" } else { "ahead of" };
+    Some(CheckResult::fail(
+        "clock_skew",
+        format!(
+            "System clock is {skew_secs}s {direction} the server. \
+             Signed requests will fail once skew exceeds 300s. \
+             Sync your clock (Windows: Settings → Time & Language → Date & Time → \
+             \"Sync now\"; macOS: `sudo sntp -sS time.apple.com`)."
+        ),
+    ))
 }
 
 /// Check if there's a valid session.

--- a/crates/vouch-cli/src/http.rs
+++ b/crates/vouch-cli/src/http.rs
@@ -77,6 +77,60 @@ impl HttpResponse {
     }
 }
 
+/// Skew threshold in seconds — well below the server's 300s max_age (RFC 9421).
+pub const CLOCK_SKEW_THRESHOLD_SECS: u64 = 60;
+
+/// Parse the response `Date` header and return the skew in seconds.
+///
+/// Returns `None` if the header is missing or unparseable. The returned
+/// value is the magnitude of the skew (always non-negative); direction is
+/// in the second tuple element (`true` if local is behind server).
+#[must_use]
+pub fn compute_clock_skew(headers: &reqwest::header::HeaderMap) -> Option<(u64, bool)> {
+    let date_str = headers.get("date").and_then(|v| v.to_str().ok())?;
+    let server_zoned = jiff::fmt::rfc2822::parse(date_str).ok()?;
+    let server_secs = server_zoned.timestamp().as_second();
+    let local_secs = jiff::Timestamp::now().as_second();
+    let skew = server_secs.saturating_sub(local_secs).unsigned_abs();
+    let local_behind = local_secs < server_secs;
+    Some((skew, local_behind))
+}
+
+/// Check the response `Date` header against the local clock and warn the
+/// user once per process if the skew exceeds the threshold.
+///
+/// Clock skew is silent until it crosses the server's signature
+/// `max_age` (300s default per RFC 9421), at which point all signed
+/// requests fail with an opaque "signature verification failed" 401.
+/// Warning at 60s gives the user a clear reason to fix it before that.
+fn check_clock_skew(headers: &reqwest::header::HeaderMap) {
+    static WARNED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+    if WARNED.get().is_some() {
+        return;
+    }
+
+    let Some((skew_secs, local_behind)) = compute_clock_skew(headers) else {
+        return;
+    };
+
+    if skew_secs >= CLOCK_SKEW_THRESHOLD_SECS {
+        WARNED.get_or_init(|| {
+            let direction = if local_behind { "behind" } else { "ahead of" };
+            eprintln!(
+                "Warning: system clock is {skew_secs}s {direction} the server. \
+                 Signed requests may fail. Sync your clock — \
+                 on Windows: Settings → Time & Language → Date & Time → \"Sync now\"; \
+                 on macOS: `sudo sntp -sS time.apple.com`."
+            );
+            tracing::warn!(
+                skew_seconds = skew_secs,
+                direction,
+                "Clock skew exceeds threshold; signed requests may fail"
+            );
+        });
+    }
+}
+
 /// Extract common response headers from a `HeaderMap`.
 ///
 /// Returns `(www_authenticate, dpop_nonce, retry_after)` extracted from
@@ -250,6 +304,7 @@ impl HttpClient for ReqwestClient {
         let status = response.status().as_u16();
         let (www_authenticate, dpop_nonce, sig_nonce, retry_after) =
             extract_response_headers(status, response.headers());
+        check_clock_skew(response.headers());
 
         // Trace-level response logging
         if tracing::enabled!(tracing::Level::TRACE) {

--- a/crates/vouch-httpsig/Cargo.toml
+++ b/crates/vouch-httpsig/Cargo.toml
@@ -10,7 +10,7 @@ workspace = true
 
 [features]
 default = []
-axum = ["dep:axum"]
+axum = ["dep:axum", "dep:tracing"]
 
 [dependencies]
 aws-lc-rs = { workspace = true, features = ["aws-lc-sys"] }
@@ -19,7 +19,7 @@ base64 = { workspace = true, features = ["std"] }
 http = { workspace = true, features = ["std"] }
 jiff = { workspace = true, features = ["std"] }
 thiserror = { workspace = true }
-tracing = { workspace = true, features = ["std"] }
+tracing = { workspace = true, features = ["std"], optional = true }
 
 [dev-dependencies]
 proptest = { workspace = true, features = ["std"] }

--- a/crates/vouch-httpsig/src/sign.rs
+++ b/crates/vouch-httpsig/src/sign.rs
@@ -157,13 +157,6 @@ impl SignatureBuilder {
         // Serialize the params once — used for both signature base and Signature-Input header
         let params_str = params.serialize();
         let base = build_request_base_with_params_str(req, &params, &params_str)?;
-        tracing::trace!(
-            label = %self.label,
-            keyid = ?signer.key_id(),
-            alg = %signer.algorithm_id(),
-            base = %String::from_utf8_lossy(&base),
-            "signing HTTP request"
-        );
         let signature = signer.sign(&base)?;
 
         append_signature_headers_with_params_str(
@@ -188,13 +181,6 @@ impl SignatureBuilder {
         let params = self.build_params(signer);
         let params_str = params.serialize();
         let base = build_response_base_with_params_str(resp, req, &params, &params_str)?;
-        tracing::trace!(
-            label = %self.label,
-            keyid = ?signer.key_id(),
-            alg = %signer.algorithm_id(),
-            base = %String::from_utf8_lossy(&base),
-            "signing HTTP response"
-        );
         let signature = signer.sign(&base)?;
 
         append_signature_headers_with_params_str(

--- a/crates/vouch-httpsig/src/verify.rs
+++ b/crates/vouch-httpsig/src/verify.rs
@@ -38,13 +38,6 @@ pub fn verify_request_signature<T>(
     validate_timestamps(&params, max_age)?;
 
     let base = build_request_base_with_params_str(req, &params, &params_str)?;
-    tracing::trace!(
-        label = %label,
-        keyid = ?params.keyid,
-        alg = ?params.alg,
-        base = %String::from_utf8_lossy(&base),
-        "verifying HTTP request signature"
-    );
     verifier.verify(&base, &signature_bytes)?;
 
     Ok(params)
@@ -68,13 +61,6 @@ pub fn verify_response_signature<T, U>(
     validate_timestamps(&params, max_age)?;
 
     let base = build_response_base_with_params_str(resp, req, &params, &params_str)?;
-    tracing::trace!(
-        label = %label,
-        keyid = ?params.keyid,
-        alg = ?params.alg,
-        base = %String::from_utf8_lossy(&base),
-        "verifying HTTP response signature"
-    );
     verifier.verify(&base, &signature_bytes)?;
 
     Ok(params)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds non-fatal clock-skew detection/warnings and a new `doctor` check, plus removes trace logging from `vouch-httpsig` and makes `tracing` optional behind the `axum` feature.
> 
> **Overview**
> Adds clock-skew detection based on the server response `Date` header and surfaces it in two places: `vouch doctor` now reports a separate **Clock in sync with server** check, and the CLI HTTP layer emits a once-per-process warning when skew exceeds `60s` (to preempt RFC 9421 signature failures at `300s`).
> 
> Cleans up `vouch-httpsig` by removing per-request/response `tracing::trace!` logs of signature bases and making `tracing` an optional dependency enabled by the `axum` feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c84c87962a5207b845dc67d80e96940c95d3289a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->