### PR TITLE
refactor(common): remove orphaned ClientContext scaffolding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6056,7 +6056,6 @@ dependencies = [
  "base64 0.22.1",
  "ciborium",
  "dirs",
- "gethostname",
  "hex",
  "hickory-resolver",
  "jiff",

--- a/crates/vouch-common/Cargo.toml
+++ b/crates/vouch-common/Cargo.toml
@@ -13,7 +13,6 @@ anyhow = { workspace = true, features = ["std"] }
 base64 = { workspace = true, features = ["std"] }
 ciborium = { workspace = true }
 dirs = { workspace = true }
-gethostname = { workspace = true }
 hex = { workspace = true, features = ["std"] }
 hickory-resolver = { workspace = true, features = ["dnssec-aws-lc-rs", "https-aws-lc-rs", "tokio", "webpki-roots"] }
 jiff = { workspace = true, features = ["std", "serde", "tz-system"] }

--- a/crates/vouch-common/src/api.rs
+++ b/crates/vouch-common/src/api.rs
@@ -72,45 +72,6 @@ pub struct RegisterCompleteResponse {
     pub message: String,
 }
 
-// ============================================================================
-// Client Context (device/environment info sent with requests)
-// ============================================================================
-
-/// Context about the client environment, sent with authentication requests.
-/// This enables future anomaly detection (e.g., impossible travel, new device).
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct ClientContext {
-    /// CLI version (from `CARGO_PKG_VERSION`).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cli_version: Option<String>,
-    /// Operating system (e.g., "macos", "linux", "windows").
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub os: Option<String>,
-    /// OS version (e.g., "14.2.1").
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub os_version: Option<String>,
-    /// CPU architecture (e.g., "aarch64", "x86_64").
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub arch: Option<String>,
-    /// Client hostname.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub hostname: Option<String>,
-}
-
-impl ClientContext {
-    /// Create a new client context with current system information.
-    #[must_use]
-    pub fn current() -> Self {
-        Self {
-            cli_version: Some(env!("CARGO_PKG_VERSION").to_string()),
-            os: Some(std::env::consts::OS.to_string()),
-            os_version: None, // Filled in by CLI if available
-            arch: Some(std::env::consts::ARCH.to_string()),
-            hostname: gethostname::gethostname().to_str().map(String::from),
-        }
-    }
-}
-
 /// Response from `POST /oauth/fido2/challenge`.
 ///
 /// Used by the CLI login flow (FAPI 2.0 FIDO2 assertion grant).

--- a/crates/vouch-common/src/api_tests.rs
+++ b/crates/vouch-common/src/api_tests.rs
@@ -262,46 +262,6 @@ mod tests {
     }
 
     // =========================================================================
-    // Client Context Tests
-    // =========================================================================
-
-    #[test]
-    fn test_client_context_all_fields_none() {
-        let ctx = ClientContext {
-            cli_version: None,
-            os: None,
-            os_version: None,
-            arch: None,
-            hostname: None,
-        };
-        let json = serde_json::to_string(&ctx).unwrap();
-        let decoded: ClientContext = serde_json::from_str(&json).unwrap();
-        assert!(decoded.cli_version.is_none());
-        assert!(decoded.os.is_none());
-        assert!(decoded.os_version.is_none());
-        assert!(decoded.arch.is_none());
-        assert!(decoded.hostname.is_none());
-    }
-
-    #[test]
-    fn test_client_context_partial_fields() {
-        let ctx = ClientContext {
-            cli_version: Some("1.0.0".to_string()),
-            os: Some("linux".to_string()),
-            os_version: None,
-            arch: None,
-            hostname: Some("workstation".to_string()),
-        };
-        let json = serde_json::to_string(&ctx).unwrap();
-        let decoded: ClientContext = serde_json::from_str(&json).unwrap();
-        assert_eq!(decoded.cli_version.as_deref(), Some("1.0.0"));
-        assert_eq!(decoded.os.as_deref(), Some("linux"));
-        assert!(decoded.os_version.is_none());
-        assert!(decoded.arch.is_none());
-        assert_eq!(decoded.hostname.as_deref(), Some("workstation"));
-    }
-
-    // =========================================================================
     // Invalid JSON Format Tests
     // =========================================================================
 
@@ -342,19 +302,5 @@ mod tests {
         let decoded: RegisterStartResponse = serde_json::from_str(&json).unwrap();
         assert_eq!(decoded.rp_name, "テスト会社 🔐");
         assert_eq!(decoded.user_name, "用户@example.com");
-    }
-
-    #[test]
-    fn test_client_context_unicode_hostname() {
-        let ctx = ClientContext {
-            cli_version: Some("1.0.0".to_string()),
-            os: Some("macos".to_string()),
-            os_version: None,
-            arch: None,
-            hostname: Some("开发机-αβγ".to_string()), // Chinese + Greek
-        };
-        let json = serde_json::to_string(&ctx).unwrap();
-        let decoded: ClientContext = serde_json::from_str(&json).unwrap();
-        assert_eq!(decoded.hostname.as_deref(), Some("开发机-αβγ"));
     }
 }


