### PR TITLE
fix(server): SSRF egress guard for client-controlled JWKS/request_uri fetches

### DIFF
--- a/crates/vouch-server/src/geo.rs
+++ b/crates/vouch-server/src/geo.rs
@@ -41,7 +41,7 @@ pub(crate) struct GeoLocation {
 /// or if the GeoIP database failed to load.
 pub(crate) fn lookup(ip: IpAddr) -> Option<GeoLocation> {
     let ip = ip.to_canonical();
-    if is_non_global(&ip) {
+    if crate::infra::ssrf::is_non_global(&ip) {
         return None;
     }
     let country_db = COUNTRY_DB.as_ref()?;
@@ -64,42 +64,6 @@ pub(crate) fn lookup(ip: IpAddr) -> Option<GeoLocation> {
         asn,
         org_name,
     })
-}
-
-fn is_non_global(ip: &IpAddr) -> bool {
-    match ip {
-        IpAddr::V4(v4) => {
-            let octets = v4.octets();
-            v4.is_loopback()
-                || v4.is_private()
-                || v4.is_link_local()
-                || v4.is_broadcast()
-                || v4.is_unspecified()
-                || v4.is_documentation()
-                || v4.is_multicast()
-                || (octets[0] == 100 && (octets[1] & 0xC0 == 64)) // shared/CGNAT 100.64.0.0/10
-                || (octets[0] == 192 && octets[1] == 0 && octets[2] == 0) // IETF 192.0.0.0/24
-                || (octets[0] == 192 && octets[1] == 88 && octets[2] == 99) // 6to4 192.88.99.0/24
-                || (octets[0] == 198 && (octets[1] & 0xFE == 18)) // benchmarking 198.18.0.0/15
-                || (octets[0] & 0xF0 == 240) // reserved 240.0.0.0/4
-        }
-        IpAddr::V6(v6) => {
-            let octets = v6.octets();
-            v6.is_loopback()
-                || v6.is_unspecified()
-                || v6.is_multicast()
-                || (octets[0] & 0xfe == 0xfc) // ULA fc00::/7
-                || (octets[0] == 0xfe && octets[1] & 0xc0 == 0x80) // link-local fe80::/10
-                || (octets[0] == 0x20 && octets[1] == 0x01
-                    && octets[2] == 0x0d && octets[3] == 0xb8) // documentation 2001:db8::/32
-                || (octets[0] == 0x20 && octets[1] == 0x01
-                    && octets[2] == 0x00 && octets[3] == 0x02) // benchmarking 2001:2::/48
-                || (octets[0] == 0x01 && octets[1] == 0x00
-                    && octets[2] == 0x00 && octets[3] == 0x00
-                    && octets[4] == 0x00 && octets[5] == 0x00
-                    && octets[6] == 0x00 && octets[7] == 0x00) // discard 100::/64
-        }
-    }
 }
 
 /// Force-initialize the GeoIP databases.

--- a/crates/vouch-server/src/handlers/oidc/authorize.rs
+++ b/crates/vouch-server/src/handlers/oidc/authorize.rs
@@ -919,20 +919,24 @@ async fn fetch_and_resolve_request_uri(
     }
 
     // Step 4: fetch the Request Object JWT from the URL.
-    let fetched_jwt = match fetch_request_object(request_uri, &state.http_client).await {
-        Ok(jwt) => jwt,
-        Err(e) => {
-            let description = match &e {
-                crate::services::ServiceError::OAuth { description, .. } => description.clone(),
-                _ => e.to_string(),
-            };
-            return Err(AuthorizeDeniedTemplate {
-                client_name: oauth_client.name,
-                error_message: format!("Failed to fetch Request Object: {description}"),
+    // Loopback request_uri destinations are permitted only in local development
+    // (no TLS configured); private/link-local targets stay blocked.
+    let allow_loopback = !state.config().tls_configured();
+    let fetched_jwt =
+        match fetch_request_object(request_uri, allow_loopback, &state.http_client).await {
+            Ok(jwt) => jwt,
+            Err(e) => {
+                let description = match &e {
+                    crate::services::ServiceError::OAuth { description, .. } => description.clone(),
+                    _ => e.to_string(),
+                };
+                return Err(AuthorizeDeniedTemplate {
+                    client_name: oauth_client.name,
+                    error_message: format!("Failed to fetch Request Object: {description}"),
+                }
+                .into_response());
             }
-            .into_response());
-        }
-    };
+        };
 
     // Step 5: validate the JWT.
     let query_hints = QueryParamHints {

--- a/crates/vouch-server/src/infra/dns.rs
+++ b/crates/vouch-server/src/infra/dns.rs
@@ -40,6 +40,31 @@ fn resolver() -> Result<&'static TokioResolver> {
     RESOLVER.as_ref().map_err(|e| anyhow::anyhow!("{e}"))
 }
 
+/// Resolve a hostname to the IP addresses it currently maps to, using the
+/// process-wide system resolver.
+///
+/// Used by the SSRF egress guard ([`crate::infra::ssrf`]) to vet
+/// client-controlled fetch destinations before they are requested. The same
+/// system resolver backs the server's `reqwest` client (no DoH override is
+/// installed server-side), so the addresses returned here are the ones the
+/// HTTP client will dial.
+///
+/// # Errors
+///
+/// Returns an error if the resolver is unavailable, the lookup fails, or the
+/// lookup times out.
+pub(crate) async fn resolve_host_ips(host: &str) -> Result<Vec<std::net::IpAddr>> {
+    let resolver = resolver().context("DNS resolver unavailable")?;
+    let lookup = match tokio::time::timeout(TXT_QUERY_TIMEOUT, resolver.lookup_ip(host)).await {
+        Ok(Ok(l)) => l,
+        Ok(Err(e)) => {
+            return Err(anyhow::Error::from(e).context(format!("DNS lookup for {host} failed")));
+        }
+        Err(_) => anyhow::bail!("DNS lookup for {host} timed out after {TXT_QUERY_TIMEOUT:?}"),
+    };
+    Ok(lookup.iter().collect())
+}
+
 /// Returns true if any TXT record at `_vouch-verification.<domain>` equals
 /// the expected token.
 ///

--- a/crates/vouch-server/src/infra/mod.rs
+++ b/crates/vouch-server/src/infra/mod.rs
@@ -20,6 +20,7 @@ pub mod router;
 pub mod s3_config;
 pub mod security_headers;
 pub mod serve;
+pub(crate) mod ssrf;
 pub mod startup;
 pub mod static_assets;
 pub mod telemetry;

--- a/crates/vouch-server/src/infra/ssrf.rs
+++ b/crates/vouch-server/src/infra/ssrf.rs
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! SSRF egress guard for server-side fetches of client-controlled URLs.
+//!
+//! OAuth clients can register a `jwks_uri` (RFC 7517 / RFC 7591) and supply a
+//! JAR `request_uri` (RFC 9101), both of which the server fetches
+//! **server-side** — `jwks_uri` while *verifying* a `private_key_jwt`
+//! assertion, i.e. before client authentication has even succeeded. Dynamic
+//! client registration (`POST /oauth/register`) is unauthenticated, so without
+//! an egress policy an anonymous caller could coerce the server into requesting
+//! arbitrary internal addresses (link-local metadata endpoints, RFC 1918
+//! services, loopback). HTTPS-only enforcement does not help: `https://[::1]`
+//! and `https://169.254.169.254` are valid HTTPS URLs.
+//!
+//! [`assert_public_destination`] vets a URL immediately before it is fetched.
+//! It parses the host and — resolving hostnames through the same system
+//! resolver the server's `reqwest` client uses — rejects any destination that
+//! maps to a non-global address. Combined with the existing HTTPS requirement
+//! and `redirect(Policy::none())`, this closes the private-network reach.
+//!
+//! This guard is intentionally scoped to **client-controlled** fetches. The
+//! operator-configured upstream-IdP discovery fetch
+//! (`services::idp::oidc::fetch_discovery`) is deliberately *not* gated here:
+//! it is trusted operator input and may legitimately target a private/internal
+//! IdP, and it keeps its own loopback-for-development allowance.
+
+use std::net::IpAddr;
+
+use url::Host;
+
+use crate::services::{OAuthErrorCode, ServiceError, ServiceResult};
+
+/// Returns `true` for IP addresses that must never be the target of a
+/// server-side fetch of a client-controlled URL: loopback, RFC 1918 private,
+/// link-local, CGNAT, IETF-protocol, 6to4-relay, benchmarking, documentation,
+/// multicast, broadcast, unspecified, ULA, and other non-globally-routable
+/// ranges.
+///
+/// Callers should pass a [canonicalised](IpAddr::to_canonical) address so an
+/// IPv4-mapped IPv6 address such as `::ffff:127.0.0.1` is classified as the
+/// underlying IPv4 loopback rather than slipping through the IPv6 checks.
+pub(crate) fn is_non_global(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            let [a, b, c, _d] = v4.octets();
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_broadcast()
+                || v4.is_unspecified()
+                || v4.is_documentation()
+                || v4.is_multicast()
+                || (a == 100 && (b & 0xC0 == 64)) // CGNAT 100.64.0.0/10
+                || (a == 192 && b == 0 && c == 0) // IETF protocol 192.0.0.0/24
+                || (a == 192 && b == 88 && c == 99) // 6to4 relay anycast 192.88.99.0/24
+                || (a == 198 && (b & 0xFE == 18)) // benchmarking 198.18.0.0/15
+                || (a & 0xF0 == 240) // reserved 240.0.0.0/4
+        }
+        IpAddr::V6(v6) => {
+            let [o0, o1, o2, o3, o4, o5, o6, o7, ..] = v6.octets();
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || v6.is_multicast()
+                || (o0 & 0xfe == 0xfc) // ULA fc00::/7
+                || (o0 == 0xfe && o1 & 0xc0 == 0x80) // link-local fe80::/10
+                || (o0 == 0x20 && o1 == 0x01 && o2 == 0x0d && o3 == 0xb8) // doc 2001:db8::/32
+                || (o0 == 0x20 && o1 == 0x01 && o2 == 0x00 && o3 == 0x02) // benchmarking 2001:2::/48
+                || (o0 == 0x01
+                    && o1 == 0x00
+                    && o2 == 0x00
+                    && o3 == 0x00
+                    && o4 == 0x00
+                    && o5 == 0x00
+                    && o6 == 0x00
+                    && o7 == 0x00) // discard-only 100::/64
+        }
+    }
+}
+
+/// Reject a URL whose host is — or resolves to — a non-global address.
+///
+/// Call this immediately before fetching a client-controlled URL. The host is
+/// resolved through the process-wide system resolver (the same path the
+/// server's `reqwest` client uses, since no DoH override is installed
+/// server-side), so the addresses vetted here are the ones the HTTP client
+/// will dial. If a hostname has multiple A/AAAA records, **all** are checked
+/// and any non-global address rejects the URL.
+///
+/// `allow_loopback` permits loopback destinations (`127.0.0.0/8`, `::1`,
+/// `localhost`) for local development and testing — wired from
+/// `!ServerConfig::tls_configured()`, matching the WebAuthn
+/// `allow_localhost_origin` relaxation. It only relaxes **loopback**: private,
+/// link-local, CGNAT and other internal ranges (e.g. the `169.254.169.254`
+/// cloud metadata endpoint) stay blocked even in development.
+///
+/// `code` is the OAuth error code surfaced to the caller — the JWKS path uses
+/// `invalid_client`, the JAR `request_uri` path uses `invalid_request_uri`.
+///
+/// # Errors
+///
+/// Returns an OAuth error if the URL is unparseable, has no host, fails to
+/// resolve, or resolves to a blocked address.
+pub(crate) async fn assert_public_destination(
+    url: &str,
+    allow_loopback: bool,
+    code: OAuthErrorCode,
+) -> ServiceResult<()> {
+    let parsed = url::Url::parse(url)
+        .map_err(|_| ServiceError::oauth(code, "destination URL is not parseable"))?;
+
+    match parsed.host() {
+        Some(Host::Ipv4(v4)) => reject_if_blocked(IpAddr::V4(v4), allow_loopback, code),
+        Some(Host::Ipv6(v6)) => reject_if_blocked(IpAddr::V6(v6), allow_loopback, code),
+        Some(Host::Domain(domain)) => {
+            let ips = crate::infra::dns::resolve_host_ips(domain)
+                .await
+                .map_err(|e| {
+                    tracing::warn!("SSRF guard: failed to resolve {domain}: {e}");
+                    ServiceError::oauth(code, "destination host could not be resolved")
+                })?;
+            if ips.is_empty() {
+                return Err(ServiceError::oauth(
+                    code,
+                    "destination host did not resolve to any address",
+                ));
+            }
+            for ip in ips {
+                reject_if_blocked(ip, allow_loopback, code)?;
+            }
+            Ok(())
+        }
+        None => Err(ServiceError::oauth(code, "destination URL has no host")),
+    }
+}
+
+/// Reject a single resolved address if it is blocked, logging a security event
+/// when the guard fires. Loopback is permitted when `allow_loopback` is set;
+/// all other non-global ranges are always rejected.
+fn reject_if_blocked(ip: IpAddr, allow_loopback: bool, code: OAuthErrorCode) -> ServiceResult<()> {
+    let canonical = ip.to_canonical();
+    if allow_loopback && canonical.is_loopback() {
+        return Ok(());
+    }
+    if is_non_global(&canonical) {
+        tracing::warn!(
+            target: "security",
+            %ip,
+            "SSRF guard: blocked outbound fetch to non-global address"
+        );
+        return Err(ServiceError::oauth(
+            code,
+            "destination resolves to a non-routable address",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: unwrap on parse is acceptable"
+)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    fn v6(s: &str) -> IpAddr {
+        IpAddr::V6(s.parse::<Ipv6Addr>().unwrap())
+    }
+
+    #[test]
+    fn classifies_v4_non_global() {
+        for [a, b, c, d] in [
+            [127, 0, 0, 1],       // loopback
+            [10, 0, 0, 1],        // RFC 1918
+            [172, 16, 0, 1],      // RFC 1918
+            [192, 168, 1, 1],     // RFC 1918
+            [169, 254, 169, 254], // link-local (AWS IMDS)
+            [100, 64, 0, 1],      // CGNAT
+            [192, 0, 0, 1],       // IETF protocol
+            [198, 18, 0, 1],      // benchmarking
+            [0, 0, 0, 0],         // unspecified
+            [255, 255, 255, 255], // broadcast
+        ] {
+            let ip = IpAddr::V4(Ipv4Addr::new(a, b, c, d));
+            assert!(is_non_global(&ip), "expected non-global: {ip}");
+        }
+    }
+
+    #[test]
+    fn classifies_v4_global() {
+        for [a, b, c, d] in [[1, 1, 1, 1], [8, 8, 8, 8], [93, 184, 216, 34]] {
+            let ip = IpAddr::V4(Ipv4Addr::new(a, b, c, d));
+            assert!(!is_non_global(&ip), "expected global: {ip}");
+        }
+    }
+
+    #[test]
+    fn classifies_v6() {
+        assert!(is_non_global(&IpAddr::V6(Ipv6Addr::LOCALHOST)));
+        assert!(is_non_global(&IpAddr::V6(Ipv6Addr::UNSPECIFIED)));
+        assert!(is_non_global(&v6("fe80::1"))); // link-local
+        assert!(is_non_global(&v6("fc00::1"))); // ULA
+        assert!(is_non_global(&v6("2001:db8::1"))); // documentation
+        assert!(!is_non_global(&v6("2606:4700:4700::1111"))); // Cloudflare DNS
+    }
+
+    #[test]
+    fn canonicalizes_mapped_v4_loopback() {
+        // ::ffff:127.0.0.1 must classify as loopback once canonicalised.
+        let mapped = v6("::ffff:127.0.0.1");
+        assert!(is_non_global(&mapped.to_canonical()));
+    }
+
+    #[tokio::test]
+    async fn rejects_loopback_ip_literal_in_production() {
+        assert!(
+            assert_public_destination(
+                "https://127.0.0.1/jwks.json",
+                false,
+                OAuthErrorCode::InvalidClient
+            )
+            .await
+            .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn allows_loopback_ip_literal_in_dev() {
+        // allow_loopback=true models a non-TLS local-dev deployment.
+        assert!(
+            assert_public_destination(
+                "https://127.0.0.1/jwks.json",
+                true,
+                OAuthErrorCode::InvalidClient
+            )
+            .await
+            .is_ok()
+        );
+        assert!(
+            assert_public_destination(
+                "https://[::1]/jwks",
+                true,
+                OAuthErrorCode::InvalidRequestUri
+            )
+            .await
+            .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_imds_even_in_dev() {
+        // Link-local (cloud metadata) must stay blocked regardless of dev mode.
+        assert!(
+            assert_public_destination(
+                "https://169.254.169.254/latest/meta-data/",
+                true,
+                OAuthErrorCode::InvalidClient
+            )
+            .await
+            .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_private_ip_even_in_dev() {
+        assert!(
+            assert_public_destination("https://10.1.2.3/jwks", true, OAuthErrorCode::InvalidClient)
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_bracketed_ipv6_loopback_in_production() {
+        assert!(
+            assert_public_destination(
+                "https://[::1]/jwks",
+                false,
+                OAuthErrorCode::InvalidRequestUri
+            )
+            .await
+            .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn allows_public_ip_literal() {
+        assert!(
+            assert_public_destination("https://1.1.1.1/jwks", false, OAuthErrorCode::InvalidClient)
+                .await
+                .is_ok()
+        );
+    }
+}

--- a/crates/vouch-server/src/services/oidc/jar.rs
+++ b/crates/vouch-server/src/services/oidc/jar.rs
@@ -135,10 +135,13 @@ const MAX_REQUEST_OBJECT_SIZE: usize = 64 * 1024;
 /// parameter). SSRF is mitigated by:
 /// 1. HTTPS-only enforcement (no plaintext HTTP)
 /// 2. URL structure validation (must parse as a valid URL with a hostname)
-/// 3. Caller-side allowlist (`OAuthClient.request_uris`) when configured
-/// 4. Caller verifies the client is registered and active before calling
-/// 5. 64 KB response size cap prevents data exfiltration
-/// 6. `reqwest` with `rustls` — no system cert store manipulation
+/// 3. Egress guard ([`crate::infra::ssrf::assert_public_destination`]): the
+///    host is resolved and rejected if it maps to any non-global
+///    (loopback/private/link-local/…) address
+/// 4. Caller-side allowlist (`OAuthClient.request_uris`) when configured
+/// 5. Caller verifies the client is registered and active before calling
+/// 6. 64 KB response size cap prevents data exfiltration
+/// 7. `reqwest` with `rustls` — no system cert store manipulation
 ///
 /// # Errors
 /// Returns `OAuthErrorCode::InvalidRequestUri` if the URI is not HTTPS,
@@ -146,6 +149,7 @@ const MAX_REQUEST_OBJECT_SIZE: usize = 64 * 1024;
 /// or the body exceeds `MAX_REQUEST_OBJECT_SIZE`.
 pub async fn fetch_request_object(
     uri: &str,
+    allow_loopback: bool,
     http_client: &reqwest::Client,
 ) -> ServiceResult<String> {
     if !uri.starts_with("https://") {
@@ -169,7 +173,17 @@ pub async fn fetch_request_object(
         ));
     }
 
-    // SSRF: URL has been validated (HTTPS, valid hostname, caller-side allowlist).
+    // SSRF egress guard: refuse to dial a request_uri that resolves to a
+    // private/link-local address. Loopback is permitted only in local
+    // development (`allow_loopback`). Complements the HTTPS check, structural
+    // validation, and any caller-side allowlist.
+    crate::infra::ssrf::assert_public_destination(
+        uri,
+        allow_loopback,
+        OAuthErrorCode::InvalidRequestUri,
+    )
+    .await?;
+
     let response = http_client.get(uri).send().await.map_err(|e| {
         tracing::debug!("Failed to fetch Request Object from {uri}: {e}");
         ServiceError::oauth(
@@ -353,12 +367,18 @@ pub async fn validate_request_object(
             )
         })?;
 
+    // Loopback JWKS destinations are permitted only in local development
+    // (no TLS configured), matching the WebAuthn `allow_localhost_origin`
+    // relaxation; private/link-local targets stay blocked.
+    let allow_loopback = !state.config().tls_configured();
+
     let jwks = resolve_client_jwks(
         &state.store,
         &client.id,
         client.jwks.as_ref(),
         client.jwks_uri.as_deref(),
         jwks_cache.as_ref(),
+        allow_loopback,
         &state.http_client,
     )
     .await
@@ -376,6 +396,7 @@ pub async fn validate_request_object(
         &client.id,
         client.jwks_uri.as_deref(),
         jwks_cache.as_ref(),
+        allow_loopback,
         &state.http_client,
         &jwks,
         &assertion_header,

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
@@ -201,12 +201,18 @@ pub async fn authenticate_client_jwt(
             ClientAuthError::InvalidCredentials
         })?;
 
+    // Loopback JWKS destinations are permitted only in local development
+    // (no TLS configured), matching the WebAuthn `allow_localhost_origin`
+    // relaxation; private/link-local targets stay blocked.
+    let allow_loopback = !state.config().tls_configured();
+
     let jwks = resolve_client_jwks(
         &state.store,
         &client.id,
         client.jwks.as_ref(),
         client.jwks_uri.as_deref(),
         jwks_cache.as_ref(),
+        allow_loopback,
         &state.http_client,
     )
     .await
@@ -224,6 +230,7 @@ pub async fn authenticate_client_jwt(
         &client.id,
         client.jwks_uri.as_deref(),
         jwks_cache.as_ref(),
+        allow_loopback,
         &state.http_client,
         &jwks,
         &header,

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/jwks.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/jwks.rs
@@ -67,6 +67,7 @@ pub async fn resolve_client_jwks(
     jwks: Option<&serde_json::Value>,
     jwks_uri: Option<&str>,
     jwks_cache: Option<&JwksCacheDoc>,
+    allow_loopback: bool,
     http_client: &reqwest::Client,
 ) -> ServiceResult<JwkSet> {
     // Inline JWKS takes priority
@@ -76,7 +77,15 @@ pub async fn resolve_client_jwks(
 
     // JWKS URI with caching
     if let Some(uri) = jwks_uri {
-        return resolve_jwks_uri(store, client_id, uri, jwks_cache, http_client).await;
+        return resolve_jwks_uri(
+            store,
+            client_id,
+            uri,
+            jwks_cache,
+            allow_loopback,
+            http_client,
+        )
+        .await;
     }
 
     Err(ServiceError::oauth(
@@ -91,6 +100,7 @@ async fn resolve_jwks_uri(
     parent_id: &str,
     uri: &str,
     cached: Option<&JwksCacheDoc>,
+    allow_loopback: bool,
     http_client: &reqwest::Client,
 ) -> ServiceResult<JwkSet> {
     // Check cache freshness
@@ -101,7 +111,7 @@ async fn resolve_jwks_uri(
     }
 
     // Cache is stale or missing — attempt fetch
-    match fetch_and_parse_jwks(uri, http_client).await {
+    match fetch_and_parse_jwks(uri, allow_loopback, http_client).await {
         Ok((jwks_value, jwks_set)) => {
             if let Err(e) = db::upsert_jwks_cache(store, parent_id, &jwks_value).await {
                 tracing::warn!("Failed to update JWKS cache for {parent_id}: {e}");
@@ -128,7 +138,11 @@ async fn resolve_jwks_uri(
 /// Fetch JWKS from a remote URI.
 ///
 /// Enforces HTTPS-only and response size cap.
-async fn fetch_jwks(uri: &str, http_client: &reqwest::Client) -> ServiceResult<String> {
+async fn fetch_jwks(
+    uri: &str,
+    allow_loopback: bool,
+    http_client: &reqwest::Client,
+) -> ServiceResult<String> {
     // HTTPS-only
     if !uri.starts_with("https://") {
         return Err(ServiceError::oauth(
@@ -136,6 +150,17 @@ async fn fetch_jwks(uri: &str, http_client: &reqwest::Client) -> ServiceResult<S
             "JWKS URI must use HTTPS",
         ));
     }
+
+    // SSRF egress guard: a client-registered `jwks_uri` is fetched here while
+    // verifying a `private_key_jwt` assertion, and dynamic client registration
+    // is unauthenticated — refuse to dial private/link-local targets. Loopback
+    // is permitted only in local development (`allow_loopback`).
+    crate::infra::ssrf::assert_public_destination(
+        uri,
+        allow_loopback,
+        OAuthErrorCode::InvalidClient,
+    )
+    .await?;
 
     let response = http_client.get(uri).send().await.map_err(|e| {
         tracing::warn!("Failed to fetch JWKS from {uri}: {e}");
@@ -187,9 +212,10 @@ async fn fetch_jwks(uri: &str, http_client: &reqwest::Client) -> ServiceResult<S
 /// Fetch JWKS from a URI and parse into both a `Value` (for caching) and a `JwkSet`.
 async fn fetch_and_parse_jwks(
     uri: &str,
+    allow_loopback: bool,
     http_client: &reqwest::Client,
 ) -> ServiceResult<(serde_json::Value, JwkSet)> {
-    let jwks_json = fetch_jwks(uri, http_client).await?;
+    let jwks_json = fetch_jwks(uri, allow_loopback, http_client).await?;
     let jwks_value: serde_json::Value = serde_json::from_str(&jwks_json).map_err(|e| {
         tracing::debug!("Failed to parse JWKS as JSON value: {e}");
         ServiceError::oauth(OAuthErrorCode::InvalidClient, "Invalid JWKS format")
@@ -283,12 +309,17 @@ const JWKS_FORCE_REFRESH_MIN_INTERVAL_SECONDS: i64 = 10;
 /// On initial key miss, if the client has a `jwks_uri` and it hasn't been refreshed
 /// in the last 10 seconds, fetches a fresh JWKS and retries. This handles key rotation
 /// where a client starts signing with a new key before the server's cache has expired.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "store/client/uri/cache/loopback-flag/http-client/jwks/header are all distinct inputs"
+)]
 pub async fn find_matching_key_with_refresh_client(
     store: &DocumentStore,
     client_id: &str,
     jwks_uri: Option<&str>,
     // Load once before calling resolve_client_jwks; pre-refresh timestamp matches prior behavior.
     jwks_cache: Option<&JwksCacheDoc>,
+    allow_loopback: bool,
     http_client: &reqwest::Client,
     jwks: &JwkSet,
     header: &JwtAssertionHeader,
@@ -315,7 +346,7 @@ pub async fn find_matching_key_with_refresh_client(
     }
 
     tracing::debug!("Key not found in JWKS cache for client {client_id}; force-refreshing");
-    match fetch_and_parse_jwks(uri, http_client).await {
+    match fetch_and_parse_jwks(uri, allow_loopback, http_client).await {
         Ok((jwks_value, fresh_jwks)) => {
             if let Err(e) = db::upsert_jwks_cache(store, client_id, &jwks_value).await {
                 tracing::warn!("Failed to update JWKS cache for client {client_id}: {e}");
@@ -880,7 +911,7 @@ mod tests {
     #[tokio::test]
     async fn test_fetch_jwks_rejects_http_url() {
         let client = reqwest::Client::new();
-        let result = fetch_jwks("http://example.com/jwks", &client).await;
+        let result = fetch_jwks("http://example.com/jwks", false, &client).await;
         let err = result.unwrap_err();
         assert!(
             matches!(&err, ServiceError::OAuth { code, .. } if *code == OAuthErrorCode::InvalidClient)
@@ -893,7 +924,7 @@ mod tests {
     #[tokio::test]
     async fn test_fetch_jwks_rejects_ftp_url() {
         let client = reqwest::Client::new();
-        let result = fetch_jwks("ftp://example.com/jwks", &client).await;
+        let result = fetch_jwks("ftp://example.com/jwks", false, &client).await;
         let err = result.unwrap_err();
         assert!(
             matches!(&err, ServiceError::OAuth { code, .. } if *code == OAuthErrorCode::InvalidClient)
@@ -906,7 +937,7 @@ mod tests {
     #[tokio::test]
     async fn test_fetch_jwks_rejects_empty_uri() {
         let client = reqwest::Client::new();
-        let result = fetch_jwks("", &client).await;
+        let result = fetch_jwks("", false, &client).await;
         let err = result.unwrap_err();
         assert!(
             matches!(&err, ServiceError::OAuth { code, .. } if *code == OAuthErrorCode::InvalidClient)
@@ -1066,6 +1097,7 @@ mod tests {
             "client-abc",
             None, // no JWKS URI
             None,
+            false,
             &http_client,
             &jwks,
             &hdr,
@@ -1100,6 +1132,7 @@ mod tests {
             "client-rate-limited",
             Some("https://127.0.0.1:1/jwks"),
             Some(&recent),
+            false,
             &http_client,
             &jwks,
             &hdr,
@@ -1137,6 +1170,7 @@ mod tests {
             "client-fetch-test",
             Some("http://127.0.0.1:1/jwks"),
             Some(&old_cache),
+            false,
             &http_client,
             &stale_jwks,
             &hdr,


### PR DESCRIPTION
## Summary

Implements the **SP1** finding from the second-pass security evaluation (see #469): an unauthenticated blind SSRF surface in the server-side fetches of client-controlled URLs.

OAuth clients can register a `jwks_uri` (RFC 7517/7591) and supply a JAR `request_uri` (RFC 9101), both of which the server fetches **server-side** — the `jwks_uri` while *verifying* a `private_key_jwt` assertion, i.e. **before** client authentication succeeds. Dynamic client registration (`POST /oauth/register`) is **unauthenticated**, and the only prior egress guard was an HTTPS-scheme check — which does not stop `https://[::1]` or `https://169.254.169.254`. An anonymous caller could therefore coerce the server into requesting internal/link-local/loopback addresses.

## What changed

- **New `infra::ssrf::assert_public_destination`** — parses the URL host and, resolving hostnames through the **same system resolver the `reqwest` client uses** (`infra::dns::resolve_host_ips`), rejects any destination that maps to a non-global address (loopback, RFC 1918, link-local, CGNAT, ULA, multicast, …). Because it works off `Url::host()`, decimal/hex IP obfuscation (e.g. `https://2130706433` → `127.0.0.1`) is normalised and caught.
- The non-global classifier is **shared** with `geo::lookup` (moved into `infra::ssrf::is_non_global`, no duplication).
- Wired into `fetch_jwks` (`jwt_bearer/jwks.rs`) and the JAR `fetch_request_object` (`oidc/jar.rs`).
- `fetch_discovery` (operator-configured upstream IdP) is intentionally **not** gated — it is trusted operator input and may legitimately target an internal IdP.

## Localhost / local-dev preserved

A `allow_loopback` flag — wired from `!ServerConfig::tls_configured()`, mirroring the existing WebAuthn `allow_localhost_origin` relaxation — permits **loopback** destinations when TLS is not configured, so a localhost vouch server + a localhost test client (`jwks_uri`/`request_uri` on `127.0.0.1`/`::1`/`localhost`) keep working. Private and link-local ranges (e.g. cloud metadata `169.254.169.254`) stay blocked **even in dev**.

## Tests

- New unit tests in `infra::ssrf`: IPv4/IPv6 classification, IPv4-mapped-IPv6 canonicalisation, dev-allows-loopback vs prod-blocks-loopback, and always-block for IMDS/private.
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo test -p vouch-server --lib`: 2299 passed.
- `cargo test -p vouch-tests`: all integration suites passed.

## Follow-up (not in this PR)

Resolve→pin connect (custom `reqwest` DNS resolver) would additionally close the narrow DNS-rebinding TOCTOU between the pre-flight resolve and reqwest's own resolve; the residual is already low because these are HTTPS fetches with `redirect(Policy::none())` (a rebound internal IP would not present a valid cert for the attacker hostname).

https://claude.ai/code/session_012fuKdFdthz7iVk8JLJDxhk

---
_Generated by [Claude Code](https://claude.ai/code/session_012fuKdFdthz7iVk8JLJDxhk)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security fix on unauthenticated outbound HTTP paths (dynamic registration, pre-auth JWKS/JAR); incorrect blocking or bypass could break OAuth clients or leave SSRF open.
> 
> **Overview**
> Adds an **SSRF egress guard** for server-side fetches of **client-controlled** URLs (`jwks_uri`, JAR `request_uri`), closing a path where HTTPS alone still allowed internal targets like `https://169.254.169.254` or loopback.
> 
> **`infra::ssrf::assert_public_destination`** parses the host, resolves names via new **`infra::dns::resolve_host_ips`** (same system resolver as `reqwest`), and rejects destinations that map to any non-global address; all A/AAAA answers must pass. **`is_non_global`** moves out of **`geo::lookup`** into this module so classification is shared, not duplicated.
> 
> The guard runs immediately before **`fetch_jwks`** and **`fetch_request_object`**, with **`allow_loopback`** from **`!ServerConfig::tls_configured()`** so local dev can use loopback JWKS/`request_uri` while private/link-local (e.g. cloud metadata) stay blocked. Operator-configured upstream IdP discovery is **not** gated.
> 
> Unit tests cover IP classification, dev vs prod loopback, and always-blocked internal ranges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8493255289e4747928de8004bbce7cc3fa17f2f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->