### PR TITLE
Targeted cleanup for long functions and high-arity signatures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,11 @@ map_unwrap_or = "deny"
 # Silent drops of #[must_use] (mostly Result) hide real failures
 let_underscore_must_use = "deny"
 
+# Functions over 150 LoC (threshold in .clippy.toml) need an explicit
+# #[expect(..., reason)] — ratchet against monolithic functions. warn is
+# enforced as deny by `make lint` (-D warnings).
+too_many_lines = "warn"
+
 module_name_repetitions = "allow"
 similar_names = "allow"
 

--- a/crates/vouch-cli/src/commands/diag.rs
+++ b/crates/vouch-cli/src/commands/diag.rs
@@ -58,6 +58,10 @@ struct DiagJson {
 }
 
 /// Run diagnostic test of YubiKey registration + authentication + verification.
+#[expect(
+    clippy::too_many_lines,
+    reason = "sequential FIDO2 diagnostic report; each phase prints independent results"
+)]
 pub(crate) fn run(args: DiagArgs) -> Result<()> {
     let json = args.json;
 

--- a/crates/vouch-cli/src/commands/login.rs
+++ b/crates/vouch-cli/src/commands/login.rs
@@ -94,6 +94,10 @@ struct Fapi2TokenResponse {
 }
 
 /// Run FAPI 2.0 login using the FIDO2 assertion grant.
+#[expect(
+    clippy::too_many_lines,
+    reason = "linear FAPI 2.0 login flow: challenge, assertion, token, session"
+)]
 async fn run_fapi_login(
     client: &VouchClient,
     server: &str,

--- a/crates/vouch-cli/src/commands/status.rs
+++ b/crates/vouch-cli/src/commands/status.rs
@@ -77,6 +77,7 @@ pub(crate) fn print_shell(
 }
 
 /// Run the status command.
+#[expect(clippy::too_many_lines, reason = "sequential status report output")]
 pub(crate) async fn run(server: &str, mode: OutputFormat) -> Result<()> {
     // First, try to get session from agent (Unix only)
     #[cfg(unix)]

--- a/crates/vouch-cli/src/main.rs
+++ b/crates/vouch-cli/src/main.rs
@@ -447,6 +447,10 @@ async fn main() -> ExitCode {
 }
 
 /// Inner entry point that returns `anyhow::Result`.
+#[expect(
+    clippy::too_many_lines,
+    reason = "single dispatch match over all CLI subcommands"
+)]
 async fn run() -> Result<()> {
     let argv0 = std::env::args().next().unwrap_or_default();
 

--- a/crates/vouch-server/src/crypto/webauthn_verify.rs
+++ b/crates/vouch-server/src/crypto/webauthn_verify.rs
@@ -25,8 +25,6 @@ use aws_lc_rs::digest::{self, SHA256};
 use aws_lc_rs::signature::{self, UnparsedPublicKey};
 use der::Decode;
 use thiserror::Error;
-use vouch_common::encoding::Raw;
-use vouch_common::fido2_types::{AuthData, ClientDataJson, CoseKey, Signature};
 
 /// Trait for COSE signature verification.
 ///
@@ -180,41 +178,65 @@ struct ClientData {
     cross_origin: Option<bool>,
 }
 
+/// Parameters for WebAuthn assertion verification (WebAuthn Level 2 §7.2).
+///
+/// Named fields prevent the positional byte-slice/string swaps an 11-argument
+/// signature would invite.
+#[derive(Debug, Clone, Copy)]
+pub struct AssertionParams<'a> {
+    /// Raw authenticator data bytes.
+    pub authenticator_data: &'a [u8],
+    /// Raw client data JSON bytes.
+    pub client_data_json: &'a [u8],
+    /// The signature to verify.
+    pub signature: &'a [u8],
+    /// The public key in COSE format (from registration).
+    pub public_key_cose: &'a [u8],
+    /// The expected relying party ID.
+    pub expected_rp_id: &'a str,
+    /// The expected challenge (base64url encoded).
+    pub expected_challenge: &'a str,
+    /// The expected origin URL.
+    pub expected_origin: &'a str,
+    /// The previously stored counter value.
+    pub stored_counter: u32,
+    /// Whether to require the UV flag.
+    pub require_user_verification: bool,
+    /// Whether to tolerate loopback origin variations. Development only; pass
+    /// `false` in production so an origin mismatch is always rejected.
+    pub allow_localhost_origin: bool,
+}
+
 /// Verify a WebAuthn assertion using the default COSE verifier.
 ///
 /// This is a convenience function that uses [`RealCoseVerifier`] for production use.
 /// For testing, use [`verify_assertion_with_verifier`] with a custom verifier.
+pub fn verify_assertion(params: &AssertionParams<'_>) -> Result<VerificationResult, VerifyError> {
+    verify_assertion_inner(params, &RealCoseVerifier)
+}
+
+/// Verify a WebAuthn assertion with a custom COSE verifier.
 ///
-/// # Arguments
-/// * `authenticator_data` - Raw authenticator data bytes
-/// * `client_data_json` - Raw client data JSON bytes
-/// * `signature` - The signature to verify
-/// * `public_key_cose` - The public key in COSE format (from registration)
-/// * `expected_rp_id` - The expected relying party ID
-/// * `expected_challenge` - The expected challenge (base64url encoded)
-/// * `expected_origin` - The expected origin URL
-/// * `stored_counter` - The previously stored counter value
-/// * `require_user_verification` - Whether to require UV flag
-/// * `allow_localhost_origin` - Whether to tolerate loopback origin variations
-///   (development only; pass `false` in production so an origin mismatch is
-///   always rejected)
-#[expect(
-    clippy::too_many_arguments,
-    reason = "WebAuthn assertion verification requires all per-RFC parameters"
-)]
-pub fn verify_assertion(
-    authenticator_data: &[u8],
-    client_data_json: &[u8],
-    signature: &[u8],
-    public_key_cose: &[u8],
-    expected_rp_id: &str,
-    expected_challenge: &str,
-    expected_origin: &str,
-    stored_counter: u32,
-    require_user_verification: bool,
-    allow_localhost_origin: bool,
+/// This function allows injecting a custom verifier for testing purposes.
+/// For production use, prefer [`verify_assertion`] which uses the default verifier.
+pub fn verify_assertion_with_verifier<V: CoseVerifier>(
+    params: &AssertionParams<'_>,
+    verifier: &V,
 ) -> Result<VerificationResult, VerifyError> {
-    verify_assertion_inner(
+    verify_assertion_inner(params, verifier)
+}
+
+/// Core WebAuthn assertion verification.
+///
+/// `params.allow_localhost_origin` gates the loopback origin-variation
+/// relaxation: it must be `true` only in development (no TLS). Production
+/// threads `false` so an origin mismatch is always rejected even on a
+/// misconfigured loopback `rp_id`.
+fn verify_assertion_inner<V: CoseVerifier>(
+    params: &AssertionParams<'_>,
+    verifier: &V,
+) -> Result<VerificationResult, VerifyError> {
+    let &AssertionParams {
         authenticator_data,
         client_data_json,
         signature,
@@ -225,86 +247,8 @@ pub fn verify_assertion(
         stored_counter,
         require_user_verification,
         allow_localhost_origin,
-        &RealCoseVerifier,
-    )
-}
+    } = params;
 
-/// Verify a WebAuthn assertion with a custom COSE verifier.
-///
-/// This function allows injecting a custom verifier for testing purposes.
-/// For production use, prefer [`verify_assertion`] which uses the default verifier.
-///
-/// # Arguments
-/// * `authenticator_data` - Raw authenticator data bytes
-/// * `client_data_json` - Raw client data JSON bytes
-/// * `signature` - The signature to verify
-/// * `public_key_cose` - The public key in COSE format (from registration)
-/// * `expected_rp_id` - The expected relying party ID
-/// * `expected_challenge` - The expected challenge (base64url encoded)
-/// * `expected_origin` - The expected origin URL
-/// * `stored_counter` - The previously stored counter value
-/// * `require_user_verification` - Whether to require UV flag
-/// * `verifier` - The COSE verifier to use for signature verification
-///
-/// Localhost origin relaxation is always enabled in this helper, matching its
-/// historical dev/test behavior. Production callers go through
-/// [`verify_assertion`], which threads an explicit `allow_localhost_origin`
-/// flag derived from server config.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "WebAuthn assertion verification requires all per-RFC parameters"
-)]
-pub fn verify_assertion_with_verifier<V: CoseVerifier>(
-    authenticator_data: &[u8],
-    client_data_json: &[u8],
-    signature: &[u8],
-    public_key_cose: &[u8],
-    expected_rp_id: &str,
-    expected_challenge: &str,
-    expected_origin: &str,
-    stored_counter: u32,
-    require_user_verification: bool,
-    verifier: &V,
-) -> Result<VerificationResult, VerifyError> {
-    verify_assertion_inner(
-        authenticator_data,
-        client_data_json,
-        signature,
-        public_key_cose,
-        expected_rp_id,
-        expected_challenge,
-        expected_origin,
-        stored_counter,
-        require_user_verification,
-        // Dev/test default: tolerate loopback origin variations.
-        true,
-        verifier,
-    )
-}
-
-/// Core WebAuthn assertion verification.
-///
-/// `allow_localhost_origin` gates the loopback origin-variation relaxation: it
-/// must be `true` only in development (no TLS). Production threads `false` so
-/// an origin mismatch is always rejected even on a misconfigured loopback
-/// `rp_id`.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "WebAuthn assertion verification requires all per-RFC parameters"
-)]
-fn verify_assertion_inner<V: CoseVerifier>(
-    authenticator_data: &[u8],
-    client_data_json: &[u8],
-    signature: &[u8],
-    public_key_cose: &[u8],
-    expected_rp_id: &str,
-    expected_challenge: &str,
-    expected_origin: &str,
-    stored_counter: u32,
-    require_user_verification: bool,
-    allow_localhost_origin: bool,
-    verifier: &V,
-) -> Result<VerificationResult, VerifyError> {
     // 1. Verify authenticator data structure
     // Minimum length: 32 (rpIdHash) + 1 (flags) + 4 (counter) = 37 bytes
     if authenticator_data.len() < 37 {
@@ -418,85 +362,6 @@ fn verify_assertion_inner<V: CoseVerifier>(
         counter,
         user_verified,
     })
-}
-
-// ============================================================================
-// Type-Safe Wrappers (Phase 3)
-// ============================================================================
-
-/// Verify a WebAuthn assertion using typed parameters.
-///
-/// This is a type-safe wrapper around [`verify_assertion`] that uses the
-/// `Encoded<T, E>` types from `vouch_common` for compile-time safety.
-///
-/// # Type Safety
-///
-/// Using typed parameters prevents accidentally swapping arguments:
-/// - `AuthData<Raw>` for authenticator data
-/// - `ClientDataJson<Raw>` for client data JSON
-/// - `Signature<Raw>` for the signature
-/// - `CoseKey<Raw>` for the public key
-#[expect(
-    clippy::too_many_arguments,
-    reason = "WebAuthn assertion verification requires all per-RFC parameters"
-)]
-pub fn verify_assertion_typed(
-    authenticator_data: &AuthData<Raw>,
-    client_data_json: &ClientDataJson<Raw>,
-    signature: &Signature<Raw>,
-    public_key_cose: &CoseKey<Raw>,
-    expected_rp_id: &str,
-    expected_challenge: &str,
-    expected_origin: &str,
-    stored_counter: u32,
-    require_user_verification: bool,
-    allow_localhost_origin: bool,
-) -> Result<VerificationResult, VerifyError> {
-    verify_assertion(
-        authenticator_data.as_bytes(),
-        client_data_json.as_bytes(),
-        signature.as_bytes(),
-        public_key_cose.as_bytes(),
-        expected_rp_id,
-        expected_challenge,
-        expected_origin,
-        stored_counter,
-        require_user_verification,
-        allow_localhost_origin,
-    )
-}
-
-/// Verify a WebAuthn assertion with a custom COSE verifier using typed parameters.
-///
-/// This is a type-safe wrapper around [`verify_assertion_with_verifier`].
-#[expect(
-    clippy::too_many_arguments,
-    reason = "WebAuthn assertion verification requires all per-RFC parameters"
-)]
-pub fn verify_assertion_typed_with_verifier<V: CoseVerifier>(
-    authenticator_data: &AuthData<Raw>,
-    client_data_json: &ClientDataJson<Raw>,
-    signature: &Signature<Raw>,
-    public_key_cose: &CoseKey<Raw>,
-    expected_rp_id: &str,
-    expected_challenge: &str,
-    expected_origin: &str,
-    stored_counter: u32,
-    require_user_verification: bool,
-    verifier: &V,
-) -> Result<VerificationResult, VerifyError> {
-    verify_assertion_with_verifier(
-        authenticator_data.as_bytes(),
-        client_data_json.as_bytes(),
-        signature.as_bytes(),
-        public_key_cose.as_bytes(),
-        expected_rp_id,
-        expected_challenge,
-        expected_origin,
-        stored_counter,
-        require_user_verification,
-        verifier,
-    )
 }
 
 // ============================================================================
