### PR TITLE
fix: triage five [Detail Bug] reports (#425-#429)

### DIFF
--- a/crates/vouch-cli/src/commands/credential/eks.rs
+++ b/crates/vouch-cli/src/commands/credential/eks.rs
@@ -46,10 +46,26 @@ pub(crate) async fn run(
 
     let (role_arn, region_name) = aws::resolve_role_and_region(role, region)?;
 
-    let cache_key = format!("eks:{cluster_name}:{role_arn}");
+    // Detect agent context BEFORE the cache lookup. Folding the source into
+    // the cache key ensures agent and non-agent invocations never share a
+    // cached entry, which would otherwise hand the agent credentials minted
+    // without ReadOnlyAccess / `vouch:AccessType=ai` tags (issue #426).
+    let agent_source = crate::commands::credential::aws::detect_agent_source();
+    let agent_suffix = agent_source
+        .as_deref()
+        .map_or(String::new(), |src| format!(":agent:{src}"));
+    let cache_key = format!("eks:{cluster_name}:{role_arn}{agent_suffix}");
 
+    let agent = agent_source;
     let data = cache::get_or_fetch(&cache_key, "EKS token", || async {
-        let token = generate_eks_token(server, cluster_name, &region_name, &role_arn).await?;
+        let token = generate_eks_token(
+            server,
+            cluster_name,
+            &region_name,
+            &role_arn,
+            agent.as_deref(),
+        )
+        .await?;
         let exec_cred = build_exec_credential(&token)?;
         let expires_at = expiration_rfc3339()?;
         Ok((exec_cred, expires_at))
@@ -67,14 +83,14 @@ async fn generate_eks_token(
     cluster_name: &str,
     region: &str,
     role_arn: &str,
+    agent_source: Option<&str>,
 ) -> Result<String> {
-    let agent_source = crate::commands::credential::aws::detect_agent_source();
     let result = exchange_for_sts_credentials(StsRequest {
         server,
         role_arn,
         region,
         management_role: None,
-        agent_source: agent_source.as_deref(),
+        agent_source,
     })
     .await?;
 
@@ -175,5 +191,36 @@ mod tests {
     fn test_expiration_rfc3339_valid() {
         let ts = expiration_rfc3339().expect("should compute");
         assert!(ts.parse::<jiff::Timestamp>().is_ok());
+    }
+
+    /// Mirror the cache-key construction in `run()` so we can lock in the
+    /// invariant that agent and non-agent invocations land on different keys.
+    fn build_eks_cache_key(cluster_name: &str, role_arn: &str, agent: Option<&str>) -> String {
+        let agent_suffix = agent.map_or(String::new(), |src| format!(":agent:{src}"));
+        format!("eks:{cluster_name}:{role_arn}{agent_suffix}")
+    }
+
+    #[test]
+    fn test_eks_cache_key_format() {
+        let key = build_eks_cache_key("my-cluster", "arn:aws:iam::123456789012:role/MyRole", None);
+        assert_eq!(key, "eks:my-cluster:arn:aws:iam::123456789012:role/MyRole");
+    }
+
+    /// Agent and non-agent invocations must never share a cached entry —
+    /// issue #426.
+    #[test]
+    fn test_eks_cache_key_differs_when_agent_detected() {
+        let role_arn = "arn:aws:iam::123456789012:role/MyRole";
+        let without = build_eks_cache_key("my-cluster", role_arn, None);
+        let with = build_eks_cache_key("my-cluster", role_arn, Some("claude-code"));
+        assert_ne!(without, with);
+    }
+
+    #[test]
+    fn test_eks_cache_key_differs_between_agents() {
+        let role_arn = "arn:aws:iam::123456789012:role/MyRole";
+        let claude = build_eks_cache_key("my-cluster", role_arn, Some("claude-code"));
+        let cursor = build_eks_cache_key("my-cluster", role_arn, Some("cursor"));
+        assert_ne!(claude, cursor);
     }
 }

--- a/crates/vouch-cli/src/commands/credential/rds.rs
+++ b/crates/vouch-cli/src/commands/credential/rds.rs
@@ -67,11 +67,28 @@ pub(crate) async fn fetch_rds_token(
     let effective_region = region.or(hostname_region);
     let (role_arn, region_name) = aws::resolve_role_and_region(role, effective_region)?;
 
-    let cache_key = format!("rds:{hostname}:{port}:{username}:{role_arn}");
+    // Detect agent context BEFORE the cache lookup. Folding the source into
+    // the cache key ensures agent and non-agent invocations never share a
+    // cached entry, which would otherwise hand the agent credentials minted
+    // without ReadOnlyAccess / `vouch:AccessType=ai` tags (issue #426).
+    let agent_source = crate::commands::credential::aws::detect_agent_source();
+    let agent_suffix = agent_source
+        .as_deref()
+        .map_or(String::new(), |src| format!(":agent:{src}"));
+    let cache_key = format!("rds:{hostname}:{port}:{username}:{role_arn}{agent_suffix}");
 
+    let agent = agent_source;
     let data = cache::get_or_fetch(&cache_key, "RDS token", || async {
-        let token =
-            generate_rds_token(server, hostname, port, username, &region_name, &role_arn).await?;
+        let token = generate_rds_token(
+            server,
+            hostname,
+            port,
+            username,
+            &region_name,
+            &role_arn,
+            agent.as_deref(),
+        )
+        .await?;
         let expires_at = rds_cache_expiry()?;
         let value = serde_json::Value::String(token);
         Ok((value, expires_at))
@@ -91,14 +108,14 @@ async fn generate_rds_token(
     username: &str,
     region: &str,
     role_arn: &str,
+    agent_source: Option<&str>,
 ) -> Result<String> {
-    let agent_source = crate::commands::credential::aws::detect_agent_source();
     let result = exchange_for_sts_credentials(StsRequest {
         server,
         role_arn,
         region,
         management_role: None,
-        agent_source: agent_source.as_deref(),
+        agent_source,
     })
     .await?;
 
@@ -168,17 +185,73 @@ mod tests {
         assert_eq!(endpoint, "https://mydb.us-east-1.rds.amazonaws.com:5432");
     }
 
+    /// Mirror the cache-key construction in `fetch_rds_token()` so we can lock
+    /// in the invariant that agent and non-agent invocations land on different
+    /// keys.
+    fn build_rds_cache_key(
+        hostname: &str,
+        port: u16,
+        username: &str,
+        role_arn: &str,
+        agent: Option<&str>,
+    ) -> String {
+        let agent_suffix = agent.map_or(String::new(), |src| format!(":agent:{src}"));
+        format!("rds:{hostname}:{port}:{username}:{role_arn}{agent_suffix}")
+    }
+
     #[test]
     fn test_rds_cache_key_format() {
-        let hostname = "mydb.us-east-1.rds.amazonaws.com";
-        let port: u16 = 5432;
-        let username = "admin";
-        let role_arn = "arn:aws:iam::123456789012:role/MyRole";
-        let key = format!("rds:{hostname}:{port}:{username}:{role_arn}");
+        let key = build_rds_cache_key(
+            "mydb.us-east-1.rds.amazonaws.com",
+            5432,
+            "admin",
+            "arn:aws:iam::123456789012:role/MyRole",
+            None,
+        );
         assert_eq!(
             key,
             "rds:mydb.us-east-1.rds.amazonaws.com:5432:admin:arn:aws:iam::123456789012:role/MyRole"
         );
+    }
+
+    /// Agent and non-agent invocations must never share a cached entry —
+    /// issue #426.
+    #[test]
+    fn test_rds_cache_key_differs_when_agent_detected() {
+        let without = build_rds_cache_key(
+            "mydb.us-east-1.rds.amazonaws.com",
+            5432,
+            "admin",
+            "arn:aws:iam::123456789012:role/MyRole",
+            None,
+        );
+        let with = build_rds_cache_key(
+            "mydb.us-east-1.rds.amazonaws.com",
+            5432,
+            "admin",
+            "arn:aws:iam::123456789012:role/MyRole",
+            Some("claude-code"),
+        );
+        assert_ne!(without, with);
+    }
+
+    #[test]
+    fn test_rds_cache_key_differs_between_agents() {
+        let claude = build_rds_cache_key(
+            "mydb.us-east-1.rds.amazonaws.com",
+            5432,
+            "admin",
+            "arn:aws:iam::123456789012:role/MyRole",
+            Some("claude-code"),
+        );
+        let cursor = build_rds_cache_key(
+            "mydb.us-east-1.rds.amazonaws.com",
+            5432,
+            "admin",
+            "arn:aws:iam::123456789012:role/MyRole",
+            Some("cursor"),
+        );
+        assert_ne!(claude, cursor);
     }
 
     #[test]

--- a/crates/vouch-cli/src/commands/credential/redshift.rs
+++ b/crates/vouch-cli/src/commands/credential/redshift.rs
@@ -59,18 +59,35 @@ pub(crate) async fn run(
 
     let (role_arn, region_name) = aws::resolve_role_and_region(role, region)?;
 
+    // Detect agent context BEFORE the cache lookup. Folding the source into
+    // the cache key ensures agent and non-agent invocations never share a
+    // cached entry, which would otherwise hand the agent credentials minted
+    // without ReadOnlyAccess / `vouch:AccessType=ai` tags (issue #426).
+    let agent_source = crate::commands::credential::aws::detect_agent_source();
+    let agent_suffix = agent_source
+        .as_deref()
+        .map_or(String::new(), |src| format!(":agent:{src}"));
+
     let cache_key = match &target {
         RedshiftTarget::Cluster { cluster_id, .. } => {
-            format!("redshift:{cluster_id}:{role_arn}")
+            format!("redshift:{cluster_id}:{role_arn}{agent_suffix}")
         }
         RedshiftTarget::Serverless { workgroup } => {
-            format!("redshift-serverless:{workgroup}:{role_arn}")
+            format!("redshift-serverless:{workgroup}:{role_arn}{agent_suffix}")
         }
     };
 
+    let agent = agent_source;
     let data = cache::get_or_fetch(&cache_key, "Redshift credentials", || async {
-        let creds =
-            fetch_redshift_credentials(server, &target, db_name, &region_name, &role_arn).await?;
+        let creds = fetch_redshift_credentials(
+            server,
+            &target,
+            db_name,
+            &region_name,
+            &role_arn,
+            agent.as_deref(),
+        )
+        .await?;
 
         let expires_at = creds.expiration.clone();
         let output = serde_json::json!({
@@ -97,14 +114,14 @@ pub(crate) async fn fetch_redshift_credentials(
     db_name: Option<&str>,
     region: &str,
     role_arn: &str,
+    agent_source: Option<&str>,
 ) -> Result<crate::integrations::aws::redshift::RedshiftCredentials> {
-    let agent_source = crate::commands::credential::aws::detect_agent_source();
     let result = exchange_for_sts_credentials(StsRequest {
         server,
         role_arn,
         region,
         management_role: None,
-        agent_source: agent_source.as_deref(),
+        agent_source,
     })
     .await?;
 
@@ -197,26 +214,86 @@ mod tests {
         assert!(obj.contains_key("Expiration"));
     }
 
+    /// Mirror the cache-key construction in `run()` so we can lock in the
+    /// invariant that agent and non-agent invocations land on different keys.
+    fn build_redshift_cache_key(
+        target: &RedshiftTarget<'_>,
+        role_arn: &str,
+        agent: Option<&str>,
+    ) -> String {
+        let agent_suffix = agent.map_or(String::new(), |src| format!(":agent:{src}"));
+        match target {
+            RedshiftTarget::Cluster { cluster_id, .. } => {
+                format!("redshift:{cluster_id}:{role_arn}{agent_suffix}")
+            }
+            RedshiftTarget::Serverless { workgroup } => {
+                format!("redshift-serverless:{workgroup}:{role_arn}{agent_suffix}")
+            }
+        }
+    }
+
     #[test]
     fn test_cluster_cache_key_format() {
-        let cluster_id = "my-cluster";
+        let target = RedshiftTarget::Cluster {
+            cluster_id: "my-cluster",
+            duration: None,
+        };
         let role_arn = "arn:aws:iam::123456789012:role/MyRole";
-        let key = format!("redshift:{cluster_id}:{role_arn}");
         assert_eq!(
-            key,
+            build_redshift_cache_key(&target, role_arn, None),
             "redshift:my-cluster:arn:aws:iam::123456789012:role/MyRole"
         );
     }
 
     #[test]
     fn test_serverless_cache_key_format() {
-        let workgroup = "my-workgroup";
+        let target = RedshiftTarget::Serverless {
+            workgroup: "my-workgroup",
+        };
         let role_arn = "arn:aws:iam::123456789012:role/MyRole";
-        let key = format!("redshift-serverless:{workgroup}:{role_arn}");
         assert_eq!(
-            key,
+            build_redshift_cache_key(&target, role_arn, None),
             "redshift-serverless:my-workgroup:arn:aws:iam::123456789012:role/MyRole"
         );
+    }
+
+    /// Agent and non-agent invocations must never share a cached entry —
+    /// issue #426. The agent invocation receives `ReadOnlyAccess` plus
+    /// `vouch:AccessType=ai` tags; a cache hit on a non-agent entry would
+    /// silently hand back full-access credentials.
+    #[test]
+    fn test_cluster_cache_key_differs_when_agent_detected() {
+        let target = RedshiftTarget::Cluster {
+            cluster_id: "my-cluster",
+            duration: None,
+        };
+        let role_arn = "arn:aws:iam::123456789012:role/MyRole";
+        let without = build_redshift_cache_key(&target, role_arn, None);
+        let with = build_redshift_cache_key(&target, role_arn, Some("claude-code"));
+        assert_ne!(without, with);
+    }
+
+    #[test]
+    fn test_serverless_cache_key_differs_when_agent_detected() {
+        let target = RedshiftTarget::Serverless {
+            workgroup: "my-workgroup",
+        };
+        let role_arn = "arn:aws:iam::123456789012:role/MyRole";
+        let without = build_redshift_cache_key(&target, role_arn, None);
+        let with = build_redshift_cache_key(&target, role_arn, Some("claude-code"));
+        assert_ne!(without, with);
+    }
+
+    #[test]
+    fn test_cache_key_differs_between_agents() {
+        let target = RedshiftTarget::Cluster {
+            cluster_id: "my-cluster",
+            duration: None,
+        };
+        let role_arn = "arn:aws:iam::123456789012:role/MyRole";
+        let claude = build_redshift_cache_key(&target, role_arn, Some("claude-code"));
+        let cursor = build_redshift_cache_key(&target, role_arn, Some("cursor"));
+        assert_ne!(claude, cursor);
     }
 
     #[test]

--- a/crates/vouch-cli/src/commands/exec.rs
+++ b/crates/vouch-cli/src/commands/exec.rs
@@ -326,12 +326,14 @@ pub(super) async fn fetch_redshift_with_opts(
     let (role_arn, region_name) =
         crate::integrations::aws::resolve_role_and_region(role, opts.region)?;
 
+    let agent_source = super::credential::aws::detect_agent_source();
     super::credential::redshift::fetch_redshift_credentials(
         server,
         &target,
         opts.db_name,
         &region_name,
         &role_arn,
+        agent_source.as_deref(),
     )
     .await
 }

--- a/crates/vouch-server/src/db/migrations.rs
+++ b/crates/vouch-server/src/db/migrations.rs
@@ -163,10 +163,19 @@ async fn record_migration(
 
     let elapsed_nanos = i64::try_from(elapsed.as_nanos())
         .context("migration elapsed time exceeds i64 nanoseconds")?;
+    // `ON CONFLICT DO NOTHING` handles concurrent multi-replica startup: two
+    // instances can both decide the same migration is pending, run the DDL
+    // (the duplicate-object handler above absorbs the redundant DDL), then
+    // race here to record completion. Without the conflict clause the loser
+    // hits `_sqlx_migrations.version` PRIMARY KEY (SQLSTATE 23505) and the
+    // process exits, causing a restart loop (issue #428). DSQL supports
+    // `ON CONFLICT DO NOTHING` — the AWS DSQL Loader uses the same pattern
+    // for resumable loads.
     sqlx::query(
         r#"
         INSERT INTO _sqlx_migrations (version, description, success, checksum, execution_time)
         VALUES ($1, $2, $3, $4, $5)
+        ON CONFLICT (version) DO NOTHING
         "#,
     )
     .bind(migration.version)

--- a/crates/vouch-server/src/db/pool.rs
+++ b/crates/vouch-server/src/db/pool.rs
@@ -775,13 +775,39 @@ pub(crate) const MAX_DSQL_RETRIES: u32 = 3;
 /// - `40001`: Serialization failure (standard SQL)
 /// - `OC000`: Aurora DSQL optimistic concurrency conflict
 /// - `OC001`: Aurora DSQL transaction conflict
-/// - `5`: SQLite `SQLITE_BUSY` — writer contention
+/// - `5`: SQLite `SQLITE_BUSY` — writer contention (primary code)
 /// - `6`: SQLite `SQLITE_LOCKED` — deadlock between concurrent transactions
+///   (primary code)
 ///
-/// SQLite returns its primary error code as a single-digit string via
-/// `sqlx::Error::code()`; Postgres always returns a 5-char SQLSTATE so
-/// there is no collision.
+/// Postgres/DSQL emit 5-char SQLSTATEs that match exactly. SQLite, in
+/// contrast, returns its **extended** result code as a numeric string via
+/// `sqlx::Error::code()` (e.g. `"517"` for `SQLITE_BUSY_SNAPSHOT`, primary
+/// `5`); a plain string compare against `"5"`/`"6"` therefore never fires.
+/// [`is_retryable_code`] handles that by masking numeric codes to their
+/// low byte (the primary code) before comparison (issue #429).
 const RETRYABLE_SQL_STATES: &[&str] = &["40001", "OC000", "OC001", "5", "6"];
+
+/// Match `code` against [`RETRYABLE_SQL_STATES`], normalizing SQLite extended
+/// codes to their primary code first.
+///
+/// SQLite extended result codes encode the primary code in the low byte
+/// (e.g. `SQLITE_BUSY_SNAPSHOT = 517 = (1 << 8) | 5`). We try an exact match
+/// first (covers Postgres/DSQL 5-char SQLSTATEs and the unlikely bare `"5"`/
+/// `"6"`); if that fails and the code parses as an integer, mask with
+/// `0xFF` and retry. Postgres SQLSTATEs like `"40001"` parse as integers
+/// too, but `40001 & 0xFF = 65` doesn't collide with any entry in
+/// `RETRYABLE_SQL_STATES`, so the second check is a no-op for them.
+fn is_retryable_code(code: &str) -> bool {
+    if RETRYABLE_SQL_STATES.contains(&code) {
+        return true;
+    }
+    let Ok(numeric) = code.parse::<u32>() else {
+        return false;
+    };
+    let primary = numeric & 0xFF;
+    let primary_str = primary.to_string();
+    RETRYABLE_SQL_STATES.contains(&primary_str.as_str())
+}
 
 /// Check whether an error is a transient database error worth retrying.
 ///
@@ -792,7 +818,7 @@ pub(crate) fn is_retryable_db_error(err: &anyhow::Error) -> bool {
         && let sqlx::Error::Database(db_err) = sqlx_err
         && let Some(code) = db_err.code()
     {
-        return RETRYABLE_SQL_STATES.iter().any(|s| code == *s);
+        return is_retryable_code(code.as_ref());
     }
     false
 }
@@ -917,6 +943,77 @@ mod tests {
     fn test_is_retryable_db_error_non_db() {
         let err = anyhow::anyhow!("some random error");
         assert!(!is_retryable_db_error(&err));
+    }
+
+    /// Postgres/DSQL emit 5-char SQLSTATEs verbatim — exact match path.
+    #[test]
+    fn test_is_retryable_code_postgres_serialization_failure() {
+        assert!(is_retryable_code("40001"));
+    }
+
+    #[test]
+    fn test_is_retryable_code_dsql_occ_conflict() {
+        assert!(is_retryable_code("OC000"));
+        assert!(is_retryable_code("OC001"));
+    }
+
+    /// SQLite extended `SQLITE_BUSY_SNAPSHOT` = 517 = `(2 << 8) | 5` —
+    /// primary code `5` (SQLITE_BUSY). Before #429 the string `"517"` never
+    /// matched any entry in `RETRYABLE_SQL_STATES`, so SQLite contention
+    /// silently bypassed retry. The mask-and-recompare path restores it.
+    #[test]
+    fn test_is_retryable_code_sqlite_busy_snapshot_extended() {
+        assert!(is_retryable_code("517"));
+    }
+
+    /// SQLite extended `SQLITE_LOCKED_SHAREDCACHE` = 262 = `(1 << 8) | 6` —
+    /// primary code `6` (SQLITE_LOCKED).
+    #[test]
+    fn test_is_retryable_code_sqlite_locked_sharedcache_extended() {
+        assert!(is_retryable_code("262"));
+    }
+
+    /// Primary `SQLITE_BUSY`/`SQLITE_LOCKED` as a bare digit also retries —
+    /// catches both the documented intent of the constant and any sqlx
+    /// version that ever returns the primary code directly.
+    #[test]
+    fn test_is_retryable_code_sqlite_primary_codes() {
+        assert!(is_retryable_code("5"));
+        assert!(is_retryable_code("6"));
+    }
+
+    /// Non-retryable SQLite codes must not match — `SQLITE_CONSTRAINT` (19)
+    /// is a permanent error and must surface to the client.
+    #[test]
+    fn test_is_retryable_code_sqlite_constraint_not_retryable() {
+        assert!(!is_retryable_code("19"));
+    }
+
+    /// `unique_violation` (Postgres 23505) is not retryable.
+    #[test]
+    fn test_is_retryable_code_postgres_unique_violation_not_retryable() {
+        assert!(!is_retryable_code("23505"));
+    }
+
+    /// Garbage and empty strings must not match.
+    #[test]
+    fn test_is_retryable_code_garbage_inputs() {
+        assert!(!is_retryable_code(""));
+        assert!(!is_retryable_code("not-a-code"));
+    }
+
+    /// Postgres SQLSTATEs that happen to parse as integers (e.g. `"40001"`)
+    /// must NOT pass via the masking path. `40001 & 0xFF = 65`, which is
+    /// not in `RETRYABLE_SQL_STATES`. The exact-match path already returned
+    /// true for `"40001"`; this guards against a regression where the
+    /// masking path inadvertently flags an unrelated SQLSTATE as retryable.
+    #[test]
+    fn test_is_retryable_code_numeric_postgres_does_not_alias() {
+        // 23505 (unique_violation) -- 23505 & 0xFF = 209, not a retry code.
+        assert!(!is_retryable_code("23505"));
+        // 42P07 contains a letter so doesn't parse as integer — exact match
+        // path only, and not retryable.
+        assert!(!is_retryable_code("42P07"));
     }
 
     #[test]

--- a/crates/vouch-server/src/handlers/oidc/par.rs
+++ b/crates/vouch-server/src/handlers/oidc/par.rs
@@ -285,6 +285,13 @@ pub(crate) async fn par(
             )
                 .into_response();
         }
+        Err(e @ DpopError::Database(_)) => {
+            return par_error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "server_error",
+                &e.to_string(),
+            );
+        }
         Err(e) => {
             return par_error_response(
                 StatusCode::BAD_REQUEST,

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -610,6 +610,11 @@ async fn handle_authorization_code_grant(
             Err(crate::services::oidc::dpop::DpopError::UseNonce(nonce)) => {
                 return dpop_use_nonce_response(&nonce);
             }
+            Err(e @ crate::services::oidc::dpop::DpopError::Database(_)) => {
+                return ServiceError::oauth(OAuthErrorCode::ServerError, e.to_string())
+                    .into_oauth_response()
+                    .into_response();
+            }
             Err(e) => {
                 return ServiceError::oauth(OAuthErrorCode::InvalidDpopProof, e.to_string())
                     .into_oauth_response()
@@ -946,6 +951,11 @@ async fn handle_token_exchange_grant(
             Err(crate::services::oidc::dpop::DpopError::UseNonce(nonce)) => {
                 return dpop_use_nonce_response(&nonce);
             }
+            Err(e @ crate::services::oidc::dpop::DpopError::Database(_)) => {
+                return ServiceError::oauth(OAuthErrorCode::ServerError, e.to_string())
+                    .into_oauth_response()
+                    .into_response();
+            }
             Err(e) => {
                 return ServiceError::oauth(OAuthErrorCode::InvalidDpopProof, e.to_string())
                     .into_oauth_response()
@@ -1127,6 +1137,11 @@ async fn handle_fido2_assertion_grant(
             Ok(proof) => proof,
             Err(crate::services::oidc::dpop::DpopError::UseNonce(nonce)) => {
                 return dpop_use_nonce_response(&nonce);
+            }
+            Err(e @ crate::services::oidc::dpop::DpopError::Database(_)) => {
+                return ServiceError::oauth(OAuthErrorCode::ServerError, e.to_string())
+                    .into_oauth_response()
+                    .into_response();
             }
             Err(e) => {
                 return ServiceError::oauth(OAuthErrorCode::InvalidDpopProof, e.to_string())

--- a/crates/vouch-server/src/handlers/oidc/userinfo.rs
+++ b/crates/vouch-server/src/handlers/oidc/userinfo.rs
@@ -217,6 +217,13 @@ pub(crate) async fn userinfo(
                 )
                     .into_response();
             }
+            Err(e @ DpopError::Database(_)) => {
+                return oauth_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    OAuthErrorCode::ServerError.as_str(),
+                    &e.to_string(),
+                );
+            }
             Err(e) => {
                 return oauth_error(
                     StatusCode::UNAUTHORIZED,

--- a/crates/vouch-server/src/handlers/session.rs
+++ b/crates/vouch-server/src/handlers/session.rs
@@ -162,6 +162,14 @@ pub(crate) async fn extract_resource_token(
                             }
                             dpop_source = validated.source;
                         }
+                        Err(e @ crate::services::oidc::dpop::DpopError::Database(_)) => {
+                            tracing::error!("DPoP backend failure: {e}");
+                            return Err(ServiceError::api(
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                "server_error",
+                                "DPoP validation backend error",
+                            ));
+                        }
                         Err(e) => {
                             tracing::debug!("DPoP validation failed: {e}");
                             return Err(ServiceError::api(

--- a/crates/vouch-server/src/services/idp/oidc.rs
+++ b/crates/vouch-server/src/services/idp/oidc.rs
@@ -163,6 +163,37 @@ fn is_entra_common_issuer(issuer: &str) -> bool {
         && (url.path().starts_with("/common/") || url.path() == "/common")
 }
 
+/// Check whether an issuer URL points at any Microsoft Entra endpoint.
+///
+/// Parses the URL and matches on `host_str()` so lookalike domains
+/// (`login.microsoftonline.com.evil.com`) are rejected. Used by
+/// `verify_id_token` to gate Entra-specific behavior — `xms_edov`
+/// honoring, tenant validation against `tid`, and the Entra-specific
+/// error message that walks operators through the `xms_edov` claim
+/// configuration (issue #425).
+fn is_entra_host(issuer: &str) -> bool {
+    Url::parse(issuer)
+        .ok()
+        .and_then(|u| u.host_str().map(str::to_ascii_lowercase))
+        .as_deref()
+        == Some("login.microsoftonline.com")
+}
+
+/// Check whether an issuer URL points at Google's OIDC endpoint.
+///
+/// Same rationale as [`is_entra_host`] — substring matching accepts
+/// lookalike hosts (issue #425). Discovery validation gates `provider.issuer`,
+/// but the verification path uses this for feature detection (using `hd` vs.
+/// extracting domain from `email`); the consistency-with-discovery-helpers
+/// invariant in this file matters for future-developer copy-paste safety.
+fn is_google_host(issuer: &str) -> bool {
+    Url::parse(issuer)
+        .ok()
+        .and_then(|u| u.host_str().map(str::to_ascii_lowercase))
+        .as_deref()
+        == Some("accounts.google.com")
+}
+
 /// Check whether an issuer URL is the Entra per-tenant template returned by
 /// `/organizations/` discovery (literal `{tenantid}` placeholder).
 ///
@@ -399,7 +430,7 @@ pub(crate) async fn verify_id_token(
     // emit `email_verified`; Entra never does and instead uses the optional
     // `xms_edov` (Email Domain Owner Verified) claim. `xms_edov` is honored
     // only for Entra issuers — it's an Entra-specific signal.
-    let is_entra_issuer = provider.issuer.contains("login.microsoftonline.com");
+    let is_entra_issuer = is_entra_host(&provider.issuer);
     let email_is_verified =
         claims.email_verified || (is_entra_issuer && claims.xms_edov == Some(true));
     if !email_is_verified {
@@ -447,7 +478,7 @@ pub(crate) async fn verify_id_token(
     //
     // Normalize to ASCII lowercase so that org lookups match regardless of
     // the case the IdP returned. Org domains are stored lowercase.
-    let is_google = provider.issuer.contains("accounts.google.com");
+    let is_google = is_google_host(&provider.issuer);
     let domain = if is_google {
         claims.hd.as_deref().map(str::to_ascii_lowercase)
     } else {
@@ -561,6 +592,58 @@ mod tests {
     )]
 
     use super::*;
+
+    // ── Issuer host matching (#425) ────────────────────────────────────────
+
+    #[test]
+    fn is_entra_host_matches_legitimate_endpoints() {
+        assert!(is_entra_host(
+            "https://login.microsoftonline.com/tenant-uuid/v2.0"
+        ));
+        assert!(is_entra_host(
+            "https://login.microsoftonline.com/organizations/v2.0"
+        ));
+        assert!(is_entra_host(
+            "https://login.microsoftonline.com/%7Btenantid%7D/v2.0"
+        ));
+    }
+
+    /// Lookalike host with the target domain as a substring must be
+    /// rejected — the entire point of swapping `.contains()` for host-based
+    /// matching (#425).
+    #[test]
+    fn is_entra_host_rejects_lookalike_domain() {
+        assert!(!is_entra_host(
+            "https://login.microsoftonline.com.evil.com/tenant/v2.0"
+        ));
+        assert!(!is_entra_host(
+            "https://evil.com/login.microsoftonline.com/v2.0"
+        ));
+    }
+
+    #[test]
+    fn is_entra_host_rejects_malformed_url() {
+        assert!(!is_entra_host("not a url"));
+        assert!(!is_entra_host(""));
+    }
+
+    #[test]
+    fn is_google_host_matches_legitimate_endpoint() {
+        assert!(is_google_host("https://accounts.google.com"));
+        assert!(is_google_host("https://accounts.google.com/"));
+    }
+
+    #[test]
+    fn is_google_host_rejects_lookalike_domain() {
+        assert!(!is_google_host("https://accounts.google.com.evil.com"));
+        assert!(!is_google_host("https://evil.com/accounts.google.com"));
+    }
+
+    #[test]
+    fn is_google_host_rejects_malformed_url() {
+        assert!(!is_google_host("not a url"));
+        assert!(!is_google_host(""));
+    }
 
     // ── Test helpers for verify_id_token ────────────────────────────────────
 

--- a/crates/vouch-server/src/services/oidc/dpop.rs
+++ b/crates/vouch-server/src/services/oidc/dpop.rs
@@ -172,6 +172,14 @@ pub enum DpopError {
     TokenHashMismatch,
     /// Server requires nonce.
     UseNonce(String),
+    /// Backend database failure during JTI persistence or nonce
+    /// generation/validation. Distinct from `InvalidFormat`: this is a
+    /// server-side fault (maps to `server_error` / HTTP 500), not a
+    /// client-side proof defect (issue #427). Without this variant the
+    /// catch-all in `validate_dpop_common` swallowed `ClaimError::Database`
+    /// as `InvalidFormat`, which surfaced as HTTP 400 `invalid_dpop_proof`
+    /// and prevented clients from retrying transient DB failures.
+    Database(String),
 }
 
 impl std::fmt::Display for DpopError {
@@ -188,6 +196,7 @@ impl std::fmt::Display for DpopError {
             Self::InvalidNonce => write!(f, "invalid or missing DPoP nonce"),
             Self::TokenHashMismatch => write!(f, "DPoP ath claim mismatch"),
             Self::UseNonce(nonce) => write!(f, "use_dpop_nonce: {nonce}"),
+            Self::Database(msg) => write!(f, "DPoP backend failure: {msg}"),
         }
     }
 }
@@ -500,7 +509,9 @@ async fn validate_dpop_common(
         Ok(claim) => claim,
         Err(db::claim::ClaimError::AlreadyConsumed) => return Err(DpopError::ReplayDetected),
         Err(db::claim::ClaimError::InvalidInput(msg)) => return Err(DpopError::InvalidFormat(msg)),
-        Err(e) => return Err(DpopError::InvalidFormat(format!("JTI check failed: {e}"))),
+        Err(db::claim::ClaimError::Database(msg)) => {
+            return Err(DpopError::Database(format!("JTI check failed: {msg}")));
+        }
     };
 
     // Nonce requirement: enforced at token endpoint (RFC 9449 Section 8)
@@ -509,7 +520,7 @@ async fn validate_dpop_common(
     if require_nonce && claims.nonce.is_none() {
         let new_nonce = db::generate_dpop_nonce(store, NONCE_VALIDITY_SECONDS)
             .await
-            .map_err(|e| DpopError::InvalidFormat(format!("nonce generation failed: {e}")))?;
+            .map_err(|e| DpopError::Database(format!("nonce generation failed: {e}")))?;
         return Err(DpopError::UseNonce(new_nonce));
     }
 
@@ -536,14 +547,15 @@ async fn validate_dpop_common(
             Err(db::claim::ClaimError::AlreadyConsumed) => {
                 let new_nonce = db::generate_dpop_nonce(store, NONCE_VALIDITY_SECONDS)
                     .await
-                    .map_err(|e| {
-                        DpopError::InvalidFormat(format!("nonce generation failed: {e}"))
-                    })?;
+                    .map_err(|e| DpopError::Database(format!("nonce generation failed: {e}")))?;
                 return Err(DpopError::UseNonce(new_nonce));
             }
-            Err(e) => {
-                return Err(DpopError::InvalidFormat(format!(
-                    "nonce validation failed: {e}"
+            Err(db::claim::ClaimError::InvalidInput(msg)) => {
+                return Err(DpopError::InvalidFormat(msg));
+            }
+            Err(db::claim::ClaimError::Database(msg)) => {
+                return Err(DpopError::Database(format!(
+                    "nonce validation failed: {msg}"
                 )));
             }
         }
@@ -665,6 +677,27 @@ mod tests {
         assert!(!hash.is_empty());
         // SHA-256 base64url encoded should be 43 chars
         assert_eq!(hash.len(), 43);
+    }
+
+    /// `DpopError::Database` is distinct from `DpopError::InvalidFormat` so
+    /// the handler layer can route it to HTTP 500 `server_error` instead of
+    /// HTTP 400 `invalid_dpop_proof` (issue #427). Lock in the Display form
+    /// because handlers surface it verbatim in `error_description`.
+    #[test]
+    fn dpop_error_database_display() {
+        let err = DpopError::Database("connection refused".to_string());
+        assert_eq!(err.to_string(), "DPoP backend failure: connection refused");
+    }
+
+    /// Guard against accidental collapsing of `Database` back into
+    /// `InvalidFormat`: the two map to different HTTP statuses.
+    #[test]
+    fn dpop_error_database_distinct_from_invalid_format() {
+        let db_err = DpopError::Database("x".to_string());
+        let fmt_err = DpopError::InvalidFormat("x".to_string());
+        assert!(matches!(db_err, DpopError::Database(_)));
+        assert!(!matches!(db_err, DpopError::InvalidFormat(_)));
+        assert!(matches!(fmt_err, DpopError::InvalidFormat(_)));
     }
 
     fn make_claims(htm: &str, htu: &str, iat: i64) -> DpopClaims {


### PR DESCRIPTION
## Summary

Bundles fixes for all five open `[Detail Bug]` issues, ranked by severity. Five fixes, ~491 LOC across 11 files, all behind 20+ new unit tests.

| Issue | Severity | Fix |
|-------|----------|-----|
| #426 | Critical | Redshift/EKS/RDS cache keys now include `agent_source`; agent and human invocations can no longer collide on cached STS credentials |
| #428 | High | `record_migration` INSERT uses `ON CONFLICT (version) DO NOTHING`; concurrent multi-replica DSQL startup no longer crashes the loser on PRIMARY KEY violation |
| #427 | High | New `DpopError::Database` variant; `ClaimError::Database` from JTI/nonce persistence routes to HTTP 500 `server_error` instead of HTTP 400 `invalid_dpop_proof` |
| #429 | High | `is_retryable_code` masks SQLite extended result codes with `& 0xFF` before matching `RETRYABLE_SQL_STATES`; `SQLITE_BUSY_SNAPSHOT` (517) and friends now retry |
| #425 | Medium | `is_entra_host`/`is_google_host` helpers using `Url::parse + host_str` replace `.contains()` in `verify_id_token`, matching the existing discovery-path pattern |

Fixes #425
Fixes #426 
Fixes #427 
Fixes #428 
Fixes #429

## Notes

- DSQL `ON CONFLICT DO NOTHING` is supported (AWS DSQL Loader uses the same pattern for resumable loads).
- Out-of-scope finding: `services/idp/mod.rs::IdpBrand::from_issuer`/`from_entity_id` use `.contains()` for issuer/entity-id substring matching, but only to pick a brand icon and display name — cosmetic, not security-relevant. Left alone.
- No behavioral test for #428: requires a Postgres fixture and belongs in `vouch-tests`. The DDL change is a one-line idempotency clause; existing `is_duplicate_object_sqlstate` tests cover adjacent recovery.

## Test plan
- [x] `make fmt`
- [x] `make lint` (workspace-wide `cargo clippy --all-targets --all-features -- -D warnings`)
- [x] `make test` — 2247 server-lib + 580 CLI-bin tests pass, including new tests:
  - `test_cluster_cache_key_differs_when_agent_detected`, `test_serverless_cache_key_differs_when_agent_detected`, `test_cache_key_differs_between_agents` (redshift)
  - `test_eks_cache_key_differs_when_agent_detected`, `test_eks_cache_key_differs_between_agents` (eks)
  - `test_rds_cache_key_differs_when_agent_detected`, `test_rds_cache_key_differs_between_agents` (rds)
  - `dpop_error_database_display`, `dpop_error_database_distinct_from_invalid_format`
  - `test_is_retryable_code_sqlite_busy_snapshot_extended`, `..._locked_sharedcache_extended`, `..._primary_codes`, `..._postgres_serialization_failure`, `..._dsql_occ_conflict`, `..._sqlite_constraint_not_retryable`, `..._postgres_unique_violation_not_retryable`, `..._garbage_inputs`, `..._numeric_postgres_does_not_alias`
  - `is_entra_host_matches_legitimate_endpoints`, `is_entra_host_rejects_lookalike_domain`, `is_entra_host_rejects_malformed_url`, `is_google_host_matches_legitimate_endpoint`, `is_google_host_rejects_lookalike_domain`, `is_google_host_rejects_malformed_url`
- [ ] Manual: 2 DSQL replicas concurrent startup from fresh schema (#428)
- [ ] Manual: force DPoP JTI persistence DB failure, confirm 500 not 400 (#427)
- [ ] Manual: agent vs. human `vouch credential redshift|eks|rds` runs land on distinct cache entries (#426)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Includes a critical credential-cache isolation fix for AI agents and changes to OIDC DPoP error handling and IdP issuer detection in security-sensitive paths.
> 
> **Overview**
> Bundles five targeted fixes across the CLI and server.
> 
> **CLI (#426):** EKS, RDS, and Redshift credential paths now call `detect_agent_source()` **before** cache lookup and append `:agent:{source}` to cache keys. Agent vs human (and different agents) no longer share cached STS-backed tokens that could bypass AI read-only tagging. `exec` Redshift passes the same agent hint into `fetch_redshift_credentials`.
> 
> **Server — DSQL (#428):** Migration completion inserts use `ON CONFLICT (version) DO NOTHING` so concurrent replicas racing on `_sqlx_migrations` do not crash on duplicate primary keys.
> 
> **Server — DPoP (#427):** New `DpopError::Database` for JTI/nonce persistence failures; PAR, token, userinfo, and session handlers return **500 `server_error`** instead of treating DB faults as `invalid_dpop_proof`.
> 
> **Server — SQLite (#429):** `is_retryable_code` masks numeric SQLite extended codes with `0xFF` so busy/locked contention (e.g. `517`) triggers existing DSQL retry logic.
> 
> **Server — IdP (#425):** `verify_id_token` uses `is_entra_host` / `is_google_host` (`Url` + `host_str`) instead of substring `.contains()` on issuer URLs, blocking lookalike domains for Entra `xms_edov` and Google `hd` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4412d66dcb646c15c0622ca34ea1ddb63e9ac30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->