### PR TITLE
refactor(server): remove half-implemented delegation policy machinery

### DIFF
--- a/crates/vouch-server/src/db/credentials.rs
+++ b/crates/vouch-server/src/db/credentials.rs
@@ -4,7 +4,7 @@
 
 use super::document_type::{Document, DocumentType};
 use super::documents::credential::{EnrollmentSessionDoc, SshIssuedCertDoc, SshRevokedCertDoc};
-use super::documents::oauth::{DelegationPolicyDoc, TokenExchangeDoc};
+use super::documents::oauth::TokenExchangeDoc;
 use super::store::DocumentStore;
 use anyhow::Result;
 use jiff::Timestamp;
@@ -86,112 +86,6 @@ pub async fn get_token_exchanges_for_user(
         .find_all::<TokenExchangeDoc>("subject_user_id", user_id)
         .await?;
     Ok(docs.into_iter().map(TokenExchangeRecord::from).collect())
-}
-
-// ============================================================
-// Delegation Policies
-// ============================================================
-
-/// Delegation policy record.
-#[derive(Debug)]
-pub struct DelegationPolicy {
-    pub id: String,
-    pub name: String,
-    pub grantor_pattern: String,
-    pub grantee_pattern: String,
-    pub allowed_scopes: Option<String>,
-    pub max_ttl_seconds: Option<i32>,
-    pub enabled: bool,
-    pub created_at: Timestamp,
-    pub updated_at: Timestamp,
-}
-
-impl From<Document<DelegationPolicyDoc>> for DelegationPolicy {
-    fn from(doc: Document<DelegationPolicyDoc>) -> Self {
-        Self {
-            id: doc.id,
-            name: doc.data.name,
-            grantor_pattern: doc.data.grantor_pattern,
-            grantee_pattern: doc.data.grantee_pattern,
-            allowed_scopes: doc.data.allowed_scopes,
-            max_ttl_seconds: doc.data.max_ttl_seconds,
-            enabled: doc.data.enabled,
-            created_at: doc.created_at,
-            updated_at: doc.updated_at,
-        }
-    }
-}
-
-/// Check if a delegation is allowed by any policy.
-pub async fn check_delegation_policy(
-    store: &DocumentStore,
-    grantor_email: &str,
-    grantee_audience: Option<&str>,
-) -> Result<Option<DelegationPolicy>> {
-    let docs = store
-        .find_all::<DelegationPolicyDoc>("enabled", "true")
-        .await?;
-
-    for doc in docs {
-        let policy = DelegationPolicy::from(doc);
-
-        if !pattern_matches(&policy.grantor_pattern, grantor_email) {
-            continue;
-        }
-
-        if let Some(audience) = grantee_audience
-            && !pattern_matches(&policy.grantee_pattern, audience)
-        {
-            continue;
-        }
-
-        return Ok(Some(policy));
-    }
-
-    Ok(None)
-}
-
-/// Check if a pattern matches a value.
-fn pattern_matches(pattern: &str, value: &str) -> bool {
-    if pattern == "*" {
-        return true;
-    }
-
-    if let Some(domain) = pattern.strip_prefix("*@") {
-        if let Some(email_domain) = value.rsplit('@').next() {
-            return email_domain.eq_ignore_ascii_case(domain);
-        }
-        return false;
-    }
-
-    pattern.eq_ignore_ascii_case(value)
-}
-
-/// Get all delegation policies.
-pub async fn get_delegation_policies(store: &DocumentStore) -> Result<Vec<DelegationPolicy>> {
-    let docs = store.list_all::<DelegationPolicyDoc>().await?;
-    Ok(docs.into_iter().map(DelegationPolicy::from).collect())
-}
-
-/// Update a delegation policy's enabled status.
-pub async fn set_delegation_policy_enabled(
-    store: &DocumentStore,
-    id: &str,
-    enabled: bool,
-) -> Result<bool> {
-    if let Some(doc) = store.get::<DelegationPolicyDoc>(id).await? {
-        let mut data = doc.data;
-        data.enabled = enabled;
-        store.update(id, &data).await?;
-        return Ok(true);
-    }
-    Ok(false)
-}
-
-/// Delete a delegation policy.
-pub async fn delete_delegation_policy(store: &DocumentStore, id: &str) -> Result<bool> {
-    store.delete(id).await?;
-    Ok(true)
 }
 
 // ============================================================

