### PR TITLE
Fix/quad 390 397 392 389

### DIFF
--- a/crates/vouch-server/src/db/enrollment.rs
+++ b/crates/vouch-server/src/db/enrollment.rs
@@ -7,7 +7,26 @@
 use super::documents::organization::OrganizationDoc;
 use super::documents::user::UserDoc;
 use super::store::DocumentStore;
-use anyhow::Result;
+use anyhow::{Context, Result};
+
+/// Derive a deterministic document ID from a domain so that two
+/// concurrent enrollments for the same domain collide on the primary
+/// key of the `documents` table instead of producing two organizations.
+///
+/// The unique constraint on `(document_id, index_field, index_value)`
+/// does NOT enforce uniqueness across documents on `(index_field,
+/// index_value)`, so a check-then-insert flow that generated random IDs
+/// could not be made race-free at the SQL level. Hashing the domain
+/// into a stable ID closes the TOCTOU window without requiring
+/// SERIALIZABLE isolation or an advisory lock.
+fn deterministic_org_id(domain: &str) -> String {
+    use aws_lc_rs::digest::{self, SHA256};
+
+    let mut ctx = digest::Context::new(&SHA256);
+    ctx.update(b"organization_domain\0");
+    ctx.update(domain.as_bytes());
+    hex::encode(ctx.finish().as_ref())
+}
 
 /// Result of enrolling a user with their organization.
 #[derive(Debug)]
@@ -30,7 +49,7 @@ pub struct EnrolledUser {
     pub is_org_admin: bool,
 }
 
-/// Enroll a user with their organization atomically.
+/// Enroll a user with their organization.
 ///
 /// This function:
 /// 1. Gets or creates the organization for the user's domain
