### PR TITLE
various fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4567,15 +4567,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6066,6 +6057,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tracing",
  "url",
@@ -6135,7 +6127,7 @@ dependencies = [
  "roxmltree",
  "rust-embed",
  "rustls",
- "rustls-pemfile",
+ "rustls-pki-types",
  "sea-query",
  "sea-query-sqlx",
  "secrecy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,7 +176,7 @@ rpassword = { version = "=7.5.4", default-features = false }
 rust-embed = { version = "=8.11.0", default-features = false }
 rust-ini = { version = "=0.21.3", default-features = false }
 rustls = { version = "=0.23.40", default-features = false }
-rustls-pemfile = { version = "=2.2.0", default-features = false }
+rustls-pki-types = { version = "=1.14.1", default-features = false }
 sea-query = { version = "=1.0.1", default-features = false }
 sea-query-sqlx = { version = "=0.9.1", default-features = false }
 sha2 = { version = "=0.10.9", default-features = false }

--- a/SECURITY_EVALUATION.md
+++ b/SECURITY_EVALUATION.md
@@ -59,7 +59,12 @@ engineering throughout:
 > it exists for; instead the test-mode switch now emits loud `warn`-level
 > security logs at startup and at router build, and its full blast radius
 > (login bypass, rate-limiting disabled, IdP requirement relaxed) is documented
-> at every touch point. P3.1–P3.4 remain open.
+> at every touch point. P3.1, P3.2, and P3.3 are now resolved. P3.4 is resolved
+> as well: the BER parser is already covered by a fuzz target
+> (`fuzz/fuzz_targets/fuzz_ber_parse.rs`), and migrating to the `der` crate was
+> rejected because `der` 0.8's BER support would pull a second major version of
+> `der` into the tree (the P-256/x509 stack pins `der` 0.7), tripping
+> `cargo-deny`'s `multiple-versions = "deny"`. All P3 items are now closed.
 
 ### P1 — High
 
@@ -177,37 +182,58 @@ invariant for all future routes.
 
 ### P3 — Low / Hardening
 
-#### P3.1 SSH certificate written non-atomically with default umask
+#### P3.1 SSH certificate written non-atomically with default umask — RESOLVED
 
-`crates/vouch-agent/src/ssh_agent/provisioning.rs:236-245` — the
-lazy-provisioned certificate is written with `std::fs::write` (default
+`crates/vouch-agent/src/ssh_agent/provisioning.rs` — the
+lazy-provisioned certificate was written with `std::fs::write` (default
 umask, typically 0644) and then chmod'd to 0600, leaving a brief
 world-readable window. Impact is low (SSH certificates are public
-material), but the CLI already has an `atomic_write_secure()` helper
-(`crates/vouch-cli/src/utils.rs`) that sets permissions on the temp file
-before the atomic rename — reuse that pattern for consistency.
+material), but the CLI already had an `atomic_write_secure()` helper that
+sets permissions on the temp file before the atomic rename.
 
-#### P3.2 `VOUCH_ALLOW_INSECURE` accepted silently
+**Resolution:** the atomic-write helpers moved from `vouch-cli` to
+`vouch-common` (`crates/vouch-common/src/fs.rs`, reachable by both the CLI
+and the agent), and the provisioning path now calls
+`vouch_common::fs::write_secure_file`, so the file is never visible with
+default permissions.
 
-`crates/vouch-agent/src/server.rs:295-305` — the insecure-URL override is
-honored without any prominent signal. Add a one-time `warn`-level startup
-log when the variable is set (mirroring the existing clock-skew warning
-pattern).
+#### P3.2 `VOUCH_ALLOW_INSECURE` accepted silently — RESOLVED
 
-#### P3.3 Ignored advisory RUSTSEC-2025-0134
+`crates/vouch-agent/src/server.rs` — the insecure-URL override was honored
+without any prominent boot-time signal (a per-request `warn` fired only when
+an insecure URL was actually stored).
 
-`deny.toml:19-21` — the `rustls-pemfile` advisory is ignored with a
-documented reason and tracked migration. Complete the migration to
-`rustls-pki-types` so the ignore entry can be removed.
+**Resolution:** `AgentServer::run()` now emits a one-time `warn`-level log at
+startup whenever `VOUCH_ALLOW_INSECURE` is set, so a set-but-unused flag is
+still visible. The existing per-request warning is retained.
 
-#### P3.4 Custom BER parser lacks fuzz coverage
+#### P3.3 Ignored advisory RUSTSEC-2025-0134 — RESOLVED
+
+`deny.toml` — the `rustls-pemfile` advisory was ignored with a documented
+reason and tracked migration.
+
+**Resolution:** the four PEM-parsing call sites in
+`crates/vouch-server/src/infra/tls.rs` were migrated to `rustls-pki-types`
+(`PemObject::pem_slice_iter` / `from_pem_slice`), the `rustls-pemfile`
+dependency was dropped, and the `RUSTSEC-2025-0134` ignore entry was removed
+from `deny.toml`.
+
+#### P3.4 Custom BER parser lacks fuzz coverage — RESOLVED
 
 `crates/vouch-server/src/crypto/ber.rs` — the hand-written ASN.1 BER
 parser for AWS KMS CMS envelopes is bounded (max depth 32, correct
 indefinite-length/EOC handling) and looks correct, but homegrown parsing
-of attacker-influenceable encodings warrants a `cargo-fuzz` target — or
-migration to the `der` crate, which now supports indefinite-length
-encoding.
+of attacker-influenceable encodings warrants a `cargo-fuzz` target.
+
+**Resolution:** a fuzz target already exists at
+`fuzz/fuzz_targets/fuzz_ber_parse.rs` and exercises every public
+`DerParser` entry point (`read_tlv`, `read_tlv_ber`, `expect_*`, `skip_*`,
+`read_implicit_octet_string_ber`) plus sequential indefinite-length reads.
+Migration to the `der` crate was evaluated and rejected: although `der` 0.8
+(Feb 2026) genuinely added indefinite-length BER support, adopting it would
+introduce a second major version of `der` (the P-256/x509 stack pins 0.7),
+violating `deny.toml`'s `multiple-versions = "deny"` — net new supply-chain
+debt in exchange for replacing a working, already-fuzzed parser.
 
 #### P3.5 Counter-regression events should reach the audit trail — RESOLVED
 

--- a/crates/vouch-agent/src/server.rs
+++ b/crates/vouch-agent/src/server.rs
@@ -64,6 +64,14 @@ impl AgentServer {
 
         info!("Agent listening on {}", path.display());
 
+        // Surface the insecure-URL override at boot, not just when an insecure
+        // URL is actually stored — a set-but-unused flag is still a misconfiguration.
+        if std::env::var_os("VOUCH_ALLOW_INSECURE").is_some() {
+            warn!(
+                "VOUCH_ALLOW_INSECURE is set: insecure (plain HTTP) server URLs will be accepted. Do not use in production."
+            );
+        }
+
         let mut shutdown = self.shutdown_rx.clone();
         let semaphore = Arc::new(Semaphore::new(MAX_CONNECTIONS));
 

--- a/crates/vouch-agent/src/ssh_agent/provisioning.rs
+++ b/crates/vouch-agent/src/ssh_agent/provisioning.rs
@@ -229,19 +229,17 @@ fn spawn_lazy_provision(
             }
         };
 
-        // Write certificate to disk
+        // Write certificate to disk atomically with 0600 permissions, so it is
+        // never briefly visible world-readable between create and chmod.
         let cert_path = home
             .join(".ssh")
             .join(format!("{DEFAULT_KEY_NAME}-cert.pub"));
-        if let Err(e) = std::fs::write(&cert_path, format!("{}\n", cert_response.certificate)) {
+        if let Err(e) = vouch_common::fs::write_secure_file(
+            &cert_path,
+            &format!("{}\n", cert_response.certificate),
+        ) {
             debug!("Failed to write lazy-provisioned certificate: {e}");
             return;
-        }
-        // Set certificate file permissions to 0600 (owner read/write only)
-        use std::os::unix::fs::PermissionsExt;
-        if let Err(e) = std::fs::set_permissions(&cert_path, std::fs::Permissions::from_mode(0o600))
-        {
-            debug!("Failed to set certificate permissions: {e}");
         }
 
         // Load credentials into agent state

--- a/crates/vouch-cli/src/commands/credential/ssh.rs
+++ b/crates/vouch-cli/src/commands/credential/ssh.rs
@@ -69,7 +69,7 @@ pub(crate) fn ensure_keypair(key_path: &Path) -> Result<KeypairAction> {
     let private_key_str = private_key
         .to_openssh(LineEnding::LF)
         .map_err(|e| anyhow::anyhow!("failed to serialize private key: {e}"))?;
-    crate::utils::atomic_write_secure(key_path, private_key_str.as_bytes())
+    vouch_common::fs::atomic_write_secure(key_path, private_key_str.as_bytes())
         .with_context(|| format!("failed to write {}", key_path.display()))?;
 
     // Save public key (atomic)
@@ -77,7 +77,7 @@ pub(crate) fn ensure_keypair(key_path: &Path) -> Result<KeypairAction> {
     let pub_key_str = public_key
         .to_openssh()
         .map_err(|e| anyhow::anyhow!("failed to serialize public key: {e}"))?;
-    crate::utils::atomic_write(&pub_path, format!("{pub_key_str}\n").as_bytes())
+    vouch_common::fs::atomic_write(&pub_path, format!("{pub_key_str}\n").as_bytes())
         .with_context(|| format!("failed to write {}", pub_path.display()))?;
 
     Ok(KeypairAction::Generated(public_key.clone()))
@@ -223,7 +223,7 @@ pub(crate) async fn provision_ssh_certificate(
 
     // Save certificate (atomic)
     let cert_path = PathBuf::from(format!("{}-cert.pub", key_path.display()));
-    crate::utils::atomic_write(&cert_path, format!("{}\n", response.certificate).as_bytes())
+    vouch_common::fs::atomic_write(&cert_path, format!("{}\n", response.certificate).as_bytes())
         .with_context(|| format!("failed to write {}", cert_path.display()))?;
 
     Ok(SshProvisionResult {

--- a/crates/vouch-cli/src/commands/setup/codeartifact.rs
+++ b/crates/vouch-cli/src/commands/setup/codeartifact.rs
@@ -256,7 +256,7 @@ fn write_pip_config(index_url: &str) -> Result<()> {
             config_path.display()
         )
     })?;
-    crate::utils::atomic_write_secure(&config_path, &buf)
+    vouch_common::fs::atomic_write_secure(&config_path, &buf)
         .with_context(|| format!("failed to write {}", config_path.display()))?;
 
     println!("Wrote pip config: {}", config_path.display());
@@ -362,7 +362,7 @@ fn write_uv_config(index_url: &str, repository: &str) -> Result<()> {
     }
 
     let serialized = doc.to_string();
-    crate::utils::atomic_write_secure(&config_path, serialized.as_bytes())
+    vouch_common::fs::atomic_write_secure(&config_path, serialized.as_bytes())
         .with_context(|| format!("failed to write {}", config_path.display()))?;
 
     println!("Wrote uv config: {}", config_path.display());
@@ -479,7 +479,7 @@ fn write_npmrc(ca_host: &str, repository: &str, token: &str) -> Result<()> {
     warn_npmrc_conflict(&existing, ca_host, repository, "npm");
     let content = build_npmrc_content(&existing, ca_host, repository, token);
 
-    crate::utils::atomic_write_secure(&npmrc_path, content.as_bytes())
+    vouch_common::fs::atomic_write_secure(&npmrc_path, content.as_bytes())
         .with_context(|| format!("failed to write {}", npmrc_path.display()))?;
 
     println!("Wrote npm config: {}", npmrc_path.display());
@@ -564,7 +564,7 @@ fn write_npmrc_pnpm(ca_host: &str, repository: &str, helper_path: &std::path::Pa
     warn_npmrc_conflict(&existing, ca_host, repository, "pnpm");
     let content = build_npmrc_pnpm_content(&existing, ca_host, repository, helper_path);
 
-    crate::utils::atomic_write_secure(&npmrc_path, content.as_bytes())
+    vouch_common::fs::atomic_write_secure(&npmrc_path, content.as_bytes())
         .with_context(|| format!("failed to write {}", npmrc_path.display()))?;
 
     println!("Wrote pnpm config: {}", npmrc_path.display());
@@ -682,7 +682,7 @@ async fn try_refresh_npmrc(server: &str) -> Result<()> {
     let (new_content, refreshed) = rewrite_npmrc_tokens(&content, &plain_map);
 
     if refreshed {
-        crate::utils::atomic_write_secure(&npmrc_path, new_content.as_bytes())
+        vouch_common::fs::atomic_write_secure(&npmrc_path, new_content.as_bytes())
             .with_context(|| format!("failed to write {}", npmrc_path.display()))?;
         println!("Refreshed CodeArtifact token in ~/.npmrc");
     }

--- a/crates/vouch-cli/src/commands/setup/docker.rs
+++ b/crates/vouch-cli/src/commands/setup/docker.rs
@@ -141,7 +141,7 @@ fn configure_docker_config(registries: &[String]) -> Result<()> {
     // Write config atomically to avoid corruption if interrupted
     let json =
         serde_json::to_string_pretty(&config).context("failed to serialize Docker config")?;
-    crate::utils::atomic_write(&docker_config_path, json.as_bytes())
+    vouch_common::fs::atomic_write(&docker_config_path, json.as_bytes())
         .with_context(|| format!("failed to write {}", docker_config_path.display()))?;
 
     println!("Updated: {}", docker_config_path.display());

--- a/crates/vouch-cli/src/commands/setup/kubeconfig.rs
+++ b/crates/vouch-cli/src/commands/setup/kubeconfig.rs
@@ -5,7 +5,8 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-use crate::utils::{ensure_secure_dir, write_secure_file};
+use crate::utils::ensure_secure_dir;
+use vouch_common::fs::write_secure_file;
 
 // ============================================================================
 // Kubeconfig Types

--- a/crates/vouch-cli/src/commands/setup/openai.rs
+++ b/crates/vouch-cli/src/commands/setup/openai.rs
@@ -103,7 +103,7 @@ fn configure_codex(vouch_path: &str, force: bool) -> Result<PathBuf> {
         std::fs::create_dir_all(&codex_dir)
             .with_context(|| format!("failed to create {}", codex_dir.display()))?;
     }
-    crate::utils::atomic_write(&config_path, doc.to_string().as_bytes())
+    vouch_common::fs::atomic_write(&config_path, doc.to_string().as_bytes())
         .with_context(|| format!("failed to write {}", config_path.display()))?;
 
     Ok(config_path)

--- a/crates/vouch-cli/src/commands/setup/ssh.rs
+++ b/crates/vouch-cli/src/commands/setup/ssh.rs
@@ -9,7 +9,8 @@ use std::path::PathBuf;
 use vouch_common::SshCaPublicKeyResponse;
 
 use crate::client::VouchClient;
-use crate::utils::{atomic_write, atomic_write_secure, ensure_secure_dir};
+use crate::utils::ensure_secure_dir;
+use vouch_common::fs::{atomic_write, atomic_write_secure};
 
 /// Get the SSH config path (~/.ssh/config).
 pub(crate) fn ssh_config_path() -> Result<PathBuf> {

--- a/crates/vouch-cli/src/commands/setup/ssm.rs
+++ b/crates/vouch-cli/src/commands/setup/ssm.rs
@@ -14,7 +14,8 @@ use std::fs;
 use crate::commands::setup::ssh::ssh_config_path;
 use crate::integrations::aws;
 use crate::integrations::ssm as ssm_integration;
-use crate::utils::{atomic_write_secure, ensure_secure_dir};
+use crate::utils::ensure_secure_dir;
+use vouch_common::fs::atomic_write_secure;
 
 /// Marker comment used for idempotency detection.
 pub(crate) const SSM_MARKER: &str = "# Vouch SSM Configuration";

--- a/crates/vouch-cli/src/config.rs
+++ b/crates/vouch-cli/src/config.rs
@@ -406,7 +406,7 @@ impl Config {
         let content =
             serde_json::to_string_pretty(&config_file).context("failed to serialize config")?;
 
-        crate::utils::atomic_write_secure(path.as_path(), content.as_bytes())
+        vouch_common::fs::atomic_write_secure(path.as_path(), content.as_bytes())
             .with_context(|| format!("failed to write config to {}", path.display()))?;
 
         Ok(())

--- a/crates/vouch-cli/src/fapi/key.rs
+++ b/crates/vouch-cli/src/fapi/key.rs
@@ -211,7 +211,7 @@ impl ClientKey {
         let json = serde_json::to_vec_pretty(&key_file)
             .map_err(|e| FapiError::KeySave(format!("JSON serialization error: {e}")))?;
 
-        crate::utils::atomic_write_secure(path, &json)
+        vouch_common::fs::atomic_write_secure(path, &json)
             .map_err(|e| FapiError::KeySave(format!("{}: {e}", path.display())))?;
 
         Ok(())

--- a/crates/vouch-cli/src/integrations/aws/config.rs
+++ b/crates/vouch-cli/src/integrations/aws/config.rs
@@ -177,7 +177,7 @@ impl AwsConfig {
         self.ini
             .write_to(&mut buf)
             .with_context(|| format!("failed to serialize {}", self.path.display()))?;
-        crate::utils::atomic_write(&self.path, &buf)
+        vouch_common::fs::atomic_write(&self.path, &buf)
             .with_context(|| format!("failed to write {}", self.path.display()))
     }
 

--- a/crates/vouch-cli/src/integrations/aws/sso.rs
+++ b/crates/vouch-cli/src/integrations/aws/sso.rs
@@ -368,7 +368,7 @@ fn save_registration(
     crate::utils::ensure_secure_dir(cache_dir)?;
     let path = cache_dir.join(format!("{key}.json"));
     let content = serde_json::to_vec(reg).context("failed to serialize registration")?;
-    crate::utils::atomic_write_secure(&path, &content)
+    vouch_common::fs::atomic_write_secure(&path, &content)
         .context("failed to write SSO client registration cache")
 }
 
@@ -379,7 +379,7 @@ pub(crate) fn save_access_token(config: &SsoConfig, token: &SsoAccessToken) -> R
     let key = token_cache_key(config);
     let path = cache_dir.join(format!("{key}.json"));
     let content = serde_json::to_vec(token).context("failed to serialize access token")?;
-    crate::utils::atomic_write_secure(&path, &content)
+    vouch_common::fs::atomic_write_secure(&path, &content)
         .context("failed to write SSO access token cache")
 }
 

--- a/crates/vouch-cli/src/integrations/cargo/config.rs
+++ b/crates/vouch-cli/src/integrations/cargo/config.rs
@@ -171,7 +171,7 @@ impl CargoConfig {
     /// Uses atomic write (temp file + rename) to prevent corruption
     /// if the process is interrupted mid-write.
     pub(crate) fn save(&self) -> Result<()> {
-        crate::utils::atomic_write(&self.path, self.doc.to_string().as_bytes())
+        vouch_common::fs::atomic_write(&self.path, self.doc.to_string().as_bytes())
             .with_context(|| format!("failed to write {}", self.path.display()))
     }
 

--- a/crates/vouch-cli/src/utils.rs
+++ b/crates/vouch-cli/src/utils.rs
@@ -8,7 +8,6 @@
 
 use anyhow::{Context, Result};
 use std::fs;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 
 /// Ensure a directory exists with secure permissions (0o700 on Unix).
@@ -26,98 +25,6 @@ pub(crate) fn ensure_secure_dir(path: &Path) -> Result<()> {
         fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
     }
     Ok(())
-}
-
-/// Unix file permission mode for atomic writes.
-///
-/// On non-Unix platforms, this value is accepted but ignored.
-pub(crate) enum FileMode {
-    /// Use default permissions (no explicit chmod).
-    Default,
-    /// Restrictive: owner read/write only (0o600 on Unix).
-    Secure,
-}
-
-/// Atomically write content to a file with the given permission mode.
-///
-/// Writes to a temporary file in the same directory, then renames it
-/// to the target path. This ensures the file is never left in a
-/// partially-written state if the process is interrupted.
-///
-/// Creates parent directories if they don't exist.
-/// On Unix, sets file permissions on the temp file before the rename
-/// so the file is never visible with incorrect permissions.
-fn atomic_write_impl(path: &Path, content: &[u8], mode: FileMode) -> Result<()> {
-    let parent = path.parent().context("file path has no parent directory")?;
-
-    // create_dir_all is idempotent — no existence check needed.
-    fs::create_dir_all(parent)
-        .with_context(|| format!("failed to create directory {}", parent.display()))?;
-
-    let mut tmp = tempfile::NamedTempFile::new_in(parent)
-        .with_context(|| format!("failed to create temp file in {}", parent.display()))?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let unix_mode = match mode {
-            FileMode::Default => None,
-            FileMode::Secure => Some(0o600),
-        };
-        if let Some(m) = unix_mode {
-            fs::set_permissions(tmp.path(), fs::Permissions::from_mode(m))?;
-        }
-    }
-
-    #[cfg(not(unix))]
-    let _ = mode;
-
-    tmp.write_all(content)
-        .with_context(|| format!("failed to write temp file for {}", path.display()))?;
-    tmp.flush()
-        .with_context(|| format!("failed to flush temp file for {}", path.display()))?;
-
-    // Ensure data is durable on disk before the atomic rename.
-    // Without this, a power failure after rename could leave a zero-length file.
-    tmp.as_file()
-        .sync_all()
-        .with_context(|| format!("failed to sync temp file for {}", path.display()))?;
-
-    tmp.persist(path)
-        .with_context(|| format!("failed to persist temp file to {}", path.display()))?;
-
-    Ok(())
-}
-
-/// Atomically write content to a file.
-///
-/// Writes to a temporary file in the same directory, then renames it
-/// to the target path. This ensures the file is never left in a
-/// partially-written state if the process is interrupted.
-///
-/// Creates parent directories if they don't exist.
-pub(crate) fn atomic_write(path: &Path, content: &[u8]) -> Result<()> {
-    atomic_write_impl(path, content, FileMode::Default)
-}
-
-/// Atomically write content to a file with secure permissions (0o600 on Unix).
-///
-/// Same as [`atomic_write`], but sets restrictive file permissions before
-/// the rename, so the file is never visible with default (world-readable)
-/// permissions.
-pub(crate) fn atomic_write_secure(path: &Path, content: &[u8]) -> Result<()> {
-    atomic_write_impl(path, content, FileMode::Secure)
-}
-
-/// Write content to a file with secure permissions (0o600 on Unix).
-///
-/// Creates parent directories if they don't exist.
-/// On Unix systems, sets file permissions to 0o600 (owner read/write only).
-///
-/// This is a convenience wrapper around [`atomic_write_secure`] that
-/// accepts a string slice.
-pub(crate) fn write_secure_file(path: &Path, content: &str) -> Result<()> {
-    atomic_write_secure(path, content.as_bytes())
 }
 
 /// Get the path for a vouch helper binary in `~/.local/bin/`.
@@ -227,7 +134,7 @@ pub(crate) fn create_symlink_with_fallback(
                 .with_context(|| format!("failed to remove existing {}", bat_path.display()))?;
         }
 
-        atomic_write(&bat_path, windows_batch_content.as_bytes())
+        vouch_common::fs::atomic_write(&bat_path, windows_batch_content.as_bytes())
             .with_context(|| format!("failed to create {}", bat_path.display()))?;
 
         println!("Created: {}", bat_path.display());

--- a/crates/vouch-common/Cargo.toml
+++ b/crates/vouch-common/Cargo.toml
@@ -21,6 +21,7 @@ reqwest = { workspace = true, features = ["json", "rustls", "form"] }
 secrecy = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["std", "derive"] }
 serde_json = { workspace = true, features = ["std"] }
+tempfile = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }

--- a/crates/vouch-common/src/fs.rs
+++ b/crates/vouch-common/src/fs.rs
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! Atomic, permission-aware file writes shared across the CLI and agent.
+
+use anyhow::{Context, Result};
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+/// Unix file permission mode for atomic writes.
+///
+/// On non-Unix platforms, this value is accepted but ignored.
+pub enum FileMode {
+    /// Use default permissions (no explicit chmod).
+    Default,
+    /// Restrictive: owner read/write only (0o600 on Unix).
+    Secure,
+}
+
+/// Atomically write content to a file with the given permission mode.
+///
+/// Writes to a temporary file in the same directory, then renames it
+/// to the target path. This ensures the file is never left in a
+/// partially-written state if the process is interrupted.
+///
+/// Creates parent directories if they don't exist.
+/// On Unix, sets file permissions on the temp file before the rename
+/// so the file is never visible with incorrect permissions.
+fn atomic_write_impl(path: &Path, content: &[u8], mode: FileMode) -> Result<()> {
+    let parent = path.parent().context("file path has no parent directory")?;
+
+    // create_dir_all is idempotent — no existence check needed.
+    fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create directory {}", parent.display()))?;
+
+    let mut tmp = tempfile::NamedTempFile::new_in(parent)
+        .with_context(|| format!("failed to create temp file in {}", parent.display()))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let unix_mode = match mode {
+            FileMode::Default => None,
+            FileMode::Secure => Some(0o600),
+        };
+        if let Some(m) = unix_mode {
+            fs::set_permissions(tmp.path(), fs::Permissions::from_mode(m))?;
+        }
+    }
+
+    #[cfg(not(unix))]
+    let _ = mode;
+
+    tmp.write_all(content)
+        .with_context(|| format!("failed to write temp file for {}", path.display()))?;
+    tmp.flush()
+        .with_context(|| format!("failed to flush temp file for {}", path.display()))?;
+
+    // Ensure data is durable on disk before the atomic rename.
+    // Without this, a power failure after rename could leave a zero-length file.
+    tmp.as_file()
+        .sync_all()
+        .with_context(|| format!("failed to sync temp file for {}", path.display()))?;
+
+    tmp.persist(path)
+        .with_context(|| format!("failed to persist temp file to {}", path.display()))?;
+
+    Ok(())
+}
+
+/// Atomically write content to a file.
+///
+/// Writes to a temporary file in the same directory, then renames it
+/// to the target path. This ensures the file is never left in a
+/// partially-written state if the process is interrupted.
+///
+/// Creates parent directories if they don't exist.
+pub fn atomic_write(path: &Path, content: &[u8]) -> Result<()> {
+    atomic_write_impl(path, content, FileMode::Default)
+}
+
+/// Atomically write content to a file with secure permissions (0o600 on Unix).
+///
+/// Same as [`atomic_write`], but sets restrictive file permissions before
+/// the rename, so the file is never visible with default (world-readable)
+/// permissions.
+pub fn atomic_write_secure(path: &Path, content: &[u8]) -> Result<()> {
+    atomic_write_impl(path, content, FileMode::Secure)
+}
+
+/// Write content to a file with secure permissions (0o600 on Unix).
+///
+/// Creates parent directories if they don't exist.
+/// On Unix systems, sets file permissions to 0o600 (owner read/write only).
+///
+/// This is a convenience wrapper around [`atomic_write_secure`] that
+/// accepts a string slice.
+pub fn write_secure_file(path: &Path, content: &str) -> Result<()> {
+    atomic_write_secure(path, content.as_bytes())
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::panic_in_result_fn,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_atomic_write_secure_creates_file_with_content() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("nested").join("secret.txt");
+        atomic_write_secure(&path, b"hunter2")?;
+        assert_eq!(fs::read(&path)?, b"hunter2");
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_atomic_write_secure_sets_0600() -> Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("secret.txt");
+        atomic_write_secure(&path, b"data")?;
+        let mode = fs::metadata(&path)?.permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "expected 0600, got {mode:o}");
+        Ok(())
+    }
+
+    #[test]
+    fn test_write_secure_file_accepts_str() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("cert.pub");
+        write_secure_file(&path, "ssh-ed25519 AAAA...\n")?;
+        assert_eq!(fs::read_to_string(&path)?, "ssh-ed25519 AAAA...\n");
+        Ok(())
+    }
+}

--- a/crates/vouch-common/src/lib.rs
+++ b/crates/vouch-common/src/lib.rs
@@ -10,6 +10,7 @@ pub mod encoding;
 pub(crate) mod error;
 pub mod fido2_types;
 pub mod fixtures;
+pub mod fs;
 pub mod http;
 pub mod posture;
 pub(crate) mod url;

--- a/crates/vouch-server/Cargo.toml
+++ b/crates/vouch-server/Cargo.toml
@@ -64,7 +64,7 @@ reqwest = { workspace = true, features = ["json", "rustls", "form"] }
 roxmltree = { workspace = true }
 rust-embed = { workspace = true, features = ["axum-ex", "deterministic-timestamps", "mime-guess"] }
 rustls = { workspace = true, features = ["aws-lc-rs", "std", "prefer-post-quantum", "tls12"] }
-rustls-pemfile = { workspace = true, features = ["std"] }
+rustls-pki-types = { workspace = true, features = ["alloc"] }
 sea-query = { workspace = true, features = ["backend-sqlite", "backend-postgres", "derive"] }
 sea-query-sqlx = { workspace = true, features = ["sqlx-sqlite", "sqlx-postgres", "runtime-tokio"] }
 secrecy = { workspace = true, features = ["serde"] }

--- a/crates/vouch-server/src/infra/tls.rs
+++ b/crates/vouch-server/src/infra/tls.rs
@@ -10,6 +10,8 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result, bail};
 use axum_server::tls_rustls::RustlsConfig;
+use rustls::pki_types::pem::PemObject;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use secrecy::{ExposeSecret, SecretString};
 
 use crate::config::ServerConfig;
@@ -127,13 +129,11 @@ fn build_server_config(cert_pem: &[u8], key_pem: &[u8]) -> Result<Arc<rustls::Se
     validate_pem(cert_pem, "CERTIFICATE").context("Invalid TLS certificate format")?;
     validate_pem(key_pem, "PRIVATE KEY").context("Invalid TLS private key format")?;
 
-    let certs: Vec<rustls::pki_types::CertificateDer<'_>> = rustls_pemfile::certs(&mut &*cert_pem)
+    let certs: Vec<CertificateDer<'static>> = CertificateDer::pem_slice_iter(cert_pem)
         .collect::<Result<Vec<_>, _>>()
         .context("Failed to parse PEM certificate chain")?;
 
-    let key = rustls_pemfile::private_key(&mut &*key_pem)
-        .context("Failed to parse PEM private key")?
-        .ok_or_else(|| anyhow::anyhow!("No private key found in PEM data"))?;
+    let key = PrivateKeyDer::from_pem_slice(key_pem).context("Failed to parse PEM private key")?;
 
     let mut config =
         rustls::ServerConfig::builder_with_provider(Arc::new(bcp195_crypto_provider()))
@@ -178,14 +178,12 @@ pub(crate) fn parse_server_cert_and_key(
         .context("Failed to decode TLS private key")?
         .into_bytes();
 
-    let certs: Vec<rustls::pki_types::CertificateDer<'static>> =
-        rustls_pemfile::certs(&mut &*cert_bytes)
-            .collect::<Result<Vec<_>, _>>()
-            .context("Failed to parse PEM certificate chain")?;
+    let certs: Vec<CertificateDer<'static>> = CertificateDer::pem_slice_iter(&cert_bytes)
+        .collect::<Result<Vec<_>, _>>()
+        .context("Failed to parse PEM certificate chain")?;
 
-    let key = rustls_pemfile::private_key(&mut &*key_bytes)
-        .context("Failed to parse PEM private key")?
-        .ok_or_else(|| anyhow::anyhow!("No private key found in PEM data"))?;
+    let key =
+        PrivateKeyDer::from_pem_slice(&key_bytes).context("Failed to parse PEM private key")?;
 
     Ok((certs, key))
 }
@@ -235,5 +233,49 @@ mod tests {
         // EC PRIVATE KEY also contains "PRIVATE KEY"
         let pem = b"-----BEGIN EC PRIVATE KEY-----\ndata\n-----END EC PRIVATE KEY-----";
         assert!(validate_pem(pem, "PRIVATE KEY").is_ok());
+    }
+
+    // Throwaway self-signed P-256 cert + PKCS#8 key, generated for tests only.
+    const TEST_CERT_PEM: &str = "-----BEGIN CERTIFICATE-----\n\
+MIIBiDCCAS2gAwIBAgIUAzsi4KkqvGaw6UTFs4DrQEe2KWwwCgYIKoZIzj0EAwIw\n\
+GTEXMBUGA1UEAwwOdm91Y2gtdGxzLXRlc3QwHhcNMjYwNjEwMTYxMjM3WhcNMzYw\n\
+NjA3MTYxMjM3WjAZMRcwFQYDVQQDDA52b3VjaC10bHMtdGVzdDBZMBMGByqGSM49\n\
+AgEGCCqGSM49AwEHA0IABAOqxc9YgMgXu2BGQ3KOgFNtVxG7pdencd5TOnjrr6zJ\n\
+nPi66MVoVlQ9bi3ydlRJ1ce7HHOEui/G0U0aoDJtgVmjUzBRMB0GA1UdDgQWBBQW\n\
+yEA6dBvaxTzloNCzXuJLG5z9/DAfBgNVHSMEGDAWgBQWyEA6dBvaxTzloNCzXuJL\n\
+G5z9/DAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49BAMCA0kAMEYCIQC9cwWPeNND\n\
+WFbJkO8dqEVE69Xzdj+NMgenQFOJsOW2yAIhAISz7zP/KDBC6jVhH7qJTR9E7Rnr\n\
+3wT8S2AL3BFHW6+2\n\
+-----END CERTIFICATE-----\n";
+
+    const TEST_KEY_PEM: &str = "-----BEGIN PRIVATE KEY-----\n\
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQghUolejGt3e2SfwZJ\n\
+BRRya1VbXh8fYhiJfLvrVBbs/lqhRANCAAQDqsXPWIDIF7tgRkNyjoBTbVcRu6XX\n\
+p3HeUzp466+syZz4uujFaFZUPW4t8nZUSdXHuxxzhLovxtFNGqAybYFZ\n\
+-----END PRIVATE KEY-----\n";
+
+    #[test]
+    fn test_build_server_config_parses_real_pem() {
+        // Exercises the rustls-pki-types PemObject parsing path end-to-end:
+        // PEM cert chain + PKCS#8 key must yield a usable ServerConfig.
+        let config = build_server_config(TEST_CERT_PEM.as_bytes(), TEST_KEY_PEM.as_bytes());
+        assert!(
+            config.is_ok(),
+            "valid PEM cert/key must build a ServerConfig, got: {:?}",
+            config.err()
+        );
+    }
+
+    #[test]
+    fn test_build_server_config_rejects_malformed_cert_pem() {
+        // Passes the validate_pem check (contains "CERTIFICATE") but has
+        // undecodable base64, so PemObject parsing must surface an error.
+        let bad_cert =
+            b"-----BEGIN CERTIFICATE-----\nnot valid base64 @@@@\n-----END CERTIFICATE-----\n";
+        let config = build_server_config(bad_cert, TEST_KEY_PEM.as_bytes());
+        assert!(
+            config.is_err(),
+            "malformed certificate PEM must be rejected"
+        );
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -16,9 +16,7 @@ targets = [
 ]
 
 [advisories]
-ignore = [
-    { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile is a thin wrapper around rustls-pki-types; migration tracked separately" },
-]
+ignore = []
 
 [licenses]
 confidence-threshold = 0.8


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly refactors and local hardening with tests on TLS PEM parsing; no auth or protocol behavior changes beyond safer file writes and startup logging.
> 
> **Overview**
> Closes several **P3 security-evaluation** items by centralizing file I/O hardening and cleaning up TLS dependencies.
> 
> **Shared atomic writes:** `atomic_write`, `atomic_write_secure`, and `write_secure_file` move from the CLI into **`vouch-common::fs`** (with `tempfile` on `vouch-common`). The CLI’s setup/credential paths call the shared helpers; the agent’s **lazy SSH certificate** write uses `write_secure_file` so certs are not briefly world-readable before `chmod`.
> 
> **Agent observability:** **`AgentServer::run`** logs a one-time **`warn`** when **`VOUCH_ALLOW_INSECURE`** is set, even if no insecure URL is stored yet.
> 
> **Supply chain:** Server TLS PEM loading in **`tls.rs`** switches from **`rustls-pemfile`** to **`rustls-pki-types`** (`PemObject` / `from_pem_slice`), drops the `rustls-pemfile` dependency, removes the **`RUSTSEC-2025-0134`** ignore from **`deny.toml`**, and adds PEM parsing tests.
> 
> **Docs:** **`SECURITY_EVALUATION.md`** marks P3.1–P3.4 resolved (including documenting existing BER fuzz coverage and why `der` 0.8 was not adopted).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d074ee533da2b25e05f93870b1c2634010187827. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->