--- a/crates/vouch-server/src/db/documents/oauth.rs
+++ b/crates/vouch-server/src/db/documents/oauth.rs
@@ -537,28 +537,6 @@ impl DocumentType for TokenExchangeDoc {
     }
 }
 
-/// A delegation policy for token exchange.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DelegationPolicyDoc {
-    pub name: String,
-    pub grantor_pattern: String,
-    pub grantee_pattern: String,
-    pub allowed_scopes: Option<String>,
-    pub max_ttl_seconds: Option<i32>,
-    pub enabled: bool,
-}
-
-impl DocumentType for DelegationPolicyDoc {
-    const DOC_TYPE: &'static str = "delegation_policy";
-
-    fn index_entries(&self) -> Vec<IndexEntry> {
-        vec![IndexEntry {
-            field: "enabled",
-            value: self.enabled.to_string(),
-        }]
-    }
-}
-
 #[cfg(test)]
 #[expect(
     clippy::unwrap_used,

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -156,14 +156,13 @@ pub use dpop::{
 
 // Re-export credentials types and functions
 pub use credentials::{
-    DelegationPolicy, EnrollmentSession, IssuedSshCertificate, RevokedSshCertificate,
-    TokenExchangeRecord, check_delegation_policy, create_enrollment_session,
-    delete_delegation_policy, delete_expired_enrollment_sessions, delete_expired_ssh_issued_certs,
-    delete_expired_ssh_revocations, delete_old_token_exchanges, get_delegation_policies,
+    EnrollmentSession, IssuedSshCertificate, RevokedSshCertificate, TokenExchangeRecord,
+    create_enrollment_session, delete_expired_enrollment_sessions, delete_expired_ssh_issued_certs,
+    delete_expired_ssh_revocations, delete_old_token_exchanges,
     get_enrollment_session_by_token_hash, get_issued_ssh_certificates_for_user,
     get_revoked_ssh_certificates, get_token_exchanges_for_user, insert_token_exchange,
     is_ssh_certificate_revoked, record_ssh_certificate_issuance,
-    revoke_all_ssh_certificates_for_user, revoke_ssh_certificate, set_delegation_policy_enabled,
+    revoke_all_ssh_certificates_for_user, revoke_ssh_certificate,
 };
 
 // Re-export GitHub types and functions

--- a/crates/vouch-server/src/services/oidc/exchange.rs
+++ b/crates/vouch-server/src/services/oidc/exchange.rs
@@ -34,7 +34,7 @@ pub mod token_types {
 /// (`requested_token_type=id_token`). Short because the token is presented
 /// immediately as a federation assertion (Kubernetes, Claude/OpenAI WIF) and
 /// then discarded. The effective lifetime is further capped by the subject
-/// token's remaining TTL and any delegation policy, so this is only a ceiling.
+/// token's remaining TTL, so this is only a ceiling.
 const DEFAULT_ID_TOKEN_EXPIRES_SECS: u64 = 600;
 
 /// Parameters for token exchange (RFC 8693 Section 2.1).
@@ -163,10 +163,9 @@ pub(crate) async fn exchange_token(
             )
         })?;
 
-    // Look up the user to get the email for delegation policy checks and
-    // the exchanged token. For access tokens, the email may not be in the
-    // JWT (e.g., when only "openid" scope was granted), so we always use
-    // the canonical email from the user record.
+    // Look up the user to get the email for the exchanged token. For access
+    // tokens, the email may not be in the JWT (e.g., when only "openid" scope
+    // was granted), so we always use the canonical email from the user record.
     let subject_user = db::get_user_by_id(&state.store, &subject_session.user_id)
         .await
         .map_err(|e| ServiceError::Internal(format!("Database error: {e}")))?
@@ -260,63 +259,15 @@ pub(crate) async fn exchange_token(
         None
     };
 
