### PR TITLE
docs: clarify air-gap support and platform requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ vouch init fish | source
 ## Requirements
 
 - **YubiKey 5 series** (firmware 5.2+) with FIDO2/WebAuthn support
-- **macOS** 12+ or **Linux** (glibc 2.31+) — Windows support is planned
+- **macOS** 12+, **Linux** (glibc 2.31+), or **Windows** 10+ for the CLI (FIDO2 via WebAuthn; `vouch-agent` daemon is macOS/Linux only)
 - For SSH: CA public key distributed to target hosts
 - For AWS: IAM role with OIDC federation configured
 - For EKS: Cluster with Access Entries configured for IAM role

--- a/docs/src/advanced/airgap-installation.md
+++ b/docs/src/advanced/airgap-installation.md
@@ -424,7 +424,7 @@ export VOUCH_CA_CERT=/etc/vouch/root-ca.crt
 
 ## Step 10: Enroll Users
 
-> **Important:** Enrollment requires browser access to the Vouch server's web UI on the internal network. CLI-only enrollment (`vouch enroll --airgap`) is not yet implemented.
+> **Important:** Enrollment requires browser access to the Vouch server's web UI on the internal network. Users run `vouch enroll` on a workstation that can open the device verification URL against the internal Vouch host; there is no separate headless-only enroll mode.
 
 Each user:
 

--- a/docs/src/advanced/airgap-operations.md
+++ b/docs/src/advanced/airgap-operations.md
@@ -117,7 +117,7 @@ Air-gapped environments still need audit trails for compliance.
 +-----------------+     +-------------+     +-----------------+
 ```
 
-Syslog export is planned but not yet implemented. Currently, use the periodic export method below.
+> **Roadmap:** Built-in syslog/SIEM forwarding from `vouch-server` is not implemented yet. Use the periodic export method below (or your database backup process — see [Backup and Recovery](../operations/backup-recovery.md)).
 
 ### Periodic Export
 

--- a/docs/src/advanced/airgap.md
+++ b/docs/src/advanced/airgap.md
@@ -2,7 +2,30 @@
 
 This chapter covers deploying Vouch in environments with no internet connectivity, such as defense contractors, government agencies, financial services, and critical infrastructure.
 
-> **Status: Planned** -- This document describes the air-gapped deployment architecture for Vouch. Server and CLI packages are available from [packages.vouch.sh](https://packages.vouch.sh), and the core components (SSH CA, FIDO2 authentication) exist today. However, air-gap-specific CLI commands (e.g., `vouch enroll --airgap`) and automation scripts are not yet implemented.
+> **Supported with operational constraints** — You can run `vouch-server` and the `vouch` CLI on an isolated network today using the same binaries and deployment paths as on-premise (systemd, Docker, or Kubernetes). This chapter documents that workflow. A few operator conveniences (listed under [Roadmap](#roadmap) below) are not built into the product yet.
+
+## Supported today
+
+| Capability | Where to read |
+|------------|----------------|
+| Server install (RPM/DEB, containers, Helm) | [Installation](airgap-installation.md), [Deployment Methods](../deployment/methods.md) |
+| Configuration, TLS, database, SSH CA | [Configuration Reference](../deployment/configuration.md) |
+| Internal OIDC or SAML IdP | [Identity Provider Overview](../idp/overview.md), [SAML 2.0](../idp/saml.md) |
+| Enrollment (YubiKey + browser on internal network) | [Installation](airgap-installation.md), [YubiKey Provisioning](airgap-yubikey.md) |
+| Key ceremony on a trusted workstation | [Key Ceremony](airgap-key-ceremony.md) |
+| Day-two ops (time sync, updates, audit export scripts) | [Operations](airgap-operations.md) |
+| Packages via sneakernet | [packages.vouch.sh](https://packages.vouch.sh) (download on a connected machine, transfer in) |
+
+Enrollment uses the standard `vouch enroll` device flow (browser opens the verification URL on your internal Vouch host) or browser-only `/enroll/start` on the server UI. There is no separate air-gap-only CLI mode.
+
+For general on-prem deployment (reachable IdP, standard updates), start with [Deployment Overview](../deployment/overview.md).
+
+## Roadmap
+
+These items are **not** available in the product today; the chapters above describe manual procedures instead:
+
+- **Server syslog / SIEM streaming** — use periodic database export in [Operations](airgap-operations.md#audit-log-export) until built-in export exists
+- **Headless enrollment** — enrollment without any browser on the internal network
 
 ## Overview
 


### PR DESCRIPTION
## Summary

- Replace the air-gap chapter "Status: Planned" banner with **supported today** vs **roadmap** (on-prem/isolated `vouch-server` works now; syslog/SIEM forwarding and headless enroll remain roadmap).
- Remove documentation of the non-existent `vouch enroll --airgap` flag; describe the real `vouch enroll` + internal browser flow.
- Clarify syslog/SIEM export is roadmap; point operators at periodic DB export and backup docs.
- Update README: Windows 10+ CLI (WebAuthn) is supported; `vouch-agent` remains macOS/Linux only.

## Test plan

- [x] `make docs-build`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security behavior impact.
> 
> **Overview**
> Documentation now states that **air-gapped / isolated** deployment is **supported today** for `vouch-server` and the `vouch` CLI (same on-prem paths), with a clear **roadmap** for syslog/SIEM streaming and fully headless enrollment.
> 
> The air-gap chapter drops the old “planned” framing and adds **Supported today** vs **Roadmap** tables, links to existing install/ops guides, and describes real enrollment via **`vouch enroll`** / internal browser UI—**not** a fictional `vouch enroll --airgap` flag. Syslog/SIEM is called out as **not built yet**, with pointers to periodic DB export and backup docs.
> 
> The **README** requirements line is updated: **Windows 10+** is listed for the CLI (FIDO2/WebAuthn), while **`vouch-agent`** stays **macOS/Linux only**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cacd61ab8cb8fcdbe50de7519cea7f188a05f792. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->