### PR TITLE
fix(server/oidc): close TOCTOU race in private_key_jwt JTI commitment

### DIFF
--- a/crates/vouch-server/src/handlers/oidc/par.rs
+++ b/crates/vouch-server/src/handlers/oidc/par.rs
@@ -447,28 +447,32 @@ pub async fn par(
         response_mode,
     };
 
+    // SAFETY: commit_jti() MUST run AFTER DPoP nonce validation (so use_dpop_nonce
+    // retry leaves the JTI unconsumed) and BEFORE store_par_request() so that
+    // concurrent replays of the same assertion cannot persist multiple PAR
+    // requests — see issue #391. A follow-up will replace this comment with a
+    // ParCreation witness type.
+    if let Some(ref pjti) = pending_jti
+        && let Err(e) = commit_jti(&state, pjti).await
+    {
+        tracing::warn!("JTI commit failed for PAR: {e:?}");
+        return par_error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "server_error",
+            "Failed to complete client authentication",
+        );
+    }
+
     // RFC 9126 Section 2.2: Return 201 Created
     match db::create_pushed_authorization_request(&state.store, create_params).await {
-        Ok((_id, request_uri)) => {
-            if let Some(ref pjti) = pending_jti
-                && let Err(e) = commit_jti(&state, pjti).await
-            {
-                tracing::warn!("JTI commit failed for PAR: {e:?}");
-                return par_error_response(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "server_error",
-                    "Failed to complete client authentication",
-                );
-            }
-            (
-                StatusCode::CREATED,
-                Json(ParResponse {
-                    request_uri,
-                    expires_in: PAR_EXPIRES_IN,
-                }),
-            )
-                .into_response()
-        }
+        Ok((_id, request_uri)) => (
+            StatusCode::CREATED,
+            Json(ParResponse {
+                request_uri,
+                expires_in: PAR_EXPIRES_IN,
+            }),
+        )
+            .into_response(),
         Err(e) => {
             tracing::error!("Failed to create pushed authorization request: {}", e);
             par_error_response(

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7523.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7523.rs
@@ -809,3 +809,520 @@ async fn test_non_fapi_client_accepts_token_endpoint_audience() {
         "Non-FAPI client with aud=token_endpoint_url must pass client auth (status={status}): {resp_body}"
     );
 }
+
+// ========================================================================
+// Issue #391 — concurrent JTI replay must not produce multiple tokens.
+//
+// Before the fix, `commit_jti()` ran AFTER `exchange_*()`, so N concurrent
+// requests with the same JWT assertion could each persist a token before any
+// of them committed the JTI. One won the JTI insert and returned 200; the
+// others returned `invalid_client` but their tokens remained valid in the DB.
+//
+// The fix moves `commit_jti()` to immediately before `exchange_*()`, so the
+// atomic `(jti, client_id)` insert is the serialization point. Concurrent
+// replayers either win the JTI and proceed to exchange, or lose and return
+// `invalid_client` before any token is persisted.
+//
+// Each test below fires N concurrent requests with the same JWT assertion
+// (fixed `jti`) and asserts that AT MOST one HTTP 200 is returned and AT MOST
+// one session (token) ends up in the DB.
+// ========================================================================
+
+const CONCURRENT_N: usize = 8;
+
+/// Fan out N identical POSTs to `/oauth/token` and return the response status
+/// for each. The body and headers are constant across all requests.
+async fn fan_out_token_requests(
+    app: &axum::Router,
+    body: &str,
+    headers: &[(&str, &str)],
+    n: usize,
+) -> Vec<(StatusCode, String)> {
+    let mut set = tokio::task::JoinSet::new();
+    for _ in 0..n {
+        let app = app.clone();
+        let body = body.to_string();
+        let headers: Vec<(String, String)> = headers
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        set.spawn(async move {
+            let header_refs: Vec<(&str, &str)> =
+                headers.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
+            http_post_form(&app, "/oauth/token", &body, &header_refs).await
+        });
+    }
+    let mut results = Vec::with_capacity(n);
+    while let Some(res) = set.join_next().await {
+        results.push(res.expect("Task panicked"));
+    }
+    results
+}
+
+/// Enable a list of grant types on an OAuth client.
+async fn enable_grant_types(store: &db::store::DocumentStore, client_id: &str, grants: &[&str]) {
+    let oauth_client = db::get_oauth_client_by_client_id(store, client_id)
+        .await
+        .expect("DB error")
+        .expect("Client not found");
+    let grants: Vec<String> = grants.iter().map(|s| (*s).to_string()).collect();
+    store
+        .modify::<crate::db::documents::oauth::OAuthClientDoc, _>(&oauth_client.id, |data| {
+            data.grant_types = Some(grants.clone());
+        })
+        .await
+        .expect("Failed to update grant_types");
+}
+
+/// Count `SessionDoc` rows indexed under a given user_id. For client_credentials
+/// grants the session's `user_id` is the client_id; for authorization_code it
+/// is the actual user's id.
+async fn count_sessions_for_user(store: &db::store::DocumentStore, user_id: &str) -> i64 {
+    store
+        .count::<crate::db::documents::session::SessionDoc>("user_id", user_id)
+        .await
+        .expect("count must not error")
+}
+
+#[tokio::test]
+async fn test_jwt_assertion_jti_concurrent_replay_client_credentials() {
+    // Strongest of the four concurrent-replay tests: no per-request resource
+    // (no auth code) to gate concurrency. Without the fix, every concurrent
+    // request reaches `exchange_client_credentials` and persists a session
+    // before any of them commits the JTI.
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "jti-race-cc@example.com").await;
+    let (client, pkcs8_bytes) = create_test_jwt_client(&state.store, &user.id).await;
+    enable_grant_types(&state.store, &client.client_id, &["client_credentials"]).await;
+
+    let token_endpoint = format!("{}/oauth/token", state.config().base_url);
+    let fixed_jti = "race-cc-jti-12345";
+    let assertion = build_client_assertion(
+        &client.client_id,
+        &token_endpoint,
+        &pkcs8_bytes,
+        Some(fixed_jti),
+    );
+
+    let body = format!(
+        "grant_type=client_credentials\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}"
+    );
+
+    let results = fan_out_token_requests(&app, &body, &[], CONCURRENT_N).await;
+
+    let successes = results
+        .iter()
+        .filter(|(s, _)| *s == StatusCode::OK)
+        .count();
+    assert!(
+        successes <= 1,
+        "At most one concurrent replay may succeed, got {successes}. \
+         Responses: {results:?}"
+    );
+
+    // The session's `user_id` field for a client_credentials grant is the
+    // client_id (RFC 9068 Section 2.2). At most one session must exist.
+    let session_count = count_sessions_for_user(&state.store, &client.client_id).await;
+    assert!(
+        session_count <= 1,
+        "At most one access-token session may be persisted, got {session_count}"
+    );
+}
+
+#[tokio::test]
+async fn test_jwt_assertion_jti_concurrent_replay_authorization_code() {
+    // Concurrent replay against the authorization_code grant. The auth code
+    // itself is single-use, so even without the JTI fix you'd see at most one
+    // success — but you'd see multiple persisted sessions if the JTI race were
+    // the only protection. The combined check below verifies both invariants.
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "jti-race-ac@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let (client, pkcs8_bytes) = create_test_jwt_client(&state.store, &user.id).await;
+
+    let scope_set = ScopeSet::parse("openid");
+    let code = issue_authorization_code(
+        &state,
+        AuthorizationCodeParams {
+            client_id: &client.client_id,
+            redirect_uri: "https://example.com/callback",
+            user_id: &user.id,
+            email: &user.email,
+            authenticator_id: &auth_id,
+            aaguid: None,
+            scope: &scope_set,
+            nonce: None,
+            code_challenge: None,
+            code_challenge_method: None,
+            resource: None,
+            acr_values: None,
+            dpop_jkt: None,
+            auth_code_lifetime_seconds:
+                crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
+            authorization_details: None,
+            auth_time: None,
+        },
+    )
+    .await
+    .expect("Failed to issue authorization code");
+
+    let token_endpoint = format!("{}/oauth/token", state.config().base_url);
+    let fixed_jti = "race-ac-jti-12345";
+    let assertion = build_client_assertion(
+        &client.client_id,
+        &token_endpoint,
+        &pkcs8_bytes,
+        Some(fixed_jti),
+    );
+
+    let body = format!(
+        "grant_type=authorization_code&code={code}&redirect_uri={}\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}",
+        urlencoding::encode("https://example.com/callback")
+    );
+
+    let results = fan_out_token_requests(&app, &body, &[], CONCURRENT_N).await;
+
+    let successes = results
+        .iter()
+        .filter(|(s, _)| *s == StatusCode::OK)
+        .count();
+    assert!(
+        successes <= 1,
+        "At most one concurrent replay may succeed, got {successes}. \
+         Responses: {results:?}"
+    );
+
+    let session_count = count_sessions_for_user(&state.store, &user.id).await;
+    assert!(
+        session_count <= 1,
+        "At most one access-token session may be persisted, got {session_count}"
+    );
+}
+
+#[tokio::test]
+async fn test_jwt_assertion_jti_concurrent_replay_token_exchange() {
+    // Concurrent replay against the token-exchange grant. The subject_token
+    // can be reused across exchanges, so the JTI uniqueness is the sole
+    // serialization point.
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "jti-race-tx@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let (client, pkcs8_bytes) = create_test_jwt_client(&state.store, &user.id).await;
+    // Allow both grants on the same client: authorization_code to seed the
+    // subject_token, token-exchange for the replay.
+    enable_grant_types(
+        &state.store,
+        &client.client_id,
+        &[
+            "authorization_code",
+            "urn:ietf:params:oauth:grant-type:token-exchange",
+        ],
+    )
+    .await;
+
+    // Seed an access token to use as subject_token via a one-shot
+    // authorization_code exchange (single-use, unique JTI).
+    let scope_set = ScopeSet::parse("openid");
+    let seed_code = issue_authorization_code(
+        &state,
+        AuthorizationCodeParams {
+            client_id: &client.client_id,
+            redirect_uri: "https://example.com/callback",
+            user_id: &user.id,
+            email: &user.email,
+            authenticator_id: &auth_id,
+            aaguid: None,
+            scope: &scope_set,
+            nonce: None,
+            code_challenge: None,
+            code_challenge_method: None,
+            resource: None,
+            acr_values: None,
+            dpop_jkt: None,
+            auth_code_lifetime_seconds:
+                crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
+            authorization_details: None,
+            auth_time: None,
+        },
+    )
+    .await
+    .expect("Failed to issue seed code");
+
+    let token_endpoint = format!("{}/oauth/token", state.config().base_url);
+    let seed_assertion =
+        build_client_assertion(&client.client_id, &token_endpoint, &pkcs8_bytes, None);
+    let seed_body = format!(
+        "grant_type=authorization_code&code={seed_code}&redirect_uri={}\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={seed_assertion}",
+        urlencoding::encode("https://example.com/callback")
+    );
+    let (seed_status, seed_resp) = http_post_form(&app, "/oauth/token", &seed_body, &[]).await;
+    assert_eq!(seed_status, StatusCode::OK, "seed token must issue: {seed_resp}");
+    let seed_json: serde_json::Value = serde_json::from_str(&seed_resp).expect("Valid JSON");
+    let subject_token = seed_json["access_token"].as_str().expect("access_token").to_string();
+
+    // Sessions persisted so far: the one from the seed exchange.
+    let baseline_sessions = count_sessions_for_user(&state.store, &user.id).await;
+
+    let fixed_jti = "race-tx-jti-12345";
+    let replay_assertion = build_client_assertion(
+        &client.client_id,
+        &token_endpoint,
+        &pkcs8_bytes,
+        Some(fixed_jti),
+    );
+    let body = format!(
+        "grant_type=urn:ietf:params:oauth:grant-type:token-exchange\
+         &subject_token={subject_token}\
+         &subject_token_type=urn:ietf:params:oauth:token-type:access_token\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={replay_assertion}"
+    );
+
+    let results = fan_out_token_requests(&app, &body, &[], CONCURRENT_N).await;
+
+    let successes = results
+        .iter()
+        .filter(|(s, _)| *s == StatusCode::OK)
+        .count();
+    assert!(
+        successes <= 1,
+        "At most one concurrent replay may succeed, got {successes}. \
+         Responses: {results:?}"
+    );
+
+    let new_sessions = count_sessions_for_user(&state.store, &user.id).await - baseline_sessions;
+    assert!(
+        new_sessions <= 1,
+        "At most one new exchanged-token session may be persisted, got {new_sessions}"
+    );
+}
+
+#[tokio::test]
+async fn test_jwt_assertion_jti_concurrent_replay_fido2_assertion() {
+    // The fido2-assertion grant requires a real WebAuthn signature, which
+    // can't be faked in unit tests. We use a garbage assertion so that
+    // `exchange_fido2_assertion` will fail with `invalid_grant` for any
+    // request that reaches it. The point of THIS test is to prove that
+    // `commit_jti` runs BEFORE `exchange_fido2_assertion`: with the fix, at
+    // most one of N concurrent requests can pass the JTI commit, so at most
+    // one can reach (and fail at) the exchange step, returning `invalid_grant`.
+    // The other N-1 lose the JTI race and return `invalid_client`.
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "jti-race-fido2@example.com").await;
+    let (client, pkcs8_bytes) = create_test_jwt_client(&state.store, &user.id).await;
+
+    let token_endpoint = format!("{}/oauth/token", state.config().base_url);
+    let fixed_jti = "race-fido2-jti-12345";
+    let assertion = build_client_assertion(
+        &client.client_id,
+        &token_endpoint,
+        &pkcs8_bytes,
+        Some(fixed_jti),
+    );
+
+    // Garbage FIDO2 assertion — base64url of empty JSON object will fail at
+    // state-JWT verification, returning invalid_grant from exchange_fido2_assertion.
+    let garbage_assertion = URL_SAFE_NO_PAD.encode(b"{}");
+
+    let body = format!(
+        "grant_type=urn:ietf:params:oauth:grant-type:fido2-assertion\
+         &assertion={garbage_assertion}\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}"
+    );
+
+    let results = fan_out_token_requests(&app, &body, &[], CONCURRENT_N).await;
+
+    // No request can succeed (garbage assertion), but the SHAPE of errors
+    // tells us where the JTI commit sat:
+    //   - With the fix: at most one `invalid_grant` (reached exchange), the
+    //     rest `invalid_client` (lost JTI race).
+    //   - Without the fix: all N would return `invalid_grant` because every
+    //     request reaches exchange before any one of them tries to commit,
+    //     and exchange fails for all of them on the garbage assertion before
+    //     `commit_jti` ever runs.
+    let invalid_grants = results
+        .iter()
+        .filter_map(|(_, body)| serde_json::from_str::<serde_json::Value>(body).ok())
+        .filter(|j| j["error"] == "invalid_grant")
+        .count();
+    assert!(
+        invalid_grants <= 1,
+        "At most one concurrent replay may reach exchange_fido2_assertion (and fail), \
+         got {invalid_grants} `invalid_grant` responses out of {}. Responses: {results:?}",
+        results.len()
+    );
+}
+
+// ========================================================================
+// Issue #391 — DPoP nonce retry MUST still leave the JTI unconsumed.
+//
+// The fix moves `commit_jti()` to before `exchange_*()`, but DPoP nonce
+// validation runs even earlier in the handler. If a request is rejected
+// with `use_dpop_nonce` (RFC 9449 §4.3), the JTI must NOT have been
+// committed — so the client can retry with the same JWT assertion and a
+// DPoP proof that carries the new nonce.
+//
+// The pre-existing `test_rfc9449_dpop_nonce_required_retry_with_nonce_succeeds`
+// covers this for basic_auth clients. This test seals the contract for the
+// `private_key_jwt` (JWT-assertion) client auth path.
+// ========================================================================
+
+fn generate_dpop_key_pair() -> (EcdsaKeyPair, serde_json::Value) {
+    use aws_lc_rs::signature::KeyPair;
+
+    let rng = aws_lc_rs::rand::SystemRandom::new();
+    let pkcs8 = EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &rng)
+        .expect("Failed to generate DPoP key");
+    let key_pair = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, pkcs8.as_ref())
+        .expect("Failed to parse DPoP key");
+
+    let pub_bytes = key_pair.public_key().as_ref();
+    let x = URL_SAFE_NO_PAD.encode(&pub_bytes[1..33]);
+    let y = URL_SAFE_NO_PAD.encode(&pub_bytes[33..65]);
+    let jwk = serde_json::json!({ "kty": "EC", "crv": "P-256", "x": x, "y": y });
+    (key_pair, jwk)
+}
+
+fn create_dpop_proof(
+    key_pair: &EcdsaKeyPair,
+    jwk: &serde_json::Value,
+    method: &str,
+    uri: &str,
+    nonce: Option<&str>,
+) -> String {
+    let header = serde_json::json!({
+        "typ": "dpop+jwt",
+        "alg": "ES256",
+        "jwk": jwk,
+    });
+    let now = jiff::Timestamp::now().as_second();
+    let mut claims = serde_json::json!({
+        "jti": uuid::Uuid::now_v7().to_string(),
+        "htm": method,
+        "htu": uri,
+        "iat": now,
+    });
+    if let Some(n) = nonce {
+        claims["nonce"] = serde_json::json!(n);
+    }
+    let header_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&header).expect("JSON encode"));
+    let claims_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&claims).expect("JSON encode"));
+    let signing_input = format!("{header_b64}.{claims_b64}");
+    let rng = aws_lc_rs::rand::SystemRandom::new();
+    let sig = key_pair
+        .sign(&rng, signing_input.as_bytes())
+        .expect("Failed to sign DPoP proof");
+    let sig_b64 = URL_SAFE_NO_PAD.encode(sig.as_ref());
+    format!("{header_b64}.{claims_b64}.{sig_b64}")
+}
+
+#[tokio::test]
+async fn test_jwt_assertion_dpop_use_nonce_retry_succeeds() {
+    // Setup: private_key_jwt client + authorization_code grant + DPoP.
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "jti-dpop-retry@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let (client, pkcs8_bytes) = create_test_jwt_client(&state.store, &user.id).await;
+
+    let scope_set = ScopeSet::parse("openid");
+    let code = issue_authorization_code(
+        &state,
+        AuthorizationCodeParams {
+            client_id: &client.client_id,
+            redirect_uri: "https://example.com/callback",
+            user_id: &user.id,
+            email: &user.email,
+            authenticator_id: &auth_id,
+            aaguid: None,
+            scope: &scope_set,
+            nonce: None,
+            code_challenge: None,
+            code_challenge_method: None,
+            resource: None,
+            acr_values: None,
+            dpop_jkt: None,
+            auth_code_lifetime_seconds:
+                crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
+            authorization_details: None,
+            auth_time: None,
+        },
+    )
+    .await
+    .expect("Failed to issue authorization code");
+
+    let token_endpoint = format!("{}/oauth/token", state.config().base_url);
+    let (dpop_key, dpop_jwk) = generate_dpop_key_pair();
+
+    // The SAME JTI is used for both attempts. If `commit_jti` ran before
+    // DPoP validation, the second attempt would be rejected as a replay.
+    let fixed_jti = "dpop-retry-jti-12345";
+    let assertion = build_client_assertion(
+        &client.client_id,
+        &token_endpoint,
+        &pkcs8_bytes,
+        Some(fixed_jti),
+    );
+
+    let body = format!(
+        "grant_type=authorization_code&code={code}&redirect_uri={}\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}",
+        urlencoding::encode("https://example.com/callback")
+    );
+
+    // Step 1: DPoP proof without nonce. Server returns use_dpop_nonce + a
+    // DPoP-Nonce header. The JTI must NOT be committed at this point.
+    let no_nonce_proof = create_dpop_proof(&dpop_key, &dpop_jwk, "POST", &token_endpoint, None);
+    let first = http_post_form_full(&app, "/oauth/token", &body, &[("DPoP", &no_nonce_proof)]).await;
+    assert!(
+        first.status == StatusCode::BAD_REQUEST || first.status == StatusCode::UNAUTHORIZED,
+        "First DPoP request without nonce must be rejected, got {} : {}",
+        first.status,
+        first.body
+    );
+    let server_nonce = first
+        .headers
+        .get("DPoP-Nonce")
+        .expect("DPoP-Nonce header must be present in use_dpop_nonce response")
+        .to_str()
+        .expect("DPoP-Nonce must be valid UTF-8")
+        .to_string();
+
+    // Step 2: Retry with the server-provided nonce, SAME JWT assertion
+    // (same jti). If `commit_jti` had run on the first attempt, this would
+    // fail with `invalid_client` (replay). With the fix, the JTI is committed
+    // only after DPoP validation, so the retry succeeds.
+    let nonce_proof = create_dpop_proof(
+        &dpop_key,
+        &dpop_jwk,
+        "POST",
+        &token_endpoint,
+        Some(&server_nonce),
+    );
+    let second =
+        http_post_form_full(&app, "/oauth/token", &body, &[("DPoP", &nonce_proof)]).await;
+    assert_eq!(
+        second.status,
+        StatusCode::OK,
+        "DPoP-nonce retry with same JWT assertion must succeed: {}",
+        second.body
+    );
+    let token_resp: serde_json::Value = serde_json::from_str(&second.body).expect("Valid JSON");
+    assert!(
+        token_resp.get("access_token").is_some(),
+        "Successful retry must return access_token: {}",
+        second.body
+    );
+}

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7523.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7523.rs
@@ -847,8 +847,10 @@ async fn fan_out_token_requests(
             .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
             .collect();
         set.spawn(async move {
-            let header_refs: Vec<(&str, &str)> =
-                headers.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
+            let header_refs: Vec<(&str, &str)> = headers
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str()))
+                .collect();
             http_post_form(&app, "/oauth/token", &body, &header_refs).await
         });
     }
