### PR TITLE
security: remediate P1 + P2 findings from security evaluation

### DIFF
--- a/SECURITY_EVALUATION.md
+++ b/SECURITY_EVALUATION.md
@@ -51,9 +51,19 @@ engineering throughout:
 
 ## Prioritized Remediation List
 
+> **Remediation status (update):** P1.1, P2.1, P2.2, P2.4, and P2.5 are
+> resolved, and P3.5 (audit trail for clone detection) is addressed as part of
+> P1.1. P2.3 was handled as **hardening only** (no activation guard): the
+> certification/conformance test mode runs over TLS with self-signed certs, so
+> gating it on `tls_configured()` — or a build flag — would break the very flow
+> it exists for; instead the test-mode switch now emits loud `warn`-level
+> security logs at startup and at router build, and its full blast radius
+> (login bypass, rate-limiting disabled, IdP requirement relaxed) is documented
+> at every touch point. P3.1–P3.4 remain open.
+
 ### P1 — High
 
-#### P1.1 WebAuthn signCount clone-detection bypass
+#### P1.1 WebAuthn signCount clone-detection bypass — RESOLVED
 
 `crates/vouch-server/src/crypto/webauthn_verify.rs:298`
 

--- a/crates/vouch-agent/src/server.rs
+++ b/crates/vouch-agent/src/server.rs
@@ -92,8 +92,20 @@ impl AgentServer {
                                     }
                                 }
                                 Err(e) => {
-                                    // Best-effort: allow connection if peer creds unavailable
-                                    debug!("Could not verify peer credentials: {e}");
+                                    // Fail closed: the 0600 socket mode is the
+                                    // primary gate, but the UID check is the
+                                    // defense-in-depth layer against permission
+                                    // misconfiguration. On Linux (SO_PEERCRED)
+                                    // and macOS (LOCAL_PEERCRED) retrieval
+                                    // failure is anomalous, not expected, so we
+                                    // reject rather than allow an unverified peer.
+                                    warn!("Rejecting IPC connection: could not verify peer credentials: {e}");
+                                    audit::log_event(AuditEvent::ConnectionRejected {
+                                        peer_uid: 0,
+                                        peer_pid: 0,
+                                        reason: "peer credential retrieval failed".to_string(),
+                                    });
+                                    continue;
                                 }
                             }
 