@@ -38,18 +57,40 @@ pub struct EnrolledUser {
 /// 3. Creates or gets the user with the org association
 /// 4. Updates the org's `created_by_user_id` if first user
 ///
-/// All steps execute within a single database transaction.
+/// Steps 2-4 run inside a single transaction. Step 1 runs outside the
+/// transaction so that a primary-key collision from a concurrent
+/// enrollment for the same domain can be recovered from without
+/// aborting the user-creation transaction (see the inline comment for
+/// the atomicity tradeoff).
 pub async fn enroll_user_with_org(
     store: &DocumentStore,
     email: &str,
     name: Option<&str>,
     domain: Option<&str>,
 ) -> Result<EnrollmentResult> {
-    let mut tx = store.begin().await?;
-
-    // Step 1: Get or create organization (if domain provided)
+    // Step 1: Get or create organization (if domain provided).
+    //
+    // Runs OUTSIDE the user-creation transaction so that the unique-violation
+    // recovery path doesn't abort the transaction. The deterministic ID
+    // guarantees that two concurrent enrollees for the same domain race on
+    // the documents primary key, and exactly one INSERT wins.
+    //
+    // Lookup order:
+    //   1. By deterministic ID — the fast path for new orgs.
+    //   2. By domain index — required for orgs created before this code
+    //      existed (random UUIDs); without this fallback the new code
+    //      would create a duplicate alongside the legacy row.
+    //
+    // If user creation later fails, the organization row may persist with
+    // `created_by_user_id = None`. That is a benign intermediate state: the
+    // next enrollee for the same domain will reuse the row and Step 4 below
+    // will set them as admin via `compare_and_update`.
     let (org_id, org_needs_admin) = if let Some(domain) = domain {
-        let existing = tx.find_one::<OrganizationDoc>("domain", domain).await?;
+        let id = deterministic_org_id(domain);
+        let existing = match store.get::<OrganizationDoc>(&id).await? {
+            Some(org) => Some(org),
+            None => store.find_one::<OrganizationDoc>("domain", domain).await?,
+        };
 
         match existing {
             Some(org) => {
@@ -63,13 +104,29 @@ pub async fn enroll_user_with_org(
                     created_by_user_id: None,
                     additional_domains: Vec::new(),
                 };
-                let result = tx.insert(&doc).await?;
-                (Some(result.id), true)
+                match store.insert_with_id(&id, &doc).await {
+                    Ok(result) => (Some(result.id), true),
+                    Err(e) if super::pool::is_unique_violation(&e) => {
+                        // Concurrent enrollee inserted first — re-fetch.
+                        let org = match store.get::<OrganizationDoc>(&id).await? {
+                            Some(o) => o,
+                            None => store
+                                .find_one::<OrganizationDoc>("domain", domain)
+                                .await?
+                                .context("organization vanished after unique violation")?,
+                        };
+                        let needs_admin = org.data.created_by_user_id.is_none();
+                        (Some(org.id), needs_admin)
+                    }
+                    Err(e) => return Err(e),
+                }
             }
         }
     } else {
         (None, false)
     };
+
+    let mut tx = store.begin().await?;
 
     // Step 2: Determine admin status
     let is_org_admin = if org_needs_admin {
@@ -145,4 +202,43 @@ pub async fn enroll_user_with_org(
         org_id,
         is_org_admin,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::deterministic_org_id;
+
+    #[test]
+    fn deterministic_org_id_collides_on_equal_domains() {
+        // Two callers passing the same domain string must produce the
+        // same document ID — this is what makes `store.insert_with_id`
+        // surface a unique-violation race instead of silently creating
+        // a second organization row.
+        assert_eq!(
+            deterministic_org_id("acme.example"),
+            deterministic_org_id("acme.example"),
+        );
+    }
+
+    #[test]
+    fn deterministic_org_id_differs_for_distinct_domains() {
+        assert_ne!(
+            deterministic_org_id("acme.example"),
+            deterministic_org_id("beta.example"),
+        );
+    }
+
+    #[test]
+    fn deterministic_org_id_is_case_sensitive() {
+        // Documents an existing assumption: callers (the OIDC IdP layer
+        // in particular) are responsible for normalising the domain to
+        // ASCII lowercase before calling `enroll_user_with_org`. If a
+        // future caller forgets to normalise, two cases of the same
+        // domain will produce two organizations — this assertion is a
+        // tripwire that pins the current contract.
+        assert_ne!(
+            deterministic_org_id("ACME.example"),
+            deterministic_org_id("acme.example"),
+        );
+    }
 }

--- a/crates/vouch-server/src/db/migrations.rs
+++ b/crates/vouch-server/src/db/migrations.rs
@@ -57,16 +57,35 @@ pub async fn run_dsql_migrations(pool: &PgPool) -> Result<MigrationResult> {
         let start = std::time::Instant::now();
 
         // Execute the migration SQL directly (no transaction wrapper)
-        // DSQL will auto-commit each statement
-        sqlx::raw_sql(&migration.sql)
-            .execute(pool)
-            .await
-            .with_context(|| {
-                format!(
+        // DSQL will auto-commit each statement.
+        //
+        // Crash recovery: if a previous attempt's DDL succeeded but the
+        // subsequent `record_migration` write was lost (server crashed,
+        // DSQL transient failure, …), the schema object already exists
+        // and a re-run would normally fail with "relation already
+        // exists" — leaving the server permanently unable to start.
+        //
+        // Treat a duplicate-object error here as evidence that the DDL
+        // landed on the prior attempt, then re-record the migration so
+        // future startups skip it cleanly. New deployments will hit the
+        // happy path; only recovery paths exercise this branch.
+        match sqlx::raw_sql(&migration.sql).execute(pool).await {
+            Ok(_) => {}
+            Err(e) if is_duplicate_object_error(&e) => {
+                tracing::warn!(
+                    version,
+                    description = %migration.description,
+                    "migration DDL already applied on a prior attempt — \
+                     recovering by recording completion now",
+                );
+            }
+            Err(e) => {
+                return Err(anyhow::Error::from(e).context(format!(
                     "failed to execute migration {}: {}",
                     version, migration.description
-                )
-            })?;
+                )));
+            }
+        }
 
         let elapsed = start.elapsed();
 
@@ -86,6 +105,28 @@ pub async fn run_dsql_migrations(pool: &PgPool) -> Result<MigrationResult> {
     }
 
     Ok((newly_applied, total))
+}
+
+/// Returns true if `err` is a PostgreSQL duplicate-object error.
+/// See [`is_duplicate_object_sqlstate`] for the matched codes.
+fn is_duplicate_object_error(err: &sqlx::Error) -> bool {
+    err.as_database_error()
+        .and_then(|e| e.code())
+        .is_some_and(|c| is_duplicate_object_sqlstate(c.as_ref()))
+}
+
+/// True if `code` is one of the PostgreSQL `SQLSTATE` values that
+/// indicate "this object already exists" — the family signalling a
+/// re-run of a DDL the database already executed.
+///
+/// - `42P07` — `duplicate_table`
+/// - `42710` — `duplicate_object` (catches indexes, triggers, …)
+/// - `42P06` — `duplicate_schema`
+/// - `42701` — `duplicate_column`
+/// - `42P16` — `invalid_table_definition` (raised by some PG flavours
+///   when re-adding an identical constraint)
+fn is_duplicate_object_sqlstate(code: &str) -> bool {
+    matches!(code, "42P07" | "42710" | "42P06" | "42701" | "42P16")
 }
 
 /// Create the _sqlx_migrations table if it doesn't exist.
@@ -138,4 +179,35 @@ async fn record_migration(
     .context("failed to insert migration record")?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_duplicate_object_sqlstate;
+
+    #[test]
+    fn classifies_duplicate_table() {
+        assert!(is_duplicate_object_sqlstate("42P07"));
+    }
+
+    #[test]
+    fn classifies_duplicate_object() {
+        // 42710 is raised for duplicate indexes (the case #397 cares
+        // about most: a partial-recovery re-run of CREATE INDEX ASYNC).
+        assert!(is_duplicate_object_sqlstate("42710"));
+    }
+
+    #[test]
+    fn does_not_classify_unrelated_errors() {
+        // 23505 = unique_violation (a DML conflict, not a DDL re-run)
+        assert!(!is_duplicate_object_sqlstate("23505"));
+        // 42703 = undefined_column — symptom of a wrong migration,
+        // must propagate as failure, not be silently swallowed.
+        assert!(!is_duplicate_object_sqlstate("42703"));
+        // Connection failures must propagate.
+        assert!(!is_duplicate_object_sqlstate("08006"));
+        // Empty / nonsense codes must not match.
+        assert!(!is_duplicate_object_sqlstate(""));
+        assert!(!is_duplicate_object_sqlstate("nope"));
+    }
 }

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -3693,3 +3693,92 @@ async fn test_record_recheck_result_concurrent() {
         "both record_recheck_result calls must succeed (CAS loser returns Ok(StillVerified))"
     );
 }
+
+// Regression for #389: two enrollments for the same domain must converge
+// on a single organization. Pre-fix, `enroll_user_with_org` used
+// `find_one(domain) + insert` with random UUIDs, so the second enrollee
+// either found the first's row (sequential) or — under contention —
+// both inserts succeeded with different IDs (the bug; the issue reports
+// 14/15 distinct orgs in a Postgres reproduction).
+//
+// The fix derives a deterministic org ID from the domain. This test
+// exercises the "second enrollee converges on first's org" property
+// sequentially because multi-step transactions on SQLite WAL deadlock
+// under real `tokio::join!` contention; the under-contention property
+// is guaranteed by `store.insert_with_id`'s atomic primary-key behavior
+// (covered by `test_dpop_jti_concurrent_insert_rejects_duplicates`)
+// combined with our deterministic ID.
+#[tokio::test]
+async fn test_enroll_user_with_org_same_domain_converges_on_one_org() {
+    use crate::db::documents::organization::OrganizationDoc;
+    use crate::db::enroll_user_with_org;
+
+    let (store, _audit) = test_db().await;
+    let domain = "shared-domain.example";
+
+    let alice = enroll_user_with_org(&store, "alice@shared-domain.example", None, Some(domain))
+        .await
+        .expect("alice enrollment");
+    let bob = enroll_user_with_org(&store, "bob@shared-domain.example", None, Some(domain))
+        .await
+        .expect("bob enrollment");
+
+    assert_eq!(
+        alice.org_id, bob.org_id,
+        "both enrollees must share the same org_id"
+    );
+    assert!(alice.org_id.is_some());
+
+    let org_count = store
+        .count::<OrganizationDoc>("domain", domain)
+        .await
+        .expect("count orgs by domain");
+    assert_eq!(
+        org_count, 1,
+        "exactly one organization must exist for the domain; got {org_count}"
+    );
+
+    assert!(alice.is_org_admin, "first enrollee should be admin");
+    assert!(!bob.is_org_admin, "second enrollee must not be admin");
+}
+
+// Verifies the second enrollee adopts an un-admined org and gets
+// promoted to admin. Pre-fix code with random UUIDs would skip the
+// org INSERT (because `find_one(domain)` finds the seeded row) but
+// fail to detect that a previously-orphaned org should adopt a new
+// admin — this exercises the Step 4 `compare_and_update` repair path.
+#[tokio::test]
+async fn test_enroll_promotes_admin_for_org_without_one() {
+    use crate::db::documents::organization::OrganizationDoc;
+    use crate::db::enroll_user_with_org;
+
+    let (store, _audit) = test_db().await;
+    let domain = "orphaned-org.example";
+
+    // Seed an org row with no admin (e.g. previous enrollee crashed
+    // mid-flow before Step 4 ran).
+    let seed_doc = OrganizationDoc {
+        domain: domain.to_string(),
+        name: None,
+        created_by_user_id: None,
+        additional_domains: Vec::new(),
+    };
+    store.insert(&seed_doc).await.expect("seed org row");
+
+    let user = enroll_user_with_org(&store, "rescuer@orphaned-org.example", None, Some(domain))
+        .await
+        .expect("enrollment");
+
+    assert!(
+        user.is_org_admin,
+        "an org with no admin must promote the next enrollee"
+    );
+    let org_count = store
+        .count::<OrganizationDoc>("domain", domain)
+        .await
+        .expect("count orgs by domain");
+    assert_eq!(
+        org_count, 1,
+        "no duplicate org may be created when one already exists"
+    );
+}

--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -639,6 +639,9 @@ pub async fn browser_login_complete(
         signature,
         public_key: authenticator.public_key.clone(),
         rp_id: auth_state.rp_id.clone(),
+        // Browser sets clientDataJSON.origin to the calling page's origin
+        // (the server's base_url), which may be a subdomain of rp_id.
+        expected_origin: state.config().base_url.clone(),
         challenge: auth_state.challenge.clone(),
         stored_counter,
     })

--- a/crates/vouch-server/src/handlers/oidc/tests/oidc_userinfo.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/oidc_userinfo.rs
@@ -75,6 +75,70 @@ async fn test_userinfo_returns_sub_claim() {
 }
 
 #[tokio::test]
+async fn test_userinfo_no_email_when_scope_is_none() {
+    // Regression for #390: an access token with `scope: None` (produced by
+    // token exchange when the requested scope set has an empty intersection
+    // with the available scopes) was previously interpreted by userinfo as
+    // "full access" via a backward-compat fallback, returning the user's
+    // email without the email scope. Must now return only `sub`.
+    use crate::services::auth::{
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, HardwareVerification,
+        NoClientAuth, TokenIssuanceProof, create_oauth_access_token,
+    };
+    use secrecy::ExposeSecret;
+
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "no-scope@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+
+    let result = create_oauth_access_token(
+        &state,
+        CreateOAuthTokenParams {
+            user_id: &user.id,
+            email: &user.email,
+            authenticator_id: Some(&auth_id),
+            client_id: &state.config().base_url,
+            scope: None,
+            dpop_jkt: None,
+            mtls_cert_thumbprint: None,
+            act: None,
+            audience: None,
+            auth_time: Some(jiff::Timestamp::now().as_second()),
+            hardware_verification: HardwareVerification::Verified,
+            session_purpose: db::SessionPurpose::OAuthAccessToken,
+            authorization_details: None,
+        },
+        TokenIssuanceProof {
+            grant: GrantProof::TestingOnly,
+            client_auth: ClientAuthProof::NoAuth(NoClientAuth::internal_endpoint()),
+        },
+    )
+    .await
+    .expect("issue token");
+    let token = result.token.expose_secret().to_string();
+
+    let (status, body) = http_get(
+        &app,
+        "/oauth/userinfo",
+        &[("Authorization", &format!("Bearer {token}"))],
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let userinfo: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert!(userinfo.get("sub").is_some(), "sub must be present");
+    assert!(
+        userinfo.get("email").is_none(),
+        "email must NOT be present when token has no granted scope; got: {body}"
+    );
+    assert!(
+        userinfo.get("email_verified").is_none(),
+        "email_verified must NOT be present when token has no granted scope"
+    );
+}
+
+#[tokio::test]
 async fn test_userinfo_invalid_token() {
     // Invalid token should return 401
     let (app, _state) = test_app().await;

--- a/crates/vouch-server/src/handlers/oidc/tests/oidc_userinfo.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/oidc_userinfo.rs
@@ -82,8 +82,8 @@ async fn test_userinfo_no_email_when_scope_is_none() {
     // "full access" via a backward-compat fallback, returning the user's
     // email without the email scope. Must now return only `sub`.
     use crate::services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, HardwareVerification,
-        NoClientAuth, TokenIssuanceProof, create_oauth_access_token,
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, HardwareVerification, NoClientAuth,
+        TokenIssuanceProof, create_oauth_access_token,
     };
     use secrecy::ExposeSecret;
 

--- a/crates/vouch-server/src/handlers/oidc/userinfo.rs
+++ b/crates/vouch-server/src/handlers/oidc/userinfo.rs
@@ -7,7 +7,7 @@
 //! - RFC 8705 Section 3 - mTLS certificate-bound access tokens at resource endpoints
 
 use crate::AppState;
-use crate::db::{self, JwsAlgorithm, SessionPurpose};
+use crate::db::{self, JwsAlgorithm};
 use crate::handlers::extractors::OptionalClientCert;
 use crate::services::OAuthErrorCode;
 use crate::services::auth::decode_token;
@@ -272,11 +272,12 @@ pub async fn userinfo(
     };
 
     // Determine whether email claims should be returned based on granted scope.
-    // Backward compat: legacy OAuth tokens without a scope field are treated as
-    // having full scope if they are OAuthAccessToken purpose.
+    // `scope: None` means no scope was granted — token exchange produces this
+    // when the requested scope set has an empty intersection with available
+    // scopes. Returning email in that case would be a scope escalation.
     let has_email_scope = match &result.scope {
         Some(scope_set) => scope_set.contains(OAuthScope::Email),
-        None => result.session.session_type == SessionPurpose::OAuthAccessToken,
+        None => false,
     };
 
     let response_body = UserInfoResponse {

--- a/crates/vouch-server/src/services/auth.rs
+++ b/crates/vouch-server/src/services/auth.rs
@@ -208,6 +208,12 @@ pub(crate) struct LoginAssertionParams {
     pub public_key: Vec<u8>,
     /// Relying party ID.
     pub rp_id: String,
+    /// Expected `clientDataJSON.origin`. Browsers set this to the calling
+    /// page's origin (the server's `base_url`); CLI flows construct it as
+    /// `https://{rp_id}`. Deriving it from `rp_id` here would reject valid
+    /// browser logins when `base_url`'s host is a subdomain of `rp_id`
+    /// (a configuration `webauthn-rs` accepts at startup).
+    pub expected_origin: String,
     /// Expected challenge (raw bytes).
     pub challenge: Vec<u8>,
     /// Current counter value from the database.
@@ -238,7 +244,6 @@ pub(crate) async fn verify_login_assertion(
     params: LoginAssertionParams,
 ) -> ServiceResult<LoginAssertionResult> {
     tokio::task::spawn_blocking(move || {
-        let expected_origin = format!("https://{}", params.rp_id);
         let expected_challenge = URL_SAFE_NO_PAD.encode(&params.challenge);
 
         let result = webauthn_verify::verify_assertion(
@@ -248,7 +253,7 @@ pub(crate) async fn verify_login_assertion(
             &params.public_key,
             &params.rp_id,
             &expected_challenge,
-            &expected_origin,
+            &params.expected_origin,
             params.stored_counter,
             true, // require_user_verification
         )
@@ -1068,5 +1073,62 @@ mod tests {
         // Required fields should be present
         assert_eq!(parsed["iss"], "https://example.com");
         assert_eq!(parsed["sub"], "user-123");
+    }
+
+    // Regression for #392: `verify_login_assertion` must honor the
+    // caller-supplied `expected_origin` rather than deriving it from
+    // `rp_id`. This matters when `base_url` is a subdomain of `rp_id`
+    // (e.g. `https://idp.example.com` for `rp_id=example.com`), a
+    // configuration `webauthn-rs` accepts and browsers report as the
+    // page origin in `clientDataJSON.origin`.
+    #[tokio::test]
+    async fn test_verify_login_assertion_honors_expected_origin_subdomain() {
+        use aws_lc_rs::digest::{SHA256, digest};
+
+        let rp_id = "example.com";
+        let expected_origin = "https://idp.example.com";
+        let challenge: Vec<u8> = b"regression-test-challenge".to_vec();
+
+        // Minimal valid authData: rpIdHash || flags(UP|UV) || counter
+        let rp_id_hash = digest(&SHA256, rp_id.as_bytes());
+        let mut auth_data = Vec::with_capacity(37);
+        auth_data.extend_from_slice(rp_id_hash.as_ref());
+        auth_data.push(0x05); // UP + UV
+        auth_data.extend_from_slice(&[0, 0, 0, 1]); // counter = 1
+
+        let challenge_b64 = URL_SAFE_NO_PAD.encode(&challenge);
+        let client_data_json = serde_json::json!({
+            "type": "webauthn.get",
+            "challenge": challenge_b64,
+            "origin": expected_origin,
+        })
+        .to_string()
+        .into_bytes();
+
+        let params = LoginAssertionParams {
+            authenticator_data: auth_data,
+            client_data_json,
+            signature: vec![0u8; 64],
+            // Bogus 32-byte COSE key — signature verification will fail,
+            // but only AFTER the origin check, which is what we're testing.
+            public_key: vec![0u8; 32],
+            rp_id: rp_id.to_string(),
+            expected_origin: expected_origin.to_string(),
+            challenge,
+            stored_counter: 0,
+        };
+
+        let err = verify_login_assertion(params)
+            .await
+            .err()
+            .expect("expected error — signature is bogus");
+        let description = match &err {
+            ServiceError::OAuth { description, .. } => description.clone(),
+            other => format!("unexpected error variant: {other}"),
+        };
+        assert!(
+            !description.contains("Invalid origin"),
+            "origin must not be rejected for valid subdomain config; got: {description}"
+        );
     }
 }

--- a/crates/vouch-server/src/services/oidc/fido2_grant.rs
+++ b/crates/vouch-server/src/services/oidc/fido2_grant.rs
@@ -239,6 +239,9 @@ pub(crate) async fn exchange_fido2_assertion(
         signature: signature_bytes,
         public_key: authenticator.public_key.clone(),
         rp_id: challenge_state.rp_id.clone(),
+        // CLI flow: clientDataJSON.origin is `https://{rp_id}` since the
+        // CLI is not a browser and does not have a page origin.
+        expected_origin: format!("https://{}", challenge_state.rp_id),
         challenge: challenge_state.challenge.as_bytes().to_vec(),
         stored_counter,
     })


### PR DESCRIPTION
Fixes #390 
Fixes #397 
Fixes #392 
Fixes #389 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes affect authentication (WebAuthn origin, UserInfo claims), org provisioning under concurrency, and migration startup behavior—areas where bugs impact security or availability.
> 
> **Overview**
> This PR bundles four production fixes across enrollment, migrations, OIDC UserInfo, and WebAuthn login.
> 
> **OIDC enrollment (#389)** — Organization creation no longer uses random document IDs with a check-then-insert pattern. Domains map to a **deterministic SHA-256 org ID** so concurrent enrollments collide on the primary key; org upsert runs **outside** the user transaction with unique-violation recovery and a **legacy domain-index fallback** for pre-existing orgs. Tests cover single-org convergence and promoting an admin when `created_by_user_id` was never set.
> 
> **DSQL migrations (#397)** — If migration DDL succeeded but recording the migration failed, re-runs that hit PostgreSQL “object already exists” errors are treated as recovery: log, then **record the migration** instead of leaving the server unable to start.
> 
> **UserInfo (#390)** — Tokens with **`scope: None`** (e.g. empty scope intersection after token exchange) no longer get a backward-compat path that returned **email** without the email scope; only **`sub`** (and related scoped claims) are returned.
> 
> **WebAuthn (#392)** — Login assertion verification uses a caller-supplied **`expected_origin`**: browser login passes **`base_url`** (page origin, which may be a subdomain of `rp_id`); the FIDO2 CLI grant keeps **`https://{rp_id}`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdb54c92a02002f8ffc6348685f1f358dfe777e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->