### PR TITLE
fix(config): validate IdP slug format for all config sources

### DIFF
--- a/crates/vouch-server/src/config.rs
+++ b/crates/vouch-server/src/config.rs
@@ -862,8 +862,12 @@ impl ServerConfig {
     /// Call this after all config sources (env, S3) have been merged.
     pub fn validate(&self) -> Result<()> {
         // Reject duplicate IdP slugs — order matters for UI but ids must be unique.
+        // Also enforce slug format here so all merged sources (env, S3) are
+        // checked consistently — env parsing already runs validate_provider_slug,
+        // but S3-sourced IdPs would otherwise bypass it.
         let mut seen = std::collections::HashSet::new();
         for idp in &self.idps {
+            validate_provider_slug(idp.id())?;
             if !seen.insert(idp.id()) {
                 anyhow::bail!(
                     "Duplicate IdP slug '{}' in VOUCH_IDPS / idps[].id",

--- a/crates/vouch-server/src/infra/s3_config.rs
+++ b/crates/vouch-server/src/infra/s3_config.rs
@@ -1416,6 +1416,62 @@ mod tests {
         assert_eq!(config.idps[1].kind_str(), "saml");
     }
 
+    /// Regression: S3-sourced IdP slugs must be checked against the documented
+    /// `[a-z0-9-]{1,32}` format, just like env-var-sourced slugs. Before the
+    /// fix, an uppercase id like `MyProvider` would pass validate() while the
+    /// same id via VOUCH_IDPS was rejected. See issue #382.
+    #[test]
+    fn test_merge_s3_config_validates_idp_slug_format() {
+        let json = r#"{
+            "idps": [
+                {
+                    "id": "MyProvider",
+                    "type": "oidc",
+                    "issuer": "https://accounts.google.com",
+                    "client_id": "client-abc",
+                    "client_secret": "secret-xyz"
+                }
+            ]
+        }"#;
+        let s3: S3Config = serde_json::from_str(json).expect("parse");
+        let mut config = crate::test_utils::test_config();
+        config.idps.clear();
+
+        config.merge_s3_config(&s3, false).unwrap();
+
+        let err = config
+            .validate()
+            .expect_err("uppercase slug must be rejected")
+            .to_string();
+        assert!(
+            err.contains("must match [a-z0-9-]"),
+            "expected slug format error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_merge_s3_config_rejects_underscore_in_idp_slug() {
+        let json = r#"{
+            "idps": [
+                {
+                    "id": "corp_saml",
+                    "type": "saml",
+                    "metadata_url": "https://idp.example.com/saml/metadata"
+                }
+            ]
+        }"#;
+        let s3: S3Config = serde_json::from_str(json).expect("parse");
+        let mut config = crate::test_utils::test_config();
+        config.idps.clear();
+
+        config.merge_s3_config(&s3, false).unwrap();
+
+        assert!(
+            config.validate().is_err(),
+            "underscore in slug must be rejected"
+        );
+    }
+
     #[test]
     fn test_s3_config_deserialization_with_idps_saml_only() {
         let json = r#"{


### PR DESCRIPTION
## Summary

Fixes #382. S3-sourced IdP slugs were bypassing the `[a-z0-9-]{1,32}` format check that env-var-sourced slugs enforced.

- `parse_idps()` in `crates/vouch-server/src/config.rs` already calls `validate_provider_slug()` for env-var slugs, but `S3IdpEntry::into_idp_config()` in `crates/vouch-server/src/infra/s3_config.rs` constructed `IdpConfig` directly with no validation.
- `ServerConfig::validate()` only checked for duplicate slugs, so an S3 config with `"id": "MyProvider"` or `"id": "corp_saml"` was accepted despite the documented format.
- Fix: call `validate_provider_slug(idp.id())` inside `ServerConfig::validate()` — the documented post-merge chokepoint — so both env and S3 sources are enforced consistently. The env path keeps its early call for a more localized error.

## Test plan

- [x] `cargo test --package vouch-server --lib merge_s3_config` — new regression tests pass, existing tests unchanged (15/15)
- [x] `cargo test --package vouch-server --lib config::` — full config module green (43/43)
- [x] `cargo clippy --package vouch-server --all-targets --all-features -- -D warnings` — clean
- New tests added in `s3_config.rs`:
  - `test_merge_s3_config_validates_idp_slug_format` — uppercase id `"MyProvider"` rejected with `must match [a-z0-9-]`
  - `test_merge_s3_config_rejects_underscore_in_idp_slug` — underscore id `"corp_saml"` rejected

https://claude.ai/code/session_014JtPoGhG6CgxX7EFot3A1q

---
_Generated by [Claude Code](https://claude.ai/code/session_014JtPoGhG6CgxX7EFot3A1q)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an extra validation check during `ServerConfig::validate()`, which may newly reject previously-accepted S3 configs with invalid IdP slugs but does not change runtime behavior beyond fail-fast validation.
> 
> **Overview**
> Ensures IdP slugs are validated against the documented `[a-z0-9-]{1,32}` format *after* all config sources are merged by calling `validate_provider_slug()` for every configured IdP in `ServerConfig::validate()`.
> 
> Adds regression tests covering invalid S3-provided IdP ids (uppercase and underscore) to prevent S3 configuration from bypassing slug-format enforcement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aae6841fc7d904c44e8d10382b22ec1e6c5ad14d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->