### PR TITLE
Fix anthropic

### DIFF
--- a/crates/vouch-cli/src/commands/setup/anthropic.rs
+++ b/crates/vouch-cli/src/commands/setup/anthropic.rs
@@ -1,30 +1,27 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! `vouch setup anthropic` — persist Anthropic Workload Identity Federation
-//! parameters and auto-configure Claude Code's credential helper.
+//! parameters and tell the user how to launch Claude Code against them.
 //!
-//! Writes / merges `~/.claude/settings.json` to set:
+//! Earlier versions of this command wrote an `apiKeyHelper` entry into
+//! `~/.claude/settings.json` pointing at `vouch credential anthropic`. That
+//! is structurally broken for the `sk-ant-oat01-*` OAuth tokens vouch
+//! issues: Claude Code sends `apiKeyHelper` output as **both** the
+//! `X-Api-Key` and `Authorization: Bearer` headers, and the Anthropic API
+//! rejects OAuth tokens via `X-Api-Key`. The validated path is the
+//! `ANTHROPIC_AUTH_TOKEN` env var, which is sent only as the Bearer
+//! header.
 //!
-//! - `apiKeyHelper` → `<vouch> credential anthropic`
-//! - `env.CLAUDE_CODE_API_KEY_HELPER_TTL_MS` → `3000000` (~50 min — refreshes
-//!   before the ~1 h provider token expires)
-//!
-//! If Claude Code already has a different `apiKeyHelper`, the command errors
-//! and asks the user to either remove it or re-run with `--force`. This is
-//! deliberate: configuring Vouch for an AI provider is meant to be the
-//! workforce default, not silently merge with another helper.
+//! This command now only persists federation params to
+//! `~/.vouch/config.json` and, if a previous setup run left the broken
+//! `apiKeyHelper` + `CLAUDE_CODE_API_KEY_HELPER_TTL_MS` pair in
+//! `~/.claude/settings.json`, removes them. Any other settings the user
+//! has configured are left untouched.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 
 use crate::config::{AnthropicFederation, Config};
-use crate::install_path::resolve_install_path;
-
-/// Refresh interval injected into Claude Code's environment so the
-/// `apiKeyHelper` is actually re-invoked before the short-lived provider
-/// token expires. ~50 minutes is comfortably under the ~1 h Anthropic
-/// federation token lifetime.
-const HELPER_TTL_MS: &str = "3000000";
 
 /// Arguments captured by the clap `Anthropic` setup variant.
 pub(crate) struct SetupArgs<'a> {
@@ -34,30 +31,19 @@ pub(crate) struct SetupArgs<'a> {
     pub workspace_id: &'a str,
     pub audience: Option<&'a str>,
     pub token_endpoint: Option<&'a str>,
