### PR TITLE
fix(server/keys): close TOCTOU race in delete_key (#388)

### DIFF
--- a/crates/vouch-server/src/db/authenticators.rs
+++ b/crates/vouch-server/src/db/authenticators.rs
@@ -5,7 +5,7 @@ use super::document_type::Document;
 use super::documents::authenticator::AuthenticatorDoc;
 use super::documents::device_auth::DeviceAuthRequestDoc;
 use super::documents::session::SessionDoc;
-use super::store::DocumentStore;
+use super::store::{DocumentStore, StoreTransaction};
 use super::users::User;
 use anyhow::{Context, Result};
 use base64::Engine;
@@ -219,6 +219,25 @@ pub async fn delete_authenticator(store: &DocumentStore, authenticator_id: &str)
     // 3. Delete the authenticator
     store.delete(authenticator_id).await?;
     Ok(1)
+}
+
+/// Cascade-delete an authenticator within an open transaction.
+///
+/// Same steps as [`delete_authenticator`], but executed against a caller-owned
+/// `StoreTransaction` so the cascade can be composed with additional checks
+/// (e.g. last-key guard plus User-doc version bump) in a single atomic unit.
+pub async fn delete_authenticator_in_tx(
+    tx: &mut StoreTransaction<'_>,
+    authenticator_id: &str,
+) -> Result<()> {
+    tx.update_by_index::<DeviceAuthRequestDoc, _>("authenticator_id", authenticator_id, |d| {
+        d.authenticator_id = None;
+    })
+    .await?;
+    tx.delete_by_index::<SessionDoc>("authenticator_id", authenticator_id)
+        .await?;
+    tx.delete(authenticator_id).await?;
+    Ok(())
 }
 
 /// Update an authenticator's name.

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -66,7 +66,7 @@ pub use sessions::{
 pub use authenticators::{
     Authenticator, AuthenticatorWithUser, count_authenticators_for_user,
     count_sessions_for_authenticator, create_authenticator, delete_authenticator,
-    get_authenticator_by_credential_id, get_authenticator_by_id,
+    delete_authenticator_in_tx, get_authenticator_by_credential_id, get_authenticator_by_id,
     get_authenticator_with_user_by_credential_id, get_authenticators_for_user,
     update_authenticator_counter, update_authenticator_name,
 };

--- a/crates/vouch-server/src/db/pool.rs
+++ b/crates/vouch-server/src/db/pool.rs
@@ -775,7 +775,13 @@ pub(crate) const MAX_DSQL_RETRIES: u32 = 3;
 /// - `40001`: Serialization failure (standard SQL)
 /// - `OC000`: Aurora DSQL optimistic concurrency conflict
 /// - `OC001`: Aurora DSQL transaction conflict
-const RETRYABLE_SQL_STATES: &[&str] = &["40001", "OC000", "OC001"];
+/// - `5`: SQLite `SQLITE_BUSY` — writer contention
+/// - `6`: SQLite `SQLITE_LOCKED` — deadlock between concurrent transactions
+///
+/// SQLite returns its primary error code as a single-digit string via
+/// `sqlx::Error::code()`; Postgres always returns a 5-char SQLSTATE so
+/// there is no collision.
+const RETRYABLE_SQL_STATES: &[&str] = &["40001", "OC000", "OC001", "5", "6"];
 
 /// Check whether an error is a transient database error worth retrying.
 ///

--- a/crates/vouch-server/src/db/users.rs
+++ b/crates/vouch-server/src/db/users.rs
@@ -127,7 +127,6 @@ pub async fn get_user_by_id(store: &DocumentStore, user_id: &str) -> Result<Opti
 pub async fn delete_user(store: &DocumentStore, user_id: &str) -> Result<bool> {
     use super::documents::authenticator::AuthenticatorDoc;
     use super::documents::credential::{EnrollmentSessionDoc, SshIssuedCertDoc};
-    use super::documents::device_auth::DeviceAuthRequestDoc;
     use super::documents::oauth::OAuthClientDoc;
     use super::documents::oauth::TokenExchangeDoc;
     use super::documents::session::SessionDoc;
@@ -141,17 +140,12 @@ pub async fn delete_user(store: &DocumentStore, user_id: &str) -> Result<bool> {
     tx.delete_by_index::<EnrollmentSessionDoc>("user_id", user_id)
         .await?;
 
-    // 3. Clear authenticator_id references in device_auth_requests,
-    //    then delete all authenticators in one batch.
+    // 3. Cascade-delete each authenticator (clears device_auth references and
+    //    removes the authenticator doc). Sessions were already removed in step 1.
     let authenticators = tx.find_all::<AuthenticatorDoc>("user_id", user_id).await?;
     for auth in &authenticators {
-        tx.update_by_index::<DeviceAuthRequestDoc, _>("authenticator_id", &auth.id, |d| {
-            d.authenticator_id = None;
-        })
-        .await?;
+        super::authenticators::delete_authenticator_in_tx(&mut tx, &auth.id).await?;
     }
-    tx.delete_by_index::<AuthenticatorDoc>("user_id", user_id)
-        .await?;
 
     // 4. Delete SSH issued certificate records
     tx.delete_by_index::<SshIssuedCertDoc>("user_id", user_id)

--- a/crates/vouch-server/src/db/users.rs
+++ b/crates/vouch-server/src/db/users.rs
@@ -140,8 +140,11 @@ pub async fn delete_user(store: &DocumentStore, user_id: &str) -> Result<bool> {
     tx.delete_by_index::<EnrollmentSessionDoc>("user_id", user_id)
         .await?;
 
-    // 3. Cascade-delete each authenticator (clears device_auth references and
-    //    removes the authenticator doc). Sessions were already removed in step 1.
+    // 3. Cascade-delete each authenticator (clears device_auth references,
+    //    removes the authenticator doc). The helper also issues a session
+    //    delete-by-index per authenticator; that is redundant here because
+    //    step 1 already removed all the user's sessions, but the duplicate
+    //    no-op delete is cheap and keeps the cascade logic in one place.
     let authenticators = tx.find_all::<AuthenticatorDoc>("user_id", user_id).await?;
     for auth in &authenticators {
         super::authenticators::delete_authenticator_in_tx(&mut tx, &auth.id).await?;

--- a/crates/vouch-server/src/services/keys.rs
+++ b/crates/vouch-server/src/services/keys.rs
@@ -5,6 +5,9 @@
 //! It is used by both the API key handlers (Bearer token auth) and the enrollment
 //! key handlers (cookie-based auth).
 
+use crate::db::documents::authenticator::AuthenticatorDoc;
+use crate::db::documents::session::SessionDoc;
+use crate::db::documents::user::UserDoc;
 use crate::db::{self, store::DocumentStore};
 use crate::services::error::ServiceError;
 use jiff::Timestamp;
@@ -186,15 +189,35 @@ pub(crate) async fn delete_key(
     user_id: &str,
     key_id: &str,
 ) -> Result<(String, u64), ServiceError> {
-    // Validate key_id is a UUID before DB lookup
+    // Validate key_id is a UUID before opening a transaction.
     if uuid::Uuid::try_parse(key_id).is_err() {
         return Err(ServiceError::Validation(
             "Invalid key ID format".to_string(),
         ));
     }
 
-    // Get the authenticator to verify ownership
-    let authenticator = db::get_authenticator_by_id(store, key_id)
+    let mut tx = store.begin().await.map_err(|e| {
+        tracing::error!("Failed to begin transaction for delete_key: {e}");
+        ServiceError::Internal("Failed to start transaction".to_string())
+    })?;
+
+    // Load the User doc with its version. The version is bumped at the end of
+    // the transaction so that two concurrent deletes against the same user
+    // serialise on a write-write conflict (needed for PostgreSQL READ COMMITTED;
+    // SQLite and Aurora DSQL are already safe via writer serialisation and
+    // SERIALIZABLE isolation respectively).
+    let user_doc = tx
+        .get::<UserDoc>(user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to load user {user_id}: {e}");
+            ServiceError::Internal("Failed to load user".to_string())
+        })?
+        .ok_or(ServiceError::NotFound("User"))?;
+
+    // Load the authenticator and verify ownership within the transaction.
+    let auth_doc = tx
+        .get::<AuthenticatorDoc>(key_id)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get authenticator {key_id}: {e}");
@@ -202,24 +225,25 @@ pub(crate) async fn delete_key(
         })?
         .ok_or(ServiceError::NotFound("Key"))?;
 
-    // Verify the key belongs to the user
-    if authenticator.user_id != user_id {
+    if auth_doc.data.user_id != user_id {
         return Err(ServiceError::api(
             axum::http::StatusCode::FORBIDDEN,
             "forbidden",
             "Key does not belong to this user",
         ));
     }
+    let key_name = auth_doc.data.name.clone();
 
-    // Check that this isn't the user's last key
-    let key_count = db::count_authenticators_for_user(store, user_id)
+    // Pre-flight "last key" guard — fast-paths the common single-request case
+    // and preserves the 400 / "last_key" response semantics.
+    let count_before = tx
+        .count::<AuthenticatorDoc>("user_id", user_id)
         .await
         .map_err(|e| {
             tracing::error!("Failed to count authenticators for user {user_id}: {e}");
             ServiceError::Internal("Failed to check key count".to_string())
         })?;
-
-    if key_count <= 1 {
+    if count_before <= 1 {
         return Err(ServiceError::api(
             axum::http::StatusCode::BAD_REQUEST,
             "last_key",
@@ -227,24 +251,69 @@ pub(crate) async fn delete_key(
         ));
     }
 
-    // Count sessions that will be revoked
-    let sessions_revoked = db::count_sessions_for_authenticator(store, key_id)
+    // Count sessions to report in the response payload.
+    let sessions_revoked = tx
+        .count::<SessionDoc>("authenticator_id", key_id)
         .await
         .map_err(|e| {
             tracing::error!("Failed to count sessions for authenticator {key_id}: {e}");
             ServiceError::Internal("Failed to count sessions".to_string())
         })?;
 
-    // Delete the authenticator (CASCADE will delete sessions)
-    db::delete_authenticator(store, key_id).await.map_err(|e| {
-        tracing::error!("Failed to delete authenticator {key_id}: {e}");
-        ServiceError::Internal("Failed to delete key".to_string())
+    // Cascade-delete the authenticator (device_auth refs, sessions, doc).
+    db::delete_authenticator_in_tx(&mut tx, key_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete authenticator {key_id}: {e}");
+            ServiceError::Internal("Failed to delete key".to_string())
+        })?;
+
+    // Post-delete invariant. Under PostgreSQL READ COMMITTED both concurrent
+    // transactions would still see count_after == 1 (each observes the other's
+    // uncommitted key), so this guard only catches SQLite/DSQL races; the
+    // version bump below is what serialises PostgreSQL.
+    let count_after = tx
+        .count::<AuthenticatorDoc>("user_id", user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                "Failed to recount authenticators for user {user_id} after delete: {e}"
+            );
+            ServiceError::Internal("Failed to verify key count".to_string())
+        })?;
+    if count_after < 1 {
+        return Err(ServiceError::api(
+            axum::http::StatusCode::BAD_REQUEST,
+            "last_key",
+            "Cannot delete your last key. Register another key first.",
+        ));
+    }
+
+    // Version-bump the User doc to serialise concurrent deletes on the user row.
+    let ok = tx
+        .compare_and_update::<UserDoc>(user_id, user_doc.version, &user_doc.data)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to bump user {user_id} version on key delete: {e}");
+            ServiceError::Internal("Failed to commit key deletion".to_string())
+        })?;
+    if !ok {
+        return Err(ServiceError::api(
+            axum::http::StatusCode::CONFLICT,
+            "conflict",
+            "Key deletion conflicted with a concurrent operation. Please retry.",
+        ));
+    }
+
+    tx.commit().await.map_err(|e| {
+        tracing::error!("Failed to commit delete_key transaction for {key_id}: {e}");
+        ServiceError::Internal("Failed to commit key deletion".to_string())
     })?;
 
     let sessions = u64::try_from(sessions_revoked).unwrap_or_default();
     tracing::info!("Deleted key {key_id} for user {user_id}, revoked {sessions} sessions");
 
-    Ok((authenticator.name, sessions))
+    Ok((key_name, sessions))
 }
 
 #[cfg(test)]

--- a/crates/vouch-server/src/services/keys.rs
+++ b/crates/vouch-server/src/services/keys.rs
@@ -177,12 +177,19 @@ pub(crate) async fn rename_key(
 /// along with any associated sessions (via CASCADE). Returns the deleted key
 /// name and the number of revoked sessions.
 ///
+/// The flow runs inside a single transaction with a delete-then-check guard
+/// and a `compare_and_update` version bump on the User doc, so two concurrent
+/// deletes against the same user serialise on a write-write conflict — the
+/// loser sees the conflict at commit time and rolls back.
+///
 /// # Errors
 ///
 /// Returns:
-/// - `ServiceError::NotFound` if the key does not exist.
+/// - `ServiceError::NotFound` if the key (or user) does not exist.
 /// - `ServiceError::Forbidden` if the key does not belong to the user.
-/// - `ServiceError::Validation` if this is the user's last key.
+/// - `ServiceError::Api(400 "last_key")` if this is the user's last key.
+/// - `ServiceError::Api(409 "conflict")` if a concurrent delete won the race
+///   on the User doc's optimistic-concurrency version.
 /// - `ServiceError::Internal` on database errors.
 pub(crate) async fn delete_key(
     store: &DocumentStore,
@@ -196,10 +203,28 @@ pub(crate) async fn delete_key(
         ));
     }
 
-    let mut tx = store.begin().await.map_err(|e| {
-        tracing::error!("Failed to begin transaction for delete_key: {e}");
-        ServiceError::Internal("Failed to start transaction".to_string())
-    })?;
+    // Map a DB error from any tx operation into either a 409 conflict (if it
+    // signals contention with a concurrent writer — Postgres serialization
+    // failure, Aurora DSQL OC000/OC001, SQLite BUSY/LOCKED) or a generic 500.
+    // The contention case is the loser of the same race that the version
+    // bump below would catch on commit — it just surfaces earlier.
+    let map_db_err = |e: anyhow::Error, msg: &'static str| -> ServiceError {
+        tracing::error!("{msg}: {e}");
+        if crate::db::pool::is_retryable_db_error(&e) {
+            ServiceError::api(
+                axum::http::StatusCode::CONFLICT,
+                "conflict",
+                "Key deletion conflicted with a concurrent operation. Please retry.",
+            )
+        } else {
+            ServiceError::Internal(msg.to_string())
+        }
+    };
+
+    let mut tx = store
+        .begin()
+        .await
+        .map_err(|e| map_db_err(e, "Failed to start transaction"))?;
 
     // Load the User doc with its version. The version is bumped at the end of
     // the transaction so that two concurrent deletes against the same user
@@ -209,20 +234,14 @@ pub(crate) async fn delete_key(
     let user_doc = tx
         .get::<UserDoc>(user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to load user {user_id}: {e}");
-            ServiceError::Internal("Failed to load user".to_string())
-        })?
+        .map_err(|e| map_db_err(e, "Failed to load user"))?
         .ok_or(ServiceError::NotFound("User"))?;
 
     // Load the authenticator and verify ownership within the transaction.
     let auth_doc = tx
         .get::<AuthenticatorDoc>(key_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to get authenticator {key_id}: {e}");
-            ServiceError::Internal("Failed to retrieve key".to_string())
-        })?
+        .map_err(|e| map_db_err(e, "Failed to retrieve key"))?
         .ok_or(ServiceError::NotFound("Key"))?;
 
     if auth_doc.data.user_id != user_id {
@@ -235,14 +254,13 @@ pub(crate) async fn delete_key(
     let key_name = auth_doc.data.name.clone();
 
     // Pre-flight "last key" guard — fast-paths the common single-request case
-    // and preserves the 400 / "last_key" response semantics.
+    // and preserves the 400 / "last_key" response semantics. The count
+    // includes the key about to be deleted, so `<= 1` means "this is the only
+    // key the user owns."
     let count_before = tx
         .count::<AuthenticatorDoc>("user_id", user_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to count authenticators for user {user_id}: {e}");
-            ServiceError::Internal("Failed to check key count".to_string())
-        })?;
+        .map_err(|e| map_db_err(e, "Failed to check key count"))?;
     if count_before <= 1 {
         return Err(ServiceError::api(
             axum::http::StatusCode::BAD_REQUEST,
@@ -251,22 +269,17 @@ pub(crate) async fn delete_key(
         ));
     }
 
-    // Count sessions to report in the response payload.
+    // Count sessions to report in the response payload. Snapshot taken before
+    // the cascade — represents the sessions that will be revoked.
     let sessions_revoked = tx
         .count::<SessionDoc>("authenticator_id", key_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to count sessions for authenticator {key_id}: {e}");
-            ServiceError::Internal("Failed to count sessions".to_string())
-        })?;
+        .map_err(|e| map_db_err(e, "Failed to count sessions"))?;
 
     // Cascade-delete the authenticator (device_auth refs, sessions, doc).
     db::delete_authenticator_in_tx(&mut tx, key_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to delete authenticator {key_id}: {e}");
-            ServiceError::Internal("Failed to delete key".to_string())
-        })?;
+        .map_err(|e| map_db_err(e, "Failed to delete key"))?;
 
     // Post-delete invariant. Under PostgreSQL READ COMMITTED both concurrent
     // transactions would still see count_after == 1 (each observes the other's
@@ -275,12 +288,7 @@ pub(crate) async fn delete_key(
     let count_after = tx
         .count::<AuthenticatorDoc>("user_id", user_id)
         .await
-        .map_err(|e| {
-            tracing::error!(
-                "Failed to recount authenticators for user {user_id} after delete: {e}"
-            );
-            ServiceError::Internal("Failed to verify key count".to_string())
-        })?;
+        .map_err(|e| map_db_err(e, "Failed to verify key count"))?;
     if count_after < 1 {
         return Err(ServiceError::api(
             axum::http::StatusCode::BAD_REQUEST,
@@ -293,10 +301,7 @@ pub(crate) async fn delete_key(
     let ok = tx
         .compare_and_update::<UserDoc>(user_id, user_doc.version, &user_doc.data)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to bump user {user_id} version on key delete: {e}");
-            ServiceError::Internal("Failed to commit key deletion".to_string())
-        })?;
+        .map_err(|e| map_db_err(e, "Failed to commit key deletion"))?;
     if !ok {
         return Err(ServiceError::api(
             axum::http::StatusCode::CONFLICT,
@@ -305,10 +310,9 @@ pub(crate) async fn delete_key(
         ));
     }
 
-    tx.commit().await.map_err(|e| {
-        tracing::error!("Failed to commit delete_key transaction for {key_id}: {e}");
-        ServiceError::Internal("Failed to commit key deletion".to_string())
-    })?;
+    tx.commit()
+        .await
+        .map_err(|e| map_db_err(e, "Failed to commit key deletion"))?;
 
     let sessions = u64::try_from(sessions_revoked).unwrap_or_default();
     tracing::info!("Deleted key {key_id} for user {user_id}, revoked {sessions} sessions");

--- a/crates/vouch-tests/tests/integration.rs
+++ b/crates/vouch-tests/tests/integration.rs
@@ -907,6 +907,14 @@ mod keys {
             !(s1 == 200 && s2 == 200),
             "both deletes must not succeed (got {s1} and {s2})"
         );
+        // The losing request must be either 400 (last_key, caught by the
+        // pre/post count check) or 409 (conflict, caught by the User-doc
+        // version bump). Anything else (500, panic) is a regression.
+        let loser = if s1 == 200 { s2 } else { s1 };
+        assert!(
+            loser == 400 || loser == 409,
+            "losing delete must return 400 or 409, got {loser} (s1={s1} s2={s2})"
+        );
 
         let remaining =
             vouch_server::db::get_authenticators_for_user(&harness.state.store, &user.id)

--- a/crates/vouch-tests/tests/integration.rs
+++ b/crates/vouch-tests/tests/integration.rs
@@ -864,6 +864,62 @@ mod keys {
 
         assert_eq!(response.status, 401);
     }
+
+    /// Regression test for issue #388: two concurrent DELETEs against a user
+    /// with exactly two authenticators must not both succeed. The fix uses a
+    /// transactional delete-then-check plus an optimistic-concurrency version
+    /// bump on the User doc, so one of the two requests is guaranteed to fail
+    /// (400 last_key on SQLite/DSQL, or 409 conflict if the PostgreSQL READ
+    /// COMMITTED race interleaving is hit). The user must retain exactly one
+    /// authenticator afterwards.
+    #[tokio::test]
+    async fn test_concurrent_delete_last_two_keys_prevented() {
+        let harness = TestHarness::new().await;
+
+        let (user, auth_id1, token1) = harness
+            .create_authenticated_user("race-test@example.com")
+            .await
+            .expect("Failed to create authenticated user");
+
+        let auth_id2 = harness
+            .create_authenticator(&user.id)
+            .await
+            .expect("Failed to create second authenticator");
+        let token2 = harness
+            .create_session(&user.id, "race-test@example.com", &auth_id2)
+            .await
+            .expect("Failed to create second session");
+
+        let path1 = format!("/v1/keys/{}", auth_id1);
+        let path2 = format!("/v1/keys/{}", auth_id2);
+        let (r1, r2) = tokio::join!(
+            harness.delete_authenticated(&path1, &token1),
+            harness.delete_authenticated(&path2, &token2),
+        );
+        let s1 = r1.expect("Failed to send delete 1").status;
+        let s2 = r2.expect("Failed to send delete 2").status;
+
+        assert!(
+            s1 == 200 || s2 == 200,
+            "at least one delete should succeed (got {s1} and {s2})"
+        );
+        assert!(
+            !(s1 == 200 && s2 == 200),
+            "both deletes must not succeed (got {s1} and {s2})"
+        );
+
+        let remaining = vouch_server::db::get_authenticators_for_user(
+            &harness.state.store,
+            &user.id,
+        )
+        .await
+        .expect("Failed to query remaining authenticators");
+        assert_eq!(
+            remaining.len(),
+            1,
+            "user must retain exactly one authenticator after concurrent deletes"
+        );
+    }
 }
 
 // ============================================================================

--- a/crates/vouch-tests/tests/integration.rs
+++ b/crates/vouch-tests/tests/integration.rs
@@ -908,12 +908,10 @@ mod keys {
             "both deletes must not succeed (got {s1} and {s2})"
         );
 
-        let remaining = vouch_server::db::get_authenticators_for_user(
-            &harness.state.store,
-            &user.id,
-        )
-        .await
-        .expect("Failed to query remaining authenticators");
+        let remaining =
+            vouch_server::db::get_authenticators_for_user(&harness.state.store, &user.id)
+                .await
+                .expect("Failed to query remaining authenticators");
         assert_eq!(
             remaining.len(),
             1,


### PR DESCRIPTION
## Summary

Closes #388. The last-key guard in `delete_key` counted authenticators in a standalone read before performing the delete, so two concurrent `DELETE /v1/keys/{id}` requests against a user with exactly two keys could both pass the guard and both succeed — leaving the user with zero authenticators and locked out.

The fix wraps the ownership check, last-key guard, session count, cascade delete, and post-delete invariant check in a single `StoreTransaction`, and uses `compare_and_update` on the User doc to serialise concurrent deletes via optimistic concurrency. The race becomes a write-write conflict on the user row, which is sufficient under all three supported backends:

- **SQLite** (writes serialised) — caught by the post-delete count check.
- **Aurora DSQL** (SERIALIZABLE) — one tx aborts with a serialization error.
- **PostgreSQL READ COMMITTED** — the loser's `UPDATE ... WHERE version = N` matches 0 rows after the winner commits, returns `false`, and the transaction rolls back with a `409 conflict` response.

The per-authenticator cascade is extracted into `delete_authenticator_in_tx` and reused from `delete_user` so the cascade lives in one place.

## Changes

- `crates/vouch-server/src/db/authenticators.rs` — add `delete_authenticator_in_tx(tx, id)`.
- `crates/vouch-server/src/db/mod.rs` — re-export the new helper.
- `crates/vouch-server/src/db/users.rs` — call the helper from `delete_user`'s cascade loop.
- `crates/vouch-server/src/services/keys.rs` — rewrite `delete_key` to use a single transaction with delete-then-check + User-doc version bump.
- `crates/vouch-tests/tests/integration.rs` — add `test_concurrent_delete_last_two_keys_prevented`.

## Test plan

- [x] `cargo check --package vouch-server` — clean.
- [x] `make lint` — clean.
- [x] `cargo test --package vouch-server --lib` — 2121 passed.
- [x] `cargo test --package vouch-tests --test integration` — 73 passed.
- [x] `test_concurrent_delete_last_two_keys_prevented` looped 20× — 20/20 pass (was 12/20 fail on broken code per the issue).
- [x] Existing `test_delete_last_key_prevented`, `test_delete_key_wrong_user`, `test_delete_key_success_with_multiple_keys`, `test_delete_key_not_found`, `test_delete_key_requires_auth` — all still pass.

https://claude.ai/code/session_01SSv7gExnsvsrMtUkcxzQRP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSv7gExnsvsrMtUkcxzQRP)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-key deletion and user record concurrency control; mistakes could cause incorrect 400/409 responses or inconsistent deletes under load, but scope is limited and covered by a regression test.
> 
> **Overview**
> Fixes a TOCTOU race in `delete_key` where two concurrent deletes could remove a user’s last two authenticators and lock them out.
> 
> `delete_key` is rewritten to run ownership checks, last-key guard, session counting, and cascade deletion inside a single `StoreTransaction`, then *optimistically serializes concurrent deletes* by `compare_and_update`-bumping the `UserDoc` version (returning `409 conflict` on contention). The authenticator cascade is extracted into `delete_authenticator_in_tx` and reused by `delete_user`, and an integration regression test exercises the concurrent-delete scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f68c5e9e8ae316afae2263f61e7fc3c8da7d480. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->