### PR TITLE
fix(cli/aws): fold agent context into STS credential cache key (#398)

### DIFF
--- a/crates/vouch-cli/src/commands/aws/console.rs
+++ b/crates/vouch-cli/src/commands/aws/console.rs
@@ -60,8 +60,13 @@ pub(crate) async fn run(server: &str, args: ConsoleArgs) -> Result<()> {
     //    Uses exchange_for_sts_credentials directly to keep
     //    SecretAccessKey/SessionToken as SecretString until
     //    serialization.
+    let agent_source = crate::commands::credential::aws::detect_agent_source();
     let result = crate::commands::credential::aws::exchange_for_sts_credentials(
-        server, &role_arn, &region, None,
+        server,
+        &role_arn,
+        &region,
+        None,
+        agent_source.as_deref(),
     )
     .await
     .context("failed to get AWS credentials")?;

--- a/crates/vouch-cli/src/commands/aws/console.rs
+++ b/crates/vouch-cli/src/commands/aws/console.rs
@@ -62,11 +62,13 @@ pub(crate) async fn run(server: &str, args: ConsoleArgs) -> Result<()> {
     //    serialization.
     let agent_source = crate::commands::credential::aws::detect_agent_source();
     let result = crate::commands::credential::aws::exchange_for_sts_credentials(
-        server,
-        &role_arn,
-        &region,
-        None,
-        agent_source.as_deref(),
+        crate::commands::credential::aws::StsRequest {
+            server,
+            role_arn: &role_arn,
+            region: &region,
+            management_role: None,
+            agent_source: agent_source.as_deref(),
+        },
     )
     .await
     .context("failed to get AWS credentials")?;

--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -109,6 +109,22 @@ pub(crate) struct StsExchangeResult {
     pub(crate) domain_suffix: &'static str,
 }
 
+/// Inputs to a single AWS STS credential exchange.
+///
+/// All fields are borrowed for the duration of the call. `management_role`,
+/// when `Some`, triggers role chaining; `agent_source`, when `Some`, applies
+/// AI-agent restrictions (`ReadOnlyAccess` session policy and the DPoP
+/// source claim the server turns into `vouch:AccessType=ai` /
+/// `vouch:Agent=<name>` principal tags). Contains no secrets.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct StsRequest<'a> {
+    pub(crate) server: &'a str,
+    pub(crate) role_arn: &'a str,
+    pub(crate) region: &'a str,
+    pub(crate) management_role: Option<&'a str>,
+    pub(crate) agent_source: Option<&'a str>,
+}
+
 /// Exchange a Vouch session for AWS STS credentials.
 ///
 /// Handles the full flow: OIDC token fetch → JWT decode for session tags →
@@ -237,16 +253,18 @@ where
 /// variables like `CLAUDECODE`, `CURSOR_AGENT`, etc.), automatically
 /// attaches `ReadOnlyAccess` session policy and sets a DPoP source
 /// claim for CloudTrail attribution.
-pub(crate) async fn exchange_for_sts_credentials(
-    server: &str,
-    role_arn: &str,
-    region: &str,
-    management_role: Option<&str>,
-    agent_source: Option<&str>,
-) -> Result<StsExchangeResult> {
+pub(crate) async fn exchange_for_sts_credentials(req: StsRequest<'_>) -> Result<StsExchangeResult> {
     use crate::integrations::aws::sts::{
         WebIdentityRequest, assume_role, assume_role_with_web_identity, parse_role_arn,
     };
+
+    let StsRequest {
+        server,
+        role_arn,
+        region,
+        management_role,
+        agent_source,
+    } = req;
 
     // If caller didn't pre-resolve, resolve now from config
     let resolved;
@@ -466,8 +484,14 @@ async fn fetch_and_assume(
 ) -> Result<CredentialProcessOutput> {
     let region = crate::integrations::aws::resolve_region_with_fallback(role_arn)?;
 
-    let result =
-        exchange_for_sts_credentials(server, role_arn, &region, mgmt_role, agent_source).await?;
+    let result = exchange_for_sts_credentials(StsRequest {
+        server,
+        role_arn,
+        region: &region,
+        management_role: mgmt_role,
+        agent_source,
+    })
+    .await?;
     let creds = &result.credentials;
     Ok(CredentialProcessOutput {
         version: 1,

--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -428,7 +428,11 @@ pub(crate) async fn get_aws_credentials(server: &str, role_arn: &str) -> Result<
     // cached entry, which would otherwise hand the agent credentials minted
     // without ReadOnlyAccess / `vouch:AccessType=ai` tags (issue #398).
     let agent_source = detect_agent_source();
-    let cache_key = build_cache_key(role_arn, management_role.as_deref(), agent_source.as_deref());
+    let cache_key = build_cache_key(
+        role_arn,
+        management_role.as_deref(),
+        agent_source.as_deref(),
+    );
 
     let mgmt = management_role;
     let agent = agent_source;

--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -138,8 +138,25 @@ pub(crate) struct StsExchangeResult {
 /// - `ANTIGRAVITY_AGENT`: <https://github.com/vercel/vercel/blob/main/packages/detect-agent/src/index.ts>
 /// - `OPENCODE_CLIENT`: <https://github.com/vercel/vercel/blob/main/packages/detect-agent/src/index.ts>
 /// - `CLINE_ACTIVE`: <https://github.com/cline/cline/discussions/5366>
-fn detect_agent_source() -> Option<String> {
+pub(crate) fn detect_agent_source() -> Option<String> {
     detect_agent_source_from(|k| std::env::var(k).ok())
+}
+
+/// Build the cache key for AWS STS credentials.
+///
+/// The agent source is folded into the key so that agent and non-agent
+/// invocations (and invocations from different agents) never share a
+/// cached entry — they receive credentials with different session
+/// policies and principal tags. See issue #398.
+fn build_cache_key(role_arn: &str, mgmt: Option<&str>, agent: Option<&str>) -> String {
+    let suffix = match agent {
+        Some(src) => format!(":agent:{src}"),
+        None => String::new(),
+    };
+    match mgmt {
+        Some(mgmt_role) => format!("aws:chain:{mgmt_role}:{role_arn}{suffix}"),
+        None => format!("aws:{role_arn}{suffix}"),
+    }
 }
 
 /// Inner implementation of [`detect_agent_source`] parameterised over the env
@@ -225,6 +242,7 @@ pub(crate) async fn exchange_for_sts_credentials(
     role_arn: &str,
     region: &str,
     management_role: Option<&str>,
+    agent_source: Option<&str>,
 ) -> Result<StsExchangeResult> {
     use crate::integrations::aws::sts::{
         WebIdentityRequest, assume_role, assume_role_with_web_identity, parse_role_arn,
@@ -246,8 +264,10 @@ pub(crate) async fn exchange_for_sts_credentials(
     let arn = parse_role_arn(role_arn)?;
     let domain_suffix = arn.partition.dns_suffix();
 
-    // Detect AI agent environment and apply restrictions automatically
-    let agent_source = detect_agent_source();
+    // Apply AI-agent restrictions when the caller detected an agent context.
+    // Detection must happen at the caller — and, for cached callers, before
+    // the cache lookup — otherwise a cache hit would silently return
+    // credentials minted in the wrong context (issue #398).
     let agent_policies: &[&str] = if agent_source.is_some() {
         &["ReadOnlyAccess"]
     } else {
@@ -258,7 +278,7 @@ pub(crate) async fn exchange_for_sts_credentials(
 
     // Set DPoP source claim for agent attribution (tamperproof via DPoP signature).
     // Server extracts this to add AI-specific session tags to the JWT.
-    if let Some(source) = agent_source.as_deref() {
+    if let Some(source) = agent_source {
         tracing::info!("AI agent detected ({source}), applying ReadOnlyAccess session policy");
         client.set_dpop_source(source);
     }
@@ -402,15 +422,18 @@ pub(crate) fn resolve_management_role(
 pub(crate) async fn get_aws_credentials(server: &str, role_arn: &str) -> Result<serde_json::Value> {
     let vouch_config = crate::config::Config::load()?;
     let management_role = resolve_management_role(&vouch_config)?.filter(|m| m != role_arn);
-    let cache_key = if let Some(ref mgmt_role) = management_role {
-        format!("aws:chain:{mgmt_role}:{role_arn}")
-    } else {
-        format!("aws:{role_arn}")
-    };
+
+    // Detect agent context BEFORE the cache lookup. Folding the source into
+    // the cache key ensures agent and non-agent invocations never share a
+    // cached entry, which would otherwise hand the agent credentials minted
+    // without ReadOnlyAccess / `vouch:AccessType=ai` tags (issue #398).
+    let agent_source = detect_agent_source();
+    let cache_key = build_cache_key(role_arn, management_role.as_deref(), agent_source.as_deref());
 
     let mgmt = management_role;
+    let agent = agent_source;
     super::cache::get_or_fetch(&cache_key, "AWS credentials", || async move {
-        let output = fetch_and_assume(server, role_arn, mgmt.as_deref()).await?;
+        let output = fetch_and_assume(server, role_arn, mgmt.as_deref(), agent.as_deref()).await?;
         let expires_at = output.expiration.clone();
         Ok((output.to_json(), expires_at))
     })
@@ -435,10 +458,12 @@ async fn fetch_and_assume(
     server: &str,
     role_arn: &str,
     mgmt_role: Option<&str>,
+    agent_source: Option<&str>,
 ) -> Result<CredentialProcessOutput> {
     let region = crate::integrations::aws::resolve_region_with_fallback(role_arn)?;
 
-    let result = exchange_for_sts_credentials(server, role_arn, &region, mgmt_role).await?;
+    let result =
+        exchange_for_sts_credentials(server, role_arn, &region, mgmt_role, agent_source).await?;
     let creds = &result.credentials;
     Ok(CredentialProcessOutput {
         version: 1,
@@ -647,5 +672,52 @@ mod tests {
     fn test_detect_agent_claudecode_only() {
         let got = detect_agent_source_from(env(&[("CLAUDECODE", "1")]));
         assert_eq!(got.as_deref(), Some("claude-code"));
+    }
+
+    const ROLE: &str = "arn:aws:iam::123456789012:role/target";
+    const MGMT: &str = "arn:aws:iam::123456789012:role/mgmt";
+
+    /// Direct (no chaining), no agent: backward-compatible key format.
+    #[test]
+    fn test_build_cache_key_direct_no_agent() {
+        assert_eq!(build_cache_key(ROLE, None, None), format!("aws:{ROLE}"));
+    }
+
+    /// Chained (management role), no agent: backward-compatible key format.
+    #[test]
+    fn test_build_cache_key_chain_no_agent() {
+        assert_eq!(
+            build_cache_key(ROLE, Some(MGMT), None),
+            format!("aws:chain:{MGMT}:{ROLE}")
+        );
+    }
+
+    /// Agent context produces a different key than no-agent — this is the
+    /// invariant that prevents issue #398's cache-confusion bypass.
+    #[test]
+    fn test_build_cache_key_differs_when_agent_detected() {
+        let without = build_cache_key(ROLE, None, None);
+        let with = build_cache_key(ROLE, None, Some("claude-code"));
+        assert_ne!(without, with);
+    }
+
+    /// Different agents must not share a cached entry: each agent's identity
+    /// flows into the `vouch:Agent` principal tag, so the credentials are
+    /// distinguishable in IAM and CloudTrail.
+    #[test]
+    fn test_build_cache_key_differs_between_agents() {
+        let claude = build_cache_key(ROLE, None, Some("claude-code"));
+        let cursor = build_cache_key(ROLE, None, Some("cursor"));
+        assert_ne!(claude, cursor);
+    }
+
+    /// Same inputs → same key. Lock the format so accidental refactors that
+    /// drop fields from the key are caught.
+    #[test]
+    fn test_build_cache_key_stable_for_same_agent() {
+        let a = build_cache_key(ROLE, Some(MGMT), Some("claude-code"));
+        let b = build_cache_key(ROLE, Some(MGMT), Some("claude-code"));
+        assert_eq!(a, b);
+        assert_eq!(a, format!("aws:chain:{MGMT}:{ROLE}:agent:claude-code"));
     }
 }

--- a/crates/vouch-cli/src/commands/credential/codeartifact.rs
+++ b/crates/vouch-cli/src/commands/credential/codeartifact.rs
@@ -13,7 +13,7 @@
 use anyhow::{Context, Result};
 use secrecy::{ExposeSecret, SecretString};
 
-use crate::commands::credential::aws::exchange_for_sts_credentials;
+use crate::commands::credential::aws::{StsRequest, exchange_for_sts_credentials};
 use crate::commands::credential::cache;
 use crate::config::Config;
 use crate::integrations::aws::codeartifact::{
@@ -179,9 +179,14 @@ async fn fetch_token(
     })?;
 
     let agent_source = crate::commands::credential::aws::detect_agent_source();
-    let result =
-        exchange_for_sts_credentials(server, &role_arn, region, None, agent_source.as_deref())
-            .await?;
+    let result = exchange_for_sts_credentials(StsRequest {
+        server,
+        role_arn: &role_arn,
+        region,
+        management_role: None,
+        agent_source: agent_source.as_deref(),
+    })
+    .await?;
 
     let registry = CodeArtifactRegistry {
         domain: domain.to_string(),

--- a/crates/vouch-cli/src/commands/credential/codeartifact.rs
+++ b/crates/vouch-cli/src/commands/credential/codeartifact.rs
@@ -178,7 +178,10 @@ async fn fetch_token(
         )
     })?;
 
-    let result = exchange_for_sts_credentials(server, &role_arn, region, None).await?;
+    let agent_source = crate::commands::credential::aws::detect_agent_source();
+    let result =
+        exchange_for_sts_credentials(server, &role_arn, region, None, agent_source.as_deref())
+            .await?;
 
     let registry = CodeArtifactRegistry {
         domain: domain.to_string(),

--- a/crates/vouch-cli/src/commands/credential/docker.rs
+++ b/crates/vouch-cli/src/commands/credential/docker.rs
@@ -216,7 +216,10 @@ async fn get_ecr_credential(
         )
     })?;
 
-    let result = exchange_for_sts_credentials(server, &role_arn, region, None).await?;
+    let agent_source = crate::commands::credential::aws::detect_agent_source();
+    let result =
+        exchange_for_sts_credentials(server, &role_arn, region, None, agent_source.as_deref())
+            .await?;
 
     // Call ECR GetAuthorizationToken
     let ecr_token = get_ecr_authorization_token(

--- a/crates/vouch-cli/src/commands/credential/docker.rs
+++ b/crates/vouch-cli/src/commands/credential/docker.rs
@@ -24,7 +24,7 @@ use std::io::{BufRead, Write};
 use vouch_common::{GitHubTokenRequest, GitHubTokenResponse};
 
 use crate::client::VouchClient;
-use crate::commands::credential::aws::exchange_for_sts_credentials;
+use crate::commands::credential::aws::{StsRequest, exchange_for_sts_credentials};
 use crate::integrations::aws::get_local_aws_role;
 use crate::integrations::aws::sigv4::sign_and_send_json_rpc;
 use crate::integrations::aws::sts::StsCredentials;
@@ -217,9 +217,14 @@ async fn get_ecr_credential(
     })?;
 
     let agent_source = crate::commands::credential::aws::detect_agent_source();
-    let result =
-        exchange_for_sts_credentials(server, &role_arn, region, None, agent_source.as_deref())
-            .await?;
+    let result = exchange_for_sts_credentials(StsRequest {
+        server,
+        role_arn: &role_arn,
+        region,
+        management_role: None,
+        agent_source: agent_source.as_deref(),
+    })
+    .await?;
 
     // Call ECR GetAuthorizationToken
     let ecr_token = get_ecr_authorization_token(

--- a/crates/vouch-cli/src/commands/credential/eks.rs
+++ b/crates/vouch-cli/src/commands/credential/eks.rs
@@ -15,7 +15,7 @@ use anyhow::{Context, Result};
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 
-use crate::commands::credential::aws::exchange_for_sts_credentials;
+use crate::commands::credential::aws::{StsRequest, exchange_for_sts_credentials};
 use crate::commands::credential::cache;
 use crate::integrations::aws;
 use crate::integrations::aws::sigv4::{
@@ -69,9 +69,14 @@ async fn generate_eks_token(
     role_arn: &str,
 ) -> Result<String> {
     let agent_source = crate::commands::credential::aws::detect_agent_source();
-    let result =
-        exchange_for_sts_credentials(server, role_arn, region, None, agent_source.as_deref())
-            .await?;
+    let result = exchange_for_sts_credentials(StsRequest {
+        server,
+        role_arn,
+        region,
+        management_role: None,
+        agent_source: agent_source.as_deref(),
+    })
+    .await?;
 
     // Build presigned STS GetCallerIdentity URL with cluster ID
     let sts_endpoint = format!("https://sts.{region}.{}", result.domain_suffix);

--- a/crates/vouch-cli/src/commands/credential/eks.rs
+++ b/crates/vouch-cli/src/commands/credential/eks.rs
@@ -68,7 +68,10 @@ async fn generate_eks_token(
     region: &str,
     role_arn: &str,
 ) -> Result<String> {
-    let result = exchange_for_sts_credentials(server, role_arn, region, None).await?;
+    let agent_source = crate::commands::credential::aws::detect_agent_source();
+    let result =
+        exchange_for_sts_credentials(server, role_arn, region, None, agent_source.as_deref())
+            .await?;
 
     // Build presigned STS GetCallerIdentity URL with cluster ID
     let sts_endpoint = format!("https://sts.{region}.{}", result.domain_suffix);

--- a/crates/vouch-cli/src/commands/credential/rds.rs
+++ b/crates/vouch-cli/src/commands/credential/rds.rs
@@ -17,7 +17,7 @@
 use anyhow::{Context, Result};
 use secrecy::{ExposeSecret, SecretString};
 
-use crate::commands::credential::aws::exchange_for_sts_credentials;
+use crate::commands::credential::aws::{StsRequest, exchange_for_sts_credentials};
 use crate::commands::credential::cache;
 use crate::integrations::aws;
 use crate::integrations::aws::sigv4::{
@@ -93,9 +93,14 @@ async fn generate_rds_token(
     role_arn: &str,
 ) -> Result<String> {
     let agent_source = crate::commands::credential::aws::detect_agent_source();
-    let result =
-        exchange_for_sts_credentials(server, role_arn, region, None, agent_source.as_deref())
-            .await?;
+    let result = exchange_for_sts_credentials(StsRequest {
+        server,
+        role_arn,
+        region,
+        management_role: None,
+        agent_source: agent_source.as_deref(),
+    })
+    .await?;
 
     // Build presigned URL for RDS IAM auth
     let endpoint = format!("https://{hostname}:{port}");

--- a/crates/vouch-cli/src/commands/credential/rds.rs
+++ b/crates/vouch-cli/src/commands/credential/rds.rs
@@ -92,7 +92,10 @@ async fn generate_rds_token(
     region: &str,
     role_arn: &str,
 ) -> Result<String> {
-    let result = exchange_for_sts_credentials(server, role_arn, region, None).await?;
+    let agent_source = crate::commands::credential::aws::detect_agent_source();
+    let result =
+        exchange_for_sts_credentials(server, role_arn, region, None, agent_source.as_deref())
+            .await?;
 
     // Build presigned URL for RDS IAM auth
     let endpoint = format!("https://{hostname}:{port}");

--- a/crates/vouch-cli/src/commands/credential/redshift.rs
+++ b/crates/vouch-cli/src/commands/credential/redshift.rs
@@ -98,7 +98,10 @@ pub(crate) async fn fetch_redshift_credentials(
     region: &str,
     role_arn: &str,
 ) -> Result<crate::integrations::aws::redshift::RedshiftCredentials> {
-    let result = exchange_for_sts_credentials(server, role_arn, region, None).await?;
+    let agent_source = crate::commands::credential::aws::detect_agent_source();
+    let result =
+        exchange_for_sts_credentials(server, role_arn, region, None, agent_source.as_deref())
+            .await?;
 
     match target {
         RedshiftTarget::Cluster {

--- a/crates/vouch-cli/src/commands/credential/redshift.rs
+++ b/crates/vouch-cli/src/commands/credential/redshift.rs
@@ -13,7 +13,7 @@
 use anyhow::{Context, Result, bail};
 use secrecy::ExposeSecret;
 
-use crate::commands::credential::aws::exchange_for_sts_credentials;
+use crate::commands::credential::aws::{StsRequest, exchange_for_sts_credentials};
 use crate::commands::credential::cache;
 use crate::integrations::aws;
 use crate::integrations::aws::redshift::{get_cluster_credentials, get_serverless_credentials};
@@ -99,9 +99,14 @@ pub(crate) async fn fetch_redshift_credentials(
     role_arn: &str,
 ) -> Result<crate::integrations::aws::redshift::RedshiftCredentials> {
     let agent_source = crate::commands::credential::aws::detect_agent_source();
-    let result =
-        exchange_for_sts_credentials(server, role_arn, region, None, agent_source.as_deref())
-            .await?;
+    let result = exchange_for_sts_credentials(StsRequest {
+        server,
+        role_arn,
+        region,
+        management_role: None,
+        agent_source: agent_source.as_deref(),
+    })
+    .await?;
 
     match target {
         RedshiftTarget::Cluster {

--- a/crates/vouch-cli/src/commands/setup/eks.rs
+++ b/crates/vouch-cli/src/commands/setup/eks.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result};
 use serde::Deserialize;
 use std::path::PathBuf;
 
-use crate::commands::credential::aws::exchange_for_sts_credentials;
+use crate::commands::credential::aws::{StsRequest, exchange_for_sts_credentials};
 use crate::integrations::aws;
 use crate::integrations::aws::sigv4::sign_and_send_rest;
 
@@ -50,9 +50,14 @@ async fn describe_cluster(
     role_arn: &str,
 ) -> Result<(String, String)> {
     let agent_source = crate::commands::credential::aws::detect_agent_source();
-    let result =
-        exchange_for_sts_credentials(server, role_arn, region, None, agent_source.as_deref())
-            .await?;
+    let result = exchange_for_sts_credentials(StsRequest {
+        server,
+        role_arn,
+        region,
+        management_role: None,
+        agent_source: agent_source.as_deref(),
+    })
+    .await?;
 
     // Call EKS DescribeCluster REST API
     let endpoint = format!("https://eks.{region}.{}", result.domain_suffix);

--- a/crates/vouch-cli/src/commands/setup/eks.rs
+++ b/crates/vouch-cli/src/commands/setup/eks.rs
@@ -49,7 +49,10 @@ async fn describe_cluster(
     region: &str,
     role_arn: &str,
 ) -> Result<(String, String)> {
-    let result = exchange_for_sts_credentials(server, role_arn, region, None).await?;
+    let agent_source = crate::commands::credential::aws::detect_agent_source();
+    let result =
+        exchange_for_sts_credentials(server, role_arn, region, None, agent_source.as_deref())
+            .await?;
 
     // Call EKS DescribeCluster REST API
     let endpoint = format!("https://eks.{region}.{}", result.domain_suffix);


### PR DESCRIPTION
## Summary

Closes #398. The AWS STS credential cache in `vouch credential aws` (and `exec`, `codecommit`) keyed only off role ARN, while AI-agent detection — which gates the `ReadOnlyAccess` session policy, the mgmt-hop inline policy, and the DPoP `source` claim that the server turns into `vouch:AccessType=ai` and `vouch:Agent=…` principal tags — was called *inside* the fetch closure. The closure only runs on cache miss, so a non-agent invocation that populated the cache first would silently hand subsequent agent invocations unrestricted credentials, bypassing IAM `aws:PrincipalTag/vouch:AccessType` conditions and CloudTrail attribution. The symmetric direction broke non-agent runs.

## Fix

- Detect agent context **once** in `get_aws_credentials` **before** the cache lookup.
- Fold the agent identifier into the cache key via a new pure helper `build_cache_key(role_arn, mgmt, agent)`. Suffix is `:agent:{src}` so different agents (`claude-code`, `cursor`, …) also receive distinct entries — they end up with different `vouch:Agent` tags.
- Add `agent_source: Option<&str>` to `exchange_for_sts_credentials` as an explicit parameter (no silent internal fallback). Updated the seven non-cached call sites (`eks`, `setup/eks`, `rds`, `redshift`, `codeartifact`, `docker`, `aws/console`) to detect at the call site and pass it through. Removing the internal fallback prevents the next caller from regressing the same way this bug appeared.

Server side (`vouch-server/src/services/integrations/aws.rs`) already gates principal tags on the DPoP `source` claim, so no server changes are needed once the CLI sets it on every agent invocation.

## Test plan

- [x] Added 5 unit tests covering `build_cache_key`: backward-compat for non-agent direct & chained keys, agent vs. non-agent differ, agent-A vs. agent-B differ, format stability.
- [x] `make lint` (clippy `-D warnings`) clean.
- [x] `make test` — full workspace passes (all 19 `aws.rs` unit tests included).
- [ ] Manual smoke (requires a working vouch server + AWS role):
      ```bash
      rm -rf ~/.vouch/cache
      unset CLAUDECODE CURSOR_AGENT AI_AGENT
      vouch credential aws            # populates non-agent cache entry
      CLAUDECODE=1 vouch credential aws  # must MISS, log "AI agent detected", populate distinct entry
      ```
      Confirm two cache entries are written and that CloudTrail records `principalTags` containing `vouch:AccessType=ai` only on the agent run.

https://claude.ai/code/session_01NT92f7KBRykfsjcemTdqfb

---
_Generated by [Claude Code](https://claude.ai/code/session_01NT92f7KBRykfsjcemTdqfb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how AWS STS credentials are minted and cached to prevent agent/non-agent cache reuse, which directly impacts IAM session policy/tagging and access scoping. Risk is moderate because it touches credential exchange and multiple AWS credential subcommands, but the change is narrowly scoped and covered by new unit tests.
> 
> **Overview**
> Fixes a cache-confusion issue where AWS STS credentials cached by `vouch credential aws` could be reused across *agent* and *non-agent* invocations.
> 
> Agent detection is now done **before** cache lookup, the detected agent source is folded into a new `build_cache_key(...)` (suffix `:agent:{src}`), and `exchange_for_sts_credentials(...)` now requires an explicit `agent_source` parameter (removing implicit internal detection). All direct callers (`aws console`, `codeartifact`, `docker`/ECR, `eks`, `rds`, `redshift`, `setup eks`) were updated to detect and pass the agent context, and new unit tests lock in the cache-key format and separation guarantees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33995577e1d0ad9f681ca4ea6f2343f05e7018a3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->