### PR DESCRIPTION
## Half-baked code audit + cleanup

Follow-up to the removal of the dead delegation policy framework (#433). The question was: **is anything else half-baked we should decide to remove or complete?**

### Audit result: the codebase is clean — one real orphan

I swept `vouch-server`, `vouch-common`, shared API types, docs, and the wider workspace. Findings:

**Not half-baked (no action):**
- The delegation **policy framework** is already fully removed (#433) — no traces left.
- `vouch-httpsig` (RFC 9421, ~3,250 LoC) looks orphaned (not mentioned in CLAUDE.md) but is **fully wired**: CLI request signing (`vouch-cli/src/client.rs`) + server verification middleware (`vouch-server/src/infra/router.rs`). Its lone `todo!()` is just inside a doc-comment example.
- DPoP, step-up auth, device grant, RAR/posture, SCIM, dynamic client registration, JWT-bearer, PAR, protected-resource metadata — all implemented with test coverage.
- All `#[allow(dead_code)]` sites are justified (Askama template fields / GitHub-API response fields).

**The one genuine finding → removed: `ClientContext`** (`vouch-common/src/api.rs`)

A struct with a working `current()` method, documented as enabling "future anomaly detection (impossible travel, new device)," but:
- never constructed or sent by the CLI,
- never read or stored by the server,
- not referenced in docs,
- referenced only by its own unit tests.

It can be reintroduced when anomaly detection is actually built.

### Changes
- Remove `ClientContext` struct + `current()` from `vouch-common/src/api.rs`.
- Remove the three `client_context_*` tests from `api_tests.rs`.
- Drop the now-unused `gethostname` dependency from `vouch-common/Cargo.toml` and its `use gethostname as _;` marker in `lib.rs` (workspace entry + CLI usages unaffected).
- Reword a stale "Phase 1+ / TODOs below" module-doc note in `crates/vouch-tests/tests/proptest.rs` (the `Encoded<T, E>` coverage it promised already exists).

### Verification
- `grep -rn "ClientContext" crates/` → zero matches
- `cargo clippy --all-targets --all-features -- -D warnings` → clean
- `cargo test -p vouch-common` → passing
- `cargo check -p vouch-common -p vouch-cli -p vouch-server` → clean

https://claude.ai/code/session_01EX5CEenS5gL28AdWLy4yQU

---
_Generated by [Claude Code](https://claude.ai/code/session_01EX5CEenS5gL28AdWLy4yQU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead shared types and tests only; no runtime auth or API behavior changes.
> 
> **Overview**
> Removes unused **`ClientContext`** from `vouch-common` (struct, `current()`, and related serde tests)—it was never sent by the CLI or consumed by the server.
> 
> Also drops the **`gethostname`** dependency from **`vouch-common`** only; the CLI still uses it for HTTP headers and dynamic client registration naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bfddce356fec647a242f43164304a77ecd7cc9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->