--- a/crates/vouch-server/src/config.rs
+++ b/crates/vouch-server/src/config.rs
@@ -465,8 +465,14 @@ pub struct Args {
     pub metrics_bearer_token: Option<String>,
 
     /// Secret token for the certification test-mode login endpoint.
-    /// When set, enables GET /certification/complete-login for automated OpenID conformance
-    /// testing. MUST NOT be set in production deployments.
+    ///
+    /// When set, this is a broad **test-mode switch** for automated OpenID
+    /// conformance testing, not just one route. It enables
+    /// `GET /certification/complete-login` (a login bypass that mints a session
+    /// for a synthetic test user without a FIDO2 key), **disables global rate
+    /// limiting**, and **relaxes the upstream-IdP requirement** (the server may
+    /// boot with no IdP). MUST NOT be set in production deployments — a leaked
+    /// or mistakenly set value enables a login-bypass-shaped endpoint.
     #[arg(long, env = "VOUCH_CERTIFICATION_TEST_TOKEN")]
     pub certification_test_token: Option<String>,
 

--- a/crates/vouch-server/src/crypto/webauthn_verify.rs
+++ b/crates/vouch-server/src/crypto/webauthn_verify.rs
@@ -195,6 +195,9 @@ struct ClientData {
 /// * `expected_origin` - The expected origin URL
 /// * `stored_counter` - The previously stored counter value
 /// * `require_user_verification` - Whether to require UV flag
+/// * `allow_localhost_origin` - Whether to tolerate loopback origin variations
+///   (development only; pass `false` in production so an origin mismatch is
+///   always rejected)
 #[expect(
     clippy::too_many_arguments,
     reason = "WebAuthn assertion verification requires all per-RFC parameters"
@@ -209,8 +212,9 @@ pub fn verify_assertion(
     expected_origin: &str,
     stored_counter: u32,
     require_user_verification: bool,
+    allow_localhost_origin: bool,
 ) -> Result<VerificationResult, VerifyError> {
-    verify_assertion_with_verifier(
+    verify_assertion_inner(
         authenticator_data,
         client_data_json,
         signature,
@@ -220,6 +224,7 @@ pub fn verify_assertion(
         expected_origin,
         stored_counter,
         require_user_verification,
+        allow_localhost_origin,
         &RealCoseVerifier,
     )
 }
@@ -240,6 +245,11 @@ pub fn verify_assertion(
 /// * `stored_counter` - The previously stored counter value
 /// * `require_user_verification` - Whether to require UV flag
 /// * `verifier` - The COSE verifier to use for signature verification
+///
+/// Localhost origin relaxation is always enabled in this helper, matching its
+/// historical dev/test behavior. Production callers go through
+/// [`verify_assertion`], which threads an explicit `allow_localhost_origin`
+/// flag derived from server config.
 #[expect(
     clippy::too_many_arguments,
     reason = "WebAuthn assertion verification requires all per-RFC parameters"
@@ -254,6 +264,45 @@ pub fn verify_assertion_with_verifier<V: CoseVerifier>(
     expected_origin: &str,
     stored_counter: u32,
     require_user_verification: bool,
+    verifier: &V,
+) -> Result<VerificationResult, VerifyError> {
+    verify_assertion_inner(
+        authenticator_data,
+        client_data_json,
+        signature,
+        public_key_cose,
+        expected_rp_id,
+        expected_challenge,
+        expected_origin,
+        stored_counter,
+        require_user_verification,
+        // Dev/test default: tolerate loopback origin variations.
+        true,
+        verifier,
+    )
+}
+
+/// Core WebAuthn assertion verification.
+///
+/// `allow_localhost_origin` gates the loopback origin-variation relaxation: it
+/// must be `true` only in development (no TLS). Production threads `false` so
+/// an origin mismatch is always rejected even on a misconfigured loopback
+/// `rp_id`.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "WebAuthn assertion verification requires all per-RFC parameters"
+)]
+fn verify_assertion_inner<V: CoseVerifier>(
+    authenticator_data: &[u8],
+    client_data_json: &[u8],
+    signature: &[u8],
+    public_key_cose: &[u8],
+    expected_rp_id: &str,
+    expected_challenge: &str,
+    expected_origin: &str,
+    stored_counter: u32,
+    require_user_verification: bool,
+    allow_localhost_origin: bool,
     verifier: &V,
 ) -> Result<VerificationResult, VerifyError> {
     // 1. Verify authenticator data structure
@@ -294,8 +343,20 @@ pub fn verify_assertion_with_verifier<V: CoseVerifier>(
         .map_err(|_| VerifyError::InvalidAuthDataLength)?;
     let counter = u32::from_be_bytes(counter_bytes);
 
-    // 5. Verify counter is increasing (if not zero - some authenticators don't use counters)
-    if counter != 0 && stored_counter != 0 && counter <= stored_counter {
+    // 5. Verify counter is increasing.
+    //
+    // Per WebAuthn Level 2 §6.1.1, a value of `authData.signCount <=
+    // storedSignCount` is a cloning signal whenever *either* value is nonzero.
+    // We therefore reject as soon as the *stored* counter is nonzero and the
+    // presented counter does not strictly increase — including a regression to
+    // zero. A credential that has ever reported a nonzero counter may never go
+    // backwards (YubiKeys always increment), so a zero arriving after a nonzero
+    // stored value is unambiguous evidence of cloning or forgery.
+    //
+    // Credentials that have only ever reported zero (counter-less
+    // authenticators, e.g. some CTAP1 devices) keep `stored_counter == 0` and
+    // remain accepted, preserving compatibility.
+    if stored_counter != 0 && counter <= stored_counter {
         return Err(VerifyError::CounterNotIncreasing);
     }
 
@@ -329,13 +390,15 @@ pub fn verify_assertion_with_verifier<V: CoseVerifier>(
             .ok()
             .and_then(|u| u.host_str().map(String::from))
             .is_some_and(|h| vouch_common::is_loopback_host(&h));
-        let is_localhost_match = expected_is_local && origin_is_local;
+        let is_localhost_match = allow_localhost_origin && expected_is_local && origin_is_local;
 
         if is_localhost_match {
-            tracing::debug!(
+            tracing::warn!(
+                target: "security",
                 expected = %expected_origin,
                 actual = %client_data.origin,
-                "Allowing localhost origin variation (development mode)"
+                "Allowing localhost origin variation (development mode) -- \
+                 this relaxation is disabled when TLS is configured"
             );
         } else {
             return Err(VerifyError::InvalidOrigin);
@@ -387,6 +450,7 @@ pub fn verify_assertion_typed(
     expected_origin: &str,
     stored_counter: u32,
     require_user_verification: bool,
+    allow_localhost_origin: bool,
 ) -> Result<VerificationResult, VerifyError> {
     verify_assertion(
         authenticator_data.as_bytes(),
@@ -398,6 +462,7 @@ pub fn verify_assertion_typed(
         expected_origin,
         stored_counter,
         require_user_verification,
+        allow_localhost_origin,
     )
 }
 
@@ -1779,6 +1844,93 @@ mod tests {
         );
         assert!(result.is_ok());
         assert_eq!(result.unwrap().counter, u32::MAX);
+    }
+
+    #[test]
+    fn test_counter_regression_to_zero_rejected() {
+        // A credential that previously reported a nonzero counter must never
+        // regress to zero: that is unambiguous evidence of a cloned or forged
+        // authenticator (WebAuthn L2 §6.1.1). Regression test for the
+        // clone-detection bypass where `counter == 0` skipped the check.
+        let verifier = TestCoseVerifier::always_succeed();
+        let rp_id = "example.com";
+        let auth_data = make_auth_data(rp_id, 0x05, 0); // counter regressed to 0
+        let client_data =
+            make_client_data_json("webauthn.get", "test-challenge", "https://example.com");
+        let cose_key = make_eddsa_cose_key(&[0u8; 32]);
+
+        let result = verify_assertion_with_verifier(
+            &auth_data,
+            &client_data,
+            &[0u8; 64],
+            &cose_key,
+            rp_id,
+            "test-challenge",
+            "https://example.com",
+            5, // stored counter was nonzero
+            false,
+            &verifier,
+        );
+        assert!(matches!(result, Err(VerifyError::CounterNotIncreasing)));
+    }
+
+    // =========================================================================
+    // Origin Relaxation Gating Tests (P2.2)
+    // =========================================================================
+
+    #[test]
+    fn test_localhost_origin_relaxation_allowed_when_enabled() {
+        // With relaxation enabled (development, no TLS), a loopback origin
+        // variation (localhost vs 127.0.0.1, differing ports) is tolerated.
+        let verifier = TestCoseVerifier::always_succeed();
+        let rp_id = "localhost";
+        let auth_data = make_auth_data(rp_id, 0x05, 1);
+        let client_data =
+            make_client_data_json("webauthn.get", "test-challenge", "http://127.0.0.1:9000");
+        let cose_key = make_eddsa_cose_key(&[0u8; 32]);
+
+        let result = verify_assertion_inner(
+            &auth_data,
+            &client_data,
+            &[0u8; 64],
+            &cose_key,
+            rp_id,
+            "test-challenge",
+            "http://localhost:8080",
+            0,
+            false,
+            true, // allow_localhost_origin
+            &verifier,
+        );
+        assert!(result.is_ok(), "expected ok, got {result:?}");
+    }
+
+    #[test]
+    fn test_localhost_origin_relaxation_rejected_when_disabled() {
+        // With relaxation disabled (production), the same loopback origin
+        // variation is rejected: production must never weaken origin binding,
+        // even on a misconfigured loopback rp_id.
+        let verifier = TestCoseVerifier::always_succeed();
+        let rp_id = "localhost";
+        let auth_data = make_auth_data(rp_id, 0x05, 1);
+        let client_data =
+            make_client_data_json("webauthn.get", "test-challenge", "http://127.0.0.1:9000");
+        let cose_key = make_eddsa_cose_key(&[0u8; 32]);
+
+        let result = verify_assertion_inner(
+            &auth_data,
+            &client_data,
+            &[0u8; 64],
+            &cose_key,
+            rp_id,
+            "test-challenge",
+            "http://localhost:8080",
+            0,
+            false,
+            false, // allow_localhost_origin disabled
+            &verifier,
+        );
+        assert!(matches!(result, Err(VerifyError::InvalidOrigin)));
     }
 
     // =========================================================================

--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -645,6 +645,8 @@ pub(crate) async fn browser_login_complete(
         expected_origin: state.config().base_url.clone(),
         challenge: auth_state.challenge.clone(),
         stored_counter,
+        // Tolerate loopback origin variations only in development (no TLS).
+        allow_localhost_origin: !state.config().tls_configured(),
     })
     .await
     .map_err(|e| {

--- a/crates/vouch-server/src/handlers/certification.rs
+++ b/crates/vouch-server/src/handlers/certification.rs
@@ -5,6 +5,14 @@
 //! the OpenID Foundation conformance suite at `certification.openid.net` drive
 //! the login flow without a physical FIDO2 key. Only registered when
 //! `VOUCH_CERTIFICATION_TEST_TOKEN` is set; **never enable in production**.
+//!
+//! Setting that token is a broad test-mode switch (see `config.rs` and
+//! `infra/router.rs`): besides this login bypass it also disables global rate
+//! limiting and relaxes the upstream-IdP requirement. A leaked or mistakenly
+//! set token in production therefore exposes a login-bypass-shaped endpoint.
+//! Activation is deliberately not gated on TLS because conformance runs over
+//! HTTPS with self-signed certs; the safeguards are operational discipline and
+//! the loud startup warnings.
 
 use std::sync::Arc;
 

--- a/crates/vouch-server/src/infra/router.rs
+++ b/crates/vouch-server/src/infra/router.rs
@@ -137,11 +137,19 @@ pub fn build_app(state: Arc<AppState>, config: &config::ServerConfig) -> anyhow:
 
     // Register the certification test-mode login endpoint when the secret token
     // is configured. This route MUST NOT be enabled in production deployments.
+    //
+    // Activation is intentionally NOT gated on TLS or any other config: the
+    // OpenID conformance suite drives this over HTTPS with self-signed certs,
+    // so a TLS-based guard would break the very flow it exists for. The guard
+    // is operational discipline plus the loud warning below.
     let certification_route = if let Some(ref _token) = config.certification_test_token {
         tracing::warn!(
-            "Certification test mode ENABLED — \
-             GET /certification/complete-login is active. \
-             Do NOT run this in production."
+            target: "security",
+            "CERTIFICATION TEST MODE ENABLED — this is a login bypass and MUST \
+             NOT run in production. It activates GET /certification/complete-login \
+             (mints a session for a synthetic test user without FIDO2), DISABLES \
+             global rate limiting, and relaxes the upstream-IdP requirement. \
+             Unset VOUCH_CERTIFICATION_TEST_TOKEN outside conformance testing."
         );
         Router::new()
             .route(

--- a/crates/vouch-server/src/infra/startup.rs
+++ b/crates/vouch-server/src/infra/startup.rs
@@ -144,13 +144,29 @@ pub async fn initialize(args: config::Args) -> Result<ServerComponents> {
         None => tracing::info!("CORS: same-origin only"),
     }
 
-    // Warn if rp_id is localhost but TLS is configured (likely production)
+    // Warn if rp_id is localhost but TLS is configured (likely a
+    // misconfiguration: a loopback rp_id in what looks like production).
+    // WebAuthn origin relaxation is now disabled whenever TLS is configured,
+    // so origin binding is NOT weakened here — but the loopback rp_id itself
+    // is almost certainly wrong for a TLS deployment.
     if vouch_common::is_loopback_host(&config.rp_id) && config.tls_configured() {
         tracing::warn!(
             target: "security",
-            "rp_id is '{}' but TLS is configured -- \
-             this allows WebAuthn origin relaxation in what appears to be a production deployment",
+            "rp_id is '{}' but TLS is configured -- this looks like a production \
+             deployment with a loopback relying-party ID, which is almost \
+             certainly a misconfiguration",
             config.rp_id,
+        );
+    }
+
+    // Loudly flag certification test mode at startup. This is a login-bypass
+    // switch (see router.rs) intended only for OpenID conformance testing.
+    if config.certification_test_token.is_some() {
+        tracing::warn!(
+            target: "security",
+            "CERTIFICATION TEST MODE is ENABLED (VOUCH_CERTIFICATION_TEST_TOKEN is \
+             set): login-bypass endpoint active, global rate limiting disabled, \
+             and the upstream-IdP requirement relaxed. MUST NOT be set in production."
         );
     }
 

--- a/crates/vouch-server/src/services/auth.rs
+++ b/crates/vouch-server/src/services/auth.rs
@@ -218,6 +218,10 @@ pub(crate) struct LoginAssertionParams {
     pub challenge: Vec<u8>,
     /// Current counter value from the database.
     pub stored_counter: u32,
+    /// Whether to tolerate loopback origin variations (development only).
+    /// Set to `false` whenever TLS is configured so a production deployment
+    /// never weakens origin binding, even with a loopback `rp_id`.
+    pub allow_localhost_origin: bool,
 }
 
 /// Result of WebAuthn assertion verification.
@@ -256,6 +260,7 @@ pub(crate) async fn verify_login_assertion(
             &params.expected_origin,
             params.stored_counter,
             true, // require_user_verification
+            params.allow_localhost_origin,
         )
         .map_err(|e| {
             ServiceError::oauth(
@@ -1123,6 +1128,8 @@ mod tests {
             expected_origin: expected_origin.to_string(),
             challenge,
             stored_counter: 0,
+            // Exact-match origins here; relaxation is irrelevant to this test.
+            allow_localhost_origin: false,
         };
 
         let err = verify_login_assertion(params)

--- a/crates/vouch-server/src/services/oidc/fido2_grant.rs
+++ b/crates/vouch-server/src/services/oidc/fido2_grant.rs
@@ -233,6 +233,9 @@ pub(crate) async fn exchange_fido2_assertion(
 
     // 6. Verify WebAuthn assertion
     let stored_counter = u32::try_from(authenticator.counter).unwrap_or(0);
+    // Cloned for the failure audit event below, since the success path moves
+    // `params.client_info` when it records the LoginSuccess event.
+    let failure_client_info = params.client_info.clone();
     let assertion_result = verify_login_assertion(LoginAssertionParams {
         authenticator_data: authenticator_data_bytes,
         client_data_json: client_data_json_bytes,
@@ -244,6 +247,8 @@ pub(crate) async fn exchange_fido2_assertion(
         expected_origin: format!("https://{}", challenge_state.rp_id),
         challenge: challenge_state.challenge.as_bytes().to_vec(),
         stored_counter,
+        // Tolerate loopback origin variations only in development (no TLS).
+        allow_localhost_origin: !state.config().tls_configured(),
     })
     .await
     .map_err(|e| {
@@ -251,6 +256,26 @@ pub(crate) async fn exchange_fido2_assertion(
             "FIDO2 assertion grant: assertion verification failed for user {}: {e}",
             user_id
         );
+        // P3.5: a failed assertion — including clone detection (counter
+        // regression) — is a high-signal security event. Record it in the
+        // audit trail with the credential and user IDs and the failure reason.
+        let failure_event = AuthEventParams {
+            user_id: user.id.clone(),
+            event_type: AuthEventType::LoginFailed,
+            authenticator_id: Some(authenticator.id.clone()),
+            success: false,
+            failure_reason: Some(e.to_string()),
+            ..AuthEventParams::default()
+        }
+        .with_client_info(failure_client_info);
+        let audit = state.audit.clone();
+        let user_email = user.email.clone();
+        tokio::spawn(async move {
+            if let Err(err) = db::insert_auth_event(&audit, &failure_event, Some(&user_email)).await
+            {
+                tracing::warn!("Failed to log auth event: {}", err);
+            }
+        });
         ServiceError::oauth(OAuthErrorCode::InvalidGrant, "Authentication failed")
     })?;
 

--- a/crates/vouch-server/static/js/common.js
+++ b/crates/vouch-server/static/js/common.js
@@ -10,9 +10,12 @@
 
             var text = btn.dataset.copyText;
             navigator.clipboard.writeText(text).then(function() {
-                // Capture innerHTML, not textContent — icon-only buttons (SVG
-                // children, no text) would otherwise be replaced by an empty
-                // string when restored.
+                // innerHTML is intentional and safe here: there is no
+                // user-controlled data in play. We capture innerHTML (not
+                // textContent) because icon-only buttons (SVG children, no
+                // text) would otherwise be wiped when restored, and we only
+                // ever write the hardcoded literal "Copied!". This is exempt
+                // from the structural-DOM migration applied elsewhere.
                 var original = btn.innerHTML;
                 btn.innerHTML = 'Copied!';
                 btn.classList.add('text-vouch-success');

--- a/crates/vouch-server/static/js/keys.js
+++ b/crates/vouch-server/static/js/keys.js
@@ -95,26 +95,86 @@
             document.getElementById('empty-state').classList.add('hidden');
             document.getElementById('keys-list').classList.remove('hidden');
 
+            // Build the list with DOM APIs (createElement/textContent) rather
+            // than innerHTML string concatenation, so user-controlled values
+            // (key name, device model) can never be interpreted as markup —
+            // escaping is structural, not dependent on a per-field escapeHtml().
             var container = document.getElementById('keys-items');
-            container.innerHTML = keysData.map(function(key) {
-                return '<div class="border border-vouch-border rounded-lg p-4 bg-vouch-surface" data-key-id="' + key.id + '">' +
-                    '<div class="flex items-start justify-between">' +
-                        '<div class="flex-1 min-w-0 mr-4">' +
-                            '<div class="flex items-center gap-2 mb-1">' +
-                                '<input type="text" class="key-name font-medium text-gray-200 bg-transparent border-b border-transparent hover:border-vouch-border focus:border-vouch-accent focus:outline-none transition-colors w-full" value="' + escapeHtml(key.name) + '" data-key-id="' + key.id + '" data-original="' + escapeHtml(key.name) + '" />' +
-                            '</div>' +
-                            '<div class="text-sm text-gray-500">' +
-                                (key.device_model ? '<span class="mr-3">' + escapeHtml(key.device_model) + '</span>' : '') +
-                                '<span>Added ' + formatDate(key.created_at) + '</span>' +
-                            '</div>' +
-                        '</div>' +
-                        '<button data-action="delete" data-key-id="' + key.id + '" data-key-name="' + escapeHtml(key.name) + '" class="text-gray-500 hover:text-vouch-error p-1' + (keysData.length <= 1 ? ' hidden' : '') + '" title="Delete key">' +
-                            '<svg class="w-5 h-5 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" /></svg>' +
-                        '</button>' +
-                    '</div>' +
-                '</div>';
-            }).join('');
+            container.replaceChildren();
+            keysData.forEach(function(key) {
+                container.appendChild(buildKeyItem(key));
+            });
         }
+    }
+
+    function buildKeyItem(key) {
+        var item = document.createElement('div');
+        item.className = 'border border-vouch-border rounded-lg p-4 bg-vouch-surface';
+        item.dataset.keyId = key.id;
+
+        var row = document.createElement('div');
+        row.className = 'flex items-start justify-between';
+
+        var info = document.createElement('div');
+        info.className = 'flex-1 min-w-0 mr-4';
+
+        var nameWrap = document.createElement('div');
+        nameWrap.className = 'flex items-center gap-2 mb-1';
+
+        var nameInput = document.createElement('input');
+        nameInput.type = 'text';
+        nameInput.className = 'key-name font-medium text-gray-200 bg-transparent border-b border-transparent hover:border-vouch-border focus:border-vouch-accent focus:outline-none transition-colors w-full';
+        // Assigning to .value sets the property, not parsed HTML — safe.
+        nameInput.value = key.name;
+        nameInput.dataset.keyId = key.id;
+        nameInput.dataset.original = key.name;
+        nameWrap.appendChild(nameInput);
+
+        var meta = document.createElement('div');
+        meta.className = 'text-sm text-gray-500';
+        if (key.device_model) {
+            var model = document.createElement('span');
+            model.className = 'mr-3';
+            model.textContent = key.device_model;
+            meta.appendChild(model);
+        }
+        var added = document.createElement('span');
+        added.textContent = 'Added ' + formatDate(key.created_at);
+        meta.appendChild(added);
+
+        info.appendChild(nameWrap);
+        info.appendChild(meta);
+
+        var delBtn = document.createElement('button');
+        delBtn.dataset.action = 'delete';
+        delBtn.dataset.keyId = key.id;
+        delBtn.dataset.keyName = key.name;
+        delBtn.className = 'text-gray-500 hover:text-vouch-error p-1' + (keysData.length <= 1 ? ' hidden' : '');
+        delBtn.title = 'Delete key';
+        delBtn.appendChild(makeDeleteIcon());
+
+        row.appendChild(info);
+        row.appendChild(delBtn);
+        item.appendChild(row);
+        return item;
+    }
+
+    // Build the trash/delete SVG icon. Static markup (no user data); created
+    // via the SVG namespace so it renders correctly as a DOM node.
+    function makeDeleteIcon() {
+        var ns = 'http://www.w3.org/2000/svg';
+        var svg = document.createElementNS(ns, 'svg');
+        svg.setAttribute('class', 'w-5 h-5 pointer-events-none');
+        svg.setAttribute('fill', 'none');
+        svg.setAttribute('stroke', 'currentColor');
+        svg.setAttribute('viewBox', '0 0 24 24');
+        var path = document.createElementNS(ns, 'path');
+        path.setAttribute('stroke-linecap', 'round');
+        path.setAttribute('stroke-linejoin', 'round');
+        path.setAttribute('stroke-width', '2');
+        path.setAttribute('d', 'M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16');
+        svg.appendChild(path);
+        return svg;
     }
 
     async function handleNameBlur(input) {

--- a/crates/vouch-server/static/js/tests-runner.js
+++ b/crates/vouch-server/static/js/tests-runner.js
@@ -11,33 +11,42 @@
         results.appendChild(el);
     }
 
-    function assert(description, condition) {
+    // Append a result row using DOM APIs (textContent), not innerHTML string
+    // building. `detailLines` is an optional array of extra lines.
+    function appendResult(pass, description, detailLines) {
         var el = document.createElement('div');
         el.className = 'test';
-        if (condition) {
-            el.innerHTML = '<span class="pass">PASS</span> ' + description;
-            passed++;
-        } else {
-            el.innerHTML = '<span class="fail">FAIL</span> ' + description;
-            failed++;
+        var status = document.createElement('span');
+        status.className = pass ? 'pass' : 'fail';
+        status.textContent = pass ? 'PASS' : 'FAIL';
+        el.appendChild(status);
+        el.appendChild(document.createTextNode(' ' + description));
+        if (detailLines) {
+            detailLines.forEach(function(line) {
+                el.appendChild(document.createElement('br'));
+                el.appendChild(document.createTextNode(line));
+            });
         }
         results.appendChild(el);
     }
 
+    function assert(description, condition) {
+        appendResult(condition, description);
+        if (condition) { passed++; } else { failed++; }
+    }
+
     function assertEqual(description, actual, expected) {
         var ok = actual === expected;
-        var el = document.createElement('div');
-        el.className = 'test';
         if (ok) {
-            el.innerHTML = '<span class="pass">PASS</span> ' + description;
+            appendResult(true, description);
             passed++;
         } else {
-            el.innerHTML = '<span class="fail">FAIL</span> ' + description +
-                '<br>       expected: ' + JSON.stringify(expected) +
-                '<br>       actual:   ' + JSON.stringify(actual);
+            appendResult(false, description, [
+                '       expected: ' + JSON.stringify(expected),
+                '       actual:   ' + JSON.stringify(actual)
+            ]);
             failed++;
         }
-        results.appendChild(el);
     }
 
     function assertArrayEqual(description, actual, expected) {
@@ -47,18 +56,16 @@
                 if (actual[i] !== expected[i]) { ok = false; break; }
             }
         }
-        var el = document.createElement('div');
-        el.className = 'test';
         if (ok) {
-            el.innerHTML = '<span class="pass">PASS</span> ' + description;
+            appendResult(true, description);
             passed++;
         } else {
-            el.innerHTML = '<span class="fail">FAIL</span> ' + description +
-                '<br>       expected: [' + Array.from(expected).join(', ') + ']' +
-                '<br>       actual:   [' + Array.from(actual).join(', ') + ']';
+            appendResult(false, description, [
+                '       expected: [' + Array.from(expected).join(', ') + ']',
+                '       actual:   [' + Array.from(actual).join(', ') + ']'
+            ]);
             failed++;
         }
-        results.appendChild(el);
     }
 
     // ================================================================
@@ -216,11 +223,15 @@
     // ================================================================
     var summary = document.createElement('div');
     summary.className = 'summary';
+    var summarySpan = document.createElement('span');
     if (failed === 0) {
-        summary.innerHTML = '<span class="pass">All ' + passed + ' tests passed.</span>';
+        summarySpan.className = 'pass';
+        summarySpan.textContent = 'All ' + passed + ' tests passed.';
     } else {
-        summary.innerHTML = '<span class="fail">' + failed + ' of ' + (passed + failed) + ' tests failed.</span>';
+        summarySpan.className = 'fail';
+        summarySpan.textContent = failed + ' of ' + (passed + failed) + ' tests failed.';
     }
+    summary.appendChild(summarySpan);
     results.appendChild(summary);
 
     document.title = (failed === 0 ? 'PASS' : 'FAIL') + ' — Vouch JS Unit Tests';

--- a/crates/vouch-tests/tests/negative_auth.rs
+++ b/crates/vouch-tests/tests/negative_auth.rs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! Negative-auth coverage for API routes (security evaluation P2.5).
+//!
+//! Individual handlers verify authentication correctly, but that is a
+//! per-handler property. This test turns "every handler looks right" into a
+//! mechanical, regression-proof invariant: it builds the full router and
+//! asserts that protected API routes reject unauthenticated requests with
+//! 401/403, while public routes never answer with an auth error.
+//!
+//! NOTE: axum's `Router` does not expose its route table for introspection, so
+//! the route lists below are *maintained by hand*. When you add a new
+//! authenticated API route, add it to `PROTECTED_ROUTES`. When you add a new
+//! public (no-auth) route, add it to `PUBLIC_ROUTES`. Keeping these lists
+//! current is what makes this a meaningful invariant for future routes.
+//!
+//! Scope: JSON/API routes with Bearer / HTTP-signature / JWT auth, which
+//! return 401/403. Cookie-session UI routes (e.g. `/admin/*`) redirect to
+//! `/login` instead of returning an auth status code, so they are out of
+//! scope here.
+
+use vouch_tests::TestHarness;
+
+/// Protected API routes: each must reject an unauthenticated request with
+/// 401 Unauthorized or 403 Forbidden.
+///
+/// These are probed with GET on purpose. POST routes (credential issuance,
+/// SCIM/application creation) deserialize a typed JSON body *before* the
+/// handler's token check, so an empty body returns 422 — which would mask the
+/// auth check rather than exercise it. The GET endpoints below cover every
+/// authenticated route group (`/v1/*`, `/api/v1/*`, `/scim/v2/*`), so missing
+/// auth surfaces cleanly as 401/403.
+const PROTECTED_ROUTES: &[&str] = &[
+    "/v1/keys",
+    "/v1/credentials/aws/token",
+    "/api/v1/applications",
+    "/api/v1/org/scim-tokens",
+    "/scim/v2/Users",
+    "/scim/v2/Groups",
+];
+
+/// Public routes: these must NOT answer with an auth error (401/403) when
+/// called without credentials. They may legitimately return 200/3xx/etc.
+///
+/// `/v1/auth/status` is deliberately public: with no/invalid token it returns
+/// `200 {"authenticated": false}` rather than 401, since it is a status probe.
+const PUBLIC_ROUTES: &[&str] = &[
+    "/health",
+    "/health/ready",
+    "/.well-known/openid-configuration",
+    "/.well-known/oauth-authorization-server",
+    "/oauth/jwks",
+    "/v1/credentials/ssh/ca",
+    "/v1/auth/status",
+];
+
+#[tokio::test]
+async fn protected_routes_reject_unauthenticated_requests() {
+    let harness = TestHarness::new().await;
+
+    for path in PROTECTED_ROUTES {
+        let response = harness
+            .get(path)
+            .await
+            .unwrap_or_else(|e| panic!("request to {path} failed to execute: {e}"));
+
+        assert!(
+            response.status == 401 || response.status == 403,
+            "{path} must reject unauthenticated requests with 401/403, got {}",
+            response.status
+        );
+    }
+}
+
+#[tokio::test]
+async fn public_routes_do_not_require_auth() {
+    let harness = TestHarness::new().await;
+
+    for path in PUBLIC_ROUTES {
+        let response = harness
+            .get(path)
+            .await
+            .unwrap_or_else(|e| panic!("request to {path} failed to execute: {e}"));
+
+        assert!(
+            response.status != 401 && response.status != 403,
+            "{path} is public and must not return an auth error, got {}",
+            response.status
+        );
+    }
+}


### PR DESCRIPTION
Addresses the P1 issue and all P2 issues from `SECURITY_EVALUATION.md`. P3.5 is folded into P1.1 (the audit event is part of doing P1.1 properly). P3.1–P3.4 remain out of scope.

## P1.1 + P3.5 — WebAuthn signCount clone-detection bypass
- **`crypto/webauthn_verify.rs`**: changed the counter guard from `counter != 0 && stored_counter != 0 && counter <= stored_counter` to `stored_counter != 0 && counter <= stored_counter`. A credential that has ever reported a nonzero counter may never regress — including to zero, which previously bypassed clone detection. Counter-less (always-zero) authenticators stay accepted.
- **`services/oidc/fido2_grant.rs`**: the FIDO2 grant path now records a `LoginFailed` audit event (with the failure reason) on verification failure, so clone detection reaches the audit trail. The browser path already did this via `log_failure`.
- Added `test_counter_regression_to_zero_rejected`.

## P2.1 — Agent IPC peer-credential check fails open
- **`vouch-agent/src/server.rs`**: peer-credential retrieval failure now **fails closed** — rejects the connection and emits a `ConnectionRejected` audit event, instead of allowing it with a `debug` log. `SO_PEERCRED`/`LOCAL_PEERCRED` retrieval failure is anomalous on supported platforms.

## P2.2 — Localhost origin relaxation reachable in production
- **`crypto/webauthn_verify.rs` / `services/auth.rs`**: the loopback origin-variation relaxation is now gated on an explicit `allow_localhost_origin` flag threaded through `LoginAssertionParams`. Call sites set it to `!config.tls_configured()`, so a TLS (production) deployment never weakens origin binding even with a loopback `rp_id`. The relaxation now logs at `warn` (target `security`).
- Updated the now-inverted startup warning in `infra/startup.rs` and added a positive/negative gating test.

## P2.3 — Certification/conformance test endpoint (hardening only)
The conformance suite runs over HTTPS with **self-signed certs**, so gating activation on `tls_configured()` — or a build flag — would break the very flow it exists for. Per that constraint, **no activation guard** was added. Instead:
- Loud `warn`-level security logs at startup (`infra/startup.rs`) and router build (`infra/router.rs`).
- Documented the full blast radius (login bypass, global rate limiting disabled, IdP requirement relaxed) at every touch point (`config.rs`, `handlers/certification.rs`).

## P2.4 — Fragile `innerHTML` string-building in UI JS
- **`static/js/keys.js`**: key list is now built with `createElement`/`textContent`/`dataset` (SVG via `createElementNS`), so escaping is structural — removes all `escapeHtml(key.name)` call sites.
- **`static/js/tests-runner.js`**: assertion/summary rows rebuilt with DOM nodes.
- **`static/js/common.js`**: left as-is (hardcoded `"Copied!"`, no user input) with a clarifying exemption comment.

## P2.5 — Negative-auth coverage of API routes
- New `crates/vouch-tests/tests/negative_auth.rs`: builds the full router via `TestHarness` and asserts protected API routes return 401/403 unauthenticated, and public routes never return an auth error. Hand-maintained route lists (axum can't introspect routes) with a comment instructing that new routes be added.

## Verification
- `cargo clippy -p vouch-server -p vouch-agent -p vouch-tests --all-targets -- -D warnings` — clean.
- `cargo test -p vouch-server --lib` — 2287 passed (incl. new counter + origin-gating tests).
- `cargo test -p vouch-agent` + `--test agent_ipc` — passed (fail-closed didn't break the matching-UID path).
- `cargo test -p vouch-tests --test negative_auth --test integration` — passed.

https://claude.ai/code/session_01VPQHNWtfsHM5DxNo76r6h3

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPQHNWtfsHM5DxNo76r6h3)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication (WebAuthn counters/origins, FIDO2 audit) and agent IPC fail-closed behavior; changes are targeted hardening with tests, but login and IPC paths warrant careful review.
> 
> **Overview**
> Implements **P1** and **P2** items from `SECURITY_EVALUATION.md` (P3.1–P3.4 still open).
> 
> **WebAuthn clone detection (P1.1):** Tightens sign-count checks so any nonzero stored counter must strictly increase (including rejecting regression to zero). Adds unit coverage and **`LoginFailed` audit events** on FIDO2 grant verification failures (P3.5).
> 
> **Production vs dev WebAuthn (P2.2):** Introduces `allow_localhost_origin` (off when TLS is configured) so loopback origin relaxation cannot apply in production; login paths set it from `!tls_configured()`.
> 
> **Agent IPC (P2.1):** Peer credential lookup failures now **reject** connections and audit instead of allowing them.
> 
> **Certification test mode (P2.3):** No new activation guard (conformance needs self-signed TLS); expands **security-targeted warnings** and documents full blast radius of `VOUCH_CERTIFICATION_TEST_TOKEN`.
> 
> **UI XSS hardening (P2.4):** `keys.js` and `tests-runner.js` build DOM via APIs instead of `innerHTML` for user or dynamic text.
> 
> **Regression tests (P2.5):** New `negative_auth.rs` integration tests assert protected API routes return 401/403 without credentials and public routes do not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1574f3aa537d6e600244a808032eac976ffc52cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->