### PR TITLE
fable5 updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Vouch is a hardware-backed authentication system that issues short-lived credentials after FIDO2 verification with a YubiKey. The core principle: **no credential issuance without human presence proof**.
+Vouch is a hardware-backed authentication system that issues short-lived credentials after FIDO2 verification with a YubiKey. The core principle: **no credential issuance without human presence proof**. Vouch is OpenID Certified for the FAPI 2.0 OP Security Profile (including message signing).
 
 ## Architecture Quick Reference
 
@@ -15,7 +15,9 @@ vouch/
 │   ├── vouch-agent/      # Background daemon for session/cert management (Apache-2.0/MIT)
 │   ├── vouch-server/     # Auth server with OIDC provider, SSH CA (Apache-2.0/MIT)
 │   ├── vouch-common/     # Shared types, FIDO2 helpers, API client (Apache-2.0/MIT)
+│   ├── vouch-httpsig/    # RFC 9421 HTTP Message Signatures + RFC 9530 Content-Digest
 │   └── vouch-tests/      # Integration + property-based tests
+├── fuzz/                 # libfuzzer targets: BER, attestation objects, COSE keys, HTTP sigs
 ├── docs/                 # mdBook documentation (build with `make docs-build`)
 └── packaging/            # AMI and post-install scripts
 ```
@@ -33,6 +35,8 @@ vouch/
 6. `vouch setup eks` → configure kubeconfig for EKS (chains through `vouch credential aws` → `aws eks get-token`)
 7. Native tools (ssh, aws, kubectl) call vouch helpers transparently via `credential_process`
 
+Beyond ssh/aws/eks, credential helpers and setup commands cover many more integrations (kubernetes, github, docker, cargo, codeartifact, codecommit, pip, rds, redshift, ssm, and anthropic/openai via workload identity federation) — see `crates/vouch-cli/src/commands/credential/` and `setup/`.
+
 ## Server Architecture
 
 The server has two distinct route groups sharing `AppState`:
@@ -45,6 +49,8 @@ When TLS is configured, a separate HTTP→HTTPS redirect router runs on port 80 
 **AppState** holds: `Pool` (db), `ArcSwap<ServerConfig>` (lock-free config reload), `Webauthn`, optional `SshCa`, optional `GitHubApp`, `DpopState`, and `OidcSigningKey`.
 
 **Services layer** (`crates/vouch-server/src/services/`): Business logic called by handlers — `oidc/` (authorization, token issuance, DPoP, discovery, JWKS, token exchange), `integrations/` (AWS, GitHub App/OAuth/webhooks), `auth.rs` (WebAuthn verification).
+
+**HTTP message signing:** Requests to `/v1/*` may carry RFC 9421 signatures. The generic signing/verification middleware (with an async `KeyResolver` trait) lives in `vouch-httpsig`; the server-side resolver is `infra/httpsig.rs` (extracts `client_id` from the JWT, resolves P-256 public keys from OAuth client JWKS stored at RFC 7591 dynamic registration). Enforcement is optional: verify when `Signature-Input` is present, pass through otherwise. The CLI signing adapter is `crates/vouch-cli/src/fapi/httpsig.rs`.
 
 ## Build & Development Commands
 
@@ -66,15 +72,28 @@ make run-agent             # Agent daemon in foreground
 make test                  # Unit tests (cargo test)
 make test-integration      # Integration tests (cargo test --package vouch-tests)
 cargo test test_name -- --nocapture  # Single test with output
+make test-fuzz             # Fuzz targets, 60s each (requires nightly)
+make test-coverage         # Coverage report (requires cargo-llvm-cov)
+make test-mutants          # Mutation testing (requires cargo-mutants)
+
+# Supply chain
+make audit                 # cargo-deny: advisories, licenses, bans
 
 # CSS (requires tailwindcss CLI)
 make css-dev               # Watch mode
 make css-build             # Minified production build
 
+# Docs (mdBook)
+make docs-build
+make docs-serve
+
 # Docker
 make docker-build
 make docker-run
+make bake-all              # musl binaries via Docker Bake (also bake-cli, bake-server)
 ```
+
+**Running the server locally:** at least one upstream IdP must be configured via `VOUCH_IDPS` / `VOUCH_IDP_<SLUG>_*` (the server refuses to start without one), plus `VOUCH_RP_ID`, `VOUCH_JWT_SECRET`, and `VOUCH_DATABASE_URL`. See `AGENTS.md` for a minimum viable command and `docs/src/reference/environment-variables.md` for the full reference.
 
 **Toolchain:** Rust 1.96.0, edition 2024 (pinned in `rust-toolchain.toml`). Max line width 100 chars (`.rustfmt.toml`). Release profile uses `lto = true`, `codegen-units = 1`, `opt-level = "z"`, `panic = "abort"`, `strip = true`.
 
@@ -247,8 +266,10 @@ cargo test --features yubikey-tests -- --ignored
 | FIDO2 types | `crates/vouch-common/src/fido2_types.rs` |
 | Server handlers | `crates/vouch-server/src/handlers/` |
 | Server services | `crates/vouch-server/src/services/` (oidc/, integrations/) |
-| Crypto primitives | `crates/vouch-server/src/crypto/` (jwt.rs, ssh_ca.rs, webauthn_verify.rs, tpm_decrypt.rs, ber.rs, pem.rs) |
-| Server infra | `crates/vouch-server/src/infra/` (tls.rs, cleanup.rs, s3_config.rs, encrypt_config.rs) |
+| Crypto primitives | `crates/vouch-server/src/crypto/` (jwt.rs, ssh_ca.rs, webauthn_verify.rs, kms_signer.rs, cose.rs, attestation_chain.rs, document_crypto.rs, tpm_decrypt.rs, ber.rs, pem.rs) |
+| Server infra | `crates/vouch-server/src/infra/` (router.rs, tls.rs, rate_limit.rs, security_headers.rs, mtls_listener.rs, httpsig.rs, cleanup.rs, s3_config.rs) |
+| HTTP message signatures | `crates/vouch-httpsig/` (server resolver: `infra/httpsig.rs`, CLI adapter: `fapi/httpsig.rs`) |
+| Fuzz targets | `fuzz/fuzz_targets/` |
 | Database modules | `crates/vouch-server/src/db/` (pool.rs, users.rs, sessions.rs, etc.) |
 | HTML templates | `crates/vouch-server/templates/` |
 | CSS source | `crates/vouch-server/styles/input.css` |

--- a/crates/vouch-agent/src/daemon.rs
+++ b/crates/vouch-agent/src/daemon.rs
@@ -112,7 +112,7 @@ pub fn write_pid_file() -> Result<()> {
     let pid = process::id();
 
     // Write to a temp file in the same directory, then rename atomically
-    let tmp_path = pid_path.with_extension("tmp");
+    let tmp_path = pid_path.with_added_extension("tmp");
     let mut file = fs::File::create(&tmp_path)
         .map_err(|e| AgentError::Config(format!("Failed to create temp PID file: {e}")))?;
 

--- a/crates/vouch-agent/src/ssh_agent/provisioning.rs
+++ b/crates/vouch-agent/src/ssh_agent/provisioning.rs
@@ -139,7 +139,7 @@ fn spawn_lazy_provision(
         None => return,
     };
     let key_path = home.join(".ssh").join(DEFAULT_KEY_NAME);
-    let pub_path = key_path.with_extension("pub");
+    let pub_path = key_path.with_added_extension("pub");
 
     if !key_path.exists() || !pub_path.exists() {
         debug!("No SSH keypair on disk, cannot lazy-provision");

--- a/crates/vouch-cli/src/commands/credential/ssh.rs
+++ b/crates/vouch-cli/src/commands/credential/ssh.rs
@@ -47,7 +47,7 @@ pub(crate) fn default_key_path() -> Result<PathBuf> {
 /// Generate a new Ed25519 SSH keypair if it doesn't exist.
 /// Returns what action was taken (loaded existing vs generated new).
 pub(crate) fn ensure_keypair(key_path: &Path) -> Result<KeypairAction> {
-    let pub_path = key_path.with_extension("pub");
+    let pub_path = key_path.with_added_extension("pub");
 
     if key_path.exists() && pub_path.exists() {
         // Load existing public key
@@ -348,7 +348,7 @@ pub(crate) async fn run(server: &str, key_path: Option<&str>, force: bool) -> Re
         println!("Created: {}", result.key_path.display());
         println!(
             "Created: {}",
-            result.key_path.with_extension("pub").display()
+            result.key_path.with_added_extension("pub").display()
         );
     }
 

--- a/crates/vouch-cli/src/commands/setup/ssh.rs
+++ b/crates/vouch-cli/src/commands/setup/ssh.rs
@@ -210,7 +210,7 @@ Host *
 
 /// Add a @cert-authority entry to known_hosts for the given host patterns.
 ///
-/// Uses advisory file locking (`flock`) on Unix to prevent concurrent
+/// Uses advisory file locking (`File::lock`) to prevent concurrent
 /// modifications from corrupting the file. The lock is held for the
 /// entire read-modify-write cycle.
 fn add_trusted_ca_to_known_hosts(ca_path: &std::path::Path, host_patterns: &str) -> Result<()> {
@@ -241,7 +241,7 @@ fn add_trusted_ca_to_known_hosts(ca_path: &std::path::Path, host_patterns: &str)
     }
 
     // Acquire advisory lock for the read-modify-write cycle
-    let lock_path = known_hosts_path.with_extension("lock");
+    let lock_path = known_hosts_path.with_added_extension("lock");
     let lock_file = fs::OpenOptions::new()
         .create(true)
         .write(true)
@@ -256,8 +256,9 @@ fn add_trusted_ca_to_known_hosts(ca_path: &std::path::Path, host_patterns: &str)
         let _chmod = fs::set_permissions(&lock_path, fs::Permissions::from_mode(0o600));
     }
 
-    #[cfg(unix)]
-    crate::utils::flock_exclusive(&lock_file).context("failed to acquire known_hosts lock")?;
+    lock_file
+        .lock()
+        .context("failed to acquire known_hosts lock")?;
 
     // Read existing known_hosts under the lock
     let existing = if known_hosts_path.exists() {

--- a/crates/vouch-cli/src/config.rs
+++ b/crates/vouch-cli/src/config.rs
@@ -421,7 +421,7 @@ impl Config {
     #[cfg(unix)]
     pub(crate) fn modify(f: impl FnOnce(&mut Config)) -> Result<()> {
         let path = Self::config_path()?;
-        let lock_path = path.with_extension("lock");
+        let lock_path = path.with_added_extension("lock");
 
         if let Some(parent) = lock_path.parent() {
             fs::create_dir_all(parent)
@@ -443,7 +443,9 @@ impl Config {
                 std::fs::set_permissions(&lock_path, std::fs::Permissions::from_mode(0o600));
         }
 
-        crate::utils::flock_exclusive(&lock_file).context("failed to acquire config file lock")?;
+        lock_file
+            .lock()
+            .context("failed to acquire config file lock")?;
 
         let mut config = Self::load()?;
         f(&mut config);

--- a/crates/vouch-cli/src/integrations/aws/sigv4.rs
+++ b/crates/vouch-cli/src/integrations/aws/sigv4.rs
@@ -514,14 +514,7 @@ pub(crate) fn validate_sigv4_input(value: &str, label: &str) -> Result<()> {
 /// AWS error XML/JSON can contain account IDs, ARNs, and request IDs.
 /// Limiting the length avoids leaking excessive detail.
 fn truncate_error_body(body: &str, max_len: usize) -> &str {
-    if body.len() <= max_len {
-        return body;
-    }
-    // Find the last char boundary at or before max_len
-    let mut end = max_len;
-    while !body.is_char_boundary(end) && end > 0 {
-        end = end.saturating_sub(1);
-    }
+    let end = body.floor_char_boundary(max_len);
     body.get(..end).unwrap_or(body)
 }
 

--- a/crates/vouch-cli/src/utils.rs
+++ b/crates/vouch-cli/src/utils.rs
@@ -153,24 +153,6 @@ pub(crate) fn create_symlink_with_fallback(
     Ok(())
 }
 
-/// Acquire an exclusive advisory lock on a file using `flock(2)`.
-///
-/// This is the only `unsafe` call in the CLI crate. `flock` is a well-defined
-/// POSIX API and the file descriptor is guaranteed valid by the borrow of `File`.
-#[cfg(unix)]
-#[expect(
-    unsafe_code,
-    reason = "POSIX flock; safety documented inline above call site"
-)]
-pub(crate) fn flock_exclusive(file: &fs::File) -> Result<(), std::io::Error> {
-    use std::os::unix::io::{AsFd, AsRawFd};
-    let ret = unsafe { libc::flock(file.as_fd().as_raw_fd(), libc::LOCK_EX) };
-    if ret != 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 #[expect(
     clippy::panic_in_result_fn,

--- a/crates/vouch-server/src/crypto/ssh_ca.rs
+++ b/crates/vouch-server/src/crypto/ssh_ca.rs
@@ -174,7 +174,7 @@ impl SshCa {
         );
 
         // Also save public key alongside private key for convenience
-        let pub_path = path.with_extension("pub");
+        let pub_path = path.with_added_extension("pub");
         let pub_key_str = format!(
             "{} {}\n",
             private_key

--- a/crates/vouch-server/src/db/pool.rs
+++ b/crates/vouch-server/src/db/pool.rs
@@ -260,7 +260,7 @@ impl Pool {
         let pool = PgPoolOptions::new()
             .max_connections(max_connections)
             .min_connections(pool_cfg.min_connections)
-            .max_lifetime(Duration::from_secs(55 * 60))
+            .max_lifetime(Duration::from_mins(55))
             .idle_timeout(Duration::from_secs(pool_cfg.idle_timeout_secs))
             .acquire_timeout(Duration::from_secs(pool_cfg.acquire_timeout_secs))
             .test_before_acquire(false)
@@ -703,7 +703,7 @@ pub(crate) fn redact_database_url(url: &str) -> String {
 fn spawn_token_refresh(pool: sqlx::PgPool, dsql: DsqlEndpoint, user: String, is_admin: bool) {
     tokio::spawn(async move {
         // Refresh every 10 minutes (tokens expire after 15 min by default)
-        let refresh_interval = Duration::from_secs(10 * 60);
+        let refresh_interval = Duration::from_mins(10);
         let region = dsql.region().to_string();
 
         tracing::info!(

--- a/crates/vouch-server/src/infra/security_headers.rs
+++ b/crates/vouch-server/src/infra/security_headers.rs
@@ -38,7 +38,7 @@ pub fn build_api_cors_layer() -> CorsLayer {
             HeaderName::from_static("dpop"),
         ])
         .expose_headers([HeaderName::from_static("dpop-nonce")])
-        .max_age(std::time::Duration::from_secs(3600))
+        .max_age(std::time::Duration::from_hours(1))
 }
 
 /// Build restrictive CORS layer for UI routes (login, enroll, applications, etc.).
@@ -68,7 +68,7 @@ pub fn build_ui_cors_layer(config: &config::ServerConfig) -> CorsLayer {
                     header::ORIGIN,
                 ])
                 .allow_credentials(true)
-                .max_age(std::time::Duration::from_secs(3600))
+                .max_age(std::time::Duration::from_hours(1))
         }
         _ => {
             // No CORS configured -- restrictive same-origin defaults


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mechanical API and doc changes; advisory locking behavior should be equivalent but uses a different mechanism than `flock`.
> 
> **Overview**
> **Documentation:** `CLAUDE.md` is expanded with FAPI certification, `vouch-httpsig`/fuzz targets, broader credential integrations, HTTP message signing, extra `make` targets (fuzz, coverage, audit, docs, bake), and local server env requirements; the file-location table lists more crypto/infra modules.
> 
> **Rust 1.96-style API cleanup:** Path helpers switch from `with_extension` to `with_added_extension` for SSH keys, PID temps, lock sidecars, and CA `.pub` files so names like `id_ed25519_vouch` get `id_ed25519_vouch.pub` instead of replacing the last extension segment.
> 
> **File locking:** The CLI drops the unsafe `libc::flock` helper in `utils.rs`; config and `known_hosts` updates now use `File::lock()` on dedicated `.lock` files (comments updated in SSH setup).
> 
> **Small std/jiff helpers:** SigV4 error truncation uses `str::floor_char_boundary`; server pool/CORS code uses `Duration::from_mins` / `from_hours` instead of manual second math.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40897e8305e8573cd96597b08e1bc585143f7d4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->