### PR TITLE
fix(server/oidc): correct error classification on commit_jti failure

### DIFF
--- a/crates/vouch-server/src/handlers/oidc/par.rs
+++ b/crates/vouch-server/src/handlers/oidc/par.rs
@@ -456,10 +456,14 @@ pub async fn par(
         && let Err(e) = commit_jti(&state, pjti).await
     {
         tracing::warn!("JTI commit failed for PAR: {e:?}");
+        // commit_jti failure here means a JWT-assertion JTI replay was
+        // detected (RFC 7523 §3). That's a client-auth failure, not a server
+        // error — match the four token-grant arms (invalid_client / 401) so
+        // well-behaved clients don't retry-loop with the same consumed JTI.
         return par_error_response(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "server_error",
-            "Failed to complete client authentication",
+            StatusCode::UNAUTHORIZED,
+            "invalid_client",
+            "Client authentication failed",
         );
     }
 

--- a/crates/vouch-server/src/handlers/oidc/par.rs
+++ b/crates/vouch-server/src/handlers/oidc/par.rs
@@ -13,7 +13,7 @@ use crate::services::oidc::authorization::{
 };
 use crate::services::oidc::jar::{validate_request_object, validate_request_object_header};
 use crate::services::oidc::jwt_bearer::commit_jti;
-use crate::services::oidc::token::validate_dpop_if_present;
+use crate::services::oidc::token::{ClientAuthError, validate_dpop_if_present};
 use axum::{
     Json,
     extract::State,
@@ -456,15 +456,22 @@ pub async fn par(
         && let Err(e) = commit_jti(&state, pjti).await
     {
         tracing::warn!("JTI commit failed for PAR: {e:?}");
-        // commit_jti failure here means a JWT-assertion JTI replay was
-        // detected (RFC 7523 §3). That's a client-auth failure, not a server
-        // error — match the four token-grant arms (invalid_client / 401) so
-        // well-behaved clients don't retry-loop with the same consumed JTI.
-        return par_error_response(
-            StatusCode::UNAUTHORIZED,
-            "invalid_client",
-            "Client authentication failed",
-        );
+        // Distinguish replay (client-auth failure) from transient DB error
+        // (server problem). Returning 401 for a DB outage tells well-behaved
+        // clients to abandon credentials they should reuse on retry; returning
+        // 500 for a replay tempts them to retry-loop with a consumed JTI.
+        return match e {
+            ClientAuthError::InvalidCredentials => par_error_response(
+                StatusCode::UNAUTHORIZED,
+                "invalid_client",
+                "Client authentication failed",
+            ),
+            _ => par_error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "server_error",
+                "Failed to complete client authentication",
+            ),
+        };
     }
 
     // RFC 9126 Section 2.2: Return 201 Created

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
@@ -1311,3 +1311,73 @@ async fn test_rfc9126_par_already_consumed_returns_error_not_login() {
         "Pre-consumed PAR must not redirect to /login"
     );
 }
+
+#[tokio::test]
+async fn test_rfc9126_par_jti_replay_returns_invalid_client() {
+    // Regression: PAR's commit_jti() failure must return 401 invalid_client
+    // (the JTI replay is a client-auth failure), not 500 server_error.
+    // Returning 500 would tempt well-behaved clients to retry-loop with the
+    // same already-consumed JTI. The four token-grant arms in
+    // handlers/oidc/token.rs return invalid_client for the same failure;
+    // PAR must match.
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "par-jti-replay@example.com").await;
+    let (client, pkcs8_bytes) = create_test_jwt_client(&state.store, &user.id).await;
+
+    let par_endpoint = format!("{}/oauth/par", state.config().base_url);
+    let fixed_jti = "par-replay-jti-12345";
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    let challenge = sha256_base64url(verifier);
+
+    let build_body = |assertion: &str| {
+        format!(
+            "response_type=code\
+             &client_id={}\
+             &redirect_uri={}\
+             &code_challenge={}\
+             &code_challenge_method=S256\
+             &scope=openid\
+             &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+             &client_assertion={}",
+            client.client_id,
+            urlencoding::encode("https://example.com/callback"),
+            challenge,
+            assertion,
+        )
+    };
+
+    let assertion1 = build_client_assertion(
+        &client.client_id,
+        &par_endpoint,
+        &pkcs8_bytes,
+        Some(fixed_jti),
+    );
+    let (status1, body1) = http_post_form(&app, "/oauth/par", &build_body(&assertion1), &[]).await;
+    assert_eq!(
+        status1,
+        StatusCode::CREATED,
+        "First PAR with JWT assertion must succeed: {body1}"
+    );
+
+    // Replay the same JTI in a new assertion (re-signed for freshness on iat/exp,
+    // but with the same jti — JTI uniqueness is per (client_id, jti)).
+    let assertion2 = build_client_assertion(
+        &client.client_id,
+        &par_endpoint,
+        &pkcs8_bytes,
+        Some(fixed_jti),
+    );
+    let (status2, body2) = http_post_form(&app, "/oauth/par", &build_body(&assertion2), &[]).await;
+
+    assert_eq!(
+        status2,
+        StatusCode::UNAUTHORIZED,
+        "PAR JTI replay must return 401 (invalid_client), not 500 (server_error): {body2}"
+    );
+    let err: serde_json::Value = serde_json::from_str(&body2).expect("Valid JSON");
+    assert_eq!(
+        err["error"], "invalid_client",
+        "PAR JTI replay must return error=invalid_client, got: {body2}"
+    );
+}

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -637,12 +637,10 @@ async fn handle_authorization_code_grant(
         && let Err(e) = commit_jti(&state, pending_jti).await
     {
         tracing::warn!("JTI commit failed for authorization_code: {e:?}");
-        return ServiceError::oauth(
-            OAuthErrorCode::InvalidClient,
-            "Client authentication failed",
-        )
-        .into_oauth_response()
-        .into_response();
+        // InvalidCredentials (JTI replay) -> 401 invalid_client; DatabaseError
+        // (transient) -> 5xx internal_error. ClientAuthError::into_service_error
+        // already discriminates correctly.
+        return e.into_service_error().into_oauth_response().into_response();
     }
 
     match exchange_authorization_code(&state, exchange_params).await {
@@ -725,12 +723,7 @@ async fn handle_client_credentials_grant(
         && let Err(e) = commit_jti(&state, jti).await
     {
         tracing::warn!("JTI commit failed for client_credentials: {e:?}");
-        return ServiceError::oauth(
-            OAuthErrorCode::InvalidClient,
-            "Client authentication failed",
-        )
-        .into_oauth_response()
-        .into_response();
+        return e.into_service_error().into_oauth_response().into_response();
     }
 
     match exchange_client_credentials(
@@ -884,12 +877,7 @@ async fn handle_token_exchange_grant(
         && let Err(e) = commit_jti(&state, jti).await
     {
         tracing::warn!("JTI commit failed for token_exchange: {e:?}");
-        return ServiceError::oauth(
-            OAuthErrorCode::InvalidClient,
-            "Client authentication failed",
-        )
-        .into_oauth_response()
-        .into_response();
+        return e.into_service_error().into_oauth_response().into_response();
     }
 
     match exchange_token(&state, exchange_params).await {
@@ -1022,12 +1010,7 @@ async fn handle_fido2_assertion_grant(
     // TokenIssuanceProof witness type consumed by create_oauth_access_token.
     if let Err(e) = commit_jti(&state, &jwt_pending_jti).await {
         tracing::warn!("JTI commit failed for fido2_assertion: {e:?}");
-        return ServiceError::oauth(
-            OAuthErrorCode::InvalidClient,
-            "Client authentication failed",
-        )
-        .into_oauth_response()
-        .into_response();
+        return e.into_service_error().into_oauth_response().into_response();
     }
 
     match crate::services::oidc::fido2_grant::exchange_fido2_assertion(&state, exchange_params)


### PR DESCRIPTION
Follow-ups to #407, addressing two [Cursor Bugbot findings](https://github.com/vouch-sh/vouch/pull/408#discussion_r3295024015):

1. PAR's `commit_jti` failure returned 500 `server_error`. In its new position (the primary client-auth gate against JTI replay) that's wrong — it tempts well-behaved clients to retry-loop with the same consumed JTI. Aligned with the four token-grant arms, which return 401 `invalid_client`.
2. But "401 invalid_client for every commit_jti failure" was itself too coarse: `commit_jti` returns `ClientAuthError::InvalidCredentials` (JTI replay, client-auth failure) OR `ClientAuthError::DatabaseError` (transient DB outage, server problem). Returning 401 for a DB blip tells clients their credentials are bad and to regenerate, when in reality they should retry. The four token-grant arms had the same defect; fixed all five spots.

The existing `introspect.rs` handler already follows the variant-matching pattern.

## Files

- `crates/vouch-server/src/handlers/oidc/par.rs` — match on `ClientAuthError` variant: `InvalidCredentials → 401 invalid_client`, anything else → `500 server_error`.
- `crates/vouch-server/src/handlers/oidc/token.rs` — all four grant arms (authorization_code, client_credentials, token_exchange, fido2_assertion) now use `e.into_service_error().into_oauth_response()`, which `ClientAuthError::into_service_error` already discriminates correctly (`InvalidCredentials → InvalidClient`, `DatabaseError → Internal`). This is a one-line collapse per arm.
- `crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs` — regression test `test_rfc9126_par_jti_replay_returns_invalid_client` confirms the replay path returns 401 `invalid_client`.

## Test plan

- [x] `cargo test -p vouch-server --lib` — targeted suites (rfc7523, rfc9126, rfc9449, rfc8693, fido2_grant) all green (105 passed in targeted run)
- [x] `cargo clippy -p vouch-server --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Verified the regression test catches the original bug (revert par.rs → test fails with status=500, error=server_error)
- [ ] CI

## Scope note

The bugbot review only flagged par.rs (since that was the diff in this PR's first commit), but the same defect existed in the four token.rs arms — left over from #407. Fixed them in the same PR because (a) it's the same one-line fix per arm, (b) leaving a known bug in main for a second follow-up PR isn't worth the round-trip, and (c) the diff is still small (24 insertions, 34 deletions).