### PR TITLE
refactor(server): typestate witnesses + chokepoint at token issuance

### DIFF
--- a/crates/vouch-server/src/db/authorization_codes.rs
+++ b/crates/vouch-server/src/db/authorization_codes.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Authorization code single-use enforcement (RFC 6749 Section 10.5).
 
+use super::claim::ClaimError;
 use super::document_type::DocumentType;
 use super::documents::authorization_code::AuthorizationCodeDoc;
 use super::store::DocumentStore;
@@ -28,35 +29,62 @@ pub async fn store_authorization_code(
     Ok(())
 }
 
-/// Try to consume an authorization code.
+/// Witness that an authorization code (RFC 6749 Section 10.5) was
+/// atomically marked consumed by this caller. Construction is private to
+/// this module — the only path to an instance is a successful return from
+/// [`try_consume_authorization_code`], whose optimistic-concurrency
+/// `compare_and_update` guarantees that at most one concurrent caller
+/// succeeds. Holding an `AuthCodeClaim` is compile-time evidence that
+/// this caller "won" the consume.
 ///
-/// Returns `true` if the code was successfully consumed (first use).
-/// Returns `false` if already consumed, does not exist, or was
-/// concurrently consumed by another request (optimistic lock).
+/// Intentionally not `Clone`. The `#[must_use]` ensures the witness is
+/// bound at the call site (typically threaded into
+/// `GrantProof::AuthorizationCode(claim)`).
+#[must_use = "the authorization code was atomically consumed; bind this \
+              witness so it can be threaded into TokenIssuanceProof"]
+#[derive(Debug)]
+pub struct AuthCodeClaim {
+    _private: (),
+}
+
+/// Atomically consume an authorization code.
+///
+/// On success returns an [`AuthCodeClaim`] witness — proof that this caller
+/// won the OCC consume. All "lost" cases (code not found, expired,
+/// already consumed, concurrent consumer won via version mismatch) map to
+/// [`ClaimError::AlreadyConsumed`] — deliberately indistinguishable, each
+/// rejected as `invalid_grant`. The caller is responsible for replay
+/// detection follow-up (revoking tokens for the affected user) based on
+/// the `AlreadyConsumed` signal.
 pub async fn try_consume_authorization_code(
     store: &DocumentStore,
     code_hash: &str,
-) -> Result<bool> {
+) -> std::result::Result<AuthCodeClaim, ClaimError> {
     let now = Timestamp::now();
 
     let doc = store
         .find_one::<AuthorizationCodeDoc>("code_hash", code_hash)
-        .await?;
+        .await
+        .map_err(|e| ClaimError::Database(e.to_string()))?;
     let Some(doc) = doc else {
-        return Ok(false);
+        return Err(ClaimError::AlreadyConsumed);
     };
 
-    // Check: not consumed and not expired
     if doc.data.consumed_at.is_some() || doc.data.expires_at <= now {
-        return Ok(false);
+        return Err(ClaimError::AlreadyConsumed);
     }
 
-    // Consume with optimistic concurrency — if another request already
-    // consumed this code between our read and write, compare_and_update
-    // returns false (version mismatch).
     let mut data = doc.data;
     data.consumed_at = Some(now);
-    store.compare_and_update(&doc.id, doc.version, &data).await
+    let won = store
+        .compare_and_update(&doc.id, doc.version, &data)
+        .await
+        .map_err(|e| ClaimError::Database(e.to_string()))?;
+    if won {
+        Ok(AuthCodeClaim { _private: () })
+    } else {
+        Err(ClaimError::AlreadyConsumed)
+    }
 }
 
 /// Check if an authorization code has already been consumed.

--- a/crates/vouch-server/src/db/challenge_states.rs
+++ b/crates/vouch-server/src/db/challenge_states.rs
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! FIDO2 challenge state single-use enforcement.
 
+use super::claim::ClaimError;
 use super::document_type::DocumentType;
 use super::documents::challenge_state::ChallengeStateDoc;
 use super::store::DocumentStore;
 use anyhow::Result;
 use jiff::Timestamp;
 
-/// Derive a deterministic document ID from a registration state JWT.
+/// Derive a deterministic document ID from a state JWT.
 ///
 /// The `"challenge_state\0"` domain separator prevents cross-type ID
 /// collisions with `deterministic_jti_id` (`db/oauth.rs:794`) and
@@ -22,31 +23,55 @@ fn deterministic_challenge_state_id(state_jwt: &str) -> String {
     hex::encode(ctx.finish().as_ref())
 }
 
-/// Atomically mark a registration state JWT as consumed (single-use enforcement).
+/// Witness that a state JWT (WebAuthn challenge, registration state, or
+/// browser-login state) was atomically marked consumed by this caller.
 ///
-/// Returns `true` if this is the first use (the document was inserted).
-/// Returns `false` if the state has already been consumed (replay detected).
+/// Construction is private to this module — the only path to an instance
+/// is a successful return from [`try_consume_challenge_state`], whose
+/// atomic INSERT on a deterministic PRIMARY KEY guarantees that at most
+/// one concurrent caller's insert commits. Holding a `ChallengeStateClaim`
+/// is compile-time evidence that this caller "won" the consume.
 ///
-/// **Race safety across all three backends (SQLite, Postgres, DSQL):**
+/// Intentionally not `Clone`. The `#[must_use]` ensures the witness is
+/// bound at the call site (typically threaded into one of
+/// `GrantProof::Fido2Assertion`, `GrantProof::BrowserLogin`, or
+/// `GrantProof::EnrollmentComplete`). The same witness type is reused
+/// across these three semantically-distinct flows because the security
+/// property is identical — the chokepoint variant name carries the
+/// semantic context; the witness only proves the consume happened.
+#[must_use = "the challenge state was atomically consumed; bind this \
+              witness so it can be threaded into TokenIssuanceProof"]
+#[derive(Debug)]
+pub struct ChallengeStateClaim {
+    _private: (),
+}
+
+/// Atomically mark a state JWT as consumed (single-use enforcement).
 ///
-/// A deterministic document ID derived from the JWT is used as the PRIMARY KEY.
-/// Two concurrent calls with the same `state_jwt` will both attempt
-/// `insert_with_id` with the same ID. Exactly one will commit; the other will
-/// observe a unique violation (`SQLSTATE 23505`) and return `Ok(false)`.
+/// On success returns a [`ChallengeStateClaim`] witness; on replay returns
+/// [`ClaimError::AlreadyConsumed`]. All three backends (SQLite, Postgres,
+/// DSQL) detect the collision via a unique-violation on the deterministic
+/// PRIMARY KEY.
 ///
-/// **DSQL OCC retry interaction:** Under Aurora DSQL's optimistic concurrency
-/// control, the losing concurrent transaction first receives a serialization
-/// error (`SQLSTATE 40001` / `OC000`/`OC001`). The `with_dsql_retry!` wrapper
-/// (`db/store.rs`) retries that transaction. On retry, the INSERT collides with
-/// the already-committed row from the winner, producing `SQLSTATE 23505`.
-/// `23505` is not retryable, so `with_dsql_retry!` surfaces it as `Err(e)`,
-/// which `is_unique_violation` catches and converts to `Ok(false)`. Only one
-/// transaction wins; the loser is correctly treated as a replay.
-pub async fn try_mark_challenge_used(
+/// **Race safety:** A deterministic document ID derived from the JWT is
+/// used as the PRIMARY KEY. Two concurrent calls with the same `state_jwt`
+/// will both attempt `insert_with_id` with the same ID. Exactly one will
+/// commit; the other will observe a unique violation (`SQLSTATE 23505`)
+/// and is reported as `AlreadyConsumed`.
+///
+/// **DSQL OCC retry interaction:** Under Aurora DSQL's optimistic
+/// concurrency control, the losing concurrent transaction first receives
+/// a serialization error (`SQLSTATE 40001` / `OC000`/`OC001`). The
+/// `with_dsql_retry!` wrapper (`db/store.rs`) retries that transaction.
+/// On retry, the INSERT collides with the already-committed row from the
+/// winner, producing `SQLSTATE 23505`. `23505` is not retryable, so
+/// `with_dsql_retry!` surfaces it as `Err(e)`, which `is_unique_violation`
+/// catches. Only one transaction wins; the loser is reported as a replay.
+pub async fn try_consume_challenge_state(
     store: &DocumentStore,
     state_jwt: &str,
     expires_at: Timestamp,
-) -> Result<bool> {
+) -> std::result::Result<ChallengeStateClaim, ClaimError> {
     let id = deterministic_challenge_state_id(state_jwt);
     let doc = ChallengeStateDoc {
         doc_id: id.clone(),
@@ -55,9 +80,9 @@ pub async fn try_mark_challenge_used(
     };
 
     match store.insert_with_id(&id, &doc).await {
-        Ok(_) => Ok(true),
-        Err(e) if super::pool::is_unique_violation(&e) => Ok(false),
-        Err(e) => Err(e),
+        Ok(_) => Ok(ChallengeStateClaim { _private: () }),
+        Err(e) if super::pool::is_unique_violation(&e) => Err(ClaimError::AlreadyConsumed),
+        Err(e) => Err(ClaimError::Database(e.to_string())),
     }
 }
 

--- a/crates/vouch-server/src/db/claim.rs
+++ b/crates/vouch-server/src/db/claim.rs
@@ -17,6 +17,7 @@ use std::fmt;
 /// `Expired` and `NotFound` are operational cases — the claim was never
 /// valid or has aged out. `Database` wraps an unexpected backend failure.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ClaimError {
     /// A prior caller already claimed this token. Replay detected.
     AlreadyConsumed,

--- a/crates/vouch-server/src/db/claim.rs
+++ b/crates/vouch-server/src/db/claim.rs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! Shared error type for single-use claim primitives.
+//!
+//! The codebase has several "consume-once" database operations — auth codes,
+//! device codes, DPoP JTIs, JWT-assertion JTIs, PAR records, challenge states,
+//! pending OAuth records — whose security property is the same: only one
+//! caller can succeed, the rest are replays. Their per-module witness types
+//! (`AuthCodeClaim`, `DpopJtiClaim`, etc.) all surface failures through this
+//! shared error, which each call site translates to its layer-specific
+//! HTTP/OAuth error at the boundary.
+
+use std::fmt;
+
+/// Outcome of a failed single-use claim attempt.
+///
+/// `AlreadyConsumed` is the security-relevant case (replay detected).
+/// `Expired` and `NotFound` are operational cases — the claim was never
+/// valid or has aged out. `Database` wraps an unexpected backend failure.
+#[derive(Debug)]
+pub enum ClaimError {
+    /// A prior caller already claimed this token. Replay detected.
+    AlreadyConsumed,
+    /// The claim TTL has elapsed.
+    Expired,
+    /// No record exists for the supplied key.
+    NotFound,
+    /// Backend database failure unrelated to claim semantics.
+    Database(String),
+}
+
+impl fmt::Display for ClaimError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AlreadyConsumed => write!(f, "already consumed (replay detected)"),
+            Self::Expired => write!(f, "claim expired"),
+            Self::NotFound => write!(f, "claim not found"),
+            Self::Database(msg) => write!(f, "database error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for ClaimError {}
+
+impl From<anyhow::Error> for ClaimError {
+    fn from(err: anyhow::Error) -> Self {
+        Self::Database(err.to_string())
+    }
+}

--- a/crates/vouch-server/src/db/claim.rs
+++ b/crates/vouch-server/src/db/claim.rs
@@ -15,7 +15,10 @@ use std::fmt;
 ///
 /// `AlreadyConsumed` is the security-relevant case (replay detected).
 /// `Expired` and `NotFound` are operational cases — the claim was never
-/// valid or has aged out. `Database` wraps an unexpected backend failure.
+/// valid or has aged out. `InvalidInput` is a client-input validation
+/// failure (e.g., oversized JTI) — callers should map it to the
+/// equivalent of `invalid_client`/400, not a 500 retry-prompting error.
+/// `Database` wraps an unexpected backend failure.
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum ClaimError {
@@ -25,6 +28,9 @@ pub enum ClaimError {
     Expired,
     /// No record exists for the supplied key.
     NotFound,
+    /// Caller-supplied input violated a validation bound (length, format,
+    /// etc.). Not a database failure — the client must fix its request.
+    InvalidInput(String),
     /// Backend database failure unrelated to claim semantics.
     Database(String),
 }
@@ -35,6 +41,7 @@ impl fmt::Display for ClaimError {
             Self::AlreadyConsumed => write!(f, "already consumed (replay detected)"),
             Self::Expired => write!(f, "claim expired"),
             Self::NotFound => write!(f, "claim not found"),
+            Self::InvalidInput(msg) => write!(f, "invalid input: {msg}"),
             Self::Database(msg) => write!(f, "database error: {msg}"),
         }
     }

--- a/crates/vouch-server/src/db/claim.rs
+++ b/crates/vouch-server/src/db/claim.rs
@@ -13,21 +13,22 @@ use std::fmt;
 
 /// Outcome of a failed single-use claim attempt.
 ///
-/// `AlreadyConsumed` is the security-relevant case (replay detected).
-/// `Expired` and `NotFound` are operational cases — the claim was never
-/// valid or has aged out. `InvalidInput` is a client-input validation
-/// failure (e.g., oversized JTI) — callers should map it to the
-/// equivalent of `invalid_client`/400, not a 500 retry-prompting error.
-/// `Database` wraps an unexpected backend failure.
+/// Every primitive deliberately collapses its "lost" cases (not found,
+/// expired, already consumed, concurrent race loser) into the single
+/// `AlreadyConsumed` variant — the cases are indistinguishable from the
+/// caller's perspective and each is rejected the same way (invalid_grant
+/// / invalid_client). `InvalidInput` is a client-input validation
+/// failure (e.g., oversized JTI) — callers should map it to a 4xx so
+/// the client fixes its request rather than retrying. `Database` wraps
+/// an unexpected backend failure.
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum ClaimError {
-    /// A prior caller already claimed this token. Replay detected.
+    /// A prior caller already claimed this token, OR the token never
+    /// existed, OR has expired. Deliberately indistinguishable — callers
+    /// must not be able to probe state existence via response timing or
+    /// error messages.
     AlreadyConsumed,
-    /// The claim TTL has elapsed.
-    Expired,
-    /// No record exists for the supplied key.
-    NotFound,
     /// Caller-supplied input violated a validation bound (length, format,
     /// etc.). Not a database failure — the client must fix its request.
     InvalidInput(String),
@@ -39,8 +40,6 @@ impl fmt::Display for ClaimError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::AlreadyConsumed => write!(f, "already consumed (replay detected)"),
-            Self::Expired => write!(f, "claim expired"),
-            Self::NotFound => write!(f, "claim not found"),
             Self::InvalidInput(msg) => write!(f, "invalid input: {msg}"),
             Self::Database(msg) => write!(f, "database error: {msg}"),
         }

--- a/crates/vouch-server/src/db/device_auth.rs
+++ b/crates/vouch-server/src/db/device_auth.rs
@@ -76,6 +76,24 @@ impl From<Document<OidcStateDoc>> for OidcState {
     }
 }
 
+/// Witness that an OIDC state record was atomically transitioned to
+/// `consumed_at = Some(now)` by this caller. Construction is private to
+/// this module — the only path to an instance is a successful return from
+/// [`try_consume_oidc_state`], whose optimistic-concurrency
+/// `compare_and_update` guarantees that at most one concurrent caller
+/// succeeds. Holding an `OidcStateClaim` is compile-time evidence that
+/// this caller "won" the consume.
+///
+/// Intentionally not `Clone`. The `#[must_use]` ensures the witness is
+/// bound at the call site (threaded into
+/// `GrantProof::EnrollmentBootstrap(claim)`).
+#[must_use = "the OIDC state was atomically consumed; bind this witness so \
+              it can be threaded into TokenIssuanceProof"]
+#[derive(Debug)]
+pub struct OidcStateClaim {
+    _private: (),
+}
+
 /// Create a new device authorization request.
 pub async fn create_device_auth_request(
     store: &DocumentStore,
@@ -346,6 +364,7 @@ pub async fn create_oidc_state(
         code_verifier: code_verifier.to_string(),
         expires_at,
         provider_id: provider_id.to_string(),
+        consumed_at: None,
     };
     let result = store.insert(&doc).await?;
     Ok(result.id)
@@ -355,6 +374,62 @@ pub async fn create_oidc_state(
 pub async fn get_oidc_state(store: &DocumentStore, state: &str) -> Result<Option<OidcState>> {
     let doc = store.find_one::<OidcStateDoc>("state", state).await?;
     Ok(doc.map(OidcState::from))
+}
+
+/// Atomically consume an OIDC state record.
+///
+/// On success returns `(OidcState, OidcStateClaim)` — the state data
+/// needed for downstream processing plus the witness proving this caller
+/// won the OCC consume. All "lost" cases (state not found, already
+/// consumed, expired, concurrent consumer won via version mismatch) map
+/// to [`ClaimError::AlreadyConsumed`] — deliberately indistinguishable,
+/// each rejected the same way at the handler.
+///
+/// This closes the read-vs-consume TOCTOU window that existed when
+/// callers used `get_oidc_state` + `delete_oidc_state` as separate steps:
+/// two concurrent enrollment-callback requests could both read the same
+/// state, both pass validation, and both proceed to issue tokens before
+/// either delete completed.
+pub async fn try_consume_oidc_state(
+    store: &DocumentStore,
+    state: &str,
+) -> std::result::Result<(OidcState, OidcStateClaim), ClaimError> {
+    let now = Timestamp::now();
+
+    let doc = store
+        .find_one::<OidcStateDoc>("state", state)
+        .await
+        .map_err(|e| ClaimError::Database(e.to_string()))?;
+    let Some(doc) = doc else {
+        return Err(ClaimError::AlreadyConsumed);
+    };
+
+    if doc.data.consumed_at.is_some() || doc.data.expires_at <= now {
+        return Err(ClaimError::AlreadyConsumed);
+    }
+
+    let mut data = doc.data;
+    data.consumed_at = Some(now);
+    let won = store
+        .compare_and_update(&doc.id, doc.version, &data)
+        .await
+        .map_err(|e| ClaimError::Database(e.to_string()))?;
+    if won {
+        Ok((
+            OidcState {
+                id: doc.id,
+                state: data.state,
+                device_auth_id: data.device_auth_id,
+                nonce: data.nonce,
+                code_verifier: data.code_verifier,
+                expires_at: data.expires_at,
+                provider_id: data.provider_id,
+            },
+            OidcStateClaim { _private: () },
+        ))
+    } else {
+        Err(ClaimError::AlreadyConsumed)
+    }
 }
 
 /// Delete an OIDC state.

--- a/crates/vouch-server/src/db/device_auth.rs
+++ b/crates/vouch-server/src/db/device_auth.rs
@@ -173,9 +173,7 @@ pub async fn authorize_device_auth(
         bail!("authorize_device_auth called with empty id");
     }
 
-    let mut tx = store.begin().await?;
-
-    let doc = tx.get::<DeviceAuthRequestDoc>(id).await?;
+    let doc = store.get::<DeviceAuthRequestDoc>(id).await?;
     let Some(doc) = doc else {
         bail!(
             "authorize_device_auth: no device auth request \
@@ -199,7 +197,7 @@ pub async fn authorize_device_auth(
     data.user_id = Some(user_id.to_string());
     data.user_email = Some(user_email.to_string());
     data.authenticator_id = Some(authenticator_id.to_string());
-    let won = tx.compare_and_update(id, version, &data).await?;
+    let won = store.compare_and_update(id, version, &data).await?;
     if !won {
         bail!(
             "authorize_device_auth: device auth request '{}' was \
@@ -208,7 +206,6 @@ pub async fn authorize_device_auth(
         );
     }
 
-    tx.commit().await?;
     Ok(())
 }
 
@@ -222,9 +219,7 @@ pub async fn deny_device_auth(store: &DocumentStore, id: &str) -> Result<()> {
         bail!("deny_device_auth called with empty id");
     }
 
-    let mut tx = store.begin().await?;
-
-    let doc = tx.get::<DeviceAuthRequestDoc>(id).await?;
+    let doc = store.get::<DeviceAuthRequestDoc>(id).await?;
     let Some(doc) = doc else {
         bail!(
             "deny_device_auth: no device auth request \
@@ -245,7 +240,7 @@ pub async fn deny_device_auth(store: &DocumentStore, id: &str) -> Result<()> {
     let version = doc.version;
     let mut data = doc.data;
     data.status = DeviceAuthStatus::Denied;
-    let won = tx.compare_and_update(id, version, &data).await?;
+    let won = store.compare_and_update(id, version, &data).await?;
     if !won {
         bail!(
             "deny_device_auth: device auth request '{}' was \
@@ -254,7 +249,6 @@ pub async fn deny_device_auth(store: &DocumentStore, id: &str) -> Result<()> {
         );
     }
 
-    tx.commit().await?;
     Ok(())
 }
 

--- a/crates/vouch-server/src/db/device_auth.rs
+++ b/crates/vouch-server/src/db/device_auth.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Device Authorization (RFC 8628) database operations.
 
+use super::claim::ClaimError;
 use super::document_type::Document;
 use super::documents::device_auth::{DeviceAuthRequestDoc, OidcStateDoc};
 use super::store::DocumentStore;
@@ -219,36 +220,64 @@ pub async fn deny_device_auth(store: &DocumentStore, id: &str) -> Result<()> {
     Ok(())
 }
 
+/// Witness that an authorized device code (RFC 8628 Section 3.5) was
+/// atomically transitioned to `Consumed` by this caller. Construction is
+/// private to this module — the only path to an instance is a successful
+/// return from [`try_consume_device_auth`], whose optimistic-concurrency
+/// `compare_and_update` guarantees that at most one concurrent caller
+/// succeeds. Holding a `DeviceCodeClaim` is compile-time evidence that
+/// this caller "won" the consume.
+///
+/// Intentionally not `Clone`. The `#[must_use]` ensures the witness is
+/// bound at the call site even when threaded into a downstream consumer
+/// (e.g., `GrantProof::DeviceCode(claim)`).
+#[must_use = "the device code was atomically consumed; bind this witness so \
+              it can be threaded into TokenIssuanceProof"]
+#[derive(Debug)]
+pub struct DeviceCodeClaim {
+    _private: (),
+}
+
 /// Try to consume an authorized device code (RFC 8628 Section 3.5).
 ///
-/// Returns `true` if the code was successfully consumed (first use).
-/// Returns `false` if already consumed, not authorized, expired,
-/// or was concurrently consumed by another request (optimistic lock).
+/// On success returns a [`DeviceCodeClaim`] witness — proof that this caller
+/// won the optimistic-concurrency consume. All "lost" cases (not found,
+/// not currently `Authorized`, expired, or concurrent consumer won via
+/// version mismatch) map to [`ClaimError::AlreadyConsumed`] — deliberately
+/// indistinguishable, each rejected as an invalid_grant.
 pub async fn try_consume_device_auth(
     store: &DocumentStore,
     device_code_hash: &str,
-) -> Result<bool> {
+) -> std::result::Result<DeviceCodeClaim, ClaimError> {
     let now = Timestamp::now();
 
     let doc = store
         .find_one::<DeviceAuthRequestDoc>("device_code_hash", device_code_hash)
-        .await?;
+        .await
+        .map_err(|e| ClaimError::Database(e.to_string()))?;
     let Some(doc) = doc else {
-        return Ok(false);
+        return Err(ClaimError::AlreadyConsumed);
     };
 
-    // Only consume if currently Authorized and not expired
+    // Only consume if currently Authorized and not expired.
     if doc.data.status != DeviceAuthStatus::Authorized || doc.data.expires_at <= now {
-        return Ok(false);
+        return Err(ClaimError::AlreadyConsumed);
     }
 
-    // Atomically transition to Consumed with optimistic concurrency.
-    // If another request consumed between our read and write,
-    // compare_and_update returns false (version mismatch).
+    // Atomic transition: compare_and_update returns false on version mismatch
+    // (a concurrent caller wrote a newer version first).
     let mut data = doc.data;
     data.status = DeviceAuthStatus::Consumed;
     data.consumed_at = Some(now);
-    store.compare_and_update(&doc.id, doc.version, &data).await
+    let won = store
+        .compare_and_update(&doc.id, doc.version, &data)
+        .await
+        .map_err(|e| ClaimError::Database(e.to_string()))?;
+    if won {
+        Ok(DeviceCodeClaim { _private: () })
+    } else {
+        Err(ClaimError::AlreadyConsumed)
+    }
 }
 
 /// Update the last poll time for a device auth request.

--- a/crates/vouch-server/src/db/device_auth.rs
+++ b/crates/vouch-server/src/db/device_auth.rs
@@ -157,8 +157,11 @@ pub(crate) async fn get_device_auth_by_id(
 
 /// Authorize a device auth request.
 ///
-/// The read and status update execute within a single transaction so
-/// concurrent authorization attempts are serialized correctly.
+/// Uses `compare_and_update` (OCC) so two concurrent authorization
+/// attempts cannot both succeed under PostgreSQL READ COMMITTED — the
+/// loser sees a version mismatch and is reported as a conflict. The
+/// blind `tx.update` it replaced would have let both writers commit,
+/// each clobbering the other's user attribution.
 pub async fn authorize_device_auth(
     store: &DocumentStore,
     id: &str,
@@ -190,12 +193,20 @@ pub async fn authorize_device_auth(
         );
     }
 
+    let version = doc.version;
     let mut data = doc.data;
     data.status = DeviceAuthStatus::Authorized;
     data.user_id = Some(user_id.to_string());
     data.user_email = Some(user_email.to_string());
     data.authenticator_id = Some(authenticator_id.to_string());
-    tx.update(id, &data).await?;
+    let won = tx.compare_and_update(id, version, &data).await?;
+    if !won {
+        bail!(
+            "authorize_device_auth: device auth request '{}' was \
+             concurrently modified",
+            id
+        );
+    }
 
     tx.commit().await?;
     Ok(())
@@ -203,8 +214,9 @@ pub async fn authorize_device_auth(
 
 /// Deny a device auth request.
 ///
-/// The read and status update execute within a single transaction so
-/// concurrent denial attempts are serialized correctly.
+/// Uses `compare_and_update` (OCC) for the same reason as
+/// [`authorize_device_auth`]: two concurrent denials (or a concurrent
+/// authorize + deny) cannot both win under READ COMMITTED.
 pub async fn deny_device_auth(store: &DocumentStore, id: &str) -> Result<()> {
     if id.is_empty() {
         bail!("deny_device_auth called with empty id");
@@ -230,9 +242,17 @@ pub async fn deny_device_auth(store: &DocumentStore, id: &str) -> Result<()> {
         );
     }
 
+    let version = doc.version;
     let mut data = doc.data;
     data.status = DeviceAuthStatus::Denied;
-    tx.update(id, &data).await?;
+    let won = tx.compare_and_update(id, version, &data).await?;
+    if !won {
+        bail!(
+            "deny_device_auth: device auth request '{}' was \
+             concurrently modified",
+            id
+        );
+    }
 
     tx.commit().await?;
     Ok(())

--- a/crates/vouch-server/src/db/documents/device_auth.rs
+++ b/crates/vouch-server/src/db/documents/device_auth.rs
@@ -82,6 +82,11 @@ pub struct OidcStateDoc {
     /// Empty string for SAML flows or pre-multi-provider state docs (rolling deploy compat).
     #[serde(default)]
     pub provider_id: String,
+    /// Timestamp at which the state was atomically consumed (single-use).
+    /// Set by `try_consume_oidc_state`. A state with `consumed_at: Some(_)`
+    /// is treated as already-used for replay protection.
+    #[serde(default)]
+    pub consumed_at: Option<Timestamp>,
 }
 
 impl DocumentType for OidcStateDoc {

--- a/crates/vouch-server/src/db/documents/dpop.rs
+++ b/crates/vouch-server/src/db/documents/dpop.rs
@@ -17,10 +17,9 @@ impl DocumentType for DpopNonceDoc {
     const DOC_TYPE: &'static str = "dpop_nonce";
 
     fn index_entries(&self) -> Vec<IndexEntry> {
-        vec![IndexEntry {
-            field: "nonce",
-            value: self.nonce.clone(),
-        }]
+        // No index needed — consumption uses deterministic document IDs
+        // (atomic DELETE by primary key), not index lookups.
+        Vec::new()
     }
 
     fn expires_at(&self) -> Option<Timestamp> {

--- a/crates/vouch-server/src/db/dpop.rs
+++ b/crates/vouch-server/src/db/dpop.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! DPoP nonce and JTI database operations (RFC 9449).
 
+use super::claim::ClaimError;
 use super::document_type::DocumentType;
 use super::documents::dpop::{DpopJtiDoc, DpopNonceDoc};
 use super::store::DocumentStore;
@@ -27,6 +28,17 @@ fn deterministic_dpop_jti_id(jti: &str) -> String {
     hex::encode(ctx.finish().as_ref())
 }
 
+/// Derive a deterministic document ID from a DPoP nonce. Separate domain
+/// from JTIs so the two types' IDs can never collide.
+fn deterministic_dpop_nonce_id(nonce: &str) -> String {
+    use aws_lc_rs::digest::{self, SHA256};
+
+    let mut ctx = digest::Context::new(&SHA256);
+    ctx.update(b"dpop_nonce\0");
+    ctx.update(nonce.as_bytes());
+    hex::encode(ctx.finish().as_ref())
+}
+
 /// Generate a random URL-safe string.
 fn generate_random_string(len: usize) -> Result<String> {
     let mut bytes = vec![0u8; len];
@@ -34,7 +46,30 @@ fn generate_random_string(len: usize) -> Result<String> {
     Ok(URL_SAFE_NO_PAD.encode(&bytes))
 }
 
+/// Witness that a DPoP nonce (RFC 9449 §8) has been atomically consumed.
+///
+/// Construction is private to this module — the only path to an instance is
+/// a successful return from [`validate_and_consume_dpop_nonce`], which runs
+/// a single `DELETE WHERE id = ? AND expires_at > ?` SQL statement.
+/// Returning the witness means *this caller* was the one whose DELETE
+/// affected a row — no concurrent consumer can hold the same witness.
+///
+/// Intentionally not `Clone`. The `#[must_use]` ensures it is bound at the
+/// call site even when it isn't threaded further downstream (today its only
+/// consumer is the DPoP validation pipeline itself, but the witness exists
+/// so future code can require it as a precondition).
+#[must_use = "the DPoP nonce was atomically consumed; bind this witness so \
+              future code can require it as a precondition"]
+#[derive(Debug)]
+pub struct DpopNonceClaim {
+    _private: (),
+}
+
 /// Generate and store a DPoP nonce. Returns the nonce string.
+///
+/// Stores the nonce under a deterministic document ID derived from the
+/// nonce itself, so [`validate_and_consume_dpop_nonce`] can perform an
+/// atomic primary-key DELETE without a find-then-delete TOCTOU window.
 pub async fn generate_dpop_nonce(store: &DocumentStore, validity_seconds: i64) -> Result<String> {
     let nonce = generate_random_string(32)?;
     let now = Timestamp::now();
@@ -42,36 +77,38 @@ pub async fn generate_dpop_nonce(store: &DocumentStore, validity_seconds: i64) -
         .checked_add(validity_seconds.seconds())
         .context("DPoP nonce expiry timestamp overflow")?;
 
+    let id = deterministic_dpop_nonce_id(&nonce);
     let doc = DpopNonceDoc {
         nonce: nonce.clone(),
         expires_at,
     };
-    store.insert(&doc).await?;
+    store.insert_with_id(&id, &doc).await?;
     Ok(nonce)
 }
 
-/// Validate and consume a nonce.
+/// Atomically validate and consume a DPoP nonce.
 ///
-/// Returns `true` if valid and consumed, `false` if not found or expired.
-pub async fn validate_and_consume_dpop_nonce(store: &DocumentStore, nonce: &str) -> Result<bool> {
+/// Uses a single `DELETE WHERE id = ? AND expires_at > ?` statement, so the
+/// claim is decided by the database row count — no find-then-delete race.
+/// On success returns a [`DpopNonceClaim`] witness; on a "lost" race (nonce
+/// not found, expired, or already consumed by a concurrent caller) returns
+/// [`ClaimError::AlreadyConsumed`]. The three "lost" cases are deliberately
+/// indistinguishable: each is rejected the same way by RFC 9449.
+pub async fn validate_and_consume_dpop_nonce(
+    store: &DocumentStore,
+    nonce: &str,
+) -> std::result::Result<DpopNonceClaim, ClaimError> {
+    let id = deterministic_dpop_nonce_id(nonce);
     let now = Timestamp::now();
-
-    let doc = store.find_one::<DpopNonceDoc>("nonce", nonce).await?;
-
-    let Some(doc) = doc else {
-        return Ok(false);
-    };
-
-    // Check expiry
-    if doc.data.expires_at <= now {
-        // Expired — delete it and return false
-        store.delete(&doc.id).await?;
-        return Ok(false);
+    let won = store
+        .delete_if_not_expired(&id, &now)
+        .await
+        .map_err(|e| ClaimError::Database(e.to_string()))?;
+    if won {
+        Ok(DpopNonceClaim { _private: () })
+    } else {
+        Err(ClaimError::AlreadyConsumed)
     }
-
-    // Valid — consume by deleting
-    store.delete(&doc.id).await?;
-    Ok(true)
 }
 
 /// Check if JTI exists (replay) and store it atomically.

--- a/crates/vouch-server/src/db/dpop.rs
+++ b/crates/vouch-server/src/db/dpop.rs
@@ -46,25 +46,6 @@ fn generate_random_string(len: usize) -> Result<String> {
     Ok(URL_SAFE_NO_PAD.encode(&bytes))
 }
 
-/// Witness that a DPoP nonce (RFC 9449 §8) has been atomically consumed.
-///
-/// Construction is private to this module — the only path to an instance is
-/// a successful return from [`validate_and_consume_dpop_nonce`], which runs
-/// a single `DELETE WHERE id = ? AND expires_at > ?` SQL statement.
-/// Returning the witness means *this caller* was the one whose DELETE
-/// affected a row — no concurrent consumer can hold the same witness.
-///
-/// Intentionally not `Clone`. The `#[must_use]` ensures it is bound at the
-/// call site even when it isn't threaded further downstream (today its only
-/// consumer is the DPoP validation pipeline itself, but the witness exists
-/// so future code can require it as a precondition).
-#[must_use = "the DPoP nonce was atomically consumed; bind this witness so \
-              future code can require it as a precondition"]
-#[derive(Debug)]
-pub struct DpopNonceClaim {
-    _private: (),
-}
-
 /// Generate and store a DPoP nonce. Returns the nonce string.
 ///
 /// Stores the nonce under a deterministic document ID derived from the
@@ -89,15 +70,21 @@ pub async fn generate_dpop_nonce(store: &DocumentStore, validity_seconds: i64) -
 /// Atomically validate and consume a DPoP nonce.
 ///
 /// Uses a single `DELETE WHERE id = ? AND expires_at > ?` statement, so the
-/// claim is decided by the database row count — no find-then-delete race.
-/// On success returns a [`DpopNonceClaim`] witness; on a "lost" race (nonce
-/// not found, expired, or already consumed by a concurrent caller) returns
-/// [`ClaimError::AlreadyConsumed`]. The three "lost" cases are deliberately
-/// indistinguishable: each is rejected the same way by RFC 9449.
+/// outcome is decided by the database row count — no find-then-delete race.
+/// On a "lost" race (nonce not found, expired, or already consumed by a
+/// concurrent caller) returns [`ClaimError::AlreadyConsumed`]. The three
+/// lost cases are deliberately indistinguishable: each is rejected the
+/// same way by RFC 9449.
+///
+/// No witness type is returned because `ValidatedDpopProof` already
+/// carries the "DPoP validation succeeded" marker at the call site
+/// ([`crate::services::oidc::dpop::validate_dpop_common`]); a separate
+/// `DpopNonceClaim` would duplicate that guarantee without any
+/// downstream consumer requiring it.
 pub async fn validate_and_consume_dpop_nonce(
     store: &DocumentStore,
     nonce: &str,
-) -> std::result::Result<DpopNonceClaim, ClaimError> {
+) -> std::result::Result<(), ClaimError> {
     let id = deterministic_dpop_nonce_id(nonce);
     let now = Timestamp::now();
     let won = store
@@ -105,36 +92,59 @@ pub async fn validate_and_consume_dpop_nonce(
         .await
         .map_err(|e| ClaimError::Database(e.to_string()))?;
     if won {
-        Ok(DpopNonceClaim { _private: () })
+        Ok(())
     } else {
         Err(ClaimError::AlreadyConsumed)
     }
 }
 
-/// Check if JTI exists (replay) and store it atomically.
-/// Returns `true` if new, `false` if replay.
+/// Witness that a DPoP JTI (RFC 9449 §11.1) was atomically committed by
+/// this caller. Construction is private to this module — the only path
+/// to an instance is a successful return from [`check_and_store_dpop_jti`],
+/// whose atomic INSERT on the deterministic PRIMARY KEY guarantees that
+/// at most one concurrent caller's insert commits.
+///
+/// Intentionally not `Clone`. The `#[must_use]` ensures the witness is
+/// bound at the call site; today it is carried into `ValidatedDpopProof`
+/// by `validate_dpop_common` so the structural guarantee flows through
+/// to downstream code that requires a validated proof.
+#[must_use = "the DPoP JTI was atomically committed; bind this witness so \
+              it can be carried into ValidatedDpopProof"]
+#[derive(Debug)]
+pub struct DpopJtiClaim {
+    _private: (),
+}
+
+/// Atomically commit a DPoP JTI to the replay-prevention table.
 ///
 /// Uses a deterministic document ID derived from the JTI so that
-/// concurrent inserts collide on the PRIMARY KEY constraint,
-/// preventing TOCTOU races.
+/// concurrent inserts collide on the PRIMARY KEY constraint, preventing
+/// TOCTOU races across SQLite, Postgres, and DSQL.
+///
+/// On success returns a [`DpopJtiClaim`] witness; on replay returns
+/// [`ClaimError::AlreadyConsumed`]. Oversized or empty JTI is
+/// `ClaimError::InvalidInput` (client error → 401, not a 500 that would
+/// prompt retry).
 pub async fn check_and_store_dpop_jti(
     store: &DocumentStore,
     jti: &str,
     validity_seconds: i64,
-) -> Result<bool> {
+) -> std::result::Result<DpopJtiClaim, ClaimError> {
     if jti.is_empty() {
-        return Err(anyhow::anyhow!("DPoP JTI must not be empty"));
+        return Err(ClaimError::InvalidInput(
+            "DPoP JTI must not be empty".to_string(),
+        ));
     }
     if jti.len() > MAX_JTI_LENGTH {
-        return Err(anyhow::anyhow!(
+        return Err(ClaimError::InvalidInput(format!(
             "DPoP JTI exceeds maximum length ({MAX_JTI_LENGTH})"
-        ));
+        )));
     }
 
     let now = Timestamp::now();
     let expires_at = now
         .checked_add(validity_seconds.seconds())
-        .context("DPoP JTI expiry timestamp overflow")?;
+        .map_err(|e| ClaimError::Database(format!("DPoP JTI expiry overflow: {e}")))?;
 
     let id = deterministic_dpop_jti_id(jti);
     let doc = DpopJtiDoc {
@@ -143,14 +153,9 @@ pub async fn check_and_store_dpop_jti(
     };
 
     match store.insert_with_id(&id, &doc).await {
-        Ok(_) => Ok(true),
-        Err(e) => {
-            if super::pool::is_unique_violation(&e) {
-                Ok(false)
-            } else {
-                Err(e)
-            }
-        }
+        Ok(_) => Ok(DpopJtiClaim { _private: () }),
+        Err(e) if super::pool::is_unique_violation(&e) => Err(ClaimError::AlreadyConsumed),
+        Err(e) => Err(ClaimError::Database(e.to_string())),
     }
 }
 

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -88,6 +88,7 @@ pub use organizations::{
 pub use organizations::create_organization;
 
 // Re-export device auth types and functions
+pub(crate) use device_auth::DeviceCodeClaim;
 pub use device_auth::{
     DeviceAuthRequest, DeviceAuthStatus, OidcState, authorize_device_auth,
     create_device_auth_request, create_oidc_state, delete_expired_device_auth_requests,

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -88,14 +88,14 @@ pub use organizations::{
 pub use organizations::create_organization;
 
 // Re-export device auth types and functions
-pub(crate) use device_auth::DeviceCodeClaim;
 pub use device_auth::{
     DeviceAuthRequest, DeviceAuthStatus, OidcState, authorize_device_auth,
     create_device_auth_request, create_oidc_state, delete_expired_device_auth_requests,
     delete_expired_oidc_states, delete_oidc_state, deny_device_auth, get_device_auth_by_code_hash,
-    get_device_auth_by_user_code, get_oidc_state, try_consume_device_auth,
+    get_device_auth_by_user_code, get_oidc_state, try_consume_device_auth, try_consume_oidc_state,
     update_device_auth_poll_time,
 };
+pub(crate) use device_auth::{DeviceCodeClaim, OidcStateClaim};
 
 // Re-export device auth test helpers (only available in tests)
 #[cfg(test)]
@@ -192,7 +192,11 @@ pub use pending_oauth::{
 };
 
 // Re-export challenge state functions (FIDO2 single-use enforcement)
-pub use challenge_states::{delete_expired_challenge_states, try_mark_challenge_used};
+pub(crate) use challenge_states::ChallengeStateClaim;
+pub use challenge_states::{delete_expired_challenge_states, try_consume_challenge_state};
+
+// Re-export claim error type so handlers can pattern-match on it.
+pub(crate) use claim::ClaimError;
 
 // Re-export authorization code functions (RFC 6749 Section 10.5)
 pub(crate) use authorization_codes::AuthCodeClaim;

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -195,6 +195,7 @@ pub use pending_oauth::{
 pub use challenge_states::{delete_expired_challenge_states, try_mark_challenge_used};
 
 // Re-export authorization code functions (RFC 6749 Section 10.5)
+pub(crate) use authorization_codes::AuthCodeClaim;
 pub use authorization_codes::{
     delete_expired_authorization_codes, get_authorization_code_details,
     get_authorization_code_owner, get_consumed_code_owner, is_authorization_code_consumed,

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -122,9 +122,10 @@ pub use documents::oauth::{
 };
 
 // Re-export OAuth domain types and functions
+pub(crate) use oauth::JwtAssertionJtiClaim;
 pub use oauth::{
-    CreateOAuthClientParams, JwtAssertionJtiClaim, OAuthClient, OAuthClientSecret, OAuthEventType,
-    OAuthUsageStats, UpdateClientRegistrationParams, UpdateOAuthClientParams, create_oauth_client,
+    CreateOAuthClientParams, OAuthClient, OAuthClientSecret, OAuthEventType, OAuthUsageStats,
+    UpdateClientRegistrationParams, UpdateOAuthClientParams, create_oauth_client,
     create_oauth_client_secret, delete_expired_jwt_assertion_jtis, delete_oauth_client,
     delete_old_oauth_usage_events, get_oauth_client_by_client_id, get_oauth_client_by_id,
     get_oauth_client_secret_by_id, get_oauth_client_secrets, get_oauth_clients_for_user,
@@ -175,10 +176,11 @@ pub use github::{
 };
 
 // Re-export PAR types and functions (RFC 9126)
+pub(crate) use par::create_pushed_authorization_request;
 pub use par::{
     CreateParParams, PAR_EXPIRES_IN, ParConsumptionMode, PushedAuthorizationRequest,
-    consume_pushed_authorization_request, create_pushed_authorization_request,
-    delete_expired_pushed_authorization_requests, get_pushed_authorization_request,
+    consume_pushed_authorization_request, delete_expired_pushed_authorization_requests,
+    get_pushed_authorization_request,
 };
 
 // Re-export pending OAuth types and functions (RFC 6749, RFC 9700)

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod audit;
 mod authenticators;
 mod authorization_codes;
 mod challenge_states;
+pub(crate) mod claim;
 mod config;
 mod credentials;
 mod device_auth;
@@ -122,8 +123,8 @@ pub use documents::oauth::{
 
 // Re-export OAuth domain types and functions
 pub use oauth::{
-    CreateOAuthClientParams, OAuthClient, OAuthClientSecret, OAuthEventType, OAuthUsageStats,
-    UpdateClientRegistrationParams, UpdateOAuthClientParams, create_oauth_client,
+    CreateOAuthClientParams, JwtAssertionJtiClaim, OAuthClient, OAuthClientSecret, OAuthEventType,
+    OAuthUsageStats, UpdateClientRegistrationParams, UpdateOAuthClientParams, create_oauth_client,
     create_oauth_client_secret, delete_expired_jwt_assertion_jtis, delete_oauth_client,
     delete_old_oauth_usage_events, get_oauth_client_by_client_id, get_oauth_client_by_id,
     get_oauth_client_secret_by_id, get_oauth_client_secrets, get_oauth_clients_for_user,

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -185,10 +185,10 @@ pub use par::{
 };
 
 // Re-export pending OAuth types and functions (RFC 6749, RFC 9700)
+pub(crate) use pending_oauth::consume_pending_oauth_authorization;
 pub use pending_oauth::{
-    CreatePendingOAuthParams, PendingOAuthAuthorization, consume_pending_oauth_authorization,
-    create_pending_oauth_authorization, delete_expired_pending_oauth_authorizations,
-    get_pending_oauth_authorization,
+    CreatePendingOAuthParams, PendingOAuthAuthorization, create_pending_oauth_authorization,
+    delete_expired_pending_oauth_authorizations, get_pending_oauth_authorization,
 };
 
 // Re-export challenge state functions (FIDO2 single-use enforcement)

--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -871,6 +871,14 @@ pub async fn delete_expired_jwt_assertion_jtis(store: &DocumentStore) -> Result<
 // ============================================================================
 
 /// Validate client credentials (client_id + client_secret).
+///
+/// The presented secret is hashed by the caller (SHA-256, via `hash_token`)
+/// and looked up by hash. There is no application-level `ct_eq` call
+/// because the comparison happens inside the SQL engine on an indexed
+/// column — the timing of "row found" vs "row not found" is not
+/// distinguishable from the HTTP client's perspective, and we never see
+/// the raw stored secret in application code. Do NOT replace this with
+/// a fetch-then-compare pattern; that would reintroduce a timing channel.
 pub async fn validate_oauth_client_credentials(
     store: &DocumentStore,
     client_id: &str,

--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -802,23 +802,44 @@ fn deterministic_jti_id(jti: &str, client_id: &str) -> String {
     hex::encode(ctx.finish().as_ref())
 }
 
+/// Witness that the atomic JTI insert in [`store_jwt_assertion_jti`]
+/// succeeded for a specific `(jti, client_id)` pair.
+///
+/// Construction is private to this module — the only way to obtain a
+/// `JwtAssertionJtiClaim` is to call `store_jwt_assertion_jti` and receive
+/// `Ok(_)`, which means the atomic INSERT serialized this caller as the
+/// first/only one to claim the JTI. Callers that hold this witness can
+/// rely on it as compile-time evidence that the RFC 7523 single-use
+/// requirement was enforced for the corresponding assertion.
+///
+/// Intentionally not `Clone` or `Copy` — the witness represents a one-shot
+/// claim. The `#[must_use]` ensures the value is bound at the call site
+/// even when the caller does not yet thread it into a downstream consumer.
+#[derive(Debug)]
+#[must_use = "the JTI was atomically claimed; bind this witness so future code can require it"]
+pub struct JwtAssertionJtiClaim {
+    _private: (),
+}
+
 /// Store a JWT assertion JTI for replay prevention.
 ///
-/// Returns `true` if the JTI was stored (first use), `false` if it
-/// already exists (replay). Uses a deterministic document ID derived
-/// from (jti, client_id) so that concurrent inserts collide on the
-/// PRIMARY KEY constraint, preventing TOCTOU races regardless of
-/// transaction isolation level or database backend.
+/// On success, returns a [`JwtAssertionJtiClaim`] witness — the atomic
+/// INSERT with the PRIMARY KEY derived from `(jti, client_id)` serialized
+/// this caller as the first to claim the JTI. Concurrent replayers receive
+/// [`ClaimError::AlreadyConsumed`] regardless of transaction isolation
+/// level or database backend.
 pub async fn store_jwt_assertion_jti(
     store: &DocumentStore,
     jti: &str,
     client_id: &str,
     expires_at: Timestamp,
-) -> Result<bool> {
+) -> std::result::Result<JwtAssertionJtiClaim, super::claim::ClaimError> {
+    use super::claim::ClaimError;
+
     if jti.len() > MAX_JTI_LENGTH {
-        return Err(anyhow::anyhow!(
+        return Err(ClaimError::Database(format!(
             "JTI exceeds maximum length ({MAX_JTI_LENGTH})"
-        ));
+        )));
     }
 
     let id = deterministic_jti_id(jti, client_id);
@@ -829,12 +850,12 @@ pub async fn store_jwt_assertion_jti(
     };
 
     match store.insert_with_id(&id, &doc).await {
-        Ok(_) => Ok(true),
+        Ok(_) => Ok(JwtAssertionJtiClaim { _private: () }),
         Err(e) => {
             if super::pool::is_unique_violation(&e) {
-                Ok(false)
+                Err(ClaimError::AlreadyConsumed)
             } else {
-                Err(e)
+                Err(ClaimError::Database(e.to_string()))
             }
         }
     }

--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -837,7 +837,7 @@ pub async fn store_jwt_assertion_jti(
     use super::claim::ClaimError;
 
     if jti.len() > MAX_JTI_LENGTH {
-        return Err(ClaimError::Database(format!(
+        return Err(ClaimError::InvalidInput(format!(
             "JTI exceeds maximum length ({MAX_JTI_LENGTH})"
         )));
     }

--- a/crates/vouch-server/src/db/organizations.rs
+++ b/crates/vouch-server/src/db/organizations.rs
@@ -424,9 +424,7 @@ pub async fn remove_additional_domain(
 ) -> Result<Option<DomainRemovalSummary>> {
     let normalized = normalize_domain(domain)?;
 
-    let mut tx = store.begin().await?;
-
-    let org_doc = tx
+    let org_doc = store
         .get::<OrganizationDoc>(org_id)
         .await?
         .ok_or_else(|| anyhow::anyhow!("organization not found"))?;
@@ -439,10 +437,9 @@ pub async fn remove_additional_domain(
         return Ok(None);
     }
 
-    if !tx.compare_and_update(org_id, version, &data).await? {
+    if !store.compare_and_update(org_id, version, &data).await? {
         bail!("organization was modified concurrently; please retry");
     }
-    tx.commit().await?;
 
     // Revoke sessions for org users whose email's domain matches the removed
     // entry. Done OUTSIDE the org-doc transaction: per-user session deletes
@@ -766,8 +763,7 @@ pub async fn record_recheck_result(
 ) -> Result<RecheckEffect> {
     let normalized = normalize_domain(domain)?;
 
-    let mut tx = store.begin().await?;
-    let Some(org_doc) = tx.get::<OrganizationDoc>(org_id).await? else {
+    let Some(org_doc) = store.get::<OrganizationDoc>(org_id).await? else {
         return Ok(RecheckEffect::NotFound);
     };
     let version = org_doc.version;
@@ -818,7 +814,7 @@ pub async fn record_recheck_result(
         }
     };
 
-    if !tx.compare_and_update(org_id, version, &data).await? {
+    if !store.compare_and_update(org_id, version, &data).await? {
         // Lost a race against another writer (admin re-verify, concurrent
         // cleanup tick, or remove). The DB state reflects the winning
         // writer's change, not ours — so the in-memory `effect` value is
@@ -827,7 +823,6 @@ pub async fn record_recheck_result(
         // any actual flip is fired by whichever writer's update succeeded.
         return Ok(RecheckEffect::StillVerified);
     }
-    tx.commit().await?;
     Ok(effect)
 }
 

--- a/crates/vouch-server/src/db/par.rs
+++ b/crates/vouch-server/src/db/par.rs
@@ -4,6 +4,7 @@
 //! Stores authorization request parameters pushed by authenticated clients
 //! before the browser-based authorization flow begins.
 
+use super::claim::ClaimError;
 use super::document_type::{Document, DocumentType};
 use super::documents::par::PushedAuthorizationRequestDoc;
 use super::store::DocumentStore;
@@ -183,10 +184,34 @@ pub enum ParConsumptionMode {
     SkipExpiry,
 }
 
+/// Witness that a PAR record (RFC 9126) was atomically consumed by this
+/// caller. Construction is private to this module — the only path to an
+/// instance is a successful return from
+/// [`consume_pushed_authorization_request`], whose
+/// optimistic-concurrency `compare_and_update` guarantees that at most one
+/// concurrent caller succeeds. Holding a `ParStateClaim` is compile-time
+/// evidence that this caller's PAR consume "won" the OCC race.
+///
+/// Intentionally not `Clone`. The `#[must_use]` ensures the witness is
+/// bound at the call site; today it is dropped immediately after
+/// consumption (the immediate consumer issues an auth code rather than a
+/// token), but the type exists so future code can require it as a
+/// precondition for PAR-derived downstream operations.
+#[must_use = "the PAR record was atomically consumed; bind this witness so \
+              future code can require it as a precondition"]
+#[derive(Debug)]
+pub struct ParStateClaim {
+    _private: (),
+}
+
 /// Consume a pushed authorization request (single-use).
 ///
-/// Returns `Ok(true)` if successfully consumed, `Ok(false)` if not
-/// found, already consumed, or bound to a different client.
+/// On success returns a [`ParStateClaim`] witness — proof that this caller
+/// won the optimistic-concurrency consume. On any "lost" case (PAR not
+/// found, client_id mismatch, already consumed, or expired when expiry is
+/// enforced) returns [`ClaimError::AlreadyConsumed`]. These cases are
+/// deliberately indistinguishable from the caller's perspective: each is
+/// rejected as an invalid request_uri.
 ///
 /// # Client Binding
 ///
@@ -198,31 +223,41 @@ pub async fn consume_pushed_authorization_request(
     request_uri: &str,
     client_id: &str,
     mode: ParConsumptionMode,
-) -> Result<bool> {
+) -> std::result::Result<ParStateClaim, ClaimError> {
     let now = Timestamp::now();
 
     let doc = store
         .find_one::<PushedAuthorizationRequestDoc>("request_uri", request_uri)
-        .await?;
+        .await
+        .map_err(|e| ClaimError::Database(e.to_string()))?;
 
     let Some(doc) = doc else {
-        return Ok(false);
+        return Err(ClaimError::AlreadyConsumed);
     };
 
     if doc.data.client_id != client_id || doc.data.consumed_at.is_some() {
-        return Ok(false);
+        return Err(ClaimError::AlreadyConsumed);
     }
 
     if mode == ParConsumptionMode::EnforceExpiry && doc.data.expires_at <= now {
-        return Ok(false);
+        return Err(ClaimError::AlreadyConsumed);
     }
 
-    // Consume with optimistic concurrency — if another request already
-    // consumed this PAR between our read and write, compare_and_update
-    // returns false (version mismatch).
+    // Atomic consume via optimistic concurrency. If a concurrent caller
+    // already consumed this PAR between our read and write,
+    // compare_and_update returns false (version mismatch) — that caller
+    // wins the race and we report AlreadyConsumed.
     let mut data = doc.data;
     data.consumed_at = Some(now);
-    store.compare_and_update(&doc.id, doc.version, &data).await
+    let won = store
+        .compare_and_update(&doc.id, doc.version, &data)
+        .await
+        .map_err(|e| ClaimError::Database(e.to_string()))?;
+    if won {
+        Ok(ParStateClaim { _private: () })
+    } else {
+        Err(ClaimError::AlreadyConsumed)
+    }
 }
 
 /// Look up a pushed authorization request without consuming it.

--- a/crates/vouch-server/src/db/par.rs
+++ b/crates/vouch-server/src/db/par.rs
@@ -126,10 +126,20 @@ fn generate_request_uri() -> Result<String> {
 ///
 /// Returns `(id, request_uri)` for the created record.
 /// The PAR expires after [`PAR_EXPIRES_IN`] seconds.
-pub async fn create_pushed_authorization_request(
+///
+/// The `proof` parameter is a compile-time witness that the caller has
+/// consumed the relevant single-use client-authentication primitive
+/// (typically a JWT assertion JTI) before persisting the PAR record.
+/// It is dropped immediately on entry — its only purpose is to make this
+/// PAR storage chokepoint unforgeable from outside the crate.
+pub(crate) async fn create_pushed_authorization_request(
     store: &DocumentStore,
     params: CreateParParams<'_>,
+    proof: crate::services::auth::ParCreationProof,
 ) -> Result<(String, String)> {
+    let crate::services::auth::ParCreationProof { client_auth } = proof;
+    tracing::debug!(?client_auth, "PAR creation proof consumed");
+
     let request_uri = generate_request_uri()?;
     let now = Timestamp::now();
     let expires_at = now

--- a/crates/vouch-server/src/db/pending_oauth.rs
+++ b/crates/vouch-server/src/db/pending_oauth.rs
@@ -7,7 +7,6 @@ use super::documents::pending_oauth::PendingOAuthAuthDoc;
 use super::store::DocumentStore;
 use anyhow::Result;
 use jiff::{Span, Timestamp};
-use std::ops::Deref;
 
 /// Pending OAuth authorization record.
 #[derive(Debug)]
@@ -150,33 +149,18 @@ pub async fn get_pending_oauth_authorization(
 /// Construction is private to this module — the only path to an instance
 /// is a successful return from [`consume_pending_oauth_authorization`],
 /// which uses optimistic-concurrency `compare_and_update` to ensure at
-/// most one concurrent caller succeeds. The carried
-/// [`PendingOAuthAuthorization`] is the consumed record's data, exposed
-/// via [`Deref`] so call sites can read fields naturally.
+/// most one concurrent caller succeeds.
 ///
 /// Intentionally not `Clone`. The `#[must_use]` ensures the witness is
-/// bound at the call site.
+/// bound at the call site. Same shape as the other consume-once
+/// witnesses (`AuthCodeClaim`, `ParStateClaim`, `OidcStateClaim`, etc.) —
+/// the consumed record's data is returned alongside the witness rather
+/// than carried inside it, matching the codebase convention.
 #[must_use = "the pending OAuth authorization was atomically consumed; bind \
-              this witness so the data can be read and downstream code can \
-              require it as a precondition"]
+              this witness so downstream code can require it as a precondition"]
 #[derive(Debug)]
-pub struct PendingOauthClaim {
-    auth: PendingOAuthAuthorization,
+pub(crate) struct PendingOauthClaim {
     _private: (),
-}
-
-impl Deref for PendingOauthClaim {
-    type Target = PendingOAuthAuthorization;
-    fn deref(&self) -> &Self::Target {
-        &self.auth
-    }
-}
-
-impl PendingOauthClaim {
-    /// Consume the witness and return the underlying authorization record.
-    pub fn into_inner(self) -> PendingOAuthAuthorization {
-        self.auth
-    }
 }
 
 /// Atomically consume a pending OAuth authorization (single-use).
@@ -191,10 +175,10 @@ impl PendingOauthClaim {
 /// All "lost" cases (not found, expired, already consumed, concurrent
 /// consumer won) map to [`ClaimError::AlreadyConsumed`] — deliberately
 /// indistinguishable, each rejected as an invalid `pending_auth`.
-pub async fn consume_pending_oauth_authorization(
+pub(crate) async fn consume_pending_oauth_authorization(
     store: &DocumentStore,
     id: &str,
-) -> std::result::Result<PendingOauthClaim, ClaimError> {
+) -> std::result::Result<(PendingOAuthAuthorization, PendingOauthClaim), ClaimError> {
     let now = Timestamp::now();
 
     let mut tx = store
@@ -214,6 +198,7 @@ pub async fn consume_pending_oauth_authorization(
         return Err(ClaimError::AlreadyConsumed);
     }
 
+    let created_at = doc.created_at;
     let version = doc.version;
     let mut data = doc.data;
     data.consumed_at = Some(now);
@@ -224,22 +209,37 @@ pub async fn consume_pending_oauth_authorization(
     if !won {
         return Err(ClaimError::AlreadyConsumed);
     }
-
-    let updated = tx
-        .get::<PendingOAuthAuthDoc>(id)
-        .await
-        .map_err(|e| ClaimError::Database(e.to_string()))?
-        .ok_or_else(|| {
-            ClaimError::Database("consumed record disappeared after update".to_string())
-        })?;
     tx.commit()
         .await
         .map_err(|e| ClaimError::Database(e.to_string()))?;
 
-    Ok(PendingOauthClaim {
-        auth: PendingOAuthAuthorization::from(updated),
-        _private: (),
-    })
+    // Build the result from the in-memory mutated `data` rather than
+    // re-reading. The fields we care about are either already in `data`
+    // (mutated copy of the row we read) or are the document metadata
+    // (`id`, `created_at`) captured from the first read.
+    let auth = PendingOAuthAuthorization {
+        id: id.to_string(),
+        client_id: data.client_id,
+        redirect_uri: data.redirect_uri,
+        response_type: data.response_type,
+        state: data.state,
+        scope: data.scope,
+        nonce: data.nonce,
+        code_challenge: data.code_challenge,
+        code_challenge_method: data.code_challenge_method,
+        created_at,
+        expires_at: data.expires_at,
+        consumed_at: data.consumed_at,
+        resource: data.resource,
+        acr_values: data.acr_values,
+        max_age: data.max_age,
+        prompt: data.prompt,
+        dpop_jkt: data.dpop_jkt,
+        authorization_details: data.authorization_details,
+        response_mode: data.response_mode,
+        par_request_uri: data.par_request_uri,
+    };
+    Ok((auth, PendingOauthClaim { _private: () }))
 }
 
 /// Delete expired pending OAuth authorizations.

--- a/crates/vouch-server/src/db/pending_oauth.rs
+++ b/crates/vouch-server/src/db/pending_oauth.rs
@@ -181,12 +181,7 @@ pub(crate) async fn consume_pending_oauth_authorization(
 ) -> std::result::Result<(PendingOAuthAuthorization, PendingOauthClaim), ClaimError> {
     let now = Timestamp::now();
 
-    let mut tx = store
-        .begin()
-        .await
-        .map_err(|e| ClaimError::Database(e.to_string()))?;
-
-    let doc = tx
+    let doc = store
         .get::<PendingOAuthAuthDoc>(id)
         .await
         .map_err(|e| ClaimError::Database(e.to_string()))?;
@@ -202,16 +197,13 @@ pub(crate) async fn consume_pending_oauth_authorization(
     let version = doc.version;
     let mut data = doc.data;
     data.consumed_at = Some(now);
-    let won = tx
+    let won = store
         .compare_and_update(id, version, &data)
         .await
         .map_err(|e| ClaimError::Database(e.to_string()))?;
     if !won {
         return Err(ClaimError::AlreadyConsumed);
     }
-    tx.commit()
-        .await
-        .map_err(|e| ClaimError::Database(e.to_string()))?;
 
     // Build the result from the in-memory mutated `data` rather than
     // re-reading. The fields we care about are either already in `data`

--- a/crates/vouch-server/src/db/pending_oauth.rs
+++ b/crates/vouch-server/src/db/pending_oauth.rs
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Pending OAuth authorization database operations.
 
+use super::claim::ClaimError;
 use super::document_type::{Document, DocumentType};
 use super::documents::pending_oauth::PendingOAuthAuthDoc;
 use super::store::DocumentStore;
 use anyhow::Result;
 use jiff::{Span, Timestamp};
+use std::ops::Deref;
 
 /// Pending OAuth authorization record.
 #[derive(Debug)]
@@ -143,40 +145,101 @@ pub async fn get_pending_oauth_authorization(
     }
 }
 
-/// Consume a pending OAuth authorization (single-use).
+/// Witness that a pending OAuth authorization was atomically consumed.
 ///
-/// The read and mark-as-consumed execute within a single transaction
-/// to prevent a double-spend race between concurrent requests.
+/// Construction is private to this module — the only path to an instance
+/// is a successful return from [`consume_pending_oauth_authorization`],
+/// which uses optimistic-concurrency `compare_and_update` to ensure at
+/// most one concurrent caller succeeds. The carried
+/// [`PendingOAuthAuthorization`] is the consumed record's data, exposed
+/// via [`Deref`] so call sites can read fields naturally.
 ///
-/// Returns None if not found, expired, or already consumed.
+/// Intentionally not `Clone`. The `#[must_use]` ensures the witness is
+/// bound at the call site.
+#[must_use = "the pending OAuth authorization was atomically consumed; bind \
+              this witness so the data can be read and downstream code can \
+              require it as a precondition"]
+#[derive(Debug)]
+pub struct PendingOauthClaim {
+    auth: PendingOAuthAuthorization,
+    _private: (),
+}
+
+impl Deref for PendingOauthClaim {
+    type Target = PendingOAuthAuthorization;
+    fn deref(&self) -> &Self::Target {
+        &self.auth
+    }
+}
+
+impl PendingOauthClaim {
+    /// Consume the witness and return the underlying authorization record.
+    pub fn into_inner(self) -> PendingOAuthAuthorization {
+        self.auth
+    }
+}
+
+/// Atomically consume a pending OAuth authorization (single-use).
+///
+/// Runs `get` + `compare_and_update` + `get` inside a single transaction
+/// (same as the prior implementation, one round-trip). The
+/// `compare_and_update` version check ensures at most one concurrent
+/// caller wins the write, preventing a double-consume race regardless of
+/// DB isolation level (the prior `tx.update` had no version predicate, so
+/// two concurrent READ-COMMITTED transactions could both lost-update).
+///
+/// All "lost" cases (not found, expired, already consumed, concurrent
+/// consumer won) map to [`ClaimError::AlreadyConsumed`] — deliberately
+/// indistinguishable, each rejected as an invalid `pending_auth`.
 pub async fn consume_pending_oauth_authorization(
     store: &DocumentStore,
     id: &str,
-) -> Result<Option<PendingOAuthAuthorization>> {
+) -> std::result::Result<PendingOauthClaim, ClaimError> {
     let now = Timestamp::now();
 
-    let mut tx = store.begin().await?;
+    let mut tx = store
+        .begin()
+        .await
+        .map_err(|e| ClaimError::Database(e.to_string()))?;
 
-    let doc = tx.get::<PendingOAuthAuthDoc>(id).await?;
+    let doc = tx
+        .get::<PendingOAuthAuthDoc>(id)
+        .await
+        .map_err(|e| ClaimError::Database(e.to_string()))?;
     let Some(doc) = doc else {
-        return Ok(None);
+        return Err(ClaimError::AlreadyConsumed);
     };
 
-    // Check conditions
     if doc.data.consumed_at.is_some() || doc.data.expires_at <= now {
-        return Ok(None);
+        return Err(ClaimError::AlreadyConsumed);
     }
 
-    // Mark as consumed
+    let version = doc.version;
     let mut data = doc.data;
     data.consumed_at = Some(now);
-    tx.update(id, &data).await?;
+    let won = tx
+        .compare_and_update(id, version, &data)
+        .await
+        .map_err(|e| ClaimError::Database(e.to_string()))?;
+    if !won {
+        return Err(ClaimError::AlreadyConsumed);
+    }
 
-    // Snapshot the consumed record before committing
-    let updated = tx.get::<PendingOAuthAuthDoc>(id).await?;
-    tx.commit().await?;
+    let updated = tx
+        .get::<PendingOAuthAuthDoc>(id)
+        .await
+        .map_err(|e| ClaimError::Database(e.to_string()))?
+        .ok_or_else(|| {
+            ClaimError::Database("consumed record disappeared after update".to_string())
+        })?;
+    tx.commit()
+        .await
+        .map_err(|e| ClaimError::Database(e.to_string()))?;
 
-    Ok(updated.map(PendingOAuthAuthorization::from))
+    Ok(PendingOauthClaim {
+        auth: PendingOAuthAuthorization::from(updated),
+        _private: (),
+    })
 }
 
 /// Delete expired pending OAuth authorizations.

--- a/crates/vouch-server/src/db/store.rs
+++ b/crates/vouch-server/src/db/store.rs
@@ -875,6 +875,21 @@ impl DocumentStore {
         })
     }
 
+    /// Atomically delete a document by ID if it exists and is not expired.
+    /// See [`StoreTransaction::delete_if_not_expired`] for semantics.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database operation fails.
+    pub async fn delete_if_not_expired(&self, id: &str, now: &Timestamp) -> Result<bool> {
+        crate::with_dsql_retry!(async {
+            let mut tx = self.begin().await?;
+            let won = tx.delete_if_not_expired(id, now).await?;
+            tx.commit().await?;
+            Ok(won)
+        })
+    }
+
     /// Delete all documents matching an index entry.
     ///
     /// Returns the number of documents deleted.
@@ -1446,6 +1461,51 @@ impl StoreTransaction<'_> {
         crate::tx_execute!(self.tx, delete_doc_stmt)?;
 
         Ok(())
+    }
+
+    /// Atomically delete a document by ID if it exists and is not expired.
+    ///
+    /// Used by consume-once primitives (DPoP nonces, PAR records, challenge
+    /// states, etc.) to claim a single-use record without a find-then-delete
+    /// TOCTOU window. The whole "is it present and unexpired" check happens
+    /// in a single SQL DELETE statement; the returned row count is the
+    /// atomic claim witness.
+    ///
+    /// Returns `true` when exactly one document row was deleted (the caller
+    /// "won" the consume). `false` covers all losing cases: the document
+    /// never existed, it has no expiry, it has already expired, or another
+    /// concurrent caller claimed it first. From a security standpoint these
+    /// are indistinguishable — every loss is rejected the same way.
+    ///
+    /// Index entries for the document are also deleted (best-effort cleanup),
+    /// regardless of whether the document delete won. Orphan index entries
+    /// from a prior partial delete would be cleaned up by this call.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database operation fails.
+    pub async fn delete_if_not_expired(&mut self, id: &str, now: &Timestamp) -> Result<bool> {
+        let delete_doc_stmt = Query::delete()
+            .from_table(Documents::Table)
+            .and_where(Expr::col(Documents::Id).eq(id))
+            .and_where(Expr::col(Documents::ExpiresAt).is_not_null())
+            .and_where(Expr::col(Documents::ExpiresAt).gt(now.to_string()))
+            .to_owned();
+        let result = crate::tx_execute!(self.tx, delete_doc_stmt)?;
+        let won = result.rows_affected() == 1;
+
+        // Best-effort: clear any index entries associated with this id.
+        // Safe to run unconditionally — if the doc delete didn't win, there
+        // are typically no index entries to remove either.
+        if won {
+            let delete_idx_stmt = Query::delete()
+                .from_table(DocumentIndexes::Table)
+                .and_where(Expr::col(DocumentIndexes::DocumentId).eq(id))
+                .to_owned();
+            crate::tx_execute!(self.tx, delete_idx_stmt)?;
+        }
+
+        Ok(won)
     }
 
     /// Delete all documents matching an index entry within this transaction.

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -3129,3 +3129,322 @@ async fn test_jwks_refresh_does_not_modify_oauth_client_doc() {
         "upsert_jwks_cache must not change parent updated_at"
     );
 }
+
+// ========================================================================
+// OIDC state — atomic consume + concurrent-replay regression coverage
+// (slice 7b)
+// ========================================================================
+
+/// Seed a fresh OIDC state row tied to a fresh device-auth row.
+async fn seed_oidc_state(
+    store: &DocumentStore,
+    state_value: &str,
+    expires_at: jiff::Timestamp,
+) -> String {
+    let device_auth_id = create_device_auth_request(
+        store,
+        &format!("device_hash_for_{state_value}"),
+        &format!("UC-{state_value}"),
+        None,
+        expires_at,
+        5,
+    )
+    .await
+    .expect("create_device_auth_request");
+
+    create_oidc_state(
+        store,
+        state_value,
+        &device_auth_id,
+        "nonce-value",
+        "",
+        expires_at,
+        "",
+    )
+    .await
+    .expect("create_oidc_state");
+
+    device_auth_id
+}
+
+#[tokio::test]
+async fn test_oidc_state_consume_happy_path() {
+    let (store, _audit) = test_db().await;
+    let expires_at: jiff::Timestamp = "2099-12-31T23:59:59Z".parse().unwrap();
+    let device_auth_id = seed_oidc_state(&store, "happy-state", expires_at).await;
+
+    let (data, _claim) = try_consume_oidc_state(&store, "happy-state")
+        .await
+        .expect("first consume must succeed");
+
+    assert_eq!(data.state, "happy-state");
+    assert_eq!(data.device_auth_id, device_auth_id);
+    assert_eq!(data.nonce, "nonce-value");
+}
+
+#[tokio::test]
+async fn test_oidc_state_consume_replay_rejected() {
+    use crate::db::claim::ClaimError;
+    let (store, _audit) = test_db().await;
+    let expires_at: jiff::Timestamp = "2099-12-31T23:59:59Z".parse().unwrap();
+    seed_oidc_state(&store, "replay-state", expires_at).await;
+
+    let _first = try_consume_oidc_state(&store, "replay-state")
+        .await
+        .expect("first consume must succeed");
+
+    let replayed = try_consume_oidc_state(&store, "replay-state").await;
+    assert!(
+        matches!(replayed, Err(ClaimError::AlreadyConsumed)),
+        "second consume must be rejected as AlreadyConsumed, got: {replayed:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_oidc_state_consume_expired_rejected() {
+    use crate::db::claim::ClaimError;
+    let (store, _audit) = test_db().await;
+    // Past expiry.
+    let expires_at: jiff::Timestamp = "2000-01-01T00:00:00Z".parse().unwrap();
+    seed_oidc_state(&store, "expired-state", expires_at).await;
+
+    let result = try_consume_oidc_state(&store, "expired-state").await;
+    assert!(
+        matches!(result, Err(ClaimError::AlreadyConsumed)),
+        "expired state must be reported as AlreadyConsumed (indistinguishable \
+         from replay so the caller cannot probe state existence): got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_oidc_state_consume_not_found_rejected() {
+    use crate::db::claim::ClaimError;
+    let (store, _audit) = test_db().await;
+
+    let result = try_consume_oidc_state(&store, "never-existed").await;
+    assert!(
+        matches!(result, Err(ClaimError::AlreadyConsumed)),
+        "missing state must be reported as AlreadyConsumed: got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_oidc_state_consume_concurrent() {
+    use crate::db::claim::ClaimError;
+    let (store, _audit) = test_db().await;
+    let expires_at: jiff::Timestamp = "2099-12-31T23:59:59Z".parse().unwrap();
+    seed_oidc_state(&store, "race-state", expires_at).await;
+
+    let store_a = store.clone();
+    let store_b = store.clone();
+    let (result_a, result_b) = tokio::join!(
+        try_consume_oidc_state(&store_a, "race-state"),
+        try_consume_oidc_state(&store_b, "race-state"),
+    );
+
+    let a_won = result_a.is_ok();
+    let b_won = result_b.is_ok();
+    assert!(
+        a_won ^ b_won,
+        "exactly one concurrent consume must win, got a={a_won}, b={b_won}"
+    );
+    for r in [result_a, result_b] {
+        if let Err(e) = r {
+            assert!(
+                matches!(e, ClaimError::AlreadyConsumed),
+                "loser must be AlreadyConsumed (not Database), got: {e:?}"
+            );
+        }
+    }
+}
+
+// ========================================================================
+// Concurrent-replay regression coverage for the older single-use
+// primitives. Mirrors the slice 7a pattern (`tokio::join` two consume
+// calls, assert exactly one wins + loser is AlreadyConsumed). SQLite-only;
+// the underlying OCC patterns are race-safe by construction on the other
+// backends as well, but these tests guard against accidental regressions
+// in the helper functions themselves.
+// ========================================================================
+
+#[tokio::test]
+async fn test_authorization_code_consume_concurrent() {
+    use crate::db::claim::ClaimError;
+    let (store, _audit) = test_db().await;
+
+    let expires_at: jiff::Timestamp = "2099-12-31T23:59:59Z".parse().unwrap();
+    store_authorization_code(
+        &store,
+        "race-code-hash",
+        "client-race",
+        "user-race",
+        expires_at,
+        None,
+    )
+    .await
+    .expect("seed authorization code");
+
+    let store_a = store.clone();
+    let store_b = store.clone();
+    let (result_a, result_b) = tokio::join!(
+        try_consume_authorization_code(&store_a, "race-code-hash"),
+        try_consume_authorization_code(&store_b, "race-code-hash"),
+    );
+
+    let a_won = result_a.is_ok();
+    let b_won = result_b.is_ok();
+    assert!(
+        a_won ^ b_won,
+        "exactly one auth-code consume must win, got a={a_won}, b={b_won}"
+    );
+    for r in [result_a, result_b] {
+        if let Err(e) = r {
+            assert!(
+                matches!(e, ClaimError::AlreadyConsumed),
+                "loser must be AlreadyConsumed, got: {e:?}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_device_auth_consume_concurrent() {
+    use crate::db::claim::ClaimError;
+    let (store, _audit) = test_db().await;
+
+    let expires_at: jiff::Timestamp = "2099-12-31T23:59:59Z".parse().unwrap();
+    let device_code_hash = "race-device-hash";
+    let id = create_device_auth_request(&store, device_code_hash, "RACE-DC", None, expires_at, 5)
+        .await
+        .expect("create device auth");
+    let (user_id, _) = upsert_user(&store, "race-device@example.com", Some("Test"))
+        .await
+        .expect("upsert user");
+    let auth_id = create_authenticator(
+        &store,
+        &user_id,
+        "race-device@example.com",
+        "Key",
+        b"cred-race-device",
+        &[0u8; 32],
+        None,
+        None,
+        false,
+    )
+    .await
+    .expect("create authenticator");
+    authorize_device_auth(&store, &id, &user_id, "race-device@example.com", &auth_id)
+        .await
+        .expect("authorize");
+
+    let store_a = store.clone();
+    let store_b = store.clone();
+    let (result_a, result_b) = tokio::join!(
+        try_consume_device_auth(&store_a, device_code_hash),
+        try_consume_device_auth(&store_b, device_code_hash),
+    );
+
+    let a_won = result_a.is_ok();
+    let b_won = result_b.is_ok();
+    assert!(
+        a_won ^ b_won,
+        "exactly one device-auth consume must win, got a={a_won}, b={b_won}"
+    );
+    for r in [result_a, result_b] {
+        if let Err(e) = r {
+            assert!(
+                matches!(e, ClaimError::AlreadyConsumed),
+                "loser must be AlreadyConsumed, got: {e:?}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_dpop_nonce_consume_concurrent() {
+    use crate::db::claim::ClaimError;
+    let (store, _audit) = test_db().await;
+
+    // Seed a fresh nonce; the function returns the nonce string.
+    let nonce = generate_dpop_nonce(&store, 300)
+        .await
+        .expect("generate_dpop_nonce");
+
+    let store_a = store.clone();
+    let store_b = store.clone();
+    let nonce_a = nonce.clone();
+    let nonce_b = nonce.clone();
+    let (result_a, result_b) = tokio::join!(
+        async move { validate_and_consume_dpop_nonce(&store_a, &nonce_a).await },
+        async move { validate_and_consume_dpop_nonce(&store_b, &nonce_b).await },
+    );
+
+    let a_won = result_a.is_ok();
+    let b_won = result_b.is_ok();
+    assert!(
+        a_won ^ b_won,
+        "exactly one DPoP-nonce consume must win, got a={a_won}, b={b_won}"
+    );
+    for r in [result_a, result_b] {
+        if let Err(e) = r {
+            assert!(
+                matches!(e, ClaimError::AlreadyConsumed),
+                "loser must be AlreadyConsumed, got: {e:?}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_pending_oauth_consume_concurrent() {
+    use crate::db::claim::ClaimError;
+    let (store, _audit) = test_db().await;
+
+    let id = create_pending_oauth_authorization(
+        &store,
+        CreatePendingOAuthParams {
+            client_id: "race-pending-client",
+            redirect_uri: "https://example.com/cb",
+            response_type: "code",
+            state: None,
+            scope: Some("openid"),
+            nonce: None,
+            code_challenge: None,
+            code_challenge_method: None,
+            resource: None,
+            acr_values: None,
+            max_age: None,
+            prompt: None,
+            dpop_jkt: None,
+            authorization_details: None,
+            response_mode: Default::default(),
+            par_request_uri: None,
+        },
+    )
+    .await
+    .expect("create pending_oauth");
+
+    let store_a = store.clone();
+    let store_b = store.clone();
+    let id_a = id.clone();
+    let id_b = id.clone();
+    let (result_a, result_b) = tokio::join!(
+        async move { consume_pending_oauth_authorization(&store_a, &id_a).await },
+        async move { consume_pending_oauth_authorization(&store_b, &id_b).await },
+    );
+
+    let a_won = result_a.is_ok();
+    let b_won = result_b.is_ok();
+    assert!(
+        a_won ^ b_won,
+        "exactly one pending_oauth consume must win, got a={a_won}, b={b_won}"
+    );
+    for r in [result_a, result_b] {
+        if let Err(e) = r {
+            assert!(
+                matches!(e, ClaimError::AlreadyConsumed),
+                "loser must be AlreadyConsumed, got: {e:?}"
+            );
+        }
+    }
+}

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -2425,34 +2425,32 @@ fn test_oauth_client_secret_is_valid_no_expiry() {
 
 #[tokio::test]
 async fn test_store_jwt_assertion_jti_replay_prevention() {
+    use crate::db::claim::ClaimError;
     let (store, _audit) = test_db().await;
 
     let expires: jiff::Timestamp = "2099-01-01T00:00:00Z".parse().unwrap();
 
-    // First use returns true
-    let stored = store_jwt_assertion_jti(&store, "jti-abc", "client-1", expires)
+    // First use returns the witness
+    let _claim = store_jwt_assertion_jti(&store, "jti-abc", "client-1", expires)
         .await
-        .expect("first store should not error");
-    assert!(stored, "First use of a JTI should be accepted");
+        .expect("First use of a JTI should be accepted");
 
-    // Replay with same jti + client_id returns false
-    let replayed = store_jwt_assertion_jti(&store, "jti-abc", "client-1", expires)
-        .await
-        .expect("replay check should not error");
-    assert!(!replayed, "Replay of same JTI+client_id should be rejected");
+    // Replay with same jti + client_id returns AlreadyConsumed
+    let replayed = store_jwt_assertion_jti(&store, "jti-abc", "client-1", expires).await;
+    assert!(
+        matches!(replayed, Err(ClaimError::AlreadyConsumed)),
+        "Replay of same JTI+client_id should be rejected: got {replayed:?}"
+    );
 
     // Same JTI from a different client_id is allowed
-    let different_client = store_jwt_assertion_jti(&store, "jti-abc", "client-2", expires)
+    let _different_client = store_jwt_assertion_jti(&store, "jti-abc", "client-2", expires)
         .await
-        .expect("different client should not error");
-    assert!(
-        different_client,
-        "Same JTI from a different client should be accepted"
-    );
+        .expect("Same JTI from a different client should be accepted");
 }
 
 #[tokio::test]
 async fn test_store_jwt_assertion_jti_too_long() {
+    use crate::db::claim::ClaimError;
     let (store, _audit) = test_db().await;
 
     // JTI longer than MAX_JTI_LENGTH (256) must be rejected immediately
@@ -2465,26 +2463,26 @@ async fn test_store_jwt_assertion_jti_too_long() {
     )
     .await;
     assert!(
-        result.is_err(),
-        "JTI exceeding max length must return an error"
+        matches!(result, Err(ClaimError::Database(_))),
+        "JTI exceeding max length must return a Database error: got {result:?}"
     );
 }
 
 #[tokio::test]
 async fn test_store_jwt_assertion_jti_at_max_length() {
+    use crate::db::claim::ClaimError;
     let (store, _audit) = test_db().await;
 
     // Exactly MAX_JTI_LENGTH (256) must be accepted
     let max_jti = "j".repeat(256);
-    let stored = store_jwt_assertion_jti(
+    let _claim = store_jwt_assertion_jti(
         &store,
         &max_jti,
         "client-1",
         "2099-01-01T00:00:00Z".parse().unwrap(),
     )
     .await
-    .expect("256-char JTI should not error");
-    assert!(stored, "JTI at max length should be accepted");
+    .expect("JTI at max length should be accepted");
 
     // Replay still detected
     let replayed = store_jwt_assertion_jti(
@@ -2493,58 +2491,53 @@ async fn test_store_jwt_assertion_jti_at_max_length() {
         "client-1",
         "2099-01-01T00:00:00Z".parse().unwrap(),
     )
-    .await
-    .expect("replay check should not error");
-    assert!(!replayed, "Replay of max-length JTI should be rejected");
+    .await;
+    assert!(
+        matches!(replayed, Err(ClaimError::AlreadyConsumed)),
+        "Replay of max-length JTI should be rejected: got {replayed:?}"
+    );
 }
 
 #[tokio::test]
 async fn test_store_jwt_assertion_jti_client_isolation() {
+    use crate::db::claim::ClaimError;
     let (store, _audit) = test_db().await;
 
     let expires: jiff::Timestamp = "2099-01-01T00:00:00Z".parse().unwrap();
 
     // Three independent (jti, client_id) pairs must all succeed
-    let a = store_jwt_assertion_jti(&store, "jti-xyz", "client-A", expires)
+    let _a = store_jwt_assertion_jti(&store, "jti-xyz", "client-A", expires)
         .await
-        .expect("pair A should not error");
-    let b = store_jwt_assertion_jti(&store, "jti-xyz", "client-B", expires)
+        .expect("First pair should be accepted");
+    let _b = store_jwt_assertion_jti(&store, "jti-xyz", "client-B", expires)
         .await
-        .expect("pair B should not error");
-    let c = store_jwt_assertion_jti(&store, "jti-pqr", "client-A", expires)
+        .expect("Same JTI, different client should be accepted");
+    let _c = store_jwt_assertion_jti(&store, "jti-pqr", "client-A", expires)
         .await
-        .expect("pair C should not error");
-    assert!(a, "First pair should be accepted");
-    assert!(b, "Same JTI, different client should be accepted");
-    assert!(c, "Different JTI, same client should be accepted");
+        .expect("Different JTI, same client should be accepted");
 
-    // Each pair replays to false independently
-    let a2 = store_jwt_assertion_jti(&store, "jti-xyz", "client-A", expires)
-        .await
-        .expect("replay A");
-    let b2 = store_jwt_assertion_jti(&store, "jti-xyz", "client-B", expires)
-        .await
-        .expect("replay B");
-    let c2 = store_jwt_assertion_jti(&store, "jti-pqr", "client-A", expires)
-        .await
-        .expect("replay C");
-    assert!(!a2, "Replay of pair A should be rejected");
-    assert!(!b2, "Replay of pair B should be rejected");
-    assert!(!c2, "Replay of pair C should be rejected");
+    // Each pair replays to AlreadyConsumed independently
+    let a2 = store_jwt_assertion_jti(&store, "jti-xyz", "client-A", expires).await;
+    let b2 = store_jwt_assertion_jti(&store, "jti-xyz", "client-B", expires).await;
+    let c2 = store_jwt_assertion_jti(&store, "jti-pqr", "client-A", expires).await;
+    assert!(matches!(a2, Err(ClaimError::AlreadyConsumed)));
+    assert!(matches!(b2, Err(ClaimError::AlreadyConsumed)));
+    assert!(matches!(c2, Err(ClaimError::AlreadyConsumed)));
 }
 
 #[tokio::test]
 async fn test_delete_expired_jwt_assertion_jtis() {
+    use crate::db::claim::ClaimError;
     let (store, _audit) = test_db().await;
 
     let past_expires: jiff::Timestamp = "2020-01-01T00:00:00Z".parse().unwrap();
     let future_expires: jiff::Timestamp = "2099-01-01T00:00:00Z".parse().unwrap();
 
     // Insert one expired and one valid JTI
-    store_jwt_assertion_jti(&store, "expired-jti", "c1", past_expires)
+    let _expired_claim = store_jwt_assertion_jti(&store, "expired-jti", "c1", past_expires)
         .await
         .expect("insert expired");
-    store_jwt_assertion_jti(&store, "valid-jti", "c1", future_expires)
+    let _valid_claim = store_jwt_assertion_jti(&store, "valid-jti", "c1", future_expires)
         .await
         .expect("insert valid");
 
@@ -2553,20 +2546,17 @@ async fn test_delete_expired_jwt_assertion_jtis() {
         .expect("delete_expired should not error");
     assert!(deleted >= 1, "Should delete at least the expired JTI");
 
-    // The valid one is still usable (replay returns false only if it exists)
-    let still_stored = store_jwt_assertion_jti(&store, "valid-jti", "c1", future_expires)
-        .await
-        .expect("check");
-    assert!(!still_stored, "Valid JTI should still block replay");
+    // The valid one is still in place — replay returns AlreadyConsumed
+    let still_stored = store_jwt_assertion_jti(&store, "valid-jti", "c1", future_expires).await;
+    assert!(
+        matches!(still_stored, Err(ClaimError::AlreadyConsumed)),
+        "Valid JTI should still block replay: got {still_stored:?}"
+    );
 
     // The expired one was deleted and can be reused
-    let reused = store_jwt_assertion_jti(&store, "expired-jti", "c1", future_expires)
+    let _reused = store_jwt_assertion_jti(&store, "expired-jti", "c1", future_expires)
         .await
-        .expect("reuse after expiry cleanup");
-    assert!(
-        reused,
-        "Expired+deleted JTI should be accepted again after cleanup"
-    );
+        .expect("Expired+deleted JTI should be accepted again after cleanup");
 }
 
 // ========================================================================

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -374,11 +374,10 @@ async fn test_try_consume_device_auth_authorized_succeeds() {
         .await
         .expect("authorize");
 
-    // Consume
-    let consumed = try_consume_device_auth(&store, device_code_hash)
+    // Consume — claim binding satisfies #[must_use].
+    let _claim = try_consume_device_auth(&store, device_code_hash)
         .await
-        .expect("consume");
-    assert!(consumed, "First consumption should succeed");
+        .expect("First consumption should succeed");
 
     // Verify status and consumed_at
     let request = get_device_auth_by_code_hash(&store, device_code_hash)
@@ -426,15 +425,15 @@ async fn test_try_consume_device_auth_already_consumed_returns_false() {
         .await
         .expect("authorize");
 
-    let first = try_consume_device_auth(&store, device_code_hash)
+    let _first = try_consume_device_auth(&store, device_code_hash)
         .await
-        .expect("first consume");
-    assert!(first, "First consumption should succeed");
+        .expect("First consumption should succeed");
 
-    let second = try_consume_device_auth(&store, device_code_hash)
-        .await
-        .expect("second consume");
-    assert!(!second, "Second consumption must return false");
+    let second = try_consume_device_auth(&store, device_code_hash).await;
+    assert!(
+        matches!(second, Err(crate::db::claim::ClaimError::AlreadyConsumed)),
+        "Second consumption must fail with AlreadyConsumed, got: {second:?}"
+    );
 }
 
 #[tokio::test]
@@ -454,10 +453,11 @@ async fn test_try_consume_device_auth_pending_returns_false() {
     .expect("create");
 
     // Attempt to consume a Pending request (never authorized)
-    let consumed = try_consume_device_auth(&store, device_code_hash)
-        .await
-        .expect("consume");
-    assert!(!consumed, "Pending device code must not be consumable");
+    let consumed = try_consume_device_auth(&store, device_code_hash).await;
+    assert!(
+        matches!(consumed, Err(crate::db::claim::ClaimError::AlreadyConsumed)),
+        "Pending device code must not be consumable, got: {consumed:?}"
+    );
 }
 
 #[tokio::test]
@@ -492,20 +492,22 @@ async fn test_try_consume_device_auth_expired_returns_false() {
         .await
         .expect("authorize");
 
-    let consumed = try_consume_device_auth(&store, device_code_hash)
-        .await
-        .expect("consume");
-    assert!(!consumed, "Expired device code must not be consumable");
+    let consumed = try_consume_device_auth(&store, device_code_hash).await;
+    assert!(
+        matches!(consumed, Err(crate::db::claim::ClaimError::AlreadyConsumed)),
+        "Expired device code must not be consumable, got: {consumed:?}"
+    );
 }
 
 #[tokio::test]
 async fn test_try_consume_device_auth_not_found_returns_false() {
     let (store, _audit) = test_db().await;
 
-    let consumed = try_consume_device_auth(&store, "nonexistent_hash")
-        .await
-        .expect("consume");
-    assert!(!consumed, "Nonexistent hash must return false");
+    let consumed = try_consume_device_auth(&store, "nonexistent_hash").await;
+    assert!(
+        matches!(consumed, Err(crate::db::claim::ClaimError::AlreadyConsumed)),
+        "Nonexistent hash must fail with AlreadyConsumed, got: {consumed:?}"
+    );
 }
 
 #[tokio::test]
@@ -2463,8 +2465,10 @@ async fn test_store_jwt_assertion_jti_too_long() {
     )
     .await;
     assert!(
-        matches!(result, Err(ClaimError::Database(_))),
-        "JTI exceeding max length must return a Database error: got {result:?}"
+        matches!(result, Err(ClaimError::InvalidInput(_))),
+        "JTI exceeding max length must return InvalidInput (client error, \
+         not Database — a Database error would tell well-behaved clients to \
+         retry the oversized JTI): got {result:?}"
     );
 }
 

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -2877,15 +2877,15 @@ async fn test_challenge_state_mark_used() {
         .checked_add(jiff::SignedDuration::from_secs(300))
         .unwrap();
 
-    // First use should succeed
-    let used = try_mark_challenge_used(&store, state_jwt, expires_at)
+    // First use should succeed and return a witness
+    let _claim = try_consume_challenge_state(&store, state_jwt, expires_at)
         .await
-        .expect("Failed to mark challenge used");
-    assert!(used, "First use should succeed");
+        .expect("First use should succeed");
 }
 
 #[tokio::test]
 async fn test_challenge_state_replay_rejected() {
+    use crate::db::claim::ClaimError;
     let (store, _audit) = test_db().await;
 
     let state_jwt = "test-jwt-replay";
@@ -2894,16 +2894,16 @@ async fn test_challenge_state_replay_rejected() {
         .unwrap();
 
     // First use succeeds
-    let first = try_mark_challenge_used(&store, state_jwt, expires_at)
+    let _first = try_consume_challenge_state(&store, state_jwt, expires_at)
         .await
-        .expect("Failed on first use");
-    assert!(first, "First use should succeed");
+        .expect("First use should succeed");
 
     // Second use must fail (replay)
-    let second = try_mark_challenge_used(&store, state_jwt, expires_at)
-        .await
-        .expect("Failed on second use");
-    assert!(!second, "Second use (replay) should be rejected");
+    let second = try_consume_challenge_state(&store, state_jwt, expires_at).await;
+    assert!(
+        matches!(second, Err(ClaimError::AlreadyConsumed)),
+        "Second use (replay) should be rejected, got: {second:?}"
+    );
 }
 
 #[tokio::test]
@@ -2911,7 +2911,7 @@ async fn test_challenge_state_new_hash_succeeds() {
     let (store, _audit) = test_db().await;
 
     // A never-seen hash should succeed on first use
-    let used = try_mark_challenge_used(
+    let _claim = try_consume_challenge_state(
         &store,
         "never_seen_hash",
         jiff::Timestamp::now()
@@ -2919,14 +2919,14 @@ async fn test_challenge_state_new_hash_succeeds() {
             .unwrap(),
     )
     .await
-    .expect("Failed to mark challenge used");
-    assert!(used, "New challenge hash should succeed");
+    .expect("New challenge hash should succeed");
 }
 
 #[tokio::test]
 async fn test_challenge_state_concurrent_calls_produce_one_row() {
+    use crate::db::claim::ClaimError;
     // Two concurrent calls with the same state_jwt must produce exactly one
-    // document row — deterministic ID ensures they collide on the PRIMARY KEY
+    // winner — deterministic ID ensures they collide on the PRIMARY KEY
     // rather than creating two rows.
     let (store, _audit) = test_db().await;
 
@@ -2938,18 +2938,25 @@ async fn test_challenge_state_concurrent_calls_produce_one_row() {
     let store_a = store.clone();
     let store_b = store.clone();
     let (result_a, result_b) = tokio::join!(
-        try_mark_challenge_used(&store_a, state_jwt, expires_at),
-        try_mark_challenge_used(&store_b, state_jwt, expires_at),
+        try_consume_challenge_state(&store_a, state_jwt, expires_at),
+        try_consume_challenge_state(&store_b, state_jwt, expires_at),
     );
 
-    let a = result_a.expect("first concurrent call must not error");
-    let b = result_b.expect("second concurrent call must not error");
-
-    // Exactly one winner and one loser — the sum of the two booleans is 1.
+    let a_won = result_a.is_ok();
+    let b_won = result_b.is_ok();
     assert!(
-        a ^ b,
-        "exactly one concurrent call should return true (winner), got a={a}, b={b}"
+        a_won ^ b_won,
+        "exactly one concurrent call should win, got a={a_won}, b={b_won}"
     );
+    // The loser must report AlreadyConsumed (not a database error).
+    for r in [result_a, result_b] {
+        if let Err(e) = r {
+            assert!(
+                matches!(e, ClaimError::AlreadyConsumed),
+                "loser must be AlreadyConsumed, got: {e:?}"
+            );
+        }
+    }
 }
 
 #[test]

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -3132,7 +3132,6 @@ async fn test_jwks_refresh_does_not_modify_oauth_client_doc() {
 
 // ========================================================================
 // OIDC state — atomic consume + concurrent-replay regression coverage
-// (slice 7b)
 // ========================================================================
 
 /// Seed a fresh OIDC state row tied to a fresh device-auth row.
@@ -3259,12 +3258,12 @@ async fn test_oidc_state_consume_concurrent() {
 }
 
 // ========================================================================
-// Concurrent-replay regression coverage for the older single-use
-// primitives. Mirrors the slice 7a pattern (`tokio::join` two consume
-// calls, assert exactly one wins + loser is AlreadyConsumed). SQLite-only;
-// the underlying OCC patterns are race-safe by construction on the other
-// backends as well, but these tests guard against accidental regressions
-// in the helper functions themselves.
+// Concurrent-replay regression coverage for single-use primitives:
+// `tokio::join` two consume calls, assert exactly one wins and the loser
+// is AlreadyConsumed. SQLite-only; the underlying OCC patterns are
+// race-safe by construction on the other backends as well, but these
+// tests guard against accidental regressions in the helper functions
+// themselves.
 // ========================================================================
 
 #[tokio::test]

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -3498,8 +3498,26 @@ async fn test_authorize_device_auth_concurrent() {
     let aid_a = auth_id.clone();
     let aid_b = auth_id.clone();
     let (result_a, result_b) = tokio::join!(
-        async move { authorize_device_auth(&store_a, &id_a, &uid_a, "race-authorize@example.com", &aid_a).await },
-        async move { authorize_device_auth(&store_b, &id_b, &uid_b, "race-authorize@example.com", &aid_b).await },
+        async move {
+            authorize_device_auth(
+                &store_a,
+                &id_a,
+                &uid_a,
+                "race-authorize@example.com",
+                &aid_a,
+            )
+            .await
+        },
+        async move {
+            authorize_device_auth(
+                &store_b,
+                &id_b,
+                &uid_b,
+                "race-authorize@example.com",
+                &aid_b,
+            )
+            .await
+        },
     );
 
     for (label, r) in [("a", &result_a), ("b", &result_b)] {
@@ -3612,8 +3630,8 @@ async fn test_remove_additional_domain_concurrent() {
 #[tokio::test]
 async fn test_record_recheck_result_concurrent() {
     use crate::db::organizations::{
-        add_additional_domain, mark_additional_domain_verified, record_recheck_result,
-        RecheckOutcome,
+        RecheckOutcome, add_additional_domain, mark_additional_domain_verified,
+        record_recheck_result,
     };
 
     let (store, _audit) = test_db().await;
@@ -3642,12 +3660,22 @@ async fn test_record_recheck_result_concurrent() {
     let org_b = org.id.clone();
     let (result_a, result_b) = tokio::join!(
         async move {
-            record_recheck_result(&store_a, &org_a, "extra-recheck.com", RecheckOutcome::Success)
-                .await
+            record_recheck_result(
+                &store_a,
+                &org_a,
+                "extra-recheck.com",
+                RecheckOutcome::Success,
+            )
+            .await
         },
         async move {
-            record_recheck_result(&store_b, &org_b, "extra-recheck.com", RecheckOutcome::Success)
-                .await
+            record_recheck_result(
+                &store_b,
+                &org_b,
+                "extra-recheck.com",
+                RecheckOutcome::Success,
+            )
+            .await
         },
     );
 

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -2569,61 +2569,67 @@ async fn test_delete_expired_jwt_assertion_jtis() {
 
 #[tokio::test]
 async fn test_dpop_jti_replay_prevention() {
+    use crate::db::claim::ClaimError;
     let (store, _audit) = test_db().await;
 
-    // First use returns true
-    let stored = check_and_store_dpop_jti(&store, "dpop-jti-1", 600)
+    // First use returns the witness
+    let _claim = check_and_store_dpop_jti(&store, "dpop-jti-1", 600)
         .await
-        .expect("first store should not error");
-    assert!(stored, "First use of a JTI should be accepted");
+        .expect("First use of a JTI should be accepted");
 
-    // Replay returns false
-    let replayed = check_and_store_dpop_jti(&store, "dpop-jti-1", 600)
-        .await
-        .expect("replay check should not error");
-    assert!(!replayed, "Replay of same JTI should be rejected");
+    // Replay returns AlreadyConsumed
+    let replayed = check_and_store_dpop_jti(&store, "dpop-jti-1", 600).await;
+    assert!(
+        matches!(replayed, Err(ClaimError::AlreadyConsumed)),
+        "Replay of same JTI should be AlreadyConsumed, got: {replayed:?}"
+    );
 
     // Different JTI succeeds
-    let different = check_and_store_dpop_jti(&store, "dpop-jti-2", 600)
+    let _different = check_and_store_dpop_jti(&store, "dpop-jti-2", 600)
         .await
-        .expect("different JTI should not error");
-    assert!(different, "Different JTI should be accepted");
+        .expect("Different JTI should be accepted");
 }
 
 #[tokio::test]
 async fn test_dpop_jti_empty() {
+    use crate::db::claim::ClaimError;
     let (store, _audit) = test_db().await;
 
     let result = check_and_store_dpop_jti(&store, "", 600).await;
-    assert!(result.is_err(), "Empty JTI must return an error");
+    assert!(
+        matches!(result, Err(ClaimError::InvalidInput(_))),
+        "Empty JTI must return InvalidInput, got: {result:?}"
+    );
 }
 
 #[tokio::test]
 async fn test_dpop_jti_too_long() {
+    use crate::db::claim::ClaimError;
     let (store, _audit) = test_db().await;
 
     let long_jti = "x".repeat(257);
     let result = check_and_store_dpop_jti(&store, &long_jti, 600).await;
     assert!(
-        result.is_err(),
-        "JTI exceeding max length must return an error"
+        matches!(result, Err(ClaimError::InvalidInput(_))),
+        "JTI exceeding max length must return InvalidInput, got: {result:?}"
     );
 }
 
 #[tokio::test]
 async fn test_dpop_jti_at_max_length() {
+    use crate::db::claim::ClaimError;
     let (store, _audit) = test_db().await;
 
     let max_jti = "d".repeat(256);
-    let stored = check_and_store_dpop_jti(&store, &max_jti, 600)
+    let _stored = check_and_store_dpop_jti(&store, &max_jti, 600)
         .await
-        .expect("256-char JTI should not error");
-    assert!(stored, "JTI at max length should be accepted");
+        .expect("JTI at max length should be accepted");
 
-    let replayed = check_and_store_dpop_jti(&store, &max_jti, 600)
-        .await
-        .expect("replay check should not error");
-    assert!(!replayed, "Replay of max-length JTI should be rejected");
+    let replayed = check_and_store_dpop_jti(&store, &max_jti, 600).await;
+    assert!(
+        matches!(replayed, Err(ClaimError::AlreadyConsumed)),
+        "Replay of max-length JTI should be AlreadyConsumed, got: {replayed:?}"
+    );
 }
 
 #[tokio::test]
@@ -2644,7 +2650,7 @@ async fn test_dpop_jti_concurrent_insert_rejects_duplicates() {
     let mut successes = 0u32;
     for handle in handles {
         let result = handle.await.expect("task should not panic");
-        if let Ok(true) = result {
+        if result.is_ok() {
             successes += 1;
         }
     }
@@ -2662,7 +2668,7 @@ async fn test_delete_expired_dpop_jtis() {
     // Insert one with past expiry (validity_seconds=0 won't work since
     // it computes from now; instead insert directly with short validity
     // and rely on the fact that we can test cleanup.)
-    check_and_store_dpop_jti(&store, "valid-dpop-jti", 3600)
+    let _valid = check_and_store_dpop_jti(&store, "valid-dpop-jti", 3600)
         .await
         .expect("insert valid");
 
@@ -2673,10 +2679,12 @@ async fn test_delete_expired_dpop_jtis() {
     assert_eq!(deleted, 0, "No expired JTIs to delete");
 
     // The valid one should still block replay
-    let still_blocked = check_and_store_dpop_jti(&store, "valid-dpop-jti", 3600)
-        .await
-        .expect("check");
-    assert!(!still_blocked, "Valid JTI should still block replay");
+    use crate::db::claim::ClaimError;
+    let result = check_and_store_dpop_jti(&store, "valid-dpop-jti", 3600).await;
+    assert!(
+        matches!(result, Err(ClaimError::AlreadyConsumed)),
+        "Valid JTI should still block replay, got: {result:?}"
+    );
 }
 
 // ========================================================================

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -3455,3 +3455,213 @@ async fn test_pending_oauth_consume_concurrent() {
         }
     }
 }
+
+// ============================================================================
+// Concurrent CAS regression tests for state-transition helpers
+// (non-consume helpers that share the same outer-tx + read + compare_and_update
+// pattern — included to empirically confirm whether each site exhibits the
+// SQLite shared-cache deadlock or not).
+// ============================================================================
+
+#[tokio::test]
+async fn test_authorize_device_auth_concurrent() {
+    let (store, _audit) = test_db().await;
+
+    let expires_at: jiff::Timestamp = "2099-12-31T23:59:59Z".parse().unwrap();
+    let device_code_hash = "race-authorize-hash";
+    let id = create_device_auth_request(&store, device_code_hash, "RACE-AUTH", None, expires_at, 5)
+        .await
+        .expect("create device auth");
+    let (user_id, _) = upsert_user(&store, "race-authorize@example.com", Some("Test"))
+        .await
+        .expect("upsert user");
+    let auth_id = create_authenticator(
+        &store,
+        &user_id,
+        "race-authorize@example.com",
+        "Key",
+        b"cred-race-authorize",
+        &[0u8; 32],
+        None,
+        None,
+        false,
+    )
+    .await
+    .expect("create authenticator");
+
+    let store_a = store.clone();
+    let store_b = store.clone();
+    let id_a = id.clone();
+    let id_b = id.clone();
+    let uid_a = user_id.clone();
+    let uid_b = user_id.clone();
+    let aid_a = auth_id.clone();
+    let aid_b = auth_id.clone();
+    let (result_a, result_b) = tokio::join!(
+        async move { authorize_device_auth(&store_a, &id_a, &uid_a, "race-authorize@example.com", &aid_a).await },
+        async move { authorize_device_auth(&store_b, &id_b, &uid_b, "race-authorize@example.com", &aid_b).await },
+    );
+
+    for (label, r) in [("a", &result_a), ("b", &result_b)] {
+        if let Err(e) = r {
+            let msg = format!("{e:#}");
+            assert!(
+                !msg.contains("deadlock"),
+                "task {label} should not fail with a DB deadlock: {msg}"
+            );
+        }
+    }
+    let a_won = result_a.is_ok();
+    let b_won = result_b.is_ok();
+    assert!(
+        a_won ^ b_won,
+        "exactly one authorize must win, got a={a_won}, b={b_won}"
+    );
+}
+
+#[tokio::test]
+async fn test_deny_device_auth_concurrent() {
+    let (store, _audit) = test_db().await;
+
+    let expires_at: jiff::Timestamp = "2099-12-31T23:59:59Z".parse().unwrap();
+    let device_code_hash = "race-deny-hash";
+    let id = create_device_auth_request(&store, device_code_hash, "RACE-DENY", None, expires_at, 5)
+        .await
+        .expect("create device auth");
+
+    let store_a = store.clone();
+    let store_b = store.clone();
+    let id_a = id.clone();
+    let id_b = id.clone();
+    let (result_a, result_b) = tokio::join!(
+        async move { deny_device_auth(&store_a, &id_a).await },
+        async move { deny_device_auth(&store_b, &id_b).await },
+    );
+
+    for (label, r) in [("a", &result_a), ("b", &result_b)] {
+        if let Err(e) = r {
+            let msg = format!("{e:#}");
+            assert!(
+                !msg.contains("deadlock"),
+                "task {label} should not fail with a DB deadlock: {msg}"
+            );
+        }
+    }
+    let a_won = result_a.is_ok();
+    let b_won = result_b.is_ok();
+    assert!(
+        a_won ^ b_won,
+        "exactly one deny must win, got a={a_won}, b={b_won}"
+    );
+}
+
+#[tokio::test]
+async fn test_remove_additional_domain_concurrent() {
+    use crate::db::organizations::{
+        add_additional_domain, mark_additional_domain_verified, remove_additional_domain,
+    };
+
+    let (store, _audit) = test_db().await;
+    let org = create_organization(&store, "race-remove.com", Some("Race Org"), None)
+        .await
+        .expect("create org");
+    let (uid, _) = upsert_user(&store, "race-remove-admin@race-remove.com", Some("Admin"))
+        .await
+        .expect("upsert admin");
+    add_additional_domain(
+        &store,
+        &org.id,
+        "extra-remove.com",
+        &uid,
+        "race-remove-admin@race-remove.com",
+    )
+    .await
+    .expect("add additional domain");
+    mark_additional_domain_verified(&store, &org.id, "extra-remove.com")
+        .await
+        .expect("verify additional domain");
+
+    let store_a = store.clone();
+    let store_b = store.clone();
+    let org_a = org.id.clone();
+    let org_b = org.id.clone();
+    let (result_a, result_b) = tokio::join!(
+        async move { remove_additional_domain(&store_a, &org_a, "extra-remove.com").await },
+        async move { remove_additional_domain(&store_b, &org_b, "extra-remove.com").await },
+    );
+
+    for (label, r) in [("a", &result_a), ("b", &result_b)] {
+        if let Err(e) = r {
+            let msg = format!("{e:#}");
+            assert!(
+                !msg.contains("deadlock"),
+                "task {label} should not fail with a DB deadlock: {msg}"
+            );
+        }
+    }
+    let some_count = [&result_a, &result_b]
+        .iter()
+        .filter(|r| matches!(r, Ok(Some(_))))
+        .count();
+    assert!(
+        some_count == 1,
+        "exactly one remove must return Ok(Some), got a={result_a:?}, b={result_b:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_record_recheck_result_concurrent() {
+    use crate::db::organizations::{
+        add_additional_domain, mark_additional_domain_verified, record_recheck_result,
+        RecheckOutcome,
+    };
+
+    let (store, _audit) = test_db().await;
+    let org = create_organization(&store, "race-recheck.com", Some("Race Org"), None)
+        .await
+        .expect("create org");
+    let (uid, _) = upsert_user(&store, "race-recheck-admin@race-recheck.com", Some("Admin"))
+        .await
+        .expect("upsert admin");
+    add_additional_domain(
+        &store,
+        &org.id,
+        "extra-recheck.com",
+        &uid,
+        "race-recheck-admin@race-recheck.com",
+    )
+    .await
+    .expect("add additional domain");
+    mark_additional_domain_verified(&store, &org.id, "extra-recheck.com")
+        .await
+        .expect("verify additional domain");
+
+    let store_a = store.clone();
+    let store_b = store.clone();
+    let org_a = org.id.clone();
+    let org_b = org.id.clone();
+    let (result_a, result_b) = tokio::join!(
+        async move {
+            record_recheck_result(&store_a, &org_a, "extra-recheck.com", RecheckOutcome::Success)
+                .await
+        },
+        async move {
+            record_recheck_result(&store_b, &org_b, "extra-recheck.com", RecheckOutcome::Success)
+                .await
+        },
+    );
+
+    for (label, r) in [("a", &result_a), ("b", &result_b)] {
+        if let Err(e) = r {
+            let msg = format!("{e:#}");
+            assert!(
+                !msg.contains("deadlock"),
+                "task {label} should not fail with a DB deadlock: {msg}"
+            );
+        }
+    }
+    assert!(
+        result_a.is_ok() && result_b.is_ok(),
+        "both record_recheck_result calls must succeed (CAS loser returns Ok(StillVerified))"
+    );
+}

--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -1006,4 +1006,70 @@ mod tests {
 
         assert!(result.is_err());
     }
+
+    #[tokio::test]
+    async fn test_browser_login_complete_rejects_replayed_state() {
+        // Pre-consume a valid state JWT, then submit `POST
+        // /login/webauthn/complete` with that JWT. The Phase 3b consume
+        // (added in slice 7a) must reject the request with 400 +
+        // `state_already_used` before any base64 decoding, DB lookup, or
+        // WebAuthn verification work happens. This guards against a
+        // regression where the consume call is reordered or removed.
+        let (app, state) = crate::test_utils::test_app().await;
+
+        // Build a valid BrowserAuthenticationState JWT signed by the test
+        // signer, with a far-future expiry.
+        let now = jiff::Timestamp::now();
+        let exp = now.as_second().saturating_add(300);
+        let auth_state = BrowserAuthenticationState {
+            challenge: vec![0u8; 32],
+            rp_id: state.config().rp_id.clone(),
+            created_at: now.as_second(),
+            exp,
+            pending_auth: None,
+        };
+        let state_jwt = auth_state
+            .encode(&state.state_signer)
+            .await
+            .expect("encode auth state");
+
+        // Pre-consume the state JWT to simulate a prior successful login.
+        let expires_at = jiff::Timestamp::from_second(exp).expect("valid exp");
+        let _claim = crate::db::try_consume_challenge_state(&state.store, &state_jwt, expires_at)
+            .await
+            .expect("pre-consume must succeed");
+
+        // POST to `/login/webauthn/complete` with the already-consumed state
+        // and length-bounded dummy fields. The replay check runs in Phase
+        // 3b (after state decode, before base64 decode), so plain
+        // base64url-of-zero-bytes fields are sufficient to reach it.
+        let dummy = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(vec![0u8; 32]);
+        let body = serde_json::json!({
+            "state": state_jwt,
+            "credential_id": dummy,
+            "authenticator_data": dummy,
+            "client_data_json": dummy,
+            "signature": dummy,
+            "user_handle": dummy,
+        })
+        .to_string();
+
+        let (status, resp_body) = crate::test_utils::http_post_json(
+            &app,
+            "/login/webauthn/complete",
+            &body,
+            &[("Origin", state.config().base_url.as_str())],
+        )
+        .await;
+
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "replay must be rejected with 400, got {status}: {resp_body}"
+        );
+        assert!(
+            resp_body.contains("state_already_used"),
+            "expected 'state_already_used' in response body, got: {resp_body}"
+        );
+    }
 }

--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -1011,10 +1011,10 @@ mod tests {
     async fn test_browser_login_complete_rejects_replayed_state() {
         // Pre-consume a valid state JWT, then submit `POST
         // /login/webauthn/complete` with that JWT. The Phase 3b consume
-        // (added in slice 7a) must reject the request with 400 +
-        // `state_already_used` before any base64 decoding, DB lookup, or
-        // WebAuthn verification work happens. This guards against a
-        // regression where the consume call is reordered or removed.
+        // must reject the request with 400 + `state_already_used` before
+        // any base64 decoding, DB lookup, or WebAuthn verification work
+        // happens. This guards against a regression where the consume
+        // call is reordered or removed.
         let (app, state) = crate::test_utils::test_app().await;
 
         // Build a valid BrowserAuthenticationState JWT signed by the test

--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -27,7 +27,10 @@ use crate::handlers::HasVersion;
 use crate::handlers::session::{create_session_cookie, get_auth_context};
 use crate::impl_template_response;
 use crate::redact_email;
-use crate::services::auth::{CreateOAuthTokenParams, create_oauth_access_token};
+use crate::services::auth::{
+    ClientAuthProof, CreateOAuthTokenParams, GrantProof, TokenIssuanceProof,
+    create_oauth_access_token,
+};
 use crate::services::error::ServiceError;
 use crate::services::oidc::ScopeSet;
 use askama::Template;
@@ -655,6 +658,10 @@ pub async fn browser_login_complete(
             hardware_verification: crate::services::auth::HardwareVerification::Verified,
             session_purpose: db::SessionPurpose::OAuthAccessToken,
             authorization_details: None,
+        },
+        TokenIssuanceProof {
+            grant: GrantProof::UnconvertedBrowserLogin,
+            client_auth: ClientAuthProof::None,
         },
     )
     .await

--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -449,6 +449,31 @@ pub async fn browser_login_complete(
         ));
     }
 
+    // ── Phase 3b: Atomic single-use challenge consume ─────────────────────
+    // Mark the authentication state JWT consumed before any side effects.
+    // The returned `WebauthnChallengeClaim` witness is the structural proof
+    // threaded into the TokenIssuanceProof below — the only path to
+    // `GrantProof::BrowserLogin`. Two concurrent requests with the same
+    // state JWT collide on the deterministic PRIMARY KEY; only one wins.
+    let expires_at = Timestamp::from_second(auth_state.exp).unwrap_or_else(|_| Timestamp::now());
+    let challenge_claim =
+        match db::try_consume_challenge_state(&state.store, &req.state, expires_at).await {
+            Ok(claim) => claim,
+            Err(db::ClaimError::AlreadyConsumed) => {
+                return Err(ServiceError::api(
+                    StatusCode::BAD_REQUEST,
+                    "state_already_used",
+                    "Authentication state has already been used",
+                ));
+            }
+            Err(e) => {
+                tracing::error!("Failed to mark browser login state used: {e}");
+                return Err(ServiceError::Internal(
+                    "Failed to mark authentication state used".to_string(),
+                ));
+            }
+        };
+
     // ── Phase 4: Base64url decode all fields ─────────────────────────────
     let credential_id = URL_SAFE_NO_PAD.decode(&req.credential_id).map_err(|_| {
         ServiceError::api(
@@ -660,7 +685,7 @@ pub async fn browser_login_complete(
             authorization_details: None,
         },
         TokenIssuanceProof {
-            grant: GrantProof::UnconvertedBrowserLogin,
+            grant: GrantProof::BrowserLogin(challenge_claim),
             client_auth: ClientAuthProof::None,
         },
     )

--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -686,7 +686,9 @@ pub async fn browser_login_complete(
         },
         TokenIssuanceProof {
             grant: GrantProof::BrowserLogin(challenge_claim),
-            client_auth: ClientAuthProof::None,
+            client_auth: ClientAuthProof::NoAuth(
+                crate::services::auth::NoClientAuth::internal_endpoint(),
+            ),
         },
     )
     .await

--- a/crates/vouch-server/src/handlers/certification.rs
+++ b/crates/vouch-server/src/handlers/certification.rs
@@ -214,8 +214,10 @@ pub async fn deny_login(
     // Consume pending authorization.
     let pending =
         match db::consume_pending_oauth_authorization(&state.store, &query.pending_auth).await {
-            Ok(Some(p)) => p,
-            Ok(None) => return StatusCode::NOT_FOUND.into_response(),
+            Ok(claim) => claim,
+            Err(db::claim::ClaimError::AlreadyConsumed) => {
+                return StatusCode::NOT_FOUND.into_response();
+            }
             Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
         };
 

--- a/crates/vouch-server/src/handlers/certification.rs
+++ b/crates/vouch-server/src/handlers/certification.rs
@@ -24,7 +24,10 @@ use crate::{
     AppState, db,
     handlers::browser_login::hmac_sha256_base64url,
     handlers::session::create_session_cookie,
-    services::auth::{CreateOAuthTokenParams, create_oauth_access_token},
+    services::auth::{
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, TokenIssuanceProof,
+        create_oauth_access_token,
+    },
     services::oidc::ScopeSet,
 };
 
@@ -145,6 +148,10 @@ pub async fn complete_login(
             hardware_verification: crate::services::auth::HardwareVerification::Verified,
             session_purpose: db::SessionPurpose::OAuthAccessToken,
             authorization_details: None,
+        },
+        TokenIssuanceProof {
+            grant: GrantProof::CertificationBypass,
+            client_auth: ClientAuthProof::None,
         },
     )
     .await

--- a/crates/vouch-server/src/handlers/certification.rs
+++ b/crates/vouch-server/src/handlers/certification.rs
@@ -151,7 +151,9 @@ pub async fn complete_login(
         },
         TokenIssuanceProof {
             grant: GrantProof::CertificationBypass,
-            client_auth: ClientAuthProof::None,
+            client_auth: ClientAuthProof::NoAuth(
+                crate::services::auth::NoClientAuth::internal_endpoint(),
+            ),
         },
     )
     .await
@@ -211,10 +213,11 @@ pub async fn deny_login(
         return StatusCode::FORBIDDEN.into_response();
     }
 
-    // Consume pending authorization.
-    let pending =
+    // Consume pending authorization. The `_claim` witness is bound to
+    // satisfy `#[must_use]`; downstream code uses `pending` directly.
+    let (pending, _claim) =
         match db::consume_pending_oauth_authorization(&state.store, &query.pending_auth).await {
-            Ok(claim) => claim,
+            Ok(pair) => pair,
             Err(db::claim::ClaimError::AlreadyConsumed) => {
                 return StatusCode::NOT_FOUND.into_response();
             }

--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -3,7 +3,10 @@
 
 use crate::AppState;
 use crate::db::{self, DeviceAuthStatus};
-use crate::services::auth::{CreateOAuthTokenParams, create_oauth_access_token};
+use crate::services::auth::{
+    ClientAuthProof, CreateOAuthTokenParams, GrantProof, TokenIssuanceProof,
+    create_oauth_access_token,
+};
 use crate::services::oidc::ScopeSet;
 use aws_lc_rs::digest::{self, SHA256};
 use axum::{Json, extract::State, http::StatusCode};
@@ -329,6 +332,10 @@ pub async fn device_token(
                     hardware_verification: crate::services::auth::HardwareVerification::Verified,
                     session_purpose: crate::db::SessionPurpose::OAuthAccessToken,
                     authorization_details: None,
+                },
+                TokenIssuanceProof {
+                    grant: GrantProof::UnconvertedDeviceCode,
+                    client_auth: ClientAuthProof::None,
                 },
             )
             .await

--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -272,23 +272,20 @@ pub async fn device_token(
         }
         DeviceAuthStatus::Authorized => {
             // RFC 8628 Section 3.5: Atomically consume the device
-            // code before issuing a token.
-            let consumed = db::try_consume_device_auth(&state.store, &device_code_hash)
+            // code before issuing a token. The returned claim is the
+            // structural proof that this caller won the consume; it is
+            // threaded into TokenIssuanceProof below.
+            let device_claim = db::try_consume_device_auth(&state.store, &device_code_hash)
                 .await
-                .map_err(|_| {
-                    oauth_error(
+                .map_err(|e| match e {
+                    db::claim::ClaimError::AlreadyConsumed => {
+                        oauth_error(StatusCode::BAD_REQUEST, OAuthError::invalid_grant())
+                    }
+                    _ => oauth_error(
                         StatusCode::INTERNAL_SERVER_ERROR,
                         OAuthError::invalid_grant(),
-                    )
+                    ),
                 })?;
-
-            if !consumed {
-                // Lost the race — another request consumed first.
-                return Err(oauth_error(
-                    StatusCode::BAD_REQUEST,
-                    OAuthError::invalid_grant(),
-                ));
-            }
 
             // Get user info and create OAuth access token
             let user_id = request.user_id.ok_or_else(|| {
@@ -334,7 +331,7 @@ pub async fn device_token(
                     authorization_details: None,
                 },
                 TokenIssuanceProof {
-                    grant: GrantProof::UnconvertedDeviceCode,
+                    grant: GrantProof::DeviceCode(device_claim),
                     client_auth: ClientAuthProof::None,
                 },
             )
@@ -960,10 +957,9 @@ mod tests {
             .await
             .expect("authorize");
 
-        let consumed = crate::db::try_consume_device_auth(&state.store, &device_code_hash)
+        let _claim = crate::db::try_consume_device_auth(&state.store, &device_code_hash)
             .await
-            .expect("consume");
-        assert!(consumed, "Consumption should succeed");
+            .expect("Consumption should succeed");
 
         // Poll — must return invalid_grant
         let body = format!(

--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -332,7 +332,13 @@ pub async fn device_token(
                 },
                 TokenIssuanceProof {
                     grant: GrantProof::DeviceCode(device_claim),
-                    client_auth: ClientAuthProof::None,
+                    // RFC 8628 device authorization grant: the consumed
+                    // `device_code` is itself the client credential at
+                    // this endpoint — see GrantProof::DeviceCode above.
+                    // No separate external client-auth step takes place.
+                    client_auth: ClientAuthProof::NoAuth(
+                        crate::services::auth::NoClientAuth::internal_endpoint(),
+                    ),
                 },
             )
             .await

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -410,38 +410,32 @@ pub async fn oidc_callback(
         .into_response();
     }
 
-    // Verify state
-    let stored_state = match db::get_oidc_state(&state.store, &oidc_state).await {
-        Ok(Some(s)) => s,
-        Ok(None) => {
-            return ErrorTemplate {
-                title: "Error".to_string(),
-                message: "Invalid state".to_string(),
-                back_url: None,
+    // Atomically consume the OIDC state. The returned witness is the
+    // structural proof threaded into TokenIssuanceProof below — the only
+    // path to `GrantProof::EnrollmentBootstrap`. Replaces the prior
+    // get-then-delete pattern, closing the read-vs-consume TOCTOU that
+    // let two concurrent callbacks both pass validation and issue tokens.
+    let (stored_state, oidc_state_claim) =
+        match db::try_consume_oidc_state(&state.store, &oidc_state).await {
+            Ok(pair) => pair,
+            Err(db::ClaimError::AlreadyConsumed) => {
+                return ErrorTemplate {
+                    title: "Error".to_string(),
+                    message: "Invalid or expired state".to_string(),
+                    back_url: None,
+                }
+                .into_response();
             }
-            .into_response();
-        }
-        Err(e) => {
-            tracing::error!("Failed to verify OIDC state: {e:#}");
-            return ErrorTemplate {
-                title: "Error".to_string(),
-                message: "Failed to verify state".to_string(),
-                back_url: None,
+            Err(e) => {
+                tracing::error!("Failed to consume OIDC state: {e:#}");
+                return ErrorTemplate {
+                    title: "Error".to_string(),
+                    message: "Failed to verify state".to_string(),
+                    back_url: None,
+                }
+                .into_response();
             }
-            .into_response();
-        }
-    };
-
-    // Check if state expired
-    let now = Timestamp::now();
-    if now > stored_state.expires_at {
-        return ErrorTemplate {
-            title: "Error".to_string(),
-            message: "State has expired".to_string(),
-            back_url: None,
-        }
-        .into_response();
-    }
+        };
 
     // Exchange code for tokens using discovered OIDC token endpoint.
     // This handler is OIDC-specific: SAML responses go to POST /saml/acs.
@@ -556,14 +550,14 @@ pub async fn oidc_callback(
         }
     };
 
-    complete_enrollment_after_identity(&state, &stored_state, &oidc_state, identity).await
+    complete_enrollment_after_identity(&state, &stored_state, identity, oidc_state_claim).await
 }
 
 pub(crate) async fn complete_enrollment_after_identity(
     state: &Arc<AppState>,
     stored_state: &db::OidcState,
-    state_key: &str,
     identity: IdentityResult,
+    oidc_state_claim: db::OidcStateClaim,
 ) -> Response {
     // Check domain restriction.
     // For Google consumers (no `hd` claim), `identity.domain` is `None`,
@@ -661,7 +655,7 @@ pub(crate) async fn complete_enrollment_after_identity(
             authorization_details: None,
         },
         TokenIssuanceProof {
-            grant: GrantProof::UnconvertedEnrollmentBootstrap,
+            grant: GrantProof::EnrollmentBootstrap(oidc_state_claim),
             client_auth: ClientAuthProof::None,
         },
     )
@@ -718,10 +712,9 @@ pub(crate) async fn complete_enrollment_after_identity(
         }
     }
 
-    // Delete state only after enrollment/session creation succeeds.
-    if let Err(e) = db::delete_oidc_state(&state.store, state_key).await {
-        tracing::warn!("Failed to delete state: {e}");
-    }
+    // No explicit state delete here — `try_consume_oidc_state` already
+    // marked the row `consumed_at = Some(now)` (replay-blocking) and
+    // `delete_expired_oidc_states` will reclaim the row at expiry.
 
     tracing::info!(
         "Session created for user: {}",
@@ -1034,34 +1027,45 @@ pub async fn browser_register_complete(
     // ── Phase 2b: Single-use enforcement ───────────────────────────────
     // Consume the state token before any WebAuthn work so that a captured
     // state JWT cannot be replayed within the 5-minute validity window.
-    if !key_svc::consume_registration_state(&state.store, &req.state, reg_state.exp).await? {
-        tracing::warn!(
-            user_id = %reg_state.user_id,
-            "browser registration state replay rejected"
-        );
-        let audit_data = serde_json::json!({
-            "flow": "browser_register",
-            "success": false,
-            "error_code": "state_already_used",
-        });
-        if let Err(e) = state
-            .audit
-            .insert_event(
-                "key_registration_replay",
-                Some(&reg_state.user_id.to_string()),
-                Some(&reg_state.user_email),
-                &audit_data.to_string(),
-            )
-            .await
-        {
-            tracing::warn!(error = %e, "failed to write key_registration_replay audit event");
+    // The witness is threaded into TokenIssuanceProof below — the only
+    // path to `GrantProof::EnrollmentComplete`.
+    let registration_claim = match key_svc::consume_registration_state(
+        &state.store,
+        &req.state,
+        reg_state.exp,
+    )
+    .await?
+    {
+        key_svc::RegistrationStateConsumed::Won(claim) => claim,
+        key_svc::RegistrationStateConsumed::Replay => {
+            tracing::warn!(
+                user_id = %reg_state.user_id,
+                "browser registration state replay rejected"
+            );
+            let audit_data = serde_json::json!({
+                "flow": "browser_register",
+                "success": false,
+                "error_code": "state_already_used",
+            });
+            if let Err(e) = state
+                .audit
+                .insert_event(
+                    "key_registration_replay",
+                    Some(&reg_state.user_id.to_string()),
+                    Some(&reg_state.user_email),
+                    &audit_data.to_string(),
+                )
+                .await
+            {
+                tracing::warn!(error = %e, "failed to write key_registration_replay audit event");
+            }
+            return Err(ServiceError::api(
+                StatusCode::BAD_REQUEST,
+                "state_already_used",
+                "This registration link has already been used",
+            ));
         }
-        return Err(ServiceError::api(
-            StatusCode::BAD_REQUEST,
-            "state_already_used",
-            "This registration link has already been used",
-        ));
-    }
+    };
 
     // ── Phase 3: Base64url decode all fields ────────────────────────────
     let credential_id_bytes = URL_SAFE_NO_PAD.decode(&req.credential_id).map_err(|e| {
@@ -1345,7 +1349,7 @@ pub async fn browser_register_complete(
             authorization_details: None,
         },
         TokenIssuanceProof {
-            grant: GrantProof::UnconvertedEnrollmentComplete,
+            grant: GrantProof::EnrollmentComplete(registration_claim),
             client_auth: ClientAuthProof::None,
         },
     )
@@ -1751,10 +1755,9 @@ mod tests {
 
         // Pre-consume the state token to simulate prior use.
         let expires_at = jiff::Timestamp::from_second(exp).expect("valid exp");
-        let consumed = crate::db::try_mark_challenge_used(&state.store, &state_jwt, expires_at)
+        let _claim = crate::db::try_consume_challenge_state(&state.store, &state_jwt, expires_at)
             .await
             .expect("pre-consume must succeed");
-        assert!(consumed, "pre-consume should return true on first use");
 
         // POST to the complete endpoint with the already-consumed state.
         // The replay check runs before any base64 decoding, so non-empty base64

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -30,7 +30,10 @@ use super::{
     validate_registration_attestation,
 };
 use crate::redact_email;
-use crate::services::auth::{CreateOAuthTokenParams, create_oauth_access_token};
+use crate::services::auth::{
+    ClientAuthProof, CreateOAuthTokenParams, GrantProof, TokenIssuanceProof,
+    create_oauth_access_token,
+};
 use crate::services::error::ServiceError;
 use crate::services::idp::IdentityResult;
 use crate::services::keys as key_svc;
@@ -656,6 +659,10 @@ pub(crate) async fn complete_enrollment_after_identity(
             hardware_verification: crate::services::auth::HardwareVerification::NotVerified,
             session_purpose: db::SessionPurpose::OAuthAccessToken,
             authorization_details: None,
+        },
+        TokenIssuanceProof {
+            grant: GrantProof::UnconvertedEnrollmentBootstrap,
+            client_auth: ClientAuthProof::None,
         },
     )
     .await
@@ -1336,6 +1343,10 @@ pub async fn browser_register_complete(
             hardware_verification: crate::services::auth::HardwareVerification::Verified,
             session_purpose: db::SessionPurpose::OAuthAccessToken,
             authorization_details: None,
+        },
+        TokenIssuanceProof {
+            grant: GrantProof::UnconvertedEnrollmentComplete,
+            client_auth: ClientAuthProof::None,
         },
     )
     .await

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -1806,4 +1806,71 @@ mod tests {
             "expected 'invalid_credential' in body, got: {resp_body}"
         );
     }
+
+    // ── test_oidc_callback_rejects_replayed_state ───────────────────────────
+
+    #[tokio::test]
+    async fn test_oidc_callback_rejects_replayed_state() {
+        // GET /oauth/callback must reject a replayed `state` query param —
+        // the atomic `try_consume_oidc_state` (slice 7b) closes the
+        // read-vs-consume TOCTOU that previously let two concurrent
+        // callbacks both pass validation. We pre-consume the state in the
+        // DB, then submit the callback — the handler must fail at the
+        // consume step and return the "Invalid or expired state" error
+        // template WITHOUT calling the upstream IdP `/token` endpoint.
+        use crate::test_utils::http_get;
+
+        let (app, state) = test_app().await;
+
+        // Seed a fresh OIDC state row + the device-auth row it FKs to.
+        let expires_at: jiff::Timestamp = "2099-12-31T23:59:59Z".parse().expect("valid timestamp");
+        let device_auth_id = crate::db::create_device_auth_request(
+            &state.store,
+            "callback-replay-device-hash",
+            "CBRP-CODE",
+            None,
+            expires_at,
+            5,
+        )
+        .await
+        .expect("create_device_auth_request");
+
+        let oidc_state_value = "callback-replay-state-12345";
+        crate::db::create_oidc_state(
+            &state.store,
+            oidc_state_value,
+            &device_auth_id,
+            "test-nonce",
+            "",
+            expires_at,
+            "",
+        )
+        .await
+        .expect("create_oidc_state");
+
+        // Pre-consume to simulate a successful prior callback.
+        let _claim = crate::db::try_consume_oidc_state(&state.store, oidc_state_value)
+            .await
+            .expect("pre-consume must succeed");
+
+        // Submit the callback with the now-consumed state. The handler
+        // calls `try_consume_oidc_state` first, which returns
+        // AlreadyConsumed, so the upstream IdP is never reached.
+        let (status, body) = http_get(
+            &app,
+            &format!("/oauth/callback?state={oidc_state_value}&code=dummy-auth-code"),
+            &[],
+        )
+        .await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "error template renders with 200 OK; got {status}: {body}"
+        );
+        assert!(
+            body.contains("Invalid or expired state"),
+            "expected 'Invalid or expired state' in body, got: {body}"
+        );
+    }
 }

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -656,7 +656,9 @@ pub(crate) async fn complete_enrollment_after_identity(
         },
         TokenIssuanceProof {
             grant: GrantProof::EnrollmentBootstrap(oidc_state_claim),
-            client_auth: ClientAuthProof::None,
+            client_auth: ClientAuthProof::NoAuth(
+                crate::services::auth::NoClientAuth::internal_endpoint(),
+            ),
         },
     )
     .await
@@ -1350,7 +1352,9 @@ pub async fn browser_register_complete(
         },
         TokenIssuanceProof {
             grant: GrantProof::EnrollmentComplete(registration_claim),
-            client_auth: ClientAuthProof::None,
+            client_auth: ClientAuthProof::NoAuth(
+                crate::services::auth::NoClientAuth::internal_endpoint(),
+            ),
         },
     )
     .await

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -1811,13 +1811,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_oidc_callback_rejects_replayed_state() {
-        // GET /oauth/callback must reject a replayed `state` query param —
-        // the atomic `try_consume_oidc_state` (slice 7b) closes the
-        // read-vs-consume TOCTOU that previously let two concurrent
-        // callbacks both pass validation. We pre-consume the state in the
-        // DB, then submit the callback — the handler must fail at the
-        // consume step and return the "Invalid or expired state" error
-        // template WITHOUT calling the upstream IdP `/token` endpoint.
+        // GET /oauth/callback must reject a replayed `state` query param.
+        // `try_consume_oidc_state` closes the read-vs-consume TOCTOU that
+        // would otherwise let two concurrent callbacks both pass
+        // validation. Pre-consume the state in the DB, then submit the
+        // callback — the handler must fail at the consume step and return
+        // the "Invalid or expired state" error template WITHOUT calling
+        // the upstream IdP `/token` endpoint.
         use crate::test_utils::http_get;
 
         let (app, state) = test_app().await;

--- a/crates/vouch-server/src/handlers/keys.rs
+++ b/crates/vouch-server/src/handlers/keys.rs
@@ -206,34 +206,42 @@ pub async fn register_complete(
 
     // Single-use enforcement: consume the state token before any WebAuthn work.
     // A captured state JWT cannot be replayed within the 5-minute validity window.
-    if !key_svc::consume_registration_state(&state.store, &req.state, reg_state.exp).await? {
-        tracing::warn!(
-            user_id = %reg_state.user_id,
-            "CLI registration state replay rejected"
-        );
-        let audit_data = serde_json::json!({
-            "flow": "cli_register",
-            "success": false,
-            "error_code": "state_already_used",
-        });
-        if let Err(e) = state
-            .audit
-            .insert_event(
-                "key_registration_replay",
-                Some(&reg_state.user_id.to_string()),
-                Some(&reg_state.user_name),
-                &audit_data.to_string(),
-            )
-            .await
-        {
-            tracing::warn!(error = %e, "failed to write key_registration_replay audit event");
+    // CLI registration adds an authenticator without issuing a token, so the
+    // returned witness is dropped — sealing is enforced by `#[must_use]` plus
+    // the binding to `_claim`.
+    let _claim = match key_svc::consume_registration_state(&state.store, &req.state, reg_state.exp)
+        .await?
+    {
+        key_svc::RegistrationStateConsumed::Won(claim) => claim,
+        key_svc::RegistrationStateConsumed::Replay => {
+            tracing::warn!(
+                user_id = %reg_state.user_id,
+                "CLI registration state replay rejected"
+            );
+            let audit_data = serde_json::json!({
+                "flow": "cli_register",
+                "success": false,
+                "error_code": "state_already_used",
+            });
+            if let Err(e) = state
+                .audit
+                .insert_event(
+                    "key_registration_replay",
+                    Some(&reg_state.user_id.to_string()),
+                    Some(&reg_state.user_name),
+                    &audit_data.to_string(),
+                )
+                .await
+            {
+                tracing::warn!(error = %e, "failed to write key_registration_replay audit event");
+            }
+            return Err(ServiceError::api(
+                StatusCode::BAD_REQUEST,
+                "state_already_used",
+                "This registration link has already been used",
+            ));
         }
-        return Err(ServiceError::api(
-            StatusCode::BAD_REQUEST,
-            "state_already_used",
-            "This registration link has already been used",
-        ));
-    }
+    };
 
     // Server-side WebAuthn attestation verification
     // Verify the attestation object, client data, RP ID, challenge, and origin
@@ -725,10 +733,9 @@ mod tests {
 
         // Pre-consume the state token to simulate prior use.
         let expires_at = jiff::Timestamp::from_second(exp).expect("valid exp");
-        let consumed = crate::db::try_mark_challenge_used(&state.store, &state_jwt, expires_at)
+        let _claim = crate::db::try_consume_challenge_state(&state.store, &state_jwt, expires_at)
             .await
             .expect("pre-consume must succeed");
-        assert!(consumed, "pre-consume should return true on first use");
 
         // POST to register/complete with the already-consumed state and dummy bytes.
         // consume_registration_state runs before WebAuthn verification, so dummy

--- a/crates/vouch-server/src/handlers/oidc/authorize.rs
+++ b/crates/vouch-server/src/handlers/oidc/authorize.rs
@@ -977,29 +977,32 @@ async fn fetch_and_resolve_request_uri(
 /// Phase A: consume pending → resolve client (lookup + active + redirect_uri re-validation).
 /// Phase C: session check + max_age check + code issuance.
 async fn handle_pending_auth(state: &Arc<AppState>, pending_id: &str, jar: &CookieJar) -> Response {
-    // Consume the pending auth (single-use).
-    let pending = match db::consume_pending_oauth_authorization(&state.store, pending_id).await {
-        Ok(claim) => claim,
-        Err(db::claim::ClaimError::AlreadyConsumed) => {
-            tracing::warn!(
-                pending_id,
-                "Pending OAuth authorization not found or expired"
-            );
-            return AuthorizeDeniedTemplate {
-                client_name: "Unknown Application".to_string(),
-                error_message: "Authorization session expired. Please try again.".to_string(),
+    // Consume the pending auth (single-use). The `_claim` witness is
+    // bound to satisfy `#[must_use]`; downstream code uses `pending`
+    // (the consumed record's data) directly.
+    let (pending, _claim) =
+        match db::consume_pending_oauth_authorization(&state.store, pending_id).await {
+            Ok(pair) => pair,
+            Err(db::claim::ClaimError::AlreadyConsumed) => {
+                tracing::warn!(
+                    pending_id,
+                    "Pending OAuth authorization not found or expired"
+                );
+                return AuthorizeDeniedTemplate {
+                    client_name: "Unknown Application".to_string(),
+                    error_message: "Authorization session expired. Please try again.".to_string(),
+                }
+                .into_response();
             }
-            .into_response();
-        }
-        Err(e) => {
-            tracing::error!("Failed to retrieve pending OAuth authorization: {}", e);
-            return AuthorizeDeniedTemplate {
-                client_name: "Unknown Application".to_string(),
-                error_message: "An error occurred. Please try again.".to_string(),
+            Err(e) => {
+                tracing::error!("Failed to retrieve pending OAuth authorization: {}", e);
+                return AuthorizeDeniedTemplate {
+                    client_name: "Unknown Application".to_string(),
+                    error_message: "An error occurred. Please try again.".to_string(),
+                }
+                .into_response();
             }
-            .into_response();
-        }
-    };
+        };
 
     // Phase A: re-validate client active + redirect_uri (errors → page).
     // This guards against the client being deactivated or redirect_uri removed

--- a/crates/vouch-server/src/handlers/oidc/authorize.rs
+++ b/crates/vouch-server/src/handlers/oidc/authorize.rs
@@ -979,8 +979,8 @@ async fn fetch_and_resolve_request_uri(
 async fn handle_pending_auth(state: &Arc<AppState>, pending_id: &str, jar: &CookieJar) -> Response {
     // Consume the pending auth (single-use).
     let pending = match db::consume_pending_oauth_authorization(&state.store, pending_id).await {
-        Ok(Some(p)) => p,
-        Ok(None) => {
+        Ok(claim) => claim,
+        Err(db::claim::ClaimError::AlreadyConsumed) => {
             tracing::warn!(
                 pending_id,
                 "Pending OAuth authorization not found or expired"

--- a/crates/vouch-server/src/handlers/oidc/authorize.rs
+++ b/crates/vouch-server/src/handlers/oidc/authorize.rs
@@ -1116,8 +1116,8 @@ async fn complete_pending_auth(
         )
         .await
         {
-            Ok(true) => {} // successfully consumed
-            Ok(false) => {
+            Ok(_claim) => {} // successfully consumed
+            Err(db::claim::ClaimError::AlreadyConsumed) => {
                 return resolved
                     .error_redirect(
                         state,
@@ -1507,8 +1507,8 @@ async fn issue_code_after_reauth_check(
         )
         .await
         {
-            Ok(true) => {} // Successfully consumed
-            Ok(false) => {
+            Ok(_claim) => {} // Successfully consumed
+            Err(db::claim::ClaimError::AlreadyConsumed) => {
                 return oauth_error_response(
                     state,
                     oauth_client,

--- a/crates/vouch-server/src/handlers/oidc/client_auth.rs
+++ b/crates/vouch-server/src/handlers/oidc/client_auth.rs
@@ -154,24 +154,38 @@ pub(crate) fn extract_client_auth<T: ClientAuthFields>(
     Ok(ExtractedClientAuth::None)
 }
 
+/// Result of a successful `complete_client_auth` dispatch.
+pub(crate) struct ClientAuthOutcome {
+    pub(crate) client: AuthenticatedClient,
+    pub(crate) client_id: String,
+    /// `Some` only for JWT-authenticated clients — caller must commit.
+    pub(crate) pending_jti: Option<PendingJti>,
+    /// `Some` only when a `client_secret` was validated.
+    pub(crate) secret_verification: Option<crate::services::oidc::token::ClientSecretVerification>,
+}
+
 /// Authenticate a client using any supported method.
 ///
 /// Dispatches to secret-based or JWT-based authentication depending on
-/// the extracted authentication method.
-///
-/// For JWT assertions, returns a [`PendingJti`] that MUST be committed via
-/// [`PendingJti::commit`](crate::services::oidc::jwt_bearer::client_auth::PendingJti::commit)
-/// after the full request succeeds. For all other auth methods, returns
-/// `None` for the pending JTI.
-pub(crate) async fn authenticate_client_any(
+/// the extracted authentication method. Returns the verification witnesses
+/// produced by the dispatched method (JTI claim for JWT, secret-verification
+/// for client_secret_basic/post). mTLS verification is performed separately
+/// by the handler via [`validate_mtls_client_auth`] because it requires the
+/// client certificate from the request extractor.
+pub(crate) async fn complete_client_auth(
     state: &Arc<AppState>,
     auth: ExtractedClientAuth,
-) -> Result<Option<(AuthenticatedClient, String, Option<PendingJti>)>, Response> {
+) -> Result<Option<ClientAuthOutcome>, Response> {
     match auth {
         ExtractedClientAuth::Secret(creds) => {
             let client_id = creds.client_id.clone();
             match authenticate_client(state, &creds).await {
-                Ok(client) => Ok(Some((client, client_id, None))),
+                Ok((client, secret_verification)) => Ok(Some(ClientAuthOutcome {
+                    client,
+                    client_id,
+                    pending_jti: None,
+                    secret_verification,
+                })),
                 Err(e) => Err(e.into_service_error().into_oauth_response().into_response()),
             }
         }
@@ -181,7 +195,12 @@ pub(crate) async fn authenticate_client_any(
         } => match authenticate_client_jwt(state, &client_assertion, client_id.as_deref()).await {
             Ok((client, pending_jti)) => {
                 let cid = client.client.client_id.clone();
-                Ok(Some((client, cid, Some(pending_jti))))
+                Ok(Some(ClientAuthOutcome {
+                    client,
+                    client_id: cid,
+                    pending_jti: Some(pending_jti),
+                    secret_verification: None,
+                }))
             }
             Err(e) => Err(e.into_service_error().into_oauth_response().into_response()),
         },
@@ -192,7 +211,12 @@ pub(crate) async fn authenticate_client_any(
                 client_secret: None,
             };
             match authenticate_client(state, &creds).await {
-                Ok(client) => Ok(Some((client, client_id, None))),
+                Ok((client, secret_verification)) => Ok(Some(ClientAuthOutcome {
+                    client,
+                    client_id,
+                    pending_jti: None,
+                    secret_verification,
+                })),
                 Err(e) => Err(e.into_service_error().into_oauth_response().into_response()),
             }
         }

--- a/crates/vouch-server/src/handlers/oidc/client_auth.rs
+++ b/crates/vouch-server/src/handlers/oidc/client_auth.rs
@@ -160,6 +160,10 @@ pub(crate) struct ClientAuthOutcome {
     pub(crate) client_id: String,
     /// `Some` only for JWT-authenticated clients — caller must commit.
     pub(crate) pending_jti: Option<PendingJti>,
+    /// `Some` only for JWT-authenticated clients — pair with `pending_jti.commit()`
+    /// to construct `ClientAuthProof::PrivateKeyJwt`. Independent of jti presence
+    /// because RFC 7523 §3 makes `jti` OPTIONAL for non-FAPI clients.
+    pub(crate) jwt_auth: Option<crate::services::oidc::jwt_bearer::client_auth::JwtAuthSucceeded>,
     /// `Some` only when a `client_secret` was validated.
     pub(crate) secret_verification: Option<crate::services::oidc::token::ClientSecretVerification>,
 }
@@ -184,6 +188,7 @@ pub(crate) async fn complete_client_auth(
                     client,
                     client_id,
                     pending_jti: None,
+                    jwt_auth: None,
                     secret_verification,
                 })),
                 Err(e) => Err(e.into_service_error().into_oauth_response().into_response()),
@@ -193,12 +198,13 @@ pub(crate) async fn complete_client_auth(
             client_assertion,
             client_id,
         } => match authenticate_client_jwt(state, &client_assertion, client_id.as_deref()).await {
-            Ok((client, pending_jti)) => {
+            Ok((client, pending_jti, jwt_auth)) => {
                 let cid = client.client.client_id.clone();
                 Ok(Some(ClientAuthOutcome {
                     client,
                     client_id: cid,
                     pending_jti: Some(pending_jti),
+                    jwt_auth: Some(jwt_auth),
                     secret_verification: None,
                 }))
             }
@@ -215,6 +221,7 @@ pub(crate) async fn complete_client_auth(
                     client,
                     client_id,
                     pending_jti: None,
+                    jwt_auth: None,
                     secret_verification,
                 })),
                 Err(e) => Err(e.into_service_error().into_oauth_response().into_response()),

--- a/crates/vouch-server/src/handlers/oidc/client_auth.rs
+++ b/crates/vouch-server/src/handlers/oidc/client_auth.rs
@@ -160,9 +160,9 @@ pub(crate) fn extract_client_auth<T: ClientAuthFields>(
 /// the extracted authentication method.
 ///
 /// For JWT assertions, returns a [`PendingJti`] that MUST be committed via
-/// [`crate::services::oidc::jwt_bearer::client_auth::commit_jti`] after the
-/// full request succeeds. For all other auth methods, returns `None` for the
-/// pending JTI.
+/// [`PendingJti::commit`](crate::services::oidc::jwt_bearer::client_auth::PendingJti::commit)
+/// after the full request succeeds. For all other auth methods, returns
+/// `None` for the pending JTI.
 pub(crate) async fn authenticate_client_any(
     state: &Arc<AppState>,
     auth: ExtractedClientAuth,

--- a/crates/vouch-server/src/handlers/oidc/introspect.rs
+++ b/crates/vouch-server/src/handlers/oidc/introspect.rs
@@ -11,7 +11,6 @@ use crate::services::oidc::introspection::{
     IntrospectionResult, introspect_token as svc_introspect, revoke_token as svc_revoke,
     wrap_introspection_jwt,
 };
-use crate::services::oidc::jwt_bearer::commit_jti;
 use crate::services::oidc::token::ClientAuthError;
 use axum::{
     Json,
@@ -152,9 +151,9 @@ pub async fn revoke(
     .await;
 
     // Commit JTI after revocation so clients can retry on failure.
-    if let Some(ref jti) = pending_jti {
-        match commit_jti(&state, jti).await {
-            Ok(()) => {}
+    if let Some(p) = pending_jti {
+        match p.commit(&state).await {
+            Ok(_claim) => {}
             Err(ClientAuthError::InvalidCredentials) => {
                 // JTI was already used — reject so the client generates a new assertion.
                 return StatusCode::UNAUTHORIZED.into_response();
@@ -218,9 +217,9 @@ pub async fn introspect(
     };
 
     // Commit JTI after introspection so clients can retry on failure.
-    if let Some(ref jti) = pending_jti {
-        match commit_jti(&state, jti).await {
-            Ok(()) => {}
+    if let Some(p) = pending_jti {
+        match p.commit(&state).await {
+            Ok(_claim) => {}
             Err(ClientAuthError::InvalidCredentials) => {
                 // JTI was already used — reject so the client generates a new assertion.
                 return StatusCode::UNAUTHORIZED.into_response();

--- a/crates/vouch-server/src/handlers/oidc/introspect.rs
+++ b/crates/vouch-server/src/handlers/oidc/introspect.rs
@@ -22,7 +22,7 @@ use secrecy::SecretString;
 use serde::Deserialize;
 use std::sync::Arc;
 
-use super::client_auth::{ClientAuthFields, authenticate_client_any, extract_client_auth};
+use super::client_auth::{ClientAuthFields, complete_client_auth, extract_client_auth};
 
 /// Token revocation request (RFC 7009 Section 2.1).
 ///
@@ -132,8 +132,8 @@ pub async fn revoke(
         Err(response) => return response,
     };
 
-    let (caller_client_id, pending_jti) = match authenticate_client_any(&state, auth).await {
-        Ok(Some((_client, client_id, jti))) => (client_id, jti),
+    let (caller_client_id, pending_jti) = match complete_client_auth(&state, auth).await {
+        Ok(Some(a)) => (a.client_id, a.pending_jti),
         Ok(None) => {
             // No credentials provided → 401
             return (StatusCode::UNAUTHORIZED, [("www-authenticate", "Basic")]).into_response();
@@ -188,8 +188,8 @@ pub async fn introspect(
         Err(response) => return response,
     };
 
-    let (authenticated_client, pending_jti) = match authenticate_client_any(&state, auth).await {
-        Ok(Some((client, _client_id, jti))) => (client.client, jti),
+    let (authenticated_client, pending_jti) = match complete_client_auth(&state, auth).await {
+        Ok(Some(a)) => (a.client.client, a.pending_jti),
         Ok(None) => {
             // No credentials provided → 401
             return (StatusCode::UNAUTHORIZED, [("www-authenticate", "Basic")]).into_response();

--- a/crates/vouch-server/src/handlers/oidc/par.rs
+++ b/crates/vouch-server/src/handlers/oidc/par.rs
@@ -475,13 +475,24 @@ pub async fn par(
     };
     // PAR doesn't currently validate mTLS (FAPI 2.0 §5.2.2 requires
     // private_key_jwt anyway; non-FAPI mTLS at PAR isn't supported here).
-    // If/when PAR-mTLS lands, capture the MtlsCertVerification and pass it
-    // as the second argument instead of None.
+    // Resolve client-auth proof by precedence: JWT → secret. If neither
+    // succeeded, fall back to `for_public_client` against the loaded
+    // client — fails for confidential clients that should have authed.
+    let par_client_auth = if let Some(claim) = jti_claim {
+        ClientAuthProof::PrivateKeyJwt(claim)
+    } else if let Some(s) = secret_verification {
+        ClientAuthProof::ClientSecret(s)
+    } else {
+        let witness = match crate::services::auth::NoClientAuth::for_public_client(
+            &authenticated_client.client,
+        ) {
+            Ok(w) => w,
+            Err(svc) => return svc.into_oauth_response().into_response(),
+        };
+        ClientAuthProof::NoAuth(witness)
+    };
     let proof = ParCreationProof {
-        client_auth: ClientAuthProof::from_jti_or(
-            jti_claim,
-            ClientAuthProof::from_verifications(secret_verification, None),
-        ),
+        client_auth: par_client_auth,
     };
 
     // RFC 9126 Section 2.2: Return 201 Created

--- a/crates/vouch-server/src/handlers/oidc/par.rs
+++ b/crates/vouch-server/src/handlers/oidc/par.rs
@@ -192,6 +192,7 @@ pub async fn par(
     };
     let authenticated_client = any_auth.client;
     let pending_jti = any_auth.pending_jti;
+    let jwt_auth = any_auth.jwt_auth;
     let secret_verification = any_auth.secret_verification;
 
     // RFC 8705 §2 / FAPI 2.0 §5.2.2: mTLS dispatch. When the client is
@@ -514,8 +515,15 @@ pub async fn par(
     // Resolve client-auth proof by precedence: JWT → secret → mTLS. If
     // none succeeded, fall back to `for_public_client` against the loaded
     // client — fails for confidential clients that should have authed.
-    let par_client_auth = if let Some(claim) = jti_claim {
-        ClientAuthProof::PrivateKeyJwt(claim)
+    //
+    // RFC 7523 §3 makes `jti` OPTIONAL — so JWT auth can succeed with
+    // `jti_claim == None`. We gate on the `jwt_auth` witness, not on
+    // `jti_claim`, to avoid silently rejecting a non-FAPI client that
+    // legitimately omitted `jti`.
+    let par_client_auth = if let Some(auth) = jwt_auth {
+        ClientAuthProof::PrivateKeyJwt(crate::services::auth::JwtClientAuthProof::new(
+            auth, jti_claim,
+        ))
     } else if let Some(s) = secret_verification {
         ClientAuthProof::ClientSecret(s)
     } else if let Some(v) = mtls_verification {

--- a/crates/vouch-server/src/handlers/oidc/par.rs
+++ b/crates/vouch-server/src/handlers/oidc/par.rs
@@ -142,6 +142,7 @@ impl ClientAuthFields for ParRequest {
 /// Returns 201 Created with a JSON body containing `request_uri` and `expires_in`.
 pub async fn par(
     State(state): State<Arc<AppState>>,
+    client_cert: crate::handlers::extractors::OptionalClientCert,
     headers: HeaderMap,
     axum::Form(params): axum::Form<ParRequest>,
 ) -> Response {
@@ -192,6 +193,43 @@ pub async fn par(
     let authenticated_client = any_auth.client;
     let pending_jti = any_auth.pending_jti;
     let secret_verification = any_auth.secret_verification;
+
+    // RFC 8705 §2 / FAPI 2.0 §5.2.2: mTLS dispatch. When the client is
+    // registered with `tls_client_auth` or `self_signed_tls_client_auth`
+    // and no body-level credential has authenticated it, verify the TLS
+    // client certificate. Must run before FAPI auth-method validation so
+    // a successfully mTLS-authenticated client is accepted by that gate.
+    let mtls_verification = if pending_jti.is_none()
+        && secret_verification.is_none()
+        && matches!(
+            authenticated_client.client.token_endpoint_auth_method,
+            crate::db::TokenEndpointAuthMethod::TlsClientAuth
+                | crate::db::TokenEndpointAuthMethod::SelfSignedTlsClientAuth
+        ) {
+        let Some(cert) = client_cert.0.as_ref() else {
+            return par_error_response(
+                StatusCode::UNAUTHORIZED,
+                "invalid_client",
+                "mTLS client certificate required",
+            );
+        };
+        let jwks_cache_value =
+            crate::db::get_jwks_cache(&state.store, &authenticated_client.client.id)
+                .await
+                .ok()
+                .flatten()
+                .map(|c| c.value);
+        match crate::services::oidc::token::authenticate_client_mtls(
+            &authenticated_client.client,
+            cert,
+            jwks_cache_value.as_ref(),
+        ) {
+            Ok(verification) => Some(verification),
+            Err(e) => return e.into_service_error().into_oauth_response().into_response(),
+        }
+    } else {
+        None
+    };
 
     // FAPI 2.0: Validate client authentication method.
     //
@@ -473,15 +511,15 @@ pub async fn par(
         },
         None => None,
     };
-    // PAR doesn't currently validate mTLS (FAPI 2.0 §5.2.2 requires
-    // private_key_jwt anyway; non-FAPI mTLS at PAR isn't supported here).
-    // Resolve client-auth proof by precedence: JWT → secret. If neither
-    // succeeded, fall back to `for_public_client` against the loaded
+    // Resolve client-auth proof by precedence: JWT → secret → mTLS. If
+    // none succeeded, fall back to `for_public_client` against the loaded
     // client — fails for confidential clients that should have authed.
     let par_client_auth = if let Some(claim) = jti_claim {
         ClientAuthProof::PrivateKeyJwt(claim)
     } else if let Some(s) = secret_verification {
         ClientAuthProof::ClientSecret(s)
+    } else if let Some(v) = mtls_verification {
+        ClientAuthProof::MutualTls(v)
     } else {
         let witness = match crate::services::auth::NoClientAuth::for_public_client(
             &authenticated_client.client,

--- a/crates/vouch-server/src/handlers/oidc/par.rs
+++ b/crates/vouch-server/src/handlers/oidc/par.rs
@@ -6,6 +6,7 @@ use crate::AppState;
 use crate::db::par::PAR_EXPIRES_IN;
 use crate::db::{self, CreateParParams};
 use crate::services::ServiceError;
+use crate::services::auth::{ClientAuthProof, ParCreationProof};
 use crate::services::error::OAuthErrorResponse;
 use crate::services::oidc::DpopError;
 use crate::services::oidc::authorization::{
@@ -446,11 +447,7 @@ pub async fn par(
         response_mode,
     };
 
-    // SAFETY: PendingJti::commit MUST run AFTER DPoP nonce validation (so a
-    // use_dpop_nonce retry leaves the JTI unconsumed) and BEFORE
-    // store_par_request() (so concurrent replays of the same assertion cannot
-    // persist multiple PAR requests — see issue #391).
-    let _jwt_jti_claim = match pending_jti {
+    let jti_claim = match pending_jti {
         Some(p) => match p.commit(&state).await {
             Ok(claim) => claim,
             Err(e) => {
@@ -475,9 +472,12 @@ pub async fn par(
         },
         None => None,
     };
+    let proof = ParCreationProof {
+        client_auth: ClientAuthProof::from_jti_or(jti_claim, ClientAuthProof::None),
+    };
 
     // RFC 9126 Section 2.2: Return 201 Created
-    match db::create_pushed_authorization_request(&state.store, create_params).await {
+    match db::create_pushed_authorization_request(&state.store, create_params, proof).await {
         Ok((_id, request_uri)) => (
             StatusCode::CREATED,
             Json(ParResponse {

--- a/crates/vouch-server/src/handlers/oidc/par.rs
+++ b/crates/vouch-server/src/handlers/oidc/par.rs
@@ -12,7 +12,6 @@ use crate::services::oidc::authorization::{
     AuthorizeRequestParams, Prompt, require_pkce_for_client, validate_authorize_request,
 };
 use crate::services::oidc::jar::{validate_request_object, validate_request_object_header};
-use crate::services::oidc::jwt_bearer::commit_jti;
 use crate::services::oidc::token::{ClientAuthError, validate_dpop_if_present};
 use axum::{
     Json,
@@ -447,32 +446,35 @@ pub async fn par(
         response_mode,
     };
 
-    // SAFETY: commit_jti() MUST run AFTER DPoP nonce validation (so use_dpop_nonce
-    // retry leaves the JTI unconsumed) and BEFORE store_par_request() so that
-    // concurrent replays of the same assertion cannot persist multiple PAR
-    // requests — see issue #391. A follow-up will replace this comment with a
-    // ParCreation witness type.
-    if let Some(ref pjti) = pending_jti
-        && let Err(e) = commit_jti(&state, pjti).await
-    {
-        tracing::warn!("JTI commit failed for PAR: {e:?}");
-        // Distinguish replay (client-auth failure) from transient DB error
-        // (server problem). Returning 401 for a DB outage tells well-behaved
-        // clients to abandon credentials they should reuse on retry; returning
-        // 500 for a replay tempts them to retry-loop with a consumed JTI.
-        return match e {
-            ClientAuthError::InvalidCredentials => par_error_response(
-                StatusCode::UNAUTHORIZED,
-                "invalid_client",
-                "Client authentication failed",
-            ),
-            _ => par_error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "server_error",
-                "Failed to complete client authentication",
-            ),
-        };
-    }
+    // SAFETY: PendingJti::commit MUST run AFTER DPoP nonce validation (so a
+    // use_dpop_nonce retry leaves the JTI unconsumed) and BEFORE
+    // store_par_request() (so concurrent replays of the same assertion cannot
+    // persist multiple PAR requests — see issue #391).
+    let _jwt_jti_claim = match pending_jti {
+        Some(p) => match p.commit(&state).await {
+            Ok(claim) => claim,
+            Err(e) => {
+                tracing::warn!("JTI commit failed for PAR: {e:?}");
+                // Distinguish replay (client-auth failure) from transient DB error
+                // (server problem). Returning 401 for a DB outage tells well-behaved
+                // clients to abandon credentials they should reuse on retry; returning
+                // 500 for a replay tempts them to retry-loop with a consumed JTI.
+                return match e {
+                    ClientAuthError::InvalidCredentials => par_error_response(
+                        StatusCode::UNAUTHORIZED,
+                        "invalid_client",
+                        "Client authentication failed",
+                    ),
+                    _ => par_error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "server_error",
+                        "Failed to complete client authentication",
+                    ),
+                };
+            }
+        },
+        None => None,
+    };
 
     // RFC 9126 Section 2.2: Return 201 Created
     match db::create_pushed_authorization_request(&state.store, create_params).await {

--- a/crates/vouch-server/src/handlers/oidc/par.rs
+++ b/crates/vouch-server/src/handlers/oidc/par.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Pushed Authorization Request (PAR) endpoint handler (RFC 9126).
 
-use super::client_auth::{ClientAuthFields, authenticate_client_any, extract_client_auth};
+use super::client_auth::{ClientAuthFields, complete_client_auth, extract_client_auth};
 use crate::AppState;
 use crate::db::par::PAR_EXPIRES_IN;
 use crate::db::{self, CreateParParams};
@@ -179,18 +179,19 @@ pub async fn par(
     };
 
     // RFC 9126 Section 2: Client authentication is REQUIRED
-    let Some((authenticated_client, _client_id, pending_jti)) =
-        (match authenticate_client_any(&state, client_auth).await {
-            Ok(result) => result,
-            Err(resp) => return resp,
-        })
-    else {
+    let Some(any_auth) = (match complete_client_auth(&state, client_auth).await {
+        Ok(result) => result,
+        Err(resp) => return resp,
+    }) else {
         return par_error_response(
             StatusCode::UNAUTHORIZED,
             "invalid_client",
             "Client authentication is required for pushed authorization requests",
         );
     };
+    let authenticated_client = any_auth.client;
+    let pending_jti = any_auth.pending_jti;
+    let secret_verification = any_auth.secret_verification;
 
     // FAPI 2.0: Validate client authentication method.
     //
@@ -472,12 +473,14 @@ pub async fn par(
         },
         None => None,
     };
+    // PAR doesn't currently validate mTLS (FAPI 2.0 §5.2.2 requires
+    // private_key_jwt anyway; non-FAPI mTLS at PAR isn't supported here).
+    // If/when PAR-mTLS lands, capture the MtlsCertVerification and pass it
+    // as the second argument instead of None.
     let proof = ParCreationProof {
         client_auth: ClientAuthProof::from_jti_or(
             jti_claim,
-            ClientAuthProof::from_auth_method(
-                authenticated_client.client.token_endpoint_auth_method,
-            ),
+            ClientAuthProof::from_verifications(secret_verification, None),
         ),
     };
 

--- a/crates/vouch-server/src/handlers/oidc/par.rs
+++ b/crates/vouch-server/src/handlers/oidc/par.rs
@@ -473,7 +473,12 @@ pub async fn par(
         None => None,
     };
     let proof = ParCreationProof {
-        client_auth: ClientAuthProof::from_jti_or(jti_claim, ClientAuthProof::None),
+        client_auth: ClientAuthProof::from_jti_or(
+            jti_claim,
+            ClientAuthProof::from_auth_method(
+                authenticated_client.client.token_endpoint_auth_method,
+            ),
+        ),
     };
 
     // RFC 9126 Section 2.2: Return 201 Created

--- a/crates/vouch-server/src/handlers/oidc/tests/helpers.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/helpers.rs
@@ -210,6 +210,31 @@ pub(super) fn build_client_assertion(
     sign_jwt_assertion(pkcs8_bytes, &header, &claims)
 }
 
+/// Build a JWT assertion for `private_key_jwt` client auth, deliberately
+/// omitting the `jti` claim. RFC 7523 §3 makes `jti` OPTIONAL for non-FAPI
+/// clients; this helper exercises that path. Use only with non-FAPI clients —
+/// FAPI 2.0 §5.3.2.1 requires `jti`.
+pub(super) fn build_client_assertion_omit_jti(
+    client_id: &str,
+    audience: &str,
+    pkcs8_bytes: &[u8],
+) -> String {
+    let now = jiff::Timestamp::now().as_second();
+    let header = serde_json::json!({
+        "alg": "ES256",
+        "typ": "JWT",
+        "kid": "test-key-1"
+    });
+    let claims = serde_json::json!({
+        "iss": client_id,
+        "sub": client_id,
+        "aud": audience,
+        "iat": now,
+        "exp": now + 60
+    });
+    sign_jwt_assertion(pkcs8_bytes, &header, &claims)
+}
+
 /// Decode a JWT payload (middle part) without signature verification.
 pub(super) fn decode_jwt_payload(token: &str) -> serde_json::Value {
     let parts: Vec<&str> = token.split('.').collect();

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7523.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7523.rs
@@ -811,6 +811,132 @@ async fn test_non_fapi_client_accepts_token_endpoint_audience() {
 }
 
 // ========================================================================
+// RFC 7523 §3 — `jti` is OPTIONAL for non-FAPI clients
+//
+// Regression tests for PR #409 cursor-bot finding 3299919906. Previously
+// the proof-resolution in each grant handler conflated "JTI committed"
+// with "JWT auth happened" — a non-FAPI client legitimately omitting
+// `jti` was authenticated by `authenticate_client_jwt` but then rejected
+// by the downstream proof construction (fell through to NoClientAuth /
+// "Client authentication required").
+// ========================================================================
+
+#[tokio::test]
+async fn test_rfc7523_authorization_code_grant_accepts_non_fapi_jwt_without_jti() {
+    // Non-FAPI private_key_jwt + authorization_code grant + no jti → 200.
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "no-jti-authcode@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let (client, pkcs8_bytes) = create_test_jwt_client(&state.store, &user.id).await;
+
+    let scope_set = ScopeSet::parse("openid");
+    let code = issue_authorization_code(
+        &state,
+        AuthorizationCodeParams {
+            client_id: &client.client_id,
+            redirect_uri: "https://example.com/callback",
+            user_id: &user.id,
+            email: &user.email,
+            authenticator_id: &auth_id,
+            aaguid: None,
+            scope: &scope_set,
+            nonce: None,
+            code_challenge: None,
+            code_challenge_method: None,
+            resource: None,
+            acr_values: None,
+            dpop_jkt: None,
+            auth_code_lifetime_seconds:
+                crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
+            authorization_details: None,
+            auth_time: None,
+        },
+    )
+    .await
+    .expect("issue authorization code");
+
+    let token_endpoint = format!("{}/oauth/token", state.config().base_url);
+    let assertion =
+        build_client_assertion_omit_jti(&client.client_id, &token_endpoint, &pkcs8_bytes);
+
+    let body = format!(
+        "grant_type=authorization_code&code={}&redirect_uri={}\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}",
+        code,
+        urlencoding::encode("https://example.com/callback"),
+    );
+
+    let (status, resp_body) = http_post_form(&app, "/oauth/token", &body, &[]).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "authorization_code + private_key_jwt without jti must succeed (RFC 7523 §3): {resp_body}"
+    );
+    let response: serde_json::Value = serde_json::from_str(&resp_body).expect("Valid JSON");
+    assert!(response.get("access_token").is_some());
+}
+
+#[tokio::test]
+async fn test_rfc7523_client_credentials_grant_accepts_non_fapi_jwt_without_jti() {
+    // Non-FAPI private_key_jwt + client_credentials grant + no jti → not 401.
+    // The grant itself may be denied (unauthorized_client) because the test
+    // client isn't enabled for client_credentials, but client auth itself
+    // must succeed — `invalid_client` would mean auth was rejected.
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "no-jti-cc@example.com").await;
+    let (client, pkcs8_bytes) = create_test_jwt_client(&state.store, &user.id).await;
+
+    let token_endpoint = format!("{}/oauth/token", state.config().base_url);
+    let assertion =
+        build_client_assertion_omit_jti(&client.client_id, &token_endpoint, &pkcs8_bytes);
+
+    let body = format!(
+        "grant_type=client_credentials\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}",
+    );
+
+    let (status, resp_body) = http_post_form(&app, "/oauth/token", &body, &[]).await;
+    let error: serde_json::Value = serde_json::from_str(&resp_body).expect("Valid JSON");
+    assert_ne!(
+        error["error"], "invalid_client",
+        "client_credentials + private_key_jwt without jti must pass client auth \
+         (status={status}, RFC 7523 §3): {resp_body}"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc7523_token_exchange_grant_accepts_non_fapi_jwt_without_jti() {
+    // Non-FAPI private_key_jwt + token_exchange grant + no jti → not 401.
+    // Grant may fail downstream on subject_token validation, but client
+    // auth itself must succeed.
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "no-jti-exchange@example.com").await;
+    let (client, pkcs8_bytes) = create_test_jwt_client(&state.store, &user.id).await;
+
+    let token_endpoint = format!("{}/oauth/token", state.config().base_url);
+    let assertion =
+        build_client_assertion_omit_jti(&client.client_id, &token_endpoint, &pkcs8_bytes);
+
+    let body = format!(
+        "grant_type=urn:ietf:params:oauth:grant-type:token-exchange\
+         &subject_token=dummy\
+         &subject_token_type=urn:ietf:params:oauth:token-type:access_token\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}",
+    );
+
+    let (status, resp_body) = http_post_form(&app, "/oauth/token", &body, &[]).await;
+    let error: serde_json::Value = serde_json::from_str(&resp_body).expect("Valid JSON");
+    assert_ne!(
+        error["error"], "invalid_client",
+        "token_exchange + private_key_jwt without jti must pass client auth \
+         (status={status}, RFC 7523 §3): {resp_body}"
+    );
+}
+
+// ========================================================================
 // Issue #391 — concurrent JTI replay must not produce multiple tokens.
 //
 // Before the fix, `commit_jti()` ran AFTER `exchange_*()`, so N concurrent

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc8705.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc8705.rs
@@ -8,7 +8,7 @@ use super::helpers::*;
 // ========================================================================
 
 /// Generate a self-signed P-256 certificate DER for testing.
-fn make_test_cert_der(cn: &str) -> Vec<u8> {
+pub(super) fn make_test_cert_der(cn: &str) -> Vec<u8> {
     use der::{Decode as _, Encode, asn1::Utf8StringRef};
     use p256::ecdsa::SigningKey;
     use spki::EncodePublicKey as _;

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
@@ -1006,9 +1006,9 @@ async fn test_rfc9126_consume_par_with_stale_version_returns_false() {
 
 #[tokio::test]
 async fn test_rfc9126_consume_par_concurrent_replay() {
-    // Mirrors the slice 7a pattern: two concurrent consume calls must
-    // produce exactly one winner; the loser must be AlreadyConsumed (not
-    // a Database error from the OCC version-mismatch path).
+    // Two concurrent consume calls must produce exactly one winner; the
+    // loser must be AlreadyConsumed (not a Database error from the OCC
+    // version-mismatch path).
     use crate::db::claim::ClaimError;
 
     let (_app, state) = test_app().await;

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
@@ -1637,3 +1637,1146 @@ async fn test_rfc9126_par_rejects_mtls_with_non_matching_cert() {
     let json: serde_json::Value = serde_json::from_str(&response_body).expect("Valid JSON");
     assert_eq!(json["error"], "invalid_client");
 }
+
+// ========================================================================
+// FAPI 2.0 / JAR / DPoP at PAR — conformance coverage
+//
+// Tests in this section cover the 39 scenarios captured in the
+// OpenID conformance suite handoff for `POST /oauth/par`. Each test
+// exercises a distinct handler branch and lists the conformance
+// scenario IDs it satisfies. See PAR_TEST_HANDOFF.md in the
+// vouch-conformance repository.
+// ========================================================================
+
+/// Kid used by [`generate_es256_signing_key`] and [`build_client_assertion`] from helpers.rs.
+/// FAPI request-object signing must use the same kid so the JWKS lookup matches.
+const PAR_FAPI_JWK_KID: &str = "test-key-1";
+
+/// Create a FAPI 2.0 OAuth client authenticated via `private_key_jwt`.
+/// Returns (client, pkcs8 signing key) — caller signs client_assertions / Request Objects.
+async fn create_fapi_jwt_client(
+    store: &db::store::DocumentStore,
+    user_id: &str,
+) -> (TestOAuthClient, Vec<u8>) {
+    let (client, pkcs8_bytes) = create_test_jwt_client(store, user_id).await;
+    db::update_oauth_client_fapi_settings(
+        store,
+        &client.app_id,
+        crate::db::FapiProfile::Fapi2Security,
+        false,
+    )
+    .await
+    .expect("Failed to set FAPI profile");
+    (client, pkcs8_bytes)
+}
+
+/// FAPI client that additionally requires a signed Request Object (RFC 9101).
+async fn create_fapi_jwt_client_requiring_request_object(
+    store: &db::store::DocumentStore,
+    user_id: &str,
+) -> (TestOAuthClient, Vec<u8>) {
+    let (client, pkcs8_bytes) = create_fapi_jwt_client(store, user_id).await;
+    db::update_oauth_client_jar_settings(store, &client.app_id, None, true)
+        .await
+        .expect("Failed to set require_signed_request_object");
+    (client, pkcs8_bytes)
+}
+
+/// Create a FAPI mTLS-authenticated OAuth client bound to the given subject DN.
+/// JWKS is also attached so Request Objects can be verified against the same key.
+async fn create_fapi_mtls_client(
+    store: &db::store::DocumentStore,
+    user_id: &str,
+    subject_dn: &str,
+) -> (String, Vec<u8>) {
+    let (pkcs8_bytes, jwk) = generate_es256_signing_key();
+    let jwks_value = serde_json::json!({ "keys": [jwk] });
+    let (_doc, client_id) = crate::db::create_oauth_client(
+        store,
+        &crate::db::CreateOAuthClientParams {
+            user_id: Some(user_id),
+            name: "Test FAPI mTLS PAR Client",
+            description: None,
+            application_type: crate::db::OAuthClientType::Web,
+            redirect_uris: &["https://example.com/callback".to_string()],
+            access_scope: crate::db::AccessScope::Public,
+            org_id: None,
+            resource_uris: &[],
+            token_endpoint_auth_method: Some(crate::db::TokenEndpointAuthMethod::TlsClientAuth),
+            jwks: Some(&jwks_value),
+            jwks_uri: None,
+            fapi_profile: Some(crate::db::FapiProfile::Fapi2Security),
+            dpop_bound_access_tokens: None,
+            grant_types: None,
+            response_types: None,
+            software_id: None,
+            software_version: None,
+            registration_source: crate::db::RegistrationSource::Manual,
+            registration_access_token_hash: None,
+            registration_metadata: None,
+            id_token_signed_response_alg: crate::db::JwsAlgorithm::Rs256,
+            tls_client_auth_subject_dn: Some(subject_dn),
+            tls_client_auth_san_dns: None,
+            tls_client_auth_san_uri: None,
+            tls_client_auth_san_ip: None,
+            tls_client_auth_san_email: None,
+            tls_client_certificate_bound_access_tokens: None,
+            authorization_signed_response_alg: None,
+            introspection_signed_response_alg: None,
+            request_object_signing_alg: None,
+            require_signed_request_object: None,
+            userinfo_signed_response_alg: None,
+            request_uris: None,
+        },
+    )
+    .await
+    .expect("Failed to create FAPI mTLS test client");
+    (client_id, pkcs8_bytes)
+}
+
+/// Build a FAPI 2.0 Request Object JWT with all required claims.
+/// `override_claims` lets a test mutate the claims (e.g. remove `exp`, oversize `nonce`)
+/// before signing.
+fn build_fapi_request_object<F>(
+    client_id: &str,
+    issuer: &str,
+    pkcs8_bytes: &[u8],
+    code_challenge: &str,
+    override_claims: F,
+) -> String
+where
+    F: FnOnce(&mut serde_json::Value),
+{
+    let now = jiff::Timestamp::now().as_second();
+    let header = serde_json::json!({
+        "alg": "ES256",
+        "typ": "oauth-authz-req+jwt",
+        "kid": PAR_FAPI_JWK_KID,
+    });
+    let mut claims = serde_json::json!({
+        "iss": client_id,
+        "aud": issuer,
+        "exp": now + 60,
+        "nbf": now,
+        "iat": now,
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": "https://example.com/callback",
+        "scope": "openid",
+        "state": "par-fapi-state",
+        "nonce": "par-fapi-nonce",
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+    });
+    override_claims(&mut claims);
+    sign_jwt_assertion(pkcs8_bytes, &header, &claims)
+}
+
+/// Build a DPoP proof JWT bound to the given key pair, with `htm`, `htu`, optional
+/// `nonce`. Returns the proof string and the JWK thumbprint (base64url SHA-256).
+fn build_dpop_proof_with_jkt(
+    pkcs8_bytes: &[u8],
+    method: &str,
+    uri: &str,
+    nonce: Option<&str>,
+) -> (String, String) {
+    use aws_lc_rs::digest;
+    use aws_lc_rs::signature::{ECDSA_P256_SHA256_FIXED_SIGNING, EcdsaKeyPair, KeyPair};
+
+    let key_pair = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, pkcs8_bytes)
+        .expect("Failed to parse DPoP key");
+    let pub_bytes = key_pair.public_key().as_ref();
+    let x = URL_SAFE_NO_PAD.encode(&pub_bytes[1..33]);
+    let y = URL_SAFE_NO_PAD.encode(&pub_bytes[33..65]);
+    let jwk = serde_json::json!({
+        "kty": "EC",
+        "crv": "P-256",
+        "x": x.clone(),
+        "y": y.clone(),
+    });
+    // JWK thumbprint per RFC 7638: SHA-256 of canonical JSON {crv,kty,x,y}.
+    let thumbprint_input = format!(r#"{{"crv":"P-256","kty":"EC","x":"{x}","y":"{y}"}}"#);
+    let jkt = URL_SAFE_NO_PAD
+        .encode(digest::digest(&digest::SHA256, thumbprint_input.as_bytes()).as_ref());
+
+    let header = serde_json::json!({
+        "typ": "dpop+jwt",
+        "alg": "ES256",
+        "jwk": jwk,
+    });
+
+    let now = jiff::Timestamp::now().as_second();
+    let mut claims = serde_json::json!({
+        "jti": uuid::Uuid::now_v7().to_string(),
+        "htm": method,
+        "htu": uri,
+        "iat": now,
+    });
+    if let Some(n) = nonce {
+        claims["nonce"] = serde_json::json!(n);
+    }
+
+    let header_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&header).unwrap());
+    let claims_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&claims).unwrap());
+    let signing_input = format!("{header_b64}.{claims_b64}");
+    let rng = aws_lc_rs::rand::SystemRandom::new();
+    let sig = key_pair.sign(&rng, signing_input.as_bytes()).expect("sign");
+    let sig_b64 = URL_SAFE_NO_PAD.encode(sig.as_ref());
+    (format!("{header_b64}.{claims_b64}.{sig_b64}"), jkt)
+}
+
+/// Generate a fresh ES256 pkcs8 byte vector for DPoP keys.
+fn generate_dpop_pkcs8() -> Vec<u8> {
+    use aws_lc_rs::signature::{ECDSA_P256_SHA256_FIXED_SIGNING, EcdsaKeyPair};
+    let rng = aws_lc_rs::rand::SystemRandom::new();
+    let pkcs8 = EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &rng)
+        .expect("Failed to generate DPoP key");
+    pkcs8.as_ref().to_vec()
+}
+
+/// POST a form to `/oauth/par` with optional DPoP proof and optional mTLS cert,
+/// returning status, body and headers. This bridges a small gap in `test_utils`:
+/// `http_post_form_with_cert` strips headers, and `http_post_form_full` strips certs.
+async fn par_post_full(
+    app: &axum::Router,
+    body: &str,
+    dpop_proof: Option<&str>,
+    cert_der: Option<Vec<u8>>,
+    extra_headers: &[(&str, &str)],
+) -> crate::test_utils::HttpResponse {
+    use tower::ServiceExt;
+
+    let mut req_builder = axum::http::Request::builder()
+        .method("POST")
+        .uri("/oauth/par")
+        .header("Content-Type", "application/x-www-form-urlencoded");
+    if let Some(p) = dpop_proof {
+        req_builder = req_builder.header("DPoP", p);
+    }
+    for (name, value) in extra_headers {
+        req_builder = req_builder.header(*name, *value);
+    }
+    let request = req_builder
+        .body(axum::body::Body::from(body.to_string()))
+        .expect("Failed to build request");
+    let (mut parts, body_inner) = request.into_parts();
+    parts
+        .extensions
+        .insert(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+            [127, 0, 0, 1],
+            0,
+        ))));
+    parts.extensions.insert(axum::extract::ConnectInfo(
+        crate::infra::mtls_listener::PeerClientCert(cert_der),
+    ));
+    let request = axum::http::Request::from_parts(parts, body_inner);
+    let response = app
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("Failed to execute request");
+    let status = response.status();
+    let response_headers = response.headers().clone();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read response body");
+    crate::test_utils::HttpResponse {
+        status,
+        body: String::from_utf8_lossy(&body_bytes).to_string(),
+        headers: response_headers,
+    }
+}
+
+/// Acquire a DPoP nonce from the PAR endpoint by submitting a proof without one.
+/// The first request returns `400 use_dpop_nonce` with a `DPoP-Nonce` header;
+/// the second request uses that nonce.
+async fn acquire_par_dpop_nonce(
+    app: &axum::Router,
+    pkcs8_bytes: &[u8],
+    par_uri: &str,
+    body_with_no_dpop: &str,
+    cert_der: Option<Vec<u8>>,
+) -> String {
+    let (proof, _jkt) = build_dpop_proof_with_jkt(pkcs8_bytes, "POST", par_uri, None);
+    let response = par_post_full(app, body_with_no_dpop, Some(&proof), cert_der, &[]).await;
+    assert_eq!(
+        response.status,
+        StatusCode::BAD_REQUEST,
+        "expected use_dpop_nonce: {}",
+        response.body
+    );
+    response
+        .headers
+        .get("dpop-nonce")
+        .expect("server must return dpop-nonce header")
+        .to_str()
+        .expect("dpop-nonce header must be utf-8")
+        .to_string()
+}
+
+/// Submit a form POST to `/oauth/par` with a DPoP header.
+async fn par_post_with_dpop(
+    app: &axum::Router,
+    body: &str,
+    dpop_proof: &str,
+    extra_headers: &[(&str, &str)],
+) -> (StatusCode, String) {
+    let mut all = vec![("DPoP", dpop_proof)];
+    all.extend_from_slice(extra_headers);
+    http_post_form(app, "/oauth/par", body, &all).await
+}
+
+// ------------------------------------------------------------------------
+// Negative-path tests
+// ------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_rfc9126_par_rejects_missing_pkce_for_fapi_client() {
+    // FAPI 2.0 §5.3.2.1: PKCE is required for FAPI clients.
+    // Covers conformance scenarios:
+    //   - mtls | plain | 400 invalid_request
+    //   - private_key_jwt | plain | 400 invalid_request
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "par-fapi-pkce@example.com").await;
+    let (client, pkcs8_bytes) = create_fapi_jwt_client(&state.store, &user.id).await;
+
+    let assertion = build_client_assertion(
+        &client.client_id,
+        &state.config().base_url,
+        &pkcs8_bytes,
+        None,
+    );
+    let body = format!(
+        "response_type=code\
+         &client_id={}\
+         &redirect_uri={}\
+         &scope=openid\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}",
+        client.client_id,
+        urlencoding::encode("https://example.com/callback"),
+    );
+
+    let (status, response_body) = http_post_form(&app, "/oauth/par", &body, &[]).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "FAPI client without PKCE must be rejected: {response_body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&response_body).expect("Valid JSON");
+    assert_eq!(json["error"], "invalid_request");
+    assert_eq!(
+        json["error_description"],
+        "PKCE is required: code_challenge and code_challenge_method=S256 must be provided"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc9126_par_rejects_plain_pkce_method() {
+    // FAPI 2.0 / RFC 9700: Only S256 is supported as code_challenge_method.
+    // Covers conformance scenarios:
+    //   - mtls | has_pkce,pkce_plain | 400 invalid_request
+    //   - private_key_jwt | has_pkce,pkce_plain | 400 invalid_request
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "par-plain-pkce@example.com").await;
+    let (client, pkcs8_bytes) = create_fapi_jwt_client(&state.store, &user.id).await;
+
+    let assertion = build_client_assertion(
+        &client.client_id,
+        &state.config().base_url,
+        &pkcs8_bytes,
+        None,
+    );
+    // Per RFC 7636 §4.2 the plain verifier itself can be the challenge.
+    let plain_challenge = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    let body = format!(
+        "response_type=code\
+         &client_id={}\
+         &redirect_uri={}\
+         &scope=openid\
+         &code_challenge={plain_challenge}\
+         &code_challenge_method=plain\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}",
+        client.client_id,
+        urlencoding::encode("https://example.com/callback"),
+    );
+
+    let (status, response_body) = http_post_form(&app, "/oauth/par", &body, &[]).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "plain PKCE method must be rejected: {response_body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&response_body).expect("Valid JSON");
+    assert_eq!(json["error"], "invalid_request");
+    assert_eq!(
+        json["error_description"],
+        "Unsupported code_challenge_method. Only S256 is supported"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc9126_par_rejects_missing_request_object_when_required() {
+    // RFC 9101: If client.require_signed_request_object is true, the `request`
+    // parameter is mandatory at PAR.
+    // Covers conformance scenarios:
+    //   - mtls | has_pkce | 400 invalid_request (description "This client requires a signed Request Object (RFC 9101)")
+    //   - private_key_jwt | has_pkce | 400 invalid_request (same description)
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "par-needs-ro@example.com").await;
+    let (client, pkcs8_bytes) =
+        create_fapi_jwt_client_requiring_request_object(&state.store, &user.id).await;
+
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    let challenge = sha256_base64url(verifier);
+    let assertion = build_client_assertion(
+        &client.client_id,
+        &state.config().base_url,
+        &pkcs8_bytes,
+        None,
+    );
+
+    let body = format!(
+        "response_type=code\
+         &client_id={}\
+         &redirect_uri={}\
+         &scope=openid\
+         &code_challenge={challenge}\
+         &code_challenge_method=S256\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}",
+        client.client_id,
+        urlencoding::encode("https://example.com/callback"),
+    );
+
+    let (status, response_body) = http_post_form(&app, "/oauth/par", &body, &[]).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "client requiring signed Request Object must reject plain PAR: {response_body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&response_body).expect("Valid JSON");
+    assert_eq!(json["error"], "invalid_request");
+    assert_eq!(
+        json["error_description"],
+        "This client requires a signed Request Object (RFC 9101)"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc9126_par_rejects_unsupported_response_type() {
+    // Only response_type=code is supported. `code id_token` and `token` are rejected.
+    // Covers conformance scenarios across all 4 auth methods × form/JAR shapes:
+    //   - mtls | has_pkce | 400 unsupported_response_type
+    //   - mtls | has_request_jwt | 400 unsupported_response_type
+    //   - private_key_jwt | has_pkce | 400 unsupported_response_type
+    //   - private_key_jwt | has_request_jwt | 400 unsupported_response_type
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "par-bad-rt@example.com").await;
+    let (client, pkcs8_bytes) = create_fapi_jwt_client(&state.store, &user.id).await;
+
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    let challenge = sha256_base64url(verifier);
+    let assertion = build_client_assertion(
+        &client.client_id,
+        &state.config().base_url,
+        &pkcs8_bytes,
+        None,
+    );
+
+    let body = format!(
+        "response_type={}\
+         &client_id={}\
+         &redirect_uri={}\
+         &scope=openid\
+         &code_challenge={challenge}\
+         &code_challenge_method=S256\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}",
+        urlencoding::encode("code id_token"),
+        client.client_id,
+        urlencoding::encode("https://example.com/callback"),
+    );
+
+    let (status, response_body) = http_post_form(&app, "/oauth/par", &body, &[]).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "non-`code` response_type must be rejected: {response_body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&response_body).expect("Valid JSON");
+    assert_eq!(json["error"], "unsupported_response_type");
+    assert_eq!(
+        json["error_description"],
+        "Only 'code' response type is supported"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc9126_par_rejects_nonce_over_max_length_in_request_object() {
+    // Authorization-request param length enforcement (256 bytes for nonce/state).
+    // Exercised through a JAR with an oversized nonce so the JAR validation path
+    // unwraps the claim and applies the length check.
+    // Covers conformance scenarios:
+    //   - mtls | has_request_jwt | 400 invalid_request ("nonce exceeds maximum length of 256")
+    //   - private_key_jwt | has_request_jwt | 400 invalid_request (same)
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "par-long-nonce@example.com").await;
+    let (client, pkcs8_bytes) = create_fapi_jwt_client(&state.store, &user.id).await;
+
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    let challenge = sha256_base64url(verifier);
+    let oversized_nonce = "n".repeat(300);
+    let request_jwt = build_fapi_request_object(
+        &client.client_id,
+        &state.config().base_url,
+        &pkcs8_bytes,
+        &challenge,
+        |claims| {
+            claims["nonce"] = serde_json::Value::String(oversized_nonce.clone());
+        },
+    );
+    let assertion = build_client_assertion(
+        &client.client_id,
+        &state.config().base_url,
+        &pkcs8_bytes,
+        None,
+    );
+
+    let body = format!(
+        "request={request_jwt}\
+         &client_id={}\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}",
+        client.client_id,
+    );
+
+    let (status, response_body) = http_post_form(&app, "/oauth/par", &body, &[]).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "oversized nonce in JAR must be rejected: {response_body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&response_body).expect("Valid JSON");
+    assert_eq!(json["error"], "invalid_request");
+    assert_eq!(
+        json["error_description"],
+        "nonce exceeds maximum length of 256"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc9126_par_rejects_request_object_missing_exp() {
+    // FAPI 2.0: Request Object must contain `exp`, `nbf`, `iss`, `aud`.
+    // Covers conformance scenarios:
+    //   - mtls | has_request_jwt | 400 invalid_request_object
+    //   - private_key_jwt | has_request_jwt | 400 invalid_request_object
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "par-noexp-ro@example.com").await;
+    let (client, pkcs8_bytes) = create_fapi_jwt_client(&state.store, &user.id).await;
+
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    let challenge = sha256_base64url(verifier);
+    let request_jwt = build_fapi_request_object(
+        &client.client_id,
+        &state.config().base_url,
+        &pkcs8_bytes,
+        &challenge,
+        |claims| {
+            // Drop the required `exp` claim.
+            if let Some(obj) = claims.as_object_mut() {
+                obj.remove("exp");
+            }
+        },
+    );
+    let assertion = build_client_assertion(
+        &client.client_id,
+        &state.config().base_url,
+        &pkcs8_bytes,
+        None,
+    );
+
+    let body = format!(
+        "request={request_jwt}\
+         &client_id={}\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}",
+        client.client_id,
+    );
+
+    let (status, response_body) = http_post_form(&app, "/oauth/par", &body, &[]).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "Request Object without exp must be rejected: {response_body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&response_body).expect("Valid JSON");
+    assert_eq!(json["error"], "invalid_request_object");
+    assert_eq!(
+        json["error_description"],
+        "FAPI 2.0: Request Object must contain 'exp' claim"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc9126_par_rejects_dpop_jkt_form_mismatch() {
+    // RFC 9449 §10: When `dpop_jkt` form param is provided alongside a DPoP proof,
+    // the two thumbprints MUST match.
+    // Covers conformance scenarios:
+    //   - mtls | has_dpop_header,has_pkce | 400 invalid_dpop_proof (form-param branch)
+    //   - private_key_jwt | has_dpop_header,has_pkce | 400 invalid_dpop_proof
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "par-dpop-jkt-form@example.com").await;
+    let (client, pkcs8_bytes) = create_fapi_jwt_client(&state.store, &user.id).await;
+
+    let par_uri = format!("{}/oauth/par", state.config().base_url);
+    let dpop_key = generate_dpop_pkcs8();
+
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    let challenge = sha256_base64url(verifier);
+    let assertion = build_client_assertion(
+        &client.client_id,
+        &state.config().base_url,
+        &pkcs8_bytes,
+        None,
+    );
+    let body_no_dpop = format!(
+        "response_type=code\
+         &client_id={}\
+         &redirect_uri={}\
+         &scope=openid\
+         &code_challenge={challenge}\
+         &code_challenge_method=S256\
+         &dpop_jkt=not-the-actual-thumbprint\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}",
+        client.client_id,
+        urlencoding::encode("https://example.com/callback"),
+    );
+
+    let nonce = acquire_par_dpop_nonce(&app, &dpop_key, &par_uri, &body_no_dpop, None).await;
+    let (proof, _jkt) = build_dpop_proof_with_jkt(&dpop_key, "POST", &par_uri, Some(&nonce));
+
+    let (status, response_body) = par_post_with_dpop(&app, &body_no_dpop, &proof, &[]).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "dpop_jkt form-param mismatch must be rejected: {response_body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&response_body).expect("Valid JSON");
+    assert_eq!(json["error"], "invalid_dpop_proof");
+    assert_eq!(
+        json["error_description"],
+        "dpop_jkt parameter does not match DPoP proof JWK thumbprint"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc9126_par_rejects_dpop_jkt_jar_claim_mismatch() {
+    // RFC 9449 §10: When `dpop_jkt` appears as a JAR claim alongside a DPoP proof,
+    // the two thumbprints MUST match. The handler reports this with a slightly
+    // different description than the form-param branch.
+    // Covers conformance scenarios:
+    //   - private_key_jwt | has_dpop_header,has_request_jwt | 400 invalid_dpop_proof
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "par-dpop-jkt-jar@example.com").await;
+    let (client, pkcs8_bytes) = create_fapi_jwt_client(&state.store, &user.id).await;
+
+    let par_uri = format!("{}/oauth/par", state.config().base_url);
+    let dpop_key = generate_dpop_pkcs8();
+
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    let challenge = sha256_base64url(verifier);
+
+    // Build a Request Object that carries a dpop_jkt claim NOT matching the DPoP proof.
+    let request_jwt = build_fapi_request_object(
+        &client.client_id,
+        &state.config().base_url,
+        &pkcs8_bytes,
+        &challenge,
+        |claims| {
+            claims["dpop_jkt"] = serde_json::Value::String(
+                "wrong-thumbprint-aaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+            );
+        },
+    );
+    let assertion = build_client_assertion(
+        &client.client_id,
+        &state.config().base_url,
+        &pkcs8_bytes,
+        None,
+    );
+
+    let body_no_dpop = format!(
+        "request={request_jwt}\
+         &client_id={}\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}",
+        client.client_id,
+    );
+
+    let nonce = acquire_par_dpop_nonce(&app, &dpop_key, &par_uri, &body_no_dpop, None).await;
+    let (proof, _jkt) = build_dpop_proof_with_jkt(&dpop_key, "POST", &par_uri, Some(&nonce));
+
+    let (status, response_body) = par_post_with_dpop(&app, &body_no_dpop, &proof, &[]).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "JAR dpop_jkt mismatch must be rejected: {response_body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&response_body).expect("Valid JSON");
+    assert_eq!(json["error"], "invalid_dpop_proof");
+    assert_eq!(
+        json["error_description"],
+        "dpop_jkt does not match DPoP proof JWK thumbprint"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc9126_par_requires_dpop_nonce_returns_use_dpop_nonce() {
+    // RFC 9449 §8: The token endpoint (and PAR, which shares DPoP enforcement)
+    // requires a nonce in the DPoP proof; first request returns `use_dpop_nonce`
+    // and a `DPoP-Nonce` header for the client to retry with.
+    // Covers conformance scenarios:
+    //   - mtls | has_dpop_header,has_pkce | 400 use_dpop_nonce
+    //   - private_key_jwt | has_dpop_header,has_pkce | 400 use_dpop_nonce
+    //   - private_key_jwt | has_dpop_header,has_request_jwt | 400 use_dpop_nonce
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "par-use-dpop-nonce@example.com").await;
+    let (client, pkcs8_bytes) = create_fapi_jwt_client(&state.store, &user.id).await;
+
+    let par_uri = format!("{}/oauth/par", state.config().base_url);
+    let dpop_key = generate_dpop_pkcs8();
+    let (proof, _jkt) = build_dpop_proof_with_jkt(&dpop_key, "POST", &par_uri, None);
+
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    let challenge = sha256_base64url(verifier);
+    let assertion = build_client_assertion(
+        &client.client_id,
+        &state.config().base_url,
+        &pkcs8_bytes,
+        None,
+    );
+
+    let body = format!(
+        "response_type=code\
+         &client_id={}\
+         &redirect_uri={}\
+         &scope=openid\
+         &code_challenge={challenge}\
+         &code_challenge_method=S256\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}",
+        client.client_id,
+        urlencoding::encode("https://example.com/callback"),
+    );
+
+    let response = crate::test_utils::http_post_form_full(
+        &app,
+        "/oauth/par",
+        &body,
+        &[("DPoP", proof.as_str())],
+    )
+    .await;
+    assert_eq!(
+        response.status,
+        StatusCode::BAD_REQUEST,
+        "DPoP without nonce must return use_dpop_nonce: {}",
+        response.body
+    );
+    assert!(
+        response.headers.get("dpop-nonce").is_some(),
+        "response must include DPoP-Nonce header"
+    );
+    let json: serde_json::Value = serde_json::from_str(&response.body).expect("Valid JSON");
+    assert_eq!(json["error"], "use_dpop_nonce");
+    assert_eq!(
+        json["error_description"],
+        "Authorization server requires nonce in DPoP proof"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc9126_par_rejects_private_key_jwt_with_bad_aud() {
+    // RFC 7523 / FAPI 2.0: client_assertion `aud` must match the issuer URL for
+    // FAPI clients. A wrong audience causes the assertion to fail validation,
+    // returning 401 invalid_client.
+    // Covers conformance scenarios:
+    //   - private_key_jwt | has_pkce | 401 invalid_client (par-test-token-endpoint-url-as-audience-fails et al.)
+    //   - private_key_jwt | has_request_jwt | 401 invalid_client
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "par-bad-aud@example.com").await;
+    let (client, pkcs8_bytes) = create_fapi_jwt_client(&state.store, &user.id).await;
+
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    let challenge = sha256_base64url(verifier);
+    let wrong_aud = "https://attacker.example.com";
+    let assertion = build_client_assertion(&client.client_id, wrong_aud, &pkcs8_bytes, None);
+
+    let body = format!(
+        "response_type=code\
+         &client_id={}\
+         &redirect_uri={}\
+         &scope=openid\
+         &code_challenge={challenge}\
+         &code_challenge_method=S256\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}",
+        client.client_id,
+        urlencoding::encode("https://example.com/callback"),
+    );
+
+    let (status, response_body) = http_post_form(&app, "/oauth/par", &body, &[]).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "client_assertion with wrong aud must return 401: {response_body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&response_body).expect("Valid JSON");
+    assert_eq!(json["error"], "invalid_client");
+}
+
+#[tokio::test]
+async fn test_rfc9126_par_rejects_private_key_jwt_with_nbf_too_far_future() {
+    // RFC 7523 / FAPI 2.0: client_assertion `nbf` must be within clock-skew
+    // tolerance of "now". An `nbf` 70 seconds in the future exceeds the FAPI
+    // 10-second window and fails validation.
+    // Covers conformance scenarios:
+    //   - private_key_jwt | has_pkce | 401 invalid_client (nbf-over-60-seconds-in-the-future-fails)
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "par-bad-nbf@example.com").await;
+    let (client, pkcs8_bytes) = create_fapi_jwt_client(&state.store, &user.id).await;
+
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    let challenge = sha256_base64url(verifier);
+
+    // Hand-craft a client assertion with future nbf.
+    let now = jiff::Timestamp::now().as_second();
+    let header = serde_json::json!({
+        "alg": "ES256",
+        "typ": "JWT",
+        "kid": PAR_FAPI_JWK_KID,
+    });
+    let claims = serde_json::json!({
+        "iss": client.client_id,
+        "sub": client.client_id,
+        "aud": state.config().base_url,
+        "iat": now,
+        "nbf": now + 120,
+        "exp": now + 300,
+        "jti": uuid::Uuid::now_v7().to_string(),
+    });
+    let assertion = sign_jwt_assertion(&pkcs8_bytes, &header, &claims);
+
+    let body = format!(
+        "response_type=code\
+         &client_id={}\
+         &redirect_uri={}\
+         &scope=openid\
+         &code_challenge={challenge}\
+         &code_challenge_method=S256\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}",
+        client.client_id,
+        urlencoding::encode("https://example.com/callback"),
+    );
+
+    let (status, response_body) = http_post_form(&app, "/oauth/par", &body, &[]).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "client_assertion with future nbf must return 401: {response_body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&response_body).expect("Valid JSON");
+    assert_eq!(json["error"], "invalid_client");
+}
+
+#[tokio::test]
+async fn test_rfc9126_par_get_returns_method_not_allowed() {
+    // The PAR endpoint is POST-only. GET MUST return 405 Method Not Allowed.
+    // Covers conformance scenarios:
+    //   - mtls | has_pkce | 405
+    //   - mtls | has_request_jwt | 405
+    //   - mtls+private_key_jwt | has_pkce | 405
+    //   - private_key_jwt | has_pkce | 405
+    //   - private_key_jwt | has_request_jwt | 405
+    let (app, _state) = test_app().await;
+    let (status, _body) = http_get(&app, "/oauth/par", &[]).await;
+    assert_eq!(
+        status,
+        StatusCode::METHOD_NOT_ALLOWED,
+        "GET /oauth/par must return 405"
+    );
+}
+
+// ------------------------------------------------------------------------
+// Positive-path tests — happy paths for auth/feature compositions not
+// already covered by the existing 34 tests.
+// ------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_rfc9126_par_accepts_private_key_jwt_with_pkce() {
+    // Covers conformance scenarios:
+    //   - private_key_jwt | has_pkce | 201
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "par-pkjwt-pkce@example.com").await;
+    let (client, pkcs8_bytes) = create_fapi_jwt_client(&state.store, &user.id).await;
+
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    let challenge = sha256_base64url(verifier);
+    let assertion = build_client_assertion(
+        &client.client_id,
+        &state.config().base_url,
+        &pkcs8_bytes,
+        None,
+    );
+    let body = format!(
+        "response_type=code\
+         &client_id={}\
+         &redirect_uri={}\
+         &scope=openid\
+         &code_challenge={challenge}\
+         &code_challenge_method=S256\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}",
+        client.client_id,
+        urlencoding::encode("https://example.com/callback"),
+    );
+
+    let (status, response_body) = http_post_form(&app, "/oauth/par", &body, &[]).await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "private_key_jwt + PKCE PAR must succeed: {response_body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&response_body).expect("Valid JSON");
+    assert!(json["request_uri"].is_string());
+    assert!(json["expires_in"].is_number());
+}
+
+#[tokio::test]
+async fn test_rfc9126_par_accepts_private_key_jwt_with_request_object() {
+    // Covers conformance scenarios:
+    //   - private_key_jwt | has_request_jwt | 201
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "par-pkjwt-ro@example.com").await;
+    let (client, pkcs8_bytes) = create_fapi_jwt_client(&state.store, &user.id).await;
+
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    let challenge = sha256_base64url(verifier);
+    let request_jwt = build_fapi_request_object(
+        &client.client_id,
+        &state.config().base_url,
+        &pkcs8_bytes,
+        &challenge,
+        |_| {},
+    );
+    let assertion = build_client_assertion(
+        &client.client_id,
+        &state.config().base_url,
+        &pkcs8_bytes,
+        None,
+    );
+    let body = format!(
+        "request={request_jwt}\
+         &client_id={}\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}",
+        client.client_id,
+    );
+
+    let (status, response_body) = http_post_form(&app, "/oauth/par", &body, &[]).await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "private_key_jwt + Request Object PAR must succeed: {response_body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&response_body).expect("Valid JSON");
+    assert!(json["request_uri"].is_string());
+}
+
+#[tokio::test]
+async fn test_rfc9126_par_accepts_private_key_jwt_with_dpop_and_pkce() {
+    // Covers conformance scenarios:
+    //   - private_key_jwt | has_dpop_header,has_pkce | 201
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "par-pkjwt-dpop-pkce@example.com").await;
+    let (client, pkcs8_bytes) = create_fapi_jwt_client(&state.store, &user.id).await;
+
+    let par_uri = format!("{}/oauth/par", state.config().base_url);
+    let dpop_key = generate_dpop_pkcs8();
+
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    let challenge = sha256_base64url(verifier);
+    let assertion = build_client_assertion(
+        &client.client_id,
+        &state.config().base_url,
+        &pkcs8_bytes,
+        None,
+    );
+
+    let body = format!(
+        "response_type=code\
+         &client_id={}\
+         &redirect_uri={}\
+         &scope=openid\
+         &code_challenge={challenge}\
+         &code_challenge_method=S256\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}",
+        client.client_id,
+        urlencoding::encode("https://example.com/callback"),
+    );
+
+    let nonce = acquire_par_dpop_nonce(&app, &dpop_key, &par_uri, &body, None).await;
+    let (proof, _jkt) = build_dpop_proof_with_jkt(&dpop_key, "POST", &par_uri, Some(&nonce));
+    let (status, response_body) = par_post_with_dpop(&app, &body, &proof, &[]).await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "private_key_jwt + DPoP + PKCE PAR must succeed: {response_body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&response_body).expect("Valid JSON");
+    assert!(json["request_uri"].is_string());
+}
+
+#[tokio::test]
+async fn test_rfc9126_par_accepts_private_key_jwt_with_dpop_and_request_object() {
+    // Covers conformance scenarios:
+    //   - private_key_jwt | has_dpop_header,has_request_jwt | 201
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "par-pkjwt-dpop-ro@example.com").await;
+    let (client, pkcs8_bytes) = create_fapi_jwt_client(&state.store, &user.id).await;
+
+    let par_uri = format!("{}/oauth/par", state.config().base_url);
+    let dpop_key = generate_dpop_pkcs8();
+
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    let challenge = sha256_base64url(verifier);
+    let request_jwt = build_fapi_request_object(
+        &client.client_id,
+        &state.config().base_url,
+        &pkcs8_bytes,
+        &challenge,
+        |_| {},
+    );
+    let assertion = build_client_assertion(
+        &client.client_id,
+        &state.config().base_url,
+        &pkcs8_bytes,
+        None,
+    );
+    let body = format!(
+        "request={request_jwt}\
+         &client_id={}\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}",
+        client.client_id,
+    );
+
+    let nonce = acquire_par_dpop_nonce(&app, &dpop_key, &par_uri, &body, None).await;
+    let (proof, _jkt) = build_dpop_proof_with_jkt(&dpop_key, "POST", &par_uri, Some(&nonce));
+    let (status, response_body) = par_post_with_dpop(&app, &body, &proof, &[]).await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "private_key_jwt + DPoP + Request Object PAR must succeed: {response_body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&response_body).expect("Valid JSON");
+    assert!(json["request_uri"].is_string());
+}
+
+#[tokio::test]
+async fn test_rfc9126_par_accepts_mtls_with_request_object() {
+    // Covers conformance scenarios:
+    //   - mtls | has_request_jwt | 201
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "par-mtls-ro@example.com").await;
+    let _auth_id = create_test_authenticator(&state.store, &user.id).await;
+
+    let cert_der = super::rfc8705::make_test_cert_der("par-mtls-ro-client");
+    let parsed = crate::services::oidc::mtls::parse_client_certificate(&cert_der)
+        .expect("parse generated cert");
+    let subject_dn = parsed.subject_dn.expect("generated cert has subject DN");
+
+    let (client_id, pkcs8_bytes) =
+        create_fapi_mtls_client(&state.store, &user.id, &subject_dn).await;
+
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    let challenge = sha256_base64url(verifier);
+    let request_jwt = build_fapi_request_object(
+        &client_id,
+        &state.config().base_url,
+        &pkcs8_bytes,
+        &challenge,
+        |_| {},
+    );
+
+    let body = format!("request={request_jwt}&client_id={client_id}");
+    let (status, response_body) =
+        http_post_form_with_cert(&app, "/oauth/par", &body, &[], Some(cert_der)).await;
+
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "mTLS + Request Object PAR must succeed: {response_body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&response_body).expect("Valid JSON");
+    assert!(json["request_uri"].is_string());
+}
+
+#[tokio::test]
+async fn test_rfc9126_par_accepts_mtls_with_dpop_and_pkce() {
+    // Covers conformance scenarios:
+    //   - mtls | has_dpop_header,has_pkce | 201
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "par-mtls-dpop-pkce@example.com").await;
+    let _auth_id = create_test_authenticator(&state.store, &user.id).await;
+
+    let cert_der = super::rfc8705::make_test_cert_der("par-mtls-dpop-client");
+    let parsed = crate::services::oidc::mtls::parse_client_certificate(&cert_der)
+        .expect("parse generated cert");
+    let subject_dn = parsed.subject_dn.expect("generated cert has subject DN");
+
+    let (client_id, _pkcs8) = create_fapi_mtls_client(&state.store, &user.id, &subject_dn).await;
+
+    let par_uri = format!("{}/oauth/par", state.config().base_url);
+    let dpop_key = generate_dpop_pkcs8();
+
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    let challenge = sha256_base64url(verifier);
+    let body = format!(
+        "response_type=code\
+         &client_id={client_id}\
+         &redirect_uri={}\
+         &scope=openid\
+         &code_challenge={challenge}\
+         &code_challenge_method=S256",
+        urlencoding::encode("https://example.com/callback"),
+    );
+
+    let nonce =
+        acquire_par_dpop_nonce(&app, &dpop_key, &par_uri, &body, Some(cert_der.clone())).await;
+    let (proof, _jkt) = build_dpop_proof_with_jkt(&dpop_key, "POST", &par_uri, Some(&nonce));
+    let response = par_post_full(&app, &body, Some(&proof), Some(cert_der), &[]).await;
+    assert_eq!(
+        response.status,
+        StatusCode::CREATED,
+        "mTLS + DPoP + PKCE PAR must succeed: {}",
+        response.body
+    );
+    let json: serde_json::Value = serde_json::from_str(&response.body).expect("Valid JSON");
+    assert!(json["request_uri"].is_string());
+}

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
@@ -969,15 +969,14 @@ async fn test_rfc9126_consume_par_with_stale_version_returns_false() {
     .unwrap();
 
     // First consumption should succeed.
-    let result = db::consume_pushed_authorization_request(
+    let _claim = db::consume_pushed_authorization_request(
         &state.store,
         &request_uri,
         &client.client_id,
         db::ParConsumptionMode::EnforceExpiry,
     )
     .await
-    .unwrap();
-    assert!(result, "First consumption should succeed");
+    .expect("First consumption should succeed");
 
     // Verify the PAR is now consumed.
     let doc = state
@@ -998,9 +997,11 @@ async fn test_rfc9126_consume_par_with_stale_version_returns_false() {
         &client.client_id,
         db::ParConsumptionMode::EnforceExpiry,
     )
-    .await
-    .unwrap();
-    assert!(!result, "Second consumption should fail (already consumed)");
+    .await;
+    assert!(
+        matches!(result, Err(crate::db::claim::ClaimError::AlreadyConsumed)),
+        "Second consumption should fail with AlreadyConsumed, got: {result:?}"
+    );
 }
 
 // ========================================================================
@@ -1250,15 +1251,14 @@ async fn test_rfc9126_par_already_consumed_returns_error_not_login() {
     let request_uri = create_par_request(&app, &client).await;
 
     // Consume the PAR directly via DB before the authorize request arrives.
-    let consumed = crate::db::consume_pushed_authorization_request(
+    let _claim = crate::db::consume_pushed_authorization_request(
         &state.store,
         &request_uri,
         &client.client_id,
         crate::db::ParConsumptionMode::EnforceExpiry,
     )
     .await
-    .unwrap();
-    assert!(consumed, "Pre-consumption should succeed");
+    .expect("Pre-consumption should succeed");
 
     // Confirm consumed_at is set.
     let doc = state

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
@@ -1004,6 +1004,87 @@ async fn test_rfc9126_consume_par_with_stale_version_returns_false() {
     );
 }
 
+#[tokio::test]
+async fn test_rfc9126_consume_par_concurrent_replay() {
+    // Mirrors the slice 7a pattern: two concurrent consume calls must
+    // produce exactly one winner; the loser must be AlreadyConsumed (not
+    // a Database error from the OCC version-mismatch path).
+    use crate::db::claim::ClaimError;
+
+    let (_app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "par-race@example.com").await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+
+    let (_, request_uri) = db::create_pushed_authorization_request(
+        &state.store,
+        db::CreateParParams {
+            client_id: &client.client_id,
+            response_type: "code",
+            redirect_uri: "https://example.com/callback",
+            scope: Some("openid"),
+            state: None,
+            nonce: None,
+            code_challenge: None,
+            code_challenge_method: None,
+            resource: None,
+            acr_values: None,
+            max_age: None,
+            prompt: None,
+            dpop_jkt: None,
+            authorization_details: None,
+            response_mode: Default::default(),
+        },
+        crate::services::auth::ParCreationProof {
+            client_auth: crate::services::auth::ClientAuthProof::None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let store_a = state.store.clone();
+    let store_b = state.store.clone();
+    let request_uri_a = request_uri.clone();
+    let request_uri_b = request_uri.clone();
+    let client_id_a = client.client_id.clone();
+    let client_id_b = client.client_id.clone();
+    let (result_a, result_b) = tokio::join!(
+        async move {
+            db::consume_pushed_authorization_request(
+                &store_a,
+                &request_uri_a,
+                &client_id_a,
+                db::ParConsumptionMode::EnforceExpiry,
+            )
+            .await
+        },
+        async move {
+            db::consume_pushed_authorization_request(
+                &store_b,
+                &request_uri_b,
+                &client_id_b,
+                db::ParConsumptionMode::EnforceExpiry,
+            )
+            .await
+        },
+    );
+
+    let a_won = result_a.is_ok();
+    let b_won = result_b.is_ok();
+    assert!(
+        a_won ^ b_won,
+        "exactly one concurrent PAR consume must win, got a={a_won}, b={b_won}"
+    );
+    for r in [result_a, result_b] {
+        if let Err(e) = r {
+            assert!(
+                matches!(e, ClaimError::AlreadyConsumed),
+                "loser must be AlreadyConsumed, got: {e:?}"
+            );
+        }
+    }
+}
+
 // ========================================================================
 // FAPI 2.0 Section 5.3.2.2 — PAR Reuse Before Auth Completion
 // ========================================================================

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
@@ -961,6 +961,9 @@ async fn test_rfc9126_consume_par_with_stale_version_returns_false() {
             authorization_details: None,
             response_mode: Default::default(),
         },
+        crate::services::auth::ParCreationProof {
+            client_auth: crate::services::auth::ClientAuthProof::None,
+        },
     )
     .await
     .unwrap();

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
@@ -1609,8 +1609,8 @@ async fn test_rfc9126_par_rejects_mtls_with_non_matching_cert() {
 
     // Client is registered against cert A's subject DN.
     let cert_a_der = super::rfc8705::make_test_cert_der("par-mtls-registered");
-    let parsed_a = crate::services::oidc::mtls::parse_client_certificate(&cert_a_der)
-        .expect("parse cert A");
+    let parsed_a =
+        crate::services::oidc::mtls::parse_client_certificate(&cert_a_der).expect("parse cert A");
     let subject_dn_a = parsed_a.subject_dn.expect("cert A has subject DN");
     let client_id = create_mtls_oauth_client(&state.store, &user.id, &subject_dn_a).await;
 

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
@@ -1469,3 +1469,171 @@ async fn test_rfc9126_par_jti_replay_returns_invalid_client() {
         "PAR JTI replay must return error=invalid_client, got: {body2}"
     );
 }
+
+// ========================================================================
+// RFC 8705 §2 / FAPI 2.0 §5.2.2 — mTLS Client Authentication at PAR
+//
+// Regressions for the gap that conformance caught: PAR previously never
+// validated the TLS client certificate for clients registered with
+// tls_client_auth, so mTLS-registered clients were either silently
+// accepted by client_id alone (pre-refactor, fail-open) or rejected at
+// the for_public_client chokepoint (post-refactor, 401). The fix adds
+// the same mTLS dispatch the token endpoint has.
+// ========================================================================
+
+/// Register an OAuth client with `tls_client_auth` bound to the given subject DN.
+async fn create_mtls_oauth_client(
+    store: &crate::db::store::DocumentStore,
+    user_id: &str,
+    subject_dn: &str,
+) -> String {
+    let (_client_doc, client_id) = crate::db::create_oauth_client(
+        store,
+        &crate::db::CreateOAuthClientParams {
+            user_id: Some(user_id),
+            name: "Test mTLS PAR Client",
+            description: None,
+            application_type: crate::db::OAuthClientType::Web,
+            redirect_uris: &["https://example.com/callback".to_string()],
+            access_scope: crate::db::AccessScope::Public,
+            org_id: None,
+            resource_uris: &[],
+            token_endpoint_auth_method: Some(crate::db::TokenEndpointAuthMethod::TlsClientAuth),
+            jwks: None,
+            jwks_uri: None,
+            fapi_profile: None,
+            dpop_bound_access_tokens: None,
+            grant_types: None,
+            response_types: None,
+            software_id: None,
+            software_version: None,
+            registration_source: crate::db::RegistrationSource::Manual,
+            registration_access_token_hash: None,
+            registration_metadata: None,
+            id_token_signed_response_alg: crate::db::JwsAlgorithm::Rs256,
+            tls_client_auth_subject_dn: Some(subject_dn),
+            tls_client_auth_san_dns: None,
+            tls_client_auth_san_uri: None,
+            tls_client_auth_san_ip: None,
+            tls_client_auth_san_email: None,
+            tls_client_certificate_bound_access_tokens: None,
+            authorization_signed_response_alg: None,
+            introspection_signed_response_alg: None,
+            request_object_signing_alg: None,
+            require_signed_request_object: None,
+            userinfo_signed_response_alg: None,
+            request_uris: None,
+        },
+    )
+    .await
+    .expect("Failed to create mTLS test client");
+    client_id
+}
+
+#[tokio::test]
+async fn test_rfc9126_par_accepts_mtls_with_matching_cert() {
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "par-mtls-ok@example.com").await;
+    let _auth_id = create_test_authenticator(&state.store, &user.id).await;
+
+    let cert_der = super::rfc8705::make_test_cert_der("par-mtls-client");
+    let parsed = crate::services::oidc::mtls::parse_client_certificate(&cert_der)
+        .expect("parse generated cert");
+    let subject_dn = parsed.subject_dn.expect("generated cert has subject DN");
+
+    let client_id = create_mtls_oauth_client(&state.store, &user.id, &subject_dn).await;
+
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    let challenge = sha256_base64url(verifier);
+    let body = format!(
+        "response_type=code\
+         &client_id={client_id}\
+         &redirect_uri={}\
+         &code_challenge={challenge}\
+         &code_challenge_method=S256\
+         &scope=openid",
+        urlencoding::encode("https://example.com/callback"),
+    );
+
+    let (status, response_body) =
+        http_post_form_with_cert(&app, "/oauth/par", &body, &[], Some(cert_der)).await;
+
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "mTLS client with matching cert at PAR must return 201: {response_body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&response_body).expect("Valid JSON");
+    assert!(json["request_uri"].is_string());
+}
+
+#[tokio::test]
+async fn test_rfc9126_par_rejects_mtls_without_cert() {
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "par-mtls-nocert@example.com").await;
+    let _auth_id = create_test_authenticator(&state.store, &user.id).await;
+
+    let cert_der = super::rfc8705::make_test_cert_der("par-mtls-nocert-client");
+    let parsed = crate::services::oidc::mtls::parse_client_certificate(&cert_der)
+        .expect("parse generated cert");
+    let subject_dn = parsed.subject_dn.expect("generated cert has subject DN");
+
+    let client_id = create_mtls_oauth_client(&state.store, &user.id, &subject_dn).await;
+
+    let body = format!(
+        "response_type=code\
+         &client_id={client_id}\
+         &redirect_uri={}\
+         &code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM\
+         &code_challenge_method=S256",
+        urlencoding::encode("https://example.com/callback"),
+    );
+
+    let (status, response_body) =
+        http_post_form_with_cert(&app, "/oauth/par", &body, &[], None).await;
+
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "mTLS-registered client without a cert at PAR must return 401: {response_body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&response_body).expect("Valid JSON");
+    assert_eq!(json["error"], "invalid_client");
+}
+
+#[tokio::test]
+async fn test_rfc9126_par_rejects_mtls_with_non_matching_cert() {
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "par-mtls-wrong@example.com").await;
+    let _auth_id = create_test_authenticator(&state.store, &user.id).await;
+
+    // Client is registered against cert A's subject DN.
+    let cert_a_der = super::rfc8705::make_test_cert_der("par-mtls-registered");
+    let parsed_a = crate::services::oidc::mtls::parse_client_certificate(&cert_a_der)
+        .expect("parse cert A");
+    let subject_dn_a = parsed_a.subject_dn.expect("cert A has subject DN");
+    let client_id = create_mtls_oauth_client(&state.store, &user.id, &subject_dn_a).await;
+
+    // Caller presents cert B — different subject DN.
+    let cert_b_der = super::rfc8705::make_test_cert_der("par-mtls-imposter");
+
+    let body = format!(
+        "response_type=code\
+         &client_id={client_id}\
+         &redirect_uri={}\
+         &code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM\
+         &code_challenge_method=S256",
+        urlencoding::encode("https://example.com/callback"),
+    );
+
+    let (status, response_body) =
+        http_post_form_with_cert(&app, "/oauth/par", &body, &[], Some(cert_b_der)).await;
+
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "mTLS-registered client with wrong cert at PAR must return 401: {response_body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&response_body).expect("Valid JSON");
+    assert_eq!(json["error"], "invalid_client");
+}

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
@@ -1401,6 +1401,46 @@ async fn test_rfc9126_par_already_consumed_returns_error_not_login() {
 }
 
 #[tokio::test]
+async fn test_rfc9126_par_accepts_non_fapi_private_key_jwt_without_jti() {
+    // RFC 7523 §3: `jti` is OPTIONAL. A non-FAPI `private_key_jwt` client
+    // that submits a valid assertion without a `jti` claim MUST be
+    // authenticated successfully. Regression test for PR #409 cursor-bot
+    // finding 3299722437 — the proof-resolution previously conflated
+    // "JTI committed" with "JWT auth happened" and rejected this client.
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "par-no-jti@example.com").await;
+    let (client, pkcs8_bytes) = create_test_jwt_client(&state.store, &user.id).await;
+
+    let assertion =
+        build_client_assertion_omit_jti(&client.client_id, &state.config().base_url, &pkcs8_bytes);
+
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    let challenge = sha256_base64url(verifier);
+    let body = format!(
+        "response_type=code\
+         &client_id={}\
+         &redirect_uri={}\
+         &scope=openid\
+         &code_challenge={challenge}\
+         &code_challenge_method=S256\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}",
+        client.client_id,
+        urlencoding::encode("https://example.com/callback"),
+    );
+
+    let (status, response_body) = http_post_form(&app, "/oauth/par", &body, &[]).await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "non-FAPI private_key_jwt without jti must succeed at PAR (RFC 7523 §3): {response_body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&response_body).expect("Valid JSON");
+    assert!(json["request_uri"].is_string());
+}
+
+#[tokio::test]
 async fn test_rfc9126_par_jti_replay_returns_invalid_client() {
     // Regression: PAR's commit_jti() failure must return 401 invalid_client
     // (the JTI replay is a client-auth failure), not 500 server_error.

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
@@ -962,7 +962,9 @@ async fn test_rfc9126_consume_par_with_stale_version_returns_false() {
             response_mode: Default::default(),
         },
         crate::services::auth::ParCreationProof {
-            client_auth: crate::services::auth::ClientAuthProof::None,
+            client_auth: crate::services::auth::ClientAuthProof::NoAuth(
+                crate::services::auth::NoClientAuth::internal_endpoint(),
+            ),
         },
     )
     .await
@@ -1036,7 +1038,9 @@ async fn test_rfc9126_consume_par_concurrent_replay() {
             response_mode: Default::default(),
         },
         crate::services::auth::ParCreationProof {
-            client_auth: crate::services::auth::ClientAuthProof::None,
+            client_auth: crate::services::auth::ClientAuthProof::NoAuth(
+                crate::services::auth::NoClientAuth::internal_endpoint(),
+            ),
         },
     )
     .await

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -662,6 +662,10 @@ async fn handle_authorization_code_grant(
     // layer, but any `credentials.client_secret.is_some()` came through
     // `client_secret_basic`/`client_secret_post`, so the variant is
     // unambiguous. Public clients (no auth) fall through to `None`.
+    // The `GrantProof::AuthorizationCode` half of the chokepoint is
+    // produced inside `exchange_authorization_code` (only that function
+    // has access to the `AuthCodeClaim` from `enforce_single_use_code`).
+    // The handler supplies only the client-auth axis.
     let fallback = jwt_authenticated
         .as_ref()
         .or(mtls_authenticated.as_ref())
@@ -678,12 +682,9 @@ async fn handle_authorization_code_grant(
             },
             |c| ClientAuthProof::from_auth_method(c.client.token_endpoint_auth_method),
         );
-    let proof = TokenIssuanceProof {
-        grant: GrantProof::UnconvertedAuthorizationCode,
-        client_auth: ClientAuthProof::from_jti_or(jti_claim, fallback),
-    };
+    let client_auth = ClientAuthProof::from_jti_or(jti_claim, fallback);
 
-    match exchange_authorization_code(&state, exchange_params, proof).await {
+    match exchange_authorization_code(&state, exchange_params, client_auth).await {
         Ok(result) => {
             crate::infra::metrics::record_auth_event("authorization_code_success");
             token_success_response(TokenResponse {

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -11,7 +11,7 @@ use crate::services::oidc::{
     ScopeSet,
     client_credentials::exchange_client_credentials,
     exchange::{TokenExchangeParams, exchange_token},
-    jwt_bearer::client_auth::{authenticate_client_jwt, commit_jti},
+    jwt_bearer::client_auth::authenticate_client_jwt,
     token::{AuthCodeExchangeParams, exchange_authorization_code, validate_dpop_if_present},
 };
 use crate::services::{OAuthErrorCode, ServiceError};
@@ -628,20 +628,25 @@ async fn handle_authorization_code_grant(
         mtls_cert_thumbprint: mtls_thumbprint.as_deref(),
     };
 
-    // SAFETY: commit_jti() MUST run AFTER DPoP nonce validation (so use_dpop_nonce
-    // retry leaves the JTI unconsumed) and BEFORE exchange_*() / store_par_request()
-    // (so concurrent replays of the same assertion cannot persist multiple tokens —
-    // see issue #391). A follow-up will replace this comment with a TokenIssuanceProof
-    // witness type consumed by create_oauth_access_token.
-    if let Some(ref pending_jti) = jwt_pending_jti
-        && let Err(e) = commit_jti(&state, pending_jti).await
-    {
-        tracing::warn!("JTI commit failed for authorization_code: {e:?}");
-        // InvalidCredentials (JTI replay) -> 401 invalid_client; DatabaseError
-        // (transient) -> 5xx internal_error. ClientAuthError::into_service_error
-        // already discriminates correctly.
-        return e.into_service_error().into_oauth_response().into_response();
-    }
+    // SAFETY: PendingJti::commit MUST run AFTER DPoP nonce validation (so a
+    // use_dpop_nonce retry leaves the JTI unconsumed) and BEFORE exchange_*()
+    // / store_par_request() (so concurrent replays of the same assertion cannot
+    // persist multiple tokens — see issue #391). The returned claim is
+    // discarded here; a future change will thread it into create_oauth_access_token
+    // as part of a TokenIssuanceProof witness.
+    let _jwt_jti_claim = match jwt_pending_jti {
+        Some(p) => match p.commit(&state).await {
+            Ok(claim) => claim,
+            Err(e) => {
+                tracing::warn!("JTI commit failed for authorization_code: {e:?}");
+                // InvalidCredentials (JTI replay) -> 401 invalid_client;
+                // DatabaseError (transient) -> 5xx internal_error.
+                // ClientAuthError::into_service_error discriminates correctly.
+                return e.into_service_error().into_oauth_response().into_response();
+            }
+        },
+        None => None,
+    };
 
     match exchange_authorization_code(&state, exchange_params).await {
         Ok(result) => {
@@ -714,17 +719,20 @@ async fn handle_client_credentials_grant(
     // RFC 8705 Section 3: Bind access token to cert thumbprint only when opted in.
     let mtls_thumbprint = extract_mtls_thumbprint(&authenticated_client, &client_cert);
 
-    // SAFETY: commit_jti() MUST run AFTER DPoP nonce validation (no DPoP path here,
-    // so the constraint is vacuous in this arm) and BEFORE exchange_*() so that
-    // concurrent replays of the same assertion cannot persist multiple tokens —
-    // see issue #391. A follow-up will replace this comment with a
-    // TokenIssuanceProof witness type consumed by create_oauth_access_token.
-    if let Some(ref jti) = pending_jti
-        && let Err(e) = commit_jti(&state, jti).await
-    {
-        tracing::warn!("JTI commit failed for client_credentials: {e:?}");
-        return e.into_service_error().into_oauth_response().into_response();
-    }
+    // SAFETY: PendingJti::commit MUST run BEFORE exchange_*() so that
+    // concurrent replays of the same assertion cannot persist multiple
+    // tokens — see issue #391. No DPoP path here, so the
+    // "after DPoP nonce validation" half of the invariant is vacuous.
+    let _jwt_jti_claim = match pending_jti {
+        Some(p) => match p.commit(&state).await {
+            Ok(claim) => claim,
+            Err(e) => {
+                tracing::warn!("JTI commit failed for client_credentials: {e:?}");
+                return e.into_service_error().into_oauth_response().into_response();
+            }
+        },
+        None => None,
+    };
 
     match exchange_client_credentials(
         &state,
@@ -868,17 +876,20 @@ async fn handle_token_exchange_grant(
         mtls_cert_thumbprint: mtls_thumbprint.as_deref(),
     };
 
-    // SAFETY: commit_jti() MUST run AFTER DPoP nonce validation (so use_dpop_nonce
-    // retry leaves the JTI unconsumed) and BEFORE exchange_*() so that concurrent
-    // replays of the same assertion cannot persist multiple tokens —
-    // see issue #391. A follow-up will replace this comment with a
-    // TokenIssuanceProof witness type consumed by create_oauth_access_token.
-    if let Some(ref jti) = pending_jti
-        && let Err(e) = commit_jti(&state, jti).await
-    {
-        tracing::warn!("JTI commit failed for token_exchange: {e:?}");
-        return e.into_service_error().into_oauth_response().into_response();
-    }
+    // SAFETY: PendingJti::commit MUST run AFTER DPoP nonce validation (so a
+    // use_dpop_nonce retry leaves the JTI unconsumed) and BEFORE exchange_*()
+    // (so concurrent replays of the same assertion cannot persist multiple
+    // tokens — see issue #391).
+    let _jwt_jti_claim = match pending_jti {
+        Some(p) => match p.commit(&state).await {
+            Ok(claim) => claim,
+            Err(e) => {
+                tracing::warn!("JTI commit failed for token_exchange: {e:?}");
+                return e.into_service_error().into_oauth_response().into_response();
+            }
+        },
+        None => None,
+    };
 
     match exchange_token(&state, exchange_params).await {
         Ok(result) => token_success_response(TokenExchangeResponse {
@@ -1003,15 +1014,17 @@ async fn handle_fido2_assertion_grant(
         mtls_cert_thumbprint: mtls_thumbprint.as_deref(),
     };
 
-    // SAFETY: commit_jti() MUST run AFTER DPoP nonce validation (so use_dpop_nonce
-    // retry leaves the JTI unconsumed) and BEFORE exchange_*() so that concurrent
-    // replays of the same assertion cannot persist multiple tokens —
-    // see issue #391. A follow-up will replace this comment with a
-    // TokenIssuanceProof witness type consumed by create_oauth_access_token.
-    if let Err(e) = commit_jti(&state, &jwt_pending_jti).await {
-        tracing::warn!("JTI commit failed for fido2_assertion: {e:?}");
-        return e.into_service_error().into_oauth_response().into_response();
-    }
+    // SAFETY: PendingJti::commit MUST run AFTER DPoP nonce validation (so a
+    // use_dpop_nonce retry leaves the JTI unconsumed) and BEFORE exchange_*()
+    // (so concurrent replays of the same assertion cannot persist multiple
+    // tokens — see issue #391).
+    let _jwt_jti_claim = match jwt_pending_jti.commit(&state).await {
+        Ok(claim) => claim,
+        Err(e) => {
+            tracing::warn!("JTI commit failed for fido2_assertion: {e:?}");
+            return e.into_service_error().into_oauth_response().into_response();
+        }
+    };
 
     match crate::services::oidc::fido2_grant::exchange_fido2_assertion(&state, exchange_params)
         .await

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -2,7 +2,7 @@
 //! Token endpoint handler.
 
 use super::client_auth::{
-    ClientAuthFields, ExtractedClientAuth, authenticate_client_any, extract_client_auth,
+    ClientAuthFields, ExtractedClientAuth, complete_client_auth, extract_client_auth,
     extract_client_credentials,
 };
 use crate::AppState;
@@ -477,62 +477,57 @@ async fn handle_authorization_code_grant(
     };
 
     // For non-JWT auth, extract traditional credentials or mTLS auth.
-    let (credentials, mtls_authenticated) = if !has_jwt_assertion {
+    let (credentials, mtls_authenticated, mtls_verification) = if !has_jwt_assertion {
         let creds =
             extract_client_credentials(&headers, params.client_id.as_deref(), params.client_secret);
 
-        // RFC 8705: If only client_id (no secret) and a cert is present,
-        // try mTLS authentication. authenticate_client() will skip secret
-        // validation for mTLS-registered clients.
-        let mtls_auth = if let Some(ref c) = creds
+        // RFC 8705: For client_id-only requests (no client_secret), look up
+        // the registered token_endpoint_auth_method once and dispatch:
+        //   - mTLS-registered + cert present → validate the cert
+        //   - mTLS-registered + no cert      → reject (cert required)
+        //   - not mTLS-registered            → fall through; exchange does
+        //                                      secret/public auth
+        let (mtls_auth, mtls_v) = if let Some(ref c) = creds
             && c.client_secret.is_none()
-            && client_cert.0.is_some()
         {
-            match crate::services::oidc::token::authenticate_client(&state, c).await {
-                Ok(client)
-                    if matches!(
-                        client.client.token_endpoint_auth_method,
-                        crate::db::TokenEndpointAuthMethod::TlsClientAuth
-                            | crate::db::TokenEndpointAuthMethod::SelfSignedTlsClientAuth
-                    ) =>
-                {
-                    // Validate the certificate against registered identity.
-                    if let Some(ref cert) = client_cert.0 {
-                        let jwks_cache_value =
-                            crate::db::get_jwks_cache(&state.store, &client.client.id)
-                                .await
-                                .map_err(|e| {
-                                    tracing::warn!("JWKS cache lookup failed: {e}");
-                                })
-                                .ok()
-                                .flatten()
-                                .map(|c| c.value);
-                        if let Err(e) = crate::services::oidc::token::authenticate_client_mtls(
-                            &client.client,
-                            cert,
-                            jwks_cache_value.as_ref(),
-                        ) {
+            let client_lookup =
+                crate::db::get_oauth_client_by_client_id(&state.store, &c.client_id)
+                    .await
+                    .ok()
+                    .flatten()
+                    .filter(|oc| oc.active);
+            let is_mtls_registered = client_lookup.as_ref().is_some_and(|oc| {
+                matches!(
+                    oc.token_endpoint_auth_method,
+                    crate::db::TokenEndpointAuthMethod::TlsClientAuth
+                        | crate::db::TokenEndpointAuthMethod::SelfSignedTlsClientAuth
+                )
+            });
+            match (client_lookup, is_mtls_registered, client_cert.0.as_ref()) {
+                (Some(client), true, Some(cert)) => {
+                    let jwks_cache_value = crate::db::get_jwks_cache(&state.store, &client.id)
+                        .await
+                        .ok()
+                        .flatten()
+                        .map(|c| c.value);
+                    match crate::services::oidc::token::authenticate_client_mtls(
+                        &client,
+                        cert,
+                        jwks_cache_value.as_ref(),
+                    ) {
+                        Ok(mtls_verification) => (
+                            Some(crate::services::oidc::token::AuthenticatedClient {
+                                client,
+                                is_public: false,
+                            }),
+                            Some(mtls_verification),
+                        ),
+                        Err(e) => {
                             return e.into_service_error().into_oauth_response().into_response();
                         }
                     }
-                    Some(client)
                 }
-                Ok(_) => None, // Not an mTLS client, fall through
-                Err(_) => None,
-            }
-        } else if let Some(ref c) = creds
-            && c.client_secret.is_none()
-        {
-            // No secret and no certificate — check if this client requires mTLS.
-            // If so, reject immediately per RFC 8705 Section 2.
-            match crate::services::oidc::token::authenticate_client(&state, c).await {
-                Ok(client)
-                    if matches!(
-                        client.client.token_endpoint_auth_method,
-                        crate::db::TokenEndpointAuthMethod::TlsClientAuth
-                            | crate::db::TokenEndpointAuthMethod::SelfSignedTlsClientAuth
-                    ) =>
-                {
+                (Some(_), true, None) => {
                     return ServiceError::oauth(
                         OAuthErrorCode::InvalidClient,
                         "mTLS client certificate required",
@@ -540,15 +535,15 @@ async fn handle_authorization_code_grant(
                     .into_oauth_response()
                     .into_response();
                 }
-                _ => None,
+                _ => (None, None), // Not mTLS-registered (or client not found) — exchange handles it.
             }
         } else {
-            None
+            (None, None)
         };
 
-        (creds, mtls_auth)
+        (creds, mtls_auth, mtls_v)
     } else {
-        (None, None)
+        (None, None, None)
     };
 
     // Resolve the authenticated client from either path
@@ -665,24 +660,18 @@ async fn handle_authorization_code_grant(
     // The `GrantProof::AuthorizationCode` half of the chokepoint is
     // produced inside `exchange_authorization_code` (only that function
     // has access to the `AuthCodeClaim` from `enforce_single_use_code`).
-    // The handler supplies only the client-auth axis.
-    let fallback = jwt_authenticated
-        .as_ref()
-        .or(mtls_authenticated.as_ref())
-        .map_or_else(
-            || {
-                if credentials
-                    .as_ref()
-                    .is_some_and(|c| c.client_secret.is_some())
-                {
-                    ClientAuthProof::UnconvertedClientSecret
-                } else {
-                    ClientAuthProof::None
-                }
-            },
-            |c| ClientAuthProof::from_auth_method(c.client.token_endpoint_auth_method),
-        );
-    let client_auth = ClientAuthProof::from_jti_or(jti_claim, fallback);
+    // The handler supplies only the client-auth axis using the witnesses
+    // it has produced so far:
+    //   - JWT auth → PrivateKeyJwt(jti_claim) via from_jti_or
+    //   - mTLS auth → MutualTls(mtls_verification) via from_verifications
+    //   - secret auth → handler doesn't run authenticate_client (that
+    //     happens inside exchange), so pass None here; the exchange
+    //     function promotes None → ClientSecret(verification) using the
+    //     witness from authenticate_and_validate_client.
+    let client_auth = ClientAuthProof::from_jti_or(
+        jti_claim,
+        ClientAuthProof::from_verifications(None, mtls_verification),
+    );
 
     match exchange_authorization_code(&state, exchange_params, client_auth).await {
         Ok(result) => {
@@ -721,12 +710,10 @@ async fn handle_client_credentials_grant(
         Err(resp) => return resp,
     };
 
-    let Some((authenticated_client, _client_id, pending_jti)) =
-        (match authenticate_client_any(&state, client_auth).await {
-            Ok(result) => result,
-            Err(resp) => return resp,
-        })
-    else {
+    let Some(any_auth) = (match complete_client_auth(&state, client_auth).await {
+        Ok(result) => result,
+        Err(resp) => return resp,
+    }) else {
         return ServiceError::oauth(
             OAuthErrorCode::InvalidClient,
             "Client authentication required for client_credentials grant",
@@ -734,6 +721,9 @@ async fn handle_client_credentials_grant(
         .into_oauth_response()
         .into_response();
     };
+    let authenticated_client = any_auth.client;
+    let pending_jti = any_auth.pending_jti;
+    let secret_verification = any_auth.secret_verification;
 
     // RFC 6749 Section 4.4: client_credentials requires a confidential client
     if authenticated_client.is_public {
@@ -746,11 +736,11 @@ async fn handle_client_credentials_grant(
     }
 
     // RFC 8705 Section 2: Validate mTLS client auth if the client uses it.
-    if let Err(resp) =
-        validate_mtls_client_auth(&state.store, &authenticated_client, &client_cert).await
-    {
-        return *resp;
-    }
+    let mtls_verification =
+        match validate_mtls_client_auth(&state.store, &authenticated_client, &client_cert).await {
+            Ok(v) => v,
+            Err(resp) => return *resp,
+        };
 
     // RFC 8705 Section 3: Bind access token to cert thumbprint only when opted in.
     let mtls_thumbprint = extract_mtls_thumbprint(&authenticated_client, &client_cert);
@@ -763,9 +753,7 @@ async fn handle_client_credentials_grant(
         grant: GrantProof::ClientCredentials,
         client_auth: ClientAuthProof::from_jti_or(
             jti_claim,
-            ClientAuthProof::from_auth_method(
-                authenticated_client.client.token_endpoint_auth_method,
-            ),
+            ClientAuthProof::from_verifications(secret_verification, mtls_verification),
         ),
     };
 
@@ -841,12 +829,10 @@ async fn handle_token_exchange_grant(
     };
 
     // Authenticate client (required for token exchange)
-    let Some((authenticated_client, _client_id, pending_jti)) =
-        (match authenticate_client_any(&state, client_auth).await {
-            Ok(result) => result,
-            Err(resp) => return resp,
-        })
-    else {
+    let Some(any_auth) = (match complete_client_auth(&state, client_auth).await {
+        Ok(result) => result,
+        Err(resp) => return resp,
+    }) else {
         return ServiceError::oauth(
             OAuthErrorCode::InvalidClient,
             "Client authentication required for token exchange",
@@ -854,6 +840,9 @@ async fn handle_token_exchange_grant(
         .into_oauth_response()
         .into_response();
     };
+    let authenticated_client = any_auth.client;
+    let pending_jti = any_auth.pending_jti;
+    let secret_verification = any_auth.secret_verification;
 
     // RFC 9449 Section 5: Validate DPoP proof if present at the token endpoint
     let dpop_header = headers.get("DPoP").and_then(|v| v.to_str().ok());
@@ -873,11 +862,11 @@ async fn handle_token_exchange_grant(
     let dpop_jkt = dpop_proof.as_ref().map(|p| p.jkt.clone());
 
     // RFC 8705 Section 2: Validate mTLS client auth if the client uses it.
-    if let Err(resp) =
-        validate_mtls_client_auth(&state.store, &authenticated_client, &client_cert).await
-    {
-        return *resp;
-    }
+    let mtls_verification =
+        match validate_mtls_client_auth(&state.store, &authenticated_client, &client_cert).await {
+            Ok(v) => v,
+            Err(resp) => return *resp,
+        };
 
     // RFC 8705 Section 3: Bind access token to cert thumbprint only when opted in.
     let mtls_thumbprint = extract_mtls_thumbprint(&authenticated_client, &client_cert);
@@ -920,9 +909,7 @@ async fn handle_token_exchange_grant(
         grant: GrantProof::TokenExchange,
         client_auth: ClientAuthProof::from_jti_or(
             jti_claim,
-            ClientAuthProof::from_auth_method(
-                authenticated_client.client.token_endpoint_auth_method,
-            ),
+            ClientAuthProof::from_verifications(secret_verification, mtls_verification),
         ),
     };
 
@@ -1088,19 +1075,20 @@ async fn handle_fido2_assertion_grant(
 /// Validate mTLS client authentication when the client uses `tls_client_auth`
 /// or `self_signed_tls_client_auth` (RFC 8705 Section 2).
 ///
-/// Returns `Ok(())` if the auth method is not mTLS-based, or if the cert
-/// is present and validates successfully. Returns `Err(Box<Response>)` with a
-/// 401-equivalent OAuth error response if the cert is absent or invalid.
+/// Returns `Ok(None)` if the auth method is not mTLS-based (no verification
+/// performed); `Ok(Some(verification))` if the cert validated successfully.
+/// Returns `Err(Box<Response>)` with a 401-equivalent OAuth error if the
+/// cert is absent or invalid.
 async fn validate_mtls_client_auth(
     store: &crate::db::store::DocumentStore,
     client: &crate::services::oidc::token::AuthenticatedClient,
     client_cert: &crate::handlers::extractors::OptionalClientCert,
-) -> Result<(), Box<Response>> {
+) -> Result<Option<crate::services::oidc::token::MtlsCertVerification>, Box<Response>> {
     if client.client.token_endpoint_auth_method != crate::db::TokenEndpointAuthMethod::TlsClientAuth
         && client.client.token_endpoint_auth_method
             != crate::db::TokenEndpointAuthMethod::SelfSignedTlsClientAuth
     {
-        return Ok(());
+        return Ok(None);
     }
     let Some(ref cert) = client_cert.0 else {
         return Err(Box::new(
@@ -1125,6 +1113,7 @@ async fn validate_mtls_client_auth(
         cert,
         jwks_cache_value.as_ref(),
     )
+    .map(Some)
     .map_err(|e| Box::new(e.into_service_error().into_oauth_response().into_response()))
 }
 

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -428,6 +428,129 @@ async fn commit_optional_jti(
     })
 }
 
+/// Resolve non-JWT client authentication for the `authorization_code`
+/// grant. Returns the resolved client paired with a fully-formed
+/// [`ClientAuthProof`] (one of `ClientSecret`, `MutualTls`, `NoAuth`)
+/// on success, or a response-ready `Response` on any auth failure
+/// (unknown client, invalid secret, missing required cert, confidential
+/// client presented without auth, etc.).
+async fn resolve_non_jwt_auth(
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    params: &TokenRequest,
+    client_cert: &crate::handlers::extractors::OptionalClientCert,
+) -> Result<
+    (
+        crate::services::oidc::token::AuthenticatedClient,
+        ClientAuthProof,
+    ),
+    Response,
+> {
+    let creds = extract_client_credentials(
+        headers,
+        params.client_id.as_deref(),
+        params.client_secret.clone(),
+    );
+    let Some(c) = creds else {
+        return Err(ServiceError::oauth(
+            OAuthErrorCode::InvalidClient,
+            "Client authentication or client_id required",
+        )
+        .into_oauth_response()
+        .into_response());
+    };
+
+    // If a secret was presented, try secret auth first. `authenticate_client`
+    // returns `Ok((client, None))` for mTLS-registered clients (RFC 8705 §2:
+    // mTLS is the auth method — the secret is intentionally NOT validated).
+    // In that case we fall through to the mTLS dispatch below.
+    let secret_auth_outcome = if c.client_secret.is_some() {
+        match crate::services::oidc::token::authenticate_client(state, &c).await {
+            Ok((auth_client, Some(verification))) => {
+                return Ok((auth_client, ClientAuthProof::ClientSecret(verification)));
+            }
+            Ok((auth_client, None)) => Some(auth_client),
+            Err(e) => {
+                return Err(e.into_service_error().into_oauth_response().into_response());
+            }
+        }
+    } else {
+        None
+    };
+
+    // No verified client_secret. Dispatch on the client's registered
+    // `token_endpoint_auth_method` — RFC 8705 §2 for mTLS-registered
+    // clients, RFC 6749 §2.1 for public. If `secret_auth_outcome` is
+    // `Some`, we already loaded the client; otherwise look it up.
+    let client = match secret_auth_outcome {
+        Some(auth_client) => auth_client.client,
+        None => match crate::db::get_oauth_client_by_client_id(&state.store, &c.client_id)
+            .await
+            .ok()
+            .flatten()
+            .filter(|oc| oc.active)
+        {
+            Some(client) => client,
+            None => {
+                return Err(ServiceError::oauth(
+                    OAuthErrorCode::InvalidClient,
+                    "Unknown client_id",
+                )
+                .into_oauth_response()
+                .into_response());
+            }
+        },
+    };
+    let is_mtls_registered = matches!(
+        client.token_endpoint_auth_method,
+        crate::db::TokenEndpointAuthMethod::TlsClientAuth
+            | crate::db::TokenEndpointAuthMethod::SelfSignedTlsClientAuth
+    );
+    if is_mtls_registered {
+        let Some(cert) = client_cert.0.as_ref() else {
+            return Err(ServiceError::oauth(
+                OAuthErrorCode::InvalidClient,
+                "mTLS client certificate required",
+            )
+            .into_oauth_response()
+            .into_response());
+        };
+        let jwks_cache_value = crate::db::get_jwks_cache(&state.store, &client.id)
+            .await
+            .ok()
+            .flatten()
+            .map(|c| c.value);
+        return match crate::services::oidc::token::authenticate_client_mtls(
+            &client,
+            cert,
+            jwks_cache_value.as_ref(),
+        ) {
+            Ok(verification) => Ok((
+                crate::services::oidc::token::AuthenticatedClient {
+                    client,
+                    is_public: false,
+                },
+                ClientAuthProof::MutualTls(verification),
+            )),
+            Err(e) => Err(e.into_service_error().into_oauth_response().into_response()),
+        };
+    }
+    // Not mTLS-registered, no secret presented — must be a public client.
+    // `for_public_client` errors if the client is confidential, closing
+    // the "developer forgot to authenticate" hole at the type system level.
+    let witness = match crate::services::auth::NoClientAuth::for_public_client(&client) {
+        Ok(w) => w,
+        Err(svc) => return Err(svc.into_oauth_response().into_response()),
+    };
+    Ok((
+        crate::services::oidc::token::AuthenticatedClient {
+            client,
+            is_public: true,
+        },
+        ClientAuthProof::NoAuth(witness),
+    ))
+}
+
 /// Handle authorization code grant.
 async fn handle_authorization_code_grant(
     State(state): State<Arc<AppState>>,
@@ -476,81 +599,10 @@ async fn handle_authorization_code_grant(
         (None, None)
     };
 
-    // For non-JWT auth, extract traditional credentials or mTLS auth.
-    let (credentials, mtls_authenticated, mtls_verification) = if !has_jwt_assertion {
-        let creds =
-            extract_client_credentials(&headers, params.client_id.as_deref(), params.client_secret);
-
-        // RFC 8705: For client_id-only requests (no client_secret), look up
-        // the registered token_endpoint_auth_method once and dispatch:
-        //   - mTLS-registered + cert present → validate the cert
-        //   - mTLS-registered + no cert      → reject (cert required)
-        //   - not mTLS-registered            → fall through; exchange does
-        //                                      secret/public auth
-        let (mtls_auth, mtls_v) = if let Some(ref c) = creds
-            && c.client_secret.is_none()
-        {
-            let client_lookup =
-                crate::db::get_oauth_client_by_client_id(&state.store, &c.client_id)
-                    .await
-                    .ok()
-                    .flatten()
-                    .filter(|oc| oc.active);
-            let is_mtls_registered = client_lookup.as_ref().is_some_and(|oc| {
-                matches!(
-                    oc.token_endpoint_auth_method,
-                    crate::db::TokenEndpointAuthMethod::TlsClientAuth
-                        | crate::db::TokenEndpointAuthMethod::SelfSignedTlsClientAuth
-                )
-            });
-            match (client_lookup, is_mtls_registered, client_cert.0.as_ref()) {
-                (Some(client), true, Some(cert)) => {
-                    let jwks_cache_value = crate::db::get_jwks_cache(&state.store, &client.id)
-                        .await
-                        .ok()
-                        .flatten()
-                        .map(|c| c.value);
-                    match crate::services::oidc::token::authenticate_client_mtls(
-                        &client,
-                        cert,
-                        jwks_cache_value.as_ref(),
-                    ) {
-                        Ok(mtls_verification) => (
-                            Some(crate::services::oidc::token::AuthenticatedClient {
-                                client,
-                                is_public: false,
-                            }),
-                            Some(mtls_verification),
-                        ),
-                        Err(e) => {
-                            return e.into_service_error().into_oauth_response().into_response();
-                        }
-                    }
-                }
-                (Some(_), true, None) => {
-                    return ServiceError::oauth(
-                        OAuthErrorCode::InvalidClient,
-                        "mTLS client certificate required",
-                    )
-                    .into_oauth_response()
-                    .into_response();
-                }
-                _ => (None, None), // Not mTLS-registered (or client not found) — exchange handles it.
-            }
-        } else {
-            (None, None)
-        };
-
-        (creds, mtls_auth, mtls_v)
-    } else {
-        (None, None, None)
-    };
-
-    // Resolve the authenticated client from either path
-    let authenticated_client: Option<&crate::services::oidc::token::AuthenticatedClient> =
-        jwt_authenticated.as_ref().or(mtls_authenticated.as_ref());
-
-    // RFC 9449 Section 5: Validate DPoP proof if present at the token endpoint
+    // RFC 9449 Section 5: Validate DPoP proof if present. Must happen
+    // BEFORE client-auth resolution so the `use_dpop_nonce` recovery
+    // path (nonce header in the response) fires regardless of whether
+    // the request also has invalid client auth.
     let dpop_header = headers.get("DPoP").and_then(|v| v.to_str().ok());
     let dpop_proof =
         match validate_dpop_if_present(&state, dpop_header, "POST", "/oauth/token").await {
@@ -565,24 +617,58 @@ async fn handle_authorization_code_grant(
             }
         };
 
+    // For non-JWT auth, resolve `(AuthenticatedClient, ClientAuthProof)`
+    // directly. The handler runs ALL non-JWT authentication itself so
+    // the constructed `ClientAuthProof` is fully resolved before the
+    // exchange — no transitional placeholders or downstream promotion.
+    let non_jwt_auth = if has_jwt_assertion {
+        None
+    } else {
+        match resolve_non_jwt_auth(&state, &headers, &params, &client_cert).await {
+            Ok(pair) => Some(pair),
+            Err(resp) => return resp,
+        }
+    };
+
+    // Commit the JTI (if any) and resolve `(authenticated_client,
+    // client_auth)` in one move from both auth paths. Each branch
+    // carries a sealed witness produced by the upstream auth step —
+    // there is no path that produces a `ClientAuthProof` without a real
+    // witness, which is the chokepoint guarantee.
+    let jti_claim = match commit_optional_jti(&state, jwt_pending_jti, "authorization_code").await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    let (authenticated_client, client_auth) = match (jti_claim, jwt_authenticated, non_jwt_auth) {
+        (Some(claim), Some(client), _) => (client, ClientAuthProof::PrivateKeyJwt(claim)),
+        (_, _, Some(pair)) => pair,
+        _ => {
+            return ServiceError::oauth(
+                OAuthErrorCode::InvalidClient,
+                "Client authentication required",
+            )
+            .into_oauth_response()
+            .into_response();
+        }
+    };
+
     // RFC 8705 Section 2: Validate mTLS client auth for JWT-authenticated clients
     // that are also registered for mTLS (e.g., FAPI clients using both).
     let has_mtls_cert = client_cert.0.is_some();
-    if let Some(ref auth) = jwt_authenticated
-        && mtls_authenticated.is_none()
-        && let Err(resp) = validate_mtls_client_auth(&state.store, auth, &client_cert).await
+    if !matches!(client_auth, ClientAuthProof::MutualTls(_))
+        && matches!(client_auth, ClientAuthProof::PrivateKeyJwt(_))
+        && let Err(resp) =
+            validate_mtls_client_auth(&state.store, &authenticated_client, &client_cert).await
     {
         return *resp;
     }
 
     // FAPI 2.0: Require DPoP for FAPI clients (sender-constrained tokens).
-    if let Some(auth) = authenticated_client
-        && let Err(e) = crate::services::oidc::fapi::validate_fapi_token_request(
-            &auth.client,
-            dpop_proof.is_some(),
-            has_mtls_cert,
-        )
-    {
+    if let Err(e) = crate::services::oidc::fapi::validate_fapi_token_request(
+        &authenticated_client.client,
+        dpop_proof.is_some(),
+        has_mtls_cert,
+    ) {
         return e.into_oauth_response().into_response();
     }
 
@@ -590,10 +676,7 @@ async fn handle_authorization_code_grant(
     // a valid DPoP proof MUST be present. The client explicitly opted into
     // DPoP binding via dpop_bound_access_tokens=true, so mTLS alone does
     // not satisfy this — the access token must carry a jkt confirmation.
-    if let Some(auth) = authenticated_client
-        && auth.client.dpop_bound_access_tokens
-        && dpop_proof.is_none()
-    {
+    if authenticated_client.client.dpop_bound_access_tokens && dpop_proof.is_none() {
         return ServiceError::oauth(
             OAuthErrorCode::InvalidRequest,
             "Client requires DPoP-bound access tokens \
@@ -608,8 +691,9 @@ async fn handle_authorization_code_grant(
     // would be issued without a cnf.x5t#S256 binding, violating the client's
     // registered constraint. DPoP is accepted as an alternative sender
     // constraint mechanism.
-    if let Some(auth) = authenticated_client
-        && auth.client.tls_client_certificate_bound_access_tokens
+    if authenticated_client
+        .client
+        .tls_client_certificate_bound_access_tokens
         && !has_mtls_cert
         && dpop_proof.is_none()
     {
@@ -623,55 +707,21 @@ async fn handle_authorization_code_grant(
     }
 
     // RFC 8705 Section 3: Bind access token to cert thumbprint only when opted in.
-    let mtls_thumbprint =
-        authenticated_client.and_then(|auth| extract_mtls_thumbprint(auth, &client_cert));
+    let mtls_thumbprint = extract_mtls_thumbprint(&authenticated_client, &client_cert);
 
-    // Extract client_id for audience validation (RFC 8725 §3.9)
-    let exchange_client_id = authenticated_client
-        .map(|c| c.client.client_id.as_str())
-        .or_else(|| credentials.as_ref().map(|c| c.client_id.as_str()))
-        .or(params.client_id.as_deref())
-        .unwrap_or("");
-
-    // Exchange the authorization code
+    // Exchange the authorization code. `authenticated_client` is the
+    // client_id used for RFC 8725 §3.9 audience validation.
     let exchange_params = AuthCodeExchangeParams {
         code,
         redirect_uri: params.redirect_uri.as_deref(),
-        credentials: credentials.as_ref(),
-        jwt_authenticated_client: jwt_authenticated.as_ref().or(mtls_authenticated.as_ref()),
+        authenticated_client: Some(&authenticated_client),
         code_verifier: params.code_verifier.as_deref(),
         dpop_proof,
-        client_id: exchange_client_id,
+        client_id: &authenticated_client.client.client_id,
         resource: params.resource.as_deref(),
         authorization_details: params.authorization_details.as_deref(),
         mtls_cert_thumbprint: mtls_thumbprint.as_deref(),
     };
-
-    let jti_claim = match commit_optional_jti(&state, jwt_pending_jti, "authorization_code").await {
-        Ok(c) => c,
-        Err(r) => return r,
-    };
-    // Resolve the non-JWT fallback. When the client authenticated via JWT or
-    // mTLS we already have the AuthenticatedClient and use its registered
-    // method. The secret-auth path doesn't carry an OAuthClient at this
-    // layer, but any `credentials.client_secret.is_some()` came through
-    // `client_secret_basic`/`client_secret_post`, so the variant is
-    // unambiguous. Public clients (no auth) fall through to `None`.
-    // The `GrantProof::AuthorizationCode` half of the chokepoint is
-    // produced inside `exchange_authorization_code` (only that function
-    // has access to the `AuthCodeClaim` from `enforce_single_use_code`).
-    // The handler supplies only the client-auth axis using the witnesses
-    // it has produced so far:
-    //   - JWT auth → PrivateKeyJwt(jti_claim) via from_jti_or
-    //   - mTLS auth → MutualTls(mtls_verification) via from_verifications
-    //   - secret auth → handler doesn't run authenticate_client (that
-    //     happens inside exchange), so pass None here; the exchange
-    //     function promotes None → ClientSecret(verification) using the
-    //     witness from authenticate_and_validate_client.
-    let client_auth = ClientAuthProof::from_jti_or(
-        jti_claim,
-        ClientAuthProof::from_verifications(None, mtls_verification),
-    );
 
     match exchange_authorization_code(&state, exchange_params, client_auth).await {
         Ok(result) => {
@@ -749,12 +799,41 @@ async fn handle_client_credentials_grant(
         Ok(c) => c,
         Err(r) => return r,
     };
+    // Client-credentials grant: the client MUST authenticate (RFC 6749
+    // §4.4). Resolve the client-auth proof by precedence: JWT → secret
+    // → mTLS. If none succeeded, validate that the client is registered
+    // as public via `NoClientAuth::for_public_client` (which fails if
+    // the client is confidential — closing the "developer forgot to
+    // authenticate" hole).
+    let client_auth = if let Some(claim) = jti_claim {
+        ClientAuthProof::PrivateKeyJwt(claim)
+    } else {
+        match (secret_verification, mtls_verification) {
+            (Some(_), Some(_)) => {
+                return ServiceError::oauth(
+                    OAuthErrorCode::InvalidClient,
+                    "client presented multiple authentication methods \
+                     (RFC 6749 §2.3 violation)",
+                )
+                .into_oauth_response()
+                .into_response();
+            }
+            (Some(s), None) => ClientAuthProof::ClientSecret(s),
+            (None, Some(m)) => ClientAuthProof::MutualTls(m),
+            (None, None) => {
+                let witness = match crate::services::auth::NoClientAuth::for_public_client(
+                    &authenticated_client.client,
+                ) {
+                    Ok(w) => w,
+                    Err(svc) => return svc.into_oauth_response().into_response(),
+                };
+                ClientAuthProof::NoAuth(witness)
+            }
+        }
+    };
     let proof = TokenIssuanceProof {
         grant: GrantProof::ClientCredentials,
-        client_auth: ClientAuthProof::from_jti_or(
-            jti_claim,
-            ClientAuthProof::from_verifications(secret_verification, mtls_verification),
-        ),
+        client_auth,
     };
 
     match exchange_client_credentials(
@@ -905,12 +984,40 @@ async fn handle_token_exchange_grant(
         Ok(c) => c,
         Err(r) => return r,
     };
+    // Token exchange: same precedence + public-client validation as
+    // client_credentials. Token exchange does not mandate confidential
+    // clients per RFC 8693, but `NoClientAuth::for_public_client` is
+    // still the right check for the "no method succeeded" case — a
+    // confidential client must authenticate.
+    let client_auth = if let Some(claim) = jti_claim {
+        ClientAuthProof::PrivateKeyJwt(claim)
+    } else {
+        match (secret_verification, mtls_verification) {
+            (Some(_), Some(_)) => {
+                return ServiceError::oauth(
+                    OAuthErrorCode::InvalidClient,
+                    "client presented multiple authentication methods \
+                     (RFC 6749 §2.3 violation)",
+                )
+                .into_oauth_response()
+                .into_response();
+            }
+            (Some(s), None) => ClientAuthProof::ClientSecret(s),
+            (None, Some(m)) => ClientAuthProof::MutualTls(m),
+            (None, None) => {
+                let witness = match crate::services::auth::NoClientAuth::for_public_client(
+                    &authenticated_client.client,
+                ) {
+                    Ok(w) => w,
+                    Err(svc) => return svc.into_oauth_response().into_response(),
+                };
+                ClientAuthProof::NoAuth(witness)
+            }
+        }
+    };
     let proof = TokenIssuanceProof {
         grant: GrantProof::TokenExchange,
-        client_auth: ClientAuthProof::from_jti_or(
-            jti_claim,
-            ClientAuthProof::from_verifications(secret_verification, mtls_verification),
-        ),
+        client_auth,
     };
 
     match exchange_token(&state, exchange_params, proof).await {
@@ -1036,12 +1143,23 @@ async fn handle_fido2_assertion_grant(
         mtls_cert_thumbprint: mtls_thumbprint.as_deref(),
     };
 
-    let jti_claim =
-        match commit_optional_jti(&state, Some(jwt_pending_jti), "fido2_assertion").await {
-            Ok(c) => c,
-            Err(r) => return r,
-        };
-    let client_auth = ClientAuthProof::from_jti_or(jti_claim, ClientAuthProof::None);
+    // FIDO2 assertion grant requires `private_key_jwt` client auth (the
+    // CLI signs assertions with its FAPI key). `jwt_pending_jti` is
+    // always present here — `commit_optional_jti(Some(_))` cannot return
+    // `Ok(None)`.
+    let jti_claim = match commit_optional_jti(&state, Some(jwt_pending_jti), "fido2_assertion")
+        .await
+    {
+        Ok(Some(c)) => c,
+        Ok(None) => {
+            tracing::error!("fido2_assertion: commit_optional_jti returned None for Some input");
+            return ServiceError::Internal("internal_error".to_string())
+                .into_oauth_response()
+                .into_response();
+        }
+        Err(r) => return r,
+    };
+    let client_auth = ClientAuthProof::PrivateKeyJwt(jti_claim);
 
     match crate::services::oidc::fido2_grant::exchange_fido2_assertion(
         &state,

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -1041,15 +1041,12 @@ async fn handle_fido2_assertion_grant(
             Ok(c) => c,
             Err(r) => return r,
         };
-    let proof = TokenIssuanceProof {
-        grant: GrantProof::UnconvertedFido2Assertion,
-        client_auth: ClientAuthProof::from_jti_or(jti_claim, ClientAuthProof::None),
-    };
+    let client_auth = ClientAuthProof::from_jti_or(jti_claim, ClientAuthProof::None);
 
     match crate::services::oidc::fido2_grant::exchange_fido2_assertion(
         &state,
         exchange_params,
-        proof,
+        client_auth,
     )
     .await
     {

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -673,7 +673,12 @@ async fn handle_authorization_code_grant(
         grant: GrantProof::UnconvertedAuthorizationCode,
         client_auth: ClientAuthProof::from_jti_or(
             jti_claim,
-            fallback_client_auth(mtls_authenticated.is_some(), credentials.is_some()),
+            fallback_client_auth(
+                mtls_authenticated.is_some(),
+                credentials
+                    .as_ref()
+                    .is_some_and(|c| c.client_secret.is_some()),
+            ),
         ),
     };
 

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -6,12 +6,14 @@ use super::client_auth::{
     extract_client_credentials,
 };
 use crate::AppState;
+use crate::db::JwtAssertionJtiClaim;
+use crate::services::auth::{ClientAuthProof, GrantProof, TokenIssuanceProof};
 use crate::services::error::OAuthErrorResponse;
 use crate::services::oidc::{
     ScopeSet,
     client_credentials::exchange_client_credentials,
     exchange::{TokenExchangeParams, exchange_token},
-    jwt_bearer::client_auth::authenticate_client_jwt,
+    jwt_bearer::client_auth::{PendingJti, authenticate_client_jwt},
     token::{AuthCodeExchangeParams, exchange_authorization_code, validate_dpop_if_present},
 };
 use crate::services::{OAuthErrorCode, ServiceError};
@@ -404,6 +406,41 @@ pub async fn token(
     }
 }
 
+/// Commit an optional pending JTI and translate failures to a response-ready
+/// `Response`. Used by token-issuance handlers to share the per-grant log +
+/// error-mapping pattern that previously lived inline at every call site.
+///
+/// The MUST-run-before-grant-state-persistence invariant (issue #391) is now
+/// enforced by the type system: the returned `Option<JwtAssertionJtiClaim>` is
+/// the only path to building a `ClientAuthProof::PrivateKeyJwt`, which is the
+/// only path to a `TokenIssuanceProof` carrying that client-auth method.
+async fn commit_optional_jti(
+    state: &Arc<AppState>,
+    pending: Option<PendingJti>,
+    grant_name: &'static str,
+) -> Result<Option<JwtAssertionJtiClaim>, Response> {
+    let Some(p) = pending else {
+        return Ok(None);
+    };
+    p.commit(state).await.map_err(|e| {
+        tracing::warn!("JTI commit failed for {grant_name}: {e:?}");
+        e.into_service_error().into_oauth_response().into_response()
+    })
+}
+
+/// Pick the non-JWT client-auth witness for a request, given the auth methods
+/// that succeeded. The JWT case is handled by [`commit_optional_jti`] + the
+/// `from_jti_or` combinator at each call site.
+fn fallback_client_auth(has_mtls: bool, has_client_secret: bool) -> ClientAuthProof {
+    if has_mtls {
+        ClientAuthProof::UnconvertedMutualTls
+    } else if has_client_secret {
+        ClientAuthProof::UnconvertedClientSecret
+    } else {
+        ClientAuthProof::None
+    }
+}
+
 /// Handle authorization code grant.
 async fn handle_authorization_code_grant(
     State(state): State<Arc<AppState>>,
@@ -628,27 +665,19 @@ async fn handle_authorization_code_grant(
         mtls_cert_thumbprint: mtls_thumbprint.as_deref(),
     };
 
-    // SAFETY: PendingJti::commit MUST run AFTER DPoP nonce validation (so a
-    // use_dpop_nonce retry leaves the JTI unconsumed) and BEFORE exchange_*()
-    // / store_par_request() (so concurrent replays of the same assertion cannot
-    // persist multiple tokens — see issue #391). The returned claim is
-    // discarded here; a future change will thread it into create_oauth_access_token
-    // as part of a TokenIssuanceProof witness.
-    let _jwt_jti_claim = match jwt_pending_jti {
-        Some(p) => match p.commit(&state).await {
-            Ok(claim) => claim,
-            Err(e) => {
-                tracing::warn!("JTI commit failed for authorization_code: {e:?}");
-                // InvalidCredentials (JTI replay) -> 401 invalid_client;
-                // DatabaseError (transient) -> 5xx internal_error.
-                // ClientAuthError::into_service_error discriminates correctly.
-                return e.into_service_error().into_oauth_response().into_response();
-            }
-        },
-        None => None,
+    let jti_claim = match commit_optional_jti(&state, jwt_pending_jti, "authorization_code").await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    let proof = TokenIssuanceProof {
+        grant: GrantProof::UnconvertedAuthorizationCode,
+        client_auth: ClientAuthProof::from_jti_or(
+            jti_claim,
+            fallback_client_auth(mtls_authenticated.is_some(), credentials.is_some()),
+        ),
     };
 
-    match exchange_authorization_code(&state, exchange_params).await {
+    match exchange_authorization_code(&state, exchange_params, proof).await {
         Ok(result) => {
             crate::infra::metrics::record_auth_event("authorization_code_success");
             token_success_response(TokenResponse {
@@ -719,19 +748,16 @@ async fn handle_client_credentials_grant(
     // RFC 8705 Section 3: Bind access token to cert thumbprint only when opted in.
     let mtls_thumbprint = extract_mtls_thumbprint(&authenticated_client, &client_cert);
 
-    // SAFETY: PendingJti::commit MUST run BEFORE exchange_*() so that
-    // concurrent replays of the same assertion cannot persist multiple
-    // tokens — see issue #391. No DPoP path here, so the
-    // "after DPoP nonce validation" half of the invariant is vacuous.
-    let _jwt_jti_claim = match pending_jti {
-        Some(p) => match p.commit(&state).await {
-            Ok(claim) => claim,
-            Err(e) => {
-                tracing::warn!("JTI commit failed for client_credentials: {e:?}");
-                return e.into_service_error().into_oauth_response().into_response();
-            }
-        },
-        None => None,
+    let jti_claim = match commit_optional_jti(&state, pending_jti, "client_credentials").await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    let proof = TokenIssuanceProof {
+        grant: GrantProof::ClientCredentials,
+        client_auth: ClientAuthProof::from_jti_or(
+            jti_claim,
+            fallback_client_auth(client_cert.0.is_some(), true),
+        ),
     };
 
     match exchange_client_credentials(
@@ -739,6 +765,7 @@ async fn handle_client_credentials_grant(
         &authenticated_client.client,
         params.scope.as_deref(),
         mtls_thumbprint.as_deref(),
+        proof,
     )
     .await
     {
@@ -876,22 +903,19 @@ async fn handle_token_exchange_grant(
         mtls_cert_thumbprint: mtls_thumbprint.as_deref(),
     };
 
-    // SAFETY: PendingJti::commit MUST run AFTER DPoP nonce validation (so a
-    // use_dpop_nonce retry leaves the JTI unconsumed) and BEFORE exchange_*()
-    // (so concurrent replays of the same assertion cannot persist multiple
-    // tokens — see issue #391).
-    let _jwt_jti_claim = match pending_jti {
-        Some(p) => match p.commit(&state).await {
-            Ok(claim) => claim,
-            Err(e) => {
-                tracing::warn!("JTI commit failed for token_exchange: {e:?}");
-                return e.into_service_error().into_oauth_response().into_response();
-            }
-        },
-        None => None,
+    let jti_claim = match commit_optional_jti(&state, pending_jti, "token_exchange").await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    let proof = TokenIssuanceProof {
+        grant: GrantProof::TokenExchange,
+        client_auth: ClientAuthProof::from_jti_or(
+            jti_claim,
+            fallback_client_auth(mtls_thumbprint.is_some(), false),
+        ),
     };
 
-    match exchange_token(&state, exchange_params).await {
+    match exchange_token(&state, exchange_params, proof).await {
         Ok(result) => token_success_response(TokenExchangeResponse {
             access_token: result.access_token,
             issued_token_type: result.issued_token_type,
@@ -1014,20 +1038,22 @@ async fn handle_fido2_assertion_grant(
         mtls_cert_thumbprint: mtls_thumbprint.as_deref(),
     };
 
-    // SAFETY: PendingJti::commit MUST run AFTER DPoP nonce validation (so a
-    // use_dpop_nonce retry leaves the JTI unconsumed) and BEFORE exchange_*()
-    // (so concurrent replays of the same assertion cannot persist multiple
-    // tokens — see issue #391).
-    let _jwt_jti_claim = match jwt_pending_jti.commit(&state).await {
-        Ok(claim) => claim,
-        Err(e) => {
-            tracing::warn!("JTI commit failed for fido2_assertion: {e:?}");
-            return e.into_service_error().into_oauth_response().into_response();
-        }
+    let jti_claim =
+        match commit_optional_jti(&state, Some(jwt_pending_jti), "fido2_assertion").await {
+            Ok(c) => c,
+            Err(r) => return r,
+        };
+    let proof = TokenIssuanceProof {
+        grant: GrantProof::UnconvertedFido2Assertion,
+        client_auth: ClientAuthProof::from_jti_or(jti_claim, ClientAuthProof::None),
     };
 
-    match crate::services::oidc::fido2_grant::exchange_fido2_assertion(&state, exchange_params)
-        .await
+    match crate::services::oidc::fido2_grant::exchange_fido2_assertion(
+        &state,
+        exchange_params,
+        proof,
+    )
+    .await
     {
         Ok(result) => {
             crate::infra::metrics::record_auth_event("fido2_login_success");

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -578,7 +578,7 @@ async fn handle_authorization_code_grant(
     let has_jwt_assertion = params.client_assertion.is_some();
 
     // For JWT assertion, authenticate and extract the client
-    let (jwt_authenticated, jwt_pending_jti) = if has_jwt_assertion {
+    let (jwt_authenticated, jwt_pending_jti, jwt_auth) = if has_jwt_assertion {
         let client_auth = match extract_client_auth(&headers, &params) {
             Ok(auth) => auth,
             Err(resp) => return resp,
@@ -589,14 +589,14 @@ async fn handle_authorization_code_grant(
         } = client_auth
         {
             match authenticate_client_jwt(&state, &client_assertion, client_id.as_deref()).await {
-                Ok((client, pending_jti)) => (Some(client), Some(pending_jti)),
+                Ok((client, pending_jti, auth)) => (Some(client), Some(pending_jti), Some(auth)),
                 Err(e) => return e.into_service_error().into_oauth_response().into_response(),
             }
         } else {
-            (None, None)
+            (None, None, None)
         }
     } else {
-        (None, None)
+        (None, None, None)
     };
 
     // RFC 9449 Section 5: Validate DPoP proof if present. Must happen
@@ -639,8 +639,16 @@ async fn handle_authorization_code_grant(
         Ok(c) => c,
         Err(r) => return r,
     };
-    let (authenticated_client, client_auth) = match (jti_claim, jwt_authenticated, non_jwt_auth) {
-        (Some(claim), Some(client), _) => (client, ClientAuthProof::PrivateKeyJwt(claim)),
+    // RFC 7523 §3: `jti` is OPTIONAL. Gate on `jwt_auth` (the auth-succeeded
+    // witness), not on `jti_claim` — a non-FAPI client may legitimately omit
+    // `jti`, in which case `jti_claim == None` but JWT auth still succeeded.
+    let (authenticated_client, client_auth) = match (jwt_authenticated, jwt_auth, non_jwt_auth) {
+        (Some(client), Some(auth), _) => (
+            client,
+            ClientAuthProof::PrivateKeyJwt(crate::services::auth::JwtClientAuthProof::new(
+                auth, jti_claim,
+            )),
+        ),
         (_, _, Some(pair)) => pair,
         _ => {
             return ServiceError::oauth(
@@ -773,6 +781,7 @@ async fn handle_client_credentials_grant(
     };
     let authenticated_client = any_auth.client;
     let pending_jti = any_auth.pending_jti;
+    let jwt_auth = any_auth.jwt_auth;
     let secret_verification = any_auth.secret_verification;
 
     // RFC 6749 Section 4.4: client_credentials requires a confidential client
@@ -805,8 +814,13 @@ async fn handle_client_credentials_grant(
     // as public via `NoClientAuth::for_public_client` (which fails if
     // the client is confidential — closing the "developer forgot to
     // authenticate" hole).
-    let client_auth = if let Some(claim) = jti_claim {
-        ClientAuthProof::PrivateKeyJwt(claim)
+    //
+    // RFC 7523 §3: `jti` is OPTIONAL — gate the JWT arm on `jwt_auth`,
+    // not on `jti_claim`, so a non-FAPI client without `jti` is accepted.
+    let client_auth = if let Some(auth) = jwt_auth {
+        ClientAuthProof::PrivateKeyJwt(crate::services::auth::JwtClientAuthProof::new(
+            auth, jti_claim,
+        ))
     } else {
         match (secret_verification, mtls_verification) {
             (Some(_), Some(_)) => {
@@ -921,6 +935,7 @@ async fn handle_token_exchange_grant(
     };
     let authenticated_client = any_auth.client;
     let pending_jti = any_auth.pending_jti;
+    let jwt_auth = any_auth.jwt_auth;
     let secret_verification = any_auth.secret_verification;
 
     // RFC 9449 Section 5: Validate DPoP proof if present at the token endpoint
@@ -989,8 +1004,13 @@ async fn handle_token_exchange_grant(
     // clients per RFC 8693, but `NoClientAuth::for_public_client` is
     // still the right check for the "no method succeeded" case — a
     // confidential client must authenticate.
-    let client_auth = if let Some(claim) = jti_claim {
-        ClientAuthProof::PrivateKeyJwt(claim)
+    //
+    // RFC 7523 §3: `jti` is OPTIONAL — gate the JWT arm on `jwt_auth`,
+    // not on `jti_claim`, so a non-FAPI client without `jti` is accepted.
+    let client_auth = if let Some(auth) = jwt_auth {
+        ClientAuthProof::PrivateKeyJwt(crate::services::auth::JwtClientAuthProof::new(
+            auth, jti_claim,
+        ))
     } else {
         match (secret_verification, mtls_verification) {
             (Some(_), Some(_)) => {
@@ -1084,12 +1104,12 @@ async fn handle_fido2_assertion_grant(
         Err(resp) => return resp,
     };
 
-    let (jwt_authenticated, jwt_pending_jti) = match client_auth {
+    let (jwt_authenticated, jwt_pending_jti, jwt_auth) = match client_auth {
         ExtractedClientAuth::JwtAssertion {
             client_assertion,
             client_id,
         } => match authenticate_client_jwt(&state, &client_assertion, client_id.as_deref()).await {
-            Ok((client, pending_jti)) => (client, pending_jti),
+            Ok((client, pending_jti, auth)) => (client, pending_jti, auth),
             Err(e) => return e.into_service_error().into_oauth_response().into_response(),
         },
         _ => {
@@ -1144,22 +1164,19 @@ async fn handle_fido2_assertion_grant(
     };
 
     // FIDO2 assertion grant requires `private_key_jwt` client auth (the
-    // CLI signs assertions with its FAPI key). `jwt_pending_jti` is
-    // always present here — `commit_optional_jti(Some(_))` cannot return
-    // `Ok(None)`.
-    let jti_claim = match commit_optional_jti(&state, Some(jwt_pending_jti), "fido2_assertion")
-        .await
-    {
-        Ok(Some(c)) => c,
-        Ok(None) => {
-            tracing::error!("fido2_assertion: commit_optional_jti returned None for Some input");
-            return ServiceError::Internal("internal_error".to_string())
-                .into_oauth_response()
-                .into_response();
-        }
-        Err(r) => return r,
-    };
-    let client_auth = ClientAuthProof::PrivateKeyJwt(jti_claim);
+    // CLI signs assertions with its FAPI key). The CLI is a FAPI client
+    // and therefore always emits `jti`, so `jti_claim` is expected to be
+    // `Some` — but the proof construction does not depend on it:
+    // `jwt_auth` is the structural witness for "RFC 7523 §3 validation
+    // passed", and `jti` is an additive replay-prevention witness.
+    let jti_claim =
+        match commit_optional_jti(&state, Some(jwt_pending_jti), "fido2_assertion").await {
+            Ok(c) => c,
+            Err(r) => return r,
+        };
+    let client_auth = ClientAuthProof::PrivateKeyJwt(
+        crate::services::auth::JwtClientAuthProof::new(jwt_auth, jti_claim),
+    );
 
     match crate::services::oidc::fido2_grant::exchange_fido2_assertion(
         &state,

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -428,19 +428,6 @@ async fn commit_optional_jti(
     })
 }
 
-/// Pick the non-JWT client-auth witness for a request, given the auth methods
-/// that succeeded. The JWT case is handled by [`commit_optional_jti`] + the
-/// `from_jti_or` combinator at each call site.
-fn fallback_client_auth(has_mtls: bool, has_client_secret: bool) -> ClientAuthProof {
-    if has_mtls {
-        ClientAuthProof::UnconvertedMutualTls
-    } else if has_client_secret {
-        ClientAuthProof::UnconvertedClientSecret
-    } else {
-        ClientAuthProof::None
-    }
-}
-
 /// Handle authorization code grant.
 async fn handle_authorization_code_grant(
     State(state): State<Arc<AppState>>,
@@ -669,17 +656,31 @@ async fn handle_authorization_code_grant(
         Ok(c) => c,
         Err(r) => return r,
     };
+    // Resolve the non-JWT fallback. When the client authenticated via JWT or
+    // mTLS we already have the AuthenticatedClient and use its registered
+    // method. The secret-auth path doesn't carry an OAuthClient at this
+    // layer, but any `credentials.client_secret.is_some()` came through
+    // `client_secret_basic`/`client_secret_post`, so the variant is
+    // unambiguous. Public clients (no auth) fall through to `None`.
+    let fallback = jwt_authenticated
+        .as_ref()
+        .or(mtls_authenticated.as_ref())
+        .map_or_else(
+            || {
+                if credentials
+                    .as_ref()
+                    .is_some_and(|c| c.client_secret.is_some())
+                {
+                    ClientAuthProof::UnconvertedClientSecret
+                } else {
+                    ClientAuthProof::None
+                }
+            },
+            |c| ClientAuthProof::from_auth_method(c.client.token_endpoint_auth_method),
+        );
     let proof = TokenIssuanceProof {
         grant: GrantProof::UnconvertedAuthorizationCode,
-        client_auth: ClientAuthProof::from_jti_or(
-            jti_claim,
-            fallback_client_auth(
-                mtls_authenticated.is_some(),
-                credentials
-                    .as_ref()
-                    .is_some_and(|c| c.client_secret.is_some()),
-            ),
-        ),
+        client_auth: ClientAuthProof::from_jti_or(jti_claim, fallback),
     };
 
     match exchange_authorization_code(&state, exchange_params, proof).await {
@@ -761,7 +762,9 @@ async fn handle_client_credentials_grant(
         grant: GrantProof::ClientCredentials,
         client_auth: ClientAuthProof::from_jti_or(
             jti_claim,
-            fallback_client_auth(client_cert.0.is_some(), true),
+            ClientAuthProof::from_auth_method(
+                authenticated_client.client.token_endpoint_auth_method,
+            ),
         ),
     };
 
@@ -916,7 +919,9 @@ async fn handle_token_exchange_grant(
         grant: GrantProof::TokenExchange,
         client_auth: ClientAuthProof::from_jti_or(
             jti_claim,
-            fallback_client_auth(mtls_thumbprint.is_some(), false),
+            ClientAuthProof::from_auth_method(
+                authenticated_client.client.token_endpoint_auth_method,
+            ),
         ),
     };
 

--- a/crates/vouch-server/src/handlers/saml.rs
+++ b/crates/vouch-server/src/handlers/saml.rs
@@ -14,7 +14,6 @@ use axum::{
     http::header,
     response::{IntoResponse, Response},
 };
-use jiff::Timestamp;
 use serde::Deserialize;
 
 use crate::AppState;
@@ -95,38 +94,32 @@ pub async fn acs(State(state): State<Arc<AppState>>, Form(form): Form<SamlAcsFor
         .into_response();
     }
 
-    // Step 3: Look up stored SAML state by RelayState (= state column in oidc_state table).
-    let stored_state = match db::get_oidc_state(&state.store, &relay_state).await {
-        Ok(Some(s)) => s,
-        Ok(None) => {
-            return ErrorTemplate {
-                title: "Error".to_string(),
-                message: "Invalid or expired state".to_string(),
-                back_url: None,
+    // Step 3: Atomically consume the SAML state record (stored in the
+    // shared oidc_state table). The returned witness is threaded into the
+    // downstream TokenIssuanceProof and is the only path to
+    // `GrantProof::EnrollmentBootstrap`. Replaces the prior
+    // get-then-delete pattern, closing the read-vs-consume TOCTOU.
+    let (stored_state, oidc_state_claim) =
+        match db::try_consume_oidc_state(&state.store, &relay_state).await {
+            Ok(pair) => pair,
+            Err(db::ClaimError::AlreadyConsumed) => {
+                return ErrorTemplate {
+                    title: "Error".to_string(),
+                    message: "Invalid or expired state".to_string(),
+                    back_url: None,
+                }
+                .into_response();
             }
-            .into_response();
-        }
-        Err(e) => {
-            tracing::error!("Failed to look up SAML state: {e:#}");
-            return ErrorTemplate {
-                title: "Error".to_string(),
-                message: "Failed to verify state".to_string(),
-                back_url: None,
+            Err(e) => {
+                tracing::error!("Failed to consume SAML state: {e:#}");
+                return ErrorTemplate {
+                    title: "Error".to_string(),
+                    message: "Failed to verify state".to_string(),
+                    back_url: None,
+                }
+                .into_response();
             }
-            .into_response();
-        }
-    };
-
-    // Step 4: Check if state has expired.
-    let now = Timestamp::now();
-    if now > stored_state.expires_at {
-        return ErrorTemplate {
-            title: "Error".to_string(),
-            message: "State has expired. Please start the enrollment process again.".to_string(),
-            back_url: None,
-        }
-        .into_response();
-    }
+        };
 
     // Step 5: Look up the SAML IdP by the slug stored in the state row.
     // Fall back to the first configured SAML IdP for state docs written before
@@ -177,7 +170,7 @@ pub async fn acs(State(state): State<Arc<AppState>>, Form(form): Form<SamlAcsFor
         domain: assertion.domain,
     };
 
-    complete_enrollment_after_identity(&state, &stored_state, &relay_state, identity).await
+    complete_enrollment_after_identity(&state, &stored_state, identity, oidc_state_claim).await
 }
 
 // ============================================================================

--- a/crates/vouch-server/src/lib.rs
+++ b/crates/vouch-server/src/lib.rs
@@ -4,6 +4,15 @@
 //! This crate provides the Vouch identity server with OIDC provider,
 //! WebAuthn authentication, and credential issuance.
 
+// Prevent test-utils from being enabled in any release build of this
+// library. The feature exposes `test_utils` (helpers that bypass FIDO2
+// and construct `GrantProof::TestingOnly` / `TestCoseVerifier`) — none
+// of which should ever reach production code. Release builds disable
+// `debug_assertions`, so this guard fires for `cargo build --release
+// --features test-utils` on either the binary or any consumer.
+#[cfg(all(feature = "test-utils", not(debug_assertions)))]
+compile_error!("test-utils feature must not be enabled in release builds");
+
 pub mod attestation;
 pub mod config;
 pub mod crypto;

--- a/crates/vouch-server/src/main.rs
+++ b/crates/vouch-server/src/main.rs
@@ -10,13 +10,6 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 use anyhow::Result;
 use clap::Parser;
 
-// Prevent test-utils from being enabled in release builds. The feature gates
-// functions that bypass security invariants (e.g. upsert_user without FIDO2,
-// TestCoseVerifier that accepts any signature). If a CI pipeline or Docker build
-// accidentally enables --all-features, this halts compilation.
-#[cfg(all(feature = "test-utils", not(debug_assertions)))]
-compile_error!("test-utils feature must not be enabled in release builds");
-
 use vouch_server::{
     config,
     infra::{generate_document_key, router, serve, startup, telemetry},

--- a/crates/vouch-server/src/services/auth.rs
+++ b/crates/vouch-server/src/services/auth.rs
@@ -399,13 +399,15 @@ pub(crate) enum ClientAuthProof {
     /// the witness returned from `db::store_jwt_assertion_jti`.
     PrivateKeyJwt(crate::db::JwtAssertionJtiClaim),
 
-    /// `client_secret_basic` / `client_secret_post`.
-    /// TODO(slice-8): carry a `ClientSecretVerification` witness.
-    UnconvertedClientSecret,
+    /// `client_secret_basic` / `client_secret_post` (RFC 6749 §2.3.1).
+    /// Carries the verification witness from
+    /// [`crate::services::oidc::token::authenticate_client`].
+    ClientSecret(crate::services::oidc::token::ClientSecretVerification),
 
-    /// `tls_client_auth` / `self_signed_tls_client_auth` (RFC 8705).
-    /// TODO(slice-8): carry an `MtlsCertVerification` witness.
-    UnconvertedMutualTls,
+    /// `tls_client_auth` / `self_signed_tls_client_auth` (RFC 8705 §2).
+    /// Carries the verification witness from
+    /// [`crate::services::oidc::token::authenticate_client_mtls`].
+    MutualTls(crate::services::oidc::token::MtlsCertVerification),
 
     /// Public client — no client authentication was performed.
     None,
@@ -431,20 +433,25 @@ impl ClientAuthProof {
         }
     }
 
-    /// Map a registered `TokenEndpointAuthMethod` to the matching placeholder
-    /// variant. Used by call sites that don't separately track which auth
-    /// method succeeded but do hold the authenticated client's registered
-    /// method (e.g., PAR). The `PrivateKeyJwt` arm returns `None` here because
-    /// the JTI claim is the only valid construction path — callers with a JWT
-    /// client must use [`Self::from_jti_or`] with the committed claim.
-    pub(crate) fn from_auth_method(method: crate::db::TokenEndpointAuthMethod) -> Self {
-        use crate::db::TokenEndpointAuthMethod;
-        match method {
-            TokenEndpointAuthMethod::ClientSecretBasic
-            | TokenEndpointAuthMethod::ClientSecretPost => Self::UnconvertedClientSecret,
-            TokenEndpointAuthMethod::TlsClientAuth
-            | TokenEndpointAuthMethod::SelfSignedTlsClientAuth => Self::UnconvertedMutualTls,
-            TokenEndpointAuthMethod::PrivateKeyJwt | TokenEndpointAuthMethod::None => Self::None,
+    /// Compose a non-JWT [`ClientAuthProof`] from the two verification
+    /// witnesses produced by the handler-level auth flow. Single named
+    /// place for the precedence rule:
+    ///
+    /// - `Some(secret)` → `ClientSecret(secret)` (client_secret_basic/post)
+    /// - `Some(mtls)` (no secret) → `MutualTls(mtls)` (RFC 8705)
+    /// - neither → `None` (public client)
+    ///
+    /// JWT-authenticated clients are handled separately by [`Self::from_jti_or`]
+    /// because the JTI claim and the verification are produced at different
+    /// points in the flow.
+    pub(crate) fn from_verifications(
+        secret: Option<crate::services::oidc::token::ClientSecretVerification>,
+        mtls: Option<crate::services::oidc::token::MtlsCertVerification>,
+    ) -> Self {
+        match (secret, mtls) {
+            (Some(s), _) => Self::ClientSecret(s),
+            (None, Some(m)) => Self::MutualTls(m),
+            (None, None) => Self::None,
         }
     }
 }

--- a/crates/vouch-server/src/services/auth.rs
+++ b/crates/vouch-server/src/services/auth.rs
@@ -338,9 +338,10 @@ pub(crate) struct TokenIssuanceProof {
 /// migration plan.
 #[derive(Debug)]
 pub(crate) enum GrantProof {
-    /// `authorization_code` grant.
-    /// TODO(slice-2): carry an `AuthCodeClaim` from `db::try_consume_auth_code`.
-    UnconvertedAuthorizationCode,
+    /// `authorization_code` grant. Carries a [`crate::db::AuthCodeClaim`]
+    /// witness — proof that the authorization code was atomically consumed
+    /// before this token issuance.
+    AuthorizationCode(crate::db::AuthCodeClaim),
 
     /// `client_credentials` grant — no grant-level replay primitive; the
     /// single-use guarantee is enforced entirely via [`ClientAuthProof`].

--- a/crates/vouch-server/src/services/auth.rs
+++ b/crates/vouch-server/src/services/auth.rs
@@ -415,50 +415,65 @@ pub(crate) enum ClientAuthProof {
     /// [`crate::services::oidc::token::authenticate_client_mtls`].
     MutualTls(crate::services::oidc::token::MtlsCertVerification),
 
-    /// Public client — no client authentication was performed.
-    None,
+    /// No external client authentication was performed. Carries a
+    /// [`NoClientAuth`] witness whose two named constructors document
+    /// why client auth is absent — either the client is a registered
+    /// public OAuth client (RFC 6749 §2.1), or the request originates
+    /// from an internal flow where the server is both issuer and client
+    /// (browser login, enrollment, device polling).
+    NoAuth(NoClientAuth),
 }
 
-impl ClientAuthProof {
-    /// Compose a `ClientAuthProof` from an optional JTI claim and a fallback.
-    ///
-    /// `Some(claim)` produces `PrivateKeyJwt(claim)` — the only path to that
-    /// variant, since `JwtAssertionJtiClaim` has no public constructor. `None`
-    /// is *any* non-`private_key_jwt` case: the assertion omitted `jti`, the
-    /// client used `client_secret_basic`/`client_secret_post`, the client
-    /// used `tls_client_auth`/`self_signed_tls_client_auth`, or the client is
-    /// public (no auth). The caller supplies the appropriate fallback variant
-    /// describing whichever non-JWT method actually succeeded.
-    pub(crate) fn from_jti_or(
-        jti_claim: Option<crate::db::JwtAssertionJtiClaim>,
-        fallback: Self,
-    ) -> Self {
-        match jti_claim {
-            Some(claim) => Self::PrivateKeyJwt(claim),
-            None => fallback,
+/// Witness justifying a [`ClientAuthProof::NoAuth`] variant. The two
+/// named constructors split the legitimate cases:
+///
+/// - [`Self::for_public_client`] — the request carries a `client_id`
+///   for a registered OAuth client whose `token_endpoint_auth_method`
+///   is `None` (public client, RFC 6749 §2.1).
+/// - [`Self::internal_endpoint`] — the request originates from a
+///   server-internal endpoint (browser login, enrollment callbacks,
+///   device-code polling) where there is no external OAuth client and
+///   the server itself is the client.
+///
+/// A confidential client's grant arm cannot accidentally satisfy the
+/// chokepoint with this witness — `for_public_client` rejects clients
+/// registered with a non-`None` auth method, and `internal_endpoint`
+/// is a grep-auditable explicit choice. Future grant arms for
+/// confidential clients must construct `PrivateKeyJwt`, `ClientSecret`,
+/// or `MutualTls` instead.
+#[derive(Debug)]
+pub(crate) struct NoClientAuth {
+    _private: (),
+}
+
+impl NoClientAuth {
+    /// Construct evidence that the request is for a public OAuth client
+    /// (RFC 6749 §2.1 — `token_endpoint_auth_method = None`). Returns
+    /// `Err` if the client is registered as confidential; in that case
+    /// the caller must produce a real verification witness instead.
+    pub(crate) fn for_public_client(
+        client: &crate::db::OAuthClient,
+    ) -> Result<Self, crate::services::ServiceError> {
+        if client.token_endpoint_auth_method == crate::db::TokenEndpointAuthMethod::None {
+            Ok(Self { _private: () })
+        } else {
+            Err(crate::services::ServiceError::oauth(
+                crate::services::OAuthErrorCode::InvalidClient,
+                "client authentication required",
+            ))
         }
     }
 
-    /// Compose a non-JWT [`ClientAuthProof`] from the two verification
-    /// witnesses produced by the handler-level auth flow. Single named
-    /// place for the precedence rule:
+    /// Construct evidence that the request originates from a
+    /// server-internal endpoint where there is no external OAuth client.
     ///
-    /// - `Some(secret)` → `ClientSecret(secret)` (client_secret_basic/post)
-    /// - `Some(mtls)` (no secret) → `MutualTls(mtls)` (RFC 8705)
-    /// - neither → `None` (public client)
-    ///
-    /// JWT-authenticated clients are handled separately by [`Self::from_jti_or`]
-    /// because the JTI claim and the verification are produced at different
-    /// points in the flow.
-    pub(crate) fn from_verifications(
-        secret: Option<crate::services::oidc::token::ClientSecretVerification>,
-        mtls: Option<crate::services::oidc::token::MtlsCertVerification>,
-    ) -> Self {
-        match (secret, mtls) {
-            (Some(s), _) => Self::ClientSecret(s),
-            (None, Some(m)) => Self::MutualTls(m),
-            (None, None) => Self::None,
-        }
+    /// Use **only** for endpoints where the server is acting as both
+    /// issuer and client — browser login, enrollment callbacks, device
+    /// polling, certification test bypass. Adding new call sites is an
+    /// audit-relevant decision: grep for this constructor before merging
+    /// any change that introduces a new caller.
+    pub(crate) fn internal_endpoint() -> Self {
+        Self { _private: () }
     }
 }
 

--- a/crates/vouch-server/src/services/auth.rs
+++ b/crates/vouch-server/src/services/auth.rs
@@ -396,14 +396,49 @@ pub(crate) enum GrantProof {
     TestingOnly,
 }
 
+/// Witness bundle for a `private_key_jwt` (RFC 7523) client authentication.
+///
+/// Composes the two independent invariants:
+/// - **auth** — RFC 7523 §3 validation passed (signature, audience, timing,
+///   `iss == sub == client_id`, client configured for `private_key_jwt`).
+///   Constructible only by
+///   [`crate::services::oidc::jwt_bearer::client_auth::authenticate_client_jwt`].
+/// - **jti** — present when the assertion carried a `jti` claim and the atomic
+///   replay-prevention insert succeeded. `None` is valid for non-FAPI clients
+///   (RFC 7523 §3 makes `jti` OPTIONAL); FAPI 2.0 §5.3.2.1 enforces presence
+///   upstream so a FAPI client reaching this struct cannot have `jti: None`.
+///
+/// Fields are private; construction goes through [`Self::new`] so callers
+/// must supply both witnesses. Witnesses are consumed by drop.
+#[derive(Debug)]
+pub(crate) struct JwtClientAuthProof {
+    _auth: crate::services::oidc::jwt_bearer::client_auth::JwtAuthSucceeded,
+    _jti: Option<crate::db::JwtAssertionJtiClaim>,
+}
+
+impl JwtClientAuthProof {
+    pub(crate) fn new(
+        auth: crate::services::oidc::jwt_bearer::client_auth::JwtAuthSucceeded,
+        jti: Option<crate::db::JwtAssertionJtiClaim>,
+    ) -> Self {
+        Self {
+            _auth: auth,
+            _jti: jti,
+        }
+    }
+}
+
 /// Witness for the client-authentication replay primitive consumed during
 /// token issuance.
 #[derive(Debug)]
 pub(crate) enum ClientAuthProof {
-    /// `private_key_jwt` (RFC 7523) — the JTI was atomically committed to
-    /// the replay-prevention table. The carried `JwtAssertionJtiClaim` is
-    /// the witness returned from `db::store_jwt_assertion_jti`.
-    PrivateKeyJwt(crate::db::JwtAssertionJtiClaim),
+    /// `private_key_jwt` (RFC 7523). Carries the auth-succeeded witness plus
+    /// an optional JTI replay-prevention claim — see [`JwtClientAuthProof`].
+    #[expect(
+        dead_code,
+        reason = "witness payload is consumed by drop, not by field access"
+    )]
+    PrivateKeyJwt(JwtClientAuthProof),
 
     /// `client_secret_basic` / `client_secret_post` (RFC 6749 §2.3.1).
     /// Carries the verification witness from

--- a/crates/vouch-server/src/services/auth.rs
+++ b/crates/vouch-server/src/services/auth.rs
@@ -355,9 +355,10 @@ pub(crate) enum GrantProof {
     /// TODO(slice-4): carry a `Fido2ChallengeClaim`.
     UnconvertedFido2Assertion,
 
-    /// Device authorization grant (RFC 8628).
-    /// TODO(slice-5): carry a `DeviceCodeClaim` from `db::try_consume_device_auth`.
-    UnconvertedDeviceCode,
+    /// Device authorization grant (RFC 8628). Carries a [`crate::db::DeviceCodeClaim`]
+    /// witness — proof that the device code was atomically transitioned to
+    /// `Consumed` before this token issuance.
+    DeviceCode(crate::db::DeviceCodeClaim),
 
     /// Enrollment bootstrap session — issued post-IdP authentication and
     /// pre-FIDO2 registration. `hardware_verified` is false here.

--- a/crates/vouch-server/src/services/auth.rs
+++ b/crates/vouch-server/src/services/auth.rs
@@ -332,10 +332,11 @@ pub(crate) struct TokenIssuanceProof {
 
 /// Witness for the grant-level replay primitive consumed during token issuance.
 ///
-/// `Unconverted*` variants are transitional placeholders that will be
-/// replaced by typed claim witnesses in subsequent slices. See
-/// `.local/handoff/single-use-witness-consolidation-plan.md` for the
-/// migration plan.
+/// Every variant either carries a sealed claim witness produced by an
+/// atomic consume-once operation, or is explicitly a no-replay-primitive
+/// variant (`ClientCredentials`, `TokenExchange` — protected via
+/// `ClientAuthProof`; `CertificationBypass` — gated by env-var; and
+/// `TestingOnly` — `cfg`-gated to test builds).
 #[derive(Debug)]
 pub(crate) enum GrantProof {
     /// `authorization_code` grant. Carries a [`crate::db::AuthCodeClaim`]
@@ -352,9 +353,10 @@ pub(crate) enum GrantProof {
     /// [`ClientAuthProof`].
     TokenExchange,
 
-    /// FIDO2 assertion grant.
-    /// TODO(slice-4): carry a `Fido2ChallengeClaim`.
-    UnconvertedFido2Assertion,
+    /// FIDO2 assertion grant. Carries a [`crate::db::ChallengeStateClaim`]
+    /// witness — proof that the challenge state JWT was atomically marked
+    /// consumed before this token issuance.
+    Fido2Assertion(crate::db::ChallengeStateClaim),
 
     /// Device authorization grant (RFC 8628). Carries a [`crate::db::DeviceCodeClaim`]
     /// witness — proof that the device code was atomically transitioned to
@@ -362,17 +364,24 @@ pub(crate) enum GrantProof {
     DeviceCode(crate::db::DeviceCodeClaim),
 
     /// Enrollment bootstrap session — issued post-IdP authentication and
-    /// pre-FIDO2 registration. `hardware_verified` is false here.
-    /// TODO(slice-6): carry an `OidcStateClaim`.
-    UnconvertedEnrollmentBootstrap,
+    /// pre-FIDO2 registration. `hardware_verified` is false here. Carries
+    /// an [`crate::db::OidcStateClaim`] witness — proof that the OIDC
+    /// state record was atomically transitioned to `consumed_at = Some(_)`
+    /// before this token issuance, closing the read-vs-consume TOCTOU
+    /// window that existed when callers used `get_oidc_state` +
+    /// `delete_oidc_state` as separate steps.
+    EnrollmentBootstrap(crate::db::OidcStateClaim),
 
     /// Enrollment complete session — issued after WebAuthn registration.
-    /// TODO(slice-6): carry a `RegistrationStateClaim`.
-    UnconvertedEnrollmentComplete,
+    /// Carries a [`crate::db::ChallengeStateClaim`] witness — proof that
+    /// the registration state JWT was atomically marked consumed before
+    /// this token issuance.
+    EnrollmentComplete(crate::db::ChallengeStateClaim),
 
-    /// Browser WebAuthn login.
-    /// TODO(slice-7): carry a `WebauthnChallengeClaim`.
-    UnconvertedBrowserLogin,
+    /// Browser WebAuthn login. Carries a [`crate::db::ChallengeStateClaim`]
+    /// witness — proof that the authentication state JWT was atomically
+    /// marked consumed before this token issuance.
+    BrowserLogin(crate::db::ChallengeStateClaim),
 
     /// Certification test bypass (only available when
     /// `VOUCH_CERTIFICATION_TEST_TOKEN` is configured). Deliberately does
@@ -389,9 +398,6 @@ pub(crate) enum GrantProof {
 
 /// Witness for the client-authentication replay primitive consumed during
 /// token issuance.
-///
-/// `Unconverted*` variants are transitional placeholders; see
-/// `GrantProof` documentation.
 #[derive(Debug)]
 pub(crate) enum ClientAuthProof {
     /// `private_key_jwt` (RFC 7523) — the JTI was atomically committed to

--- a/crates/vouch-server/src/services/auth.rs
+++ b/crates/vouch-server/src/services/auth.rs
@@ -410,13 +410,15 @@ pub(crate) enum ClientAuthProof {
 }
 
 impl ClientAuthProof {
-    /// Compose a `ClientAuthProof` from an optional JTI claim and a fallback
-    /// for the case where the client did not use `private_key_jwt`.
+    /// Compose a `ClientAuthProof` from an optional JTI claim and a fallback.
     ///
-    /// Call sites typically receive `Option<JwtAssertionJtiClaim>` from
-    /// `PendingJti::commit` — `Some(claim)` means the JTI was atomically
-    /// committed, `None` means either the assertion omitted `jti` or the
-    /// client did not use JWT auth. The fallback covers the latter case.
+    /// `Some(claim)` produces `PrivateKeyJwt(claim)` — the only path to that
+    /// variant, since `JwtAssertionJtiClaim` has no public constructor. `None`
+    /// is *any* non-`private_key_jwt` case: the assertion omitted `jti`, the
+    /// client used `client_secret_basic`/`client_secret_post`, the client
+    /// used `tls_client_auth`/`self_signed_tls_client_auth`, or the client is
+    /// public (no auth). The caller supplies the appropriate fallback variant
+    /// describing whichever non-JWT method actually succeeded.
     pub(crate) fn from_jti_or(
         jti_claim: Option<crate::db::JwtAssertionJtiClaim>,
         fallback: Self,
@@ -424,6 +426,23 @@ impl ClientAuthProof {
         match jti_claim {
             Some(claim) => Self::PrivateKeyJwt(claim),
             None => fallback,
+        }
+    }
+
+    /// Map a registered `TokenEndpointAuthMethod` to the matching placeholder
+    /// variant. Used by call sites that don't separately track which auth
+    /// method succeeded but do hold the authenticated client's registered
+    /// method (e.g., PAR). The `PrivateKeyJwt` arm returns `None` here because
+    /// the JTI claim is the only valid construction path — callers with a JWT
+    /// client must use [`Self::from_jti_or`] with the committed claim.
+    pub(crate) fn from_auth_method(method: crate::db::TokenEndpointAuthMethod) -> Self {
+        use crate::db::TokenEndpointAuthMethod;
+        match method {
+            TokenEndpointAuthMethod::ClientSecretBasic
+            | TokenEndpointAuthMethod::ClientSecretPost => Self::UnconvertedClientSecret,
+            TokenEndpointAuthMethod::TlsClientAuth
+            | TokenEndpointAuthMethod::SelfSignedTlsClientAuth => Self::UnconvertedMutualTls,
+            TokenEndpointAuthMethod::PrivateKeyJwt | TokenEndpointAuthMethod::None => Self::None,
         }
     }
 }
@@ -566,6 +585,9 @@ pub(crate) async fn create_oauth_access_token(
     // Consume the witness. Its presence is the structural guarantee that the
     // caller has consumed the required replay primitives — once consumed
     // here, the proof cannot be reused for another token issuance.
+    //
+    // `JwtAssertionJtiClaim` holds only `_private: ()` — the JTI string is
+    // not retained in the witness, so the Debug log cannot leak it.
     let TokenIssuanceProof { grant, client_auth } = proof;
     tracing::debug!(?grant, ?client_auth, "token issuance proof consumed");
 

--- a/crates/vouch-server/src/services/auth.rs
+++ b/crates/vouch-server/src/services/auth.rs
@@ -307,6 +307,144 @@ impl ActorClaim {
 /// Prevents unbounded nesting in token exchange delegation chains.
 pub(crate) const MAX_DELEGATION_DEPTH: usize = 5;
 
+// ============================================================================
+// Token Issuance Proof (single-use witness chokepoint)
+// ============================================================================
+
+/// Proof that a token-issuance request has consumed its replay-prevention
+/// primitives. Required parameter to [`create_oauth_access_token`].
+///
+/// The presence of a `TokenIssuanceProof` value is compile-time evidence that
+/// the caller has consumed the relevant grant-level and client-authentication
+/// replay primitives, in the correct order, before invoking the chokepoint.
+/// The proof is constructed only at call sites that have already executed
+/// those consume-once operations.
+///
+/// `TokenIssuanceProof` is not `Clone` — the proof represents a one-shot
+/// authorization to issue a token and cannot be duplicated.
+#[must_use = "the proof was constructed to authorize a single token issuance; \
+              dropping it without calling create_oauth_access_token is a bug"]
+#[derive(Debug)]
+pub(crate) struct TokenIssuanceProof {
+    pub(crate) grant: GrantProof,
+    pub(crate) client_auth: ClientAuthProof,
+}
+
+/// Witness for the grant-level replay primitive consumed during token issuance.
+///
+/// `Unconverted*` variants are transitional placeholders that will be
+/// replaced by typed claim witnesses in subsequent slices. See
+/// `.local/handoff/single-use-witness-consolidation-plan.md` for the
+/// migration plan.
+#[derive(Debug)]
+pub(crate) enum GrantProof {
+    /// `authorization_code` grant.
+    /// TODO(slice-2): carry an `AuthCodeClaim` from `db::try_consume_auth_code`.
+    UnconvertedAuthorizationCode,
+
+    /// `client_credentials` grant — no grant-level replay primitive; the
+    /// single-use guarantee is enforced entirely via [`ClientAuthProof`].
+    ClientCredentials,
+
+    /// `urn:ietf:params:oauth:grant-type:token-exchange` — RFC 8693 does not
+    /// require single-use of the subject token; replay protection is via
+    /// [`ClientAuthProof`].
+    TokenExchange,
+
+    /// FIDO2 assertion grant.
+    /// TODO(slice-4): carry a `Fido2ChallengeClaim`.
+    UnconvertedFido2Assertion,
+
+    /// Device authorization grant (RFC 8628).
+    /// TODO(slice-5): carry a `DeviceCodeClaim` from `db::try_consume_device_auth`.
+    UnconvertedDeviceCode,
+
+    /// Enrollment bootstrap session — issued post-IdP authentication and
+    /// pre-FIDO2 registration. `hardware_verified` is false here.
+    /// TODO(slice-6): carry an `OidcStateClaim`.
+    UnconvertedEnrollmentBootstrap,
+
+    /// Enrollment complete session — issued after WebAuthn registration.
+    /// TODO(slice-6): carry a `RegistrationStateClaim`.
+    UnconvertedEnrollmentComplete,
+
+    /// Browser WebAuthn login.
+    /// TODO(slice-7): carry a `WebauthnChallengeClaim`.
+    UnconvertedBrowserLogin,
+
+    /// Certification test bypass (only available when
+    /// `VOUCH_CERTIFICATION_TEST_TOKEN` is configured). Deliberately does
+    /// not consume the pending authorization — the authorize endpoint
+    /// handles consumption on the subsequent redirect.
+    CertificationBypass,
+
+    /// Test-only variant used by `test_utils` session helpers. Gated by
+    /// the same `cfg` as the `test_utils` module so it cannot appear in
+    /// production builds.
+    #[cfg(any(test, feature = "test-utils"))]
+    TestingOnly,
+}
+
+/// Witness for the client-authentication replay primitive consumed during
+/// token issuance.
+///
+/// `Unconverted*` variants are transitional placeholders; see
+/// `GrantProof` documentation.
+#[derive(Debug)]
+pub(crate) enum ClientAuthProof {
+    /// `private_key_jwt` (RFC 7523) — the JTI was atomically committed to
+    /// the replay-prevention table. The carried `JwtAssertionJtiClaim` is
+    /// the witness returned from `db::store_jwt_assertion_jti`.
+    PrivateKeyJwt(crate::db::JwtAssertionJtiClaim),
+
+    /// `client_secret_basic` / `client_secret_post`.
+    /// TODO(slice-8): carry a `ClientSecretVerification` witness.
+    UnconvertedClientSecret,
+
+    /// `tls_client_auth` / `self_signed_tls_client_auth` (RFC 8705).
+    /// TODO(slice-8): carry an `MtlsCertVerification` witness.
+    UnconvertedMutualTls,
+
+    /// Public client — no client authentication was performed.
+    None,
+}
+
+impl ClientAuthProof {
+    /// Compose a `ClientAuthProof` from an optional JTI claim and a fallback
+    /// for the case where the client did not use `private_key_jwt`.
+    ///
+    /// Call sites typically receive `Option<JwtAssertionJtiClaim>` from
+    /// `PendingJti::commit` — `Some(claim)` means the JTI was atomically
+    /// committed, `None` means either the assertion omitted `jti` or the
+    /// client did not use JWT auth. The fallback covers the latter case.
+    pub(crate) fn from_jti_or(
+        jti_claim: Option<crate::db::JwtAssertionJtiClaim>,
+        fallback: Self,
+    ) -> Self {
+        match jti_claim {
+            Some(claim) => Self::PrivateKeyJwt(claim),
+            None => fallback,
+        }
+    }
+}
+
+/// Proof that a PAR (RFC 9126) creation request has consumed its
+/// client-authentication replay primitive. Required parameter to
+/// [`crate::db::create_pushed_authorization_request`].
+///
+/// PAR does not issue an access token, so the [`TokenIssuanceProof`]
+/// chokepoint does not fit. `ParCreationProof` is the analog for the
+/// PAR-storage chokepoint: a caller must construct one before persisting
+/// a PAR record, and the only path to a `ClientAuthProof::PrivateKeyJwt`
+/// is via a committed [`crate::db::JwtAssertionJtiClaim`].
+#[must_use = "the proof was constructed to authorize a single PAR creation; \
+              dropping it without calling create_pushed_authorization_request \
+              is a bug"]
+#[derive(Debug)]
+pub(crate) struct ParCreationProof {
+    pub(crate) client_auth: ClientAuthProof,
+}
+
 /// JWT Access Token claims per RFC 9068 Section 2.2.
 ///
 /// These claims are included in OAuth 2.0 access tokens signed with ES256.
@@ -412,13 +550,25 @@ pub(crate) struct CreateSessionResult {
 /// The `authenticator_id` is stored server-side in the session record
 /// and NOT included in the JWT to prevent information leakage.
 ///
+/// The `proof` parameter is a compile-time witness that the caller has
+/// consumed the relevant single-use replay-prevention primitives in the
+/// correct order. It is dropped immediately on entry — its only purpose
+/// is to make the chokepoint unforgeable from outside the crate.
+///
 /// # Errors
 ///
 /// Returns `ServiceError::Internal` if token signing or database operations fail.
 pub(crate) async fn create_oauth_access_token(
     state: &AppState,
     params: CreateOAuthTokenParams<'_>,
+    proof: TokenIssuanceProof,
 ) -> ServiceResult<CreateSessionResult> {
+    // Consume the witness. Its presence is the structural guarantee that the
+    // caller has consumed the required replay primitives — once consumed
+    // here, the proof cannot be reused for another token issuance.
+    let TokenIssuanceProof { grant, client_auth } = proof;
+    tracing::debug!(?grant, ?client_auth, "token issuance proof consumed");
+
     let now = Timestamp::now();
     let session_hours = i64::try_from(state.config().session_hours)
         .map_err(|_| ServiceError::Internal("Invalid session hours".to_string()))?;

--- a/crates/vouch-server/src/services/keys.rs
+++ b/crates/vouch-server/src/services/keys.rs
@@ -16,10 +16,20 @@ use vouch_common::{KeyInfo, lookup_device_model};
 /// Maximum session age (in seconds) for destructive key operations.
 pub(crate) const KEY_DELETE_MAX_AGE_SECS: i64 = 60;
 
+/// Outcome of a [`consume_registration_state`] call.
+pub(crate) enum RegistrationStateConsumed {
+    /// First use — returns the witness for the chokepoint.
+    Won(db::ChallengeStateClaim),
+    /// Already consumed (replay). The handler emits the audit event and
+    /// HTTP error response.
+    Replay,
+}
+
 /// Atomically consume a registration state JWT for single-use enforcement.
 ///
-/// Returns `Ok(true)` on first use, `Ok(false)` if already consumed (replay).
-/// The caller is responsible for constructing the appropriate error response and
+/// Returns [`RegistrationStateConsumed::Won`] with the witness on first use,
+/// or [`RegistrationStateConsumed::Replay`] if already consumed. The caller
+/// is responsible for constructing the appropriate error response and
 /// emitting the audit event, since only the handler has access to the user
 /// context and the audit store.
 ///
@@ -30,15 +40,19 @@ pub(crate) async fn consume_registration_state(
     store: &DocumentStore,
     state_jwt: &str,
     exp_seconds: i64,
-) -> Result<bool, ServiceError> {
+) -> Result<RegistrationStateConsumed, ServiceError> {
     let expires_at = Timestamp::from_second(exp_seconds).unwrap_or_else(|_| Timestamp::now());
 
-    db::try_mark_challenge_used(store, state_jwt, expires_at)
-        .await
-        .map_err(|e| {
+    match db::try_consume_challenge_state(store, state_jwt, expires_at).await {
+        Ok(claim) => Ok(RegistrationStateConsumed::Won(claim)),
+        Err(db::ClaimError::AlreadyConsumed) => Ok(RegistrationStateConsumed::Replay),
+        Err(e) => {
             tracing::error!("Failed to mark registration state used: {e}");
-            ServiceError::Internal("Failed to mark registration state used".to_string())
-        })
+            Err(ServiceError::Internal(
+                "Failed to mark registration state used".to_string(),
+            ))
+        }
+    }
 }
 
 /// Require the given issued-at or auth timestamp to be within `max_age_secs` seconds.

--- a/crates/vouch-server/src/services/oidc/client_credentials.rs
+++ b/crates/vouch-server/src/services/oidc/client_credentials.rs
@@ -191,7 +191,9 @@ mod tests {
             Some(thumbprint),
             TokenIssuanceProof {
                 grant: GrantProof::ClientCredentials,
-                client_auth: ClientAuthProof::UnconvertedMutualTls,
+                client_auth: ClientAuthProof::MutualTls(
+                    crate::services::oidc::token::MtlsCertVerification::for_testing(),
+                ),
             },
         )
         .await

--- a/crates/vouch-server/src/services/oidc/client_credentials.rs
+++ b/crates/vouch-server/src/services/oidc/client_credentials.rs
@@ -10,7 +10,9 @@
 
 use crate::AppState;
 use crate::db::{OAuthClient, SessionPurpose};
-use crate::services::auth::{CreateOAuthTokenParams, create_oauth_access_token};
+use crate::services::auth::{
+    CreateOAuthTokenParams, TokenIssuanceProof, create_oauth_access_token,
+};
 use crate::services::oidc::ScopeSet;
 use crate::services::{OAuthErrorCode, ServiceError, ServiceResult};
 use secrecy::ExposeSecret;
@@ -39,11 +41,12 @@ pub struct ClientCredentialsResult {
 /// # Errors
 /// Returns `unauthorized_client` if the client does not have the
 /// `client_credentials` grant type registered.
-pub async fn exchange_client_credentials(
+pub(crate) async fn exchange_client_credentials(
     state: &Arc<AppState>,
     client: &OAuthClient,
     requested_scope: Option<&str>,
     mtls_cert_thumbprint: Option<&str>,
+    proof: TokenIssuanceProof,
 ) -> ServiceResult<ClientCredentialsResult> {
     // Verify client has client_credentials in its registered grant_types
     let has_grant = client
@@ -84,6 +87,7 @@ pub async fn exchange_client_credentials(
             session_purpose: SessionPurpose::M2MAccessToken,
             authorization_details: None,
         },
+        proof,
     )
     .await?;
 
@@ -107,6 +111,7 @@ pub async fn exchange_client_credentials(
 )]
 mod tests {
     use super::*;
+    use crate::services::auth::{ClientAuthProof, GrantProof};
     use crate::services::oidc::OAuthScope;
 
     #[test]
@@ -179,9 +184,18 @@ mod tests {
         let client = client_record;
 
         let thumbprint = "test-mtls-thumbprint-xxxxxxxxxxxxxxxxxxxxxxxxxxx";
-        let result = exchange_client_credentials(&state, &client, None, Some(thumbprint))
-            .await
-            .expect("exchange_client_credentials");
+        let result = exchange_client_credentials(
+            &state,
+            &client,
+            None,
+            Some(thumbprint),
+            TokenIssuanceProof {
+                grant: GrantProof::ClientCredentials,
+                client_auth: ClientAuthProof::UnconvertedMutualTls,
+            },
+        )
+        .await
+        .expect("exchange_client_credentials");
 
         // Decode the access token JWT and verify the cnf claim
         let config = state.config();

--- a/crates/vouch-server/src/services/oidc/dpop.rs
+++ b/crates/vouch-server/src/services/oidc/dpop.rs
@@ -521,16 +521,27 @@ async fn validate_dpop_common(
         expected_ath,
     )?;
 
-    // Validate nonce via database if provided — atomic DELETE WHERE nonce=? AND expires_at > now
+    // Atomically consume the nonce via the database. A successful return
+    // means a single DELETE statement decided the claim — no TOCTOU window
+    // between read and consume. The witness is dropped here; its only
+    // purpose at present is the compile-time guarantee that the consume
+    // happened, which future code can require by holding a `DpopNonceClaim`.
     if let Some(nonce) = claims.nonce.as_deref() {
-        let valid = db::validate_and_consume_dpop_nonce(store, nonce)
-            .await
-            .map_err(|e| DpopError::InvalidFormat(format!("nonce validation failed: {e}")))?;
-        if !valid {
-            let new_nonce = db::generate_dpop_nonce(store, NONCE_VALIDITY_SECONDS)
-                .await
-                .map_err(|e| DpopError::InvalidFormat(format!("nonce generation failed: {e}")))?;
-            return Err(DpopError::UseNonce(new_nonce));
+        match db::validate_and_consume_dpop_nonce(store, nonce).await {
+            Ok(_claim) => {}
+            Err(db::claim::ClaimError::AlreadyConsumed) => {
+                let new_nonce = db::generate_dpop_nonce(store, NONCE_VALIDITY_SECONDS)
+                    .await
+                    .map_err(|e| {
+                        DpopError::InvalidFormat(format!("nonce generation failed: {e}"))
+                    })?;
+                return Err(DpopError::UseNonce(new_nonce));
+            }
+            Err(e) => {
+                return Err(DpopError::InvalidFormat(format!(
+                    "nonce validation failed: {e}"
+                )));
+            }
         }
     }
 

--- a/crates/vouch-server/src/services/oidc/dpop.rs
+++ b/crates/vouch-server/src/services/oidc/dpop.rs
@@ -194,17 +194,54 @@ impl std::fmt::Display for DpopError {
 
 impl std::error::Error for DpopError {}
 
-/// Validated DPoP proof information.
-#[derive(Debug, Clone)]
+/// Witness that a DPoP proof (RFC 9449) has been fully validated AND its
+/// `jti` has been atomically committed to the replay-prevention table.
+///
+/// Construction is private to this module — the only path to an instance is
+/// a successful return from [`validate_dpop_proof`] (or its userinfo-bound
+/// variant), both of which call [`validate_dpop_common`], which performs
+/// signature verification, claim validation (`htm`/`htu`/`exp`/`nonce`),
+/// and an atomic insert into the DPoP JTI table. Callers that hold a
+/// `ValidatedDpopProof` can rely on it as compile-time evidence that the
+/// proof was not a replay and is bound to the carried `jkt`.
+///
+/// The carried `jkt`/`jti`/`source` are the validation metadata downstream
+/// consumers need (e.g., binding the access token via `cnf.jkt`, recording
+/// `source` in audit logs). Reading those fields is fine; the sealing only
+/// prevents *fabrication* of a witness without going through validation.
+///
+/// Intentionally not `Clone` — the witness represents a single one-shot
+/// validation. The `#[must_use]` ensures it is bound at the call site.
+#[must_use = "the DPoP proof was validated and its JTI atomically committed; \
+              bind this witness so it can be threaded into downstream consumers"]
+#[derive(Debug)]
 pub struct ValidatedDpopProof {
-    /// JWK thumbprint of the sender's key.
-    pub jkt: String,
-    /// The public key from the proof.
-    pub jwk: DpopJwk,
+    /// JWK thumbprint of the sender's key. Used to bind access tokens
+    /// via `cnf.jkt` (RFC 9449 §6).
+    pub(crate) jkt: String,
     /// Unique identifier from the proof.
-    pub jti: String,
+    pub(crate) jti: String,
     /// Credential source identifier from the DPoP proof (custom claim).
-    pub source: Option<String>,
+    pub(crate) source: Option<String>,
+    /// Seals construction to this module — without setting this field,
+    /// code outside `services::oidc::dpop` cannot build a
+    /// `ValidatedDpopProof` via struct literal. Stronger than
+    /// `#[non_exhaustive]`, which would still allow in-crate construction.
+    _private: (),
+}
+
+impl ValidatedDpopProof {
+    /// Test-only constructor. Production code must obtain a witness via
+    /// [`validate_dpop_proof`] / [`validate_userinfo_dpop_proof`].
+    #[cfg(test)]
+    pub(crate) fn for_testing(jkt: String, jti: String, source: Option<String>) -> Self {
+        Self {
+            jkt,
+            jti,
+            source,
+            _private: (),
+        }
+    }
 }
 
 /// Compute the access token hash (`ath`) for DPoP (RFC 9449 Section 4.2).
@@ -500,9 +537,9 @@ async fn validate_dpop_common(
     let jkt = header.jwk.thumbprint()?;
     Ok(ValidatedDpopProof {
         jkt,
-        jwk: header.jwk,
         jti: claims.jti,
         source: claims.source,
+        _private: (),
     })
 }
 

--- a/crates/vouch-server/src/services/oidc/dpop.rs
+++ b/crates/vouch-server/src/services/oidc/dpop.rs
@@ -491,13 +491,17 @@ async fn validate_dpop_common(
     // Parse header, verify signature, and extract claims in a single pass
     let (header, claims) = parse_and_verify_dpop_proof(proof)?;
 
-    // Check for replay (JTI must be unique) — atomic INSERT on PRIMARY KEY
-    let is_new = db::check_and_store_dpop_jti(store, &claims.jti, config_max_age)
-        .await
-        .map_err(|e| DpopError::InvalidFormat(format!("JTI check failed: {e}")))?;
-    if !is_new {
-        return Err(DpopError::ReplayDetected);
-    }
+    // Check for replay (JTI must be unique) — atomic INSERT on PRIMARY KEY.
+    // The returned `DpopJtiClaim` witness is bound to `_jti_claim` and
+    // dropped at function return; its compile-time guarantee that the JTI
+    // commit happened flows forward via the `ValidatedDpopProof` `_private:
+    // ()` marker constructed below.
+    let _jti_claim = match db::check_and_store_dpop_jti(store, &claims.jti, config_max_age).await {
+        Ok(claim) => claim,
+        Err(db::claim::ClaimError::AlreadyConsumed) => return Err(DpopError::ReplayDetected),
+        Err(db::claim::ClaimError::InvalidInput(msg)) => return Err(DpopError::InvalidFormat(msg)),
+        Err(e) => return Err(DpopError::InvalidFormat(format!("JTI check failed: {e}"))),
+    };
 
     // Nonce requirement: enforced at token endpoint (RFC 9449 Section 8)
     // where precomputation attacks are a concern. Resource endpoints use
@@ -522,13 +526,13 @@ async fn validate_dpop_common(
     )?;
 
     // Atomically consume the nonce via the database. A successful return
-    // means a single DELETE statement decided the claim — no TOCTOU window
-    // between read and consume. The witness is dropped here; its only
-    // purpose at present is the compile-time guarantee that the consume
-    // happened, which future code can require by holding a `DpopNonceClaim`.
+    // means a single DELETE statement decided the outcome — no TOCTOU
+    // window between read and consume. The "this DPoP proof validated
+    // successfully" guarantee is carried forward by the returned
+    // `ValidatedDpopProof` (`_private: ()` marker).
     if let Some(nonce) = claims.nonce.as_deref() {
         match db::validate_and_consume_dpop_nonce(store, nonce).await {
-            Ok(_claim) => {}
+            Ok(()) => {}
             Err(db::claim::ClaimError::AlreadyConsumed) => {
                 let new_nonce = db::generate_dpop_nonce(store, NONCE_VALIDITY_SECONDS)
                     .await

--- a/crates/vouch-server/src/services/oidc/exchange.rs
+++ b/crates/vouch-server/src/services/oidc/exchange.rs
@@ -9,8 +9,8 @@ use crate::crypto::hash_token;
 use crate::db;
 use crate::redact_email;
 use crate::services::auth::{
-    ActorClaim, CreateOAuthTokenParams, MAX_DELEGATION_DEPTH, create_oauth_access_token,
-    decode_token,
+    ActorClaim, CreateOAuthTokenParams, MAX_DELEGATION_DEPTH, TokenIssuanceProof,
+    create_oauth_access_token, decode_token,
 };
 use crate::services::oidc::ScopeSet;
 use crate::services::oidc::authorization_details::AuthorizationDetails;
@@ -92,9 +92,10 @@ pub struct TokenExchangeResult {
     clippy::too_many_lines,
     reason = "RFC 8693 token exchange: validate all params, resolve subject, issue tokens"
 )]
-pub async fn exchange_token(
+pub(crate) async fn exchange_token(
     state: &Arc<AppState>,
     params: TokenExchangeParams<'_>,
+    proof: TokenIssuanceProof,
 ) -> ServiceResult<TokenExchangeResult> {
     // Validate subject token type
     let valid_token_types = [
@@ -371,6 +372,7 @@ pub async fn exchange_token(
             session_purpose: crate::db::SessionPurpose::OAuthAccessToken,
             authorization_details: effective_ad_value.as_ref(),
         },
+        proof,
     )
     .await?;
 

--- a/crates/vouch-server/src/services/oidc/fido2_grant.rs
+++ b/crates/vouch-server/src/services/oidc/fido2_grant.rs
@@ -17,8 +17,9 @@ use crate::AppState;
 use crate::crypto::jwt::JwtType;
 use crate::db::{self, AuthEventParams, AuthEventType};
 use crate::services::auth::{
-    AuthenticatorLookupParams, CreateOAuthTokenParams, LoginAssertionParams, TokenIssuanceProof,
-    create_oauth_access_token, lookup_and_verify_authenticator, verify_login_assertion,
+    AuthenticatorLookupParams, ClientAuthProof, CreateOAuthTokenParams, GrantProof,
+    LoginAssertionParams, TokenIssuanceProof, create_oauth_access_token,
+    lookup_and_verify_authenticator, verify_login_assertion,
 };
 use crate::services::oidc::authorization_details::AuthorizationDetails;
 use crate::services::oidc::token::AuthenticatedClient;
@@ -113,7 +114,7 @@ pub struct Fido2AssertionResult {
 pub(crate) async fn exchange_fido2_assertion(
     state: &Arc<AppState>,
     params: Fido2AssertionParams<'_>,
-    proof: TokenIssuanceProof,
+    client_auth: ClientAuthProof,
 ) -> ServiceResult<Fido2AssertionResult> {
     // 1. Base64url-decode and parse the assertion JSON
     let assertion_bytes = URL_SAFE_NO_PAD.decode(params.assertion).map_err(|_| {
@@ -189,12 +190,22 @@ pub(crate) async fn exchange_fido2_assertion(
     })?;
 
     // 5. Mark challenge used + look up authenticator in parallel
-    //    (independent DB operations on different tables)
-    let (consumed_result, lookup_result) = tokio::try_join!(
+    //    (independent DB operations on different tables). The returned
+    //    `WebauthnChallengeClaim` witness is the structural proof threaded
+    //    into the TokenIssuanceProof below — the only path to
+    //    `GrantProof::Fido2Assertion`.
+    let (challenge_claim_result, lookup_result) = tokio::try_join!(
         async {
-            db::try_mark_challenge_used(&state.store, &payload.state, expires_at)
-                .await
-                .map_err(|e| ServiceError::Internal(format!("Failed to mark challenge used: {e}")))
+            match db::try_consume_challenge_state(&state.store, &payload.state, expires_at).await {
+                Ok(claim) => Ok(claim),
+                Err(db::ClaimError::AlreadyConsumed) => Err(ServiceError::oauth(
+                    OAuthErrorCode::InvalidGrant,
+                    "Challenge state has already been used or expired",
+                )),
+                Err(e) => Err(ServiceError::Internal(format!(
+                    "Failed to mark challenge used: {e}"
+                ))),
+            }
         },
         async {
             lookup_and_verify_authenticator(
@@ -212,13 +223,7 @@ pub(crate) async fn exchange_fido2_assertion(
         },
     )?;
 
-    if !consumed_result {
-        return Err(ServiceError::oauth(
-            OAuthErrorCode::InvalidGrant,
-            "Challenge state has already been used or expired",
-        ));
-    }
-
+    let challenge_claim = challenge_claim_result;
     let authenticator = lookup_result.authenticator;
     let user = lookup_result.user;
 
@@ -301,6 +306,13 @@ pub(crate) async fn exchange_fido2_assertion(
     let dpop_jkt = params.dpop_proof.as_ref().map(|p| p.jkt.as_str());
     let now = jiff::Timestamp::now().as_second();
 
+    // Build the chokepoint proof here: `GrantProof::Fido2Assertion` can
+    // only be constructed by code that holds a WebauthnChallengeClaim,
+    // produced above by `try_consume_webauthn_challenge`.
+    let proof = TokenIssuanceProof {
+        grant: GrantProof::Fido2Assertion(challenge_claim),
+        client_auth,
+    };
     let session_result = create_oauth_access_token(
         state,
         CreateOAuthTokenParams {

--- a/crates/vouch-server/src/services/oidc/fido2_grant.rs
+++ b/crates/vouch-server/src/services/oidc/fido2_grant.rs
@@ -143,9 +143,13 @@ pub(crate) async fn exchange_fido2_assertion(
             )
         })?;
 
-    // 2b. Prepare single-use challenge check
-    let expires_at = jiff::Timestamp::from_second(challenge_state.exp)
-        .unwrap_or_else(|_| jiff::Timestamp::now());
+    // 2b. Prepare single-use challenge check. A malformed `exp` is a
+    // security-relevant signal — a captured token with garbage `exp`
+    // must not be silently accepted with a "now" fallback that would
+    // extend its validity. Reject as InvalidGrant.
+    let expires_at = jiff::Timestamp::from_second(challenge_state.exp).map_err(|_| {
+        ServiceError::oauth(OAuthErrorCode::InvalidGrant, "Invalid challenge state exp")
+    })?;
 
     // 3. Decode assertion fields from base64url (CPU-only, no I/O)
     let credential_id_bytes = URL_SAFE_NO_PAD
@@ -307,8 +311,8 @@ pub(crate) async fn exchange_fido2_assertion(
     let now = jiff::Timestamp::now().as_second();
 
     // Build the chokepoint proof here: `GrantProof::Fido2Assertion` can
-    // only be constructed by code that holds a WebauthnChallengeClaim,
-    // produced above by `try_consume_webauthn_challenge`.
+    // only be constructed by code that holds a `ChallengeStateClaim`,
+    // produced above by `try_consume_challenge_state`.
     let proof = TokenIssuanceProof {
         grant: GrantProof::Fido2Assertion(challenge_claim),
         client_auth,

--- a/crates/vouch-server/src/services/oidc/fido2_grant.rs
+++ b/crates/vouch-server/src/services/oidc/fido2_grant.rs
@@ -17,7 +17,7 @@ use crate::AppState;
 use crate::crypto::jwt::JwtType;
 use crate::db::{self, AuthEventParams, AuthEventType};
 use crate::services::auth::{
-    AuthenticatorLookupParams, CreateOAuthTokenParams, LoginAssertionParams,
+    AuthenticatorLookupParams, CreateOAuthTokenParams, LoginAssertionParams, TokenIssuanceProof,
     create_oauth_access_token, lookup_and_verify_authenticator, verify_login_assertion,
 };
 use crate::services::oidc::authorization_details::AuthorizationDetails;
@@ -110,9 +110,10 @@ pub struct Fido2AssertionResult {
     clippy::too_many_lines,
     reason = "FIDO2 grant: parse assertion, verify, bind tokens, audit"
 )]
-pub async fn exchange_fido2_assertion(
+pub(crate) async fn exchange_fido2_assertion(
     state: &Arc<AppState>,
     params: Fido2AssertionParams<'_>,
+    proof: TokenIssuanceProof,
 ) -> ServiceResult<Fido2AssertionResult> {
     // 1. Base64url-decode and parse the assertion JSON
     let assertion_bytes = URL_SAFE_NO_PAD.decode(params.assertion).map_err(|_| {
@@ -317,6 +318,7 @@ pub async fn exchange_fido2_assertion(
             session_purpose: db::SessionPurpose::OAuthAccessToken,
             authorization_details: ad_value.as_ref(),
         },
+        proof,
     )
     .await?;
 

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
@@ -86,9 +86,6 @@ impl PendingJti {
                     );
                     ClientAuthError::InvalidCredentials
                 }
-                // Not produced by `store_jwt_assertion_jti` today; map
-                // defensively to invalid_client if a future variant lands here.
-                ClaimError::Expired | ClaimError::NotFound => ClientAuthError::InvalidCredentials,
                 ClaimError::Database(msg) => ClientAuthError::DatabaseError(msg),
             })
     }

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
@@ -74,9 +74,7 @@ impl PendingJti {
                     );
                     ClientAuthError::InvalidCredentials
                 }
-                ClaimError::Expired | ClaimError::NotFound => {
-                    ClientAuthError::InvalidCredentials
-                }
+                ClaimError::Expired | ClaimError::NotFound => ClientAuthError::InvalidCredentials,
                 ClaimError::Database(msg) => ClientAuthError::DatabaseError(msg),
             })
     }

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
@@ -34,6 +34,23 @@ pub struct PendingJti {
     max_lifetime: i64,
 }
 
+/// Witness that a JWT client assertion passed RFC 7523 §3 validation
+/// (signature verified against the client's JWKS, audience matched, exp/nbf
+/// within clock skew, `iss == sub == client_id`, client is registered for
+/// `private_key_jwt`).
+///
+/// Constructible only inside this module — returned exclusively by
+/// [`authenticate_client_jwt`]. This is the structural answer to
+/// "did JWT client authentication happen?", separate from
+/// [`JwtAssertionJtiClaim`] which answers "was the JTI atomically
+/// committed for replay prevention?". The two are independent because
+/// RFC 7523 §3 makes `jti` OPTIONAL for non-FAPI clients — auth can
+/// succeed without a JTI commit.
+#[derive(Debug)]
+pub struct JwtAuthSucceeded {
+    _private: (),
+}
+
 impl PendingJti {
     /// Commit this pending JTI to the replay-prevention database.
     ///
@@ -99,17 +116,22 @@ impl PendingJti {
 /// * `client_id_hint` - Optional client_id from the request body (for lookup)
 ///
 /// # Returns
-/// The authenticated client and a pending JTI that MUST be committed via
-/// [`PendingJti::commit`] immediately before grant-state persistence
-/// (`exchange_*` / `store_par_request`). If a validator earlier in the
-/// request rejects with a retryable error (in particular DPoP
-/// `use_dpop_nonce`, RFC 9449 §4.3), drop the [`PendingJti`] without
-/// committing so the client can retry with the same assertion.
+/// On success, returns:
+/// - `AuthenticatedClient` — the resolved OAuth client record;
+/// - `PendingJti` — caller MUST `.commit()` it immediately before grant-state
+///   persistence (`exchange_*` / `store_par_request`). If a later validator
+///   returns a retryable error (notably DPoP `use_dpop_nonce`, RFC 9449 §4.3),
+///   drop the [`PendingJti`] without committing so the client can retry with
+///   the same assertion;
+/// - [`JwtAuthSucceeded`] — the structural witness that RFC 7523 §3 validation
+///   passed. Thread it forward to construct
+///   [`crate::services::auth::ClientAuthProof::PrivateKeyJwt`] regardless of
+///   whether the assertion carried a `jti`.
 pub async fn authenticate_client_jwt(
     state: &Arc<AppState>,
     client_assertion: &str,
     client_id_hint: Option<&str>,
-) -> Result<(AuthenticatedClient, PendingJti), ClientAuthError> {
+) -> Result<(AuthenticatedClient, PendingJti, JwtAuthSucceeded), ClientAuthError> {
     // 1. Parse JWT header to get algorithm and kid
     let header = parse_assertion_header(client_assertion).map_err(|e| {
         tracing::debug!("JWT assertion header parse failed: {e}");
@@ -297,6 +319,7 @@ pub async fn authenticate_client_jwt(
             is_public: false,
         },
         pending_jti,
+        JwtAuthSucceeded { _private: () },
     ))
 }
 

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
@@ -9,56 +9,77 @@ use super::validate::{
     decode_claims_unverified, map_algorithm, parse_assertion_header, validate_jwt_assertion,
 };
 use crate::AppState;
-use crate::db::{self, TokenEndpointAuthMethod};
+use crate::db::claim::ClaimError;
+use crate::db::{self, JwtAssertionJtiClaim, TokenEndpointAuthMethod};
 use crate::services::oidc::token::{AuthenticatedClient, ClientAuthError};
 use jiff::{Timestamp, ToSpan};
 use std::sync::Arc;
 
 /// A JTI that has been validated but not yet committed to the database.
 ///
-/// Call [`commit_jti`] immediately before any grant-state persistence
-/// (`exchange_*` / `store_par_request`) so concurrent replays serialize on
-/// the JTI uniqueness constraint. Commit MUST run after any validator that
-/// returns a retryable error (in particular DPoP `use_dpop_nonce`, RFC 9449
-/// §4.3) so that those failures leave the JTI unconsumed and the client can
-/// retry with the same assertion.
-#[must_use = "JTI must be committed via commit_jti() before token issuance"]
+/// Call [`PendingJti::commit`] immediately before any grant-state
+/// persistence (`exchange_*` / `store_par_request`) so concurrent replays
+/// serialize on the JTI uniqueness constraint. The commit MUST run after
+/// any validator that returns a retryable error (in particular DPoP
+/// `use_dpop_nonce`, RFC 9449 §4.3) so that those failures leave the JTI
+/// unconsumed and the client can retry with the same assertion.
+///
+/// `PendingJti` is not `Clone` and `commit` takes `self` by value, so the
+/// type system prevents double-commit and ensures the value is either
+/// committed or dropped — dropping without committing is the correct
+/// behavior for retryable error paths.
 pub struct PendingJti {
     jti: Option<String>,
     client_id: String,
     max_lifetime: i64,
 }
 
-/// Commit a pending JTI to the replay-prevention database.
-///
-/// Must be called immediately before the grant-state persistence step
-/// (`exchange_*` / `store_par_request`) so that the atomic
-/// `db::store_jwt_assertion_jti` insert is the serializing point under
-/// concurrent replay of the same assertion.
-pub async fn commit_jti(
-    state: &Arc<AppState>,
-    pending: &PendingJti,
-) -> Result<(), ClientAuthError> {
-    let Some(ref jti) = pending.jti else {
-        return Ok(());
-    };
-    let expires_at = Timestamp::now()
-        .checked_add(pending.max_lifetime.seconds())
-        .map_err(|e| ClientAuthError::DatabaseError(e.to_string()))?;
+impl PendingJti {
+    /// Commit this pending JTI to the replay-prevention database.
+    ///
+    /// On success returns a [`JwtAssertionJtiClaim`] witness — proof that
+    /// the atomic INSERT serialized this caller as the first to claim the
+    /// JTI. The witness is `#[must_use]` so callers must bind it (typically
+    /// to thread it to a downstream consumer like token issuance).
+    ///
+    /// Consumes `self` by value — a `PendingJti` can be committed at most
+    /// once, and dropping it without committing is the intended behavior
+    /// for retryable error paths.
+    ///
+    /// Returns `Ok(Some(claim))` when the assertion carried a `jti` and
+    /// the atomic insert succeeded, `Ok(None)` when the assertion omitted
+    /// `jti` (non-FAPI clients — the commit is a no-op), and
+    /// `Err(InvalidCredentials)` when a concurrent caller already claimed
+    /// the same JTI.
+    pub async fn commit(
+        self,
+        state: &Arc<AppState>,
+    ) -> Result<Option<JwtAssertionJtiClaim>, ClientAuthError> {
+        let Some(jti) = self.jti else {
+            return Ok(None);
+        };
+        let expires_at = Timestamp::now()
+            .checked_add(self.max_lifetime.seconds())
+            .map_err(|e| ClientAuthError::DatabaseError(e.to_string()))?;
 
-    let is_new = db::store_jwt_assertion_jti(&state.store, jti, &pending.client_id, expires_at)
-        .await
-        .map_err(|e| ClientAuthError::DatabaseError(e.to_string()))?;
-
-    if !is_new {
-        tracing::warn!(
-            target: "security",
-            client_id = %pending.client_id,
-            "JWT assertion JTI replay detected"
-        );
-        return Err(ClientAuthError::InvalidCredentials);
+        db::store_jwt_assertion_jti(&state.store, &jti, &self.client_id, expires_at)
+            .await
+            .map(Some)
+            .map_err(|e| match e {
+                ClaimError::AlreadyConsumed => {
+                    tracing::warn!(
+                        target: "security",
+                        client_id = %self.client_id,
+                        "JWT assertion JTI replay detected"
+                    );
+                    ClientAuthError::InvalidCredentials
+                }
+                ClaimError::Expired | ClaimError::NotFound => {
+                    ClientAuthError::InvalidCredentials
+                }
+                ClaimError::Database(msg) => ClientAuthError::DatabaseError(msg),
+            })
     }
-    Ok(())
 }
 
 /// Authenticate a client using a JWT assertion (RFC 7523 Section 2.2).
@@ -70,11 +91,11 @@ pub async fn commit_jti(
 ///
 /// # Returns
 /// The authenticated client and a pending JTI that MUST be committed via
-/// [`commit_jti`] immediately before grant-state persistence (`exchange_*` /
-/// `store_par_request`). If a validator earlier in the request rejects with
-/// a retryable error (in particular DPoP `use_dpop_nonce`, RFC 9449 §4.3),
-/// drop the [`PendingJti`] without committing so the client can retry with
-/// the same assertion.
+/// [`PendingJti::commit`] immediately before grant-state persistence
+/// (`exchange_*` / `store_par_request`). If a validator earlier in the
+/// request rejects with a retryable error (in particular DPoP
+/// `use_dpop_nonce`, RFC 9449 §4.3), drop the [`PendingJti`] without
+/// committing so the client can retry with the same assertion.
 pub async fn authenticate_client_jwt(
     state: &Arc<AppState>,
     client_assertion: &str,
@@ -406,7 +427,7 @@ mod tests {
     // ========================================================================
 
     #[tokio::test]
-    async fn test_commit_jti_succeeds_on_first_call() {
+    async fn test_commit_succeeds_on_first_call() {
         let state = make_state().await;
         let pending = PendingJti {
             jti: Some("unique-jti-abc".to_string()),
@@ -414,30 +435,37 @@ mod tests {
             max_lifetime: 300,
         };
 
-        let result = commit_jti(&state, &pending).await;
+        let result = pending.commit(&state).await;
 
         assert!(
-            result.is_ok(),
-            "First commit_jti call must succeed: {result:?}"
+            matches!(result, Ok(Some(_))),
+            "First commit must return Ok(Some(claim)): {result:?}"
         );
     }
 
     #[tokio::test]
-    async fn test_commit_jti_replay_returns_error_on_second_call() {
+    async fn test_commit_replay_returns_error_on_second_call() {
         let state = make_state().await;
-        let pending = PendingJti {
+        let first = PendingJti {
             jti: Some("replay-jti-xyz".to_string()),
             client_id: "client-replay".to_string(),
             max_lifetime: 300,
         };
 
         // First commit succeeds.
-        commit_jti(&state, &pending)
+        let _first_claim = first
+            .commit(&state)
             .await
             .expect("first commit must succeed");
 
         // Second commit with the same JTI is a replay — must fail.
-        let result = commit_jti(&state, &pending).await;
+        // PendingJti is not Clone, so we construct a second one with the same data.
+        let second = PendingJti {
+            jti: Some("replay-jti-xyz".to_string()),
+            client_id: "client-replay".to_string(),
+            max_lifetime: 300,
+        };
+        let result = second.commit(&state).await;
 
         assert!(
             matches!(result, Err(ClientAuthError::InvalidCredentials)),
@@ -446,9 +474,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_commit_jti_none_jti_is_noop() {
+    async fn test_commit_none_jti_returns_none() {
         // When jti is None (e.g. the assertion omitted the jti claim),
-        // commit_jti must return Ok without touching the database.
+        // commit must return Ok(None) without touching the database.
         let state = make_state().await;
         let pending = PendingJti {
             jti: None,
@@ -456,11 +484,11 @@ mod tests {
             max_lifetime: 300,
         };
 
-        let result = commit_jti(&state, &pending).await;
+        let result = pending.commit(&state).await;
 
         assert!(
-            result.is_ok(),
-            "commit_jti with None jti must be a no-op: {result:?}"
+            matches!(result, Ok(None)),
+            "commit with None jti must return Ok(None): {result:?}"
         );
     }
 
@@ -468,34 +496,34 @@ mod tests {
     async fn test_uncommitted_pending_jti_does_not_prevent_later_commit() {
         // Simulates the use_dpop_nonce retry scenario:
         // 1. authenticate_client_jwt returns a PendingJti.
-        // 2. The handler returns use_dpop_nonce WITHOUT calling commit_jti.
+        // 2. The handler returns use_dpop_nonce WITHOUT calling commit.
         // 3. The client retries with the same assertion.
-        // 4. commit_jti on the retry must succeed because the JTI was never stored.
+        // 4. commit on the retry must succeed because the JTI was never stored.
         let state = make_state().await;
 
         let jti = "retry-jti-001".to_string();
 
         // First attempt: PendingJti is built but NOT committed (dropped here).
-        let _first_pending = PendingJti {
+        let first_pending = PendingJti {
             jti: Some(jti.clone()),
             client_id: "client-retry".to_string(),
             max_lifetime: 300,
         };
-        // Intentionally do NOT call commit_jti — simulates a retryable error path.
-        drop(_first_pending);
+        // Intentionally do NOT call commit — simulates a retryable error path.
+        drop(first_pending);
 
-        // Second attempt (retry): commit_jti is called with the same JTI.
+        // Second attempt (retry): commit is called with the same JTI.
         // Because the first PendingJti was never committed, this must succeed.
         let second_pending = PendingJti {
             jti: Some(jti),
             client_id: "client-retry".to_string(),
             max_lifetime: 300,
         };
-        let result = commit_jti(&state, &second_pending).await;
+        let result = second_pending.commit(&state).await;
 
         assert!(
-            result.is_ok(),
-            "commit_jti on retry must succeed when the first PendingJti was not committed: {result:?}"
+            matches!(result, Ok(Some(_))),
+            "commit on retry must succeed when the first PendingJti was not committed: {result:?}"
         );
     }
 }

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
@@ -74,6 +74,20 @@ impl PendingJti {
                     );
                     ClientAuthError::InvalidCredentials
                 }
+                // Client-supplied input violated a validation bound (e.g.,
+                // oversized JTI). Map to 401 invalid_client so the client
+                // fixes its assertion rather than retrying.
+                ClaimError::InvalidInput(msg) => {
+                    tracing::warn!(
+                        target: "security",
+                        client_id = %self.client_id,
+                        error = %msg,
+                        "JWT assertion JTI rejected: invalid input"
+                    );
+                    ClientAuthError::InvalidCredentials
+                }
+                // Not produced by `store_jwt_assertion_jti` today; map
+                // defensively to invalid_client if a future variant lands here.
                 ClaimError::Expired | ClaimError::NotFound => ClientAuthError::InvalidCredentials,
                 ClaimError::Database(msg) => ClientAuthError::DatabaseError(msg),
             })

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/mod.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/mod.rs
@@ -14,6 +14,5 @@ pub mod client_auth;
 pub mod jwks;
 pub mod validate;
 
-pub use client_auth::commit_jti;
 pub use jwks::{find_matching_key_with_refresh_client, resolve_client_jwks};
 pub use validate::SUPPORTED_ALGORITHMS;

--- a/crates/vouch-server/src/services/oidc/token.rs
+++ b/crates/vouch-server/src/services/oidc/token.rs
@@ -15,7 +15,8 @@ use crate::crypto::hash_token;
 use crate::db::{self, Authenticator, OAuthClient, Session, User};
 use crate::redact_email;
 use crate::services::auth::{
-    AuthMethod, CreateOAuthTokenParams, TokenIssuanceProof, create_oauth_access_token, decode_token,
+    AuthMethod, ClientAuthProof, CreateOAuthTokenParams, GrantProof, TokenIssuanceProof,
+    create_oauth_access_token, decode_token,
 };
 use crate::services::{OAuthErrorCode, ServiceError, ServiceResult};
 use aws_lc_rs::digest::{self, SHA256};
@@ -197,7 +198,7 @@ pub struct IdTokenClaims {
 pub(crate) async fn exchange_authorization_code(
     state: &Arc<AppState>,
     params: AuthCodeExchangeParams<'_>,
-    proof: TokenIssuanceProof,
+    client_auth: ClientAuthProof,
 ) -> ServiceResult<AuthCodeExchangeResult> {
     // Decode and validate the authorization code
     let auth_code = decode_authorization_code(state, params.code, params.client_id).await?;
@@ -205,8 +206,10 @@ pub(crate) async fn exchange_authorization_code(
     // RFC 6749 Section 10.5: Enforce single-use authorization codes.
     // This MUST happen before any other validation to ensure codes are always
     // consumed, enabling replay detection regardless of subsequent check outcomes.
+    // The returned witness is the structural proof threaded into the
+    // TokenIssuanceProof below — the only path to `GrantProof::AuthorizationCode`.
     let code_hash = hash_token(params.code);
-    enforce_single_use_code(state, &code_hash, &auth_code).await?;
+    let auth_code_claim = enforce_single_use_code(state, &code_hash, &auth_code).await?;
 
     // Reject deactivated users before issuing tokens
     let user = db::get_user_by_id(&state.store, &auth_code.user_id)
@@ -254,8 +257,15 @@ pub(crate) async fn exchange_authorization_code(
     )
     .await?;
 
-    // Generate access token as an RFC 9068 JWT (ES256, verifiable via JWKS)
+    // Generate access token as an RFC 9068 JWT (ES256, verifiable via JWKS).
+    // Build the chokepoint proof here: `GrantProof::AuthorizationCode` can
+    // only be constructed by code that holds an AuthCodeClaim, which is
+    // produced by `enforce_single_use_code` above.
     let dpop_jkt = params.dpop_proof.as_ref().map(|p| p.jkt.as_str());
+    let proof = TokenIssuanceProof {
+        grant: GrantProof::AuthorizationCode(auth_code_claim),
+        client_auth,
+    };
     let session_result = create_oauth_access_token(
         state,
         CreateOAuthTokenParams {
@@ -364,16 +374,18 @@ struct ResolvedGrants {
 
 /// RFC 6749 Section 10.5: Enforce single-use authorization codes.
 ///
-/// Tries to consume the code atomically. If it was already consumed,
-/// revoke all tokens issued under the compromised code (replay defense).
+/// Atomically consumes the code; on success returns an [`crate::db::AuthCodeClaim`]
+/// witness. On a replay (`ClaimError::AlreadyConsumed`), revokes all tokens
+/// for the user the original code was issued to before returning the OAuth
+/// `invalid_grant` error.
 async fn enforce_single_use_code(
     state: &Arc<AppState>,
     code_hash: &str,
     auth_code: &AuthorizationCode,
-) -> ServiceResult<()> {
+) -> ServiceResult<crate::db::AuthCodeClaim> {
     match db::try_consume_authorization_code(&state.store, code_hash).await {
-        Ok(true) => Ok(()),
-        Ok(false) => {
+        Ok(claim) => Ok(claim),
+        Err(db::claim::ClaimError::AlreadyConsumed) => {
             if let Ok(Some((user_id, _client_id))) =
                 db::get_consumed_code_owner(&state.store, code_hash).await
             {

--- a/crates/vouch-server/src/services/oidc/token.rs
+++ b/crates/vouch-server/src/services/oidc/token.rs
@@ -97,6 +97,53 @@ pub struct AuthenticatedClient {
     pub is_public: bool,
 }
 
+/// Witness that an OAuth client successfully authenticated via
+/// `client_secret_basic` / `client_secret_post` (RFC 6749 Section 2.3.1).
+///
+/// Construction is private to this module — the only path to an instance
+/// is a successful return from [`authenticate_client`] when the client's
+/// stored secret hash matched the constant-time comparison against the
+/// caller-supplied secret. Holding this witness is compile-time evidence
+/// that secret-based client auth succeeded for this request.
+///
+/// Intentionally not `Clone`. The `#[must_use]` ensures the witness is
+/// bound at the call site (typically threaded into
+/// `ClientAuthProof::ClientSecret(verification)`).
+#[must_use = "client_secret authentication succeeded; bind this witness so \
+              it can be threaded into the ClientAuthProof"]
+#[derive(Debug)]
+pub struct ClientSecretVerification {
+    _private: (),
+}
+
+/// Witness that an OAuth client successfully authenticated via mTLS
+/// (RFC 8705 Section 2) — either PKI (`tls_client_auth`) or self-signed
+/// (`self_signed_tls_client_auth`).
+///
+/// Construction is private to this module — the only path to an instance
+/// is a successful return from [`authenticate_client_mtls`] after the
+/// presented certificate validated against the client's registered
+/// identity (subject DN / SAN) or its self-signed x5c JWKS entry.
+///
+/// Intentionally not `Clone`. The `#[must_use]` ensures the witness is
+/// bound at the call site (typically threaded into
+/// `ClientAuthProof::MutualTls(verification)`).
+#[must_use = "mTLS client authentication succeeded; bind this witness so \
+              it can be threaded into the ClientAuthProof"]
+#[derive(Debug)]
+pub struct MtlsCertVerification {
+    _private: (),
+}
+
+impl MtlsCertVerification {
+    /// Test-only constructor. Production code must obtain a verification via
+    /// [`authenticate_client_mtls`].
+    #[cfg(test)]
+    pub(crate) fn for_testing() -> Self {
+        Self { _private: () }
+    }
+}
+
 /// Client authentication error.
 #[derive(Debug)]
 pub enum ClientAuthError {
@@ -235,9 +282,17 @@ pub(crate) async fn exchange_authorization_code(
             "Authenticator not found",
         ))?;
 
-    // RFC 6749 Section 4.1.3: Authenticate the client (if credentials provided)
-    let authenticated_client =
+    // RFC 6749 Section 4.1.3: Authenticate the client (if credentials provided).
+    // If a `client_secret` was just verified, promote the caller-supplied
+    // `ClientAuthProof::None` to `ClientSecret(verification)`. The handler
+    // passes `None` for the secret case because the secret check happens
+    // here (after `enforce_single_use_code`, per RFC 6749 §10.5 ordering).
+    let (authenticated_client, secret_verification) =
         authenticate_and_validate_client(state, params.credentials, &auth_code).await?;
+    let client_auth = match (client_auth, secret_verification) {
+        (ClientAuthProof::None, Some(v)) => ClientAuthProof::ClientSecret(v),
+        (other, _) => other,
+    };
 
     // Validate redirect_uri, PKCE, DPoP binding, and ACR
     validate_code_bindings(
@@ -432,12 +487,15 @@ async fn authenticate_and_validate_client(
     state: &Arc<AppState>,
     credentials: Option<&ClientCredentials>,
     auth_code: &AuthorizationCode,
-) -> ServiceResult<Option<AuthenticatedClient>> {
+) -> ServiceResult<(
+    Option<AuthenticatedClient>,
+    Option<ClientSecretVerification>,
+)> {
     let Some(creds) = credentials else {
-        return Ok(None);
+        return Ok((None, None));
     };
     match authenticate_client(state, creds).await {
-        Ok(client) => {
+        Ok((client, secret_verification)) => {
             if client.client.client_id != auth_code.client_id {
                 tracing::warn!(
                     "Client ID mismatch: token request from {} but code was issued to {}",
@@ -460,7 +518,7 @@ async fn authenticate_and_validate_client(
                     "PKCE required for this client type",
                 ));
             }
-            Ok(Some(client))
+            Ok((Some(client), secret_verification))
         }
         Err(ClientAuthError::InvalidClient | ClientAuthError::MissingClientId) => {
             Err(ServiceError::oauth(
@@ -658,10 +716,16 @@ impl AuthorizationCode {
 /// Supports:
 /// - Confidential clients with `client_secret` (RFC 6749 Section 2.3.1)
 /// - Public clients (native/SPA) without secret (must use PKCE per RFC 7636)
+///
+/// The returned `Option<ClientSecretVerification>` is `Some` only when the
+/// client_secret was validated against its stored hash. For mTLS-registered
+/// clients (whose secret is intentionally skipped here and the cert
+/// validated separately by [`authenticate_client_mtls`]) and public
+/// clients (no auth), the option is `None`.
 pub async fn authenticate_client(
     state: &Arc<AppState>,
     credentials: &ClientCredentials,
-) -> Result<AuthenticatedClient, ClientAuthError> {
+) -> Result<(AuthenticatedClient, Option<ClientSecretVerification>), ClientAuthError> {
     // Look up the client
     let client = db::get_oauth_client_by_client_id(&state.store, &credentials.client_id)
         .await
@@ -691,10 +755,13 @@ pub async fn authenticate_client(
         if let Err(e) = db::update_oauth_client_last_used(&state.store, &client.id).await {
             tracing::warn!("Failed to update OAuth client last_used: {e}");
         }
-        return Ok(AuthenticatedClient {
-            client,
-            is_public: false,
-        });
+        return Ok((
+            AuthenticatedClient {
+                client,
+                is_public: false,
+            },
+            None,
+        ));
     }
 
     if requires_secret {
@@ -720,10 +787,13 @@ pub async fn authenticate_client(
             return Err(ClientAuthError::InvalidCredentials);
         }
 
-        Ok(AuthenticatedClient {
-            client,
-            is_public: false,
-        })
+        Ok((
+            AuthenticatedClient {
+                client,
+                is_public: false,
+            },
+            Some(ClientSecretVerification { _private: () }),
+        ))
     } else {
         // Public client - no secret required, but PKCE should be used
         // Update last used timestamp
@@ -731,10 +801,13 @@ pub async fn authenticate_client(
             tracing::warn!("Failed to update OAuth client last_used: {e}");
         }
 
-        Ok(AuthenticatedClient {
-            client,
-            is_public: true,
-        })
+        Ok((
+            AuthenticatedClient {
+                client,
+                is_public: true,
+            },
+            None,
+        ))
     }
 }
 
@@ -842,7 +915,7 @@ pub(crate) fn authenticate_client_mtls(
     client: &crate::db::OAuthClient,
     cert: &crate::services::oidc::mtls::ClientCertificate,
     jwks_cache_value: Option<&serde_json::Value>,
-) -> Result<(), ClientAuthError> {
+) -> Result<MtlsCertVerification, ClientAuthError> {
     match client.token_endpoint_auth_method {
         crate::db::TokenEndpointAuthMethod::TlsClientAuth => {
             crate::services::oidc::mtls::verify_tls_client_auth(
@@ -853,6 +926,7 @@ pub(crate) fn authenticate_client_mtls(
                 client.tls_client_auth_san_uri.as_deref(),
                 client.tls_client_auth_san_ip.as_deref(),
             )
+            .map(|()| MtlsCertVerification { _private: () })
             .map_err(|e| ClientAuthError::MtlsVerificationFailed(e.to_string()))
         }
         crate::db::TokenEndpointAuthMethod::SelfSignedTlsClientAuth => {
@@ -862,6 +936,7 @@ pub(crate) fn authenticate_client_mtls(
                 )
             })?;
             crate::services::oidc::mtls::verify_self_signed_tls_client_auth(cert, jwks)
+                .map(|()| MtlsCertVerification { _private: () })
                 .map_err(|e| ClientAuthError::MtlsVerificationFailed(e.to_string()))
         }
         _ => Err(ClientAuthError::MtlsVerificationFailed(

--- a/crates/vouch-server/src/services/oidc/token.rs
+++ b/crates/vouch-server/src/services/oidc/token.rs
@@ -15,7 +15,7 @@ use crate::crypto::hash_token;
 use crate::db::{self, Authenticator, OAuthClient, Session, User};
 use crate::redact_email;
 use crate::services::auth::{
-    AuthMethod, CreateOAuthTokenParams, create_oauth_access_token, decode_token,
+    AuthMethod, CreateOAuthTokenParams, TokenIssuanceProof, create_oauth_access_token, decode_token,
 };
 use crate::services::{OAuthErrorCode, ServiceError, ServiceResult};
 use aws_lc_rs::digest::{self, SHA256};
@@ -194,9 +194,10 @@ pub struct IdTokenClaims {
 ///
 /// # Errors
 /// Returns `ServiceError` for invalid requests.
-pub async fn exchange_authorization_code(
+pub(crate) async fn exchange_authorization_code(
     state: &Arc<AppState>,
     params: AuthCodeExchangeParams<'_>,
+    proof: TokenIssuanceProof,
 ) -> ServiceResult<AuthCodeExchangeResult> {
     // Decode and validate the authorization code
     let auth_code = decode_authorization_code(state, params.code, params.client_id).await?;
@@ -272,6 +273,7 @@ pub async fn exchange_authorization_code(
             session_purpose: db::SessionPurpose::OAuthAccessToken,
             authorization_details: grants.authorization_details_value.as_ref(),
         },
+        proof,
     )
     .await?;
     let access_token = session_result.token;

--- a/crates/vouch-server/src/services/oidc/token.rs
+++ b/crates/vouch-server/src/services/oidc/token.rs
@@ -1113,17 +1113,7 @@ mod tests {
     }
 
     fn make_dpop_proof(jkt: &str) -> ValidatedDpopProof {
-        ValidatedDpopProof {
-            jkt: jkt.to_string(),
-            jwk: dpop::DpopJwk::Ec(dpop::EcJwk {
-                kty: "EC".to_string(),
-                crv: "P-256".to_string(),
-                x: "test-x".to_string(),
-                y: "test-y".to_string(),
-            }),
-            jti: "jti-value".to_string(),
-            source: None,
-        }
+        ValidatedDpopProof::for_testing(jkt.to_string(), "jti-value".to_string(), None)
     }
 
     #[test]

--- a/crates/vouch-server/src/services/oidc/token.rs
+++ b/crates/vouch-server/src/services/oidc/token.rs
@@ -31,16 +31,28 @@ use subtle::ConstantTimeEq;
 use super::authorization::{AuthorizationCode, decode_authorization_code};
 
 /// Parameters for exchanging an authorization code for tokens (RFC 6749 Section 4.1.3).
+///
+/// The handler runs all client authentication (JWT, mTLS, secret, public-client
+/// validation) BEFORE calling `exchange_authorization_code`, then passes the
+/// fully-resolved [`AuthenticatedClient`] here. The exchange function only
+/// re-checks that the authenticated client matches the auth code's recorded
+/// client_id — it never runs an authentication step of its own.
 #[derive(Debug)]
 pub struct AuthCodeExchangeParams<'a> {
     /// RFC 6749 Section 4.1.3: The authorization code received from the authorization server.
     pub code: &'a str,
     /// RFC 6749 Section 4.1.3: The redirect URI (REQUIRED if included in authorization request).
     pub redirect_uri: Option<&'a str>,
-    /// RFC 6749 Section 2.3: Client credentials for authentication.
-    pub credentials: Option<&'a ClientCredentials>,
-    /// RFC 7523 Section 2.2: JWT-authenticated client (private_key_jwt), if used.
-    pub jwt_authenticated_client: Option<&'a AuthenticatedClient>,
+    /// RFC 6749 Section 2.3 / RFC 7523 Section 2.2 / RFC 8705 Section 2:
+    /// The client resolved by the handler, regardless of which
+    /// authentication method (`client_secret_basic`/`client_secret_post`,
+    /// `private_key_jwt`, `tls_client_auth`/`self_signed_tls_client_auth`,
+    /// or public-client validation) succeeded. The handler runs all
+    /// authentication so that `exchange_authorization_code` receives a
+    /// fully-resolved `AuthenticatedClient` and never re-runs an auth
+    /// step. `None` only when the handler was unable to determine the
+    /// client — exchange treats that as invalid_client.
+    pub authenticated_client: Option<&'a AuthenticatedClient>,
     /// RFC 7636 Section 4.5: The PKCE code verifier.
     pub code_verifier: Option<&'a str>,
     /// RFC 9449 Section 5: Validated DPoP proof (if present).
@@ -282,17 +294,39 @@ pub(crate) async fn exchange_authorization_code(
             "Authenticator not found",
         ))?;
 
-    // RFC 6749 Section 4.1.3: Authenticate the client (if credentials provided).
-    // If a `client_secret` was just verified, promote the caller-supplied
-    // `ClientAuthProof::None` to `ClientSecret(verification)`. The handler
-    // passes `None` for the secret case because the secret check happens
-    // here (after `enforce_single_use_code`, per RFC 6749 §10.5 ordering).
-    let (authenticated_client, secret_verification) =
-        authenticate_and_validate_client(state, params.credentials, &auth_code).await?;
-    let client_auth = match (client_auth, secret_verification) {
-        (ClientAuthProof::None, Some(v)) => ClientAuthProof::ClientSecret(v),
-        (other, _) => other,
-    };
+    // RFC 6749 Section 4.1.3: Verify the handler-authenticated client
+    // matches the authorization code's recorded client_id, and that PKCE
+    // (RFC 7636) is present when required for this client type. Client
+    // authentication itself (RFC 6749 §2.3 / RFC 7523 §2.2 / RFC 8705)
+    // ran at the handler before this function was called; here we only
+    // check consistency with the auth code.
+    let authenticated_client = params.authenticated_client;
+    if let Some(client) = authenticated_client
+        && client.client.client_id != auth_code.client_id
+    {
+        tracing::warn!(
+            "Client ID mismatch: token request from {} but code was issued to {}",
+            client.client.client_id,
+            auth_code.client_id
+        );
+        return Err(ServiceError::oauth(
+            OAuthErrorCode::InvalidGrant,
+            "Client ID mismatch",
+        ));
+    }
+    if let Some(client) = authenticated_client {
+        let pkce_required = client.is_public || client.client.application_type.requires_pkce();
+        if pkce_required && auth_code.code_challenge.is_none() {
+            tracing::warn!(
+                "Client {} requires PKCE but no code_challenge was present",
+                client.client.client_id
+            );
+            return Err(ServiceError::oauth(
+                OAuthErrorCode::InvalidRequest,
+                "PKCE required for this client type",
+            ));
+        }
+    }
 
     // Validate redirect_uri, PKCE, DPoP binding, and ACR
     validate_code_bindings(
@@ -346,15 +380,8 @@ pub(crate) async fn exchange_authorization_code(
 
     // Extract the per-client ID token signing algorithm.
     // Public/unauthenticated clients fall back to "RS256" per OIDC Core default.
-    let id_token_alg = authenticated_client
-        .as_ref()
-        .map(|c| c.client.id_token_signed_response_alg.as_str())
-        .or_else(|| {
-            params
-                .jwt_authenticated_client
-                .map(|c| c.client.id_token_signed_response_alg.as_str())
-        })
-        .unwrap_or("RS256");
+    let id_token_alg =
+        authenticated_client.map_or("RS256", |c| c.client.id_token_signed_response_alg.as_str());
 
     // Generate ID token (with at_hash computed from the access token)
     let id_token = generate_id_token(
@@ -376,7 +403,7 @@ pub(crate) async fn exchange_authorization_code(
     .await?;
 
     // Record usage event for registered clients
-    if let Some(ref auth_client) = authenticated_client
+    if let Some(auth_client) = authenticated_client
         && let Err(e) = db::record_oauth_event(
             &state.audit,
             &auth_client.client.id,
@@ -476,57 +503,6 @@ async fn enforce_single_use_code(
                 "Failed to validate authorization code".to_string(),
             ))
         }
-    }
-}
-
-/// Authenticate client credentials and validate against the authorization code.
-///
-/// Verifies the client_id matches the code's client_id and that PKCE is
-/// present when required for the client type.
-async fn authenticate_and_validate_client(
-    state: &Arc<AppState>,
-    credentials: Option<&ClientCredentials>,
-    auth_code: &AuthorizationCode,
-) -> ServiceResult<(
-    Option<AuthenticatedClient>,
-    Option<ClientSecretVerification>,
-)> {
-    let Some(creds) = credentials else {
-        return Ok((None, None));
-    };
-    match authenticate_client(state, creds).await {
-        Ok((client, secret_verification)) => {
-            if client.client.client_id != auth_code.client_id {
-                tracing::warn!(
-                    "Client ID mismatch: token request from {} but code was issued to {}",
-                    client.client.client_id,
-                    auth_code.client_id
-                );
-                return Err(ServiceError::oauth(
-                    OAuthErrorCode::InvalidGrant,
-                    "Client ID mismatch",
-                ));
-            }
-            let pkce_required = client.is_public || client.client.application_type.requires_pkce();
-            if pkce_required && auth_code.code_challenge.is_none() {
-                tracing::warn!(
-                    "Client {} requires PKCE but no code_challenge was present",
-                    client.client.client_id
-                );
-                return Err(ServiceError::oauth(
-                    OAuthErrorCode::InvalidRequest,
-                    "PKCE required for this client type",
-                ));
-            }
-            Ok((Some(client), secret_verification))
-        }
-        Err(ClientAuthError::InvalidClient | ClientAuthError::MissingClientId) => {
-            Err(ServiceError::oauth(
-                OAuthErrorCode::InvalidClient,
-                "Client authentication required",
-            ))
-        }
-        Err(e) => Err(e.into_service_error()),
     }
 }
 

--- a/crates/vouch-server/src/test_utils.rs
+++ b/crates/vouch-server/src/test_utils.rs
@@ -388,6 +388,40 @@ pub async fn http_delete_full(app: &Router, uri: &str, headers: &[(&str, &str)])
     http_request_full(app, "DELETE", uri, None, headers).await
 }
 
+/// Helper for making POST form requests with an injected mTLS client certificate.
+///
+/// Mirrors [`http_post_form`] but injects the certificate via
+/// `ConnectInfo<PeerClientCert>` so [`OptionalClientCert`] extracts it in the
+/// handler. Pass `None` for `cert_der` to simulate a connection where no client
+/// certificate was presented.
+pub async fn http_post_form_with_cert(
+    app: &Router,
+    uri: &str,
+    body: &str,
+    headers: &[(&str, &str)],
+    cert_der: Option<Vec<u8>>,
+) -> (StatusCode, String) {
+    let mut all_headers = vec![("Content-Type", "application/x-www-form-urlencoded")];
+    all_headers.extend_from_slice(headers);
+    let request = build_test_request_with_cert(
+        "POST",
+        uri,
+        Some(body.to_string()),
+        &all_headers,
+        cert_der,
+    );
+    let response: axum::response::Response = app
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("Failed to execute request");
+    let status = response.status();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read response body");
+    (status, String::from_utf8_lossy(&body_bytes).to_string())
+}
+
 /// Helper for making GET requests with an injected mTLS client certificate.
 ///
 /// The `cert_der` is injected via `ConnectInfo<PeerClientCert>` so that

--- a/crates/vouch-server/src/test_utils.rs
+++ b/crates/vouch-server/src/test_utils.rs
@@ -403,13 +403,8 @@ pub async fn http_post_form_with_cert(
 ) -> (StatusCode, String) {
     let mut all_headers = vec![("Content-Type", "application/x-www-form-urlencoded")];
     all_headers.extend_from_slice(headers);
-    let request = build_test_request_with_cert(
-        "POST",
-        uri,
-        Some(body.to_string()),
-        &all_headers,
-        cert_der,
-    );
+    let request =
+        build_test_request_with_cert("POST", uri, Some(body.to_string()), &all_headers, cert_der);
     let response: axum::response::Response = app
         .clone()
         .oneshot(request)

--- a/crates/vouch-server/src/test_utils.rs
+++ b/crates/vouch-server/src/test_utils.rs
@@ -501,7 +501,9 @@ pub async fn create_test_session(
         },
         TokenIssuanceProof {
             grant: GrantProof::TestingOnly,
-            client_auth: ClientAuthProof::None,
+            client_auth: ClientAuthProof::NoAuth(
+                crate::services::auth::NoClientAuth::internal_endpoint(),
+            ),
         },
     )
     .await
@@ -547,7 +549,9 @@ pub async fn create_test_session_with_iat(
         },
         TokenIssuanceProof {
             grant: GrantProof::TestingOnly,
-            client_auth: ClientAuthProof::None,
+            client_auth: ClientAuthProof::NoAuth(
+                crate::services::auth::NoClientAuth::internal_endpoint(),
+            ),
         },
     )
     .await
@@ -593,7 +597,9 @@ pub async fn create_test_session_for_client(
         },
         TokenIssuanceProof {
             grant: GrantProof::TestingOnly,
-            client_auth: ClientAuthProof::None,
+            client_auth: ClientAuthProof::NoAuth(
+                crate::services::auth::NoClientAuth::internal_endpoint(),
+            ),
         },
     )
     .await
@@ -639,7 +645,9 @@ pub async fn create_test_session_with_dpop(
         },
         TokenIssuanceProof {
             grant: GrantProof::TestingOnly,
-            client_auth: ClientAuthProof::None,
+            client_auth: ClientAuthProof::NoAuth(
+                crate::services::auth::NoClientAuth::internal_endpoint(),
+            ),
         },
     )
     .await
@@ -685,7 +693,9 @@ pub async fn create_test_session_with_mtls(
         },
         TokenIssuanceProof {
             grant: GrantProof::TestingOnly,
-            client_auth: ClientAuthProof::None,
+            client_auth: ClientAuthProof::NoAuth(
+                crate::services::auth::NoClientAuth::internal_endpoint(),
+            ),
         },
     )
     .await

--- a/crates/vouch-server/src/test_utils.rs
+++ b/crates/vouch-server/src/test_utils.rs
@@ -475,7 +475,10 @@ pub async fn create_test_session(
     email: &str,
     auth_id: &str,
 ) -> String {
-    use crate::services::auth::{CreateOAuthTokenParams, create_oauth_access_token};
+    use crate::services::auth::{
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, TokenIssuanceProof,
+        create_oauth_access_token,
+    };
     use crate::services::oidc::ScopeSet;
     use secrecy::ExposeSecret;
 
@@ -496,6 +499,10 @@ pub async fn create_test_session(
             session_purpose: crate::db::SessionPurpose::OAuthAccessToken,
             authorization_details: None,
         },
+        TokenIssuanceProof {
+            grant: GrantProof::TestingOnly,
+            client_auth: ClientAuthProof::None,
+        },
     )
     .await
     .expect("Failed to create test session");
@@ -514,7 +521,10 @@ pub async fn create_test_session_with_iat(
     auth_id: &str,
     iat: i64,
 ) -> String {
-    use crate::services::auth::{CreateOAuthTokenParams, create_oauth_access_token};
+    use crate::services::auth::{
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, TokenIssuanceProof,
+        create_oauth_access_token,
+    };
     use crate::services::oidc::ScopeSet;
     use secrecy::ExposeSecret;
 
@@ -535,6 +545,10 @@ pub async fn create_test_session_with_iat(
             session_purpose: crate::db::SessionPurpose::OAuthAccessToken,
             authorization_details: None,
         },
+        TokenIssuanceProof {
+            grant: GrantProof::TestingOnly,
+            client_auth: ClientAuthProof::None,
+        },
     )
     .await
     .expect("Failed to create test session");
@@ -553,7 +567,10 @@ pub async fn create_test_session_for_client(
     auth_id: &str,
     client_id: &str,
 ) -> String {
-    use crate::services::auth::{CreateOAuthTokenParams, create_oauth_access_token};
+    use crate::services::auth::{
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, TokenIssuanceProof,
+        create_oauth_access_token,
+    };
     use crate::services::oidc::ScopeSet;
     use secrecy::ExposeSecret;
 
@@ -574,6 +591,10 @@ pub async fn create_test_session_for_client(
             session_purpose: crate::db::SessionPurpose::OAuthAccessToken,
             authorization_details: None,
         },
+        TokenIssuanceProof {
+            grant: GrantProof::TestingOnly,
+            client_auth: ClientAuthProof::None,
+        },
     )
     .await
     .expect("Failed to create test session");
@@ -592,7 +613,10 @@ pub async fn create_test_session_with_dpop(
     auth_id: &str,
     dpop_jkt: &str,
 ) -> String {
-    use crate::services::auth::{CreateOAuthTokenParams, create_oauth_access_token};
+    use crate::services::auth::{
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, TokenIssuanceProof,
+        create_oauth_access_token,
+    };
     use crate::services::oidc::ScopeSet;
     use secrecy::ExposeSecret;
 
@@ -613,6 +637,10 @@ pub async fn create_test_session_with_dpop(
             session_purpose: crate::db::SessionPurpose::OAuthAccessToken,
             authorization_details: None,
         },
+        TokenIssuanceProof {
+            grant: GrantProof::TestingOnly,
+            client_auth: ClientAuthProof::None,
+        },
     )
     .await
     .expect("Failed to create DPoP-bound test session");
@@ -631,7 +659,10 @@ pub async fn create_test_session_with_mtls(
     auth_id: &str,
     mtls_cert_thumbprint: &str,
 ) -> String {
-    use crate::services::auth::{CreateOAuthTokenParams, create_oauth_access_token};
+    use crate::services::auth::{
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, TokenIssuanceProof,
+        create_oauth_access_token,
+    };
     use crate::services::oidc::ScopeSet;
     use secrecy::ExposeSecret;
 
@@ -651,6 +682,10 @@ pub async fn create_test_session_with_mtls(
             hardware_verification: crate::services::auth::HardwareVerification::Verified,
             session_purpose: crate::db::SessionPurpose::OAuthAccessToken,
             authorization_details: None,
+        },
+        TokenIssuanceProof {
+            grant: GrantProof::TestingOnly,
+            client_auth: ClientAuthProof::None,
         },
     )
     .await


### PR DESCRIPTION
Consolidates PR #407's follow-up plan into one branch. Every single-use
replay primitive in the OAuth/OIDC stack now returns a sealed,
`!Clone`, `#[must_use]` witness type, and `create_oauth_access_token` /
`create_pushed_authorization_request` require a typed proof parameter
that can only be constructed from those witnesses.

The original PR description (JTI-only) is preserved at the bottom for
context.

## Summary

All five `// SAFETY:` comments from PR #407 are gone. The "commit JTI
before token issuance" ordering is now a compile-time precondition of
the function that issues the token.

### Primitives converted (sealed `*Claim` witness)

| Primitive | Witness | DB op |
|--|--|--|
| JWT assertion JTI | `JwtAssertionJtiClaim` | atomic INSERT on deterministic PK |
| Authorization code | `AuthCodeClaim` | OCC `compare_and_update` |
| Device authorization code | `DeviceCodeClaim` | OCC `compare_and_update` |
| DPoP JTI | `ValidatedDpopProof` | atomic INSERT on deterministic PK |
| DPoP nonce | `DpopNonceClaim` | `delete_if_not_expired` (atomic DELETE + rowcount) |
| PAR request | `ParStateClaim` | OCC `compare_and_update` |
| Pending OAuth authorization | `PendingOauthClaim` | OCC `compare_and_update` inside tx |
| WebAuthn / registration / browser-login state | `ChallengeStateClaim` | atomic INSERT on deterministic PK |
| OIDC state | `OidcStateClaim` | OCC `compare_and_update` |

### Client-authentication verifications

| Method | Witness |
|--|--|
| `client_secret_basic` / `client_secret_post` | `ClientSecretVerification` |
| `tls_client_auth` / `self_signed_tls_client_auth` | `MtlsCertVerification` |

### Chokepoints

```rust
pub(crate) struct TokenIssuanceProof {
    pub(crate) grant: GrantProof,        // one of 9 variants, each carries a claim
    pub(crate) client_auth: ClientAuthProof, // PrivateKeyJwt | ClientSecret | MutualTls | None
}

pub(crate) struct ParCreationProof {
    pub(crate) client_auth: ClientAuthProof,
}
```

Both enums contain zero `Unconverted*` variants. Every variant either
carries a sealed witness or is explicitly a no-replay-primitive variant
(`ClientCredentials` / `TokenExchange` — protected via `ClientAuthProof`;
`CertificationBypass` — env-var-gated; `TestingOnly` — `cfg`-gated).

## Bugs fixed during execution (not in the original plan)

1. **DPoP nonce TOCTOU** (slice 5): `validate_and_consume_dpop_nonce`
   was `find_one` → check expiry → `delete` (three calls). Fixed by
   switching to deterministic IDs + atomic `delete_if_not_expired`
   (single SQL DELETE returning rowcount). Visible only on non-SQLite
   backends.
2. **Pending OAuth lost-update race** (slice 8):
   `consume_pending_oauth_authorization` used `tx.update` (no version
   check) inside a transaction. Under Postgres READ COMMITTED, two
   concurrent readers could both pass the check and both UPDATE, both
   returning a successful consume for the same record. Fixed by
   switching to `compare_and_update` (OCC version check). Visible only
   on Postgres/DSQL.
3. **OIDC state read-vs-consume TOCTOU** (slice 7b): `oidc_callback` /
   SAML ACS used `get_oidc_state` then `delete_oidc_state` as separate
   steps. Two concurrent callbacks with the same `state` query param
   could both pass validation and both issue tokens. Fixed by adding
   `consumed_at` to `OidcStateDoc` and using `try_consume_oidc_state`
   (OCC compare_and_update, same pattern as auth code).
4. **Browser login missing replay protection** (slice 7a):
   `browser_login_complete` never atomically consumed its
   `BrowserAuthenticationState` JWT. A captured state JWT + assertion
   could be replayed within the 5-minute validity window before the
   counter check caught it. Fixed by adding `try_consume_challenge_state`
   at Phase 3b of the handler.
5. **token_exchange wrong fallback signal** (bugbot finding):
   `fallback_client_auth(mtls_thumbprint.is_some(), false)` misclassified
   mTLS-only clients and made secret-authenticated clients look like
   public ones. Fixed via `ClientAuthProof::from_verifications`.
6. **JTI length validation classified as DB error** (bugbot finding):
   oversized JTI was wrapped as `ClaimError::Database` → 500
   (retry-prompting) instead of 401 invalid_client (fix-your-input).
   Fixed by adding `ClaimError::InvalidInput(String)` variant.

## What runtime behaviour does NOT change

The fast path of every grant is identical: same SQL atomicity guarantees,
same concurrent-replay outcome. The structural changes are compile-time
only — the type system now prevents double-commits, missing-commits, and
the "issue token without consuming the primitive" class of bug.

## Test coverage

- `cargo test -p vouch-server --lib` → **2139 passed, 0 failed**
  (12 new tests, no regressions vs the 2127 baseline).
- `cargo clippy --all-targets --all-features -- -D warnings` → clean.
- Full workspace `cargo check` → clean.

### New regression coverage

- 5 unit tests for the new `try_consume_oidc_state` primitive (happy
  path, replay, expired, not-found, concurrent).
- Concurrent-replay tests (`tokio::join` two consume calls, assert
  exactly one wins) for the 5 older primitives that lacked them:
  auth_code, device_auth, dpop_nonce, pending_oauth, PAR.
- `test_browser_login_complete_rejects_replayed_state` — verifies the
  new consume call in slice 7a is wired correctly (pre-consume → POST →
  expect 400 `state_already_used`).
- `test_oidc_callback_rejects_replayed_state` — verifies the slice 7b
  TOCTOU fix (pre-consume OIDC state → GET callback → expect "Invalid
  or expired state"; upstream IdP `/token` is never called).

### Honest residual risk

- The TOCTOU fixes in slices 5, 7b, and 8 have not been tested against
  the backends where the bugs originally manifested (Postgres / DSQL).
  The fixes use well-trodden patterns (atomic DELETE returning
  rowcount; `compare_and_update` OCC) that are known race-safe by
  construction, but empirical confirmation under those backends is
  out-of-scope for this PR.
- The chokepoint's structural guarantee is enforced by the compiler;
  no test currently asserts "this code MUST NOT compile" against a
  contrived bypass attempt. Compile-fail tests (`trybuild`) are listed
  as a follow-up.
- Behaviour change worth watching in conformance: in `oidc_callback`,
  consuming the OIDC state up-front means a failed upstream IdP token
  exchange now invalidates the state (can't be retried). This is
  consistent with the upstream auth code itself being single-use, but
  it is a behaviour change vs the previous "delete after success"
  pattern.
- **DPoP nonce storage format changed** (slice 5): old code persisted
  nonces under an auto-generated UUID plus a `nonce` index entry; new
  code uses a deterministic SHA-256 PK with no index. If the deploy
  strategy keeps two versions running against the same database
  simultaneously (rolling deploy with overlap, canary, blue/green),
  clients whose nonce is issued by one version and consumed by the
  other will get a `use_dpop_nonce` 401, refetch a nonce, and retry —
  RFC 9449 §8's standard recovery path. One-time cost, scoped to the
  deploy window; orphan rows expire via `delete_expired_dpop_nonces`
  (~5 min). Stop-the-world deploys avoid the issue entirely.

## Follow-up (out of scope here)

- Compile-fail tests via `trybuild` for the chokepoint structural
  guarantee.
- Concurrent-replay test runs against a Postgres CI lane.

---

<details>
<summary>Original PR description (slice 1 / JTI only)</summary>

First slice of the PR #407 follow-up plan to simplify the codebase's
single-use claim primitives.

Replaces the free function `commit_jti(state, &PendingJti)` with a
by-value method `PendingJti::commit(self, state) -> Result<Option<JwtAssertionJtiClaim>, ClientAuthError>`.
The new `JwtAssertionJtiClaim` is a sealed, `!Clone`, `#[must_use]`
witness type whose only constructor is the atomic INSERT in
`db::store_jwt_assertion_jti`.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication, authorization, and token-issuance ordering across many OAuth flows; includes deploy-time DPoP nonce storage format change and OIDC callback state consumed before upstream token exchange (failed IdP exchange cannot retry the same state).
> 
> **Overview**
> This PR turns OAuth/OIDC **single-use** database operations into sealed **`#[must_use]` witness types** (`AuthCodeClaim`, `DeviceCodeClaim`, `ChallengeStateClaim`, etc.) and routes failures through a shared **`ClaimError`** (`AlreadyConsumed`, `InvalidInput`, `Database`). **`create_oauth_access_token`** and **`create_pushed_authorization_request`** now require **`TokenIssuanceProof` / `ParCreationProof`** so tokens and PAR rows cannot be issued without the matching consume proof.
> 
> **Runtime hardening** beyond the typestate layer: **DPoP nonces** use deterministic IDs and **`delete_if_not_expired`** (no find-then-delete race); **OIDC enrollment state** gains **`consumed_at`** and **`try_consume_oidc_state`** instead of get-then-delete; **browser login** consumes challenge state before WebAuthn; **pending OAuth** and several device-auth transitions use **`compare_and_update`** OCC. Handlers thread witnesses into **`GrantProof` / `ClientAuthProof`**; PAR commits JWT JTIs before persist and accepts **RFC 7523 optional `jti`** via **`JwtAuthSucceeded`** (not JTI presence alone). Tests add concurrent-replay and handler regression coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38e3443f7784313ced9e4317dbd1c690a0cd286f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->