-    // Check delegation policy if audience is specified
-    let max_ttl_override = if params.audience.is_some() {
-        let policy = db::check_delegation_policy(&state.store, subject_email, params.audience)
-            .await
-            .map_err(|e| ServiceError::Internal(format!("Database error: {e}")))?;
-
-        match policy {
-            Some(p) => {
-                tracing::debug!(
-                    "Token exchange allowed by policy '{}' for {} -> {:?}",
-                    p.name,
-                    redact_email(subject_email),
-                    params.audience
-                );
-                p.max_ttl_seconds
-            }
-            None => {
-                // No matching policy - check if any policies exist
-                let all_policies = db::get_delegation_policies(&state.store)
-                    .await
-                    .unwrap_or_default();
-
-                if all_policies.iter().any(|p| p.enabled) {
-                    // Policies exist but none match - deny
-                    return Err(ServiceError::oauth(
-                        OAuthErrorCode::AccessDenied,
-                        "No delegation policy allows this token exchange",
-                    ));
-                }
-                // No policies configured - allow by default (open mode)
-                None
-            }
-        }
-    } else {
-        None
-    };
-
     // Calculate granted scope (intersection of requested and available).
     // For FIDO2 sessions (scope: None), require explicit scope in the request
     // rather than defaulting to ScopeSet::all() to prevent scope escalation.
     let granted_scope = calculate_granted_scope(params.scope, subject_decoded.scope());
 
-    // Calculate expiration with policy TTL limit and subject token remaining TTL.
-    // RFC 8693 Section 2.2: The exchanged token's lifetime should not exceed
-    // the remaining lifetime of the subject token.
-    let default_expires_in = state.config().session_hours.saturating_mul(3600);
-    let mut expires_in = match max_ttl_override {
-        Some(max_ttl) => {
-            let max_ttl_u64 = u64::try_from(max_ttl).map_err(|_| {
-                ServiceError::Internal("Delegation policy max_ttl is negative".to_string())
-            })?;
-            default_expires_in.min(max_ttl_u64)
-        }
-        None => default_expires_in,
-    };
+    // Cap exchanged-token lifetime by subject token's remaining TTL
+    // (RFC 8693 Section 2.2).
+    let mut expires_in = state.config().session_hours.saturating_mul(3600);
 
-    // Cap by subject token's remaining TTL
     if let Some(subject_exp) = subject_decoded.exp() {
         let now = Timestamp::now().as_second();
         let remaining = subject_exp.saturating_sub(now);
@@ -341,7 +292,7 @@ pub(crate) async fn exchange_token(
     // instead of an RFC 9068 access token. The ID token carries only the
     // standard OIDC claim set, is never persisted as a session, and is
     // short-lived. `expires_in` is already capped by the subject token's
-    // remaining TTL and any delegation policy at this point; `issue_id_token`
+    // remaining TTL at this point; `issue_id_token`
     // additionally caps it at `DEFAULT_ID_TOKEN_EXPIRES_SECS` (600s), so the
     // value passed in is an upper bound that the federation ceiling will
     // tighten further if needed — never bypassable.


### PR DESCRIPTION
## Summary

- Removes `DelegationPolicyDoc`, the four DB functions (`check_delegation_policy`, `get_delegation_policies`, `set_delegation_policy_enabled`, `delete_delegation_policy`), and the enforcement block in `services/oidc/exchange.rs`. None of this had a creator (no CLI command, admin handler, or API), so the enforcement always fell through to "no policies → open mode → allow."
- Simplifies the `expires_in` calculation in `exchange.rs` to drop the now-unreachable `max_ttl_override` branch, removing the only `u64::try_from` in that block.
- Net: 4 files, 191 lines deleted, 13 added. Behavior unchanged.

## Test plan

- [x] `cargo check --all-targets --all-features`
- [x] `make lint` (clippy with `-D warnings`)
- [x] `make fmt`
- [x] `make test` — all unit tests pass
- [x] `make test-integration` — full suite passes, including `test_token_exchange_valid`, `test_token_exchange_scope_downgrade`, `test_token_exchange_invalid_subject_token`, `test_token_exchange_invalid_token_type`
- [x] `rg 'DelegationPolicy|delegation_policy|check_delegation_policy' --type rust` — zero hits

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead code removal with no creation path for policies; exchange logic simplifies to prior effective open-mode behavior plus unchanged subject-TTL capping.
> 
> **Overview**
> Removes **delegation policy** storage and enforcement that was never wired to any admin API or CLI, so token exchange always behaved as open mode when policies were absent.
> 
> **Deleted:** `DelegationPolicyDoc`, DB helpers (`check_delegation_policy`, list/update/delete policies), pattern-matching logic, and the `exchange_token` block that denied exchanges when enabled policies existed but none matched an audience.
> 
> **Simplified:** `expires_in` for RFC 8693 exchange now uses session config capped only by the subject token’s remaining TTL—no `max_ttl_seconds` from policies.
> 
> Public `db` re-exports and comments in `exchange.rs` are trimmed accordingly; runtime token-exchange behavior is unchanged for current deployments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5792fd00d139a594906d92778945f57567a70fad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->