### PR TITLE
try and fix winget again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1160,11 +1160,14 @@ jobs:
       - name: Normalize manifest line endings to CRLF
         # Workaround for komac v2.16.0 bug: --release-notes-url value is
         # written with LF instead of CRLF, which fails winget-pkgs validation.
+        # Slurp each file (-0) so we can normalize any line ending (CRLF, CR,
+        # or LF) and append a trailing CRLF if missing — the prior yq step
+        # can drop the trailing newline, which line-mode perl wouldn't add back.
         run: |
           find ./winget-manifests -name '*.yaml' -print0 \
-            | xargs -0 perl -i -pe 's/\r?\n/\r\n/g'
-          if grep -RPLz '\r\n$' ./winget-manifests; then
-            echo "::error::manifests still contain non-CRLF line endings"
+            | xargs -0 perl -i -0pe 's/\r\n|\r|\n/\r\n/g; s/([^\n])\z/$1\r\n/'
+          if grep -RPlz '(?<!\r)\n' ./winget-manifests; then
+            echo "::error::manifests contain bare LF line endings"
             exit 1
           fi
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Release workflow only; no application or auth changes, and the winget job already uses continue-on-error.
> 
> **Overview**
> Hardens the **winget** release step that normalizes manifest YAML to **CRLF** so `winget-pkgs` validation passes after komac/`yq` edits.
> 
> The workflow now runs **whole-file** `perl` (`-0`) to map CRLF, CR, or LF to CRLF and to **append a trailing CRLF** when the prior `yq` step strips the final newline. The post-check switches from “anything not ending in CRLF” to **`grep -P`** for **bare LF** (`(?<!\r)\n`), with a clearer error message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2335b6d20d599f28adc0d0f0f181eb9e3e90b78e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->