@@ -1556,15 +1421,18 @@ mod tests {
         let cose_key = make_eddsa_cose_key(&[0u8; 32]);
 
         let result = verify_assertion_with_verifier(
-            &short_auth_data,
-            &client_data,
-            &[0u8; 64],
-            &cose_key,
-            rp_id,
-            "test-challenge",
-            "https://example.com",
-            0,
-            false,
+            &AssertionParams {
+                authenticator_data: &short_auth_data,
+                client_data_json: &client_data,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: rp_id,
+                expected_challenge: "test-challenge",
+                expected_origin: "https://example.com",
+                stored_counter: 0,
+                require_user_verification: false,
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
         assert!(matches!(result, Err(VerifyError::InvalidAuthDataLength)));
@@ -1580,15 +1448,18 @@ mod tests {
         let cose_key = make_eddsa_cose_key(&[0u8; 32]);
 
         let result = verify_assertion_with_verifier(
-            &auth_data,
-            &client_data,
-            &[0u8; 64],
-            &cose_key,
-            rp_id,
-            "test-challenge",
-            "https://example.com",
-            0,
-            false,
+            &AssertionParams {
+                authenticator_data: &auth_data,
+                client_data_json: &client_data,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: rp_id,
+                expected_challenge: "test-challenge",
+                expected_origin: "https://example.com",
+                stored_counter: 0,
+                require_user_verification: false,
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
         assert!(result.is_ok());
@@ -1603,15 +1474,18 @@ mod tests {
         let cose_key = make_eddsa_cose_key(&[0u8; 32]);
 
         let result = verify_assertion_with_verifier(
-            &auth_data,
-            &client_data,
-            &[0u8; 64],
-            &cose_key,
-            "example.com", // Expected RP ID doesn't match auth_data
-            "test-challenge",
-            "https://example.com",
-            0,
-            false,
+            &AssertionParams {
+                authenticator_data: &auth_data,
+                client_data_json: &client_data,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: "example.com", // Expected RP ID doesn't match auth_data
+                expected_challenge: "test-challenge",
+                expected_origin: "https://example.com",
+                stored_counter: 0,
+                require_user_verification: false,
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
         assert!(matches!(result, Err(VerifyError::RpIdMismatch)));
@@ -1627,15 +1501,18 @@ mod tests {
         let cose_key = make_eddsa_cose_key(&[0u8; 32]);
 
         let result = verify_assertion_with_verifier(
-            &auth_data,
-            &client_data,
-            &[0u8; 64],
-            &cose_key,
-            rp_id,
-            "test-challenge",
-            "https://example.com",
-            0,
-            false,
+            &AssertionParams {
+                authenticator_data: &auth_data,
+                client_data_json: &client_data,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: rp_id,
+                expected_challenge: "test-challenge",
+                expected_origin: "https://example.com",
+                stored_counter: 0,
+                require_user_verification: false,
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
         assert!(matches!(result, Err(VerifyError::UserNotPresent)));
@@ -1651,15 +1528,18 @@ mod tests {
         let cose_key = make_eddsa_cose_key(&[0u8; 32]);
 
         let result = verify_assertion_with_verifier(
-            &auth_data,
-            &client_data,
-            &[0u8; 64],
-            &cose_key,
-            rp_id,
-            "test-challenge",
-            "https://example.com",
-            0,
-            true, // Require UV
+            &AssertionParams {
+                authenticator_data: &auth_data,
+                client_data_json: &client_data,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: rp_id,
+                expected_challenge: "test-challenge",
+                expected_origin: "https://example.com",
+                stored_counter: 0,
+                require_user_verification: true, // Require UV
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
         assert!(matches!(result, Err(VerifyError::UserNotVerified)));
@@ -1675,15 +1555,18 @@ mod tests {
         let cose_key = make_eddsa_cose_key(&[0u8; 32]);
 
         let result = verify_assertion_with_verifier(
-            &auth_data,
-            &client_data,
-            &[0u8; 64],
-            &cose_key,
-            rp_id,
-            "test-challenge",
-            "https://example.com",
-            0,
-            false, // Don't require UV
+            &AssertionParams {
+                authenticator_data: &auth_data,
+                client_data_json: &client_data,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: rp_id,
+                expected_challenge: "test-challenge",
+                expected_origin: "https://example.com",
+                stored_counter: 0,
+                require_user_verification: false, // Don't require UV
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
         assert!(result.is_ok());
@@ -1704,15 +1587,18 @@ mod tests {
 
         // With stored counter 4, new counter 5 should succeed
         let result = verify_assertion_with_verifier(
-            &auth_data,
-            &client_data,
-            &[0u8; 64],
-            &cose_key,
-            rp_id,
-            "test-challenge",
-            "https://example.com",
-            4, // stored counter
-            false,
+            &AssertionParams {
+                authenticator_data: &auth_data,
+                client_data_json: &client_data,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: rp_id,
+                expected_challenge: "test-challenge",
+                expected_origin: "https://example.com",
+                stored_counter: 4, // stored counter
+                require_user_verification: false,
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
         assert!(result.is_ok());
@@ -1730,15 +1616,18 @@ mod tests {
 
         // Same counter = replay attack
         let result = verify_assertion_with_verifier(
-            &auth_data,
-            &client_data,
-            &[0u8; 64],
-            &cose_key,
-            rp_id,
-            "test-challenge",
-            "https://example.com",
-            5, // Same as auth_data counter
-            false,
+            &AssertionParams {
+                authenticator_data: &auth_data,
+                client_data_json: &client_data,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: rp_id,
+                expected_challenge: "test-challenge",
+                expected_origin: "https://example.com",
+                stored_counter: 5, // Same as auth_data counter
+                require_user_verification: false,
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
         assert!(matches!(result, Err(VerifyError::CounterNotIncreasing)));
@@ -1755,15 +1644,18 @@ mod tests {
 
         // Lower counter = cloned authenticator
         let result = verify_assertion_with_verifier(
-            &auth_data,
-            &client_data,
-            &[0u8; 64],
-            &cose_key,
-            rp_id,
-            "test-challenge",
-            "https://example.com",
-            5, // stored counter is higher
-            false,
+            &AssertionParams {
+                authenticator_data: &auth_data,
+                client_data_json: &client_data,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: rp_id,
+                expected_challenge: "test-challenge",
+                expected_origin: "https://example.com",
+                stored_counter: 5, // stored counter is higher
+                require_user_verification: false,
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
         assert!(matches!(result, Err(VerifyError::CounterNotIncreasing)));
@@ -1781,15 +1673,18 @@ mod tests {
 
         // Zero counter should be accepted (authenticator doesn't support counters)
         let result = verify_assertion_with_verifier(
-            &auth_data,
-            &client_data,
-            &[0u8; 64],
-            &cose_key,
-            rp_id,
-            "test-challenge",
-            "https://example.com",
-            0, // stored counter also 0
-            false,
+            &AssertionParams {
+                authenticator_data: &auth_data,
+                client_data_json: &client_data,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: rp_id,
+                expected_challenge: "test-challenge",
+                expected_origin: "https://example.com",
+                stored_counter: 0, // stored counter also 0
+                require_user_verification: false,
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
         assert!(result.is_ok());
@@ -1806,15 +1701,18 @@ mod tests {
         let cose_key = make_eddsa_cose_key(&[0u8; 32]);
 
         let result = verify_assertion_with_verifier(
-            &auth_data,
-            &client_data,
-            &[0u8; 64],
-            &cose_key,
-            rp_id,
-            "test-challenge",
-            "https://example.com",
-            0, // Initial stored counter
-            false,
+            &AssertionParams {
+                authenticator_data: &auth_data,
+                client_data_json: &client_data,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: rp_id,
+                expected_challenge: "test-challenge",
+                expected_origin: "https://example.com",
+                stored_counter: 0, // Initial stored counter
+                require_user_verification: false,
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
         assert!(result.is_ok());
@@ -1831,15 +1729,18 @@ mod tests {
         let cose_key = make_eddsa_cose_key(&[0u8; 32]);
 
         let result = verify_assertion_with_verifier(
-            &auth_data,
-            &client_data,
-            &[0u8; 64],
-            &cose_key,
-            rp_id,
-            "test-challenge",
-            "https://example.com",
-            u32::MAX - 1, // stored counter just below max
-            false,
+            &AssertionParams {
+                authenticator_data: &auth_data,
+                client_data_json: &client_data,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: rp_id,
+                expected_challenge: "test-challenge",
+                expected_origin: "https://example.com",
+                stored_counter: u32::MAX - 1, // stored counter just below max
+                require_user_verification: false,
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
         assert!(result.is_ok());
@@ -1860,15 +1761,18 @@ mod tests {
         let cose_key = make_eddsa_cose_key(&[0u8; 32]);
 
         let result = verify_assertion_with_verifier(
-            &auth_data,
-            &client_data,
-            &[0u8; 64],
-            &cose_key,
-            rp_id,
-            "test-challenge",
-            "https://example.com",
-            5, // stored counter was nonzero
-            false,
+            &AssertionParams {
+                authenticator_data: &auth_data,
+                client_data_json: &client_data,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: rp_id,
+                expected_challenge: "test-challenge",
+                expected_origin: "https://example.com",
+                stored_counter: 5, // stored counter was nonzero
+                require_user_verification: false,
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
         assert!(matches!(result, Err(VerifyError::CounterNotIncreasing)));
@@ -1890,16 +1794,18 @@ mod tests {
         let cose_key = make_eddsa_cose_key(&[0u8; 32]);
 
         let result = verify_assertion_inner(
-            &auth_data,
-            &client_data,
-            &[0u8; 64],
-            &cose_key,
-            rp_id,
-            "test-challenge",
-            "http://localhost:8080",
-            0,
-            false,
-            true, // allow_localhost_origin
+            &AssertionParams {
+                authenticator_data: &auth_data,
+                client_data_json: &client_data,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: rp_id,
+                expected_challenge: "test-challenge",
+                expected_origin: "http://localhost:8080",
+                stored_counter: 0,
+                require_user_verification: false,
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
         assert!(result.is_ok(), "expected ok, got {result:?}");
@@ -1918,16 +1824,18 @@ mod tests {
         let cose_key = make_eddsa_cose_key(&[0u8; 32]);
 
         let result = verify_assertion_inner(
-            &auth_data,
-            &client_data,
-            &[0u8; 64],
-            &cose_key,
-            rp_id,
-            "test-challenge",
-            "http://localhost:8080",
-            0,
-            false,
-            false, // allow_localhost_origin disabled
+            &AssertionParams {
+                authenticator_data: &auth_data,
+                client_data_json: &client_data,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: rp_id,
+                expected_challenge: "test-challenge",
+                expected_origin: "http://localhost:8080",
+                stored_counter: 0,
+                require_user_verification: false,
+                allow_localhost_origin: false,
+            },
             &verifier,
         );
         assert!(matches!(result, Err(VerifyError::InvalidOrigin)));
@@ -1946,15 +1854,18 @@ mod tests {
         let cose_key = make_eddsa_cose_key(&[0u8; 32]);
 
         let result = verify_assertion_with_verifier(
-            &auth_data,
-            invalid_json,
-            &[0u8; 64],
-            &cose_key,
-            rp_id,
-            "test-challenge",
-            "https://example.com",
-            0,
-            false,
+            &AssertionParams {
+                authenticator_data: &auth_data,
+                client_data_json: invalid_json,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: rp_id,
+                expected_challenge: "test-challenge",
+                expected_origin: "https://example.com",
+                stored_counter: 0,
+                require_user_verification: false,
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
         assert!(matches!(result, Err(VerifyError::InvalidClientData(_))));
@@ -1971,15 +1882,18 @@ mod tests {
 
         // Type should be "webauthn.get" for assertions
         let result = verify_assertion_with_verifier(
-            &auth_data,
-            &client_data,
-            &[0u8; 64],
-            &cose_key,
-            rp_id,
-            "test-challenge",
-            "https://example.com",
-            0,
-            false,
+            &AssertionParams {
+                authenticator_data: &auth_data,
+                client_data_json: &client_data,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: rp_id,
+                expected_challenge: "test-challenge",
+                expected_origin: "https://example.com",
+                stored_counter: 0,
+                require_user_verification: false,
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
         assert!(
@@ -1997,15 +1911,18 @@ mod tests {
         let cose_key = make_eddsa_cose_key(&[0u8; 32]);
 
         let result = verify_assertion_with_verifier(
-            &auth_data,
-            &client_data,
-            &[0u8; 64],
-            &cose_key,
-            rp_id,
-            "expected-challenge",
-            "https://example.com",
-            0,
-            false,
+            &AssertionParams {
+                authenticator_data: &auth_data,
+                client_data_json: &client_data,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: rp_id,
+                expected_challenge: "expected-challenge",
+                expected_origin: "https://example.com",
+                stored_counter: 0,
+                require_user_verification: false,
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
         assert!(matches!(result, Err(VerifyError::ChallengeMismatch)));
@@ -2021,15 +1938,18 @@ mod tests {
         let cose_key = make_eddsa_cose_key(&[0u8; 32]);
 
         let result = verify_assertion_with_verifier(
-            &auth_data,
-            &client_data,
-            &[0u8; 64],
-            &cose_key,
-            rp_id,
-            "test-challenge",
-            "https://example.com",
-            0,
-            false,
+            &AssertionParams {
+                authenticator_data: &auth_data,
+                client_data_json: &client_data,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: rp_id,
+                expected_challenge: "test-challenge",
+                expected_origin: "https://example.com",
+                stored_counter: 0,
+                require_user_verification: false,
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
         assert!(matches!(result, Err(VerifyError::InvalidOrigin)));
@@ -2046,15 +1966,18 @@ mod tests {
 
         // localhost and 127.0.0.1 should be treated as equivalent
         let result = verify_assertion_with_verifier(
-            &auth_data,
-            &client_data,
-            &[0u8; 64],
-            &cose_key,
-            rp_id,
-            "test-challenge",
-            "https://localhost:8080",
-            0,
-            false,
+            &AssertionParams {
+                authenticator_data: &auth_data,
+                client_data_json: &client_data,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: rp_id,
+                expected_challenge: "test-challenge",
+                expected_origin: "https://localhost:8080",
+                stored_counter: 0,
+                require_user_verification: false,
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
         assert!(result.is_ok());
@@ -2071,15 +1994,18 @@ mod tests {
 
         // host.docker.internal and localhost are both loopback
         let result = verify_assertion_with_verifier(
-            &auth_data,
-            &client_data,
-            &[0u8; 64],
-            &cose_key,
-            rp_id,
-            "test-challenge",
-            "http://host.docker.internal:3000",
-            0,
-            false,
+            &AssertionParams {
+                authenticator_data: &auth_data,
+                client_data_json: &client_data,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: rp_id,
+                expected_challenge: "test-challenge",
+                expected_origin: "http://host.docker.internal:3000",
+                stored_counter: 0,
+                require_user_verification: false,
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
         assert!(result.is_ok());
@@ -2096,15 +2022,18 @@ mod tests {
 
         // [::1] and localhost are both loopback
         let result = verify_assertion_with_verifier(
-            &auth_data,
-            &client_data,
-            &[0u8; 64],
-            &cose_key,
-            rp_id,
-            "test-challenge",
-            "http://localhost:3000",
-            0,
-            false,
+            &AssertionParams {
+                authenticator_data: &auth_data,
+                client_data_json: &client_data,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: rp_id,
+                expected_challenge: "test-challenge",
+                expected_origin: "http://localhost:3000",
+                stored_counter: 0,
+                require_user_verification: false,
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
         assert!(result.is_ok());
@@ -2121,15 +2050,18 @@ mod tests {
         let cose_key = make_eddsa_cose_key(&[0u8; 32]);
 
         let result = verify_assertion_with_verifier(
-            &auth_data,
-            &client_data,
-            &[0u8; 64],
-            &cose_key,
-            rp_id,
-            "test-challenge",
-            "https://example.com",
-            0,
-            false,
+            &AssertionParams {
+                authenticator_data: &auth_data,
+                client_data_json: &client_data,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: rp_id,
+                expected_challenge: "test-challenge",
+                expected_origin: "https://example.com",
+                stored_counter: 0,
+                require_user_verification: false,
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
         assert!(matches!(result, Err(VerifyError::InvalidOrigin)));
@@ -2146,15 +2078,18 @@ mod tests {
         let cose_key = make_eddsa_cose_key(&[0u8; 32]);
 
         let result = verify_assertion_with_verifier(
-            &auth_data,
-            &client_data,
-            &[0u8; 64],
-            &cose_key,
-            rp_id,
-            "test-challenge",
-            "http://localhost:3000",
-            0,
-            false,
+            &AssertionParams {
+                authenticator_data: &auth_data,
+                client_data_json: &client_data,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: rp_id,
+                expected_challenge: "test-challenge",
+                expected_origin: "http://localhost:3000",
+                stored_counter: 0,
+                require_user_verification: false,
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
         assert!(matches!(result, Err(VerifyError::InvalidOrigin)));
@@ -2175,15 +2110,18 @@ mod tests {
         let cose_key = make_eddsa_cose_key(&[0u8; 32]);
 
         let result = verify_assertion_with_verifier(
-            &auth_data,
-            &client_data,
-            &[0u8; 64],
-            &cose_key,
-            rp_id,
-            "test-challenge",
-            "http://localhost:3000",
-            0,
-            false,
+            &AssertionParams {
+                authenticator_data: &auth_data,
+                client_data_json: &client_data,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: rp_id,
+                expected_challenge: "test-challenge",
+                expected_origin: "http://localhost:3000",
+                stored_counter: 0,
+                require_user_verification: false,
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
         assert!(matches!(result, Err(VerifyError::InvalidOrigin)));
@@ -2203,15 +2141,18 @@ mod tests {
         let cose_key = make_eddsa_cose_key(&[0u8; 32]);
 
         let result = verify_assertion_with_verifier(
-            &auth_data,
-            &client_data,
-            &[0u8; 64],
-            &cose_key,
-            rp_id,
-            "test-challenge",
-            "https://example.com",
-            0,
-            false,
+            &AssertionParams {
+                authenticator_data: &auth_data,
+                client_data_json: &client_data,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: rp_id,
+                expected_challenge: "test-challenge",
+                expected_origin: "https://example.com",
+                stored_counter: 0,
+                require_user_verification: false,
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
 
@@ -2231,15 +2172,18 @@ mod tests {
         let cose_key = make_eddsa_cose_key(&[0u8; 32]);
 
         let result = verify_assertion_with_verifier(
-            &auth_data,
-            &client_data,
-            &[0u8; 64],
-            &cose_key,
-            rp_id,
-            "test-challenge",
-            "https://example.com",
-            0,
-            false,
+            &AssertionParams {
+                authenticator_data: &auth_data,
+                client_data_json: &client_data,
+                signature: &[0u8; 64],
+                public_key_cose: &cose_key,
+                expected_rp_id: rp_id,
+                expected_challenge: "test-challenge",
+                expected_origin: "https://example.com",
+                stored_counter: 0,
+                require_user_verification: false,
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
         assert!(matches!(result, Err(VerifyError::SignatureInvalid)));

--- a/crates/vouch-server/src/db/authenticators.rs
+++ b/crates/vouch-server/src/db/authenticators.rs
@@ -69,34 +69,35 @@ pub struct AuthenticatorWithUser {
     pub user: User,
 }
 
-/// Create a new authenticator.
+/// Parameters for creating a new authenticator.
 ///
 /// `user_email` is denormalized into the document to eliminate JOINs.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "authenticator record requires all denormalized fields"
-)]
+pub struct CreateAuthenticatorParams<'a> {
+    pub user_id: &'a str,
+    pub user_email: &'a str,
+    pub name: &'a str,
+    pub credential_id: &'a [u8],
+    pub public_key: &'a [u8],
+    pub aaguid: Option<&'a str>,
+    pub user_handle: Option<&'a [u8]>,
+    pub attestation_verified: bool,
+}
+
+/// Create a new authenticator.
 pub async fn create_authenticator(
     store: &DocumentStore,
-    user_id: &str,
-    user_email: &str,
-    name: &str,
-    credential_id: &[u8],
-    public_key: &[u8],
-    aaguid: Option<&str>,
-    user_handle: Option<&[u8]>,
-    attestation_verified: bool,
+    params: &CreateAuthenticatorParams<'_>,
 ) -> Result<String> {
     let doc = AuthenticatorDoc {
-        user_id: user_id.to_string(),
-        user_email: user_email.to_string(),
-        name: name.to_string(),
-        credential_id: URL_SAFE_NO_PAD.encode(credential_id),
-        public_key: URL_SAFE_NO_PAD.encode(public_key),
+        user_id: params.user_id.to_string(),
+        user_email: params.user_email.to_string(),
+        name: params.name.to_string(),
+        credential_id: URL_SAFE_NO_PAD.encode(params.credential_id),
+        public_key: URL_SAFE_NO_PAD.encode(params.public_key),
         counter: 0,
-        aaguid: aaguid.map(String::from),
-        user_handle: user_handle.map(|h| URL_SAFE_NO_PAD.encode(h)),
-        attestation_verified,
+        aaguid: params.aaguid.map(String::from),
+        user_handle: params.user_handle.map(|h| URL_SAFE_NO_PAD.encode(h)),
+        attestation_verified: params.attestation_verified,
     };
     let result = store.insert(&doc).await?;
     Ok(result.id)

--- a/crates/vouch-server/src/db/credentials.rs
+++ b/crates/vouch-server/src/db/credentials.rs
@@ -13,29 +13,30 @@ use jiff::Timestamp;
 // Token Exchange (RFC 8693)
 // ============================================================
 
+/// Parameters for a token exchange audit record (RFC 8693).
+pub struct InsertTokenExchangeParams<'a> {
+    pub subject_user_id: &'a str,
+    pub subject_token_hash: &'a str,
+    pub actor_user_id: Option<&'a str>,
+    pub issued_token_hash: &'a str,
+    pub requested_audience: Option<&'a str>,
+    pub granted_scope: Option<&'a str>,
+    pub expires_at: Timestamp,
+}
+
 /// Insert a token exchange audit record.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "token-exchange audit row requires all RFC 8693 fields"
-)]
 pub async fn insert_token_exchange(
     store: &DocumentStore,
-    subject_user_id: &str,
-    subject_token_hash: &str,
-    actor_user_id: Option<&str>,
-    issued_token_hash: &str,
-    requested_audience: Option<&str>,
-    granted_scope: Option<&str>,
-    expires_at: Timestamp,
+    params: &InsertTokenExchangeParams<'_>,
 ) -> Result<String> {
     let doc = TokenExchangeDoc {
-        subject_user_id: subject_user_id.to_string(),
-        subject_token_hash: subject_token_hash.to_string(),
-        actor_user_id: actor_user_id.map(String::from),
-        issued_token_hash: issued_token_hash.to_string(),
-        requested_audience: requested_audience.map(String::from),
-        granted_scope: granted_scope.map(String::from),
-        expires_at,
+        subject_user_id: params.subject_user_id.to_string(),
+        subject_token_hash: params.subject_token_hash.to_string(),
+        actor_user_id: params.actor_user_id.map(String::from),
+        issued_token_hash: params.issued_token_hash.to_string(),
+        requested_audience: params.requested_audience.map(String::from),
+        granted_scope: params.granted_scope.map(String::from),
+        expires_at: params.expires_at,
     };
     let result = store.insert(&doc).await?;
     Ok(result.id)

--- a/crates/vouch-server/src/db/github.rs
+++ b/crates/vouch-server/src/db/github.rs
@@ -49,30 +49,31 @@ impl From<Document<GitHubInstallationDoc>> for GitHubInstallation {
     }
 }
 
+/// Parameters for creating a new GitHub App installation.
+pub struct CreateGitHubInstallationParams<'a> {
+    pub org_id: &'a str,
+    pub installation_id: i64,
+    pub github_account_login: &'a str,
+    pub github_account_type: &'a str,
+    pub permissions: &'a HashMap<String, String>,
+    pub repository_selection: &'a str,
+    pub installed_by_user_id: Option<&'a str>,
+}
+
 /// Create a new GitHub App installation for an organization.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "GitHub installation record requires all webhook fields"
-)]
 pub async fn create_github_installation(
     store: &DocumentStore,
-    org_id: &str,
-    installation_id: i64,
-    github_account_login: &str,
-    github_account_type: &str,
-    permissions: &HashMap<String, String>,
-    repository_selection: &str,
-    installed_by_user_id: Option<&str>,
+    params: &CreateGitHubInstallationParams<'_>,
 ) -> Result<String> {
     let doc = GitHubInstallationDoc {
-        org_id: org_id.to_string(),
-        installation_id,
-        github_account_login: github_account_login.to_string(),
-        github_account_type: github_account_type.to_string(),
-        permissions: permissions.clone(),
-        repository_selection: repository_selection.to_string(),
+        org_id: params.org_id.to_string(),
+        installation_id: params.installation_id,
+        github_account_login: params.github_account_login.to_string(),
+        github_account_type: params.github_account_type.to_string(),
+        permissions: params.permissions.clone(),
+        repository_selection: params.repository_selection.to_string(),
         installed_at: Timestamp::now(),
-        installed_by_user_id: installed_by_user_id.map(String::from),
+        installed_by_user_id: params.installed_by_user_id.map(String::from),
         suspended_at: None,
         repositories: None,
     };

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -58,14 +58,14 @@ pub use users::{upsert_user, upsert_user_with_org};
 
 // Re-export session types and functions
 pub use sessions::{
-    Session, SessionCache, SessionPurpose, create_session, delete_expired_sessions,
-    delete_oauth_sessions_for_user, delete_session_by_token_hash, delete_sessions_for_user,
-    get_session_by_token_hash,
+    CreateSessionParams, Session, SessionCache, SessionPurpose, create_session,
+    delete_expired_sessions, delete_oauth_sessions_for_user, delete_session_by_token_hash,
+    delete_sessions_for_user, get_session_by_token_hash,
 };
 
 // Re-export authenticator types and functions
 pub use authenticators::{
-    Authenticator, AuthenticatorWithUser, count_authenticators_for_user,
+    Authenticator, AuthenticatorWithUser, CreateAuthenticatorParams, count_authenticators_for_user,
     count_sessions_for_authenticator, create_authenticator, delete_authenticator,
     delete_authenticator_in_tx, get_authenticator_by_credential_id, get_authenticator_by_id,
     get_authenticator_with_user_by_credential_id, get_authenticators_for_user,
@@ -156,9 +156,9 @@ pub use dpop::{
 
 // Re-export credentials types and functions
 pub use credentials::{
-    EnrollmentSession, IssuedSshCertificate, RevokedSshCertificate, TokenExchangeRecord,
-    create_enrollment_session, delete_expired_enrollment_sessions, delete_expired_ssh_issued_certs,
-    delete_expired_ssh_revocations, delete_old_token_exchanges,
+    EnrollmentSession, InsertTokenExchangeParams, IssuedSshCertificate, RevokedSshCertificate,
+    TokenExchangeRecord, create_enrollment_session, delete_expired_enrollment_sessions,
+    delete_expired_ssh_issued_certs, delete_expired_ssh_revocations, delete_old_token_exchanges,
     get_enrollment_session_by_token_hash, get_issued_ssh_certificates_for_user,
     get_revoked_ssh_certificates, get_token_exchanges_for_user, insert_token_exchange,
     is_ssh_certificate_revoked, record_ssh_certificate_issuance,
@@ -167,12 +167,12 @@ pub use credentials::{
 
 // Re-export GitHub types and functions
 pub use github::{
-    GitHubInstallation, create_github_installation, delete_github_installation_by_installation_id,
-    delete_old_github_credential_events, get_all_linked_installation_ids,
-    get_github_installation_by_installation_id, get_github_installation_by_org_and_account,
-    get_github_installations_by_org, log_github_credential_event, suspend_github_installation,
-    unsuspend_github_installation, update_github_installation_repos,
-    update_github_installation_repos_delta,
+    CreateGitHubInstallationParams, GitHubInstallation, create_github_installation,
+    delete_github_installation_by_installation_id, delete_old_github_credential_events,
+    get_all_linked_installation_ids, get_github_installation_by_installation_id,
+    get_github_installation_by_org_and_account, get_github_installations_by_org,
+    log_github_credential_event, suspend_github_installation, unsuspend_github_installation,
+    update_github_installation_repos, update_github_installation_repos_delta,
 };
 
 // Re-export PAR types and functions (RFC 9126)

--- a/crates/vouch-server/src/db/sessions.rs
+++ b/crates/vouch-server/src/db/sessions.rs
@@ -51,37 +51,38 @@ impl From<Document<SessionDoc>> for Session {
     }
 }
 
-/// Create a new session.
+/// Parameters for creating a new session.
 ///
 /// `authenticator_id` is optional for OIDC-authenticated users who haven't
 /// registered a security key yet.
 /// `user_email` is denormalized into the session document.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "session record requires all denormalized client/user fields"
-)]
+pub struct CreateSessionParams<'a> {
+    pub user_id: &'a str,
+    pub user_email: &'a str,
+    pub token_hash: &'a str,
+    pub authenticator_id: Option<&'a str>,
+    pub expires_at: Timestamp,
+    pub session_type: SessionPurpose,
+    pub authorization_details: Option<&'a serde_json::Value>,
+    pub hardware_aaguid: Option<&'a str>,
+    pub org_domain: Option<&'a str>,
+}
+
+/// Create a new session.
 pub async fn create_session(
     store: &DocumentStore,
-    user_id: &str,
-    user_email: &str,
-    token_hash: &str,
-    authenticator_id: Option<&str>,
-    expires_at: Timestamp,
-    session_type: SessionPurpose,
-    authorization_details: Option<&serde_json::Value>,
-    hardware_aaguid: Option<&str>,
-    org_domain: Option<&str>,
+    params: &CreateSessionParams<'_>,
 ) -> Result<String> {
     let doc = SessionDoc {
-        user_id: user_id.to_string(),
-        user_email: user_email.to_string(),
-        token_hash: token_hash.to_string(),
-        authenticator_id: authenticator_id.map(String::from),
-        session_type,
-        expires_at,
-        authorization_details: authorization_details.cloned(),
-        hardware_aaguid: hardware_aaguid.map(String::from),
-        org_domain: org_domain.map(String::from),
+        user_id: params.user_id.to_string(),
+        user_email: params.user_email.to_string(),
+        token_hash: params.token_hash.to_string(),
+        authenticator_id: params.authenticator_id.map(String::from),
+        session_type: params.session_type,
+        expires_at: params.expires_at,
+        authorization_details: params.authorization_details.cloned(),
+        hardware_aaguid: params.hardware_aaguid.map(String::from),
+        org_domain: params.org_domain.map(String::from),
     };
     let result = store.insert(&doc).await?;
     Ok(result.id)

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -117,14 +117,16 @@ async fn test_session_lifecycle() {
     // Create authenticator (with user_email parameter)
     let auth_id = create_authenticator(
         &store,
-        &user_id,
-        "session@example.com",
-        "Test Key",
-        b"test-cred-id",
-        &[0u8; 32],
-        None,
-        Some(user_id.as_bytes()),
-        false,
+        &CreateAuthenticatorParams {
+            user_id: &user_id,
+            user_email: "session@example.com",
+            name: "Test Key",
+            credential_id: b"test-cred-id",
+            public_key: &[0u8; 32],
+            aaguid: None,
+            user_handle: Some(user_id.as_bytes()),
+            attestation_verified: false,
+        },
     )
     .await
     .expect("Failed to create authenticator");
@@ -133,15 +135,17 @@ async fn test_session_lifecycle() {
     let token_hash = "test_token_hash_123";
     let session_id = create_session(
         &store,
-        &user_id,
-        "session@example.com",
-        token_hash,
-        Some(&auth_id),
-        "2099-12-31T23:59:59Z".parse().unwrap(),
-        SessionPurpose::OAuthAccessToken,
-        None,
-        None,
-        None,
+        &CreateSessionParams {
+            user_id: &user_id,
+            user_email: "session@example.com",
+            token_hash,
+            authenticator_id: Some(&auth_id),
+            expires_at: "2099-12-31T23:59:59Z".parse().unwrap(),
+            session_type: SessionPurpose::OAuthAccessToken,
+            authorization_details: None,
+            hardware_aaguid: None,
+            org_domain: None,
+        },
     )
     .await
     .expect("Failed to create session");
@@ -241,14 +245,16 @@ async fn test_device_auth_authorization_flow() {
     // Create authenticator
     let auth_id = create_authenticator(
         &store,
-        &user_id,
-        "device@example.com",
-        "Test Key",
-        b"test-cred-id-device",
-        &[0u8; 32],
-        None,
-        Some(user_id.as_bytes()),
-        false,
+        &CreateAuthenticatorParams {
+            user_id: &user_id,
+            user_email: "device@example.com",
+            name: "Test Key",
+            credential_id: b"test-cred-id-device",
+            public_key: &[0u8; 32],
+            aaguid: None,
+            user_handle: Some(user_id.as_bytes()),
+            attestation_verified: false,
+        },
     )
     .await
     .expect("Failed to create authenticator");
@@ -360,14 +366,16 @@ async fn test_try_consume_device_auth_authorized_succeeds() {
         .expect("user");
     let auth_id = create_authenticator(
         &store,
-        &user_id,
-        "consume@example.com",
-        "Key",
-        b"cred-consume",
-        &[0u8; 32],
-        None,
-        None,
-        false,
+        &CreateAuthenticatorParams {
+            user_id: &user_id,
+            user_email: "consume@example.com",
+            name: "Key",
+            credential_id: b"cred-consume",
+            public_key: &[0u8; 32],
+            aaguid: None,
+            user_handle: None,
+            attestation_verified: false,
+        },
     )
     .await
     .expect("auth");
@@ -411,14 +419,16 @@ async fn test_try_consume_device_auth_already_consumed_returns_false() {
         .expect("user");
     let auth_id = create_authenticator(
         &store,
-        &user_id,
-        "double@example.com",
-        "Key",
-        b"cred-double",
-        &[0u8; 32],
-        None,
-        None,
-        false,
+        &CreateAuthenticatorParams {
+            user_id: &user_id,
+            user_email: "double@example.com",
+            name: "Key",
+            credential_id: b"cred-double",
+            public_key: &[0u8; 32],
+            aaguid: None,
+            user_handle: None,
+            attestation_verified: false,
+        },
     )
     .await
     .expect("auth");
@@ -478,14 +488,16 @@ async fn test_try_consume_device_auth_expired_returns_false() {
         .expect("user");
     let auth_id = create_authenticator(
         &store,
-        &user_id,
-        "expired@example.com",
-        "Key",
-        b"cred-expired",
-        &[0u8; 32],
-        None,
-        None,
-        false,
+        &CreateAuthenticatorParams {
+            user_id: &user_id,
+            user_email: "expired@example.com",
+            name: "Key",
+            credential_id: b"cred-expired",
+            public_key: &[0u8; 32],
+            aaguid: None,
+            user_handle: None,
+            attestation_verified: false,
+        },
     )
     .await
     .expect("auth");
@@ -1319,14 +1331,16 @@ async fn test_scim_session_invalidation_on_deactivation() {
     // Create authenticator (with user_email parameter)
     let auth_id = create_authenticator(
         &store,
-        &user.id,
-        "invalidate@example.com",
-        "SCIM Key",
-        b"scim-cred-id",
-        &[0u8; 32],
-        None,
-        Some(user.id.as_bytes()),
-        false,
+        &CreateAuthenticatorParams {
+            user_id: &user.id,
+            user_email: "invalidate@example.com",
+            name: "SCIM Key",
+            credential_id: b"scim-cred-id",
+            public_key: &[0u8; 32],
+            aaguid: None,
+            user_handle: Some(user.id.as_bytes()),
+            attestation_verified: false,
+        },
     )
     .await
     .expect("Failed to create authenticator");
@@ -1334,15 +1348,17 @@ async fn test_scim_session_invalidation_on_deactivation() {
     // Create session (with user_email parameter)
     create_session(
         &store,
-        &user.id,
-        "invalidate@example.com",
-        "scim_token_hash",
-        Some(&auth_id),
-        "2099-12-31T23:59:59Z".parse().unwrap(),
-        SessionPurpose::OAuthAccessToken,
-        None,
-        None,
-        None,
+        &CreateSessionParams {
+            user_id: &user.id,
+            user_email: "invalidate@example.com",
+            token_hash: "scim_token_hash",
+            authenticator_id: Some(&auth_id),
+            expires_at: "2099-12-31T23:59:59Z".parse().unwrap(),
+            session_type: SessionPurpose::OAuthAccessToken,
+            authorization_details: None,
+            hardware_aaguid: None,
+            org_domain: None,
+        },
     )
     .await
     .expect("Failed to create session");
@@ -1460,14 +1476,16 @@ async fn test_authenticator_crud() {
 
     let auth_id = create_authenticator(
         &store,
-        &user_id,
-        "auth@example.com",
-        "YubiKey 5C",
-        &credential_id,
-        &public_key,
-        Some("2fc0579f-8113-47ea-b116-bb5a8db9202a"),
-        Some(&user_handle),
-        false,
+        &CreateAuthenticatorParams {
+            user_id: &user_id,
+            user_email: "auth@example.com",
+            name: "YubiKey 5C",
+            credential_id: &credential_id,
+            public_key: &public_key,
+            aaguid: Some("2fc0579f-8113-47ea-b116-bb5a8db9202a"),
+            user_handle: Some(&user_handle),
+            attestation_verified: false,
+        },
     )
     .await
     .expect("Failed to create authenticator");
@@ -1544,14 +1562,16 @@ async fn test_authenticator_count() {
     for i in 0..3 {
         create_authenticator(
             &store,
-            &user_id,
-            "count@example.com",
-            &format!("Key {}", i),
-            &[i as u8; 10],
-            &[0u8; 32],
-            None,
-            None,
-            false,
+            &CreateAuthenticatorParams {
+                user_id: &user_id,
+                user_email: "count@example.com",
+                name: &format!("Key {}", i),
+                credential_id: &[i as u8; 10],
+                public_key: &[0u8; 32],
+                aaguid: None,
+                user_handle: None,
+                attestation_verified: false,
+            },
         )
         .await
         .expect("Failed to create authenticator");
@@ -1666,29 +1686,33 @@ async fn test_user_cascade_delete() {
 
     let auth_id = create_authenticator(
         &store,
-        &user_id,
-        "cascade@example.com",
-        "Cascade Key",
-        &[99u8; 10],
-        &[0u8; 32],
-        None,
-        None,
-        false,
+        &CreateAuthenticatorParams {
+            user_id: &user_id,
+            user_email: "cascade@example.com",
+            name: "Cascade Key",
+            credential_id: &[99u8; 10],
+            public_key: &[0u8; 32],
+            aaguid: None,
+            user_handle: None,
+            attestation_verified: false,
+        },
     )
     .await
     .expect("Failed to create authenticator");
 
     create_session(
         &store,
-        &user_id,
-        "cascade@example.com",
-        "cascade_token",
-        Some(&auth_id),
-        "2099-12-31T23:59:59Z".parse().unwrap(),
-        SessionPurpose::OAuthAccessToken,
-        None,
-        None,
-        None,
+        &CreateSessionParams {
+            user_id: &user_id,
+            user_email: "cascade@example.com",
+            token_hash: "cascade_token",
+            authenticator_id: Some(&auth_id),
+            expires_at: "2099-12-31T23:59:59Z".parse().unwrap(),
+            session_type: SessionPurpose::OAuthAccessToken,
+            authorization_details: None,
+            hardware_aaguid: None,
+            org_domain: None,
+        },
     )
     .await
     .expect("Failed to create session");
@@ -3335,14 +3359,16 @@ async fn test_device_auth_consume_concurrent() {
         .expect("upsert user");
     let auth_id = create_authenticator(
         &store,
-        &user_id,
-        "race-device@example.com",
-        "Key",
-        b"cred-race-device",
-        &[0u8; 32],
-        None,
-        None,
-        false,
+        &CreateAuthenticatorParams {
+            user_id: &user_id,
+            user_email: "race-device@example.com",
+            name: "Key",
+            credential_id: b"cred-race-device",
+            public_key: &[0u8; 32],
+            aaguid: None,
+            user_handle: None,
+            attestation_verified: false,
+        },
     )
     .await
     .expect("create authenticator");
@@ -3483,14 +3509,16 @@ async fn test_authorize_device_auth_concurrent() {
         .expect("upsert user");
     let auth_id = create_authenticator(
         &store,
-        &user_id,
-        "race-authorize@example.com",
-        "Key",
-        b"cred-race-authorize",
-        &[0u8; 32],
-        None,
-        None,
-        false,
+        &CreateAuthenticatorParams {
+            user_id: &user_id,
+            user_email: "race-authorize@example.com",
+            name: "Key",
+            credential_id: b"cred-race-authorize",
+            public_key: &[0u8; 32],
+            aaguid: None,
+            user_handle: None,
+            attestation_verified: false,
+        },
     )
     .await
     .expect("create authenticator");

--- a/crates/vouch-server/src/handlers/applications/api.rs
+++ b/crates/vouch-server/src/handlers/applications/api.rs
@@ -74,6 +74,10 @@ pub(crate) async fn list_applications_api(
 
 /// Create a new application (API).
 /// POST /api/v1/applications
+#[expect(
+    clippy::too_many_lines,
+    reason = "dominated by the exhaustive CreateOAuthClientParams literal"
+)]
 pub(crate) async fn create_application_api(
     method: Method,
     uri: OriginalUri,
@@ -313,6 +317,10 @@ pub(crate) async fn get_application_api(
 #[expect(
     clippy::too_many_arguments,
     reason = "axum handler signature: extractors are positional parameters"
+)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "linear merge of PATCH fields with the existing client record"
 )]
 pub(crate) async fn update_application_api(
     method: Method,

--- a/crates/vouch-server/src/handlers/applications/api.rs
+++ b/crates/vouch-server/src/handlers/applications/api.rs
@@ -6,8 +6,8 @@
 
 use crate::AppState;
 use crate::db::{
-    self, AccessScope, CreateOAuthClientParams, FapiProfile, JwsAlgorithm, OAuthClientType,
-    OAuthEventType, RegistrationSource, TokenEndpointAuthMethod, UpdateOAuthClientParams,
+    self, AccessScope, CreateOAuthClientParams, FapiProfile, JwsAlgorithm, OAuthEventType,
+    RegistrationSource, TokenEndpointAuthMethod, UpdateOAuthClientParams,
 };
 use axum::extract::OriginalUri;
 use axum::http::Method;
@@ -24,13 +24,16 @@ use super::types::{
     CreateApplicationResponse, ListApplicationsResponse, ListSecretsResponse, SecretInfo,
     UpdateApplicationRequest,
 };
-use super::{MAX_ACTIVE_SECRETS, generate_client_secret, validate_redirect_uris};
+use super::validate::{
+    CreateAppInput, UpdateAppInput, validate_create_application, validate_update_fapi,
+    validate_update_format,
+};
+use super::{MAX_ACTIVE_SECRETS, generate_client_secret};
 use crate::handlers::extractors::OptionalClientCert;
 use crate::handlers::hash_token;
 use crate::handlers::session::extract_resource_token;
 use crate::handlers::{ValidPath, ValidUuid};
 use crate::services::error::ServiceError;
-use crate::services::oidc::ResourceUri;
 
 /// List user's applications (API).
 /// GET /api/v1/applications
@@ -81,133 +84,23 @@ pub(crate) async fn create_application_api(
     Json(req): Json<CreateApplicationRequest>,
 ) -> Result<Json<CreateApplicationResponse>, ServiceError> {
     // ── Pure format validation first — no DB cost for malformed requests ──
-    let name = req.name.trim();
-    if name.is_empty() {
-        return Err(ServiceError::api(
-            StatusCode::BAD_REQUEST,
-            "invalid_name",
-            "Application name is required",
-        ));
-    }
-
-    let app_type = req
-        .application_type
-        .parse::<OAuthClientType>()
-        .map_err(|_| {
-            ServiceError::api(
-                StatusCode::BAD_REQUEST,
-                "invalid_type",
-                "Invalid application type. Must be: web, native, spa, or service",
-            )
-        })?;
-
-    // For non-service apps, at least one redirect URI is required
-    if !matches!(app_type, OAuthClientType::Service) && req.redirect_uris.is_empty() {
-        return Err(ServiceError::api(
-            StatusCode::BAD_REQUEST,
-            "invalid_redirect_uris",
-            "At least one redirect URI is required",
-        ));
-    }
-
-    // Validate redirect URIs are valid URLs
-    if let Err(invalid) = validate_redirect_uris(&req.redirect_uris) {
-        return Err(ServiceError::api(
-            StatusCode::BAD_REQUEST,
-            "invalid_redirect_uris",
-            format!(
-                "Invalid redirect URI(s): {}. Each URI must be a valid http:// or https:// URL.",
-                invalid.join(", ")
-            ),
-        ));
-    }
-
     // RFC 8707: Resource URIs default to empty if not provided.
     let resource_uris = req.resource_uris.as_deref().unwrap_or(&[]);
 
-    // Validate resource URIs per RFC 8707 (absolute URI, no fragment).
-    for uri_str in resource_uris {
-        if let Err(e) = ResourceUri::parse(uri_str) {
-            return Err(ServiceError::api(
-                StatusCode::BAD_REQUEST,
-                "invalid_resource_uri",
-                format!("Invalid resource URI '{uri_str}': {e}"),
-            ));
-        }
-    }
-
-    // Determine FAPI profile
-    let is_fapi = req
-        .fapi_profile
-        .as_deref()
-        .is_some_and(|p| p == "fapi2_security");
-
-    // FAPI validation: must be a confidential client type
-    if is_fapi && !matches!(app_type, OAuthClientType::Web | OAuthClientType::Service) {
-        return Err(ServiceError::api(
-            StatusCode::BAD_REQUEST,
-            "invalid_fapi_profile",
-            "FAPI 2.0 Security Profile requires a confidential client type (web or service)",
-        ));
-    }
-
-    // FAPI validation: require JWKS or JWKS URI
-    let jwks_trimmed_str = req.jwks.as_deref().map(str::trim).filter(|s| !s.is_empty());
-    let jwks_uri_trimmed = req
-        .jwks_uri
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty());
-
-    if is_fapi && jwks_trimmed_str.is_none() && jwks_uri_trimmed.is_none() {
-        return Err(ServiceError::api(
-            StatusCode::BAD_REQUEST,
-            "missing_jwks",
-            "FAPI 2.0 requires jwks or jwks_uri for private_key_jwt authentication",
-        ));
-    }
-
-    // Validate and parse JWKS JSON if provided
-    let jwks_value = if let Some(jwks_json) = jwks_trimmed_str {
-        match serde_json::from_str::<serde_json::Value>(jwks_json) {
-            Ok(val) => {
-                if !val
-                    .get("keys")
-                    .is_some_and(|k| k.is_array() && !k.as_array().is_some_and(|a| a.is_empty()))
-                {
-                    return Err(ServiceError::api(
-                        StatusCode::BAD_REQUEST,
-                        "invalid_jwks",
-                        "JWKS must be a JSON object with a non-empty \"keys\" array",
-                    ));
-                }
-                Some(val)
-            }
-            Err(_) => {
-                return Err(ServiceError::api(
-                    StatusCode::BAD_REQUEST,
-                    "invalid_jwks",
-                    "JWKS must be valid JSON",
-                ));
-            }
-        }
-    } else {
-        None
-    };
-
-    // Validate JWKS URI if provided
-    if let Some(jwks_uri_val) = jwks_uri_trimmed {
-        match url::Url::parse(jwks_uri_val) {
-            Ok(parsed) if parsed.scheme() == "https" => {}
-            _ => {
-                return Err(ServiceError::api(
-                    StatusCode::BAD_REQUEST,
-                    "invalid_jwks_uri",
-                    "JWKS URI must be a valid https:// URL",
-                ));
-            }
-        }
-    }
+    let validated = validate_create_application(CreateAppInput {
+        name: &req.name,
+        application_type: &req.application_type,
+        redirect_uris: &req.redirect_uris,
+        resource_uris,
+        fapi_profile: req.fapi_profile.as_deref(),
+        jwks: req.jwks.as_deref(),
+        jwks_uri: req.jwks_uri.as_deref(),
+    })?;
+    let name = validated.name;
+    let app_type = validated.app_type;
+    let is_fapi = validated.is_fapi;
+    let jwks_value = validated.jwks;
+    let jwks_uri_trimmed = validated.jwks_uri;
 
     // ── Authentication — validated input is good, now check credentials ──
     let token = extract_resource_token(
@@ -432,81 +325,13 @@ pub(crate) async fn update_application_api(
     Json(req): Json<UpdateApplicationRequest>,
 ) -> Result<Json<ApplicationResponse>, ServiceError> {
     // ── Pure format validation first — no DB cost for malformed requests ──
-    // Validate request-provided redirect URIs (if any)
-    if let Some(ref uris) = req.redirect_uris
-        && let Err(invalid) = validate_redirect_uris(uris)
-    {
-        return Err(ServiceError::api(
-            StatusCode::BAD_REQUEST,
-            "invalid_redirect_uris",
-            format!(
-                "Invalid redirect URI(s): {}. Each URI must be a valid http:// or https:// URL.",
-                invalid.join(", ")
-            ),
-        ));
-    }
-
-    // Validate request-provided resource URIs (if any)
-    if let Some(ref uris) = req.resource_uris {
-        for uri_str in uris {
-            if let Err(e) = ResourceUri::parse(uri_str) {
-                return Err(ServiceError::api(
-                    StatusCode::BAD_REQUEST,
-                    "invalid_resource_uri",
-                    format!("Invalid resource URI '{uri_str}': {e}"),
-                ));
-            }
-        }
-    }
-
-    // Validate and parse JWKS JSON format if provided
-    let jwks_trimmed_str = req.jwks.as_deref().map(str::trim).filter(|s| !s.is_empty());
-    let jwks_uri_trimmed = req
-        .jwks_uri
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty());
-
-    let jwks_value = if let Some(jwks_json) = jwks_trimmed_str {
-        match serde_json::from_str::<serde_json::Value>(jwks_json) {
-            Ok(val) => {
-                if !val
-                    .get("keys")
-                    .is_some_and(|k| k.is_array() && !k.as_array().is_some_and(|a| a.is_empty()))
-                {
-                    return Err(ServiceError::api(
-                        StatusCode::BAD_REQUEST,
-                        "invalid_jwks",
-                        "JWKS must be a JSON object with a non-empty \"keys\" array",
-                    ));
-                }
-                Some(val)
-            }
-            Err(_) => {
-                return Err(ServiceError::api(
-                    StatusCode::BAD_REQUEST,
-                    "invalid_jwks",
-                    "JWKS must be valid JSON",
-                ));
-            }
-        }
-    } else {
-        None
-    };
-
-    // Validate JWKS URI format if provided
-    if let Some(jwks_uri_val) = jwks_uri_trimmed {
-        match url::Url::parse(jwks_uri_val) {
-            Ok(parsed) if parsed.scheme() == "https" => {}
-            _ => {
-                return Err(ServiceError::api(
-                    StatusCode::BAD_REQUEST,
-                    "invalid_jwks_uri",
-                    "JWKS URI must be a valid https:// URL",
-                ));
-            }
-        }
-    }
+    let validated = validate_update_format(UpdateAppInput {
+        redirect_uris: req.redirect_uris.as_deref(),
+        resource_uris: req.resource_uris.as_deref(),
+        fapi_profile: req.fapi_profile.as_deref(),
+        jwks: req.jwks.as_deref(),
+        jwks_uri: req.jwks_uri.as_deref(),
+    })?;
 
     // ── Authentication — validated input is good, now check credentials ──
     let token = extract_resource_token(
@@ -600,39 +425,11 @@ pub(crate) async fn update_application_api(
         .as_deref()
         .map_or_else(|| client.resource_uris.clone(), <[String]>::to_vec);
 
-    // Determine FAPI profile
-    let is_fapi = req
-        .fapi_profile
-        .as_deref()
-        .is_some_and(|p| p == "fapi2_security");
-
-    // FAPI validation: must be a confidential client type
-    if is_fapi
-        && !matches!(
-            client.application_type,
-            OAuthClientType::Web | OAuthClientType::Service
-        )
-    {
-        return Err(ServiceError::api(
-            StatusCode::BAD_REQUEST,
-            "invalid_fapi_profile",
-            "FAPI 2.0 Security Profile requires a confidential client type (web or service)",
-        ));
-    }
-
-    // FAPI validation: require JWKS or JWKS URI (request or existing)
-    if is_fapi
-        && jwks_value.is_none()
-        && jwks_uri_trimmed.is_none()
-        && client.jwks.is_none()
-        && client.jwks_uri.is_none()
-    {
-        return Err(ServiceError::api(
-            StatusCode::BAD_REQUEST,
-            "missing_jwks",
-            "FAPI 2.0 requires jwks or jwks_uri for private_key_jwt authentication",
-        ));
-    }
+    // FAPI rules that depend on the existing client record
+    validate_update_fapi(&validated, &client)?;
+    let is_fapi = validated.is_fapi;
+    let jwks_value = validated.jwks;
+    let jwks_uri_trimmed = validated.jwks_uri;
 
     // Compute FAPI-related values
     let fapi_profile = if is_fapi {

--- a/crates/vouch-server/src/handlers/applications/mod.rs
+++ b/crates/vouch-server/src/handlers/applications/mod.rs
@@ -6,6 +6,7 @@
 
 mod api;
 mod types;
+mod validate;
 mod web;
 
 use crate::AppState;

--- a/crates/vouch-server/src/handlers/applications/validate.rs
+++ b/crates/vouch-server/src/handlers/applications/validate.rs
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! Shared input validation for OAuth application create/update.
+//!
+//! The API handlers (`api.rs`) and web form handlers (`web.rs`) accept the
+//! same application fields and enforce identical rules; only the error
+//! rendering differs (JSON [`ServiceError`] vs HTML template). Each function
+//! here is called by both the API and the web variant of the handler.
+
+use axum::http::StatusCode;
+
+use crate::db::{OAuthClient, OAuthClientType};
+use crate::services::error::ServiceError;
+use crate::services::oidc::ResourceUri;
+
+use super::validate_redirect_uris;
+
+/// A validation failure: a machine-readable code plus a human message.
+#[derive(Debug)]
+pub(super) enum AppValidationError {
+    EmptyName,
+    InvalidApplicationType,
+    MissingRedirectUris,
+    InvalidRedirectUris(Vec<String>),
+    InvalidResourceUri { uri: String, detail: String },
+    FapiRequiresConfidentialClient,
+    FapiMissingJwks,
+    JwksNotJson,
+    JwksMissingKeys,
+    InvalidJwksUri,
+}
+
+impl AppValidationError {
+    /// Machine-readable error code (stable API contract).
+    pub(super) fn code(&self) -> &'static str {
+        match self {
+            Self::EmptyName => "invalid_name",
+            Self::InvalidApplicationType => "invalid_type",
+            Self::MissingRedirectUris | Self::InvalidRedirectUris(_) => "invalid_redirect_uris",
+            Self::InvalidResourceUri { .. } => "invalid_resource_uri",
+            Self::FapiRequiresConfidentialClient => "invalid_fapi_profile",
+            Self::FapiMissingJwks => "missing_jwks",
+            Self::JwksNotJson | Self::JwksMissingKeys => "invalid_jwks",
+            Self::InvalidJwksUri => "invalid_jwks_uri",
+        }
+    }
+
+    /// Human-readable error message.
+    pub(super) fn message(&self) -> String {
+        match self {
+            Self::EmptyName => "Application name is required".to_string(),
+            Self::InvalidApplicationType => {
+                "Invalid application type. Must be: web, native, spa, or service".to_string()
+            }
+            Self::MissingRedirectUris => "At least one redirect URI is required".to_string(),
+            Self::InvalidRedirectUris(invalid) => format!(
+                "Invalid redirect URI(s): {}. Each URI must be a valid http:// or https:// URL.",
+                invalid.join(", ")
+            ),
+            Self::InvalidResourceUri { uri, detail } => format!(
+                "Invalid resource URI '{uri}': {detail}. \
+                 Resource URIs must be absolute URIs without fragment components."
+            ),
+            Self::FapiRequiresConfidentialClient => {
+                "FAPI 2.0 Security Profile requires a confidential client type (web or service)"
+                    .to_string()
+            }
+            Self::FapiMissingJwks => {
+                "FAPI 2.0 requires jwks or jwks_uri for private_key_jwt authentication".to_string()
+            }
+            Self::JwksNotJson => "JWKS must be valid JSON".to_string(),
+            Self::JwksMissingKeys => {
+                "JWKS must be a JSON object with a non-empty \"keys\" array".to_string()
+            }
+            Self::InvalidJwksUri => "JWKS URI must be a valid https:// URL".to_string(),
+        }
+    }
+}
+
+impl From<AppValidationError> for ServiceError {
+    fn from(err: AppValidationError) -> Self {
+        ServiceError::api(StatusCode::BAD_REQUEST, err.code(), err.message())
+    }
+}
+
+/// Raw application fields for create requests.
+pub(super) struct CreateAppInput<'a> {
+    pub name: &'a str,
+    pub application_type: &'a str,
+    pub redirect_uris: &'a [String],
+    pub resource_uris: &'a [String],
+    pub fapi_profile: Option<&'a str>,
+    pub jwks: Option<&'a str>,
+    pub jwks_uri: Option<&'a str>,
+}
+
+/// Validated create fields, ready for `CreateOAuthClientParams`.
+pub(super) struct ValidatedCreateApp<'a> {
+    /// Trimmed, non-empty application name.
+    pub name: &'a str,
+    pub app_type: OAuthClientType,
+    pub is_fapi: bool,
+    /// Parsed JWKS with a non-empty `keys` array (if provided).
+    pub jwks: Option<serde_json::Value>,
+    /// Trimmed, https-validated JWKS URI (if provided).
+    pub jwks_uri: Option<&'a str>,
+}
+
+/// Validate the format of a create-application request.
+///
+/// Pure format validation — safe to call before authentication so malformed
+/// requests incur no DB cost. Handler-specific checks (access scope, org
+/// membership) stay in the handlers.
+pub(super) fn validate_create_application<'a>(
+    input: CreateAppInput<'a>,
+) -> Result<ValidatedCreateApp<'a>, AppValidationError> {
+    let name = input.name.trim();
+    if name.is_empty() {
+        return Err(AppValidationError::EmptyName);
+    }
+
+    let app_type = input
+        .application_type
+        .parse::<OAuthClientType>()
+        .map_err(|_| AppValidationError::InvalidApplicationType)?;
+
+    // For non-service apps, at least one redirect URI is required
+    if !matches!(app_type, OAuthClientType::Service) && input.redirect_uris.is_empty() {
+        return Err(AppValidationError::MissingRedirectUris);
+    }
+
+    validate_redirect_uris(input.redirect_uris).map_err(AppValidationError::InvalidRedirectUris)?;
+
+    // Validate resource URIs per RFC 8707 (absolute URI, no fragment).
+    validate_resource_uris(input.resource_uris)?;
+
+    let is_fapi = input.fapi_profile.is_some_and(|p| p == "fapi2_security");
+
+    // FAPI validation: must be a confidential client type
+    if is_fapi && !matches!(app_type, OAuthClientType::Web | OAuthClientType::Service) {
+        return Err(AppValidationError::FapiRequiresConfidentialClient);
+    }
+
+    let jwks_trimmed = trim_nonempty(input.jwks);
+    let jwks_uri = trim_nonempty(input.jwks_uri);
+
+    // FAPI validation: require JWKS or JWKS URI
+    if is_fapi && jwks_trimmed.is_none() && jwks_uri.is_none() {
+        return Err(AppValidationError::FapiMissingJwks);
+    }
+
+    let jwks = jwks_trimmed.map(parse_jwks).transpose()?;
+    validate_jwks_uri(jwks_uri)?;
+
+    Ok(ValidatedCreateApp {
+        name,
+        app_type,
+        is_fapi,
+        jwks,
+        jwks_uri,
+    })
+}
+
+/// Raw application fields for update requests.
+///
+/// `None` means the field was not provided (API PATCH semantics); web form
+/// handlers pass `Some` for fields the form always submits.
+pub(super) struct UpdateAppInput<'a> {
+    pub redirect_uris: Option<&'a [String]>,
+    pub resource_uris: Option<&'a [String]>,
+    pub fapi_profile: Option<&'a str>,
+    pub jwks: Option<&'a str>,
+    pub jwks_uri: Option<&'a str>,
+}
+
+/// Validated update fields (format phase only).
+pub(super) struct ValidatedUpdateApp<'a> {
+    pub is_fapi: bool,
+    /// Parsed JWKS with a non-empty `keys` array (if provided).
+    pub jwks: Option<serde_json::Value>,
+    /// Trimmed, https-validated JWKS URI (if provided).
+    pub jwks_uri: Option<&'a str>,
+}
+
+/// Validate the format of an update-application request.
+///
+/// Fields are validated only if provided; absent fields keep their existing
+/// values. Pure format validation — safe to call before authentication.
+/// FAPI rules that depend on the existing client record are checked by
+/// [`validate_update_fapi`] after the ownership check.
+pub(super) fn validate_update_format<'a>(
+    input: UpdateAppInput<'a>,
+) -> Result<ValidatedUpdateApp<'a>, AppValidationError> {
+    if let Some(uris) = input.redirect_uris {
+        validate_redirect_uris(uris).map_err(AppValidationError::InvalidRedirectUris)?;
+    }
+
+    if let Some(uris) = input.resource_uris {
+        validate_resource_uris(uris)?;
+    }
+
+    let is_fapi = input.fapi_profile.is_some_and(|p| p == "fapi2_security");
+
+    let jwks = trim_nonempty(input.jwks).map(parse_jwks).transpose()?;
+    let jwks_uri = trim_nonempty(input.jwks_uri);
+    validate_jwks_uri(jwks_uri)?;
+
+    Ok(ValidatedUpdateApp {
+        is_fapi,
+        jwks,
+        jwks_uri,
+    })
+}
+
+/// Validate FAPI rules for an update against the existing client record.
+///
+/// Call after authentication and the ownership check.
+pub(super) fn validate_update_fapi(
+    validated: &ValidatedUpdateApp<'_>,
+    client: &OAuthClient,
+) -> Result<(), AppValidationError> {
+    if !validated.is_fapi {
+        return Ok(());
+    }
+
+    // FAPI validation: must be a confidential client type
+    if !matches!(
+        client.application_type,
+        OAuthClientType::Web | OAuthClientType::Service
+    ) {
+        return Err(AppValidationError::FapiRequiresConfidentialClient);
+    }
+
+    // FAPI validation: require JWKS or JWKS URI (request or existing)
+    if validated.jwks.is_none()
+        && validated.jwks_uri.is_none()
+        && client.jwks.is_none()
+        && client.jwks_uri.is_none()
+    {
+        return Err(AppValidationError::FapiMissingJwks);
+    }
+
+    Ok(())
+}
+
+fn trim_nonempty(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|s| !s.is_empty())
+}
+
+fn validate_resource_uris(uris: &[String]) -> Result<(), AppValidationError> {
+    for uri in uris {
+        if let Err(e) = ResourceUri::parse(uri) {
+            return Err(AppValidationError::InvalidResourceUri {
+                uri: uri.clone(),
+                detail: e.to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn parse_jwks(jwks_json: &str) -> Result<serde_json::Value, AppValidationError> {
+    let val = serde_json::from_str::<serde_json::Value>(jwks_json)
+        .map_err(|_| AppValidationError::JwksNotJson)?;
+    if !val
+        .get("keys")
+        .is_some_and(|k| k.is_array() && !k.as_array().is_some_and(|a| a.is_empty()))
+    {
+        return Err(AppValidationError::JwksMissingKeys);
+    }
+    Ok(val)
+}
+
+fn validate_jwks_uri(jwks_uri: Option<&str>) -> Result<(), AppValidationError> {
+    if let Some(uri) = jwks_uri {
+        match url::Url::parse(uri) {
+            Ok(parsed) if parsed.scheme() == "https" => {}
+            _ => return Err(AppValidationError::InvalidJwksUri),
+        }
+    }
+    Ok(())
+}

--- a/crates/vouch-server/src/handlers/applications/web.rs
+++ b/crates/vouch-server/src/handlers/applications/web.rs
@@ -6,8 +6,8 @@
 
 use crate::AppState;
 use crate::db::{
-    self, AccessScope, CreateOAuthClientParams, FapiProfile, JwsAlgorithm, OAuthClientType,
-    RegistrationSource, TokenEndpointAuthMethod, UpdateOAuthClientParams,
+    self, AccessScope, CreateOAuthClientParams, FapiProfile, JwsAlgorithm, RegistrationSource,
+    TokenEndpointAuthMethod, UpdateOAuthClientParams,
 };
 use axum::{
     Form,
@@ -23,12 +23,25 @@ use super::types::{
     ApplicationsListTemplate, CreateApplicationForm, SecretAddedTemplate, SecretInfo,
     UpdateApplicationForm, UsageStat,
 };
+use super::validate::{
+    AppValidationError, CreateAppInput, UpdateAppInput, validate_create_application,
+    validate_update_fapi, validate_update_format,
+};
 use super::{
     MAX_ACTIVE_SECRETS, extract_auth_from_cookie, generate_client_secret, parse_redirect_uris,
-    parse_resource_uris, validate_redirect_uris,
+    parse_resource_uris,
 };
 use crate::handlers::hash_token;
-use crate::services::oidc::ResourceUri;
+
+/// Render a shared validation failure as the standard error page.
+fn validation_error_response(err: &AppValidationError, back_url: String) -> Response {
+    ApplicationErrorTemplate {
+        title: "Invalid Input".to_string(),
+        message: err.message(),
+        back_url,
+    }
+    .into_response()
+}
 
 /// List user's applications.
 /// GET /applications
@@ -84,25 +97,27 @@ pub(crate) async fn create_application_form(
 
     let user_id = auth.user_id.as_deref().unwrap_or_default();
 
-    // Validate inputs
-    let name = form.name.trim();
-    if name.is_empty() {
-        return ApplicationErrorTemplate {
-            title: "Invalid Input".to_string(),
-            message: "Application name is required.".to_string(),
-            back_url: "/applications/new".to_string(),
-        }
-        .into_response();
-    }
+    // Parse textarea inputs, then run the shared format validation
+    let redirect_uris = parse_redirect_uris(&form.redirect_uris);
+    let resource_uris = parse_resource_uris(form.resource_uris.as_deref());
 
-    let Some(app_type) = form.application_type.parse::<OAuthClientType>().ok() else {
-        return ApplicationErrorTemplate {
-            title: "Invalid Input".to_string(),
-            message: "Invalid application type.".to_string(),
-            back_url: "/applications/new".to_string(),
-        }
-        .into_response();
+    let validated = match validate_create_application(CreateAppInput {
+        name: &form.name,
+        application_type: &form.application_type,
+        redirect_uris: &redirect_uris,
+        resource_uris: &resource_uris,
+        fapi_profile: form.fapi_profile.as_deref(),
+        jwks: form.jwks.as_deref(),
+        jwks_uri: form.jwks_uri.as_deref(),
+    }) {
+        Ok(v) => v,
+        Err(e) => return validation_error_response(&e, "/applications/new".to_string()),
     };
+    let name = validated.name;
+    let app_type = validated.app_type;
+    let is_fapi = validated.is_fapi;
+    let jwks_value = validated.jwks;
+    let jwks_uri_trimmed = validated.jwks_uri;
 
     // Parse and validate access scope
     let access_scope = form.access_scope.parse::<AccessScope>().unwrap_or_default();
@@ -115,135 +130,6 @@ pub(crate) async fn create_application_form(
             back_url: "/applications/new".to_string(),
         }
         .into_response();
-    }
-
-    let redirect_uris = parse_redirect_uris(&form.redirect_uris);
-
-    // For non-service apps, at least one redirect URI is required
-    if !matches!(app_type, OAuthClientType::Service) && redirect_uris.is_empty() {
-        return ApplicationErrorTemplate {
-            title: "Invalid Input".to_string(),
-            message: "At least one redirect URI is required.".to_string(),
-            back_url: "/applications/new".to_string(),
-        }
-        .into_response();
-    }
-
-    // Validate redirect URIs are valid URLs
-    if let Err(invalid) = validate_redirect_uris(&redirect_uris) {
-        return ApplicationErrorTemplate {
-            title: "Invalid Input".to_string(),
-            message: format!(
-                "Invalid redirect URI(s): {}. Each URI must be a valid http:// or https:// URL.",
-                invalid.join(", ")
-            ),
-            back_url: "/applications/new".to_string(),
-        }
-        .into_response();
-    }
-
-    // RFC 8707: Parse and validate resource URIs from form (if provided).
-    let resource_uris = parse_resource_uris(form.resource_uris.as_deref());
-
-    for uri in &resource_uris {
-        if let Err(e) = ResourceUri::parse(uri) {
-            return ApplicationErrorTemplate {
-                title: "Invalid Input".to_string(),
-                message: format!(
-                    "Invalid resource URI '{uri}': {e}. \
-                     Resource URIs must be absolute URIs without fragment components."
-                ),
-                back_url: "/applications/new".to_string(),
-            }
-            .into_response();
-        }
-    }
-
-    // Determine FAPI profile
-    let is_fapi = form
-        .fapi_profile
-        .as_deref()
-        .is_some_and(|p| p == "fapi2_security");
-
-    // FAPI validation: must be a confidential client type
-    if is_fapi && !matches!(app_type, OAuthClientType::Web | OAuthClientType::Service) {
-        return ApplicationErrorTemplate {
-            title: "Invalid Input".to_string(),
-            message: "FAPI 2.0 Security Profile requires a confidential client type \
-                      (Web Application or Service)."
-                .to_string(),
-            back_url: "/applications/new".to_string(),
-        }
-        .into_response();
-    }
-
-    // FAPI validation: require JWKS or JWKS URI
-    let jwks_trimmed_str = form
-        .jwks
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty());
-    let jwks_uri_trimmed = form
-        .jwks_uri
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty());
-
-    if is_fapi && jwks_trimmed_str.is_none() && jwks_uri_trimmed.is_none() {
-        return ApplicationErrorTemplate {
-            title: "Invalid Input".to_string(),
-            message: "FAPI 2.0 requires a JWKS (inline JSON) or JWKS URI for \
-                      private_key_jwt authentication."
-                .to_string(),
-            back_url: "/applications/new".to_string(),
-        }
-        .into_response();
-    }
-
-    // Validate and parse JWKS JSON if provided
-    let jwks_value = if let Some(jwks_json) = jwks_trimmed_str {
-        match serde_json::from_str::<serde_json::Value>(jwks_json) {
-            Ok(val) => {
-                if !val
-                    .get("keys")
-                    .is_some_and(|k| k.is_array() && !k.as_array().is_some_and(|a| a.is_empty()))
-                {
-                    return ApplicationErrorTemplate {
-                        title: "Invalid Input".to_string(),
-                        message: "JWKS must be a JSON object with a non-empty \"keys\" array."
-                            .to_string(),
-                        back_url: "/applications/new".to_string(),
-                    }
-                    .into_response();
-                }
-                Some(val)
-            }
-            Err(_) => {
-                return ApplicationErrorTemplate {
-                    title: "Invalid Input".to_string(),
-                    message: "JWKS must be valid JSON.".to_string(),
-                    back_url: "/applications/new".to_string(),
-                }
-                .into_response();
-            }
-        }
-    } else {
-        None
-    };
-
-    // Validate JWKS URI if provided
-    if let Some(uri) = jwks_uri_trimmed {
-        match url::Url::parse(uri) {
-            Ok(parsed) if parsed.scheme() == "https" => {}
-            _ => {
-                return ApplicationErrorTemplate {
-                    title: "Invalid Input".to_string(),
-                    message: "JWKS URI must be a valid https:// URL.".to_string(),
-                    back_url: "/applications/new".to_string(),
-                }
-                .into_response();
-            }
-        }
     }
 
     // All input validated — now fetch org_id from DB (only needed for org-scoped apps)
@@ -482,12 +368,10 @@ pub(crate) async fn update_application_form(
     // Validate inputs
     let name = form.name.trim();
     if name.is_empty() {
-        return ApplicationErrorTemplate {
-            title: "Invalid Input".to_string(),
-            message: "Application name is required.".to_string(),
-            back_url: format!("/applications/{}", app_id),
-        }
-        .into_response();
+        return validation_error_response(
+            &AppValidationError::EmptyName,
+            format!("/applications/{}", app_id),
+        );
     }
 
     // Parse access scope if provided
@@ -523,132 +407,28 @@ pub(crate) async fn update_application_form(
         None
     };
 
+    // Parse textarea inputs, then run the shared format validation
     let redirect_uris = parse_redirect_uris(&form.redirect_uris);
-
-    // Validate redirect URIs are valid URLs
-    if let Err(invalid) = validate_redirect_uris(&redirect_uris) {
-        return ApplicationErrorTemplate {
-            title: "Invalid Input".to_string(),
-            message: format!(
-                "Invalid redirect URI(s): {}. Each URI must be a valid http:// or https:// URL.",
-                invalid.join(", ")
-            ),
-            back_url: format!("/applications/{}", app_id),
-        }
-        .into_response();
-    }
-
-    // RFC 8707: Parse and validate resource URIs from form (if provided).
     let resource_uris = parse_resource_uris(form.resource_uris.as_deref());
 
-    for uri in &resource_uris {
-        if let Err(e) = ResourceUri::parse(uri) {
-            return ApplicationErrorTemplate {
-                title: "Invalid Input".to_string(),
-                message: format!(
-                    "Invalid resource URI '{uri}': {e}. \
-                     Resource URIs must be absolute URIs without fragment components."
-                ),
-                back_url: format!("/applications/{}", app_id),
-            }
-            .into_response();
-        }
-    }
-
-    // Determine FAPI profile
-    let is_fapi = form
-        .fapi_profile
-        .as_deref()
-        .is_some_and(|p| p == "fapi2_security");
-
-    // FAPI validation: must be a confidential client type
-    if is_fapi
-        && !matches!(
-            client.application_type,
-            OAuthClientType::Web | OAuthClientType::Service
-        )
-    {
-        return ApplicationErrorTemplate {
-            title: "Invalid Input".to_string(),
-            message: "FAPI 2.0 Security Profile requires a confidential client type \
-                      (Web Application or Service)."
-                .to_string(),
-            back_url: format!("/applications/{}", app_id),
-        }
-        .into_response();
-    }
-
-    // FAPI validation: require JWKS or JWKS URI
-    let jwks_trimmed_str = form
-        .jwks
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty());
-    let jwks_uri_trimmed = form
-        .jwks_uri
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty());
-
-    if is_fapi && jwks_trimmed_str.is_none() && jwks_uri_trimmed.is_none() {
-        // If transitioning to FAPI, check if client already has JWKS configured
-        if client.jwks.is_none() && client.jwks_uri.is_none() {
-            return ApplicationErrorTemplate {
-                title: "Invalid Input".to_string(),
-                message: "FAPI 2.0 requires a JWKS (inline JSON) or JWKS URI for \
-                          private_key_jwt authentication."
-                    .to_string(),
-                back_url: format!("/applications/{}", app_id),
-            }
-            .into_response();
-        }
-    }
-
-    // Validate and parse JWKS JSON if provided
-    let jwks_value = if let Some(jwks_json) = jwks_trimmed_str {
-        match serde_json::from_str::<serde_json::Value>(jwks_json) {
-            Ok(val) => {
-                if !val
-                    .get("keys")
-                    .is_some_and(|k| k.is_array() && !k.as_array().is_some_and(|a| a.is_empty()))
-                {
-                    return ApplicationErrorTemplate {
-                        title: "Invalid Input".to_string(),
-                        message: "JWKS must be a JSON object with a non-empty \"keys\" array."
-                            .to_string(),
-                        back_url: format!("/applications/{}", app_id),
-                    }
-                    .into_response();
-                }
-                Some(val)
-            }
-            Err(_) => {
-                return ApplicationErrorTemplate {
-                    title: "Invalid Input".to_string(),
-                    message: "JWKS must be valid JSON.".to_string(),
-                    back_url: format!("/applications/{}", app_id),
-                }
-                .into_response();
-            }
-        }
-    } else {
-        None
+    let validated = match validate_update_format(UpdateAppInput {
+        redirect_uris: Some(&redirect_uris),
+        resource_uris: Some(&resource_uris),
+        fapi_profile: form.fapi_profile.as_deref(),
+        jwks: form.jwks.as_deref(),
+        jwks_uri: form.jwks_uri.as_deref(),
+    }) {
+        Ok(v) => v,
+        Err(e) => return validation_error_response(&e, format!("/applications/{}", app_id)),
     };
 
-    // Validate JWKS URI if provided
-    if let Some(uri) = jwks_uri_trimmed {
-        match url::Url::parse(uri) {
-            Ok(parsed) if parsed.scheme() == "https" => {}
-            _ => {
-                return ApplicationErrorTemplate {
-                    title: "Invalid Input".to_string(),
-                    message: "JWKS URI must be a valid https:// URL.".to_string(),
-                    back_url: format!("/applications/{}", app_id),
-                }
-                .into_response();
-            }
-        }
+    // FAPI rules that depend on the existing client record
+    if let Err(e) = validate_update_fapi(&validated, &client) {
+        return validation_error_response(&e, format!("/applications/{}", app_id));
     }
+    let is_fapi = validated.is_fapi;
+    let jwks_value = validated.jwks;
+    let jwks_uri_trimmed = validated.jwks_uri;
 
     // Compute FAPI-related values: merge form values with existing client values
     let fapi_profile = if is_fapi {

--- a/crates/vouch-server/src/handlers/certification.rs
+++ b/crates/vouch-server/src/handlers/certification.rs
@@ -339,14 +339,16 @@ async fn get_or_create_cert_authenticator(
 
     match db::create_authenticator(
         &state.store,
-        user_id,
-        user_email,
-        "Certification Test Authenticator",
-        &dummy_credential_id,
-        &dummy_public_key,
-        None,  // aaguid
-        None,  // user_handle
-        false, // attestation_verified
+        &db::CreateAuthenticatorParams {
+            user_id,
+            user_email,
+            name: "Certification Test Authenticator",
+            credential_id: &dummy_credential_id,
+            public_key: &dummy_public_key,
+            aaguid: None,
+            user_handle: None,
+            attestation_verified: false,
+        },
     )
     .await
     {

--- a/crates/vouch-server/src/handlers/credentials.rs
+++ b/crates/vouch-server/src/handlers/credentials.rs
@@ -514,6 +514,10 @@ pub(crate) async fn get_github_status(
     clippy::too_many_arguments,
     reason = "axum handler signature: extractors are positional parameters"
 )]
+#[expect(
+    clippy::too_many_lines,
+    reason = "sequential GitHub installation token validation and issuance"
+)]
 pub(crate) async fn get_github_token(
     method: Method,
     uri: OriginalUri,

--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -170,6 +170,10 @@ pub(crate) async fn device_code(
 /// - `expired_token` — the device code has expired
 /// - `access_denied` — the user denied the authorization request
 /// - A successful token response when the user has authorized
+#[expect(
+    clippy::too_many_lines,
+    reason = "linear RFC 8628 device token grant validation sequence"
+)]
 pub(crate) async fn device_token(
     State(state): State<Arc<AppState>>,
     Json(req): Json<DeviceTokenRequest>,

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -1374,14 +1374,16 @@ pub(crate) async fn browser_register_complete(
     let user_handle = reg_state.user_id.as_bytes().to_vec();
     let authenticator_id = db::create_authenticator(
         &state.store,
-        &reg_state.user_id.to_string(),
-        &reg_state.user_email,
-        &validated.device_name,
-        &cred_id_to_store,
-        &public_key_cbor,
-        validated.aaguid.as_deref(),
-        Some(&user_handle),
-        validated.attestation_verified,
+        &db::CreateAuthenticatorParams {
+            user_id: &reg_state.user_id.to_string(),
+            user_email: &reg_state.user_email,
+            name: &validated.device_name,
+            credential_id: &cred_id_to_store,
+            public_key: &public_key_cbor,
+            aaguid: validated.aaguid.as_deref(),
+            user_handle: Some(&user_handle),
+            attestation_verified: validated.attestation_verified,
+        },
     )
     .await?;
 

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -593,6 +593,10 @@ pub(crate) async fn oidc_callback(
     complete_enrollment_after_identity(&state, &stored_state, identity, oidc_state_claim).await
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "linear enrollment completion sequence after IdP identity"
+)]
 pub(crate) async fn complete_enrollment_after_identity(
     state: &Arc<AppState>,
     stored_state: &db::OidcState,

--- a/crates/vouch-server/src/handlers/keys.rs
+++ b/crates/vouch-server/src/handlers/keys.rs
@@ -308,14 +308,16 @@ pub(crate) async fn register_complete(
     let user_handle = reg_state.user_id.as_bytes().to_vec();
     let device_id = db::create_authenticator(
         &state.store,
-        &reg_state.user_id.to_string(),
-        &reg_state.user_name,
-        &reg_state.device_name,
-        &verified_cred_id,
-        &verified_public_key,
-        aaguid.as_deref(),
-        Some(&user_handle),
-        validated.attestation_verified,
+        &db::CreateAuthenticatorParams {
+            user_id: &reg_state.user_id.to_string(),
+            user_email: &reg_state.user_name,
+            name: &reg_state.device_name,
+            credential_id: &verified_cred_id,
+            public_key: &verified_public_key,
+            aaguid: aaguid.as_deref(),
+            user_handle: Some(&user_handle),
+            attestation_verified: validated.attestation_verified,
+        },
     )
     .await?;
 

--- a/crates/vouch-server/src/handlers/oidc/par.rs
+++ b/crates/vouch-server/src/handlers/oidc/par.rs
@@ -139,6 +139,10 @@ impl ClientAuthFields for ParRequest {
 /// ## Response
 ///
 /// Returns 201 Created with a JSON body containing `request_uri` and `expires_in`.
+#[expect(
+    clippy::too_many_lines,
+    reason = "single-pass FAPI 2.0 PAR validation per RFC 9126"
+)]
 pub(crate) async fn par(
     State(state): State<Arc<AppState>>,
     client_cert: crate::handlers::extractors::OptionalClientCert,

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc8693.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc8693.rs
@@ -968,14 +968,16 @@ async fn test_rfc8693_id_token_carries_hardware_aaguid() {
     let aaguid = "ee882879-721c-4913-9775-3dfcce97072a";
     let auth_id = crate::db::create_authenticator(
         &state.store,
-        &user.id,
-        &user.email,
-        "YubiKey 5",
-        format!("cred-{}", uuid::Uuid::now_v7()).as_bytes(),
-        &[0u8; 32],
-        Some(aaguid),
-        Some(user.id.as_bytes()),
-        true,
+        &crate::db::CreateAuthenticatorParams {
+            user_id: &user.id,
+            user_email: &user.email,
+            name: "YubiKey 5",
+            credential_id: format!("cred-{}", uuid::Uuid::now_v7()).as_bytes(),
+            public_key: &[0u8; 32],
+            aaguid: Some(aaguid),
+            user_handle: Some(user.id.as_bytes()),
+            attestation_verified: true,
+        },
     )
     .await
     .expect("create authenticator with aaguid");
@@ -1024,14 +1026,16 @@ async fn test_rfc8693_id_token_uses_session_aaguid_after_rotation() {
     let original_aaguid = "ee882879-721c-4913-9775-3dfcce97072a";
     let auth_id = crate::db::create_authenticator(
         &state.store,
-        &user.id,
-        &user.email,
-        "YubiKey 5 (original)",
-        format!("cred-{}", uuid::Uuid::now_v7()).as_bytes(),
-        &[0u8; 32],
-        Some(original_aaguid),
-        Some(user.id.as_bytes()),
-        true,
+        &crate::db::CreateAuthenticatorParams {
+            user_id: &user.id,
+            user_email: &user.email,
+            name: "YubiKey 5 (original)",
+            credential_id: format!("cred-{}", uuid::Uuid::now_v7()).as_bytes(),
+            public_key: &[0u8; 32],
+            aaguid: Some(original_aaguid),
+            user_handle: Some(user.id.as_bytes()),
+            attestation_verified: true,
+        },
     )
     .await
     .expect("create original authenticator");

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -552,6 +552,10 @@ async fn resolve_non_jwt_auth(
 }
 
 /// Handle authorization code grant.
+#[expect(
+    clippy::too_many_lines,
+    reason = "linear RFC 6749 section 4.1.3 authorization-code grant validation"
+)]
 async fn handle_authorization_code_grant(
     State(state): State<Arc<AppState>>,
     client_cert: crate::handlers::extractors::OptionalClientCert,

--- a/crates/vouch-server/src/handlers/oidc/userinfo.rs
+++ b/crates/vouch-server/src/handlers/oidc/userinfo.rs
@@ -69,6 +69,7 @@ struct UserInfoForm {
 /// Supports `Bearer` and `DPoP` authorization schemes (RFC 9449 Section 7.1),
 /// and access token in POST body (RFC 6750 Section 2.2, Bearer only).
 /// Enforces mTLS certificate binding per RFC 8705 Section 3.
+#[expect(clippy::too_many_lines, reason = "linear OIDC userinfo claim assembly")]
 pub(crate) async fn userinfo(
     State(state): State<Arc<AppState>>,
     method: Method,

--- a/crates/vouch-server/src/infra/s3_config.rs
+++ b/crates/vouch-server/src/infra/s3_config.rs
@@ -719,6 +719,10 @@ impl ServerConfig {
     /// # Runtime Updates
     /// Only TLS certificates can be updated at runtime (for hot-reload).
     /// All other configuration changes require a server restart.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "field-by-field merge of every S3-overridable config option"
+    )]
     pub fn merge_s3_config(
         &mut self,
         s3: &S3Config,

--- a/crates/vouch-server/src/infra/serve.rs
+++ b/crates/vouch-server/src/infra/serve.rs
@@ -27,6 +27,10 @@ use super::startup::ServerComponents;
 /// # Errors
 ///
 /// Returns an error if the server fails to bind or encounters a fatal error.
+#[expect(
+    clippy::too_many_lines,
+    reason = "sequential listener, TLS, and shutdown wiring"
+)]
 pub async fn serve(components: ServerComponents, app: Router) -> Result<()> {
     let ServerComponents {
         config,

--- a/crates/vouch-server/src/infra/startup.rs
+++ b/crates/vouch-server/src/infra/startup.rs
@@ -379,6 +379,10 @@ async fn connect_and_migrate(config: &config::ServerConfig) -> Result<Pool> {
 }
 
 /// Build shared application state with all service components.
+#[expect(
+    clippy::too_many_lines,
+    reason = "sequential construction of every AppState component"
+)]
 async fn build_app_state(
     config: &config::ServerConfig,
     db: Pool,

--- a/crates/vouch-server/src/services/auth.rs
+++ b/crates/vouch-server/src/services/auth.rs
@@ -250,18 +250,18 @@ pub(crate) async fn verify_login_assertion(
     tokio::task::spawn_blocking(move || {
         let expected_challenge = URL_SAFE_NO_PAD.encode(&params.challenge);
 
-        let result = webauthn_verify::verify_assertion(
-            &params.authenticator_data,
-            &params.client_data_json,
-            &params.signature,
-            &params.public_key,
-            &params.rp_id,
-            &expected_challenge,
-            &params.expected_origin,
-            params.stored_counter,
-            true, // require_user_verification
-            params.allow_localhost_origin,
-        )
+        let result = webauthn_verify::verify_assertion(&webauthn_verify::AssertionParams {
+            authenticator_data: &params.authenticator_data,
+            client_data_json: &params.client_data_json,
+            signature: &params.signature,
+            public_key_cose: &params.public_key,
+            expected_rp_id: &params.rp_id,
+            expected_challenge: &expected_challenge,
+            expected_origin: &params.expected_origin,
+            stored_counter: params.stored_counter,
+            require_user_verification: true,
+            allow_localhost_origin: params.allow_localhost_origin,
+        })
         .map_err(|e| {
             ServiceError::oauth(
                 OAuthErrorCode::InvalidGrant,
@@ -739,15 +739,17 @@ pub(crate) async fn create_oauth_access_token(
     let token_hash = hash_token(&token);
     db::create_session(
         &state.store,
-        params.user_id,
-        params.email,
-        &token_hash,
-        params.authenticator_id,
-        expires,
-        params.session_purpose,
-        params.authorization_details,
-        params.hardware_aaguid,
-        params.org_domain,
+        &db::CreateSessionParams {
+            user_id: params.user_id,
+            user_email: params.email,
+            token_hash: &token_hash,
+            authenticator_id: params.authenticator_id,
+            expires_at: expires,
+            session_type: params.session_purpose,
+            authorization_details: params.authorization_details,
+            hardware_aaguid: params.hardware_aaguid,
+            org_domain: params.org_domain,
+        },
     )
     .await
     .map_err(|e| ServiceError::Internal(format!("Failed to store session: {e}")))?;

--- a/crates/vouch-server/src/services/integrations/github/installations.rs
+++ b/crates/vouch-server/src/services/integrations/github/installations.rs
@@ -79,13 +79,15 @@ impl GitHubService<'_> {
         // Store installation in database
         db::create_github_installation(
             self.store,
-            params.org_id,
-            params.installation_id.cast_signed(),
-            &details.account.login,
-            &details.account.account_type,
-            &details.permissions,
-            &details.repository_selection,
-            Some(&params.user.id),
+            &db::CreateGitHubInstallationParams {
+                org_id: params.org_id,
+                installation_id: params.installation_id.cast_signed(),
+                github_account_login: &details.account.login,
+                github_account_type: &details.account.account_type,
+                permissions: &details.permissions,
+                repository_selection: &details.repository_selection,
+                installed_by_user_id: Some(&params.user.id),
+            },
         )
         .await
         .map_err(GitHubError::Database)?;
@@ -168,13 +170,15 @@ impl GitHubService<'_> {
         // Store installation in database
         db::create_github_installation(
             self.store,
-            params.org_id,
-            params.installation_id.cast_signed(),
-            &user_installation.account.login,
-            &user_installation.account.account_type,
-            &details.permissions,
-            &details.repository_selection,
-            Some(&params.user.id),
+            &db::CreateGitHubInstallationParams {
+                org_id: params.org_id,
+                installation_id: params.installation_id.cast_signed(),
+                github_account_login: &user_installation.account.login,
+                github_account_type: &user_installation.account.account_type,
+                permissions: &details.permissions,
+                repository_selection: &details.repository_selection,
+                installed_by_user_id: Some(&params.user.id),
+            },
         )
         .await
         .map_err(GitHubError::Database)?;
@@ -488,13 +492,15 @@ mod tests {
         let perms = HashMap::from([("contents".to_string(), "read".to_string())]);
         crate::db::create_github_installation(
             &state.store,
-            &org.id,
-            42,
-            "the-org",
-            "Organization",
-            &perms,
-            "all",
-            None,
+            &crate::db::CreateGitHubInstallationParams {
+                org_id: &org.id,
+                installation_id: 42,
+                github_account_login: "the-org",
+                github_account_type: "Organization",
+                permissions: &perms,
+                repository_selection: "all",
+                installed_by_user_id: None,
+            },
         )
         .await
         .expect("create installation");

--- a/crates/vouch-server/src/services/oidc/exchange.rs
+++ b/crates/vouch-server/src/services/oidc/exchange.rs
@@ -410,13 +410,15 @@ pub(crate) async fn exchange_token(
     };
     if let Err(e) = db::insert_token_exchange(
         &state.store,
-        &subject_session.user_id,
-        &subject_token_hash,
-        None, // actor_user_id
-        &issued_token_hash,
-        params.audience,
-        scope_string.as_deref(),
-        expires_at,
+        &db::InsertTokenExchangeParams {
+            subject_user_id: &subject_session.user_id,
+            subject_token_hash: &subject_token_hash,
+            actor_user_id: None,
+            issued_token_hash: &issued_token_hash,
+            requested_audience: params.audience,
+            granted_scope: scope_string.as_deref(),
+            expires_at,
+        },
     )
     .await
     {
@@ -511,13 +513,16 @@ async fn issue_id_token(
         });
     if let Err(e) = db::insert_token_exchange(
         &state.store,
-        ctx.user_id,
-        ctx.subject_token_hash,
-        None, // actor_user_id
-        &issued_token_hash,
-        ctx.audience,
-        None, // granted_scope — ID tokens do not carry OAuth scope
-        expires_at,
+        &db::InsertTokenExchangeParams {
+            subject_user_id: ctx.user_id,
+            subject_token_hash: ctx.subject_token_hash,
+            actor_user_id: None,
+            issued_token_hash: &issued_token_hash,
+            requested_audience: ctx.audience,
+            // ID tokens do not carry OAuth scope
+            granted_scope: None,
+            expires_at,
+        },
     )
     .await
     {

--- a/crates/vouch-server/src/services/oidc/jar.rs
+++ b/crates/vouch-server/src/services/oidc/jar.rs
@@ -319,6 +319,7 @@ fn parse_request_object_header(
 /// If `query_params` are provided, validates that any overlapping parameters
 /// (`client_id`, `response_type`, `scope`) match between query and JWT
 /// (FAPI 2.0 Section 5.3.2).
+#[expect(clippy::too_many_lines, reason = "single-pass RFC 9101 JAR validation")]
 pub async fn validate_request_object(
     state: &Arc<AppState>,
     request_jwt: &str,

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
@@ -127,6 +127,10 @@ impl PendingJti {
 ///   passed. Thread it forward to construct
 ///   [`crate::services::auth::ClientAuthProof::PrivateKeyJwt`] regardless of
 ///   whether the assertion carried a `jti`.
+#[expect(
+    clippy::too_many_lines,
+    reason = "single-pass RFC 7523 client assertion validation"
+)]
 pub async fn authenticate_client_jwt(
     state: &Arc<AppState>,
     client_assertion: &str,

--- a/crates/vouch-server/src/services/oidc/registration.rs
+++ b/crates/vouch-server/src/services/oidc/registration.rs
@@ -263,6 +263,10 @@ pub struct RegistrationResponse {
 ///
 /// # Errors
 /// Returns `ServiceError::OAuth` with the appropriate RFC 7591 error code.
+#[expect(
+    clippy::too_many_lines,
+    reason = "single-pass RFC 7591 registration metadata validation"
+)]
 pub async fn register_client(
     state: &Arc<AppState>,
     mut request: RegistrationRequest,

--- a/crates/vouch-server/src/services/oidc/token.rs
+++ b/crates/vouch-server/src/services/oidc/token.rs
@@ -254,6 +254,10 @@ pub struct IdTokenClaims {
 ///
 /// # Errors
 /// Returns `ServiceError` for invalid requests.
+#[expect(
+    clippy::too_many_lines,
+    reason = "linear authorization-code exchange sequence"
+)]
 pub(crate) async fn exchange_authorization_code(
     state: &Arc<AppState>,
     params: AuthCodeExchangeParams<'_>,

--- a/crates/vouch-server/src/test_utils.rs
+++ b/crates/vouch-server/src/test_utils.rs
@@ -500,14 +500,16 @@ pub async fn create_test_user_in_org(
 pub async fn create_test_authenticator(store: &DocumentStore, user_id: &str) -> String {
     crate::db::create_authenticator(
         store,
-        user_id,
-        "test@example.com",
-        "Test Key",
-        format!("test-cred-{}", uuid::Uuid::now_v7()).as_bytes(),
-        &[0u8; 32],
-        None,
-        Some(user_id.as_bytes()),
-        false,
+        &crate::db::CreateAuthenticatorParams {
+            user_id,
+            user_email: "test@example.com",
+            name: "Test Key",
+            credential_id: format!("test-cred-{}", uuid::Uuid::now_v7()).as_bytes(),
+            public_key: &[0u8; 32],
+            aaguid: None,
+            user_handle: Some(user_id.as_bytes()),
+            attestation_verified: false,
+        },
     )
     .await
     .expect("Failed to create authenticator")

--- a/crates/vouch-tests/tests/cleanup_task.rs
+++ b/crates/vouch-tests/tests/cleanup_task.rs
@@ -60,29 +60,33 @@ async fn run_cleanup_removes_expired_sessions_and_keeps_fresh_ones() {
     // Two sessions: one already expired, one with a future expiry.
     db::create_session(
         &harness.state.store,
-        &user.id,
-        &user.email,
-        TOKEN_HASH_EXPIRED,
-        Some(&auth_id),
-        past,
-        SessionPurpose::OAuthAccessToken,
-        None,
-        None,
-        None,
+        &db::CreateSessionParams {
+            user_id: &user.id,
+            user_email: &user.email,
+            token_hash: TOKEN_HASH_EXPIRED,
+            authenticator_id: Some(&auth_id),
+            expires_at: past,
+            session_type: SessionPurpose::OAuthAccessToken,
+            authorization_details: None,
+            hardware_aaguid: None,
+            org_domain: None,
+        },
     )
     .await
     .expect("create expired session");
     db::create_session(
         &harness.state.store,
-        &user.id,
-        &user.email,
-        TOKEN_HASH_FRESH,
-        Some(&auth_id),
-        future,
-        SessionPurpose::OAuthAccessToken,
-        None,
-        None,
-        None,
+        &db::CreateSessionParams {
+            user_id: &user.id,
+            user_email: &user.email,
+            token_hash: TOKEN_HASH_FRESH,
+            authenticator_id: Some(&auth_id),
+            expires_at: future,
+            session_type: SessionPurpose::OAuthAccessToken,
+            authorization_details: None,
+            hardware_aaguid: None,
+            org_domain: None,
+        },
     )
     .await
     .expect("create fresh session");

--- a/crates/vouch-tests/tests/db_github.rs
+++ b/crates/vouch-tests/tests/db_github.rs
@@ -36,13 +36,15 @@ async fn install(
 ) -> String {
     db::create_github_installation(
         &harness.state.store,
-        org_id,
-        installation_id,
-        login,
-        account_type,
-        &perm(&[("contents", "read")]),
-        "all",
-        Some("admin-user"),
+        &db::CreateGitHubInstallationParams {
+            org_id,
+            installation_id,
+            github_account_login: login,
+            github_account_type: account_type,
+            permissions: &perm(&[("contents", "read")]),
+            repository_selection: "all",
+            installed_by_user_id: Some("admin-user"),
+        },
     )
     .await
     .expect("create installation")

--- a/crates/vouch-tests/tests/integration.rs
+++ b/crates/vouch-tests/tests/integration.rs
@@ -2555,12 +2555,12 @@ mod encoding_verification {
         assert!(!auth_result.client_data_json.is_empty());
     }
 
-    /// Test typed verification functions
+    /// Test verification through the AssertionParams API
     #[tokio::test]
     async fn test_typed_verification_functions() {
         use vouch_cli::{FidoDevice, MockFidoDevice};
         use vouch_server::crypto::webauthn_verify::{
-            TestCoseVerifier, verify_assertion_typed_with_verifier,
+            AssertionParams, TestCoseVerifier, verify_assertion_with_verifier,
         };
 
         let device = MockFidoDevice::new();
@@ -2596,16 +2596,19 @@ mod encoding_verification {
         let client_data_json: serde_json::Value = serde_json::from_str(client_data_str).unwrap();
         let expected_challenge = client_data_json["challenge"].as_str().unwrap();
 
-        let result = verify_assertion_typed_with_verifier(
-            auth_data,
-            client_data,
-            signature,
-            public_key,
-            "test.local",
-            expected_challenge,
-            "https://test.local",
-            0,
-            true,
+        let result = verify_assertion_with_verifier(
+            &AssertionParams {
+                authenticator_data: auth_data.as_bytes(),
+                client_data_json: client_data.as_bytes(),
+                signature: signature.as_bytes(),
+                public_key_cose: public_key.as_bytes(),
+                expected_rp_id: "test.local",
+                expected_challenge,
+                expected_origin: "https://test.local",
+                stored_counter: 0,
+                require_user_verification: true,
+                allow_localhost_origin: true,
+            },
             &verifier,
         );
 


### PR DESCRIPTION
## Summary

A survey found ~37 functions ≥150 lines and ~25 with 8+ parameters. Most long functions here are linear protocol flows where splitting would only manufacture single-use helpers, so they stay as-is. This PR makes three targeted changes where action is actually warranted:

### 1. Deduplicate application create/update validation
The four application handlers (create/update × API/web) each carried a near-identical ~200-line copy of the input validation rules (name, type, redirect URIs, RFC 8707 resource URIs, FAPI constraints, JWKS format), differing only in error rendering. The rules now live in `handlers/applications/validate.rs` with a typed `AppValidationError` that preserves the existing machine-readable error codes verbatim; every extracted function has both an API and a web caller. Behavior-preserving: update handlers keep their two-phase ordering (format checks pre-auth, client-dependent FAPI rules post-ownership), and the intentionally divergent API/web merge semantics stay in the handlers.

### 2. Param structs for 9–11-argument functions
Following the existing `CreateOAuthClientParams` pattern:
- `AssertionParams<'a>` for the WebAuthn assertion verification family in `crypto/webauthn_verify.rs`. The redundant `verify_assertion_typed*` wrappers are deleted — they existed to prevent positional byte-slice swaps, which named struct fields now prevent directly. The localhost-origin relaxation previously hardcoded in `verify_assertion_with_verifier` becomes an explicit field.
- `CreateSessionParams`, `CreateAuthenticatorParams`, `CreateGitHubInstallationParams`, `InsertTokenExchangeParams` for the db create functions, eliminating adjacent-`&str` swap risk (`user_id` vs `user_email`, subject vs issued token hash).

All `too_many_arguments` expects on these functions are removed; the remaining ones (axum handlers, CLI sigv4/fido2) describe genuinely positional signatures and stay.

### 3. Enable the dormant `too_many_lines` ratchet
`.clippy.toml` already configured `too-many-lines-threshold = 150` but no lint used it. It's now on at warn level (enforced as deny by `make lint`). The 18 functions where it actually fires get `#[expect(..., reason)]` with per-function justifications; `expect` (not `allow`) makes the ratchet self-cleaning via `unfulfilled_lint_expectations` when a function later shrinks below the threshold.

## Testing

- `make lint` clean (clippy `-D warnings`, all targets, all features)
- `cargo test -p vouch-server`: 2289 passed, 0 failed (incl. the ~50 application handler tests asserting error codes)
- `cargo test -p vouch-tests`: all 16 test binaries, 0 failures

https://claude.ai/code/session_01CNf2ra5fmaUbjp9HaAiJiB

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNf2ra5fmaUbjp9HaAiJiB)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WebAuthn assertion verification and session/authenticator persistence APIs; changes are structural refactors with tests updated, but mistakes in `allow_localhost_origin` or param field mapping could affect auth behavior.
> 
> **Overview**
> Refactors long functions and wide parameter lists without changing intended behavior: enables **`clippy::too_many_lines`** (150 LoC) with documented **`#[expect]`** on linear CLI/server flows that stay monolithic on purpose.
> 
> **OAuth application registration** — duplicated create/update validation across API and web handlers moves into **`handlers/applications/validate.rs`** (`AppValidationError`, shared rules for redirect/resource URIs, FAPI, JWKS). Handlers keep their ordering (format checks before auth; FAPI rules that need the existing client after ownership).
> 
> **WebAuthn assertion verification** — **`AssertionParams`** replaces long positional argument lists; **`verify_assertion_typed*`** wrappers are removed. **`allow_localhost_origin`** is an explicit field (no longer hardcoded in the with-verifier path).
> 
> **Database creates** — **`CreateSessionParams`**, **`CreateAuthenticatorParams`**, **`CreateGitHubInstallationParams`**, and **`InsertTokenExchangeParams`** replace 8–11-argument functions; call sites and tests are updated throughout server and integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7537ecae2734dfe6c28d686280768ba77fd9141. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->