### PR TITLE
Fixes state reuse

### DIFF
--- a/crates/vouch-server/src/db/challenge_states.rs
+++ b/crates/vouch-server/src/db/challenge_states.rs
@@ -7,39 +7,58 @@ use super::store::DocumentStore;
 use anyhow::Result;
 use jiff::Timestamp;
 
-/// Atomically mark a FIDO2 challenge as used.
+/// Derive a deterministic document ID from a registration state JWT.
 ///
-/// Returns `true` if the challenge was successfully marked (first use).
-/// Returns `false` if a record with the same hash already exists
-/// (replay or concurrent use).
+/// The `"challenge_state\0"` domain separator prevents cross-type ID
+/// collisions with `deterministic_jti_id` (`db/oauth.rs:794`) and
+/// `deterministic_dpop_jti_id` (`db/dpop.rs:21`), which use different
+/// prefixes. Output is hex-encoded SHA-256 (64 chars).
+fn deterministic_challenge_state_id(state_jwt: &str) -> String {
+    use aws_lc_rs::digest::{self, SHA256};
+
+    let mut ctx = digest::Context::new(&SHA256);
+    ctx.update(b"challenge_state\0");
+    ctx.update(state_jwt.as_bytes());
+    hex::encode(ctx.finish().as_ref())
+}
+
+/// Atomically mark a registration state JWT as consumed (single-use enforcement).
 ///
-/// The transaction ensures no TOCTOU race: two concurrent requests
-/// with the same challenge cannot both succeed because the second
-/// `find_one` will see the first's insert.
+/// Returns `true` if this is the first use (the document was inserted).
+/// Returns `false` if the state has already been consumed (replay detected).
+///
+/// **Race safety across all three backends (SQLite, Postgres, DSQL):**
+///
+/// A deterministic document ID derived from the JWT is used as the PRIMARY KEY.
+/// Two concurrent calls with the same `state_jwt` will both attempt
+/// `insert_with_id` with the same ID. Exactly one will commit; the other will
+/// observe a unique violation (`SQLSTATE 23505`) and return `Ok(false)`.
+///
+/// **DSQL OCC retry interaction:** Under Aurora DSQL's optimistic concurrency
+/// control, the losing concurrent transaction first receives a serialization
+/// error (`SQLSTATE 40001` / `OC000`/`OC001`). The `with_dsql_retry!` wrapper
+/// (`db/store.rs`) retries that transaction. On retry, the INSERT collides with
+/// the already-committed row from the winner, producing `SQLSTATE 23505`.
+/// `23505` is not retryable, so `with_dsql_retry!` surfaces it as `Err(e)`,
+/// which `is_unique_violation` catches and converts to `Ok(false)`. Only one
+/// transaction wins; the loser is correctly treated as a replay.
 pub async fn try_mark_challenge_used(
     store: &DocumentStore,
-    state_hash: &str,
+    state_jwt: &str,
     expires_at: Timestamp,
 ) -> Result<bool> {
-    let mut tx = store.begin().await?;
-
-    let existing = tx
-        .find_one::<ChallengeStateDoc>("state_hash", state_hash)
-        .await?;
-    if existing.is_some() {
-        return Ok(false);
-    }
-
-    let now = Timestamp::now();
+    let id = deterministic_challenge_state_id(state_jwt);
     let doc = ChallengeStateDoc {
-        state_hash: state_hash.to_string(),
+        doc_id: id.clone(),
         expires_at,
-        consumed_at: Some(now),
+        consumed_at: Some(Timestamp::now()),
     };
-    tx.insert(&doc).await?;
-    tx.commit().await?;
 
-    Ok(true)
+    match store.insert_with_id(&id, &doc).await {
+        Ok(_) => Ok(true),
+        Err(e) if super::pool::is_unique_violation(&e) => Ok(false),
+        Err(e) => Err(e),
+    }
 }
 
 /// Delete expired challenge states.

--- a/crates/vouch-server/src/db/documents/challenge_state.rs
+++ b/crates/vouch-server/src/db/documents/challenge_state.rs
@@ -12,8 +12,11 @@ use crate::db::document_type::{DocumentType, IndexEntry};
 /// when the assertion is exchanged at the token endpoint.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct ChallengeStateDoc {