@@ -913,10 +915,7 @@ async fn test_jwt_assertion_jti_concurrent_replay_client_credentials() {
 
     let results = fan_out_token_requests(&app, &body, &[], CONCURRENT_N).await;
 
-    let successes = results
-        .iter()
-        .filter(|(s, _)| *s == StatusCode::OK)
-        .count();
+    let successes = results.iter().filter(|(s, _)| *s == StatusCode::OK).count();
     assert!(
         successes <= 1,
         "At most one concurrent replay may succeed, got {successes}. \
@@ -988,10 +987,7 @@ async fn test_jwt_assertion_jti_concurrent_replay_authorization_code() {
 
     let results = fan_out_token_requests(&app, &body, &[], CONCURRENT_N).await;
 
-    let successes = results
-        .iter()
-        .filter(|(s, _)| *s == StatusCode::OK)
-        .count();
+    let successes = results.iter().filter(|(s, _)| *s == StatusCode::OK).count();
     assert!(
         successes <= 1,
         "At most one concurrent replay may succeed, got {successes}. \
@@ -1065,9 +1061,16 @@ async fn test_jwt_assertion_jti_concurrent_replay_token_exchange() {
         urlencoding::encode("https://example.com/callback")
     );
     let (seed_status, seed_resp) = http_post_form(&app, "/oauth/token", &seed_body, &[]).await;
-    assert_eq!(seed_status, StatusCode::OK, "seed token must issue: {seed_resp}");
+    assert_eq!(
+        seed_status,
+        StatusCode::OK,
+        "seed token must issue: {seed_resp}"
+    );
     let seed_json: serde_json::Value = serde_json::from_str(&seed_resp).expect("Valid JSON");
-    let subject_token = seed_json["access_token"].as_str().expect("access_token").to_string();
+    let subject_token = seed_json["access_token"]
+        .as_str()
+        .expect("access_token")
+        .to_string();
 
     // Sessions persisted so far: the one from the seed exchange.
     let baseline_sessions = count_sessions_for_user(&state.store, &user.id).await;
@@ -1089,10 +1092,7 @@ async fn test_jwt_assertion_jti_concurrent_replay_token_exchange() {
 
     let results = fan_out_token_requests(&app, &body, &[], CONCURRENT_N).await;
 
-    let successes = results
-        .iter()
-        .filter(|(s, _)| *s == StatusCode::OK)
-        .count();
+    let successes = results.iter().filter(|(s, _)| *s == StatusCode::OK).count();
     assert!(
         successes <= 1,
         "At most one concurrent replay may succeed, got {successes}. \
@@ -1285,7 +1285,8 @@ async fn test_jwt_assertion_dpop_use_nonce_retry_succeeds() {
     // Step 1: DPoP proof without nonce. Server returns use_dpop_nonce + a
     // DPoP-Nonce header. The JTI must NOT be committed at this point.
     let no_nonce_proof = create_dpop_proof(&dpop_key, &dpop_jwk, "POST", &token_endpoint, None);
-    let first = http_post_form_full(&app, "/oauth/token", &body, &[("DPoP", &no_nonce_proof)]).await;
+    let first =
+        http_post_form_full(&app, "/oauth/token", &body, &[("DPoP", &no_nonce_proof)]).await;
     assert!(
         first.status == StatusCode::BAD_REQUEST || first.status == StatusCode::UNAUTHORIZED,
         "First DPoP request without nonce must be rejected, got {} : {}",
@@ -1311,8 +1312,7 @@ async fn test_jwt_assertion_dpop_use_nonce_retry_succeeds() {
         &token_endpoint,
         Some(&server_nonce),
     );
-    let second =
-        http_post_form_full(&app, "/oauth/token", &body, &[("DPoP", &nonce_proof)]).await;
+    let second = http_post_form_full(&app, "/oauth/token", &body, &[("DPoP", &nonce_proof)]).await;
     assert_eq!(
         second.status,
         StatusCode::OK,

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -628,19 +628,25 @@ async fn handle_authorization_code_grant(
         mtls_cert_thumbprint: mtls_thumbprint.as_deref(),
     };
 
+    // SAFETY: commit_jti() MUST run AFTER DPoP nonce validation (so use_dpop_nonce
+    // retry leaves the JTI unconsumed) and BEFORE exchange_*() / store_par_request()
+    // (so concurrent replays of the same assertion cannot persist multiple tokens —
+    // see issue #391). A follow-up will replace this comment with a TokenIssuanceProof
+    // witness type consumed by create_oauth_access_token.
+    if let Some(ref pending_jti) = jwt_pending_jti
+        && let Err(e) = commit_jti(&state, pending_jti).await
+    {
+        tracing::warn!("JTI commit failed for authorization_code: {e:?}");
+        return ServiceError::oauth(
+            OAuthErrorCode::InvalidClient,
+            "Client authentication failed",
+        )
+        .into_oauth_response()
+        .into_response();
+    }
+
     match exchange_authorization_code(&state, exchange_params).await {
         Ok(result) => {
-            if let Some(ref pending_jti) = jwt_pending_jti
-                && let Err(e) = commit_jti(&state, pending_jti).await
-            {
-                tracing::warn!("JTI commit failed for authorization_code: {e:?}");
-                return ServiceError::oauth(
-                    OAuthErrorCode::InvalidClient,
-                    "Client authentication failed",
-                )
-                .into_oauth_response()
-                .into_response();
-            }
             crate::infra::metrics::record_auth_event("authorization_code_success");
             token_success_response(TokenResponse {
                 access_token: result.access_token,
@@ -710,6 +716,23 @@ async fn handle_client_credentials_grant(
     // RFC 8705 Section 3: Bind access token to cert thumbprint only when opted in.
     let mtls_thumbprint = extract_mtls_thumbprint(&authenticated_client, &client_cert);
 
+    // SAFETY: commit_jti() MUST run AFTER DPoP nonce validation (no DPoP path here,
+    // so the constraint is vacuous in this arm) and BEFORE exchange_*() so that
+    // concurrent replays of the same assertion cannot persist multiple tokens —
+    // see issue #391. A follow-up will replace this comment with a
+    // TokenIssuanceProof witness type consumed by create_oauth_access_token.
+    if let Some(ref jti) = pending_jti
+        && let Err(e) = commit_jti(&state, jti).await
+    {
+        tracing::warn!("JTI commit failed for client_credentials: {e:?}");
+        return ServiceError::oauth(
+            OAuthErrorCode::InvalidClient,
+            "Client authentication failed",
+        )
+        .into_oauth_response()
+        .into_response();
+    }
+
     match exchange_client_credentials(
         &state,
         &authenticated_client.client,
@@ -719,19 +742,6 @@ async fn handle_client_credentials_grant(
     .await
     {
         Ok(result) => {
-            // Commit JTI after grant succeeds so clients can retry on failure.
-            if let Some(ref jti) = pending_jti
-                && let Err(e) = commit_jti(&state, jti).await
-            {
-                tracing::warn!("JTI commit failed for client_credentials: {e:?}");
-                return ServiceError::oauth(
-                    OAuthErrorCode::InvalidClient,
-                    "Client authentication failed",
-                )
-                .into_oauth_response()
-                .into_response();
-            }
-
             // Record audit event
             if let Err(e) = crate::db::record_oauth_event(
                 &state.audit,
@@ -865,20 +875,25 @@ async fn handle_token_exchange_grant(
         mtls_cert_thumbprint: mtls_thumbprint.as_deref(),
     };
 
+    // SAFETY: commit_jti() MUST run AFTER DPoP nonce validation (so use_dpop_nonce
+    // retry leaves the JTI unconsumed) and BEFORE exchange_*() so that concurrent
+    // replays of the same assertion cannot persist multiple tokens —
+    // see issue #391. A follow-up will replace this comment with a
+    // TokenIssuanceProof witness type consumed by create_oauth_access_token.
+    if let Some(ref jti) = pending_jti
+        && let Err(e) = commit_jti(&state, jti).await
+    {
+        tracing::warn!("JTI commit failed for token_exchange: {e:?}");
+        return ServiceError::oauth(
+            OAuthErrorCode::InvalidClient,
+            "Client authentication failed",
+        )
+        .into_oauth_response()
+        .into_response();
+    }
+
     match exchange_token(&state, exchange_params).await {
         Ok(result) => {
-            // Commit JTI after grant succeeds so clients can retry on failure.
-            if let Some(ref jti) = pending_jti
-                && let Err(e) = commit_jti(&state, jti).await
-            {
-                tracing::warn!("JTI commit failed for token_exchange: {e:?}");
-                return ServiceError::oauth(
-                    OAuthErrorCode::InvalidClient,
-                    "Client authentication failed",
-                )
-                .into_oauth_response()
-                .into_response();
-            }
             token_success_response(TokenExchangeResponse {
                 access_token: result.access_token,
                 issued_token_type: result.issued_token_type,
@@ -1002,19 +1017,25 @@ async fn handle_fido2_assertion_grant(
         mtls_cert_thumbprint: mtls_thumbprint.as_deref(),
     };
 
+    // SAFETY: commit_jti() MUST run AFTER DPoP nonce validation (so use_dpop_nonce
+    // retry leaves the JTI unconsumed) and BEFORE exchange_*() so that concurrent
+    // replays of the same assertion cannot persist multiple tokens —
+    // see issue #391. A follow-up will replace this comment with a
+    // TokenIssuanceProof witness type consumed by create_oauth_access_token.
+    if let Err(e) = commit_jti(&state, &jwt_pending_jti).await {
+        tracing::warn!("JTI commit failed for fido2_assertion: {e:?}");
+        return ServiceError::oauth(
+            OAuthErrorCode::InvalidClient,
+            "Client authentication failed",
+        )
+        .into_oauth_response()
+        .into_response();
+    }
+
     match crate::services::oidc::fido2_grant::exchange_fido2_assertion(&state, exchange_params)
         .await
     {
         Ok(result) => {
-            if let Err(e) = commit_jti(&state, &jwt_pending_jti).await {
-                tracing::warn!("JTI commit failed for fido2_assertion: {e:?}");
-                return ServiceError::oauth(
-                    OAuthErrorCode::InvalidClient,
-                    "Client authentication failed",
-                )
-                .into_oauth_response()
-                .into_response();
-            }
             crate::infra::metrics::record_auth_event("fido2_login_success");
             token_success_response(TokenResponse {
                 access_token: result.access_token,

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -893,19 +893,17 @@ async fn handle_token_exchange_grant(
     }
 
     match exchange_token(&state, exchange_params).await {
-        Ok(result) => {
-            token_success_response(TokenExchangeResponse {
-                access_token: result.access_token,
-                issued_token_type: result.issued_token_type,
-                token_type: result.token_type,
-                expires_in: result.expires_in,
-                scope: result.scope,
-                authorization_details: result
-                    .authorization_details
-                    .as_ref()
-                    .map(serde_json::Value::from),
-            })
-        }
+        Ok(result) => token_success_response(TokenExchangeResponse {
+            access_token: result.access_token,
+            issued_token_type: result.issued_token_type,
+            token_type: result.token_type,
+            expires_in: result.expires_in,
+            scope: result.scope,
+            authorization_details: result
+                .authorization_details
+                .as_ref()
+                .map(serde_json::Value::from),
+        }),
         Err(e) => e.into_oauth_response().into_response(),
     }
 }

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
@@ -16,10 +16,13 @@ use std::sync::Arc;
 
 /// A JTI that has been validated but not yet committed to the database.
 ///
-/// Call [`commit_jti`] after the full request succeeds to prevent replay.
-/// If the request fails with a retryable error (e.g., `use_dpop_nonce`),
-/// drop this without committing so the client can retry.
-#[must_use = "JTI must be committed via commit_jti() after the request succeeds"]
+/// Call [`commit_jti`] immediately before any grant-state persistence
+/// (`exchange_*` / `store_par_request`) so concurrent replays serialize on
+/// the JTI uniqueness constraint. Commit MUST run after any validator that
+/// returns a retryable error (in particular DPoP `use_dpop_nonce`, RFC 9449
+/// §4.3) so that those failures leave the JTI unconsumed and the client can
+/// retry with the same assertion.
+#[must_use = "JTI must be committed via commit_jti() before token issuance"]
 pub struct PendingJti {
     jti: Option<String>,
     client_id: String,
@@ -28,7 +31,10 @@ pub struct PendingJti {
 
 /// Commit a pending JTI to the replay-prevention database.
 ///
-/// Must be called after the token/PAR request fully succeeds.
+/// Must be called immediately before the grant-state persistence step
+/// (`exchange_*` / `store_par_request`) so that the atomic
+/// `db::store_jwt_assertion_jti` insert is the serializing point under
+/// concurrent replay of the same assertion.
 pub async fn commit_jti(
     state: &Arc<AppState>,
     pending: &PendingJti,
@@ -63,10 +69,12 @@ pub async fn commit_jti(
 /// * `client_id_hint` - Optional client_id from the request body (for lookup)
 ///
 /// # Returns
-/// The authenticated client and a pending JTI that MUST be committed
-/// via [`commit_jti`] after the request succeeds. If the request fails
-/// (e.g., `use_dpop_nonce`), the JTI is NOT consumed and the client
-/// can retry with the same assertion.
+/// The authenticated client and a pending JTI that MUST be committed via
+/// [`commit_jti`] immediately before grant-state persistence (`exchange_*` /
+/// `store_par_request`). If a validator earlier in the request rejects with
+/// a retryable error (in particular DPoP `use_dpop_nonce`, RFC 9449 §4.3),
+/// drop the [`PendingJti`] without committing so the client can retry with
+/// the same assertion.
 pub async fn authenticate_client_jwt(
     state: &Arc<AppState>,
     client_assertion: &str,


### PR DESCRIPTION
Closes #391.

## Summary

`commit_jti()` ran AFTER `exchange_*()` in the four token-grant arms (`authorization_code`, `client_credentials`, `token_exchange`, `fido2_assertion`) and in PAR. Under concurrent replay of the same JWT assertion, every request raced past authentication and persisted a token before any of them committed the JTI — only one won the atomic insert; the others returned `invalid_client` but their tokens remained valid in the DB.

The fix: move `commit_jti()` to immediately before `exchange_*()` / `store_par_request()` in each arm. The position is chosen so that:

- DPoP nonce validation still runs first — `use_dpop_nonce` rejections short-circuit before reaching `commit_jti`, so the JTI is left unconsumed and the client can retry with the same assertion (RFC 9449 §4.3).
- The atomic `(jti, client_id)` insert in `db::store_jwt_assertion_jti` becomes the serialization point. Concurrent replayers either win the JTI and proceed to exchange, or lose and short-circuit before any token is persisted.

Trade-off: if `exchange_*()` itself fails after the JTI is committed (e.g. transient DB error), the JTI is consumed and the client must regenerate the assertion to retry. This matches RFC 7523 single-use semantics.

## Files

- `handlers/oidc/token.rs` — four grant arms, each gets the `commit_jti` block hoisted from inside the `Ok(result)` arm of `match exchange_*` to immediately before it.
- `handlers/oidc/par.rs` — same fix shape applied to the PAR handler.
- `services/oidc/jwt_bearer/client_auth.rs` — doc-only updates to `PendingJti` and `authenticate_client_jwt` reflecting the new ordering rule.
- `handlers/oidc/tests/rfc7523.rs` — five new tests (see below).

Each moved `commit_jti` block now carries a `// SAFETY:` comment naming the invariant ("MUST run after DPoP nonce validation and before grant-state persistence"). The intent is for these comments to be deleted when the type-system follow-up lands.

## Tests

Five new tests in `handlers/oidc/tests/rfc7523.rs`:

- `test_jwt_assertion_jti_concurrent_replay_client_credentials` — N=8 concurrent requests with the same JWT assertion. Asserts ≤1 HTTP 200 and ≤1 session persisted. Strongest test: no per-request resource to gate concurrency.
- `test_jwt_assertion_jti_concurrent_replay_authorization_code` — same shape against `authorization_code`. The auth-code single-use happens to also gate this, but the test still verifies the session-count invariant.
- `test_jwt_assertion_jti_concurrent_replay_token_exchange` — same shape against `token-exchange` with a reusable `subject_token`.
- `test_jwt_assertion_jti_concurrent_replay_fido2_assertion` — fires concurrent requests with a garbage FIDO2 assertion. With the fix, ≤1 request reaches (and fails at) `exchange_fido2_assertion` returning `invalid_grant`; the rest lose the JTI race and return `invalid_client`. Without the fix, all N would return `invalid_grant`.
- `test_jwt_assertion_dpop_use_nonce_retry_succeeds` — covers a gap in existing coverage. The existing `test_rfc9449_dpop_nonce_required_retry_with_nonce_succeeds` exercises the `use_dpop_nonce` retry with basic_auth; this new test seals the contract for `private_key_jwt`: same JWT assertion (same jti) succeeds on the retry after a nonce rejection. Fails fast if a future change moves `commit_jti` before DPoP validation.

Verification: temporarily reverting the `token.rs` / `par.rs` edits makes 3 of the 4 concurrent-replay tests fail (multiple `invalid_grant`/200 responses); restoring the fix makes all 5 pass.

## Test plan

- [x] `cargo test -p vouch-server --lib` — 2126 passed, 0 failed
- [x] `cargo clippy -p vouch-server --all-targets --all-features -- -D warnings` — clean
- [x] Targeted suites: `rfc7523`, `rfc9449`, `rfc9126` (PAR), `rfc8705` (mTLS), `fido2_grant`, `fapi2`, `services::oidc::jwt_bearer` — 191 passed
- [x] Verified new tests catch the bug by stashing the source fix and re-running — 3/4 concurrent-replay tests fail without the fix
- [ ] CI

## Follow-up

A separate issue should be filed to lift the anti-replay invariant from call-site discipline into the type system. The recommended design (researched during planning):

1. Move the witness to the chokepoint — `services/auth.rs::create_oauth_access_token` is the single caller of `db::create_session` that every grant flows through. Add a `TokenIssuanceProof` witness parameter there rather than to each `exchange_*` wrapper.
2. `TokenIssuanceProof` is a sealed, `!Clone`, `#[must_use]` type with grant-specific variants (`CommittedJti`, `ConsumedAuthCode`, `ClientSecretAuth`, `DeviceCodeConsumed`, `EnrollmentBootstrap`). No catch-all escape hatch — a new grant must declare its replay primitive by adding a variant.
3. Each consume-once primitive returns its own witness type (`commit_jti(PendingJti) -> Result<CommittedJti>`, etc.) instead of `bool`/`()`. Witnesses compose into `TokenIssuanceProof` via per-variant `into_proof()` methods.
4. The DPoP code path is already the gold standard for this pattern — `validate_dpop_common` runs the atomic JTI insert and `ValidatedDpopProof` IS the witness. Use it as the template.

Estimated scope: ~250–400 LOC across 5–7 files. The `// SAFETY:` comments added here get deleted when the witness ships. Intentionally kept out of this PR so the security fix is reviewable and backportable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J9F7t7BPRek13ahTr98WU2)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes OAuth token and PAR issuance ordering for private_key_jwt replay prevention; incorrect placement could break DPoP retries or leave duplicate tokens under concurrency.
> 
> **Overview**
> Fixes a **TOCTOU race** in `private_key_jwt` flows (#391): **`commit_jti()`** now runs **after** DPoP/`use_dpop_nonce` handling and **before** any grant persistence (`exchange_*` on `/oauth/token`, **`store_par_request`** on PAR), so the atomic JTI insert serializes concurrent replays instead of allowing multiple tokens (or PAR records) while losers return `invalid_client`.
> 
> **`token.rs`** hoists JTI commit ahead of exchange in all four JWT-backed grant arms; **`par.rs`** does the same before creating the pushed request. **`client_auth.rs`** documents the new ordering for **`PendingJti`**.
> 
> Adds **regression tests** in **`rfc7523.rs`**: concurrent same-`jti` fan-out (client credentials, authorization code, token exchange, FIDO2 assertion error shape) plus **`private_key_jwt`** DPoP nonce retry with the **same** assertion.
> 
> **Trade-off:** if exchange/PAR storage fails after the JTI is committed, the assertion is spent and the client must mint a new one (RFC 7523 single-use).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86bea7aaf064d8f2129f5006b6f4f281d1e6a21e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->