### PR TITLE
chore: upgrade Rust toolchain 1.95 → 1.96

### DIFF
--- a/.kiro/steering/build-and-test.md
+++ b/.kiro/steering/build-and-test.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Rust 1.95+ (pinned in `rust-toolchain.toml`)
+- Rust 1.96+ (pinned in `rust-toolchain.toml`)
 - TailwindCSS v4 standalone CLI (not npm) for CSS compilation
 - Docker for container builds
 - System packages (Linux): `libssl-dev`, `libudev-dev`, `cmake`, `golang-go`, `clang`, `pkg-config`

--- a/.kiro/steering/project-overview.md
+++ b/.kiro/steering/project-overview.md
@@ -50,7 +50,7 @@ The data model is document-oriented by design:
 
 ## Toolchain
 
-- Rust 1.95.0, edition 2024 (pinned in `rust-toolchain.toml`)
+- Rust 1.96.0, edition 2024 (pinned in `rust-toolchain.toml`)
 - Max line width: 100 chars (`.rustfmt.toml`)
 - Release profile: `lto = true`, `codegen-units = 1`, `opt-level = "z"`, `panic = "abort"`, `strip = true`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ make docker-build
 make docker-run
 ```
 
-**Toolchain:** Rust 1.95.0, edition 2024 (pinned in `rust-toolchain.toml`). Max line width 100 chars (`.rustfmt.toml`). Release profile uses `lto = true`, `codegen-units = 1`, `opt-level = "z"`, `panic = "abort"`, `strip = true`.
+**Toolchain:** Rust 1.96.0, edition 2024 (pinned in `rust-toolchain.toml`). Max line width 100 chars (`.rustfmt.toml`). Release profile uses `lto = true`, `codegen-units = 1`, `opt-level = "z"`, `panic = "abort"`, `strip = true`.
 
 ## Code Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Be respectful and constructive. We're building security software — thoughtful 
 
 ### Prerequisites
 
-- **Rust** 1.95+ (install via [rustup](https://rustup.rs/), pinned in `rust-toolchain.toml`)
+- **Rust** 1.96+ (install via [rustup](https://rustup.rs/), pinned in `rust-toolchain.toml`)
 - **YubiKey 5 series** for testing FIDO2 flows (use a dedicated test key, not your primary)
 - **Docker** for building and running the server image
 - **TailwindCSS CLI** for CSS compilation (`make css-build`)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["crates/*"]
 version = "2026.5.4"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
-rust-version = "1.95.0"
+rust-version = "1.96.0"
 repository = "https://github.com/vouch-sh/vouch"
 
 [workspace.lints.rust]

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN cd crates/vouch-server \
     && /app/tailwindcss -i styles/input.css -o static/css/output.css --minify
 
 # cargo-chef base stage - shared between planner and builder
-FROM rust:1.95.0-alpine AS chef
+FROM rust:1.96.0-alpine AS chef
 RUN cargo install cargo-chef --locked
 WORKDIR /app
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -8,7 +8,7 @@
 # are recompiled when source changes — dependencies are cached as long as
 # Cargo.toml/Cargo.lock stay the same.
 
-FROM rust:1.95.0-alpine AS base
+FROM rust:1.96.0-alpine AS base
 RUN apk add --no-cache musl-dev pkgconfig cmake make go clang linux-headers \
     openssl-dev openssl-libs-static perl eudev-dev
 ENV AWS_LC_FIPS_SYS_CC=clang

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/vouch-sh/vouch/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/vouch-sh/vouch/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache--2.0%20OR%20MIT-blue)](LICENSE-APACHE)
-[![Rust](https://img.shields.io/badge/rust-1.95%2B-orange)](https://www.rust-lang.org)
+[![Rust](https://img.shields.io/badge/rust-1.96%2B-orange)](https://www.rust-lang.org)
 
 **Prove you're here.**
 
@@ -104,7 +104,7 @@ sudo apt install vouch
 # See https://packages.vouch.sh for repository setup
 sudo dnf install vouch
 
-# From source (requires Rust 1.95+)
+# From source (requires Rust 1.96+)
 cargo install --git https://github.com/vouch-sh/vouch vouch-cli
 ```
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

Bumps all Rust version references from `1.95` to `1.96` across the repository. This is a mechanical version-string update with no code-logic changes.

## Changes

| File | Change |
|------|--------|
| `rust-toolchain.toml` | `channel = "1.95.0"` → `"1.96.0"` |
| `Cargo.toml` | workspace `rust-version = "1.95.0"` → `"1.96.0"` |
| `Dockerfile` | `rust:1.95.0-alpine` → `rust:1.96.0-alpine` |
| `Dockerfile.build` | `rust:1.95.0-alpine` → `rust:1.96.0-alpine` |
| `README.md` | badge + "requires Rust 1.95+" → 1.96 |
| `CLAUDE.md` | toolchain note → 1.96.0 |
| `CONTRIBUTING.md` | prerequisites → 1.96+ |
| `.kiro/steering/project-overview.md` | toolchain → 1.96.0 |
| `.kiro/steering/build-and-test.md` | prerequisites → 1.96+ |

**Not changed:** `1.95` matches in `icons.rs`, `landing.html`, and `policy_icons.html` are SVG path coordinate data, unrelated to the Rust version.

## Verification

`grep -rn "1\.95" .` (excluding `target/`/`.git/`) returns only the three SVG false positives above.

https://claude.ai/code/session_01EhNYNW6qzZXR8cFQ7YBoSu

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhNYNW6qzZXR8cFQ7YBoSu)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-pin and documentation-only changes with no runtime or security logic modified; main risk is CI/local builds needing Rust 1.96.
> 
> **Overview**
> This PR **bumps the pinned Rust toolchain from 1.95 to 1.96** everywhere contributors and CI are told which compiler to use. There are **no application or library code changes**—only version strings.
> 
> **`rust-toolchain.toml`** and the workspace **`rust-version`** in **`Cargo.toml`** now require **1.96.0**. **Docker** build images move from **`rust:1.95.0-alpine`** to **`rust:1.96.0-alpine`** in both **`Dockerfile`** and **`Dockerfile.build`**.
> 
> Docs and onboarding text are updated in parallel: **`README.md`** (badge and “from source”), **`CONTRIBUTING.md`**, **`CLAUDE.md`**, and **`.kiro/steering/*`** prerequisites/overview. Unrelated **`1.95`** substrings in SVG paths are intentionally left alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24e2669b87b9f0ac4bbb2c34b023dc39b1be906f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->