### PR TITLE
fix(server): SCIM active coercion, retention validation, S3 region fallback

### DIFF
--- a/crates/vouch-server/src/config.rs
+++ b/crates/vouch-server/src/config.rs
@@ -876,6 +876,23 @@ impl ServerConfig {
             }
         }
 
+        // Retention windows are subtracted from `now` to form a deletion cutoff;
+        // a negative value yields a future cutoff, which matches every row and
+        // wipes the entire audit log. Reject at startup so an operator typo or
+        // malicious config change can't silently destroy forensic data.
+        if self.auth_events_retention_days < 0 {
+            anyhow::bail!(
+                "VOUCH_AUTH_EVENTS_RETENTION_DAYS must be non-negative (got {})",
+                self.auth_events_retention_days
+            );
+        }
+        if self.oauth_events_retention_days < 0 {
+            anyhow::bail!(
+                "VOUCH_OAUTH_EVENTS_RETENTION_DAYS must be non-negative (got {})",
+                self.oauth_events_retention_days
+            );
+        }
+
         // Skip jwt_secret validation when KMS HMAC signing is configured.
         if self.jwt_hmac_kms_key_id.is_none() {
             let secret = self.jwt_secret.expose_secret();
@@ -1063,6 +1080,47 @@ mod tests {
     #[test]
     fn test_validate_good_secret_accepted() {
         let config = test_config();
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_rejects_negative_auth_events_retention() {
+        let mut config = test_config();
+        config.auth_events_retention_days = -1;
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("AUTH_EVENTS_RETENTION_DAYS"),
+            "Error should name the offending field: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_rejects_negative_oauth_events_retention() {
+        let mut config = test_config();
+        config.oauth_events_retention_days = -1;
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("OAUTH_EVENTS_RETENTION_DAYS"),
+            "Error should name the offending field: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_rejects_i64_min_retention() {
+        // i64::MIN is the worst case: days_to_span(i64::MIN) would panic in
+        // jiff because i64::MIN * 24 overflows; validation must catch it first.
+        let mut config = test_config();
+        config.auth_events_retention_days = i64::MIN;
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_accepts_zero_retention() {
+        // Zero days is a valid choice: deletes everything older than "now",
+        // i.e. effectively disables retention. Only negative values are rejected.
+        let mut config = test_config();
+        config.auth_events_retention_days = 0;
+        config.oauth_events_retention_days = 0;
         assert!(config.validate().is_ok());
     }
 

--- a/crates/vouch-server/src/handlers/scim/tests.rs
+++ b/crates/vouch-server/src/handlers/scim/tests.rs
@@ -350,6 +350,93 @@ async fn test_rfc7644_patch_user_deactivate() {
     assert_eq!(updated["active"], false);
 }
 
+#[tokio::test]
+async fn test_patch_user_active_string_rejected() {
+    // Regression: PATCH with `"active": "false"` (string, not bool) previously
+    // coerced to `true` via `as_bool().unwrap_or(true)`, silently reactivating
+    // deactivated users. Must return 400 invalidValue per RFC 7643 §2.2.
+    let (app, state) = test_app().await;
+
+    let token = create_test_scim_token(&state.store, "test-patch-string", "test-org").await;
+    let auth_header = format!("Bearer {}", token);
+
+    let (status, body) = http_post_json(
+        &app,
+        "/scim/v2/Users",
+        r#"{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"], "userName": "stringactive@example.com", "active": false}"#,
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let created: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let user_id = created["id"].as_str().expect("user id");
+
+    // PATCH with stringified "false" — must be rejected, not silently coerced to true.
+    let (status, body) = http_request(
+        &app,
+        "PATCH",
+        &format!("/scim/v2/Users/{}", user_id),
+        Some(r#"{"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"], "Operations": [{"op": "replace", "path": "active", "value": "false"}]}"#.to_string()),
+        &[
+            ("Authorization", &auth_header),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
+    let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(error["scimType"], "invalidValue");
+
+    // Verify the user is still inactive — the bug would have flipped it to active.
+    let (status, body) = http_get(
+        &app,
+        &format!("/scim/v2/Users/{}", user_id),
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let after: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(after["active"], false, "user must remain inactive");
+}
+
+#[tokio::test]
+async fn test_patch_user_active_add_op_string_rejected() {
+    // Same regression but exercising the `Add` op path, which had its own
+    // copy of the `unwrap_or(true)` coercion.
+    let (app, state) = test_app().await;
+
+    let token = create_test_scim_token(&state.store, "test-patch-add-string", "test-org").await;
+    let auth_header = format!("Bearer {}", token);
+
+    let (status, body) = http_post_json(
+        &app,
+        "/scim/v2/Users",
+        r#"{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"], "userName": "addactive@example.com", "active": false}"#,
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let created: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let user_id = created["id"].as_str().expect("user id");
+
+    let (status, body) = http_request(
+        &app,
+        "PATCH",
+        &format!("/scim/v2/Users/{}", user_id),
+        Some(r#"{"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"], "Operations": [{"op": "add", "path": "active", "value": "false"}]}"#.to_string()),
+        &[
+            ("Authorization", &auth_header),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
+    let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(error["scimType"], "invalidValue");
+}
+
 // ========================================================================
 // RFC 7644 Section 3.5.3 - PATCH Unsupported Paths
 // ========================================================================

--- a/crates/vouch-server/src/handlers/scim/users.rs
+++ b/crates/vouch-server/src/handlers/scim/users.rs
@@ -314,7 +314,19 @@ pub async fn patch_user(
                     match path.as_str() {
                         "active" => {
                             if let Some(val) = &op.value {
-                                let new_active = val.as_bool().unwrap_or(true);
+                                // RFC 7643 §2.2 — `active` is a boolean. Coercing
+                                // non-boolean values (e.g. the string "false") to
+                                // `true` would silently reactivate disabled users.
+                                let Some(new_active) = val.as_bool() else {
+                                    return (
+                                        StatusCode::BAD_REQUEST,
+                                        Json(
+                                            ScimError::new(400, "active must be a boolean")
+                                                .with_type("invalidValue"),
+                                        ),
+                                    )
+                                        .into_response();
+                                };
                                 if active && !new_active {
                                     deactivated = true;
                                 }
@@ -368,7 +380,16 @@ pub async fn patch_user(
                     && path == "active"
                     && let Some(val) = &op.value
                 {
-                    let new_active = val.as_bool().unwrap_or(true);
+                    let Some(new_active) = val.as_bool() else {
+                        return (
+                            StatusCode::BAD_REQUEST,
+                            Json(
+                                ScimError::new(400, "active must be a boolean")
+                                    .with_type("invalidValue"),
+                            ),
+                        )
+                            .into_response();
+                    };
                     if active && !new_active {
                         deactivated = true;
                     }

--- a/crates/vouch-server/src/infra/startup.rs
+++ b/crates/vouch-server/src/infra/startup.rs
@@ -252,15 +252,14 @@ async fn load_s3_config(
         config.s3_config_key
     );
 
-    let sdk_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
-        .region(
-            config
-                .s3_config_region
-                .as_ref()
-                .map(|r| aws_config::Region::new(r.clone())),
-        )
-        .load()
-        .await;
+    // Only override the region when VOUCH_S3_CONFIG_REGION is set; passing
+    // Option::<Region>::None to `.region(...)` disables the default region
+    // provider chain (env / shared config / IMDS) and breaks S3 requests.
+    let mut builder = aws_config::defaults(aws_config::BehaviorVersion::latest());
+    if let Some(region) = &config.s3_config_region {
+        builder = builder.region(aws_config::Region::new(region.clone()));
+    }
+    let sdk_config = builder.load().await;
 
     let s3_client = aws_sdk_s3::Client::new(&sdk_config);
 


### PR DESCRIPTION
Three independent bugs grouped because each fix is small:

- Fixes #395 SCIM PATCH `active` no longer coerces non-boolean values to `true`. Both Replace and Add op paths now return 400 with scimType=invalidValue per RFC 7643 §2.2 instead of silently reactivating deactivated users.
- Fixes #399 Reject negative `auth_events_retention_days` and `oauth_events_retention_days` at startup. A negative value produced a future cutoff and wiped the entire audit log; `i64::MIN` could also panic in jiff's span arithmetic.
- Fixes #400 Use the conditional builder pattern for S3 SDK config so an unset `VOUCH_S3_CONFIG_REGION` falls through to the AWS default region chain (env / shared config / IMDS) instead of being clobbered by `Some(None)`.

Adds 4 config unit tests and 2 SCIM regression tests covering the bug trigger and the post-fix state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SCIM provisioning (user activation) and audit retention policy at startup; changes are corrective but affect security-relevant paths.
> 
> **Overview**
> This PR bundles three small, independent server fixes with regression tests.
> 
> **SCIM user PATCH** no longer treats non-boolean `active` values as `true`. Replace and Add paths now require a real boolean and return **400** with `scimType=invalidValue` (e.g. string `"false"` no longer silently reactivates deactivated users).
> 
> **Startup config validation** rejects negative `VOUCH_AUTH_EVENTS_RETENTION_DAYS` and `VOUCH_OAUTH_EVENTS_RETENTION_DAYS`, which could compute a future cutoff and delete the whole audit log; `0` remains allowed.
> 
> **S3 config loading** only sets the AWS SDK region when `VOUCH_S3_CONFIG_REGION` is set, so unset region uses the normal default chain instead of breaking S3 when `None` was passed to `.region(...)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2544728dca28855cd53877de40612b7cc3b8308c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->