-    /// SHA-256 hash of the challenge state JWT.
-    pub state_hash: String,
+    /// Deterministic document ID derived from the state JWT
+    /// (see `deterministic_challenge_state_id` in `db/challenge_states.rs`).
+    /// Mirrors the row's `documents.id` PRIMARY KEY for self-describing
+    /// payloads; the PK is what enforces single-use semantics.
+    pub doc_id: String,
     /// Expiration time (matches the JWT's 5-minute lifetime).
     pub expires_at: Timestamp,
     /// When this challenge was consumed (None = not yet consumed).
@@ -24,10 +27,13 @@ impl DocumentType for ChallengeStateDoc {
     const DOC_TYPE: &'static str = "challenge_state";
 
     fn index_entries(&self) -> Vec<IndexEntry> {
-        vec![IndexEntry {
-            field: "state_hash",
-            value: self.state_hash.clone(),
-        }]
+        // No secondary indexes: the document ID is a deterministic SHA-256
+        // hash of the state JWT (see `deterministic_challenge_state_id` in
+        // `db/challenge_states.rs`). All replay-prevention lookups go through
+        // the PRIMARY KEY on `documents.id`; the former secondary index on
+        // `state_hash` was only needed by the now-removed `find_one(...)`
+        // call. New rows no longer write to `document_indexes` for this type.
+        vec![]
     }
 
     fn expires_at(&self) -> Option<Timestamp> {

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -2878,13 +2878,13 @@ fn test_scim_filter_parse_emoji_value() {
 async fn test_challenge_state_mark_used() {
     let (store, _audit) = test_db().await;
 
-    let state_hash = "sha256_test_hash_mark_used";
+    let state_jwt = "test-jwt-mark-used";
     let expires_at = jiff::Timestamp::now()
         .checked_add(jiff::SignedDuration::from_secs(300))
         .unwrap();
 
     // First use should succeed
-    let used = try_mark_challenge_used(&store, state_hash, expires_at)
+    let used = try_mark_challenge_used(&store, state_jwt, expires_at)
         .await
         .expect("Failed to mark challenge used");
     assert!(used, "First use should succeed");
@@ -2894,19 +2894,19 @@ async fn test_challenge_state_mark_used() {
 async fn test_challenge_state_replay_rejected() {
     let (store, _audit) = test_db().await;
 
-    let state_hash = "sha256_test_hash_replay";
+    let state_jwt = "test-jwt-replay";
     let expires_at = jiff::Timestamp::now()
         .checked_add(jiff::SignedDuration::from_secs(300))
         .unwrap();
 
     // First use succeeds
-    let first = try_mark_challenge_used(&store, state_hash, expires_at)
+    let first = try_mark_challenge_used(&store, state_jwt, expires_at)
         .await
         .expect("Failed on first use");
     assert!(first, "First use should succeed");
 
     // Second use must fail (replay)
-    let second = try_mark_challenge_used(&store, state_hash, expires_at)
+    let second = try_mark_challenge_used(&store, state_jwt, expires_at)
         .await
         .expect("Failed on second use");
     assert!(!second, "Second use (replay) should be rejected");
@@ -2927,6 +2927,35 @@ async fn test_challenge_state_new_hash_succeeds() {
     .await
     .expect("Failed to mark challenge used");
     assert!(used, "New challenge hash should succeed");
+}
+
+#[tokio::test]
+async fn test_challenge_state_concurrent_calls_produce_one_row() {
+    // Two concurrent calls with the same state_jwt must produce exactly one
+    // document row — deterministic ID ensures they collide on the PRIMARY KEY
+    // rather than creating two rows.
+    let (store, _audit) = test_db().await;
+
+    let state_jwt = "concurrent-state-jwt-test-value";
+    let expires_at = jiff::Timestamp::now()
+        .checked_add(jiff::SignedDuration::from_secs(300))
+        .unwrap();
+
+    let store_a = store.clone();
+    let store_b = store.clone();
+    let (result_a, result_b) = tokio::join!(
+        try_mark_challenge_used(&store_a, state_jwt, expires_at),
+        try_mark_challenge_used(&store_b, state_jwt, expires_at),
+    );
+
+    let a = result_a.expect("first concurrent call must not error");
+    let b = result_b.expect("second concurrent call must not error");
+
+    // Exactly one winner and one loser — the sum of the two booleans is 1.
+    assert!(
+        a ^ b,
+        "exactly one concurrent call should return true (winner), got a={a}, b={b}"
+    );
 }
 
 #[test]

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -20,7 +20,6 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use jiff::{Span, Timestamp};
 use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
-use serde_json;
 use std::sync::Arc;
 use uuid::Uuid;
 use vouch_common::{BrowserRegisterCompleteRequest, BrowserRegisterStartResponse};
@@ -34,6 +33,7 @@ use crate::redact_email;
 use crate::services::auth::{CreateOAuthTokenParams, create_oauth_access_token};
 use crate::services::error::ServiceError;
 use crate::services::idp::IdentityResult;
+use crate::services::keys as key_svc;
 use crate::services::oidc::ScopeSet;
 
 // ============================================================================
@@ -1024,6 +1024,38 @@ pub async fn browser_register_complete(
         .await
         .map_err(|e| ServiceError::api(StatusCode::BAD_REQUEST, "invalid_state", e.to_string()))?;
 
+    // ── Phase 2b: Single-use enforcement ───────────────────────────────
+    // Consume the state token before any WebAuthn work so that a captured
+    // state JWT cannot be replayed within the 5-minute validity window.
+    if !key_svc::consume_registration_state(&state.store, &req.state, reg_state.exp).await? {
+        tracing::warn!(
+            user_id = %reg_state.user_id,
+            "browser registration state replay rejected"
+        );
+        let audit_data = serde_json::json!({
+            "flow": "browser_register",
+            "success": false,
+            "error_code": "state_already_used",
+        });
+        if let Err(e) = state
+            .audit
+            .insert_event(
+                "key_registration_replay",
+                Some(&reg_state.user_id.to_string()),
+                Some(&reg_state.user_email),
+                &audit_data.to_string(),
+            )
+            .await
+        {
+            tracing::warn!(error = %e, "failed to write key_registration_replay audit event");
+        }
+        return Err(ServiceError::api(
+            StatusCode::BAD_REQUEST,
+            "state_already_used",
+            "This registration link has already been used",
+        ));
+    }
+
     // ── Phase 3: Base64url decode all fields ────────────────────────────
     let credential_id_bytes = URL_SAFE_NO_PAD.decode(&req.credential_id).map_err(|e| {
         ServiceError::api(StatusCode::BAD_REQUEST, "invalid_credential", e.to_string())
@@ -1675,6 +1707,62 @@ mod tests {
         assert!(
             resp_body.contains("invalid_credential"),
             "expected 'invalid_credential' in body, got: {resp_body}"
+        );
+    }
+
+    // ── test_browser_register_complete_rejects_replayed_state ───────────────
+
+    #[tokio::test]
+    async fn test_browser_register_complete_rejects_replayed_state() {
+        let (app, state) = test_app().await;
+
+        // Build a valid BrowserRegistrationState JWT and record its expiry.
+        let user_id = Uuid::now_v7();
+        let (_ccr, webauthn_state) = state
+            .webauthn
+            .start_passkey_registration(user_id, "replay@example.com", "replay@example.com", None)
+            .expect("start_passkey_registration");
+
+        let now = jiff::Timestamp::now();
+        let exp = now.as_second() + 300;
+        let reg_state = BrowserRegistrationState {
+            device_auth_id: String::new(),
+            user_id,
+            user_email: "replay@example.com".to_string(),
+            webauthn_state,
+            iat: now.as_second(),
+            exp,
+        };
+        let state_jwt = reg_state
+            .encode(&state.state_signer)
+            .await
+            .expect("encode state");
+
+        // Pre-consume the state token to simulate prior use.
+        let expires_at = jiff::Timestamp::from_second(exp).expect("valid exp");
+        let consumed = crate::db::try_mark_challenge_used(&state.store, &state_jwt, expires_at)
+            .await
+            .expect("pre-consume must succeed");
+        assert!(consumed, "pre-consume should return true on first use");
+
+        // POST to the complete endpoint with the already-consumed state.
+        // The replay check runs before any base64 decoding, so non-empty base64
+        // strings are sufficient for the request to reach the replay check.
+        let body = serde_json::json!({
+            "state": state_jwt,
+            "credential_id": valid_credential_id(),
+            "attestation_object": valid_attestation_object(),
+            "client_data_json": valid_client_data_json(),
+        })
+        .to_string();
+
+        let (status, resp_body) =
+            http_post_json(&app, "/enroll/webauthn/complete", &body, &[]).await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(
+            resp_body.contains("state_already_used"),
+            "expected 'state_already_used' in body, got: {resp_body}"
         );
     }
 

--- a/crates/vouch-server/src/handlers/keys.rs
+++ b/crates/vouch-server/src/handlers/keys.rs
@@ -34,6 +34,11 @@ use crate::crypto::webauthn_verify;
 // Registration State (stored temporarily between start and complete)
 // ============================================================================
 
+/// Maximum accepted length of the registration state JWT (defense-in-depth).
+/// Matches the bounds used by `browser_register_complete` (`handlers/enroll.rs`)
+/// and the browser login handler.
+const MAX_STATE_TOKEN_LEN: usize = 8 * 1024;
+
 /// Registration state stored between start and complete.
 #[derive(Debug, Serialize, Deserialize)]
 struct RegistrationState {
@@ -186,10 +191,49 @@ pub async fn register_complete(
 ) -> Result<Json<RegisterCompleteResponse>, ServiceError> {
     tracing::info!("Registration complete");
 
+    if req.state.len() > MAX_STATE_TOKEN_LEN {
+        return Err(ServiceError::api(
+            StatusCode::BAD_REQUEST,
+            "invalid_state",
+            "State token exceeds maximum length",
+        ));
+    }
+
     // Decode state
     let reg_state = RegistrationState::decode(&req.state, &state.state_signer)
         .await
         .map_err(|e| ServiceError::api(StatusCode::BAD_REQUEST, "invalid_state", e.to_string()))?;
+
+    // Single-use enforcement: consume the state token before any WebAuthn work.
+    // A captured state JWT cannot be replayed within the 5-minute validity window.
+    if !key_svc::consume_registration_state(&state.store, &req.state, reg_state.exp).await? {
+        tracing::warn!(
+            user_id = %reg_state.user_id,
+            "CLI registration state replay rejected"
+        );
+        let audit_data = serde_json::json!({
+            "flow": "cli_register",
+            "success": false,
+            "error_code": "state_already_used",
+        });
+        if let Err(e) = state
+            .audit
+            .insert_event(
+                "key_registration_replay",
+                Some(&reg_state.user_id.to_string()),
+                Some(&reg_state.user_name),
+                &audit_data.to_string(),
+            )
+            .await
+        {
+            tracing::warn!(error = %e, "failed to write key_registration_replay audit event");
+        }
+        return Err(ServiceError::api(
+            StatusCode::BAD_REQUEST,
+            "state_already_used",
+            "This registration link has already been used",
+        ));
+    }
 
     // Server-side WebAuthn attestation verification
     // Verify the attestation object, client data, RP ID, challenge, and origin
@@ -651,6 +695,60 @@ mod tests {
         assert_eq!(status, StatusCode::BAD_REQUEST);
         let json: serde_json::Value = serde_json::from_str(&resp_body).expect("valid JSON");
         assert_eq!(json["code"], "invalid_state");
+    }
+
+    // ========================================================================
+    // Register Complete — Replay Rejection
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_register_complete_rejects_replayed_state() {
+        let (app, state) = test_app().await;
+
+        // Build a valid RegistrationState JWT with a far-future expiry.
+        let signer = &state.state_signer;
+        let challenge = Challenge::from(vec![2u8; 32]);
+        let now = jiff::Timestamp::now();
+        let exp = now
+            .checked_add(jiff::Span::new().minutes(5))
+            .map_or(now.as_second().saturating_add(300), |t| t.as_second());
+        let reg_state = RegistrationState {
+            user_id: Uuid::new_v4(),
+            user_name: "replay-test@example.com".to_string(),
+            device_name: "Test Device".to_string(),
+            challenge,
+            rp_id: "localhost".to_string(),
+            iat: now.as_second(),
+            exp,
+        };
+        let state_jwt = reg_state.encode(signer).await.expect("encode state");
+
+        // Pre-consume the state token to simulate prior use.
+        let expires_at = jiff::Timestamp::from_second(exp).expect("valid exp");
+        let consumed = crate::db::try_mark_challenge_used(&state.store, &state_jwt, expires_at)
+            .await
+            .expect("pre-consume must succeed");
+        assert!(consumed, "pre-consume should return true on first use");
+
+        // POST to register/complete with the already-consumed state and dummy bytes.
+        // consume_registration_state runs before WebAuthn verification, so dummy
+        // attestation bytes are sufficient to trigger the replay rejection.
+        let body = serde_json::json!({
+            "state": state_jwt,
+            "credential_id": [],
+            "public_key": [],
+            "attestation_object": [],
+            "client_data_json": [],
+        });
+        let (status, resp_body) =
+            http_post_json(&app, "/v1/keys/register/complete", &body.to_string(), &[]).await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let json: serde_json::Value = serde_json::from_str(&resp_body).expect("valid JSON");
+        assert_eq!(
+            json["code"], "state_already_used",
+            "replayed state must return state_already_used, got: {json}"
+        );
     }
 
     // ========================================================================

--- a/crates/vouch-server/src/services/keys.rs
+++ b/crates/vouch-server/src/services/keys.rs
@@ -7,10 +7,36 @@
 
 use crate::db::{self, store::DocumentStore};
 use crate::services::error::ServiceError;
+use jiff::Timestamp;
 use vouch_common::{KeyInfo, lookup_device_model};
 
 /// Maximum session age (in seconds) for destructive key operations.
 pub(crate) const KEY_DELETE_MAX_AGE_SECS: i64 = 60;
+
+/// Atomically consume a registration state JWT for single-use enforcement.
+///
+/// Returns `Ok(true)` on first use, `Ok(false)` if already consumed (replay).
+/// The caller is responsible for constructing the appropriate error response and
+/// emitting the audit event, since only the handler has access to the user
+/// context and the audit store.
+///
+/// # Errors
+///
+/// Returns `ServiceError::Internal` if the persistence check itself fails.
+pub(crate) async fn consume_registration_state(
+    store: &DocumentStore,
+    state_jwt: &str,
+    exp_seconds: i64,
+) -> Result<bool, ServiceError> {
+    let expires_at = Timestamp::from_second(exp_seconds).unwrap_or_else(|_| Timestamp::now());
+
+    db::try_mark_challenge_used(store, state_jwt, expires_at)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to mark registration state used: {e}");
+            ServiceError::Internal("Failed to mark registration state used".to_string())
+        })
+}
 
 /// Require the given issued-at or auth timestamp to be within `max_age_secs` seconds.
 ///

--- a/crates/vouch-server/src/services/oidc/fido2_grant.rs
+++ b/crates/vouch-server/src/services/oidc/fido2_grant.rs
@@ -142,7 +142,6 @@ pub async fn exchange_fido2_assertion(
         })?;
 
     // 2b. Prepare single-use challenge check
-    let state_hash = crate::crypto::hash_token(&payload.state);
     let expires_at = jiff::Timestamp::from_second(challenge_state.exp)
         .unwrap_or_else(|_| jiff::Timestamp::now());
 
@@ -192,7 +191,7 @@ pub async fn exchange_fido2_assertion(
     //    (independent DB operations on different tables)
     let (consumed_result, lookup_result) = tokio::try_join!(
         async {
-            db::try_mark_challenge_used(&state.store, &state_hash, expires_at)
+            db::try_mark_challenge_used(&state.store, &payload.state, expires_at)
                 .await
                 .map_err(|e| ServiceError::Internal(format!("Failed to mark challenge used: {e}")))
         },


### PR DESCRIPTION
Fixes #386

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes replay-prevention semantics in FIDO2/OIDC flows by switching to deterministic primary-key inserts and rejecting reused registration state JWTs, which can affect authentication/enrollment paths if edge cases were missed. Risk is mitigated by added concurrency/replay tests and explicit unique-violation handling across backends (incl. DSQL retries).
> 
> **Overview**
> **Prevents state/JWT replay in FIDO2 flows.** `try_mark_challenge_used` now derives a deterministic `documents.id` from the full state JWT and relies on atomic `insert_with_id` + unique-violation detection (instead of `find_one` on a secondary `state_hash` index), avoiding TOCTOU races and ensuring concurrent requests create at most one row.
> 
> **Applies single-use enforcement to registration completion handlers.** Both browser enrollment (`/enroll/webauthn/complete`) and CLI key registration (`/v1/keys/register/complete`) now consume the state JWT *before* WebAuthn verification, reject replays with `state_already_used`, and emit a `key_registration_replay` audit event.
> 
> **Tests updated/added** to validate replay rejection and concurrent-call behavior, and the OIDC FIDO2 grant path now marks challenges used based on the raw `payload.state` token (not a pre-hashed value).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11a89802b7f4bde296056e455285db9890a43b4f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->