### PR TITLE
add DNS-over-HTTPS for CLI and agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5887,7 +5887,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vouch-agent"
-version = "2026.4.9"
+version = "2026.4.10"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5913,7 +5913,7 @@ dependencies = [
 
 [[package]]
 name = "vouch-cli"
-version = "2026.4.9"
+version = "2026.4.10"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -5968,7 +5968,7 @@ dependencies = [
 
 [[package]]
 name = "vouch-common"
-version = "2026.4.9"
+version = "2026.4.10"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5983,13 +5983,14 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tracing",
  "url",
  "uuid",
 ]
 
 [[package]]
 name = "vouch-httpsig"
-version = "2026.4.9"
+version = "2026.4.10"
 dependencies = [
  "aws-lc-rs",
  "axum",
@@ -6005,7 +6006,7 @@ dependencies = [
 
 [[package]]
 name = "vouch-server"
-version = "2026.4.9"
+version = "2026.4.10"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6087,7 +6088,7 @@ dependencies = [
 
 [[package]]
 name = "vouch-tests"
-version = "2026.4.9"
+version = "2026.4.10"
 dependencies = [
  "anyhow",
  "aws-lc-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2405,6 +2405,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
+ "aws-lc-rs",
+ "bitflags",
  "bytes",
  "cfg-if",
  "data-encoding",
@@ -2417,9 +2419,13 @@ dependencies = [
  "idna",
  "ipnet",
  "jni",
+ "lru-cache",
+ "parking_lot",
  "rand 0.10.1",
  "rustls",
+ "rustls-pki-types",
  "thiserror 2.0.18",
+ "time",
  "tinyvec",
  "tokio",
  "tokio-rustls",
@@ -2434,6 +2440,8 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
 dependencies = [
+ "aws-lc-rs",
+ "bitflags",
  "data-encoding",
  "idna",
  "ipnet",
@@ -2442,7 +2450,9 @@ dependencies = [
  "prefix-trie",
  "rand 0.10.1",
  "ring",
+ "rustls-pki-types",
  "thiserror 2.0.18",
+ "time",
  "tinyvec",
  "tracing",
  "url",
@@ -3101,6 +3111,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-keyutils"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3173,6 +3189,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,6 +1121,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,6 +1380,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2190,6 +2216,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -2370,6 +2397,80 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "h2",
+ "hickory-proto",
+ "http 1.4.0",
+ "idna",
+ "ipnet",
+ "jni",
+ "rand 0.10.1",
+ "rustls",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "url",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto",
+ "ipnet",
+ "moka",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.1",
+ "rustls",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "webpki-roots 1.0.7",
+]
 
 [[package]]
 name = "hidapi"
@@ -2736,6 +2837,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ipnetwork"
@@ -3227,6 +3331,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "murmur3"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3395,6 +3516,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -3784,6 +3909,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23370be78b7e5bcbb0cab4a02047eb040279a693c78daad04c2c5f1c24a83503"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3963,6 +4099,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3999,6 +4146,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -4985,7 +5138,7 @@ dependencies = [
  "aes",
  "aes-gcm",
  "cbc",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "ctr",
  "poly1305",
@@ -5097,6 +5250,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
@@ -5792,6 +5951,7 @@ dependencies = [
  "dirs",
  "gethostname",
  "hex",
+ "hickory-resolver",
  "jiff",
  "reqwest",
  "secrecy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,7 @@ governor = { version = "=0.10.4", default-features = false }
 ipnet = { version = "=2.12.0", default-features = false }
 headers = { version = "=0.4.1", default-features = false }
 hex = { version = "=0.4.3", default-features = false }
-hickory-resolver = { version = "=0.26.1", default-features = false, features = ["https-aws-lc-rs", "tokio", "webpki-roots"] }
+hickory-resolver = { version = "=0.26.1", default-features = false, features = ["dnssec-aws-lc-rs", "https-aws-lc-rs", "tokio", "webpki-roots"] }
 http = { version = "=1.4.0", default-features = false }
 inquire = { version = "=0.9.4", default-features = false }
 jiff = { version = "=0.2.24", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,7 @@ governor = { version = "=0.10.4", default-features = false }
 ipnet = { version = "=2.12.0", default-features = false }
 headers = { version = "=0.4.1", default-features = false }
 hex = { version = "=0.4.3", default-features = false }
+hickory-resolver = { version = "=0.26.1", default-features = false, features = ["https-aws-lc-rs", "tokio", "webpki-roots"] }
 http = { version = "=1.4.0", default-features = false }
 inquire = { version = "=0.9.4", default-features = false }
 jiff = { version = "=0.2.24", default-features = false }
@@ -168,7 +169,6 @@ opentelemetry-otlp = { version = "=0.31.1", default-features = false }
 p256 = { version = "=0.13.2", default-features = false }
 proptest = { version = "=1.11.0", default-features = false }
 reqwest = { version = "=0.13.3", default-features = false }
-hickory-resolver = { version = "=0.26.1", default-features = false, features = ["https-aws-lc-rs", "tokio", "webpki-roots"] }
 roxmltree = { version = "=0.21.1", default-features = false }
 rpassword = { version = "=7.5.1", default-features = false }
 rust-embed = { version = "=8.11.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "2026.4.9"
+version = "2026.4.10"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 rust-version = "1.95.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,7 @@ opentelemetry-otlp = { version = "=0.31.1", default-features = false }
 p256 = { version = "=0.13.2", default-features = false }
 proptest = { version = "=1.11.0", default-features = false }
 reqwest = { version = "=0.13.3", default-features = false }
+hickory-resolver = { version = "=0.26.1", default-features = false, features = ["https-aws-lc-rs", "tokio", "webpki-roots"] }
 roxmltree = { version = "=0.21.1", default-features = false }
 rpassword = { version = "=7.5.1", default-features = false }
 rust-embed = { version = "=8.11.0", default-features = false }

--- a/crates/vouch-agent/src/config.rs
+++ b/crates/vouch-agent/src/config.rs
@@ -10,6 +10,7 @@ use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
+use vouch_common::dns::DohConfigSerde;
 
 /// Read-only view of the Vouch CLI configuration.
 ///
@@ -28,6 +29,16 @@ pub(crate) struct VouchConfig {
     server_url: Option<String>,
     /// Legacy flat session token.
     token: Option<String>,
+    /// Global network configuration (DoH, …).
+    #[serde(default)]
+    network: Option<NetworkSection>,
+}
+
+/// Read-only view of the `network` section.
+#[derive(Debug, Default, Deserialize)]
+struct NetworkSection {
+    #[serde(default)]
+    dns_over_https: Option<DohConfigSerde>,
 }
 
 /// Read-only per-server entry within the config file.
@@ -66,6 +77,13 @@ impl VouchConfig {
             return Some(tok.as_str());
         }
         self.token.as_deref()
+    }
+
+    /// Configured DoH provider, if any.
+    pub(crate) fn doh(&self) -> Option<&DohConfigSerde> {
+        self.network
+            .as_ref()
+            .and_then(|n| n.dns_over_https.as_ref())
     }
 }
 

--- a/crates/vouch-agent/src/config.rs
+++ b/crates/vouch-agent/src/config.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
-use vouch_common::dns::DohConfigSerde;
+use vouch_common::dns::{DohConfigSerde, NetworkConfig};
 
 /// Read-only view of the Vouch CLI configuration.
 ///
@@ -31,14 +31,7 @@ pub(crate) struct VouchConfig {
     token: Option<String>,
     /// Global network configuration (DoH, …).
     #[serde(default)]
-    network: Option<NetworkSection>,
-}
-
-/// Read-only view of the `network` section.
-#[derive(Debug, Default, Deserialize)]
-struct NetworkSection {
-    #[serde(default)]
-    dns_over_https: Option<DohConfigSerde>,
+    network: Option<NetworkConfig>,
 }
 
 /// Read-only per-server entry within the config file.
@@ -81,9 +74,7 @@ impl VouchConfig {
 
     /// Configured DoH provider, if any.
     pub(crate) fn doh(&self) -> Option<&DohConfigSerde> {
-        self.network
-            .as_ref()
-            .and_then(|n| n.dns_over_https.as_ref())
+        self.network.as_ref().and_then(NetworkConfig::doh)
     }
 }
 

--- a/crates/vouch-agent/src/dns.rs
+++ b/crates/vouch-agent/src/dns.rs
@@ -5,7 +5,6 @@
 //! `vouch_cli::dns::init` so that the agent honors the same configuration.
 
 use anyhow::{Context, Result};
-use vouch_common::dns::{DOH_ENV_VAR, DohResolver, install_process_resolver, resolve_doh_config};
 
 use crate::config::read_config;
 
@@ -16,26 +15,10 @@ use crate::config::read_config;
 ///
 /// # Errors
 ///
-/// Returns an error if the configured provider is invalid or the resolver
-/// cannot be built.
+/// Returns an error if the configured provider is invalid.
 pub fn init() -> Result<()> {
-    let env = std::env::var(DOH_ENV_VAR).ok();
+    let env = std::env::var(vouch_common::dns::DOH_ENV_VAR).ok();
     let config = read_config().ok().flatten();
-    let cfg = resolve_doh_config(env.as_deref(), config.as_ref().and_then(|c| c.doh()))
-        .context("invalid DNS-over-HTTPS configuration")?;
-
-    // DNSSEC validation is on whenever DoH is on; see vouch_cli::dns::init.
-    let resolver = DohResolver::for_config(&cfg, true).with_context(|| {
-        format!(
-            "failed to build DNS-over-HTTPS resolver for provider {}",
-            cfg.label()
-        )
-    })?;
-
-    if cfg.is_enabled() {
-        tracing::info!(provider = %cfg.label(), dnssec = true, "DNS-over-HTTPS enabled");
-    }
-
-    install_process_resolver(cfg, resolver);
-    Ok(())
+    vouch_common::dns::init_from(env.as_deref(), config.as_ref().and_then(|c| c.doh()))
+        .context("invalid DNS-over-HTTPS configuration")
 }

--- a/crates/vouch-agent/src/dns.rs
+++ b/crates/vouch-agent/src/dns.rs
@@ -35,6 +35,6 @@ pub fn init() -> Result<()> {
         tracing::info!(provider = %cfg.label(), "DNS-over-HTTPS enabled");
     }
 
-    install_process_resolver(cfg, resolver);
+    install_process_resolver(resolver);
     Ok(())
 }

--- a/crates/vouch-agent/src/dns.rs
+++ b/crates/vouch-agent/src/dns.rs
@@ -35,6 +35,6 @@ pub fn init() -> Result<()> {
         tracing::info!(provider = %cfg.label(), "DNS-over-HTTPS enabled");
     }
 
-    install_process_resolver(resolver);
+    install_process_resolver(cfg, resolver);
     Ok(())
 }

--- a/crates/vouch-agent/src/dns.rs
+++ b/crates/vouch-agent/src/dns.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! Initialize the process-wide DoH resolver from `~/.vouch/config.json` + env.
+//!
+//! Called once from `main.rs` before any HTTP traffic. Mirrors the CLI's
+//! `vouch_cli::dns::init` so that the agent honors the same configuration.
+
+use anyhow::{Context, Result};
+use vouch_common::dns::{DOH_ENV_VAR, DohResolver, install_process_resolver, resolve_doh_config};
+
+use crate::config::read_config;
+
+/// Initialize the process-wide DoH resolver.
+///
+/// Hard-fails when DoH is explicitly enabled and the resolver cannot be
+/// constructed.
+///
+/// # Errors
+///
+/// Returns an error if the configured provider is invalid or the resolver
+/// cannot be built.
+pub fn init() -> Result<()> {
+    let env = std::env::var(DOH_ENV_VAR).ok();
+    let config = read_config().ok().flatten();
+    let cfg = resolve_doh_config(env.as_deref(), config.as_ref().and_then(|c| c.doh()))
+        .context("invalid DNS-over-HTTPS configuration")?;
+
+    let resolver = DohResolver::for_config(&cfg).with_context(|| {
+        format!(
+            "failed to build DNS-over-HTTPS resolver for provider {}",
+            cfg.label()
+        )
+    })?;
+
+    if cfg.is_enabled() {
+        tracing::info!(provider = %cfg.label(), "DNS-over-HTTPS enabled");
+    }
+
+    install_process_resolver(cfg, resolver);
+    Ok(())
+}

--- a/crates/vouch-agent/src/dns.rs
+++ b/crates/vouch-agent/src/dns.rs
@@ -24,7 +24,8 @@ pub fn init() -> Result<()> {
     let cfg = resolve_doh_config(env.as_deref(), config.as_ref().and_then(|c| c.doh()))
         .context("invalid DNS-over-HTTPS configuration")?;
 
-    let resolver = DohResolver::for_config(&cfg).with_context(|| {
+    // DNSSEC validation is on whenever DoH is on; see vouch_cli::dns::init.
+    let resolver = DohResolver::for_config(&cfg, true).with_context(|| {
         format!(
             "failed to build DNS-over-HTTPS resolver for provider {}",
             cfg.label()
@@ -32,7 +33,7 @@ pub fn init() -> Result<()> {
     })?;
 
     if cfg.is_enabled() {
-        tracing::info!(provider = %cfg.label(), "DNS-over-HTTPS enabled");
+        tracing::info!(provider = %cfg.label(), dnssec = true, "DNS-over-HTTPS enabled");
     }
 
     install_process_resolver(cfg, resolver);

--- a/crates/vouch-agent/src/lib.rs
+++ b/crates/vouch-agent/src/lib.rs
@@ -32,6 +32,7 @@ pub mod audit;
 pub mod client;
 mod config;
 pub mod daemon;
+pub mod dns;
 pub mod error;
 #[cfg(unix)]
 pub mod expiry_monitor;

--- a/crates/vouch-agent/src/main.rs
+++ b/crates/vouch-agent/src/main.rs
@@ -140,6 +140,14 @@ fn main() -> ExitCode {
         }
     };
 
+    // Initialize the process-wide DNS-over-HTTPS resolver from config + env
+    // before any HTTP traffic. Hard-fails if DoH is configured but the
+    // resolver cannot be constructed.
+    if let Err(e) = vouch_agent::dns::init() {
+        error!("DNS-over-HTTPS initialization failed: {e:#}");
+        return ExitCode::FAILURE;
+    }
+
     runtime.block_on(run_agent_server(args.ssh_agent))
 }
 

--- a/crates/vouch-agent/src/main.rs
+++ b/crates/vouch-agent/src/main.rs
@@ -140,19 +140,20 @@ fn main() -> ExitCode {
         }
     };
 
-    // Initialize the process-wide DNS-over-HTTPS resolver from config + env
-    // before any HTTP traffic. Hard-fails if DoH is configured but the
-    // resolver cannot be constructed.
-    if let Err(e) = vouch_agent::dns::init() {
-        error!("DNS-over-HTTPS initialization failed: {e:#}");
-        return ExitCode::FAILURE;
-    }
-
     runtime.block_on(run_agent_server(args.ssh_agent))
 }
 
 /// Run the agent servers.
 async fn run_agent_server(enable_ssh_agent: bool) -> ExitCode {
+    // Initialize the process-wide DNS-over-HTTPS resolver from config + env
+    // before any HTTP traffic. Must run inside the tokio runtime: hickory's
+    // resolver spawns background tasks that require an active Handle.
+    // Hard-fails if DoH is configured but the resolver cannot be constructed.
+    if let Err(e) = vouch_agent::dns::init() {
+        error!("DNS-over-HTTPS initialization failed: {e:#}");
+        return ExitCode::FAILURE;
+    }
+
     // Create agent state
     let state = AgentState::new();
 

--- a/crates/vouch-agent/src/main.rs
+++ b/crates/vouch-agent/src/main.rs
@@ -131,6 +131,14 @@ fn main() -> ExitCode {
         }
     }
 
+    // Initialize the process-wide DNS-over-HTTPS resolver from config + env
+    // before any HTTP traffic. Validates the configuration eagerly; the
+    // hickory resolver itself is built lazily on first use.
+    if let Err(e) = vouch_agent::dns::init() {
+        error!("DNS-over-HTTPS initialization failed: {e:#}");
+        return ExitCode::FAILURE;
+    }
+
     // Run the server using a tokio runtime
     let runtime = match tokio::runtime::Runtime::new() {
         Ok(rt) => rt,
@@ -145,15 +153,6 @@ fn main() -> ExitCode {
 
 /// Run the agent servers.
 async fn run_agent_server(enable_ssh_agent: bool) -> ExitCode {
-    // Initialize the process-wide DNS-over-HTTPS resolver from config + env
-    // before any HTTP traffic. Must run inside the tokio runtime: hickory's
-    // resolver spawns background tasks that require an active Handle.
-    // Hard-fails if DoH is configured but the resolver cannot be constructed.
-    if let Err(e) = vouch_agent::dns::init() {
-        error!("DNS-over-HTTPS initialization failed: {e:#}");
-        return ExitCode::FAILURE;
-    }
-
     // Create agent state
     let state = AgentState::new();
 

--- a/crates/vouch-cli/src/commands/doctor.rs
+++ b/crates/vouch-cli/src/commands/doctor.rs
@@ -108,9 +108,14 @@ pub(crate) async fn run(server: &str, quiet: bool, json: bool) -> Result<()> {
 
     // Check 3a: DNS-over-HTTPS resolution. Only emitted when DoH is enabled —
     // when off, the system resolver is exercised by every other check already.
-    if let Some(doh_result) = check_doh(server).await {
+    // The gate is synchronous (cheap Arc clone) so the label can print *before*
+    // the network round-trip starts — matching every other check above.
+    if let Some(resolver) = vouch_common::dns::process_resolver() {
         if !suppress {
             print!("DNS-over-HTTPS resolution ... ");
+        }
+        let doh_result = check_doh(&resolver, server).await;
+        if !suppress {
             print_result(&doh_result);
         }
         checks.push(doh_result);
@@ -363,16 +368,14 @@ fn build_clock_skew_result(headers: &reqwest::header::HeaderMap) -> Option<Check
 }
 
 /// Verify that the configured DNS-over-HTTPS provider can resolve the
-/// server hostname. Returns `None` when DoH is disabled — the regular
-/// reachability check already exercises whatever resolver is in use.
+/// server hostname. Caller is responsible for gating on DoH-enabled state
+/// (typically `process_resolver().is_some()`).
 ///
 /// DNSSEC validation rides with DoH (always on), so a `[FAIL]` here may
 /// indicate either a network problem reaching the DoH provider or a
 /// DNSSEC-signed zone in the user's path that has broken signatures.
-async fn check_doh(server: &str) -> Option<CheckResult> {
-    let resolver = vouch_common::dns::process_resolver()?;
-    let cfg = vouch_common::dns::process_config();
-    let label = format!("DNS-over-HTTPS ({}, DNSSEC)", cfg.label());
+async fn check_doh(resolver: &vouch_common::dns::DohResolver, server: &str) -> CheckResult {
+    let label = format!("DNS-over-HTTPS ({}, DNSSEC)", resolver.label());
     // Parse the URL directly so IPv6 hosts (which contain colons) survive
     // intact — `hostname_from_url`/colon-splitting would mangle `[::1]`.
     let host = match url::Url::parse(server)
@@ -381,22 +384,21 @@ async fn check_doh(server: &str) -> Option<CheckResult> {
     {
         Some(h) => h,
         None => {
-            return Some(CheckResult::fail(
+            return CheckResult::fail(
                 "doh",
                 format!("{label}: cannot extract host from server URL"),
-            ));
+            );
         }
     };
     match resolver.lookup_ip(&host).await {
-        Ok(addrs) if addrs.is_empty() => Some(CheckResult::fail(
-            "doh",
-            format!("{label}: {host} resolved to zero addresses"),
-        )),
-        Ok(addrs) => Some(CheckResult::pass(
+        Ok(addrs) if addrs.is_empty() => {
+            CheckResult::fail("doh", format!("{label}: {host} resolved to zero addresses"))
+        }
+        Ok(addrs) => CheckResult::pass(
             "doh",
             format!("{label}: {host} resolved to {} address(es)", addrs.len()),
-        )),
-        Err(e) => Some(CheckResult::fail("doh", format!("{label}: {e:#}"))),
+        ),
+        Err(e) => CheckResult::fail("doh", format!("{label}: {e:#}")),
     }
 }
 

--- a/crates/vouch-cli/src/commands/doctor.rs
+++ b/crates/vouch-cli/src/commands/doctor.rs
@@ -371,8 +371,8 @@ fn build_clock_skew_result(headers: &reqwest::header::HeaderMap) -> Option<Check
 /// DNSSEC-signed zone in the user's path that has broken signatures.
 async fn check_doh(server: &str) -> Option<CheckResult> {
     let resolver = vouch_common::dns::process_resolver()?;
-    let provider = vouch_common::dns::process_config().label();
-    let label = format!("DNS-over-HTTPS ({provider}, DNSSEC)");
+    let cfg = vouch_common::dns::process_config();
+    let label = format!("DNS-over-HTTPS ({}, DNSSEC)", cfg.label());
     // Parse the URL directly so IPv6 hosts (which contain colons) survive
     // intact — `hostname_from_url`/colon-splitting would mangle `[::1]`.
     let host = match url::Url::parse(server)

--- a/crates/vouch-cli/src/commands/doctor.rs
+++ b/crates/vouch-cli/src/commands/doctor.rs
@@ -106,10 +106,13 @@ pub(crate) async fn run(server: &str, quiet: bool, json: bool) -> Result<()> {
         checks.push(clock);
     }
 
-    // Check 3a: DNS-over-HTTPS resolution. Only emitted when DoH is enabled —
-    // when off, the system resolver is exercised by every other check already.
-    // The gate is synchronous (cheap Arc clone) so the label can print *before*
-    // the network round-trip starts — matching every other check above.
+    // Check 3a: DNS-over-HTTPS resolution status.
+    //
+    // Always emit something so users discover the option. When DoH is enabled
+    // we run a real lookup through the configured provider. When disabled we
+    // print a one-line nudge — not added to `checks` so it doesn't count
+    // toward pass/fail or appear in --json output (DoH being off is a user
+    // choice, not a misconfiguration).
     if let Some(resolver) = vouch_common::dns::process_resolver() {
         if !suppress {
             print!("DNS-over-HTTPS resolution ... ");
@@ -119,6 +122,12 @@ pub(crate) async fn run(server: &str, quiet: bool, json: bool) -> Result<()> {
             print_result(&doh_result);
         }
         checks.push(doh_result);
+    } else if !suppress {
+        println!(
+            "DNS-over-HTTPS resolution ... {} disabled — DNS queries are visible to your \
+             local network. Set VOUCH_DOH=cloudflare (or google/quad9) to encrypt them.",
+            style::yellow("[INFO]"),
+        );
     }
 
     // Check 4: Session valid

--- a/crates/vouch-cli/src/commands/doctor.rs
+++ b/crates/vouch-cli/src/commands/doctor.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use vouch_agent::AgentClient;
 
 use crate::client::VouchClient;
-use crate::config::{Config, hostname_from_url};
+use crate::config::Config;
 use crate::style;
 
 /// Check result with status and optional message.
@@ -373,15 +373,17 @@ async fn check_doh(server: &str) -> Option<CheckResult> {
     let resolver = vouch_common::dns::process_resolver()?;
     let provider = vouch_common::dns::process_config().label();
     let label = format!("DNS-over-HTTPS ({provider}, DNSSEC)");
-    let host = match hostname_from_url(server) {
-        Ok(h) => {
-            // strip any :port for the lookup
-            h.split(':').next().unwrap_or(&h).to_string()
-        }
-        Err(e) => {
+    // Parse the URL directly so IPv6 hosts (which contain colons) survive
+    // intact — `hostname_from_url`/colon-splitting would mangle `[::1]`.
+    let host = match url::Url::parse(server)
+        .ok()
+        .and_then(|u| u.host_str().map(str::to_string))
+    {
+        Some(h) => h,
+        None => {
             return Some(CheckResult::fail(
                 "doh",
-                format!("{label}: cannot parse server URL: {e}"),
+                format!("{label}: cannot extract host from server URL"),
             ));
         }
     };

--- a/crates/vouch-cli/src/commands/doctor.rs
+++ b/crates/vouch-cli/src/commands/doctor.rs
@@ -365,9 +365,14 @@ fn build_clock_skew_result(headers: &reqwest::header::HeaderMap) -> Option<Check
 /// Verify that the configured DNS-over-HTTPS provider can resolve the
 /// server hostname. Returns `None` when DoH is disabled — the regular
 /// reachability check already exercises whatever resolver is in use.
+///
+/// DNSSEC validation rides with DoH (always on), so a `[FAIL]` here may
+/// indicate either a network problem reaching the DoH provider or a
+/// DNSSEC-signed zone in the user's path that has broken signatures.
 async fn check_doh(server: &str) -> Option<CheckResult> {
     let resolver = vouch_common::dns::process_resolver()?;
     let provider = vouch_common::dns::process_config().label();
+    let label = format!("DNS-over-HTTPS ({provider}, DNSSEC)");
     let host = match hostname_from_url(server) {
         Ok(h) => {
             // strip any :port for the lookup
@@ -376,26 +381,20 @@ async fn check_doh(server: &str) -> Option<CheckResult> {
         Err(e) => {
             return Some(CheckResult::fail(
                 "doh",
-                format!("DNS-over-HTTPS ({provider}): cannot parse server URL: {e}"),
+                format!("{label}: cannot parse server URL: {e}"),
             ));
         }
     };
     match resolver.lookup_ip(&host).await {
         Ok(addrs) if addrs.is_empty() => Some(CheckResult::fail(
             "doh",
-            format!("DNS-over-HTTPS ({provider}): {host} resolved to zero addresses"),
+            format!("{label}: {host} resolved to zero addresses"),
         )),
         Ok(addrs) => Some(CheckResult::pass(
             "doh",
-            format!(
-                "DNS-over-HTTPS ({provider}): {host} resolved to {} address(es)",
-                addrs.len()
-            ),
+            format!("{label}: {host} resolved to {} address(es)", addrs.len()),
         )),
-        Err(e) => Some(CheckResult::fail(
-            "doh",
-            format!("DNS-over-HTTPS ({provider}): {e:#}"),
-        )),
+        Err(e) => Some(CheckResult::fail("doh", format!("{label}: {e:#}"))),
     }
 }
 

--- a/crates/vouch-cli/src/commands/doctor.rs
+++ b/crates/vouch-cli/src/commands/doctor.rs
@@ -384,7 +384,11 @@ fn build_clock_skew_result(headers: &reqwest::header::HeaderMap) -> Option<Check
 /// indicate either a network problem reaching the DoH provider or a
 /// DNSSEC-signed zone in the user's path that has broken signatures.
 async fn check_doh(resolver: &vouch_common::dns::DohResolver, server: &str) -> CheckResult {
-    let label = format!("DNS-over-HTTPS ({}, DNSSEC)", resolver.label());
+    let label = format!(
+        "DNS-over-HTTPS via {} ({}, DNSSEC)",
+        resolver.label(),
+        resolver.endpoint_url(),
+    );
     // Parse the URL directly so IPv6 hosts (which contain colons) survive
     // intact — `hostname_from_url`/colon-splitting would mangle `[::1]`.
     let host = match url::Url::parse(server)

--- a/crates/vouch-cli/src/commands/doctor.rs
+++ b/crates/vouch-cli/src/commands/doctor.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use vouch_agent::AgentClient;
 
 use crate::client::VouchClient;
-use crate::config::Config;
+use crate::config::{Config, hostname_from_url};
 use crate::style;
 
 /// Check result with status and optional message.
@@ -104,6 +104,16 @@ pub(crate) async fn run(server: &str, quiet: bool, json: bool) -> Result<()> {
             print_result(&clock);
         }
         checks.push(clock);
+    }
+
+    // Check 3a: DNS-over-HTTPS resolution. Only emitted when DoH is enabled —
+    // when off, the system resolver is exercised by every other check already.
+    if let Some(doh_result) = check_doh(server).await {
+        if !suppress {
+            print!("DNS-over-HTTPS resolution ... ");
+            print_result(&doh_result);
+        }
+        checks.push(doh_result);
     }
 
     // Check 4: Session valid
@@ -350,6 +360,43 @@ fn build_clock_skew_result(headers: &reqwest::header::HeaderMap) -> Option<Check
              \"Sync now\"; macOS: `sudo sntp -sS time.apple.com`)."
         ),
     ))
+}
+
+/// Verify that the configured DNS-over-HTTPS provider can resolve the
+/// server hostname. Returns `None` when DoH is disabled — the regular
+/// reachability check already exercises whatever resolver is in use.
+async fn check_doh(server: &str) -> Option<CheckResult> {
+    let resolver = vouch_common::dns::process_resolver()?;
+    let provider = vouch_common::dns::process_config().label();
+    let host = match hostname_from_url(server) {
+        Ok(h) => {
+            // strip any :port for the lookup
+            h.split(':').next().unwrap_or(&h).to_string()
+        }
+        Err(e) => {
+            return Some(CheckResult::fail(
+                "doh",
+                format!("DNS-over-HTTPS ({provider}): cannot parse server URL: {e}"),
+            ));
+        }
+    };
+    match resolver.lookup_ip(&host).await {
+        Ok(addrs) if addrs.is_empty() => Some(CheckResult::fail(
+            "doh",
+            format!("DNS-over-HTTPS ({provider}): {host} resolved to zero addresses"),
+        )),
+        Ok(addrs) => Some(CheckResult::pass(
+            "doh",
+            format!(
+                "DNS-over-HTTPS ({provider}): {host} resolved to {} address(es)",
+                addrs.len()
+            ),
+        )),
+        Err(e) => Some(CheckResult::fail(
+            "doh",
+            format!("DNS-over-HTTPS ({provider}): {e:#}"),
+        )),
+    }
 }
 
 /// Check if there's a valid session.

--- a/crates/vouch-cli/src/config.rs
+++ b/crates/vouch-cli/src/config.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
-use vouch_common::dns::DohConfigSerde;
+use vouch_common::dns::{DohConfigSerde, NetworkConfig};
 
 /// AWS multi-account configuration in ~/.vouch/config.json.
 ///
@@ -131,17 +131,6 @@ pub(crate) struct Config {
     aws: Option<AwsMultiAccountConfig>,
     /// Global network configuration (DoH, …).
     network: Option<NetworkConfig>,
-}
-
-/// Global network options.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub(crate) struct NetworkConfig {
-    /// DNS-over-HTTPS provider. Accepts a boolean (`true` = Google, `false`
-    /// = off), a keyword (`off`, `google`, `cloudflare`, `quad9`), or a
-    /// custom `https://…/dns-query` URL. Overridden at runtime by the
-    /// `VOUCH_DOH` env var.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub dns_over_https: Option<DohConfigSerde>,
 }
 
 /// Per-server configuration state.
@@ -413,9 +402,7 @@ impl Config {
 
     /// Configured DoH provider, if any.
     pub(crate) fn doh(&self) -> Option<&DohConfigSerde> {
-        self.network
-            .as_ref()
-            .and_then(|n| n.dns_over_https.as_ref())
+        self.network.as_ref().and_then(NetworkConfig::doh)
     }
 
     // =====================================================================

--- a/crates/vouch-cli/src/config.rs
+++ b/crates/vouch-cli/src/config.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
+use vouch_common::dns::DohConfigSerde;
 
 /// AWS multi-account configuration in ~/.vouch/config.json.
 ///
@@ -128,6 +129,19 @@ pub(crate) struct Config {
     codeartifact: Option<CodeArtifactConfig>,
     /// AWS multi-account configuration (role chaining + SSO discovery).
     aws: Option<AwsMultiAccountConfig>,
+    /// Global network configuration (DoH, …).
+    network: Option<NetworkConfig>,
+}
+
+/// Global network options.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct NetworkConfig {
+    /// DNS-over-HTTPS provider. Accepts a boolean (`true` = Google, `false`
+    /// = off), a keyword (`off`, `google`, `cloudflare`, `quad9`), or a
+    /// custom `https://…/dns-query` URL. Overridden at runtime by the
+    /// `VOUCH_DOH` env var.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dns_over_https: Option<DohConfigSerde>,
 }
 
 /// Per-server configuration state.
@@ -194,6 +208,9 @@ struct ConfigFile {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     aws: Option<AwsMultiAccountConfig>,
 
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    network: Option<NetworkConfig>,
+
     // Legacy flat fields — read for migration, never written back.
     #[serde(default, skip_serializing)]
     server_url: Option<String>,
@@ -239,6 +256,7 @@ impl std::fmt::Debug for ConfigFile {
             .field("servers", &"[...]")
             .field("codeartifact", &self.codeartifact)
             .field("aws", &self.aws)
+            .field("network", &self.network)
             .finish()
     }
 }
@@ -250,6 +268,7 @@ impl std::fmt::Debug for Config {
             .field("servers", &self.servers.keys().collect::<Vec<_>>())
             .field("codeartifact", &self.codeartifact)
             .field("aws", &self.aws)
+            .field("network", &self.network)
             .finish()
     }
 }
@@ -386,6 +405,17 @@ impl Config {
         let mut config = Self::load()?;
         f(&mut config);
         config.save()
+    }
+
+    // =====================================================================
+    // Network
+    // =====================================================================
+
+    /// Configured DoH provider, if any.
+    pub(crate) fn doh(&self) -> Option<&DohConfigSerde> {
+        self.network
+            .as_ref()
+            .and_then(|n| n.dns_over_https.as_ref())
     }
 
     // =====================================================================
@@ -619,6 +649,7 @@ impl From<ConfigFile> for Config {
             servers,
             codeartifact: file.codeartifact.take(),
             aws: file.aws.take(),
+            network: file.network.take(),
         }
     }
 }
@@ -653,6 +684,7 @@ impl From<&Config> for ConfigFile {
             servers,
             codeartifact: config.codeartifact.clone(),
             aws: config.aws.clone(),
+            network: config.network.clone(),
             // Legacy fields are never written.
             server_url: None,
             token: None,

--- a/crates/vouch-cli/src/dns.rs
+++ b/crates/vouch-cli/src/dns.rs
@@ -39,6 +39,6 @@ pub(crate) fn init() -> Result<()> {
         tracing::debug!(provider = %cfg.label(), "DNS-over-HTTPS enabled");
     }
 
-    install_process_resolver(cfg, resolver);
+    install_process_resolver(resolver);
     Ok(())
 }

--- a/crates/vouch-cli/src/dns.rs
+++ b/crates/vouch-cli/src/dns.rs
@@ -7,43 +7,21 @@
 //! DoH resolver (or none, the default).
 
 use anyhow::{Context, Result};
-use vouch_common::dns::{DOH_ENV_VAR, DohResolver, install_process_resolver, resolve_doh_config};
 
 use crate::config::Config;
 
 /// Initialize the process-wide DoH resolver.
 ///
 /// Reads `VOUCH_DOH` first, then `network.dns_over_https` from
-/// `~/.vouch/config.json`. Defaults to `Off`. **Hard-fails** when DoH is
-/// explicitly enabled and the resolver cannot be constructed — silent
-/// fallback would defeat the security intent of opting in.
+/// `~/.vouch/config.json`. Hard-fails when DoH is explicitly enabled and the
+/// resolver cannot be constructed.
 ///
 /// # Errors
 ///
-/// Returns an error if the configured provider is invalid or the resolver
-/// cannot be built.
+/// Returns an error if the configured provider is invalid.
 pub(crate) fn init() -> Result<()> {
-    let env = std::env::var(DOH_ENV_VAR).ok();
+    let env = std::env::var(vouch_common::dns::DOH_ENV_VAR).ok();
     let config = Config::load().ok();
-    let cfg = resolve_doh_config(env.as_deref(), config.as_ref().and_then(Config::doh))
-        .context("invalid DNS-over-HTTPS configuration")?;
-
-    // DNSSEC validation is on whenever DoH is on. There is no separate
-    // toggle: hickory only sees signed/insecure responses (unsigned zones
-    // like *.amazonaws.com pass through unchanged), so the practical
-    // failure surface is "a DNSSEC-signed zone in the user's path is
-    // misconfigured" — which is what we want to surface, not hide.
-    let resolver = DohResolver::for_config(&cfg, true).with_context(|| {
-        format!(
-            "failed to build DNS-over-HTTPS resolver for provider {}",
-            cfg.label()
-        )
-    })?;
-
-    if cfg.is_enabled() {
-        tracing::debug!(provider = %cfg.label(), dnssec = true, "DNS-over-HTTPS enabled");
-    }
-
-    install_process_resolver(cfg, resolver);
-    Ok(())
+    vouch_common::dns::init_from(env.as_deref(), config.as_ref().and_then(Config::doh))
+        .context("invalid DNS-over-HTTPS configuration")
 }

--- a/crates/vouch-cli/src/dns.rs
+++ b/crates/vouch-cli/src/dns.rs
@@ -39,6 +39,6 @@ pub(crate) fn init() -> Result<()> {
         tracing::debug!(provider = %cfg.label(), "DNS-over-HTTPS enabled");
     }
 
-    install_process_resolver(resolver);
+    install_process_resolver(cfg, resolver);
     Ok(())
 }

--- a/crates/vouch-cli/src/dns.rs
+++ b/crates/vouch-cli/src/dns.rs
@@ -28,7 +28,12 @@ pub(crate) fn init() -> Result<()> {
     let cfg = resolve_doh_config(env.as_deref(), config.as_ref().and_then(Config::doh))
         .context("invalid DNS-over-HTTPS configuration")?;
 
-    let resolver = DohResolver::for_config(&cfg).with_context(|| {
+    // DNSSEC validation is on whenever DoH is on. There is no separate
+    // toggle: hickory only sees signed/insecure responses (unsigned zones
+    // like *.amazonaws.com pass through unchanged), so the practical
+    // failure surface is "a DNSSEC-signed zone in the user's path is
+    // misconfigured" — which is what we want to surface, not hide.
+    let resolver = DohResolver::for_config(&cfg, true).with_context(|| {
         format!(
             "failed to build DNS-over-HTTPS resolver for provider {}",
             cfg.label()
@@ -36,7 +41,7 @@ pub(crate) fn init() -> Result<()> {
     })?;
 
     if cfg.is_enabled() {
-        tracing::debug!(provider = %cfg.label(), "DNS-over-HTTPS enabled");
+        tracing::debug!(provider = %cfg.label(), dnssec = true, "DNS-over-HTTPS enabled");
     }
 
     install_process_resolver(cfg, resolver);

--- a/crates/vouch-cli/src/dns.rs
+++ b/crates/vouch-cli/src/dns.rs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! Initialize the process-wide DoH resolver from config + env.
+//!
+//! Called once from `main.rs` before any HTTP traffic. After this runs, every
+//! reqwest client built via `vouch_common::http::*` or
+//! `vouch_cli::http::ReqwestClient::new` automatically uses the configured
+//! DoH resolver (or none, the default).
+
+use anyhow::{Context, Result};
+use vouch_common::dns::{DOH_ENV_VAR, DohResolver, install_process_resolver, resolve_doh_config};
+
+use crate::config::Config;
+
+/// Initialize the process-wide DoH resolver.
+///
+/// Reads `VOUCH_DOH` first, then `network.dns_over_https` from
+/// `~/.vouch/config.json`. Defaults to `Off`. **Hard-fails** when DoH is
+/// explicitly enabled and the resolver cannot be constructed — silent
+/// fallback would defeat the security intent of opting in.
+///
+/// # Errors
+///
+/// Returns an error if the configured provider is invalid or the resolver
+/// cannot be built.
+pub(crate) fn init() -> Result<()> {
+    let env = std::env::var(DOH_ENV_VAR).ok();
+    let config = Config::load().ok();
+    let cfg = resolve_doh_config(env.as_deref(), config.as_ref().and_then(Config::doh))
+        .context("invalid DNS-over-HTTPS configuration")?;
+
+    let resolver = DohResolver::for_config(&cfg).with_context(|| {
+        format!(
+            "failed to build DNS-over-HTTPS resolver for provider {}",
+            cfg.label()
+        )
+    })?;
+
+    if cfg.is_enabled() {
+        tracing::debug!(provider = %cfg.label(), "DNS-over-HTTPS enabled");
+    }
+
+    install_process_resolver(cfg, resolver);
+    Ok(())
+}

--- a/crates/vouch-cli/src/http.rs
+++ b/crates/vouch-cli/src/http.rs
@@ -234,18 +234,16 @@ impl ReqwestClient {
             default_headers.insert("Vouch-Client-Hostname", v);
         }
 
-        let mut builder = reqwest::Client::builder()
+        let builder = reqwest::Client::builder()
             .user_agent(&user_agent)
             .default_headers(default_headers)
             .redirect(reqwest::redirect::Policy::none())
             .timeout(INTERACTIVE_TOTAL)
             .connect_timeout(INTERACTIVE_CONNECT);
 
-        if let Some(resolver) = vouch_common::dns::process_resolver() {
-            builder = builder.dns_resolver(resolver);
-        }
-
-        let client = builder.build().context("failed to create HTTP client")?;
+        let client = vouch_common::http::with_process_doh(builder)
+            .build()
+            .context("failed to create HTTP client")?;
 
         Ok(Self { client })
     }

--- a/crates/vouch-cli/src/http.rs
+++ b/crates/vouch-cli/src/http.rs
@@ -234,13 +234,18 @@ impl ReqwestClient {
             default_headers.insert("Vouch-Client-Hostname", v);
         }
 
-        let client = reqwest::Client::builder()
+        let mut builder = reqwest::Client::builder()
             .user_agent(&user_agent)
             .default_headers(default_headers)
+            .redirect(reqwest::redirect::Policy::none())
             .timeout(INTERACTIVE_TOTAL)
-            .connect_timeout(INTERACTIVE_CONNECT)
-            .build()
-            .context("failed to create HTTP client")?;
+            .connect_timeout(INTERACTIVE_CONNECT);
+
+        if let Some(resolver) = vouch_common::dns::process_resolver() {
+            builder = builder.dns_resolver(resolver);
+        }
+
+        let client = builder.build().context("failed to create HTTP client")?;
 
         Ok(Self { client })
     }

--- a/crates/vouch-cli/src/main.rs
+++ b/crates/vouch-cli/src/main.rs
@@ -15,6 +15,7 @@ use tracing_subscriber::EnvFilter;
 mod client;
 mod commands;
 mod config;
+mod dns;
 mod exit_code;
 #[expect(
     unreachable_pub,
@@ -447,6 +448,11 @@ async fn main() -> ExitCode {
 /// Inner entry point that returns `anyhow::Result`.
 async fn run() -> Result<()> {
     let argv0 = std::env::args().next().unwrap_or_default();
+
+    // Initialize the process-wide DNS-over-HTTPS resolver from config + env
+    // before any HTTP client is constructed (including from helper-binary
+    // dispatch below). Hard-fails if DoH is configured but unavailable.
+    dns::init()?;
 
     // Register the platform-native keyring store. Non-fatal: keychain access
     // already falls back to file storage in fapi::key_store when unavailable.

--- a/crates/vouch-common/Cargo.toml
+++ b/crates/vouch-common/Cargo.toml
@@ -15,6 +15,7 @@ ciborium = { workspace = true }
 dirs = { workspace = true }
 gethostname = { workspace = true }
 hex = { workspace = true, features = ["std"] }
+hickory-resolver = { workspace = true }
 jiff = { workspace = true, features = ["std", "serde", "tz-system"] }
 reqwest = { workspace = true, features = ["json", "rustls", "form"] }
 secrecy = { workspace = true, features = ["serde"] }

--- a/crates/vouch-common/Cargo.toml
+++ b/crates/vouch-common/Cargo.toml
@@ -22,5 +22,6 @@ secrecy = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["std", "derive"] }
 serde_json = { workspace = true, features = ["std"] }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true, features = ["v7", "serde", "std"] }

--- a/crates/vouch-common/src/dns.rs
+++ b/crates/vouch-common/src/dns.rs
@@ -6,8 +6,11 @@
 //! (Google, Cloudflare, Quad9) or a custom HTTPS endpoint.
 //!
 //! Opt-in via the `VOUCH_DOH` env var or the `network.dns_over_https` field in
-//! `~/.vouch/config.json`. When unset, the system resolver is used (default
-//! behavior).
+//! `~/.vouch/config.json`. When unset, the system resolver is used.
+//!
+//! Both `vouch-cli` and `vouch-agent` install the process-wide state via
+//! [`init_from`] before any HTTP client is constructed; [`process_resolver`]
+//! then surfaces it to every reqwest client factory.
 
 use std::net::SocketAddr;
 use std::sync::{Arc, OnceLock};
@@ -18,14 +21,78 @@ use hickory_resolver::config::{CLOUDFLARE, GOOGLE, NameServerConfig, QUAD9, Reso
 use reqwest::dns::{Addrs, Name as ReqName, Resolve, Resolving};
 use serde::{Deserialize, Serialize};
 
-/// Environment variable consulted by [`process_resolver`] when no explicit
-/// resolver has been installed.
+/// Environment variable consulted by [`init_from`].
 pub const DOH_ENV_VAR: &str = "VOUCH_DOH";
 
-/// DoH provider selection.
+// =============================================================================
+// DohEndpoint — validated custom DoH URL
+// =============================================================================
+
+/// Validated custom DoH endpoint: an `https://` URL whose host is an IP
+/// literal.
 ///
-/// `Off` means use the system resolver (current default behavior). All other
-/// variants route DNS over HTTPS to the named provider.
+/// Hostname-only endpoints are rejected at construction because they would
+/// require DNS to look up the DNS resolver — a chicken-and-egg bootstrap
+/// problem. All preprocessing for hickory's [`NameServerConfig`] is done
+/// once at construction, leaving downstream usage infallible.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DohEndpoint {
+    url: url::Url,
+    ip: std::net::IpAddr,
+    server_name: Arc<str>,
+    path: Option<Arc<str>>,
+    /// Explicit non-default port from the URL, if any. `None` means the
+    /// hickory default (443) is used.
+    port: Option<u16>,
+}
+
+impl DohEndpoint {
+    /// Construct from a URL.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the scheme is not `https://`, the URL has no
+    /// host, or the host is not an IP literal.
+    pub fn new(url: url::Url) -> Result<Self> {
+        if url.scheme() != "https" {
+            anyhow::bail!("DoH endpoint must use https://: {url}");
+        }
+        let host = url
+            .host_str()
+            .ok_or_else(|| anyhow::anyhow!("custom DoH URL has no host: {url}"))?;
+        let ip: std::net::IpAddr = host.parse().with_context(|| {
+            format!(
+                "custom DoH URL must use an IP literal (got host={host:?}); \
+                 hostnames create a DNS bootstrap problem"
+            )
+        })?;
+        let server_name: Arc<str> = host.into();
+        let path = match url.path() {
+            "" | "/" => None,
+            p => Some(Arc::from(p)),
+        };
+        let port = url.port();
+        Ok(Self {
+            url,
+            ip,
+            server_name,
+            path,
+            port,
+        })
+    }
+
+    /// The validated URL.
+    #[must_use]
+    pub fn url(&self) -> &url::Url {
+        &self.url
+    }
+}
+
+// =============================================================================
+// DohConfig — the parsed user choice
+// =============================================================================
+
+/// DoH provider selection.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DohConfig {
     /// Use the system resolver. No DoH.
@@ -37,19 +104,20 @@ pub enum DohConfig {
     Cloudflare,
     /// Quad9 9.9.9.9 over HTTPS.
     Quad9,
-    /// User-specified DoH endpoint (must be `https://…/dns-query`).
-    Custom(url::Url),
+    /// User-specified DoH endpoint (validated at parse time).
+    Custom(DohEndpoint),
 }
 
 impl DohConfig {
     /// Parse a textual DoH selector.
     ///
     /// Accepts: `off`, `on` (== `google`), `google`, `cloudflare`, `quad9`,
-    /// or any `https://…` URL.
+    /// or any `https://…` URL whose host is an IP literal.
     ///
     /// # Errors
     ///
-    /// Returns an error for an unknown keyword or a non-HTTPS URL.
+    /// Returns an error for an unknown keyword, a non-HTTPS URL, or a custom
+    /// URL whose host is not an IP literal.
     pub fn parse(value: &str) -> Result<Self> {
         let trimmed = value.trim();
         match trimmed.to_ascii_lowercase().as_str() {
@@ -60,10 +128,7 @@ impl DohConfig {
             _ => {
                 let url = url::Url::parse(trimmed)
                     .with_context(|| format!("invalid DoH provider: {trimmed:?}"))?;
-                if url.scheme() != "https" {
-                    anyhow::bail!("DoH endpoint must use https://: {url}");
-                }
-                Ok(Self::Custom(url))
+                Ok(Self::Custom(DohEndpoint::new(url)?))
             }
         }
     }
@@ -75,17 +140,24 @@ impl DohConfig {
     }
 
     /// Short human label for diagnostics (`vouch doctor`, log messages).
+    ///
+    /// Returns a borrow — static for the keyword variants, the URL string
+    /// for `Custom`. No allocation.
     #[must_use]
-    pub fn label(&self) -> String {
+    pub fn label(&self) -> &str {
         match self {
-            Self::Off => "off".to_string(),
-            Self::Google => "google".to_string(),
-            Self::Cloudflare => "cloudflare".to_string(),
-            Self::Quad9 => "quad9".to_string(),
-            Self::Custom(url) => url.to_string(),
+            Self::Off => "off",
+            Self::Google => "google",
+            Self::Cloudflare => "cloudflare",
+            Self::Quad9 => "quad9",
+            Self::Custom(endpoint) => endpoint.url.as_str(),
         }
     }
 }
+
+// =============================================================================
+// DohConfigSerde — config-file representation
+// =============================================================================
 
 /// Serializable form for `~/.vouch/config.json`. Accepts a string keyword,
 /// a URL, or a bare boolean (`true` -> Google, `false` -> Off).
@@ -104,7 +176,8 @@ impl DohConfigSerde {
     ///
     /// # Errors
     ///
-    /// Returns an error if the textual form is not a known keyword or HTTPS URL.
+    /// Returns an error if the textual form is not a known keyword or a
+    /// valid custom URL.
     pub fn resolve(&self) -> Result<DohConfig> {
         match self {
             Self::Bool(true) => Ok(DohConfig::Google),
@@ -114,8 +187,38 @@ impl DohConfigSerde {
     }
 }
 
-/// Determine the effective [`DohConfig`] from the `VOUCH_DOH` env var falling
-/// back to a config-file value.
+// =============================================================================
+// NetworkConfig — shared deserialization shape for CLI/agent config files
+// =============================================================================
+
+/// Global network options for the vouch CLI/agent configuration files.
+///
+/// Lives here so both `vouch-cli` and `vouch-agent` deserialize the same
+/// `network` section without divergent definitions.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct NetworkConfig {
+    /// DNS-over-HTTPS provider. Accepts a boolean (`true` = Google, `false`
+    /// = off), a keyword (`off`, `google`, `cloudflare`, `quad9`), or a
+    /// custom `https://…/dns-query` URL. Overridden at runtime by the
+    /// `VOUCH_DOH` environment variable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dns_over_https: Option<DohConfigSerde>,
+}
+
+impl NetworkConfig {
+    /// Configured DoH provider, if any.
+    #[must_use]
+    pub fn doh(&self) -> Option<&DohConfigSerde> {
+        self.dns_over_https.as_ref()
+    }
+}
+
+// =============================================================================
+// Precedence
+// =============================================================================
+
+/// Determine the effective [`DohConfig`] from the `VOUCH_DOH` env var
+/// falling back to a config-file value.
 ///
 /// Env wins over config; config wins over the `Off` default.
 ///
@@ -135,19 +238,23 @@ pub fn resolve_doh_config(
     Ok(DohConfig::Off)
 }
 
+// =============================================================================
+// DohResolver — reqwest-compatible DoH resolver
+// =============================================================================
+
 /// reqwest-compatible DoH resolver backed by `hickory-resolver`.
 ///
 /// The underlying `TokioResolver` is built lazily on the first DNS query so
-/// that `for_config` can be called from any context (including outside a
-/// tokio runtime). Hickory spawns background tasks at construction; building
-/// inside `resolve()` guarantees `Handle::current()` is available.
+/// that [`for_config`](Self::for_config) can be called from any context
+/// (including outside a tokio runtime). Hickory spawns background tasks at
+/// construction; building inside `resolve()` guarantees `Handle::current()`
+/// is available.
 pub struct DohResolver {
     config: ResolverConfig,
     label: String,
-    dnssec: bool,
-    /// Lazy resolver. `Err` is captured on first build failure and replayed
-    /// to every subsequent caller (since `OnceLock::get_or_try_init` is
-    /// still unstable).
+    // FIXME: replace with `OnceLock::get_or_try_init` once stable
+    // (rust-lang/rust#109737). Until then we stringify the build error so
+    // every subsequent caller sees the same message.
     inner: OnceLock<Result<hickory_resolver::TokioResolver, String>>,
 }
 
@@ -163,34 +270,27 @@ impl std::fmt::Debug for DohResolver {
 impl DohResolver {
     /// Build a resolver for the given configuration.
     ///
-    /// Returns `Ok(None)` when `cfg` is [`DohConfig::Off`]. When `dnssec` is
-    /// true, hickory performs stub DNSSEC validation: signed responses must
-    /// validate or the lookup fails; unsigned zones (e.g. `*.amazonaws.com`)
-    /// pass through unchanged.
+    /// Returns `None` when `cfg` is [`DohConfig::Off`]. DNSSEC validation is
+    /// always enabled when DoH is enabled: signed responses must validate or
+    /// the lookup fails; unsigned zones (e.g. `*.amazonaws.com`) pass
+    /// through unchanged.
     ///
-    /// The actual hickory resolver is constructed on first use (see
-    /// [`get_or_init`](Self::get_or_init)), so this is safe to call outside a
-    /// tokio runtime context.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error only if the configuration is malformed (e.g., a
-    /// custom URL whose host isn't an IP literal). Network/resolver
-    /// construction failures surface from `Resolve::resolve` instead.
-    pub fn for_config(cfg: &DohConfig, dnssec: bool) -> Result<Option<Arc<Self>>> {
+    /// The hickory resolver is built lazily on first use, so this is safe
+    /// to call outside a tokio runtime context.
+    #[must_use]
+    pub fn for_config(cfg: &DohConfig) -> Option<Arc<Self>> {
         let config = match cfg {
-            DohConfig::Off => return Ok(None),
+            DohConfig::Off => return None,
             DohConfig::Google => ResolverConfig::https(&GOOGLE),
             DohConfig::Cloudflare => ResolverConfig::https(&CLOUDFLARE),
             DohConfig::Quad9 => ResolverConfig::https(&QUAD9),
-            DohConfig::Custom(url) => custom_https_config(url)?,
+            DohConfig::Custom(endpoint) => custom_https_config(endpoint),
         };
-        Ok(Some(Arc::new(Self {
+        Some(Arc::new(Self {
             config,
-            label: cfg.label(),
-            dnssec,
+            label: cfg.label().to_string(),
             inner: OnceLock::new(),
-        })))
+        }))
     }
 
     /// Provider label used for diagnostics.
@@ -208,9 +308,7 @@ impl DohResolver {
             .get_or_init(|| {
                 let mut builder =
                     Resolver::builder_with_config(self.config.clone(), Default::default());
-                if self.dnssec {
-                    builder.options_mut().validate = true;
-                }
+                builder.options_mut().validate = true;
                 builder
                     .build()
                     .map_err(|e| format!("failed to construct DoH resolver: {e}"))
@@ -237,12 +335,17 @@ impl DohResolver {
     }
 }
 
+// =============================================================================
+// Process-wide state
+// =============================================================================
+
 /// Process-wide DoH state.
 ///
-/// Set once via [`install_process_resolver`] from the binary's startup path
-/// and read by every HTTP client factory in this crate plus
-/// `vouch_cli::http::ReqwestClient::new`. The resolver itself is lazily
-/// built on first use, so installation is safe outside a tokio runtime.
+/// Set once via [`install_process_resolver`] (typically from
+/// [`init_from`]) at the binary's startup path, read by every HTTP client
+/// factory in this crate plus `vouch_cli::http::ReqwestClient::new`. The
+/// resolver itself is built lazily on first use, so installation is safe
+/// outside a tokio runtime.
 struct ProcessState {
     config: DohConfig,
     resolver: Option<Arc<DohResolver>>,
@@ -250,8 +353,12 @@ struct ProcessState {
 
 static PROCESS_STATE: OnceLock<ProcessState> = OnceLock::new();
 
-/// Install the process-wide DoH state. Idempotent — subsequent calls are
-/// silently ignored so that re-entry from tests doesn't panic.
+/// Install the process-wide DoH state.
+///
+/// **First call wins; subsequent calls are silently ignored** — there is no
+/// error and the state is not replaced. This makes re-entry from tests safe
+/// and means binaries should call [`init_from`] exactly once before any
+/// HTTP client is constructed.
 pub fn install_process_resolver(cfg: DohConfig, resolver: Option<Arc<DohResolver>>) {
     drop(PROCESS_STATE.set(ProcessState {
         config: cfg,
@@ -261,29 +368,18 @@ pub fn install_process_resolver(cfg: DohConfig, resolver: Option<Arc<DohResolver
 
 /// Resolver previously installed via [`install_process_resolver`].
 ///
-/// If nothing has been installed yet, this falls back to the `VOUCH_DOH`
-/// environment variable so that minimal/test contexts (no config file) still
-/// honor the user's intent. Errors are silently treated as "no DoH" — the
-/// binary's startup path is the loud failure mode.
+/// Returns `None` if nothing has been installed or if the installed
+/// configuration was [`DohConfig::Off`]. There is intentionally no env-var
+/// fallback here — [`init_from`] is the single canonical entry point so
+/// that env and config-file precedence cannot disagree.
 #[must_use]
 pub fn process_resolver() -> Option<Arc<DohResolver>> {
-    if let Some(state) = PROCESS_STATE.get() {
-        return state.resolver.clone();
-    }
-    let env = std::env::var(DOH_ENV_VAR).ok();
-    let cfg = resolve_doh_config(env.as_deref(), None).unwrap_or(DohConfig::Off);
-    // Lazy fallback path: DNSSEC defaults to on whenever DoH is on.
-    let resolver = DohResolver::for_config(&cfg, true).ok().flatten();
-    drop(PROCESS_STATE.set(ProcessState {
-        config: cfg,
-        resolver: resolver.clone(),
-    }));
-    resolver
+    PROCESS_STATE.get().and_then(|s| s.resolver.clone())
 }
 
 /// Effective [`DohConfig`] for the current process (for diagnostics).
 ///
-/// Returns `Off` if no resolver has been installed and `VOUCH_DOH` is unset.
+/// Returns `Off` if no resolver has been installed.
 #[must_use]
 pub fn process_config() -> DohConfig {
     PROCESS_STATE
@@ -291,39 +387,56 @@ pub fn process_config() -> DohConfig {
         .map_or(DohConfig::Off, |s| s.config.clone())
 }
 
-/// Build a `ResolverConfig` for a user-supplied DoH endpoint URL.
+/// Single canonical init path for both `vouch-cli` and `vouch-agent`.
 ///
-/// The URL host must be a literal IP (so the resolver knows where to dial
-/// without needing DNS first). Hostname-only custom endpoints would create a
-/// chicken-and-egg bootstrap problem.
-fn custom_https_config(url: &url::Url) -> Result<ResolverConfig> {
-    let host = url
-        .host_str()
-        .ok_or_else(|| anyhow::anyhow!("custom DoH URL has no host: {url}"))?;
-    let ip: std::net::IpAddr = host.parse().with_context(|| {
-        format!(
-            "custom DoH URL must use an IP literal (got host={host:?}); \
-             hostnames create a DNS bootstrap problem"
-        )
-    })?;
-    let server_name: Arc<str> = host.into();
-    let path = if url.path().is_empty() || url.path() == "/" {
-        None
-    } else {
-        Some(Arc::from(url.path()))
-    };
-    let mut nsc = NameServerConfig::https(ip, server_name, path);
-    // `NameServerConfig::https` defaults to 443. `Url::port` returns `Some`
-    // only when the user wrote a non-default port, so apply it just in that
-    // case — otherwise a `https://1.1.1.1:8443/dns-query` would silently
-    // connect to 443.
-    if let Some(port) = url.port()
+/// Reads `VOUCH_DOH` (env wins), then the supplied config-file value, and
+/// installs the process-wide resolver. **Hard-fails** if a DoH provider is
+/// configured but the resolver cannot be constructed — silent fallback to
+/// the system resolver would defeat opt-in.
+///
+/// Idempotent in the same way as [`install_process_resolver`]: subsequent
+/// calls have no effect.
+///
+/// # Errors
+///
+/// Returns an error if the configured provider is invalid.
+pub fn init_from(env: Option<&str>, config: Option<&DohConfigSerde>) -> Result<()> {
+    let cfg = resolve_doh_config(env, config).context("invalid DNS-over-HTTPS configuration")?;
+    let resolver = DohResolver::for_config(&cfg);
+    if cfg.is_enabled() {
+        tracing::info!(provider = %cfg.label(), dnssec = true, "DNS-over-HTTPS enabled");
+    }
+    install_process_resolver(cfg, resolver);
+    Ok(())
+}
+
+// =============================================================================
+// Custom URL → ResolverConfig
+// =============================================================================
+
+/// Build a `ResolverConfig` from a [`DohEndpoint`]. Infallible — all
+/// validation happened at construction time.
+fn custom_https_config(endpoint: &DohEndpoint) -> ResolverConfig {
+    let mut nsc = NameServerConfig::https(
+        endpoint.ip,
+        endpoint.server_name.clone(),
+        endpoint.path.clone(),
+    );
+    // `NameServerConfig::https` defaults to 443. Apply the URL's port only
+    // when the user wrote a non-default port — `Url::port` returns `Some`
+    // only in that case — otherwise `https://1.1.1.1:8443/dns-query` would
+    // silently connect to 443.
+    if let Some(port) = endpoint.port
         && let Some(connection) = nsc.connections.first_mut()
     {
         connection.port = port;
     }
-    Ok(ResolverConfig::from_parts(None, vec![], vec![nsc]))
+    ResolverConfig::from_parts(None, vec![], vec![nsc])
 }
+
+// =============================================================================
+// reqwest::dns::Resolve
+// =============================================================================
 
 impl Resolve for DohResolver {
     fn resolve(&self, name: ReqName) -> Resolving {
@@ -351,6 +464,10 @@ impl Resolve for DohResolver {
         })
     }
 }
+
+// =============================================================================
+// Tests
+// =============================================================================
 
 #[cfg(test)]
 #[expect(
@@ -381,10 +498,13 @@ mod tests {
     }
 
     #[test]
-    fn parse_custom_https_url() {
+    fn parse_custom_https_url_with_ip() {
         let cfg = DohConfig::parse("https://1.1.1.1/dns-query").unwrap();
         match cfg {
-            DohConfig::Custom(url) => assert_eq!(url.scheme(), "https"),
+            DohConfig::Custom(endpoint) => {
+                assert_eq!(endpoint.url().scheme(), "https");
+                assert_eq!(endpoint.url().as_str(), "https://1.1.1.1/dns-query");
+            }
             other => panic!("expected Custom, got {other:?}"),
         }
     }
@@ -400,10 +520,47 @@ mod tests {
     }
 
     #[test]
+    fn parse_rejects_hostname_in_custom_url() {
+        // Hostname-only custom endpoints would create a DNS bootstrap
+        // problem; rejected at construction.
+        let err = DohConfig::parse("https://dns.example/dns-query").unwrap_err();
+        assert!(
+            err.to_string().contains("IP literal"),
+            "expected IP-literal complaint, got: {err}"
+        );
+    }
+
+    #[test]
+    fn doh_endpoint_new_requires_https_scheme() {
+        let url = url::Url::parse("http://1.1.1.1/dns-query").unwrap();
+        assert!(DohEndpoint::new(url).is_err());
+    }
+
+    #[test]
+    fn doh_endpoint_new_requires_ip_literal() {
+        let url = url::Url::parse("https://dns.example/dns-query").unwrap();
+        assert!(DohEndpoint::new(url).is_err());
+    }
+
+    #[test]
     fn is_enabled_only_when_not_off() {
         assert!(!DohConfig::Off.is_enabled());
         assert!(DohConfig::Google.is_enabled());
         assert!(DohConfig::Cloudflare.is_enabled());
+    }
+
+    #[test]
+    fn label_returns_static_for_keyword_variants() {
+        assert_eq!(DohConfig::Off.label(), "off");
+        assert_eq!(DohConfig::Google.label(), "google");
+        assert_eq!(DohConfig::Cloudflare.label(), "cloudflare");
+        assert_eq!(DohConfig::Quad9.label(), "quad9");
+    }
+
+    #[test]
+    fn label_returns_url_for_custom_variant() {
+        let cfg = DohConfig::parse("https://1.1.1.1/dns-query").unwrap();
+        assert_eq!(cfg.label(), "https://1.1.1.1/dns-query");
     }
 
     #[test]
@@ -447,38 +604,27 @@ mod tests {
 
     #[test]
     fn for_config_off_returns_none() {
-        assert!(
-            DohResolver::for_config(&DohConfig::Off, true)
-                .unwrap()
-                .is_none()
-        );
+        assert!(DohResolver::for_config(&DohConfig::Off).is_none());
     }
 
     #[test]
     fn for_config_google_builds_resolver() {
-        let r = DohResolver::for_config(&DohConfig::Google, true)
-            .unwrap()
-            .unwrap();
+        let r = DohResolver::for_config(&DohConfig::Google).unwrap();
         assert_eq!(r.label(), "google");
     }
 
     #[test]
-    fn custom_url_requires_ip_literal() {
-        let cfg = DohConfig::Custom(url::Url::parse("https://dns.example/dns-query").unwrap());
-        assert!(DohResolver::for_config(&cfg, true).is_err());
-    }
-
-    #[test]
-    fn custom_url_with_ip_builds() {
-        let cfg = DohConfig::Custom(url::Url::parse("https://1.1.1.1/dns-query").unwrap());
-        let r = DohResolver::for_config(&cfg, true).unwrap().unwrap();
+    fn for_config_custom_with_ip_builds() {
+        let cfg = DohConfig::parse("https://1.1.1.1/dns-query").unwrap();
+        let r = DohResolver::for_config(&cfg).unwrap();
         assert_eq!(r.label(), "https://1.1.1.1/dns-query");
     }
 
     #[test]
-    fn custom_url_preserves_non_default_port() {
-        let url = url::Url::parse("https://1.1.1.1:8443/dns-query").unwrap();
-        let cfg = custom_https_config(&url).unwrap();
+    fn custom_endpoint_preserves_non_default_port() {
+        let endpoint =
+            DohEndpoint::new(url::Url::parse("https://1.1.1.1:8443/dns-query").unwrap()).unwrap();
+        let cfg = custom_https_config(&endpoint);
         let port = cfg
             .name_servers()
             .first()
@@ -488,14 +634,47 @@ mod tests {
     }
 
     #[test]
-    fn custom_url_default_port_is_443() {
-        let url = url::Url::parse("https://1.1.1.1/dns-query").unwrap();
-        let cfg = custom_https_config(&url).unwrap();
+    fn custom_endpoint_default_port_is_443() {
+        let endpoint =
+            DohEndpoint::new(url::Url::parse("https://1.1.1.1/dns-query").unwrap()).unwrap();
+        let cfg = custom_https_config(&endpoint);
         let port = cfg
             .name_servers()
             .first()
             .and_then(|ns| ns.connections.first())
             .map(|c| c.port);
         assert_eq!(port, Some(443));
+    }
+
+    #[test]
+    fn network_config_doh_accessor() {
+        let nc = NetworkConfig::default();
+        assert!(nc.doh().is_none());
+
+        let nc = NetworkConfig {
+            dns_over_https: Some(DohConfigSerde::Text("cloudflare".into())),
+        };
+        assert!(matches!(nc.doh(), Some(DohConfigSerde::Text(_))));
+    }
+
+    #[test]
+    fn network_config_deserializes_from_json() {
+        // Boolean shortcut.
+        let nc: NetworkConfig = serde_json::from_str(r#"{"dns_over_https": true}"#).unwrap();
+        assert!(matches!(
+            nc.dns_over_https,
+            Some(DohConfigSerde::Bool(true))
+        ));
+
+        // Text keyword.
+        let nc: NetworkConfig = serde_json::from_str(r#"{"dns_over_https": "quad9"}"#).unwrap();
+        assert!(matches!(
+            nc.dns_over_https,
+            Some(DohConfigSerde::Text(ref s)) if s == "quad9"
+        ));
+
+        // Empty object — DoH unset.
+        let nc: NetworkConfig = serde_json::from_str("{}").unwrap();
+        assert!(nc.dns_over_https.is_none());
     }
 }

--- a/crates/vouch-common/src/dns.rs
+++ b/crates/vouch-common/src/dns.rs
@@ -153,6 +153,22 @@ impl DohConfig {
             Self::Custom(endpoint) => endpoint.url.as_str(),
         }
     }
+
+    /// Canonical DoH endpoint URL for diagnostics.
+    ///
+    /// Returns `None` when DoH is off. For keyword variants this is the
+    /// well-known endpoint hickory connects to (it dials the provider's
+    /// IPs with this hostname as the SNI). For `Custom`, the user's URL.
+    #[must_use]
+    pub fn endpoint_url(&self) -> Option<&str> {
+        match self {
+            Self::Off => None,
+            Self::Google => Some("https://dns.google/dns-query"),
+            Self::Cloudflare => Some("https://cloudflare-dns.com/dns-query"),
+            Self::Quad9 => Some("https://dns.quad9.net/dns-query"),
+            Self::Custom(endpoint) => Some(endpoint.url.as_str()),
+        }
+    }
 }
 
 // =============================================================================
@@ -252,6 +268,7 @@ pub fn resolve_doh_config(
 pub struct DohResolver {
     config: ResolverConfig,
     label: String,
+    endpoint_url: String,
     // FIXME: replace with `OnceLock::get_or_try_init` once stable
     // (rust-lang/rust#109737). Until then we stringify the build error so
     // every subsequent caller sees the same message.
@@ -279,6 +296,7 @@ impl DohResolver {
     /// to call outside a tokio runtime context.
     #[must_use]
     pub fn for_config(cfg: &DohConfig) -> Option<Arc<Self>> {
+        let endpoint_url = cfg.endpoint_url()?.to_string();
         let config = match cfg {
             DohConfig::Off => return None,
             DohConfig::Google => ResolverConfig::https(&GOOGLE),
@@ -289,8 +307,15 @@ impl DohResolver {
         Some(Arc::new(Self {
             config,
             label: cfg.label().to_string(),
+            endpoint_url,
             inner: OnceLock::new(),
         }))
+    }
+
+    /// Canonical DoH endpoint URL — the URL hickory dials over HTTPS.
+    #[must_use]
+    pub fn endpoint_url(&self) -> &str {
+        &self.endpoint_url
     }
 
     /// Provider label used for diagnostics.
@@ -561,6 +586,39 @@ mod tests {
     fn label_returns_url_for_custom_variant() {
         let cfg = DohConfig::parse("https://1.1.1.1/dns-query").unwrap();
         assert_eq!(cfg.label(), "https://1.1.1.1/dns-query");
+    }
+
+    #[test]
+    fn endpoint_url_off_is_none() {
+        assert!(DohConfig::Off.endpoint_url().is_none());
+    }
+
+    #[test]
+    fn endpoint_url_keyword_variants() {
+        assert_eq!(
+            DohConfig::Google.endpoint_url(),
+            Some("https://dns.google/dns-query")
+        );
+        assert_eq!(
+            DohConfig::Cloudflare.endpoint_url(),
+            Some("https://cloudflare-dns.com/dns-query")
+        );
+        assert_eq!(
+            DohConfig::Quad9.endpoint_url(),
+            Some("https://dns.quad9.net/dns-query")
+        );
+    }
+
+    #[test]
+    fn endpoint_url_custom_returns_user_url() {
+        let cfg = DohConfig::parse("https://1.1.1.1/dns-query").unwrap();
+        assert_eq!(cfg.endpoint_url(), Some("https://1.1.1.1/dns-query"));
+    }
+
+    #[test]
+    fn resolver_exposes_endpoint_url() {
+        let r = DohResolver::for_config(&DohConfig::Quad9).unwrap();
+        assert_eq!(r.endpoint_url(), "https://dns.quad9.net/dns-query");
     }
 
     #[test]

--- a/crates/vouch-common/src/dns.rs
+++ b/crates/vouch-common/src/dns.rs
@@ -144,6 +144,7 @@ pub fn resolve_doh_config(
 pub struct DohResolver {
     config: ResolverConfig,
     label: String,
+    dnssec: bool,
     /// Lazy resolver. `Err` is captured on first build failure and replayed
     /// to every subsequent caller (since `OnceLock::get_or_try_init` is
     /// still unstable).
@@ -162,7 +163,10 @@ impl std::fmt::Debug for DohResolver {
 impl DohResolver {
     /// Build a resolver for the given configuration.
     ///
-    /// Returns `Ok(None)` when `cfg` is [`DohConfig::Off`].
+    /// Returns `Ok(None)` when `cfg` is [`DohConfig::Off`]. When `dnssec` is
+    /// true, hickory performs stub DNSSEC validation: signed responses must
+    /// validate or the lookup fails; unsigned zones (e.g. `*.amazonaws.com`)
+    /// pass through unchanged.
     ///
     /// The actual hickory resolver is constructed on first use (see
     /// [`get_or_init`](Self::get_or_init)), so this is safe to call outside a
@@ -172,9 +176,8 @@ impl DohResolver {
     ///
     /// Returns an error only if the configuration is malformed (e.g., a
     /// custom URL whose host isn't an IP literal). Network/resolver
-    /// construction failures surface from [`resolve`](Self::get_or_init) /
-    /// `Resolve::resolve` instead.
-    pub fn for_config(cfg: &DohConfig) -> Result<Option<Arc<Self>>> {
+    /// construction failures surface from `Resolve::resolve` instead.
+    pub fn for_config(cfg: &DohConfig, dnssec: bool) -> Result<Option<Arc<Self>>> {
         let config = match cfg {
             DohConfig::Off => return Ok(None),
             DohConfig::Google => ResolverConfig::https(&GOOGLE),
@@ -185,6 +188,7 @@ impl DohResolver {
         Ok(Some(Arc::new(Self {
             config,
             label: cfg.label(),
+            dnssec,
             inner: OnceLock::new(),
         })))
     }
@@ -202,7 +206,12 @@ impl DohResolver {
     fn get_or_init(&self) -> Result<&hickory_resolver::TokioResolver> {
         self.inner
             .get_or_init(|| {
-                Resolver::builder_with_config(self.config.clone(), Default::default())
+                let mut builder =
+                    Resolver::builder_with_config(self.config.clone(), Default::default());
+                if self.dnssec {
+                    builder.options_mut().validate = true;
+                }
+                builder
                     .build()
                     .map_err(|e| format!("failed to construct DoH resolver: {e}"))
             })
@@ -263,7 +272,8 @@ pub fn process_resolver() -> Option<Arc<DohResolver>> {
     }
     let env = std::env::var(DOH_ENV_VAR).ok();
     let cfg = resolve_doh_config(env.as_deref(), None).unwrap_or(DohConfig::Off);
-    let resolver = DohResolver::for_config(&cfg).ok().flatten();
+    // Lazy fallback path: DNSSEC defaults to on whenever DoH is on.
+    let resolver = DohResolver::for_config(&cfg, true).ok().flatten();
     drop(PROCESS_STATE.set(ProcessState {
         config: cfg,
         resolver: resolver.clone(),
@@ -437,12 +447,16 @@ mod tests {
 
     #[test]
     fn for_config_off_returns_none() {
-        assert!(DohResolver::for_config(&DohConfig::Off).unwrap().is_none());
+        assert!(
+            DohResolver::for_config(&DohConfig::Off, true)
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]
     fn for_config_google_builds_resolver() {
-        let r = DohResolver::for_config(&DohConfig::Google)
+        let r = DohResolver::for_config(&DohConfig::Google, true)
             .unwrap()
             .unwrap();
         assert_eq!(r.label(), "google");
@@ -451,13 +465,13 @@ mod tests {
     #[test]
     fn custom_url_requires_ip_literal() {
         let cfg = DohConfig::Custom(url::Url::parse("https://dns.example/dns-query").unwrap());
-        assert!(DohResolver::for_config(&cfg).is_err());
+        assert!(DohResolver::for_config(&cfg, true).is_err());
     }
 
     #[test]
     fn custom_url_with_ip_builds() {
         let cfg = DohConfig::Custom(url::Url::parse("https://1.1.1.1/dns-query").unwrap());
-        let r = DohResolver::for_config(&cfg).unwrap().unwrap();
+        let r = DohResolver::for_config(&cfg, true).unwrap().unwrap();
         assert_eq!(r.label(), "https://1.1.1.1/dns-query");
     }
 

--- a/crates/vouch-common/src/dns.rs
+++ b/crates/vouch-common/src/dns.rs
@@ -296,7 +296,6 @@ impl DohResolver {
     /// to call outside a tokio runtime context.
     #[must_use]
     pub fn for_config(cfg: &DohConfig) -> Option<Arc<Self>> {
-        let endpoint_url = cfg.endpoint_url()?.to_string();
         let config = match cfg {
             DohConfig::Off => return None,
             DohConfig::Google => ResolverConfig::https(&GOOGLE),
@@ -304,6 +303,7 @@ impl DohResolver {
             DohConfig::Quad9 => ResolverConfig::https(&QUAD9),
             DohConfig::Custom(endpoint) => custom_https_config(endpoint),
         };
+        let endpoint_url = cfg.endpoint_url()?.to_string();
         Some(Arc::new(Self {
             config,
             label: cfg.label().to_string(),

--- a/crates/vouch-common/src/dns.rs
+++ b/crates/vouch-common/src/dns.rs
@@ -302,7 +302,16 @@ fn custom_https_config(url: &url::Url) -> Result<ResolverConfig> {
     } else {
         Some(Arc::from(url.path()))
     };
-    let nsc = NameServerConfig::https(ip, server_name, path);
+    let mut nsc = NameServerConfig::https(ip, server_name, path);
+    // `NameServerConfig::https` defaults to 443. `Url::port` returns `Some`
+    // only when the user wrote a non-default port, so apply it just in that
+    // case — otherwise a `https://1.1.1.1:8443/dns-query` would silently
+    // connect to 443.
+    if let Some(port) = url.port()
+        && let Some(connection) = nsc.connections.first_mut()
+    {
+        connection.port = port;
+    }
     Ok(ResolverConfig::from_parts(None, vec![], vec![nsc]))
 }
 
@@ -450,5 +459,29 @@ mod tests {
         let cfg = DohConfig::Custom(url::Url::parse("https://1.1.1.1/dns-query").unwrap());
         let r = DohResolver::for_config(&cfg).unwrap().unwrap();
         assert_eq!(r.label(), "https://1.1.1.1/dns-query");
+    }
+
+    #[test]
+    fn custom_url_preserves_non_default_port() {
+        let url = url::Url::parse("https://1.1.1.1:8443/dns-query").unwrap();
+        let cfg = custom_https_config(&url).unwrap();
+        let port = cfg
+            .name_servers()
+            .first()
+            .and_then(|ns| ns.connections.first())
+            .map(|c| c.port);
+        assert_eq!(port, Some(8443));
+    }
+
+    #[test]
+    fn custom_url_default_port_is_443() {
+        let url = url::Url::parse("https://1.1.1.1/dns-query").unwrap();
+        let cfg = custom_https_config(&url).unwrap();
+        let port = cfg
+            .name_servers()
+            .first()
+            .and_then(|ns| ns.connections.first())
+            .map(|c| c.port);
+        assert_eq!(port, Some(443));
     }
 }

--- a/crates/vouch-common/src/dns.rs
+++ b/crates/vouch-common/src/dns.rs
@@ -182,29 +182,21 @@ impl DohResolver {
     }
 }
 
-/// Process-wide DoH state.
+/// Process-wide DoH resolver slot.
 ///
 /// Set once via [`install_process_resolver`] from the binary's startup path
 /// (after loading the CLI/agent config) and read by every HTTP client
 /// factory in this crate plus `vouch_cli::http::ReqwestClient::new`.
-struct ProcessState {
-    config: DohConfig,
-    resolver: Option<Arc<DohResolver>>,
-}
-
-static PROCESS_STATE: OnceLock<ProcessState> = OnceLock::new();
+static PROCESS_RESOLVER: OnceLock<Option<Arc<DohResolver>>> = OnceLock::new();
 
 /// Install the process-wide DoH resolver. Idempotent — subsequent calls are
 /// silently ignored so that re-entry from tests doesn't panic.
 ///
-/// The binary should call this once on startup (after loading config and
-/// computing the effective [`DohConfig`]). HTTP client factories then pick
-/// up the installed resolver automatically.
-pub fn install_process_resolver(cfg: DohConfig, resolver: Option<Arc<DohResolver>>) {
-    drop(PROCESS_STATE.set(ProcessState {
-        config: cfg,
-        resolver,
-    }));
+/// The binary should call this once on startup from inside a tokio runtime
+/// context — hickory's resolver spawns background tasks at construction.
+/// HTTP client factories then pick up the installed resolver automatically.
+pub fn install_process_resolver(resolver: Option<Arc<DohResolver>>) {
+    drop(PROCESS_RESOLVER.set(resolver));
 }
 
 /// Resolver previously installed via [`install_process_resolver`].
@@ -212,35 +204,18 @@ pub fn install_process_resolver(cfg: DohConfig, resolver: Option<Arc<DohResolver
 /// If nothing has been installed yet, this falls back to the `VOUCH_DOH`
 /// environment variable so that minimal/test contexts (no config file) still
 /// honor the user's intent. Errors from env parsing or resolver construction
-/// are logged at WARN and treated as "no DoH" — they do not propagate to
-/// every HTTP call site.
+/// are silently treated as "no DoH" — the binary's startup path is the
+/// loud failure mode.
 #[must_use]
 pub fn process_resolver() -> Option<Arc<DohResolver>> {
-    if let Some(state) = PROCESS_STATE.get() {
-        return state.resolver.clone();
+    if let Some(slot) = PROCESS_RESOLVER.get() {
+        return slot.clone();
     }
-    // Lazy fallback: env-only, silent on errors.
-    //
-    // The binary's startup path (`vouch_cli::dns::init`) hard-fails on
-    // misconfiguration; this branch only fires for callers that bypass that
-    // setup (tests, library-only consumers). Falling back silently to the
-    // system resolver is the least-surprising behavior in those contexts.
     let env = std::env::var(DOH_ENV_VAR).ok();
     let cfg = resolve_doh_config(env.as_deref(), None).unwrap_or(DohConfig::Off);
     let resolver = DohResolver::for_config(&cfg).ok().flatten();
-    drop(PROCESS_STATE.set(ProcessState {
-        config: cfg,
-        resolver: resolver.clone(),
-    }));
+    drop(PROCESS_RESOLVER.set(resolver.clone()));
     resolver
-}
-
-/// Effective [`DohConfig`] for the current process (for diagnostics).
-#[must_use]
-pub fn process_config() -> DohConfig {
-    PROCESS_STATE
-        .get()
-        .map_or(DohConfig::Off, |s| s.config.clone())
 }
 
 /// Build a `ResolverConfig` for a user-supplied DoH endpoint URL.

--- a/crates/vouch-common/src/dns.rs
+++ b/crates/vouch-common/src/dns.rs
@@ -1,0 +1,408 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! DNS-over-HTTPS resolver for outbound HTTP clients.
+//!
+//! Provides a [`DohResolver`] that implements [`reqwest::dns::Resolve`] backed
+//! by `hickory-resolver` configured for DoH against a chosen public provider
+//! (Google, Cloudflare, Quad9) or a custom HTTPS endpoint.
+//!
+//! Opt-in via the `VOUCH_DOH` env var or the `network.dns_over_https` field in
+//! `~/.vouch/config.json`. When unset, the system resolver is used (default
+//! behavior).
+
+use std::net::SocketAddr;
+use std::sync::{Arc, OnceLock};
+
+use anyhow::{Context, Result};
+use hickory_resolver::Resolver;
+use hickory_resolver::config::{CLOUDFLARE, GOOGLE, NameServerConfig, QUAD9, ResolverConfig};
+use reqwest::dns::{Addrs, Name as ReqName, Resolve, Resolving};
+use serde::{Deserialize, Serialize};
+
+/// Environment variable consulted by [`process_resolver`] when no explicit
+/// resolver has been installed.
+pub const DOH_ENV_VAR: &str = "VOUCH_DOH";
+
+/// DoH provider selection.
+///
+/// `Off` means use the system resolver (current default behavior). All other
+/// variants route DNS over HTTPS to the named provider.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DohConfig {
+    /// Use the system resolver. No DoH.
+    Off,
+    /// Google Public DNS over HTTPS (default when DoH is enabled without a
+    /// named provider).
+    Google,
+    /// Cloudflare 1.1.1.1 over HTTPS.
+    Cloudflare,
+    /// Quad9 9.9.9.9 over HTTPS.
+    Quad9,
+    /// User-specified DoH endpoint (must be `https://…/dns-query`).
+    Custom(url::Url),
+}
+
+impl DohConfig {
+    /// Parse a textual DoH selector.
+    ///
+    /// Accepts: `off`, `on` (== `google`), `google`, `cloudflare`, `quad9`,
+    /// or any `https://…` URL.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an unknown keyword or a non-HTTPS URL.
+    pub fn parse(value: &str) -> Result<Self> {
+        let trimmed = value.trim();
+        match trimmed.to_ascii_lowercase().as_str() {
+            "" | "off" | "false" | "0" | "no" => Ok(Self::Off),
+            "on" | "true" | "1" | "yes" | "google" => Ok(Self::Google),
+            "cloudflare" => Ok(Self::Cloudflare),
+            "quad9" => Ok(Self::Quad9),
+            _ => {
+                let url = url::Url::parse(trimmed)
+                    .with_context(|| format!("invalid DoH provider: {trimmed:?}"))?;
+                if url.scheme() != "https" {
+                    anyhow::bail!("DoH endpoint must use https://: {url}");
+                }
+                Ok(Self::Custom(url))
+            }
+        }
+    }
+
+    /// Returns true when DoH is active (anything other than `Off`).
+    #[must_use]
+    pub fn is_enabled(&self) -> bool {
+        !matches!(self, Self::Off)
+    }
+
+    /// Short human label for diagnostics (`vouch doctor`, log messages).
+    #[must_use]
+    pub fn label(&self) -> String {
+        match self {
+            Self::Off => "off".to_string(),
+            Self::Google => "google".to_string(),
+            Self::Cloudflare => "cloudflare".to_string(),
+            Self::Quad9 => "quad9".to_string(),
+            Self::Custom(url) => url.to_string(),
+        }
+    }
+}
+
+/// Serializable form for `~/.vouch/config.json`. Accepts a string keyword,
+/// a URL, or a bare boolean (`true` -> Google, `false` -> Off).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum DohConfigSerde {
+    /// Boolean shortcut: `true` = Google DoH, `false` = system resolver.
+    Bool(bool),
+    /// String keyword (`off`, `google`, `cloudflare`, `quad9`) or a custom
+    /// `https://…/dns-query` URL.
+    Text(String),
+}
+
+impl DohConfigSerde {
+    /// Resolve to a concrete [`DohConfig`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the textual form is not a known keyword or HTTPS URL.
+    pub fn resolve(&self) -> Result<DohConfig> {
+        match self {
+            Self::Bool(true) => Ok(DohConfig::Google),
+            Self::Bool(false) => Ok(DohConfig::Off),
+            Self::Text(s) => DohConfig::parse(s),
+        }
+    }
+}
+
+/// Determine the effective [`DohConfig`] from the `VOUCH_DOH` env var falling
+/// back to a config-file value.
+///
+/// Env wins over config; config wins over the `Off` default.
+///
+/// # Errors
+///
+/// Returns an error if either source is malformed.
+pub fn resolve_doh_config(
+    env_value: Option<&str>,
+    config_value: Option<&DohConfigSerde>,
+) -> Result<DohConfig> {
+    if let Some(raw) = env_value {
+        return DohConfig::parse(raw);
+    }
+    if let Some(serde_value) = config_value {
+        return serde_value.resolve();
+    }
+    Ok(DohConfig::Off)
+}
+
+/// reqwest-compatible DoH resolver backed by `hickory-resolver`.
+pub struct DohResolver {
+    inner: hickory_resolver::TokioResolver,
+    label: String,
+}
+
+impl std::fmt::Debug for DohResolver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DohResolver")
+            .field("provider", &self.label)
+            .finish_non_exhaustive()
+    }
+}
+
+impl DohResolver {
+    /// Build a resolver for the given configuration.
+    ///
+    /// Returns `Ok(None)` when `cfg` is [`DohConfig::Off`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying resolver cannot be constructed
+    /// (e.g., a malformed custom URL).
+    pub fn for_config(cfg: &DohConfig) -> Result<Option<Arc<Self>>> {
+        let resolver_config = match cfg {
+            DohConfig::Off => return Ok(None),
+            DohConfig::Google => ResolverConfig::https(&GOOGLE),
+            DohConfig::Cloudflare => ResolverConfig::https(&CLOUDFLARE),
+            DohConfig::Quad9 => ResolverConfig::https(&QUAD9),
+            DohConfig::Custom(url) => custom_https_config(url)?,
+        };
+        let inner = Resolver::builder_with_config(resolver_config, Default::default())
+            .build()
+            .context("failed to construct DoH resolver")?;
+        Ok(Some(Arc::new(Self {
+            inner,
+            label: cfg.label(),
+        })))
+    }
+
+    /// Provider label used for diagnostics.
+    #[must_use]
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+}
+
+/// Process-wide DoH state.
+///
+/// Set once via [`install_process_resolver`] from the binary's startup path
+/// (after loading the CLI/agent config) and read by every HTTP client
+/// factory in this crate plus `vouch_cli::http::ReqwestClient::new`.
+struct ProcessState {
+    config: DohConfig,
+    resolver: Option<Arc<DohResolver>>,
+}
+
+static PROCESS_STATE: OnceLock<ProcessState> = OnceLock::new();
+
+/// Install the process-wide DoH resolver. Idempotent — subsequent calls are
+/// silently ignored so that re-entry from tests doesn't panic.
+///
+/// The binary should call this once on startup (after loading config and
+/// computing the effective [`DohConfig`]). HTTP client factories then pick
+/// up the installed resolver automatically.
+pub fn install_process_resolver(cfg: DohConfig, resolver: Option<Arc<DohResolver>>) {
+    drop(PROCESS_STATE.set(ProcessState {
+        config: cfg,
+        resolver,
+    }));
+}
+
+/// Resolver previously installed via [`install_process_resolver`].
+///
+/// If nothing has been installed yet, this falls back to the `VOUCH_DOH`
+/// environment variable so that minimal/test contexts (no config file) still
+/// honor the user's intent. Errors from env parsing or resolver construction
+/// are logged at WARN and treated as "no DoH" — they do not propagate to
+/// every HTTP call site.
+#[must_use]
+pub fn process_resolver() -> Option<Arc<DohResolver>> {
+    if let Some(state) = PROCESS_STATE.get() {
+        return state.resolver.clone();
+    }
+    // Lazy fallback: env-only, silent on errors.
+    //
+    // The binary's startup path (`vouch_cli::dns::init`) hard-fails on
+    // misconfiguration; this branch only fires for callers that bypass that
+    // setup (tests, library-only consumers). Falling back silently to the
+    // system resolver is the least-surprising behavior in those contexts.
+    let env = std::env::var(DOH_ENV_VAR).ok();
+    let cfg = resolve_doh_config(env.as_deref(), None).unwrap_or(DohConfig::Off);
+    let resolver = DohResolver::for_config(&cfg).ok().flatten();
+    drop(PROCESS_STATE.set(ProcessState {
+        config: cfg,
+        resolver: resolver.clone(),
+    }));
+    resolver
+}
+
+/// Effective [`DohConfig`] for the current process (for diagnostics).
+#[must_use]
+pub fn process_config() -> DohConfig {
+    PROCESS_STATE
+        .get()
+        .map_or(DohConfig::Off, |s| s.config.clone())
+}
+
+/// Build a `ResolverConfig` for a user-supplied DoH endpoint URL.
+///
+/// The URL host must be a literal IP (so the resolver knows where to dial
+/// without needing DNS first). Hostname-only custom endpoints would create a
+/// chicken-and-egg bootstrap problem.
+fn custom_https_config(url: &url::Url) -> Result<ResolverConfig> {
+    let host = url
+        .host_str()
+        .ok_or_else(|| anyhow::anyhow!("custom DoH URL has no host: {url}"))?;
+    let ip: std::net::IpAddr = host.parse().with_context(|| {
+        format!(
+            "custom DoH URL must use an IP literal (got host={host:?}); \
+             hostnames create a DNS bootstrap problem"
+        )
+    })?;
+    let server_name: Arc<str> = host.into();
+    let path = if url.path().is_empty() || url.path() == "/" {
+        None
+    } else {
+        Some(Arc::from(url.path()))
+    };
+    let nsc = NameServerConfig::https(ip, server_name, path);
+    Ok(ResolverConfig::from_parts(None, vec![], vec![nsc]))
+}
+
+impl Resolve for DohResolver {
+    fn resolve(&self, name: ReqName) -> Resolving {
+        let resolver = self.inner.clone();
+        let host = name.as_str().to_string();
+        Box::pin(async move {
+            let lookup = resolver.lookup_ip(host.as_str()).await.map_err(
+                |e| -> Box<dyn std::error::Error + Send + Sync> {
+                    Box::new(std::io::Error::other(format!(
+                        "DoH lookup for {host:?} failed: {e}"
+                    )))
+                },
+            )?;
+            let v: Vec<SocketAddr> = lookup.iter().map(|ip| SocketAddr::new(ip, 0)).collect();
+            let addrs: Addrs = Box::new(v.into_iter());
+            Ok(addrs)
+        })
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::panic,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_off_keywords() {
+        for s in ["off", "OFF", "false", "0", "no", ""] {
+            assert_eq!(DohConfig::parse(s).unwrap(), DohConfig::Off, "input={s:?}");
+        }
+    }
+
+    #[test]
+    fn parse_provider_keywords() {
+        assert_eq!(DohConfig::parse("on").unwrap(), DohConfig::Google);
+        assert_eq!(DohConfig::parse("google").unwrap(), DohConfig::Google);
+        assert_eq!(DohConfig::parse("Google").unwrap(), DohConfig::Google);
+        assert_eq!(
+            DohConfig::parse("cloudflare").unwrap(),
+            DohConfig::Cloudflare
+        );
+        assert_eq!(DohConfig::parse("quad9").unwrap(), DohConfig::Quad9);
+    }
+
+    #[test]
+    fn parse_custom_https_url() {
+        let cfg = DohConfig::parse("https://1.1.1.1/dns-query").unwrap();
+        match cfg {
+            DohConfig::Custom(url) => assert_eq!(url.scheme(), "https"),
+            other => panic!("expected Custom, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_rejects_non_https() {
+        assert!(DohConfig::parse("http://1.1.1.1/dns-query").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_unknown_keyword() {
+        assert!(DohConfig::parse("nonsense").is_err());
+    }
+
+    #[test]
+    fn is_enabled_only_when_not_off() {
+        assert!(!DohConfig::Off.is_enabled());
+        assert!(DohConfig::Google.is_enabled());
+        assert!(DohConfig::Cloudflare.is_enabled());
+    }
+
+    #[test]
+    fn serde_bool_resolves_to_google() {
+        assert_eq!(
+            DohConfigSerde::Bool(true).resolve().unwrap(),
+            DohConfig::Google
+        );
+        assert_eq!(
+            DohConfigSerde::Bool(false).resolve().unwrap(),
+            DohConfig::Off
+        );
+    }
+
+    #[test]
+    fn serde_text_dispatches_to_parse() {
+        assert_eq!(
+            DohConfigSerde::Text("cloudflare".into()).resolve().unwrap(),
+            DohConfig::Cloudflare
+        );
+    }
+
+    #[test]
+    fn precedence_env_wins_over_config() {
+        let cfg = DohConfigSerde::Text("cloudflare".into());
+        let resolved = resolve_doh_config(Some("quad9"), Some(&cfg)).unwrap();
+        assert_eq!(resolved, DohConfig::Quad9);
+    }
+
+    #[test]
+    fn precedence_config_used_when_env_absent() {
+        let cfg = DohConfigSerde::Text("cloudflare".into());
+        let resolved = resolve_doh_config(None, Some(&cfg)).unwrap();
+        assert_eq!(resolved, DohConfig::Cloudflare);
+    }
+
+    #[test]
+    fn precedence_default_off() {
+        assert_eq!(resolve_doh_config(None, None).unwrap(), DohConfig::Off);
+    }
+
+    #[test]
+    fn for_config_off_returns_none() {
+        assert!(DohResolver::for_config(&DohConfig::Off).unwrap().is_none());
+    }
+
+    #[test]
+    fn for_config_google_builds_resolver() {
+        let r = DohResolver::for_config(&DohConfig::Google)
+            .unwrap()
+            .unwrap();
+        assert_eq!(r.label(), "google");
+    }
+
+    #[test]
+    fn custom_url_requires_ip_literal() {
+        let cfg = DohConfig::Custom(url::Url::parse("https://dns.example/dns-query").unwrap());
+        assert!(DohResolver::for_config(&cfg).is_err());
+    }
+
+    #[test]
+    fn custom_url_with_ip_builds() {
+        let cfg = DohConfig::Custom(url::Url::parse("https://1.1.1.1/dns-query").unwrap());
+        let r = DohResolver::for_config(&cfg).unwrap().unwrap();
+        assert_eq!(r.label(), "https://1.1.1.1/dns-query");
+    }
+}

--- a/crates/vouch-common/src/dns.rs
+++ b/crates/vouch-common/src/dns.rs
@@ -136,15 +136,25 @@ pub fn resolve_doh_config(
 }
 
 /// reqwest-compatible DoH resolver backed by `hickory-resolver`.
+///
+/// The underlying `TokioResolver` is built lazily on the first DNS query so
+/// that `for_config` can be called from any context (including outside a
+/// tokio runtime). Hickory spawns background tasks at construction; building
+/// inside `resolve()` guarantees `Handle::current()` is available.
 pub struct DohResolver {
-    inner: hickory_resolver::TokioResolver,
+    config: ResolverConfig,
     label: String,
+    /// Lazy resolver. `Err` is captured on first build failure and replayed
+    /// to every subsequent caller (since `OnceLock::get_or_try_init` is
+    /// still unstable).
+    inner: OnceLock<Result<hickory_resolver::TokioResolver, String>>,
 }
 
 impl std::fmt::Debug for DohResolver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DohResolver")
             .field("provider", &self.label)
+            .field("initialized", &self.inner.get().is_some())
             .finish_non_exhaustive()
     }
 }
@@ -154,24 +164,28 @@ impl DohResolver {
     ///
     /// Returns `Ok(None)` when `cfg` is [`DohConfig::Off`].
     ///
+    /// The actual hickory resolver is constructed on first use (see
+    /// [`get_or_init`](Self::get_or_init)), so this is safe to call outside a
+    /// tokio runtime context.
+    ///
     /// # Errors
     ///
-    /// Returns an error if the underlying resolver cannot be constructed
-    /// (e.g., a malformed custom URL).
+    /// Returns an error only if the configuration is malformed (e.g., a
+    /// custom URL whose host isn't an IP literal). Network/resolver
+    /// construction failures surface from [`resolve`](Self::get_or_init) /
+    /// `Resolve::resolve` instead.
     pub fn for_config(cfg: &DohConfig) -> Result<Option<Arc<Self>>> {
-        let resolver_config = match cfg {
+        let config = match cfg {
             DohConfig::Off => return Ok(None),
             DohConfig::Google => ResolverConfig::https(&GOOGLE),
             DohConfig::Cloudflare => ResolverConfig::https(&CLOUDFLARE),
             DohConfig::Quad9 => ResolverConfig::https(&QUAD9),
             DohConfig::Custom(url) => custom_https_config(url)?,
         };
-        let inner = Resolver::builder_with_config(resolver_config, Default::default())
-            .build()
-            .context("failed to construct DoH resolver")?;
         Ok(Some(Arc::new(Self {
-            inner,
+            config,
             label: cfg.label(),
+            inner: OnceLock::new(),
         })))
     }
 
@@ -180,42 +194,91 @@ impl DohResolver {
     pub fn label(&self) -> &str {
         &self.label
     }
+
+    /// Get (or lazily construct) the underlying hickory resolver.
+    ///
+    /// Must be called from within a tokio runtime context — hickory spawns
+    /// background tasks at construction.
+    fn get_or_init(&self) -> Result<&hickory_resolver::TokioResolver> {
+        self.inner
+            .get_or_init(|| {
+                Resolver::builder_with_config(self.config.clone(), Default::default())
+                    .build()
+                    .map_err(|e| format!("failed to construct DoH resolver: {e}"))
+            })
+            .as_ref()
+            .map_err(|e| anyhow::anyhow!("{e}"))
+    }
+
+    /// Perform a DNS lookup through the DoH resolver.
+    ///
+    /// Used by `vouch doctor` to verify that DoH is working end-to-end.
+    /// Must be called from within a tokio runtime context.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the lookup fails (network error, NXDOMAIN, …).
+    pub async fn lookup_ip(&self, host: &str) -> Result<Vec<std::net::IpAddr>> {
+        let resolver = self.get_or_init()?;
+        let lookup = resolver
+            .lookup_ip(host)
+            .await
+            .with_context(|| format!("DoH lookup for {host:?} failed"))?;
+        Ok(lookup.iter().collect())
+    }
 }
 
-/// Process-wide DoH resolver slot.
+/// Process-wide DoH state.
 ///
 /// Set once via [`install_process_resolver`] from the binary's startup path
-/// (after loading the CLI/agent config) and read by every HTTP client
-/// factory in this crate plus `vouch_cli::http::ReqwestClient::new`.
-static PROCESS_RESOLVER: OnceLock<Option<Arc<DohResolver>>> = OnceLock::new();
+/// and read by every HTTP client factory in this crate plus
+/// `vouch_cli::http::ReqwestClient::new`. The resolver itself is lazily
+/// built on first use, so installation is safe outside a tokio runtime.
+struct ProcessState {
+    config: DohConfig,
+    resolver: Option<Arc<DohResolver>>,
+}
 
-/// Install the process-wide DoH resolver. Idempotent — subsequent calls are
+static PROCESS_STATE: OnceLock<ProcessState> = OnceLock::new();
+
+/// Install the process-wide DoH state. Idempotent — subsequent calls are
 /// silently ignored so that re-entry from tests doesn't panic.
-///
-/// The binary should call this once on startup from inside a tokio runtime
-/// context — hickory's resolver spawns background tasks at construction.
-/// HTTP client factories then pick up the installed resolver automatically.
-pub fn install_process_resolver(resolver: Option<Arc<DohResolver>>) {
-    drop(PROCESS_RESOLVER.set(resolver));
+pub fn install_process_resolver(cfg: DohConfig, resolver: Option<Arc<DohResolver>>) {
+    drop(PROCESS_STATE.set(ProcessState {
+        config: cfg,
+        resolver,
+    }));
 }
 
 /// Resolver previously installed via [`install_process_resolver`].
 ///
 /// If nothing has been installed yet, this falls back to the `VOUCH_DOH`
 /// environment variable so that minimal/test contexts (no config file) still
-/// honor the user's intent. Errors from env parsing or resolver construction
-/// are silently treated as "no DoH" — the binary's startup path is the
-/// loud failure mode.
+/// honor the user's intent. Errors are silently treated as "no DoH" — the
+/// binary's startup path is the loud failure mode.
 #[must_use]
 pub fn process_resolver() -> Option<Arc<DohResolver>> {
-    if let Some(slot) = PROCESS_RESOLVER.get() {
-        return slot.clone();
+    if let Some(state) = PROCESS_STATE.get() {
+        return state.resolver.clone();
     }
     let env = std::env::var(DOH_ENV_VAR).ok();
     let cfg = resolve_doh_config(env.as_deref(), None).unwrap_or(DohConfig::Off);
     let resolver = DohResolver::for_config(&cfg).ok().flatten();
-    drop(PROCESS_RESOLVER.set(resolver.clone()));
+    drop(PROCESS_STATE.set(ProcessState {
+        config: cfg,
+        resolver: resolver.clone(),
+    }));
     resolver
+}
+
+/// Effective [`DohConfig`] for the current process (for diagnostics).
+///
+/// Returns `Off` if no resolver has been installed and `VOUCH_DOH` is unset.
+#[must_use]
+pub fn process_config() -> DohConfig {
+    PROCESS_STATE
+        .get()
+        .map_or(DohConfig::Off, |s| s.config.clone())
 }
 
 /// Build a `ResolverConfig` for a user-supplied DoH endpoint URL.
@@ -245,7 +308,15 @@ fn custom_https_config(url: &url::Url) -> Result<ResolverConfig> {
 
 impl Resolve for DohResolver {
     fn resolve(&self, name: ReqName) -> Resolving {
-        let resolver = self.inner.clone();
+        // `get_or_init` runs the build closure inside the async context of
+        // the first request — guarantees `Handle::current()` is available.
+        let resolver = match self.get_or_init() {
+            Ok(r) => r.clone(),
+            Err(e) => {
+                let msg = e.to_string();
+                return Box::pin(async move { Err(Box::new(std::io::Error::other(msg)).into()) });
+            }
+        };
         let host = name.as_str().to_string();
         Box::pin(async move {
             let lookup = resolver.lookup_ip(host.as_str()).await.map_err(

--- a/crates/vouch-common/src/http.rs
+++ b/crates/vouch-common/src/http.rs
@@ -6,6 +6,8 @@
 
 use std::time::Duration;
 
+use crate::dns::process_resolver;
+
 /// Timeout values for different contexts.
 pub mod timeouts {
     use super::Duration;
@@ -26,11 +28,23 @@ pub mod timeouts {
     pub const SERVER_CONNECT: Duration = Duration::from_secs(5);
 }
 
+/// Apply the process-wide DoH resolver to a builder, if one is installed.
+fn with_process_doh(mut builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
+    if let Some(resolver) = process_resolver() {
+        builder = builder.dns_resolver(resolver);
+    }
+    builder
+}
+
 /// Create an HTTP client for credential helper operations.
 ///
 /// Uses short timeouts (10s total, 5s connect) for fast failure.
 /// Credential helpers are called by tools (aws, docker, gcloud) that have
 /// their own retry logic.
+///
+/// Redirects are disabled: vouch and AWS endpoints don't redirect, and
+/// allowing them could leak traffic over plain HTTP — undermining the
+/// "TCP/443 only" property when DoH is enabled.
 ///
 /// # Arguments
 ///
@@ -40,17 +54,19 @@ pub mod timeouts {
 ///
 /// Returns an error if the client cannot be built.
 pub fn credential_client(user_agent: &str) -> Result<reqwest::Client, reqwest::Error> {
-    reqwest::Client::builder()
+    let builder = reqwest::Client::builder()
         .user_agent(user_agent)
+        .redirect(reqwest::redirect::Policy::none())
         .timeout(timeouts::CREDENTIAL_TOTAL)
-        .connect_timeout(timeouts::CREDENTIAL_CONNECT)
-        .build()
+        .connect_timeout(timeouts::CREDENTIAL_CONNECT);
+    with_process_doh(builder).build()
 }
 
 /// Create an HTTP client for agent background operations.
 ///
 /// Uses short timeouts (5s total, 3s connect) for best-effort,
-/// non-blocking background work.
+/// non-blocking background work. Redirects disabled (see
+/// [`credential_client`]).
 ///
 /// # Arguments
 ///
@@ -60,11 +76,12 @@ pub fn credential_client(user_agent: &str) -> Result<reqwest::Client, reqwest::E
 ///
 /// Returns an error if the client cannot be built.
 pub fn agent_client(user_agent: &str) -> Result<reqwest::Client, reqwest::Error> {
-    reqwest::Client::builder()
+    let builder = reqwest::Client::builder()
         .user_agent(user_agent)
+        .redirect(reqwest::redirect::Policy::none())
         .timeout(timeouts::AGENT_TOTAL)
-        .connect_timeout(timeouts::AGENT_CONNECT)
-        .build()
+        .connect_timeout(timeouts::AGENT_CONNECT);
+    with_process_doh(builder).build()
 }
 
 /// Create an HTTP client for server-side API calls.

--- a/crates/vouch-common/src/http.rs
+++ b/crates/vouch-common/src/http.rs
@@ -29,7 +29,11 @@ pub mod timeouts {
 }
 
 /// Apply the process-wide DoH resolver to a builder, if one is installed.
-fn with_process_doh(mut builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
+///
+/// Public so `vouch-cli` (which builds its own `reqwest::Client` for
+/// authenticated CLI traffic) can route through the same helper as the
+/// common factories below.
+pub fn with_process_doh(mut builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
     if let Some(resolver) = process_resolver() {
         builder = builder.dns_resolver(resolver);
     }
@@ -120,7 +124,7 @@ pub fn server_client(
         }
     }
 
-    Ok(builder.build()?)
+    Ok(with_process_doh(builder).build()?)
 }
 
 #[cfg(test)]

--- a/crates/vouch-common/src/lib.rs
+++ b/crates/vouch-common/src/lib.rs
@@ -5,6 +5,7 @@ pub mod aaguid;
 pub(crate) mod api;
 pub mod aws;
 pub(crate) mod cookie;
+pub mod dns;
 pub mod encoding;
 pub(crate) mod error;
 pub mod fido2_types;

--- a/crates/vouch-tests/tests/dns_wiring.rs
+++ b/crates/vouch-tests/tests/dns_wiring.rs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! Verifies that the process-wide DoH resolver wires through to every
+//! reqwest client built via `vouch-common`'s HTTP factories.
+//!
+//! Integration scope: this is a *wiring-existence* check (every factory
+//! reaches `process_resolver()`), not an end-to-end DNS lookup. The
+//! lookup path is exercised separately by `vouch doctor` against a live
+//! provider.
+
+use vouch_common::dns::{
+    DohConfig, DohResolver, install_process_resolver, process_config, process_resolver,
+};
+use vouch_common::http::{agent_client, credential_client, server_client};
+
+#[test]
+fn install_process_resolver_wires_through_all_factories() {
+    // Pre-install: nothing has been set, so the accessors report defaults.
+    assert!(process_resolver().is_none(), "no resolver before install");
+    assert_eq!(process_config(), DohConfig::Off, "default state is Off");
+
+    // Install Cloudflare DoH for the rest of this test process.
+    let cfg = DohConfig::Cloudflare;
+    let resolver = DohResolver::for_config(&cfg);
+    assert!(
+        resolver.is_some(),
+        "for_config(Cloudflare) should produce a resolver"
+    );
+    install_process_resolver(cfg, resolver);
+
+    // After install, both accessors reflect the new state.
+    assert!(
+        process_resolver().is_some(),
+        "process_resolver should return Some after install"
+    );
+    assert_eq!(process_config(), DohConfig::Cloudflare);
+
+    // Each factory must construct successfully with the resolver applied.
+    // The build is what exercises the dns_resolver wiring; if any future
+    // edit removes `with_process_doh` from a factory, this test alone
+    // wouldn't catch a silent skip — but a build failure here would
+    // surface a misuse of the resolver type or feature flags.
+    credential_client("test-credential/1.0").expect("credential_client builds");
+    agent_client("test-agent/1.0").expect("agent_client builds");
+    server_client("test-server/1.0", None).expect("server_client builds");
+
+    // Idempotency: a second install must NOT replace the state. Attempt
+    // to install Off and verify Cloudflare survives.
+    install_process_resolver(DohConfig::Off, None);
+    assert_eq!(
+        process_config(),
+        DohConfig::Cloudflare,
+        "first install wins; subsequent calls are no-ops"
+    );
+    assert!(
+        process_resolver().is_some(),
+        "resolver from first install survives a second-call attempt"
+    );
+}


### PR DESCRIPTION
Resolve outbound hostnames via Google/Cloudflare/Quad9 DoH (or a custom
HTTPS endpoint) instead of the system resolver, removing DNS as the last
cleartext metadata leak in the local network. Opt-in via VOUCH_DOH or
network.dns_over_https in ~/.vouch/config.json; defaults to Google when
enabled without a named provider. Hard-fails when the configured
provider can't be reached. Also disables HTTP redirects on every reqwest
client we build so the "TCP/443 only" property holds end to end.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds process-wide DNS-over-HTTPS resolution and changes HTTP client behavior (DNS path + redirects) for both `vouch-cli` and `vouch-agent`, which can affect connectivity and startup failures when misconfigured.
> 
> **Overview**
> Adds opt-in **DNS-over-HTTPS (DoH)** for outbound hostname resolution across `vouch-cli` and `vouch-agent`, configurable via `VOUCH_DOH` or `network.dns_over_https` in `~/.vouch/config.json` (shared `NetworkConfig`), and hard-fails early when DoH is enabled but invalid.
> 
> Introduces `vouch-common::dns` (hickory-based, DNSSEC-validating) with a process-wide resolver that is wired into all reqwest client factories via `with_process_doh`, and disables HTTP redirects on CLI/common HTTP clients to preserve the “TCP/443 only” property.
> 
> Extends `vouch doctor` to report DoH status and perform a real DoH lookup when enabled, and bumps workspace version to `2026.4.10` while adding `hickory-resolver`/transitive deps (plus an integration test to ensure DoH wiring stays intact).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f99c66e620457dab78641801caf0f2c5f554082. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->