### PR TITLE
refactor(server): denormalize hardware_aaguid and org_domain into session

### DIFF
--- a/crates/vouch-server/src/db/documents/session.rs
+++ b/crates/vouch-server/src/db/documents/session.rs
@@ -19,8 +19,9 @@ pub enum SessionPurpose {
 
 /// An authenticated session (DPoP-bound access token).
 ///
-/// Denormalized: includes `user_email` to avoid a JOIN back to
-/// the user document.
+/// Denormalized: includes `user_email`, `hardware_aaguid`, and `org_domain` to
+/// avoid lookups (and to capture the session-time snapshot of the federation
+/// claims) when issuing tokens.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionDoc {
     pub user_id: String,
@@ -32,6 +33,15 @@ pub struct SessionDoc {
     /// RFC 9396: Rich authorization details (JSON array).
     #[serde(default)]
     pub authorization_details: Option<Value>,
+    /// AAGUID of the authenticator that established this session.
+    ///
+    /// Captured at session creation so claims reflect "what was true when this
+    /// session was created" rather than the user's current authenticator state.
+    #[serde(default)]
+    pub hardware_aaguid: Option<String>,
+    /// Organization domain (`hd` claim) at session creation time.
+    #[serde(default)]
+    pub org_domain: Option<String>,
 }
 
 impl DocumentType for SessionDoc {
@@ -59,5 +69,56 @@ impl DocumentType for SessionDoc {
 
     fn expires_at(&self) -> Option<Timestamp> {
         Some(self.expires_at)
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
+mod tests {
+    use super::*;
+
+    /// Pre-deployment session records do not have `hardware_aaguid` or
+    /// `org_domain`. They must deserialize as `None` so old sessions continue
+    /// to work without a backfill migration.
+    #[test]
+    fn deserializes_legacy_session_without_new_fields() {
+        let legacy = r#"{
+            "user_id": "u-1",
+            "user_email": "a@example.com",
+            "token_hash": "h",
+            "authenticator_id": "auth-1",
+            "session_type": "oauth_access_token",
+            "expires_at": "2099-01-01T00:00:00Z"
+        }"#;
+        let doc: SessionDoc = serde_json::from_str(legacy).expect("parse legacy session");
+        assert!(doc.hardware_aaguid.is_none());
+        assert!(doc.org_domain.is_none());
+        assert!(doc.authorization_details.is_none());
+    }
+
+    /// The denormalized fields survive a serde roundtrip on new sessions.
+    #[test]
+    fn roundtrips_denormalized_fields() {
+        let doc = SessionDoc {
+            user_id: "u-1".to_string(),
+            user_email: "a@example.com".to_string(),
+            token_hash: "h".to_string(),
+            authenticator_id: Some("auth-1".to_string()),
+            session_type: SessionPurpose::OAuthAccessToken,
+            expires_at: "2099-01-01T00:00:00Z".parse().expect("parse timestamp"),
+            authorization_details: None,
+            hardware_aaguid: Some("ee882879-721c-4913-9775-3dfcce97072a".to_string()),
+            org_domain: Some("example.com".to_string()),
+        };
+        let json = serde_json::to_string(&doc).expect("serialize");
+        let back: SessionDoc = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(
+            back.hardware_aaguid.as_deref(),
+            Some("ee882879-721c-4913-9775-3dfcce97072a")
+        );
+        assert_eq!(back.org_domain.as_deref(), Some("example.com"));
     }
 }

--- a/crates/vouch-server/src/db/organizations.rs
+++ b/crates/vouch-server/src/db/organizations.rs
@@ -1758,6 +1758,8 @@ mod tests {
             session_type: SessionPurpose::OAuthAccessToken,
             expires_at: in_one_hour,
             authorization_details: None,
+            hardware_aaguid: None,
+            org_domain: None,
         };
         store
             .insert(&mk_session(

--- a/crates/vouch-server/src/db/sessions.rs
+++ b/crates/vouch-server/src/db/sessions.rs
@@ -27,6 +27,10 @@ pub struct Session {
     pub session_type: SessionPurpose,
     /// RFC 9396: Rich authorization details (JSON array).
     pub authorization_details: Option<serde_json::Value>,
+    /// AAGUID of the authenticator that established this session (snapshot).
+    pub hardware_aaguid: Option<String>,
+    /// Organization domain (`hd` claim) at session creation time (snapshot).
+    pub org_domain: Option<String>,
 }
 
 impl From<Document<SessionDoc>> for Session {
@@ -41,6 +45,8 @@ impl From<Document<SessionDoc>> for Session {
             created_at: doc.created_at,
             session_type: doc.data.session_type,
             authorization_details: doc.data.authorization_details,
+            hardware_aaguid: doc.data.hardware_aaguid,
+            org_domain: doc.data.org_domain,
         }
     }
 }
@@ -63,6 +69,8 @@ pub async fn create_session(
     expires_at: Timestamp,
     session_type: SessionPurpose,
     authorization_details: Option<&serde_json::Value>,
+    hardware_aaguid: Option<&str>,
+    org_domain: Option<&str>,
 ) -> Result<String> {
     let doc = SessionDoc {
         user_id: user_id.to_string(),
@@ -72,6 +80,8 @@ pub async fn create_session(
         session_type,
         expires_at,
         authorization_details: authorization_details.cloned(),
+        hardware_aaguid: hardware_aaguid.map(String::from),
+        org_domain: org_domain.map(String::from),
     };
     let result = store.insert(&doc).await?;
     Ok(result.id)
@@ -291,6 +301,8 @@ mod tests {
             created_at: Timestamp::now(),
             session_type: SessionPurpose::OAuthAccessToken,
             authorization_details: None,
+            hardware_aaguid: None,
+            org_domain: None,
         }
     }
 

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -140,6 +140,8 @@ async fn test_session_lifecycle() {
         "2099-12-31T23:59:59Z".parse().unwrap(),
         SessionPurpose::OAuthAccessToken,
         None,
+        None,
+        None,
     )
     .await
     .expect("Failed to create session");
@@ -1339,6 +1341,8 @@ async fn test_scim_session_invalidation_on_deactivation() {
         "2099-12-31T23:59:59Z".parse().unwrap(),
         SessionPurpose::OAuthAccessToken,
         None,
+        None,
+        None,
     )
     .await
     .expect("Failed to create session");
@@ -1682,6 +1686,8 @@ async fn test_user_cascade_delete() {
         Some(&auth_id),
         "2099-12-31T23:59:59Z".parse().unwrap(),
         SessionPurpose::OAuthAccessToken,
+        None,
+        None,
         None,
     )
     .await

--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -671,6 +671,17 @@ pub(crate) async fn browser_login_complete(
     // Issue an OAuth access token (RFC 9068) — the server acts as both issuer and audience
     let client_id = state.config().base_url.clone();
     let auth_now = Timestamp::now();
+
+    // Snapshot org domain at session creation so the federation claims are a
+    // session-time snapshot rather than current-state lookups.
+    let org_domain = if let Some(ref org_id) = user.org_id {
+        db::get_organization_domain(&state.store, org_id)
+            .await
+            .unwrap_or(None)
+    } else {
+        None
+    };
+
     let session_result = create_oauth_access_token(
         &state,
         CreateOAuthTokenParams {
@@ -687,6 +698,8 @@ pub(crate) async fn browser_login_complete(
             hardware_verification: crate::services::auth::HardwareVerification::Verified,
             session_purpose: db::SessionPurpose::OAuthAccessToken,
             authorization_details: None,
+            hardware_aaguid: authenticator.aaguid.as_deref(),
+            org_domain: org_domain.as_deref(),
         },
         TokenIssuanceProof {
             grant: GrantProof::BrowserLogin(challenge_claim),

--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -673,11 +673,20 @@ pub(crate) async fn browser_login_complete(
     let auth_now = Timestamp::now();
 
     // Snapshot org domain at session creation so the federation claims are a
-    // session-time snapshot rather than current-state lookups.
+    // session-time snapshot rather than current-state lookups. Fail closed:
+    // the snapshot is captured exactly once, so silently dropping a transient
+    // DB error here would permanently degrade the session's `hd` claim.
     let org_domain = if let Some(ref org_id) = user.org_id {
         db::get_organization_domain(&state.store, org_id)
             .await
-            .unwrap_or(None)
+            .map_err(|e| {
+                tracing::error!("Failed to snapshot org domain: {e}");
+                ServiceError::api(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "db_error",
+                    "Failed to create session",
+                )
+            })?
     } else {
         None
     };

--- a/crates/vouch-server/src/handlers/certification.rs
+++ b/crates/vouch-server/src/handlers/certification.rs
@@ -148,6 +148,10 @@ pub(crate) async fn complete_login(
             hardware_verification: crate::services::auth::HardwareVerification::Verified,
             session_purpose: db::SessionPurpose::OAuthAccessToken,
             authorization_details: None,
+            // Cert user has no org and the cert authenticator AAGUID isn't
+            // exercised by conformance suites; omit both.
+            hardware_aaguid: None,
+            org_domain: None,
         },
         TokenIssuanceProof {
             grant: GrantProof::CertificationBypass,

--- a/crates/vouch-server/src/handlers/credentials.rs
+++ b/crates/vouch-server/src/handlers/credentials.rs
@@ -339,7 +339,18 @@ pub(crate) async fn get_aws_token(
     )
     .await?;
 
-    // Get user record once — extract both email and org_id
+    // Verify the session was hardware-verified. M2M and pre-FIDO2 bootstrap
+    // sessions have no `authenticator_id`; AWS federation requires hardware.
+    if token.authenticator_id.is_none() {
+        return Err(ServiceError::api(
+            StatusCode::FORBIDDEN,
+            "no_authenticator",
+            "Session does not have a security key - please register one first",
+        ));
+    }
+
+    // Confirm the user is still active. Email and federation claims come from
+    // the session snapshot, not from current state.
     let user = db::get_user_by_id(&state.store, &token.sub)
         .await
         .map_err(|e| {
@@ -364,47 +375,19 @@ pub(crate) async fn get_aws_token(
 
     let user_email = token.email.clone().unwrap_or_else(|| user.email.clone());
 
-    // Get user's organization domain (hd claim) if they belong to an org
-    let hd = if let Some(ref org_id) = user.org_id {
-        db::get_organization_domain(&state.store, org_id)
-            .await
-            .map_err(|e| {
-                tracing::error!("Failed to get organization domain: {e}");
-                ServiceError::api(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "db_error",
-                    "Internal database error",
-                )
-            })?
-    } else {
-        None
-    };
-
-    // Issue AWS token
+    // Issue AWS token using the session-time snapshot of aaguid and org domain.
     let config = state.config();
     let result = issue_aws_token(
-        &state.store,
         &config.base_url,
         config.session_hours,
         &state.oidc_key,
         &user_email,
-        token.authenticator_id.as_deref(),
-        hd,
+        token.hardware_aaguid.clone(),
+        token.org_domain.clone(),
         token.dpop_source.as_deref(),
     )
     .await
     .map_err(|e| match e {
-        AwsError::NoAuthenticator => {
-            ServiceError::api(StatusCode::FORBIDDEN, "no_authenticator", e.to_string())
-        }
-        AwsError::Database(ref err) => {
-            tracing::error!("AWS token database error: {err}");
-            ServiceError::api(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "db_error",
-                "Internal database error",
-            )
-        }
         AwsError::ClaimsBuild(ref err) => {
             tracing::error!("AWS token claims build error: {err}");
             ServiceError::api(

--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -316,19 +316,31 @@ pub(crate) async fn device_token(
             // The device auth request doesn't carry aaguid/org_domain, so look
             // them up once here. These reads happen at session creation and
             // eliminate per-issuance lookups for every downstream token.
+            //
+            // Fail closed on DB errors: the snapshot is captured exactly once,
+            // so silently dropping a transient failure would permanently
+            // degrade the federation claims for this session's whole lifetime.
+            let db_error = || {
+                oauth_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    OAuthError::invalid_grant(),
+                )
+            };
             let hardware_aaguid = db::get_authenticator_by_id(&state.store, &authenticator_id)
                 .await
-                .ok()
-                .flatten()
+                .map_err(|_| db_error())?
                 .and_then(|a| a.aaguid);
-            let org_domain = match db::get_user_by_id(&state.store, &user_id).await {
-                Ok(Some(u)) => match u.org_id {
+            let org_domain = match db::get_user_by_id(&state.store, &user_id)
+                .await
+                .map_err(|_| db_error())?
+            {
+                Some(u) => match u.org_id {
                     Some(org_id) => db::get_organization_domain(&state.store, &org_id)
                         .await
-                        .unwrap_or(None),
+                        .map_err(|_| db_error())?,
                     None => None,
                 },
-                _ => None,
+                None => None,
             };
 
             let session_result = create_oauth_access_token(

--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -313,6 +313,24 @@ pub(crate) async fn device_token(
                 .unwrap_or_else(|| state.config().base_url.clone());
             let now_secs = now.as_second();
 
+            // The device auth request doesn't carry aaguid/org_domain, so look
+            // them up once here. These reads happen at session creation and
+            // eliminate per-issuance lookups for every downstream token.
+            let hardware_aaguid = db::get_authenticator_by_id(&state.store, &authenticator_id)
+                .await
+                .ok()
+                .flatten()
+                .and_then(|a| a.aaguid);
+            let org_domain = match db::get_user_by_id(&state.store, &user_id).await {
+                Ok(Some(u)) => match u.org_id {
+                    Some(org_id) => db::get_organization_domain(&state.store, &org_id)
+                        .await
+                        .unwrap_or(None),
+                    None => None,
+                },
+                _ => None,
+            };
+
             let session_result = create_oauth_access_token(
                 &state,
                 CreateOAuthTokenParams {
@@ -329,6 +347,8 @@ pub(crate) async fn device_token(
                     hardware_verification: crate::services::auth::HardwareVerification::Verified,
                     session_purpose: crate::db::SessionPurpose::OAuthAccessToken,
                     authorization_details: None,
+                    hardware_aaguid: hardware_aaguid.as_deref(),
+                    org_domain: org_domain.as_deref(),
                 },
                 TokenIssuanceProof {
                     grant: GrantProof::DeviceCode(device_claim),

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -652,13 +652,23 @@ pub(crate) async fn complete_enrollment_after_identity(
     let hardware_aaguid = existing_authenticator.and_then(|a| a.aaguid.clone());
 
     // Snapshot org domain so the enrollment session carries the federation
-    // claims that match the user's state at this moment.
-    let org_domain = if let Some(ref org_id) = user.org_id {
-        db::get_organization_domain(&state.store, org_id)
-            .await
-            .unwrap_or(None)
-    } else {
-        None
+    // claims that match the user's state at this moment. Fail closed: the
+    // snapshot is captured exactly once, so silently dropping a transient
+    // DB error would permanently degrade this session's `hd` claim.
+    let org_domain = match user.org_id.as_deref() {
+        Some(org_id) => match db::get_organization_domain(&state.store, org_id).await {
+            Ok(domain) => domain,
+            Err(e) => {
+                tracing::error!("Failed to snapshot org domain: {}", e);
+                return ErrorTemplate {
+                    title: "Error".to_string(),
+                    message: "Failed to create session".to_string(),
+                    back_url: None,
+                }
+                .into_response();
+            }
+        },
+        None => None,
     };
 
     // Issue an OAuth access token for the enrollment session.
@@ -1368,15 +1378,28 @@ pub(crate) async fn browser_register_complete(
     let enroll_client_id = state.config().base_url.clone();
     let user_id_str = reg_state.user_id.to_string();
 
-    // Snapshot org domain for federation claims tied to this session.
-    let org_domain = match db::get_user_by_id(&state.store, &user_id_str).await {
-        Ok(Some(u)) => match u.org_id {
+    // Snapshot org domain for federation claims tied to this session. Fail
+    // closed: the snapshot is captured exactly once, so silently dropping a
+    // transient DB error would permanently degrade this session's `hd` claim.
+    let snapshot_error = |err: anyhow::Error| {
+        tracing::error!("Failed to snapshot org domain: {}", err);
+        ServiceError::api(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "db_error",
+            "Failed to create session",
+        )
+    };
+    let org_domain = match db::get_user_by_id(&state.store, &user_id_str)
+        .await
+        .map_err(snapshot_error)?
+    {
+        Some(u) => match u.org_id {
             Some(org_id) => db::get_organization_domain(&state.store, &org_id)
                 .await
-                .unwrap_or(None),
+                .map_err(snapshot_error)?,
             None => None,
         },
-        _ => None,
+        None => None,
     };
 
     let session_result = create_oauth_access_token(

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -647,7 +647,19 @@ pub(crate) async fn complete_enrollment_after_identity(
     let existing_auths = db::get_authenticators_for_user(&state.store, &user.id)
         .await
         .unwrap_or_default();
-    let authenticator_id = existing_auths.first().map(|a| a.id.clone());
+    let existing_authenticator = existing_auths.first();
+    let authenticator_id = existing_authenticator.map(|a| a.id.clone());
+    let hardware_aaguid = existing_authenticator.and_then(|a| a.aaguid.clone());
+
+    // Snapshot org domain so the enrollment session carries the federation
+    // claims that match the user's state at this moment.
+    let org_domain = if let Some(ref org_id) = user.org_id {
+        db::get_organization_domain(&state.store, org_id)
+            .await
+            .unwrap_or(None)
+    } else {
+        None
+    };
 
     // Issue an OAuth access token for the enrollment session.
     // This session is created after upstream IdP auth (OIDC/SAML) but BEFORE
@@ -670,6 +682,8 @@ pub(crate) async fn complete_enrollment_after_identity(
             hardware_verification: crate::services::auth::HardwareVerification::NotVerified,
             session_purpose: db::SessionPurpose::OAuthAccessToken,
             authorization_details: None,
+            hardware_aaguid: hardware_aaguid.as_deref(),
+            org_domain: org_domain.as_deref(),
         },
         TokenIssuanceProof {
             grant: GrantProof::EnrollmentBootstrap(oidc_state_claim),
@@ -1353,6 +1367,18 @@ pub(crate) async fn browser_register_complete(
     // Issue an OAuth access token (RFC 9068) — the server acts as both issuer and audience
     let enroll_client_id = state.config().base_url.clone();
     let user_id_str = reg_state.user_id.to_string();
+
+    // Snapshot org domain for federation claims tied to this session.
+    let org_domain = match db::get_user_by_id(&state.store, &user_id_str).await {
+        Ok(Some(u)) => match u.org_id {
+            Some(org_id) => db::get_organization_domain(&state.store, &org_id)
+                .await
+                .unwrap_or(None),
+            None => None,
+        },
+        _ => None,
+    };
+
     let session_result = create_oauth_access_token(
         &state,
         CreateOAuthTokenParams {
@@ -1369,6 +1395,8 @@ pub(crate) async fn browser_register_complete(
             hardware_verification: crate::services::auth::HardwareVerification::Verified,
             session_purpose: db::SessionPurpose::OAuthAccessToken,
             authorization_details: None,
+            hardware_aaguid: validated.aaguid.as_deref(),
+            org_domain: org_domain.as_deref(),
         },
         TokenIssuanceProof {
             grant: GrantProof::EnrollmentComplete(registration_claim),

--- a/crates/vouch-server/src/handlers/oidc/tests/oidc_userinfo.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/oidc_userinfo.rs
@@ -108,6 +108,8 @@ async fn test_userinfo_no_email_when_scope_is_none() {
             hardware_verification: HardwareVerification::Verified,
             session_purpose: db::SessionPurpose::OAuthAccessToken,
             authorization_details: None,
+            hardware_aaguid: None,
+            org_domain: None,
         },
         TokenIssuanceProof {
             grant: GrantProof::TestingOnly,

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc8693.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc8693.rs
@@ -1013,6 +1013,72 @@ async fn test_rfc8693_id_token_carries_hardware_aaguid() {
 }
 
 #[tokio::test]
+async fn test_rfc8693_id_token_uses_session_aaguid_after_rotation() {
+    // Regression for GH#431: the id_token must reflect the AAGUID captured at
+    // session creation, not the user's *current* authenticator. Otherwise, a
+    // user who rotates security keys retroactively invalidates the federation
+    // claims of every still-live session.
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "wif-rotation@example.com").await;
+    let original_aaguid = "ee882879-721c-4913-9775-3dfcce97072a";
+    let auth_id = crate::db::create_authenticator(
+        &state.store,
+        &user.id,
+        &user.email,
+        "YubiKey 5 (original)",
+        format!("cred-{}", uuid::Uuid::now_v7()).as_bytes(),
+        &[0u8; 32],
+        Some(original_aaguid),
+        Some(user.id.as_bytes()),
+        true,
+    )
+    .await
+    .expect("create original authenticator");
+
+    // Session captures the original AAGUID.
+    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+    let auth_header = client.basic_auth_header();
+
+    // Simulate the post-refactor invariant: the session-time snapshot survives
+    // even when the original authenticator is no longer present. (We bypass
+    // `delete_authenticator` because it cascades and removes the session
+    // along with the key — the snapshot is what makes the issued claim
+    // independent of *current* authenticator state at issuance time.)
+    state
+        .store
+        .delete(&auth_id)
+        .await
+        .expect("delete authenticator without cascade");
+
+    let (status, body) = http_post_form(
+        &app,
+        "/oauth/token",
+        &format!(
+            "grant_type=urn:ietf:params:oauth:grant-type:token-exchange\
+             &subject_token={token}\
+             &subject_token_type=urn:ietf:params:oauth:token-type:access_token\
+             &requested_token_type={ID_TOKEN_TYPE}"
+        ),
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "exchange should succeed: {body}");
+    let response: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let id_token = response["access_token"]
+        .as_str()
+        .expect("access_token present");
+    let claims = decode_jwt_payload(id_token);
+    assert_eq!(
+        claims["hardware_aaguid"], original_aaguid,
+        "ID token must reflect the AAGUID captured at session creation, \
+         not the user's current authenticator after rotation"
+    );
+}
+
+#[tokio::test]
 async fn test_rfc8693_id_token_carries_hd_for_org_user() {
     // A user in an organization gets the org's domain as the `hd` claim, so
     // relying parties can restrict federation to a corporate domain.

--- a/crates/vouch-server/src/handlers/session.rs
+++ b/crates/vouch-server/src/handlers/session.rs
@@ -71,6 +71,10 @@ pub(crate) struct ValidatedResourceToken {
     pub token_hash: String,
     /// AI coding agent identifier from DPoP proof custom claim (e.g., "claude-code").
     pub dpop_source: Option<String>,
+    /// AAGUID snapshot from the session record (federation claim).
+    pub hardware_aaguid: Option<String>,
+    /// Organization domain snapshot from the session record (`hd` claim).
+    pub org_domain: Option<String>,
 }
 
 /// Extract and validate an OAuth access token from the request.
@@ -238,18 +242,19 @@ pub(crate) async fn extract_resource_token(
         }
     }
 
-    // 5. Look up authenticator_id from DB session record
-    let authenticator_id = session.authenticator_id;
-
+    // 5. Surface the session-time federation snapshot (avoids per-request DB
+    //    lookups in handlers that need `hardware_aaguid` or `hd`).
     Ok(ValidatedResourceToken {
         sub: access_claims.sub,
         email: access_claims.email,
         client_id: access_claims.client_id,
         scope: access_claims.scope,
-        authenticator_id,
+        authenticator_id: session.authenticator_id,
         auth_time: access_claims.auth_time,
         token_hash,
         dpop_source,
+        hardware_aaguid: session.hardware_aaguid,
+        org_domain: session.org_domain,
     })
 }
 

--- a/crates/vouch-server/src/services/auth.rs
+++ b/crates/vouch-server/src/services/auth.rs
@@ -622,6 +622,11 @@ pub(crate) struct CreateOAuthTokenParams<'a> {
     pub session_purpose: SessionPurpose,
     /// RFC 9396: Rich authorization details (JSON array, stored in session).
     pub authorization_details: Option<&'a serde_json::Value>,
+    /// AAGUID of the authenticator establishing this session (snapshot for
+    /// federation claims). `None` for M2M and pre-FIDO2 enrollment sessions.
+    pub hardware_aaguid: Option<&'a str>,
+    /// Organization domain (`hd` claim) at session creation time.
+    pub org_domain: Option<&'a str>,
 }
 
 /// Result of creating a session token.
@@ -736,6 +741,8 @@ pub(crate) async fn create_oauth_access_token(
         expires,
         params.session_purpose,
         params.authorization_details,
+        params.hardware_aaguid,
+        params.org_domain,
     )
     .await
     .map_err(|e| ServiceError::Internal(format!("Failed to store session: {e}")))?;

--- a/crates/vouch-server/src/services/integrations/aws.rs
+++ b/crates/vouch-server/src/services/integrations/aws.rs
@@ -30,21 +30,12 @@
 //! }
 //! ```
 
-use crate::db::{self, Authenticator, store::DocumentStore};
 use crate::redact_email;
 use crate::services::oidc::{AwsSessionTags, OidcIdTokenClaimsBuilder, OidcSigningKey};
 
 /// Error types for AWS integration operations.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum AwsError {
-    /// User session does not have an associated authenticator.
-    #[error("Session does not have a security key - please register one first")]
-    NoAuthenticator,
-
-    /// Database error.
-    #[error("Database error: {0}")]
-    Database(#[from] anyhow::Error),
-
     /// Failed to build OIDC claims.
     #[error("Failed to build claims: {0}")]
     ClaimsBuild(String),
@@ -77,31 +68,22 @@ pub(crate) struct AwsTokenResult {
 /// - `hd`: Google Workspace hosted domain (for domain-based access control)
 ///
 /// # Arguments
-/// * `db` - Database pool
 /// * `base_url` - Server base URL (issuer)
 /// * `session_hours` - Session duration in hours
 /// * `oidc_key` - OIDC signing key
 /// * `user_email` - The authenticated user's email
-/// * `authenticator_id` - The authenticator ID from the session (for AAGUID lookup)
-/// * `hd` - The user's organization domain (Google Workspace hosted domain)
+/// * `hardware_aaguid` - AAGUID snapshot from the session record
+/// * `hd` - Organization domain snapshot from the session record
 /// * `source` - AI coding agent identifier (e.g., "claude-code", "cursor")
-#[expect(
-    clippy::too_many_arguments,
-    reason = "AWS STS AssumeRoleWithWebIdentity issuance requires full session context"
-)]
 pub(crate) async fn issue_aws_token(
-    store: &DocumentStore,
     base_url: &str,
     session_hours: u64,
     oidc_key: &OidcSigningKey,
     user_email: &str,
-    authenticator_id: Option<&str>,
+    hardware_aaguid: Option<String>,
     hd: Option<String>,
     source: Option<&str>,
 ) -> AwsResult<AwsTokenResult> {
-    // Get authenticator info for AAGUID
-    let authenticator = get_authenticator(store, authenticator_id).await?;
-
     // Token validity matches session duration
     let expires_in = session_hours.saturating_mul(3600);
 
@@ -139,7 +121,7 @@ pub(crate) async fn issue_aws_token(
     // Build OIDC claims
     // For AWS, the audience is the issuer URL (AWS matches against the OIDC provider)
     let id_claims = OidcIdTokenClaimsBuilder::for_aws(base_url, user_email)
-        .hardware_aaguid(authenticator.and_then(|a| a.aaguid))
+        .hardware_aaguid(hardware_aaguid)
         .hd(hd)
         .aws_tags(aws_tags)
         .valid_for_seconds(expires_in)
@@ -160,20 +142,6 @@ pub(crate) async fn issue_aws_token(
     })
 }
 
-/// Get authenticator info for AAGUID lookup.
-async fn get_authenticator(
-    store: &DocumentStore,
-    authenticator_id: Option<&str>,
-) -> AwsResult<Option<Authenticator>> {
-    let Some(id) = authenticator_id else {
-        return Err(AwsError::NoAuthenticator);
-    };
-
-    db::get_authenticator_by_id(store, id)
-        .await
-        .map_err(AwsError::Database)
-}
-
 #[cfg(test)]
 #[expect(
     clippy::expect_used,
@@ -182,55 +150,9 @@ async fn get_authenticator(
 )]
 mod tests {
     use super::*;
-    use crate::crypto::document_crypto::PlaintextDocumentCrypto;
-    use crate::db::{Pool, pool::PoolConfig, store::DocumentStore};
     use crate::services::oidc::OidcSigningKey;
     use base64::Engine;
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-    use std::sync::Arc;
-
-    /// Create an in-memory SQLite store with migrations for testing.
-    async fn test_store() -> DocumentStore {
-        let pool = Pool::connect("sqlite::memory:", &PoolConfig::default())
-            .await
-            .expect("Failed to create test database");
-
-        match &pool {
-            Pool::Sqlite(p) => sqlx::migrate!("./migrations/sqlite")
-                .run(p)
-                .await
-                .expect("Failed to run migrations"),
-            Pool::Postgres(p) => sqlx::migrate!("./migrations/postgres")
-                .run(p)
-                .await
-                .expect("Failed to run migrations"),
-        }
-
-        let crypto: Arc<dyn crate::crypto::document_crypto::DocumentCrypto> =
-            Arc::new(PlaintextDocumentCrypto);
-        DocumentStore::new(pool, crypto)
-    }
-
-    /// Create a user and authenticator in the store, returning the authenticator ID.
-    async fn create_test_user_and_authenticator(store: &DocumentStore, email: &str) -> String {
-        let (user_id, _) = db::upsert_user(store, email, None)
-            .await
-            .expect("Failed to create test user");
-
-        db::create_authenticator(
-            store,
-            &user_id,
-            email,
-            "Test Key",
-            b"test-credential-id",
-            &[0u8; 32],
-            None,
-            Some(user_id.as_bytes()),
-            false,
-        )
-        .await
-        .expect("Failed to create test authenticator")
-    }
 
     /// Decode a JWT payload (middle part) into a `serde_json::Value` without
     /// signature verification. Used only in tests to inspect claims.
@@ -243,29 +165,23 @@ mod tests {
         serde_json::from_slice(&payload_bytes).expect("Failed to parse JWT payload as JSON")
     }
 
-    // ── test helpers ──────────────────────────────────────────────────────────
-
     const BASE_URL: &str = "https://vouch.example.com";
     const SESSION_HOURS: u64 = 8;
     const USER_EMAIL: &str = "user@example.com";
-
-    // ── tests ─────────────────────────────────────────────────────────────────
+    const TEST_AAGUID: &str = "ee882879-721c-4913-9775-3dfcce97072a";
 
     /// Default tags present: `vouch:Email` is always included; `vouch:AccessType`
     /// and `vouch:Agent` must NOT be present when `source` is `None`.
     #[tokio::test]
     async fn test_default_tags_present_without_source() {
-        let store = test_store().await;
-        let auth_id = create_test_user_and_authenticator(&store, USER_EMAIL).await;
         let key = OidcSigningKey::generate().expect("Failed to generate OIDC key");
 
         let result = issue_aws_token(
-            &store,
             BASE_URL,
             SESSION_HOURS,
             &key,
             USER_EMAIL,
-            Some(&auth_id),
+            Some(TEST_AAGUID.to_string()),
             None,
             None, // no source
         )
@@ -295,17 +211,14 @@ mod tests {
     /// Domain tag: when `hd` is `Some`, `vouch:Domain` must be included.
     #[tokio::test]
     async fn test_domain_tag_included_when_hd_present() {
-        let store = test_store().await;
-        let auth_id = create_test_user_and_authenticator(&store, USER_EMAIL).await;
         let key = OidcSigningKey::generate().expect("Failed to generate OIDC key");
 
         let result = issue_aws_token(
-            &store,
             BASE_URL,
             SESSION_HOURS,
             &key,
             USER_EMAIL,
-            Some(&auth_id),
+            Some(TEST_AAGUID.to_string()),
             Some("example.com".to_string()),
             None,
         )
@@ -332,17 +245,14 @@ mod tests {
     /// and `vouch:Agent=<source>` must appear in `principal_tags`.
     #[tokio::test]
     async fn test_agent_tags_added_when_source_present() {
-        let store = test_store().await;
-        let auth_id = create_test_user_and_authenticator(&store, USER_EMAIL).await;
         let key = OidcSigningKey::generate().expect("Failed to generate OIDC key");
 
         let result = issue_aws_token(
-            &store,
             BASE_URL,
             SESSION_HOURS,
             &key,
             USER_EMAIL,
-            Some(&auth_id),
+            Some(TEST_AAGUID.to_string()),
             None,
             Some("claude-code"),
         )
@@ -374,17 +284,14 @@ mod tests {
     /// `vouch:AccessType` nor `vouch:Agent` may appear.
     #[tokio::test]
     async fn test_agent_tags_absent_without_source() {
-        let store = test_store().await;
-        let auth_id = create_test_user_and_authenticator(&store, USER_EMAIL).await;
         let key = OidcSigningKey::generate().expect("Failed to generate OIDC key");
 
         let result = issue_aws_token(
-            &store,
             BASE_URL,
             SESSION_HOURS,
             &key,
             USER_EMAIL,
-            Some(&auth_id),
+            Some(TEST_AAGUID.to_string()),
             Some("example.com".to_string()), // hd present, but no source
             None,
         )
@@ -409,17 +316,14 @@ mod tests {
     /// present in `principal_tags`.
     #[tokio::test]
     async fn test_all_tags_are_transitive() {
-        let store = test_store().await;
-        let auth_id = create_test_user_and_authenticator(&store, USER_EMAIL).await;
         let key = OidcSigningKey::generate().expect("Failed to generate OIDC key");
 
         let result = issue_aws_token(
-            &store,
             BASE_URL,
             SESSION_HOURS,
             &key,
             USER_EMAIL,
-            Some(&auth_id),
+            Some(TEST_AAGUID.to_string()),
             Some("example.com".to_string()),
             Some("cursor"),
         )
@@ -464,45 +368,17 @@ mod tests {
         }
     }
 
-    /// No-authenticator error: passing `authenticator_id = None` returns
-    /// `AwsError::NoAuthenticator` without touching the database.
-    #[tokio::test]
-    async fn test_no_authenticator_returns_error() {
-        let store = test_store().await;
-        let key = OidcSigningKey::generate().expect("Failed to generate OIDC key");
-
-        let result = issue_aws_token(
-            &store,
-            BASE_URL,
-            SESSION_HOURS,
-            &key,
-            USER_EMAIL,
-            None, // no authenticator
-            None,
-            None,
-        )
-        .await;
-
-        assert!(
-            matches!(result, Err(AwsError::NoAuthenticator)),
-            "expected NoAuthenticator error when authenticator_id is None, got: {result:?}"
-        );
-    }
-
     /// `expires_in` matches `session_hours * 3600`.
     #[tokio::test]
     async fn test_expires_in_matches_session_hours() {
-        let store = test_store().await;
-        let auth_id = create_test_user_and_authenticator(&store, USER_EMAIL).await;
         let key = OidcSigningKey::generate().expect("Failed to generate OIDC key");
 
         let result = issue_aws_token(
-            &store,
             BASE_URL,
             4, // 4 hours
             &key,
             USER_EMAIL,
-            Some(&auth_id),
+            Some(TEST_AAGUID.to_string()),
             None,
             None,
         )
@@ -513,6 +389,30 @@ mod tests {
             result.expires_in,
             4 * 3600,
             "expires_in must be session_hours * 3600"
+        );
+    }
+
+    /// AAGUID claim is present in the issued token when supplied.
+    #[tokio::test]
+    async fn test_hardware_aaguid_claim_is_emitted() {
+        let key = OidcSigningKey::generate().expect("Failed to generate OIDC key");
+
+        let result = issue_aws_token(
+            BASE_URL,
+            SESSION_HOURS,
+            &key,
+            USER_EMAIL,
+            Some(TEST_AAGUID.to_string()),
+            None,
+            None,
+        )
+        .await
+        .expect("issue_aws_token should succeed");
+
+        let claims = decode_jwt_payload(&result.id_token);
+        assert_eq!(
+            claims["hardware_aaguid"], TEST_AAGUID,
+            "hardware_aaguid claim must reflect the supplied snapshot"
         );
     }
 }

--- a/crates/vouch-server/src/services/oidc/client_credentials.rs
+++ b/crates/vouch-server/src/services/oidc/client_credentials.rs
@@ -86,6 +86,8 @@ pub(crate) async fn exchange_client_credentials(
             hardware_verification: crate::services::auth::HardwareVerification::NotVerified,
             session_purpose: SessionPurpose::M2MAccessToken,
             authorization_details: None,
+            hardware_aaguid: None,
+            org_domain: None,
         },
         proof,
     )

--- a/crates/vouch-server/src/services/oidc/exchange.rs
+++ b/crates/vouch-server/src/services/oidc/exchange.rs
@@ -363,12 +363,12 @@ pub(crate) async fn exchange_token(
             state,
             IdTokenContext {
                 user_id: &subject_session.user_id,
-                org_id: subject_user.org_id.as_deref(),
                 email: subject_email,
                 subject_token_hash: &subject_token_hash,
-                authenticator_id,
                 audience,
                 expires_in,
+                hardware_aaguid: subject_session.hardware_aaguid.as_deref(),
+                org_domain: subject_session.org_domain.as_deref(),
             },
         )
         .await;
@@ -430,6 +430,11 @@ pub(crate) async fn exchange_token(
             hardware_verification: subject_decoded.hardware_verification(),
             session_purpose: crate::db::SessionPurpose::OAuthAccessToken,
             authorization_details: effective_ad_value.as_ref(),
+            // Propagate the subject session's federation snapshot so the
+            // exchanged session reports the original authenticator/org even
+            // after the user rotates keys or changes orgs.
+            hardware_aaguid: subject_session.hardware_aaguid.as_deref(),
+            org_domain: subject_session.org_domain.as_deref(),
         },
         proof,
     )
@@ -494,18 +499,18 @@ pub(crate) async fn exchange_token(
 struct IdTokenContext<'a> {
     /// Subject user's ID, for the token-exchange audit record.
     user_id: &'a str,
-    /// Subject user's organization ID, for the `hd` claim lookup.
-    org_id: Option<&'a str>,
     /// Subject user's canonical email (`sub`/`email` claims).
     email: &'a str,
     /// Hash of the subject token, for the audit record.
     subject_token_hash: &'a str,
-    /// Authenticator backing the subject session (`hardware_aaguid` claim).
-    authenticator_id: Option<&'a str>,
     /// Requested audience (`aud` claim); falls back to the issuer URL.
     audience: Option<&'a str>,
     /// Lifetime ceiling in seconds, already capped by subject TTL and policy.
     expires_in: u64,
+    /// AAGUID snapshot from the subject session (`hardware_aaguid` claim).
+    hardware_aaguid: Option<&'a str>,
+    /// Organization domain snapshot from the subject session (`hd` claim).
+    org_domain: Option<&'a str>,
 }
 
 /// Mint a clean OIDC ID token (ES256) for an RFC 8693 exchange where the
@@ -522,31 +527,12 @@ async fn issue_id_token(
     let audience = ctx.audience.unwrap_or(&config.base_url);
     let expires_in = ctx.expires_in.min(DEFAULT_ID_TOKEN_EXPIRES_SECS);
 
-    // hardware_aaguid from the session's authenticator. Fail closed on DB
-    // error: a transient lookup failure must not silently downgrade the
-    // issued claim set. A stale `Ok(None)` (authenticator deleted after
-    // session creation) is still tolerated — the claim is simply omitted.
-    let hardware_aaguid = if let Some(auth_id) = ctx.authenticator_id {
-        db::get_authenticator_by_id(&state.store, auth_id)
-            .await
-            .map_err(|e| ServiceError::Internal(format!("Database error: {e}")))?
-            .and_then(|a| a.aaguid)
-    } else {
-        None
-    };
-
-    // hd claim from the user's organization domain, when they belong to one.
-    let hd = if let Some(org_id) = ctx.org_id {
-        db::get_organization_domain(&state.store, org_id)
-            .await
-            .map_err(|e| ServiceError::Internal(format!("Database error: {e}")))?
-    } else {
-        None
-    };
-
+    // `hardware_aaguid` and `hd` are session-time snapshots — they reflect the
+    // authenticator/org state at session creation and survive later rotations
+    // of the user's keys or organization membership.
     let claims = OidcIdTokenClaimsBuilder::for_audience(&config.base_url, ctx.email, audience)
-        .hardware_aaguid(hardware_aaguid)
-        .hd(hd)
+        .hardware_aaguid(ctx.hardware_aaguid.map(String::from))
+        .hd(ctx.org_domain.map(String::from))
         .valid_for_seconds(expires_in)
         .build()
         .map_err(|e| ServiceError::Internal(format!("Failed to build ID token claims: {e}")))?;

--- a/crates/vouch-server/src/services/oidc/fido2_grant.rs
+++ b/crates/vouch-server/src/services/oidc/fido2_grant.rs
@@ -313,6 +313,16 @@ pub(crate) async fn exchange_fido2_assertion(
     let dpop_jkt = params.dpop_proof.as_ref().map(|p| p.jkt.as_str());
     let now = jiff::Timestamp::now().as_second();
 
+    // Snapshot org domain at session creation so federation claims reflect
+    // the user's state at this moment, not whenever the token is issued.
+    let org_domain = if let Some(ref org_id) = user.org_id {
+        db::get_organization_domain(&state.store, org_id)
+            .await
+            .map_err(|e| ServiceError::Internal(format!("Failed to fetch org domain: {e}")))?
+    } else {
+        None
+    };
+
     // Build the chokepoint proof here: `GrantProof::Fido2Assertion` can
     // only be constructed by code that holds a `ChallengeStateClaim`,
     // produced above by `try_consume_challenge_state`.
@@ -336,6 +346,8 @@ pub(crate) async fn exchange_fido2_assertion(
             hardware_verification: crate::services::auth::HardwareVerification::Verified,
             session_purpose: db::SessionPurpose::OAuthAccessToken,
             authorization_details: ad_value.as_ref(),
+            hardware_aaguid: authenticator.aaguid.as_deref(),
+            org_domain: org_domain.as_deref(),
         },
         proof,
     )

--- a/crates/vouch-server/src/services/oidc/token.rs
+++ b/crates/vouch-server/src/services/oidc/token.rs
@@ -346,6 +346,16 @@ pub(crate) async fn exchange_authorization_code(
     )
     .await?;
 
+    // Snapshot org domain at session creation so federation claims survive
+    // later changes to the user's organization membership.
+    let org_domain = if let Some(ref org_id) = user.org_id {
+        db::get_organization_domain(&state.store, org_id)
+            .await
+            .map_err(|e| ServiceError::Internal(e.to_string()))?
+    } else {
+        None
+    };
+
     // Generate access token as an RFC 9068 JWT (ES256, verifiable via JWKS).
     // Build the chokepoint proof here: `GrantProof::AuthorizationCode` can
     // only be constructed by code that holds an AuthCodeClaim, which is
@@ -371,6 +381,8 @@ pub(crate) async fn exchange_authorization_code(
             hardware_verification: crate::services::auth::HardwareVerification::Verified,
             session_purpose: db::SessionPurpose::OAuthAccessToken,
             authorization_details: grants.authorization_details_value.as_ref(),
+            hardware_aaguid: auth_code.aaguid.as_deref(),
+            org_domain: org_domain.as_deref(),
         },
         proof,
     )

--- a/crates/vouch-server/src/test_utils.rs
+++ b/crates/vouch-server/src/test_utils.rs
@@ -513,6 +513,35 @@ pub async fn create_test_authenticator(store: &DocumentStore, user_id: &str) -> 
     .expect("Failed to create authenticator")
 }
 
+/// Resolve the session-time `hardware_aaguid` / `org_domain` snapshot the way
+/// production call sites do — by fetching the authenticator and the user's
+/// organization domain. Used by every test session helper so tests exercise
+/// the same denormalization path the server uses.
+async fn resolve_session_snapshot(
+    state: &AppState,
+    user_id: &str,
+    auth_id: Option<&str>,
+) -> (Option<String>, Option<String>) {
+    let hardware_aaguid = match auth_id {
+        Some(id) => crate::db::get_authenticator_by_id(&state.store, id)
+            .await
+            .ok()
+            .flatten()
+            .and_then(|a| a.aaguid),
+        None => None,
+    };
+    let org_domain = match crate::db::get_user_by_id(&state.store, user_id).await {
+        Ok(Some(u)) => match u.org_id {
+            Some(org_id) => crate::db::get_organization_domain(&state.store, &org_id)
+                .await
+                .unwrap_or(None),
+            None => None,
+        },
+        _ => None,
+    };
+    (hardware_aaguid, org_domain)
+}
+
 /// Create a test session with an OAuth access token stored in the database.
 ///
 /// Returns the raw access token string. Uses the real `create_oauth_access_token`
@@ -531,6 +560,9 @@ pub async fn create_test_session(
     use crate::services::oidc::ScopeSet;
     use secrecy::ExposeSecret;
 
+    let (hardware_aaguid, org_domain) =
+        resolve_session_snapshot(state, user_id, Some(auth_id)).await;
+
     let result = create_oauth_access_token(
         state,
         CreateOAuthTokenParams {
@@ -547,6 +579,8 @@ pub async fn create_test_session(
             hardware_verification: crate::services::auth::HardwareVerification::Verified,
             session_purpose: crate::db::SessionPurpose::OAuthAccessToken,
             authorization_details: None,
+            hardware_aaguid: hardware_aaguid.as_deref(),
+            org_domain: org_domain.as_deref(),
         },
         TokenIssuanceProof {
             grant: GrantProof::TestingOnly,
@@ -575,6 +609,8 @@ pub async fn create_test_bootstrap_session(state: &AppState, user_id: &str, emai
     use crate::services::oidc::ScopeSet;
     use secrecy::ExposeSecret;
 
+    let (_, org_domain) = resolve_session_snapshot(state, user_id, None).await;
+
     let result = create_oauth_access_token(
         state,
         CreateOAuthTokenParams {
@@ -591,6 +627,8 @@ pub async fn create_test_bootstrap_session(state: &AppState, user_id: &str, emai
             hardware_verification: crate::services::auth::HardwareVerification::NotVerified,
             session_purpose: crate::db::SessionPurpose::OAuthAccessToken,
             authorization_details: None,
+            hardware_aaguid: None,
+            org_domain: org_domain.as_deref(),
         },
         TokenIssuanceProof {
             grant: GrantProof::TestingOnly,
@@ -623,6 +661,9 @@ pub async fn create_test_session_with_iat(
     use crate::services::oidc::ScopeSet;
     use secrecy::ExposeSecret;
 
+    let (hardware_aaguid, org_domain) =
+        resolve_session_snapshot(state, user_id, Some(auth_id)).await;
+
     let result = create_oauth_access_token(
         state,
         CreateOAuthTokenParams {
@@ -639,6 +680,8 @@ pub async fn create_test_session_with_iat(
             hardware_verification: crate::services::auth::HardwareVerification::Verified,
             session_purpose: crate::db::SessionPurpose::OAuthAccessToken,
             authorization_details: None,
+            hardware_aaguid: hardware_aaguid.as_deref(),
+            org_domain: org_domain.as_deref(),
         },
         TokenIssuanceProof {
             grant: GrantProof::TestingOnly,
@@ -671,6 +714,9 @@ pub async fn create_test_session_for_client(
     use crate::services::oidc::ScopeSet;
     use secrecy::ExposeSecret;
 
+    let (hardware_aaguid, org_domain) =
+        resolve_session_snapshot(state, user_id, Some(auth_id)).await;
+
     let result = create_oauth_access_token(
         state,
         CreateOAuthTokenParams {
@@ -687,6 +733,8 @@ pub async fn create_test_session_for_client(
             hardware_verification: crate::services::auth::HardwareVerification::Verified,
             session_purpose: crate::db::SessionPurpose::OAuthAccessToken,
             authorization_details: None,
+            hardware_aaguid: hardware_aaguid.as_deref(),
+            org_domain: org_domain.as_deref(),
         },
         TokenIssuanceProof {
             grant: GrantProof::TestingOnly,
@@ -719,6 +767,9 @@ pub async fn create_test_session_with_dpop(
     use crate::services::oidc::ScopeSet;
     use secrecy::ExposeSecret;
 
+    let (hardware_aaguid, org_domain) =
+        resolve_session_snapshot(state, user_id, Some(auth_id)).await;
+
     let result = create_oauth_access_token(
         state,
         CreateOAuthTokenParams {
@@ -735,6 +786,8 @@ pub async fn create_test_session_with_dpop(
             hardware_verification: crate::services::auth::HardwareVerification::Verified,
             session_purpose: crate::db::SessionPurpose::OAuthAccessToken,
             authorization_details: None,
+            hardware_aaguid: hardware_aaguid.as_deref(),
+            org_domain: org_domain.as_deref(),
         },
         TokenIssuanceProof {
             grant: GrantProof::TestingOnly,
@@ -767,6 +820,9 @@ pub async fn create_test_session_with_mtls(
     use crate::services::oidc::ScopeSet;
     use secrecy::ExposeSecret;
 
+    let (hardware_aaguid, org_domain) =
+        resolve_session_snapshot(state, user_id, Some(auth_id)).await;
+
     let result = create_oauth_access_token(
         state,
         CreateOAuthTokenParams {
@@ -783,6 +839,8 @@ pub async fn create_test_session_with_mtls(
             hardware_verification: crate::services::auth::HardwareVerification::Verified,
             session_purpose: crate::db::SessionPurpose::OAuthAccessToken,
             authorization_details: None,
+            hardware_aaguid: hardware_aaguid.as_deref(),
+            org_domain: org_domain.as_deref(),
         },
         TokenIssuanceProof {
             grant: GrantProof::TestingOnly,


### PR DESCRIPTION
## Summary

- Capture `hardware_aaguid` and `org_domain` on `SessionDoc` at session creation; downstream token issuance reads them directly from the session instead of dereferencing the authenticator / organization on every issuance.
- Removes the fail-open/fail-closed inconsistency between `issue_id_token` (`services/oidc/exchange.rs`) and `issue_aws_token` (`services/integrations/aws.rs`).
- Gives federation claims a stronger semantic — an id_token issued from a given session reports the state at session creation, not whatever the user's account looks like at issuance time.

## What changed

- `SessionDoc` and `Session` gain `hardware_aaguid: Option<String>` and `org_domain: Option<String>` (with `#[serde(default)]` — old records deserialize as `None`, so no SQL migration).
- `CreateOAuthTokenParams` and `create_session` thread both fields through; populated at all nine production call sites: FIDO2 grant, auth code, RFC 8693 exchange, client credentials, enrollment bootstrap, enrollment complete, browser login, device authorization, and certification bypass.
- `issue_id_token` drops the `get_authenticator_by_id` + `get_organization_domain` lookups.
- `issue_aws_token` no longer takes a `DocumentStore`. The no-authenticator gate moves to the `get_aws_token` handler as a session check; the `get_authenticator` helper plus `NoAuthenticator` / `Database` error variants are removed.
- `ValidatedResourceToken` (`handlers/session.rs`) now surfaces both snapshot fields so resource handlers reuse the snapshot rather than re-resolving.
- Test helpers in `test_utils.rs` resolve the snapshot from the DB the same way production does, so existing tests keep working without per-test changes.

## Test plan

- [x] `make fmt`
- [x] `make lint` (clippy clean, `-D warnings`)
- [x] `make test` (2233 lib tests + integration suites, no failures)
- [x] New: `test_rfc8693_id_token_uses_session_aaguid_after_rotation` — the captured AAGUID survives deletion of the original authenticator.
- [x] New: `SessionDoc` serde roundtrip + legacy-record-deserializes-as-None tests.
- [x] New: `test_hardware_aaguid_claim_is_emitted` in the AWS token unit tests.

Closes #431.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how federation claims (`hardware_aaguid`, `hd`) are derived across OAuth exchange and AWS paths; behavior is intentional but security-sensitive and relies on correct population at every session-creation site.
> 
> **Overview**
> Sessions now **snapshot** `hardware_aaguid` and `org_domain` when they are created, and downstream issuance (RFC 8693 ID tokens, AWS federation, token exchange) reads those fields from the session instead of re-querying the authenticator or organization on every request.
> 
> **`create_session` / `CreateOAuthTokenParams`** thread the new fields through all production login and grant paths (FIDO2, auth code, browser/device/enroll, exchange, M2M, certification). **`ValidatedResourceToken`** exposes the snapshot so handlers like AWS credentials stop doing live `hd` / AAGUID lookups. **`issue_aws_token`** no longer needs a DB handle; the “must have a security key” check moves to the credentials handler.
> 
> Legacy session JSON without the new keys still deserializes as `None` (no SQL migration). Tests cover legacy serde, session AAGUID after key rotation (#431), and AWS claim emission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c5c79f1d2567f89dcadc48ad30edba7877e871c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->