### PR TITLE
refactor(agent,cli): drop unused crate-root re-exports

### DIFF
--- a/crates/vouch-agent/src/lib.rs
+++ b/crates/vouch-agent/src/lib.rs
@@ -53,8 +53,8 @@ pub mod wire;
 pub use client::AgentClient;
 pub use error::{AgentError, Result};
 #[cfg(unix)]
-pub use ssh_agent::{SshAgentServer, SshAgentState, SshCredentials, ssh_agent_socket_path};
-pub use state::{CachedCredential, SessionInfo};
+pub use ssh_agent::ssh_agent_socket_path;
+pub use state::SessionInfo;
 pub use transport::AgentTransport;
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/vouch-cli/src/lib.rs
+++ b/crates/vouch-cli/src/lib.rs
@@ -12,8 +12,8 @@ pub mod http;
 pub mod posture;
 
 // Re-export commonly used types
-pub use fido2::{AuthenticationResult, FidoDevice, RegistrationResult, YubiKey};
-pub use http::{HttpClient, HttpClientExt, HttpResponse, ReqwestClient};
+pub use fido2::{AuthenticationResult, FidoDevice, RegistrationResult};
+pub use http::{HttpClient, HttpResponse};
 
 #[cfg(feature = "test-utils")]
 pub use fido2::MockFidoDevice;


### PR DESCRIPTION
## Summary

Audited the four non-server crates for the same kind of visibility clutter cleaned up in #418.

**Result was much smaller than expected:** vouch-httpsig and vouch-common (real libraries) and the internal modules of vouch-agent / vouch-cli were already well-scoped. Zero `unreachable_pub` warnings across all four. The only finding was seven `pub use` re-exports at the crate roots with no remaining consumers.

- `vouch-agent/src/lib.rs`: drop `SshAgentServer`, `SshAgentState`, `SshCredentials` (`main.rs` imports via the `ssh_agent::` module path, not the root re-export) and `CachedCredential` (no consumer anywhere).
- `vouch-cli/src/lib.rs`: drop `YubiKey`, `HttpClientExt`, `ReqwestClient` (no consumer).

No behavior change.

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --workspace` — all tests pass
- [x] `make fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Public API narrowing only; removed symbols had no in-repo consumers and behavior is unchanged.
> 
> **Overview**
> **Trims unused crate-root re-exports** in `vouch-agent` and `vouch-cli` so public API surface matches what callers actually use.
> 
> In **`vouch-agent`**, removes root re-exports of `SshAgentServer`, `SshAgentState`, `SshCredentials`, and `CachedCredential`; keeps `ssh_agent_socket_path` and `SessionInfo` at the root. Call sites that need SSH agent types should use the `ssh_agent::` module path (as `main.rs` already does).
> 
> In **`vouch-cli`**, drops `YubiKey`, `HttpClientExt`, and `ReqwestClient` from the root; FIDO and HTTP types that remain re-exported are unchanged.
> 
> No runtime or protocol behavior change—visibility cleanup only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f610edc74c8929d3bac602eec484358ea388bf8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->