-    pub force: bool,
 }
 
 /// Run `vouch setup anthropic`.
 pub(crate) async fn run(args: SetupArgs<'_>) -> Result<()> {
-    // Confirm the user has actually enrolled before mutating anything —
-    // Config::load() succeeds on an empty file, so we have to check that a
-    // server context exists. Otherwise we'd happily write a wired
-    // apiKeyHelper for a machine that can't get a Vouch session, and the
-    // user would only discover the problem when Claude Code starts erroring.
+    // Confirm the user has actually enrolled before persisting federation
+    // params. Config::load() succeeds on an empty file, so we have to
+    // check that a server context exists.
     let config = Config::load().context("failed to load Vouch config")?;
     let _server = config
         .server_url()
         .context("not configured — run 'vouch enroll' first")?;
 
-    let vouch_path = resolve_install_path().display().to_string();
-    // `apiKeyHelper` is a shell command string executed via `/bin/sh`, so any
-    // path containing a space (or other shell-special character) must be
-    // POSIX-quoted to survive word-splitting.
-    let helper_command = format!("{} credential anthropic", posix_shell_quote(&vouch_path));
-
-    // Configure Claude Code FIRST so a conflict error doesn't leave the
-    // user with persisted Vouch state pointing at an unwired helper.
-    let settings_path = configure_claude_code(&helper_command, args.force)?;
+    let cleanup = remove_stale_claude_code_helper()?;
 
     let fed = AnthropicFederation {
         federation_rule_id: args.federation_rule_id.to_string(),
@@ -69,135 +55,138 @@ pub(crate) async fn run(args: SetupArgs<'_>) -> Result<()> {
     };
     Config::modify(move |c| c.set_ai_anthropic(fed))?;
 
-    print_success(&settings_path);
+    print_success(cleanup);
     Ok(())
 }
 
-/// Write/merge Claude Code's `~/.claude/settings.json`. Errors out if an
-/// existing `apiKeyHelper` differs from ours, unless `force` is set.
-fn configure_claude_code(helper_command: &str, force: bool) -> Result<PathBuf> {
+/// Outcome of inspecting `~/.claude/settings.json` for stale entries left
+/// by previous versions of this command.
+struct CleanupOutcome {
+    /// Path we inspected (returned even when nothing was removed, so the
+    /// success message can reference it).
+    settings_path: PathBuf,
+    /// True iff a stale `apiKeyHelper` or
+    /// `env.CLAUDE_CODE_API_KEY_HELPER_TTL_MS` was found and removed.
+    removed: bool,
+}
+
+/// Remove stale `apiKeyHelper` and `CLAUDE_CODE_API_KEY_HELPER_TTL_MS`
+/// entries from `~/.claude/settings.json` if present. Touches nothing else.
+fn remove_stale_claude_code_helper() -> Result<CleanupOutcome> {
     let home = dirs::home_dir().context("could not determine home directory")?;
     let settings_path = home.join(".claude").join("settings.json");
 
-    let mut settings: serde_json::Value = if settings_path.exists() {
-        let content = std::fs::read_to_string(&settings_path)
-            .with_context(|| format!("failed to read {}", settings_path.display()))?;
-        serde_json::from_str(&content)
-            .with_context(|| format!("failed to parse {}", settings_path.display()))?
-    } else {
-        serde_json::json!({})
-    };
-
-    // Conflict check: only error when an existing helper is configured AND
-    // it isn't the one we'd install. An exact match is idempotent.
-    if let Some(existing) = settings
-        .get("apiKeyHelper")
-        .and_then(serde_json::Value::as_str)
-        && existing != helper_command
-        && !force
-    {
-        anyhow::bail!(
-            "Claude Code already has an apiKeyHelper configured in {}:\n  \
-             {existing}\n\n\
-             Remove the `apiKeyHelper` entry from settings.json, or re-run \
-             `vouch setup anthropic --force` to overwrite it.",
-            settings_path.display(),
-        );
+    if !settings_path.exists() {
+        return Ok(CleanupOutcome {
+            settings_path,
+            removed: false,
+        });
     }
 
-    let obj = settings
-        .as_object_mut()
-        .context("~/.claude/settings.json root must be a JSON object")?;
-    obj.insert(
-        "apiKeyHelper".to_string(),
-        serde_json::Value::String(helper_command.to_string()),
-    );
+    let content = std::fs::read_to_string(&settings_path)
+        .with_context(|| format!("failed to read {}", settings_path.display()))?;
+    let mut settings: serde_json::Value = serde_json::from_str(&content)
+        .with_context(|| format!("failed to parse {}", settings_path.display()))?;
 
-    // Inject env.CLAUDE_CODE_API_KEY_HELPER_TTL_MS, preserving any other env
-    // vars the user has set. This is paired with apiKeyHelper and is
-    // overwritten without warning (the user wouldn't set it independently).
-    let env_entry = obj
-        .entry("env".to_string())
-        .or_insert_with(|| serde_json::json!({}));
-    let env_obj = env_entry
-        .as_object_mut()
-        .context("~/.claude/settings.json `env` must be a JSON object")?;
-    env_obj.insert(
-        "CLAUDE_CODE_API_KEY_HELPER_TTL_MS".to_string(),
-        serde_json::Value::String(HELPER_TTL_MS.to_string()),
-    );
+    let removed = strip_stale_keys(&mut settings);
+    if !removed {
+        return Ok(CleanupOutcome {
+            settings_path,
+            removed: false,
+        });
+    }
 
-    ensure_parent_dir(&settings_path)?;
     let json = serde_json::to_string_pretty(&settings)
         .context("failed to serialize Claude Code settings")?;
     crate::utils::atomic_write(&settings_path, json.as_bytes())
         .with_context(|| format!("failed to write {}", settings_path.display()))?;
 
-    Ok(settings_path)
+    Ok(CleanupOutcome {
+        settings_path,
+        removed: true,
+    })
 }
 
-/// POSIX-quote a string for safe embedding in a `/bin/sh` command line.
+/// The exact TTL value previous versions of this command wrote alongside
+/// `apiKeyHelper`. Used as a fingerprint when deciding whether the TTL
+/// env var is ours to remove.
+const STALE_HELPER_TTL_MS: &str = "3000000";
+
+/// Suffix that uniquely identifies an `apiKeyHelper` command vouch wrote.
+/// The leading path can vary (Homebrew, cargo-installed, etc.) and may be
+/// POSIX-quoted, but the trailing subcommand is always the same.
+const STALE_HELPER_SUFFIX: &str = " credential anthropic";
+
+/// Remove `apiKeyHelper` and `env.CLAUDE_CODE_API_KEY_HELPER_TTL_MS` from
+/// the given JSON value — but only when they look like values a previous
+/// `vouch setup anthropic` run wrote. A user-customized `apiKeyHelper`
+/// pointing at an unrelated tool is left alone.
 ///
-/// Returns the input unchanged when it contains only safe characters
-/// (`[A-Za-z0-9_\-./+:@]`). Otherwise wraps it in single quotes using the
-/// `'foo'\''bar'` idiom, which preserves every byte literally — there is no
-/// metacharacter that can survive single-quoting in POSIX shells, including
-/// spaces, `$`, backticks, `\`, and newlines.
-fn posix_shell_quote(s: &str) -> String {
-    let safe = !s.is_empty()
-        && s.chars().all(|c| {
-            c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '/' | '.' | '+' | ':' | '@')
-        });
-    if safe {
-        return s.to_string();
-    }
-    let mut out = String::with_capacity(s.len().saturating_add(2));
-    out.push('\'');
-    for c in s.chars() {
-        if c == '\'' {
-            out.push_str("'\\''");
-        } else {
-            out.push(c);
+/// The TTL env var is only removed when we also removed our own
+/// `apiKeyHelper` and the TTL value matches what we wrote. The TTL is a
+/// generic Claude Code knob; if vouch's helper is gone the user may want
+/// to keep it for a different helper they added later.
+///
+/// Operates on `serde_json::Value` so it can be exercised in unit tests
+/// without touching disk.
+fn strip_stale_keys(settings: &mut serde_json::Value) -> bool {
+    let Some(obj) = settings.as_object_mut() else {
+        return false;
+    };
+
+    let helper_is_ours = obj
+        .get("apiKeyHelper")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|s| s.ends_with(STALE_HELPER_SUFFIX));
+
+    let mut removed = false;
+    if helper_is_ours {
+        obj.remove("apiKeyHelper");
+        removed = true;
+
+        if let Some(env) = obj
+            .get_mut("env")
+            .and_then(serde_json::Value::as_object_mut)
+            && env
+                .get("CLAUDE_CODE_API_KEY_HELPER_TTL_MS")
+                .and_then(serde_json::Value::as_str)
+                == Some(STALE_HELPER_TTL_MS)
+        {
+            env.remove("CLAUDE_CODE_API_KEY_HELPER_TTL_MS");
         }
     }
-    out.push('\'');
-    out
+
+    removed
 }
 
-fn ensure_parent_dir(path: &Path) -> Result<()> {
-    if let Some(parent) = path.parent()
-        && !parent.exists()
-    {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create {}", parent.display()))?;
-    }
-    Ok(())
-}
-
-fn print_success(settings_path: &Path) {
+fn print_success(cleanup: CleanupOutcome) {
     println!("Anthropic (Claude) Workload Identity Federation configured.\n");
-    println!("  Federation params: ~/.vouch/config.json");
-    println!(
-        "  Claude Code helper: {} (apiKeyHelper + TTL env)\n",
-        settings_path.display()
-    );
+    println!("  Federation params: ~/.vouch/config.json\n");
+
+    if cleanup.removed {
+        println!(
+            "Cleaned up a previously-configured Claude Code apiKeyHelper from {}.",
+            cleanup.settings_path.display()
+        );
+        println!("(That config is incompatible with vouch's OAuth tokens — the Anthropic API");
+        println!(
+            "rejects sk-ant-oat01-* tokens via the X-Api-Key header that apiKeyHelper sets.)\n"
+        );
+    }
 
     println!("Get a token:");
     println!("  vouch login                 # YubiKey tap, once per session");
     println!("  vouch credential anthropic  # prints sk-ant-oat01-...\n");
 
-    println!("Ensure ANTHROPIC_API_KEY is UNSET in every environment Claude Code");
-    println!("runs in — it sits above the helper in the credential precedence chain");
-    println!("and will silently shadow federation.\n");
+    println!("Launch Claude Code with the token:");
+    println!("  ANTHROPIC_AUTH_TOKEN=$(vouch credential anthropic) claude\n");
 
-    println!("Smoke test:");
-    println!("  curl -sS https://api.anthropic.com/v1/messages \\");
-    println!("    -H \"authorization: Bearer $(vouch credential anthropic)\" \\");
-    println!("    -H \"anthropic-version: 2023-06-01\" \\");
-    println!("    -H \"content-type: application/json\" \\");
-    println!(
-        "    -d '{{\"model\":\"claude-sonnet-4-6\",\"max_tokens\":64,\"messages\":[{{\"role\":\"user\",\"content\":\"hi\"}}]}}'"
-    );
+    println!("The token is fixed for the Claude Code session. When it expires");
+    println!("(typically ~1 hour), restart Claude with the same command.\n");
+
+    println!("Ensure ANTHROPIC_API_KEY is UNSET in every environment Claude Code");
+    println!("runs in — it takes precedence over ANTHROPIC_AUTH_TOKEN and will");
+    println!("silently shadow federation.");
 }
 
 #[cfg(test)]
@@ -209,104 +198,123 @@ fn print_success(settings_path: &Path) {
 mod tests {
     use super::*;
 
-    /// Verify the JSON merge logic preserves unrelated keys and adds the
-    /// expected `apiKeyHelper` + `env.CLAUDE_CODE_API_KEY_HELPER_TTL_MS`
-    /// entries. Operates on an in-memory Value to avoid touching disk in
-    /// tests.
-    fn merge(existing: serde_json::Value, helper: &str) -> serde_json::Value {
-        let mut settings = existing;
-        let obj = settings.as_object_mut().expect("object");
-        obj.insert(
-            "apiKeyHelper".to_string(),
-            serde_json::Value::String(helper.to_string()),
-        );
-        let env = obj
-            .entry("env".to_string())
-            .or_insert_with(|| serde_json::json!({}));
-        env.as_object_mut().expect("env object").insert(
-            "CLAUDE_CODE_API_KEY_HELPER_TTL_MS".to_string(),
-            serde_json::Value::String(HELPER_TTL_MS.to_string()),
-        );
-        settings
-    }
-
     #[test]
-    fn test_posix_shell_quote_plain_path_unchanged() {
-        assert_eq!(
-            posix_shell_quote("/usr/local/bin/vouch"),
-            "/usr/local/bin/vouch"
-        );
-        assert_eq!(posix_shell_quote("vouch"), "vouch");
-        assert_eq!(
-            posix_shell_quote("/Users/jane/.cargo/bin/vouch"),
-            "/Users/jane/.cargo/bin/vouch"
-        );
-    }
-
-    /// The bug from review finding #8: a path containing a space must be
-    /// wrapped in single quotes so `/bin/sh` doesn't split it into multiple
-    /// arguments and report "command not found".
-    #[test]
-    fn test_posix_shell_quote_path_with_space() {
-        let quoted = posix_shell_quote("/Applications/Vouch Tools/vouch");
-        assert_eq!(quoted, "'/Applications/Vouch Tools/vouch'");
-    }
-
-    /// A literal `'` in the path is escaped using the POSIX
-    /// `'foo'\''bar'` idiom so single-quoting stays sound.
-    #[test]
-    fn test_posix_shell_quote_path_with_single_quote() {
-        let quoted = posix_shell_quote("/home/o'brien/vouch");
-        assert_eq!(quoted, "'/home/o'\\''brien/vouch'");
-    }
-
-    /// Other shell metacharacters that would survive double-quoting (`$`,
-    /// backtick, `\`) must also be neutralised. Single-quoting handles them
-    /// all.
-    #[test]
-    fn test_posix_shell_quote_path_with_metacharacters() {
-        assert_eq!(
-            posix_shell_quote("/tmp/$(rm -rf)/vouch"),
-            "'/tmp/$(rm -rf)/vouch'"
-        );
-        assert_eq!(
-            posix_shell_quote("/tmp/`whoami`/vouch"),
-            "'/tmp/`whoami`/vouch'"
-        );
-        assert_eq!(
-            posix_shell_quote("/tmp/\\evil/vouch"),
-            "'/tmp/\\evil/vouch'"
-        );
-    }
-
-    #[test]
-    fn test_posix_shell_quote_empty_string_is_quoted() {
-        assert_eq!(posix_shell_quote(""), "''");
-    }
-
-    #[test]
-    fn test_merge_preserves_unrelated_keys() {
-        let input = serde_json::json!({
+    fn strip_removes_vouch_helper_and_matching_ttl() {
+        let mut v = serde_json::json!({
+            "apiKeyHelper": "/usr/local/bin/vouch credential anthropic",
             "theme": "dark",
-            "permissions": { "allow": ["Read"] },
-            "env": { "FOO": "bar" }
+            "env": {
+                "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": "3000000",
+                "DISABLE_TELEMETRY": "1"
+            }
         });
-        let out = merge(input, "/usr/local/bin/vouch credential anthropic");
-        assert_eq!(out["theme"], "dark");
-        assert_eq!(out["permissions"]["allow"][0], "Read");
-        assert_eq!(out["env"]["FOO"], "bar");
-        assert_eq!(
-            out["apiKeyHelper"],
-            "/usr/local/bin/vouch credential anthropic"
-        );
-        assert_eq!(out["env"]["CLAUDE_CODE_API_KEY_HELPER_TTL_MS"], "3000000");
+        assert!(strip_stale_keys(&mut v));
+        assert!(v.get("apiKeyHelper").is_none());
+        assert_eq!(v["theme"], "dark");
+        let env = v["env"].as_object().expect("env object");
+        assert!(env.get("CLAUDE_CODE_API_KEY_HELPER_TTL_MS").is_none());
+        assert_eq!(env["DISABLE_TELEMETRY"], "1");
+    }
+
+    /// Helper paths can be POSIX-quoted (old code path-quoted any path
+    /// containing a space). The `credential anthropic` subcommand is the
+    /// stable suffix we match on.
+    #[test]
+    fn strip_removes_helper_with_quoted_path() {
+        let mut v = serde_json::json!({
+            "apiKeyHelper": "'/Applications/Vouch Tools/vouch' credential anthropic"
+        });
+        assert!(strip_stale_keys(&mut v));
+        assert!(v.get("apiKeyHelper").is_none());
+    }
+
+    /// A user's own `apiKeyHelper` pointing at an unrelated tool must be
+    /// preserved. This is the core "don't nuke user config" guarantee.
+    #[test]
+    fn strip_preserves_unrelated_helper() {
+        let mut v = serde_json::json!({
+            "apiKeyHelper": "/usr/local/bin/my-corporate-helper.sh"
+        });
+        let before = v.clone();
+        assert!(!strip_stale_keys(&mut v));
+        assert_eq!(v, before);
+    }
+
+    /// The trailing-subcommand match must be precise. A helper that
+    /// happens to *contain* "credential anthropic" mid-string (e.g., a
+    /// wrapper that calls it then does something else) is not ours.
+    #[test]
+    fn strip_preserves_helper_with_substring_only() {
+        let mut v = serde_json::json!({
+            "apiKeyHelper": "vouch credential anthropic | tee /tmp/log"
+        });
+        let before = v.clone();
+        assert!(!strip_stale_keys(&mut v));
+        assert_eq!(v, before);
+    }
+
+    /// If our helper is gone but the TTL was tweaked to a non-default
+    /// value, leave it — the user likely set it for a different helper.
+    #[test]
+    fn strip_preserves_ttl_with_custom_value() {
+        let mut v = serde_json::json!({
+            "apiKeyHelper": "/usr/local/bin/vouch credential anthropic",
+            "env": { "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": "60000" }
+        });
+        assert!(strip_stale_keys(&mut v));
+        assert!(v.get("apiKeyHelper").is_none());
+        assert_eq!(v["env"]["CLAUDE_CODE_API_KEY_HELPER_TTL_MS"], "60000");
+    }
+
+    /// TTL must not be touched when there's no vouch helper present, even
+    /// if its value matches what we'd write.
+    #[test]
+    fn strip_preserves_ttl_when_no_vouch_helper() {
+        let mut v = serde_json::json!({
+            "env": { "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": "3000000" }
+        });
+        let before = v.clone();
+        assert!(!strip_stale_keys(&mut v));
+        assert_eq!(v, before);
     }
 
     #[test]
-    fn test_merge_creates_env_object_when_missing() {
-        let input = serde_json::json!({});
-        let out = merge(input, "vouch credential anthropic");
-        assert!(out["env"].is_object());
-        assert_eq!(out["env"]["CLAUDE_CODE_API_KEY_HELPER_TTL_MS"], "3000000");
+    fn strip_is_noop_when_keys_absent() {
+        let mut v = serde_json::json!({
+            "theme": "dark",
+            "env": { "DISABLE_TELEMETRY": "1" }
+        });
+        let before = v.clone();
+        assert!(!strip_stale_keys(&mut v));
+        assert_eq!(v, before);
+    }
+
+    #[test]
+    fn strip_handles_non_object_root() {
+        let mut v = serde_json::json!([]);
+        assert!(!strip_stale_keys(&mut v));
+    }
+
+    /// A non-string `apiKeyHelper` value isn't ours (settings.json schema
+    /// has it as a string, but defensive against malformed input).
+    #[test]
+    fn strip_preserves_non_string_helper() {
+        let mut v = serde_json::json!({ "apiKeyHelper": 42 });
+        let before = v.clone();
+        assert!(!strip_stale_keys(&mut v));
+        assert_eq!(v, before);
+    }
+
+    /// Our helper removal must not fail when `env` is malformed — leave
+    /// the env value as-is in that case.
+    #[test]
+    fn strip_handles_non_object_env() {
+        let mut v = serde_json::json!({
+            "apiKeyHelper": "/usr/local/bin/vouch credential anthropic",
+            "env": "not-an-object"
+        });
+        assert!(strip_stale_keys(&mut v));
+        assert!(v.get("apiKeyHelper").is_none());
+        assert_eq!(v["env"], "not-an-object");
     }
 }

--- a/crates/vouch-cli/src/commands/setup/mod.rs
+++ b/crates/vouch-cli/src/commands/setup/mod.rs
@@ -133,13 +133,11 @@ pub(crate) enum SetupCommands {
     },
     /// Configure Anthropic (Claude) Workload Identity Federation.
     ///
-    /// Persists federation parameters to `~/.vouch/config.json` AND
-    /// auto-configures Claude Code's `apiKeyHelper` in
-    /// `~/.claude/settings.json` to call `vouch credential anthropic`,
-    /// with the matching `CLAUDE_CODE_API_KEY_HELPER_TTL_MS` env var.
-    ///
-    /// If Claude Code already has a different `apiKeyHelper`, the
-    /// command errors — pass `--force` to overwrite.
+    /// Persists federation parameters to `~/.vouch/config.json` and
+    /// prints the launch command for Claude Code. Earlier versions
+    /// wrote an `apiKeyHelper` entry into `~/.claude/settings.json`;
+    /// that is incompatible with vouch's OAuth tokens and is removed
+    /// on re-run if present.
     Anthropic {
         /// Anthropic federation rule ID (`fdrl_...`).
         #[arg(long)]
@@ -159,9 +157,6 @@ pub(crate) enum SetupCommands {
         /// Token endpoint override (defaults to Anthropic's public endpoint).
         #[arg(long)]
         token_endpoint: Option<String>,
-        /// Overwrite an existing Claude Code `apiKeyHelper` configuration.
-        #[arg(long)]
-        force: bool,
     },
     /// Configure OpenAI Workload Identity Federation.
     ///

--- a/crates/vouch-cli/src/main.rs
+++ b/crates/vouch-cli/src/main.rs
@@ -751,7 +751,6 @@ async fn run() -> Result<()> {
                 workspace_id,
                 audience,
                 token_endpoint,
-                force,
             } => {
                 commands::setup::anthropic::run(commands::setup::anthropic::SetupArgs {
                     federation_rule_id: &federation_rule_id,
@@ -760,7 +759,6 @@ async fn run() -> Result<()> {
                     workspace_id: &workspace_id,
                     audience: audience.as_deref(),
                     token_endpoint: token_endpoint.as_deref(),
-                    force,
                 })
                 .await
             }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how developers authenticate Claude to Anthropic and mutates ~/.claude/settings.json on upgrade paths; incorrect fingerprinting could leave broken config or remove the wrong helper, though tests constrain removal to vouch-specific patterns.
> 
> **Overview**
> **`vouch setup anthropic`** no longer writes Claude Code’s `apiKeyHelper` / `CLAUDE_CODE_API_KEY_HELPER_TTL_MS` into `~/.claude/settings.json`. Vouch’s `sk-ant-oat01-*` OAuth tokens are incompatible with that path because Claude sends helper output on both `X-Api-Key` and `Authorization: Bearer`, and Anthropic rejects OAuth on `X-Api-Key`. Setup now only saves federation settings to `~/.vouch/config.json` and documents launching Claude with **`ANTHROPIC_AUTH_TOKEN=$(vouch credential anthropic) claude`**.
> 
> On re-run, setup **selectively removes** prior vouch-written helper entries (matched by a ` credential anthropic` suffix and the old default TTL), leaving unrelated `apiKeyHelper` values and other settings intact. The **`--force`** flag and the old merge/overwrite/conflict logic for Claude settings are removed; unit tests now cover this cleanup behavior instead of JSON merge and shell quoting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c873359805e68cc123fb0da7b2f36f2ef2f90591. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->