### PR TITLE
Code-quality batch: audit helper, explicit re-exports, type safety, function decomposition, IPC timeouts

### DIFF
--- a/crates/vouch-agent/src/server.rs
+++ b/crates/vouch-agent/src/server.rs
@@ -174,8 +174,9 @@ async fn handle_connection(
     ssh_state: Arc<SshAgentState>,
 ) -> Result<()> {
     loop {
-        // Read length-prefixed message
-        let buf = match wire::read_message(&mut stream).await? {
+        // Read length-prefixed message, bounding how long an idle or
+        // stalled client can hold this connection task open.
+        let buf = match wire::read_message_timeout(&mut stream, wire::IDLE_READ_TIMEOUT).await? {
             Some(buf) => buf,
             None => return Ok(()), // Client disconnected
         };

--- a/crates/vouch-agent/src/ssh_agent/server.rs
+++ b/crates/vouch-agent/src/ssh_agent/server.rs
@@ -106,8 +106,9 @@ async fn handle_ssh_connection(
     agent_state: Option<Arc<crate::state::AgentState>>,
 ) -> Result<()> {
     loop {
-        // Read length-prefixed message
-        let buf = match wire::read_message(&mut stream).await? {
+        // Read length-prefixed message, bounding how long an idle or
+        // stalled client can hold this connection task open.
+        let buf = match wire::read_message_timeout(&mut stream, wire::IDLE_READ_TIMEOUT).await? {
             Some(buf) => buf,
             None => return Ok(()), // Clean disconnect
         };

--- a/crates/vouch-agent/src/wire.rs
+++ b/crates/vouch-agent/src/wire.rs
@@ -15,7 +15,7 @@ pub const MAX_MESSAGE_SIZE: usize = 1024 * 1024;
 ///
 /// Generous enough for legitimate long-idle clients, but bounds how long an
 /// abandoned or stalled peer can pin a per-connection task and its FD.
-pub const IDLE_READ_TIMEOUT: Duration = Duration::from_secs(300);
+pub const IDLE_READ_TIMEOUT: Duration = Duration::from_mins(5);
 
 /// Read a length-prefixed message (4-byte BE length + payload).
 ///

--- a/crates/vouch-agent/src/wire.rs
+++ b/crates/vouch-agent/src/wire.rs
@@ -5,10 +5,17 @@
 //! used by both the agent IPC protocol and the SSH agent protocol.
 
 use crate::error::{AgentError, Result};
+use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 /// Maximum message size (1MB).
 pub const MAX_MESSAGE_SIZE: usize = 1024 * 1024;
+
+/// Idle read deadline for server-side connections.
+///
+/// Generous enough for legitimate long-idle clients, but bounds how long an
+/// abandoned or stalled peer can pin a per-connection task and its FD.
+pub const IDLE_READ_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// Read a length-prefixed message (4-byte BE length + payload).
 ///
@@ -41,6 +48,21 @@ pub async fn read_message<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Option
     reader.read_exact(&mut buf).await?;
 
     Ok(Some(buf))
+}
+
+/// Read a length-prefixed message, failing if the peer stays silent (or
+/// stalls mid-message) past `timeout`.
+///
+/// Used by server-side connection loops, where every read on a
+/// peer-controlled connection needs a deadline; clients awaiting a response
+/// to their own request use [`read_message`] directly.
+pub async fn read_message_timeout<R: AsyncRead + Unpin>(
+    reader: &mut R,
+    timeout: Duration,
+) -> Result<Option<Vec<u8>>> {
+    tokio::time::timeout(timeout, read_message(reader))
+        .await
+        .map_err(|_| AgentError::Protocol("idle connection timed out".to_string()))?
 }
 
 /// Write a length-prefixed message (4-byte BE length + payload).
@@ -151,6 +173,37 @@ mod tests {
         let mut buf = Cursor::new(Vec::<u8>::new());
         let result = read_message(&mut buf).await.unwrap();
         assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_read_message_timeout_on_silent_peer() {
+        // A duplex stream with nothing written never produces data.
+        let (mut silent, _writer) = tokio::io::duplex(64);
+        let result = read_message_timeout(&mut silent, Duration::from_millis(10)).await;
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("idle connection timed out"));
+    }
+
+    #[tokio::test]
+    async fn test_read_message_timeout_on_stalled_mid_message() {
+        // Peer sends the length prefix but never the body.
+        let (mut reader, mut writer) = tokio::io::duplex(64);
+        writer.write_all(&[0, 0, 0, 8]).await.unwrap();
+        let result = read_message_timeout(&mut reader, Duration::from_millis(10)).await;
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("idle connection timed out"));
+    }
+
+    #[tokio::test]
+    async fn test_read_message_timeout_passes_through_message() {
+        let mut buf = Vec::new();
+        write_message(&mut buf, b"prompt reply").await.unwrap();
+        let mut cursor = Cursor::new(buf);
+        let read_back = read_message_timeout(&mut cursor, Duration::from_secs(5))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(read_back, b"prompt reply");
     }
 
     #[test]

--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -286,11 +286,7 @@ pub(crate) async fn exchange_for_sts_credentials(req: StsRequest<'_>) -> Result<
     // Detection must happen at the caller — and, for cached callers, before
     // the cache lookup — otherwise a cache hit would silently return
     // credentials minted in the wrong context (issue #398).
-    let agent_policies: &[&str] = if agent_source.is_some() {
-        &["ReadOnlyAccess"]
-    } else {
-        &[]
-    };
+    let policies = agent_session_policies(agent_source);
 
     let mut client = VouchClient::new(server).await?;
 
@@ -320,27 +316,6 @@ pub(crate) async fn exchange_for_sts_credentials(req: StsRequest<'_>) -> Result<
 
     let session = extract_sub_from_jwt(id_token).context("server returned invalid OIDC token")?;
 
-    let all_policies: &[&str] = agent_policies;
-
-    // Inline session policy for the management role hop when an agent is
-    // detected: restrict to only the STS actions needed for role chaining.
-    let mgmt_hop_policy = if agent_source.is_some() {
-        Some(serde_json::json!({
-            "Version": "2012-10-17",
-            "Statement": [{
-                "Effect": "Allow",
-                "Action": [
-                    "sts:AssumeRole",
-                    "sts:TagSession",
-                    "sts:SetSourceIdentity"
-                ],
-                "Resource": "*"
-            }]
-        }))
-    } else {
-        None
-    };
-
     if let Some(mgmt_role_arn) = mgmt.filter(|m| *m != role_arn) {
         // Chain: AssumeRoleWithWebIdentity into management role, then AssumeRole into target.
         // Management hop gets an inline STS-only policy; final hop gets ReadOnlyAccess.
@@ -355,7 +330,7 @@ pub(crate) async fn exchange_for_sts_credentials(req: StsRequest<'_>) -> Result<
             region,
             domain_suffix: mgmt_domain_suffix,
             session_policy_names: &[],
-            session_policy: mgmt_hop_policy.as_ref(),
+            session_policy: policies.mgmt_hop_policy.as_ref(),
         })
         .await
         .context("failed to assume management role")?;
@@ -366,7 +341,7 @@ pub(crate) async fn exchange_for_sts_credentials(req: StsRequest<'_>) -> Result<
             &session,
             region,
             &mgmt_credentials,
-            all_policies,
+            policies.session_policy_names,
             None,
         )
         .await
@@ -387,7 +362,7 @@ pub(crate) async fn exchange_for_sts_credentials(req: StsRequest<'_>) -> Result<
         web_identity_token: id_token,
         region,
         domain_suffix,
-        session_policy_names: all_policies,
+        session_policy_names: policies.session_policy_names,
         session_policy: None,
     })
     .await
@@ -398,6 +373,43 @@ pub(crate) async fn exchange_for_sts_credentials(req: StsRequest<'_>) -> Result<
         credentials,
         domain_suffix,
     })
+}
+
+/// Session policies applied to STS calls, restricted when an AI coding
+/// agent context is detected.
+struct AgentSessionPolicies {
+    /// Managed policy names attached to the issued credentials.
+    session_policy_names: &'static [&'static str],
+    /// Inline policy for the management-role hop, restricting it to only
+    /// the STS actions needed for role chaining.
+    mgmt_hop_policy: Option<serde_json::Value>,
+}
+
+/// Build the session policies for an exchange: unrestricted normally,
+/// ReadOnlyAccess plus an STS-only management-hop policy when an AI agent
+/// is detected.
+fn agent_session_policies(agent_source: Option<&str>) -> AgentSessionPolicies {
+    if agent_source.is_none() {
+        return AgentSessionPolicies {
+            session_policy_names: &[],
+            mgmt_hop_policy: None,
+        };
+    }
+    AgentSessionPolicies {
+        session_policy_names: &["ReadOnlyAccess"],
+        mgmt_hop_policy: Some(serde_json::json!({
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": [
+                    "sts:AssumeRole",
+                    "sts:TagSession",
+                    "sts:SetSourceIdentity"
+                ],
+                "Resource": "*"
+            }]
+        })),
+    }
 }
 
 /// Resolve the management role ARN from vouch config.

--- a/crates/vouch-cli/src/commands/diag.rs
+++ b/crates/vouch-cli/src/commands/diag.rs
@@ -717,7 +717,7 @@ fn print_report(
 fn extract_aaguid(reg: &Registration) -> Option<String> {
     // AAGUID lives at bytes 37-52 when the AT flag (0x40) is set
     let auth_data = &reg.attestation.auth_data;
-    if auth_data[32] & 0x40 != 0 && auth_data.len() >= 53 {
+    if auth_data.len() >= 53 && auth_data[32] & 0x40 != 0 {
         Some(hex::encode(&auth_data[37..53]))
     } else {
         None

--- a/crates/vouch-cli/src/commands/diag.rs
+++ b/crates/vouch-cli/src/commands/diag.rs
@@ -10,7 +10,6 @@
 #![expect(
     clippy::indexing_slicing,
     clippy::unwrap_used,
-    clippy::unwrap_in_result,
     clippy::expect_used,
     clippy::needless_borrows_for_generic_args,
     reason = "debugging command for diagnostics output, not production code paths"
@@ -22,16 +21,44 @@ use aws_lc_rs::signature::{ECDSA_P256_SHA256_ASN1, UnparsedPublicKey};
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use clap::Args;
+use ctap_hid_fido2::FidoKeyHid;
 use ctap_hid_fido2::FidoKeyHidFactory;
 use ctap_hid_fido2::LibCfg;
 use ctap_hid_fido2::fidokey::get_assertion::GetAssertionArgsBuilder;
-use ctap_hid_fido2::fidokey::make_credential::MakeCredentialArgsBuilder;
+use ctap_hid_fido2::fidokey::get_assertion::get_assertion_params::Assertion;
+use ctap_hid_fido2::fidokey::make_credential::{Attestation, MakeCredentialArgsBuilder};
 use ctap_hid_fido2::public_key_credential_user_entity::PublicKeyCredentialUserEntity;
 use ctap_hid_fido2::verifier;
+use ctap_hid_fido2::verifier::AttestationVerifyResult;
 use std::path::PathBuf;
 use vouch_common::fixtures::{
     AuthenticationFixture, Fido2Fixture, FixtureMetadata, RegistrationFixture,
 };
+
+/// Test relying party ID used for the local diagnostic flow.
+const RP_ID: &str = "diag.test.local";
+
+/// Print a progress line. When JSON mode is active, use stderr so stdout
+/// stays clean JSON.
+macro_rules! out {
+    ($json:expr, $($arg:tt)*) => {
+        if $json {
+            eprintln!($($arg)*);
+        } else {
+            println!($($arg)*);
+        }
+    };
+}
+/// Like [`out!`] but without a trailing newline.
+macro_rules! out_print {
+    ($json:expr, $($arg:tt)*) => {
+        if $json {
+            eprint!($($arg)*);
+        } else {
+            print!($($arg)*);
+        }
+    };
+}
 
 /// Arguments for the diag command.
 #[derive(Args)]
@@ -57,43 +84,72 @@ struct DiagJson {
     device_model: Option<String>,
 }
 
+/// Everything captured during the registration phase.
+struct Registration {
+    challenge: [u8; 32],
+    client_data_json: Vec<u8>,
+    attestation: Attestation,
+    verify_result: AttestationVerifyResult,
+    /// Raw COSE key bytes from the attested credential data.
+    cose_key: Vec<u8>,
+    /// P-256 public key x coordinate (32 bytes).
+    x: Vec<u8>,
+    /// P-256 public key y coordinate (32 bytes).
+    y: Vec<u8>,
+}
+
+/// Everything captured during the authentication phase.
+struct Authentication {
+    challenge: [u8; 32],
+    client_data_json: Vec<u8>,
+    assertion: Assertion,
+}
+
+/// Outcome of the signature verification phase.
+struct Verification {
+    lib_result: bool,
+    aws_lc_result: bool,
+    /// Signed message: authenticator_data || SHA256(raw_challenge).
+    message: Vec<u8>,
+    /// SEC1 uncompressed public key point (0x04 || x || y).
+    point: Vec<u8>,
+}
+
 /// Run diagnostic test of YubiKey registration + authentication + verification.
-#[expect(
-    clippy::too_many_lines,
-    reason = "sequential FIDO2 diagnostic report; each phase prints independent results"
-)]
 pub(crate) fn run(args: DiagArgs) -> Result<()> {
     let json = args.json;
 
-    // When json mode is active, use stderr for progress output so stdout is clean JSON.
-    // This macro dispatches to println! or eprintln! based on the json flag.
-    macro_rules! out {
-        ($($arg:tt)*) => {
-            if json {
-                eprintln!($($arg)*);
-            } else {
-                println!($($arg)*);
-            }
-        };
-    }
-    macro_rules! out_print {
-        ($($arg:tt)*) => {
-            if json {
-                eprint!($($arg)*);
-            } else {
-                print!($($arg)*);
-            }
-        };
+    out!(json, "=== YubiKey Diagnostic Test ===\n");
+    out!(json, "This test will:");
+    out!(json, "1. Register a new credential on your YubiKey");
+    out!(json, "2. Authenticate with that credential");
+    out!(json, "3. Verify the signature using aws-lc-rs\n");
+
+    let (device, pin) = wait_for_device_and_pin(json)?;
+
+    let reg = run_registration(json, &device, &pin)?;
+    let auth = run_authentication(json, &device, &pin, &reg.verify_result.credential_id)?;
+    let verification = verify_signatures(json, &reg, &auth);
+
+    print_report(json, &reg, &auth, &verification);
+
+    // JSON output
+    if json {
+        let diag_json = build_diag_json(&reg, &verification);
+        println!("{}", serde_json::to_string_pretty(&diag_json)?);
     }
 
-    out!("=== YubiKey Diagnostic Test ===\n");
-    out!("This test will:");
-    out!("1. Register a new credential on your YubiKey");
-    out!("2. Authenticate with that credential");
-    out!("3. Verify the signature using aws-lc-rs\n");
+    // Export fixture if requested
+    if let Some(ref path) = args.export_fixture {
+        export_fixture(json, path, &reg, &auth)?;
+    }
 
-    // Wait for YubiKey
-    out_print!("Please insert your YubiKey... ");
+    Ok(())
+}
+
+/// Wait for a YubiKey to be inserted and prompt for its PIN.
+fn wait_for_device_and_pin(json: bool) -> Result<(FidoKeyHid, String)> {
+    out_print!(json, "Please insert your YubiKey... ");
     if json {
         std::io::Write::flush(&mut std::io::stderr()).ok();
     } else {
@@ -103,45 +159,48 @@ pub(crate) fn run(args: DiagArgs) -> Result<()> {
     let cfg = LibCfg::init();
     let device = loop {
         if let Ok(dev) = FidoKeyHidFactory::create(&cfg) {
-            out!("detected!");
+            out!(json, "detected!");
             break dev;
         }
         std::thread::sleep(std::time::Duration::from_millis(500));
     };
 
-    // Get PIN
-    out!("");
+    out!(json, "");
     eprint!("YubiKey PIN: ");
-    let pin_raw = rpassword::read_password().context("failed to read PIN")?;
+    let pin = rpassword::read_password().context("failed to read PIN")?;
     // Note: In diag mode, we keep this as a plain String for simplicity since
     // this is a debugging tool that immediately uses and discards the PIN.
     // In production code (fido2.rs), we use SecretString.
-    let pin = pin_raw;
 
-    // Test parameters
-    let rp_id = "diag.test.local";
+    Ok((device, pin))
+}
+
+/// Register a new (non-resident) credential, verify the attestation, and
+/// extract the P-256 public key coordinates from the COSE key.
+fn run_registration(json: bool, device: &FidoKeyHid, pin: &str) -> Result<Registration> {
     let user_id = b"diag-test-user";
     let user_name = "diag@test.local";
 
     // Generate challenge for registration
-    let reg_challenge: [u8; 32] = rand::random();
+    let challenge: [u8; 32] = rand::random();
 
     // Build client data for registration
-    let reg_client_data = serde_json::json!({
+    let client_data = serde_json::json!({
         "type": "webauthn.create",
-        "challenge": URL_SAFE_NO_PAD.encode(&reg_challenge),
-        "origin": format!("https://{}", rp_id),
+        "challenge": URL_SAFE_NO_PAD.encode(&challenge),
+        "origin": format!("https://{}", RP_ID),
         "crossOrigin": false
     });
-    let reg_client_data_json = serde_json::to_vec(&reg_client_data)?;
-    let reg_client_data_hash = digest(&SHA256, &reg_client_data_json);
+    let client_data_json = serde_json::to_vec(&client_data)?;
+    let client_data_hash = digest(&SHA256, &client_data_json);
 
-    out!("\n=== REGISTRATION ===");
-    out!("RP ID: {}", rp_id);
-    out!("Challenge: {}", hex::encode(&reg_challenge));
+    out!(json, "\n=== REGISTRATION ===");
+    out!(json, "RP ID: {}", RP_ID);
+    out!(json, "Challenge: {}", hex::encode(&challenge));
     out!(
+        json,
         "Client data hash: {}",
-        hex::encode(reg_client_data_hash.as_ref())
+        hex::encode(client_data_hash.as_ref())
     );
 
     // Create user entity
@@ -150,26 +209,26 @@ pub(crate) fn run(args: DiagArgs) -> Result<()> {
     // Build make_credential arguments WITHOUT resident key (server-side credential)
     // IMPORTANT: The library expects RAW challenge bytes, not a pre-hashed clientDataHash!
     // The library handles clientDataJSON construction and hashing internally.
-    let make_cred_args = MakeCredentialArgsBuilder::new(rp_id, &reg_challenge)
+    let make_cred_args = MakeCredentialArgsBuilder::new(RP_ID, &challenge)
         .user_entity(&user)
-        .pin(&pin)
+        .pin(pin)
         // NOT using .resident_key() - credential ID stored server-side
         .build();
 
-    out!("\nTouch your YubiKey to register...");
+    out!(json, "\nTouch your YubiKey to register...");
     let attestation = device
         .make_credential_with_args(&make_cred_args)
         .context("Registration failed - check PIN and touch YubiKey")?;
 
     // Verify attestation locally - pass raw challenge, library hashes internally
-    let verify_result = verifier::verify_attestation(rp_id, &reg_challenge, &attestation);
-    let registration_success = verify_result.is_success;
-    if !registration_success {
+    let verify_result = verifier::verify_attestation(RP_ID, &challenge, &attestation);
+    if !verify_result.is_success {
         bail!("Attestation verification failed!");
     }
 
-    out!("Registration successful!");
+    out!(json, "Registration successful!");
     out!(
+        json,
         "Credential ID: {} ({} bytes)",
         hex::encode(&verify_result.credential_id),
         verify_result.credential_id.len()
@@ -179,6 +238,7 @@ pub(crate) fn run(args: DiagArgs) -> Result<()> {
     // The .der field contains the SubjectPublicKeyInfo (SPKI) format
     let public_key_der = &verify_result.credential_public_key.der;
     out!(
+        json,
         "Public key DER: {} ({} bytes)",
         hex::encode(public_key_der),
         public_key_der.len()
@@ -188,13 +248,14 @@ pub(crate) fn run(args: DiagArgs) -> Result<()> {
     // auth_data structure: rp_id_hash(32) + flags(1) + counter(4) + aaguid(16) + cred_id_len(2) + cred_id(N) + cose_key
     let auth_data = &attestation.auth_data;
     out!(
+        json,
         "Auth data: {} ({} bytes)",
         hex::encode(auth_data),
         auth_data.len()
     );
 
     let flags = auth_data[32];
-    out!("Flags: {:#04x}", flags);
+    out!(json, "Flags: {:#04x}", flags);
 
     if flags & 0x40 == 0 {
         bail!("No attested credential data in auth_data!");
@@ -202,17 +263,18 @@ pub(crate) fn run(args: DiagArgs) -> Result<()> {
 
     let cred_id_len = u16::from_be_bytes([auth_data[53], auth_data[54]]) as usize;
     let cose_key_start = 55_usize.saturating_add(cred_id_len);
-    let cose_key_bytes = &auth_data[cose_key_start..];
+    let cose_key = auth_data[cose_key_start..].to_vec();
 
     out!(
+        json,
         "COSE key bytes: {} ({} bytes)",
-        hex::encode(cose_key_bytes),
-        cose_key_bytes.len()
+        hex::encode(&cose_key),
+        cose_key.len()
     );
 
     // Parse COSE key to extract x and y
     let cose_val: ciborium::Value =
-        ciborium::from_reader(cose_key_bytes).context("Failed to parse COSE key")?;
+        ciborium::from_reader(cose_key.as_slice()).context("Failed to parse COSE key")?;
 
     let cose_map = cose_val.as_map().context("COSE key is not a map")?;
 
@@ -234,49 +296,68 @@ pub(crate) fn run(args: DiagArgs) -> Result<()> {
         }
     }
 
-    out!("\nCOSE key parsed:");
-    out!("  kty: {:?} (should be 2 for EC2)", kty);
-    out!("  alg: {:?} (should be -7 for ES256)", alg);
+    out!(json, "\nCOSE key parsed:");
+    out!(json, "  kty: {:?} (should be 2 for EC2)", kty);
+    out!(json, "  alg: {:?} (should be -7 for ES256)", alg);
 
     let x = x.context("Missing x coordinate")?;
     let y = y.context("Missing y coordinate")?;
 
-    out!("  x ({} bytes): {}", x.len(), hex::encode(&x));
-    out!("  y ({} bytes): {}", y.len(), hex::encode(&y));
+    out!(json, "  x ({} bytes): {}", x.len(), hex::encode(&x));
+    out!(json, "  y ({} bytes): {}", y.len(), hex::encode(&y));
 
     if x.len() != 32 || y.len() != 32 {
         bail!("Invalid coordinate lengths: x={}, y={}", x.len(), y.len());
     }
 
-    // Now do authentication
-    out!("\n=== AUTHENTICATION ===");
+    Ok(Registration {
+        challenge,
+        client_data_json,
+        attestation,
+        verify_result,
+        cose_key,
+        x,
+        y,
+    })
+}
 
-    let auth_challenge: [u8; 32] = rand::random();
+/// Authenticate with the registered credential and check the assertion's
+/// rpid_hash against the expected value.
+fn run_authentication(
+    json: bool,
+    device: &FidoKeyHid,
+    pin: &str,
+    credential_id: &[u8],
+) -> Result<Authentication> {
+    out!(json, "\n=== AUTHENTICATION ===");
+
+    let challenge: [u8; 32] = rand::random();
 
     // Build client data for authentication
-    let auth_client_data = serde_json::json!({
+    let client_data = serde_json::json!({
         "type": "webauthn.get",
-        "challenge": URL_SAFE_NO_PAD.encode(&auth_challenge),
-        "origin": format!("https://{}", rp_id),
+        "challenge": URL_SAFE_NO_PAD.encode(&challenge),
+        "origin": format!("https://{}", RP_ID),
         "crossOrigin": false
     });
-    let auth_client_data_json = serde_json::to_vec(&auth_client_data)?;
-    let auth_client_data_hash = digest(&SHA256, &auth_client_data_json);
+    let client_data_json = serde_json::to_vec(&client_data)?;
+    let client_data_hash = digest(&SHA256, &client_data_json);
 
-    out!("Challenge: {}", hex::encode(&auth_challenge));
+    out!(json, "Challenge: {}", hex::encode(&challenge));
     out!(
+        json,
         "Client data hash: {}",
-        hex::encode(auth_client_data_hash.as_ref())
+        hex::encode(client_data_hash.as_ref())
     );
 
     // Build get_assertion arguments with explicit credential ID (non-discoverable flow)
     // IMPORTANT: Pass raw challenge, not pre-hashed clientDataHash!
-    let get_assertion_args = GetAssertionArgsBuilder::new(rp_id, &auth_challenge)
-        .pin(&pin)
-        .add_credential_id(&verify_result.credential_id) // Explicitly specify which credential
+    let get_assertion_args = GetAssertionArgsBuilder::new(RP_ID, &challenge)
+        .pin(pin)
+        .add_credential_id(credential_id) // Explicitly specify which credential
         .build();
 
-    out!("\nTouch your YubiKey to authenticate...");
+    out!(json, "\nTouch your YubiKey to authenticate...");
     let assertions = device
         .get_assertion_with_args(&get_assertion_args)
         .context("Authentication failed")?;
@@ -286,60 +367,80 @@ pub(crate) fn run(args: DiagArgs) -> Result<()> {
         .next()
         .context("No assertion returned")?;
 
-    let authentication_success = true; // If we got here, authentication succeeded
-    out!("Authentication successful!");
+    out!(json, "Authentication successful!");
     out!(
+        json,
         "Credential ID: {} ({} bytes)",
         hex::encode(&assertion.credential_id),
         assertion.credential_id.len()
     );
     out!(
+        json,
         "Authenticator data: {} ({} bytes)",
         hex::encode(&assertion.auth_data),
         assertion.auth_data.len()
     );
     out!(
+        json,
         "Signature: {} ({} bytes)",
         hex::encode(&assertion.signature),
         assertion.signature.len()
     );
 
     // Debug: Check the rpid_hash from the assertion
-    out!("\n=== RPID VERIFICATION ===");
-    let expected_rpid_hash = digest(&SHA256, rp_id.as_bytes());
+    out!(json, "\n=== RPID VERIFICATION ===");
+    let expected_rpid_hash = digest(&SHA256, RP_ID.as_bytes());
     out!(
+        json,
         "Expected rpid_hash: {}",
         hex::encode(expected_rpid_hash.as_ref())
     );
-    out!("Assertion rpid_hash: {}", hex::encode(&assertion.rpid_hash));
+    out!(
+        json,
+        "Assertion rpid_hash: {}",
+        hex::encode(&assertion.rpid_hash)
+    );
     if expected_rpid_hash.as_ref() == assertion.rpid_hash.as_slice() {
-        out!("OK RPID hash matches");
+        out!(json, "OK RPID hash matches");
     } else {
-        out!("FAIL RPID hash MISMATCH!");
+        out!(json, "FAIL RPID hash MISMATCH!");
     }
 
+    Ok(Authentication {
+        challenge,
+        client_data_json,
+        assertion,
+    })
+}
+
+/// Verify the assertion signature two ways — via the ctap-hid-fido2 library
+/// and directly with aws-lc-rs — and dump the DER signature's r/s values.
+fn verify_signatures(json: bool, reg: &Registration, auth: &Authentication) -> Verification {
+    let assertion = &auth.assertion;
+
     // First, use the library's verify_assertion function
-    out!("\n=== LIBRARY VERIFICATION ===");
+    out!(json, "\n=== LIBRARY VERIFICATION ===");
 
     // The library's verify_assertion expects raw challenge bytes (not clientDataJSON or hash)
     // It constructs clientDataJSON internally and hashes it
     let lib_result = verifier::verify_assertion(
-        rp_id,
-        &verify_result.credential_public_key,
-        &auth_challenge, // raw challenge bytes, library handles the rest
-        &assertion,
+        RP_ID,
+        &reg.verify_result.credential_public_key,
+        &auth.challenge, // raw challenge bytes, library handles the rest
+        assertion,
     );
 
     if lib_result {
-        out!("OK ctap-hid-fido2 library verification: PASSED");
+        out!(json, "OK ctap-hid-fido2 library verification: PASSED");
     } else {
-        out!("FAIL ctap-hid-fido2 library verification: FAILED");
+        out!(json, "FAIL ctap-hid-fido2 library verification: FAILED");
 
         // Debug: Show what the library would compute
         // The library hashes the RAW challenge directly, not a clientDataJSON
-        let lib_client_data_hash = digest(&SHA256, &auth_challenge);
-        out!("\nDebug - Library computes:");
+        let lib_client_data_hash = digest(&SHA256, &auth.challenge);
+        out!(json, "\nDebug - Library computes:");
         out!(
+            json,
             "  SHA256(raw_challenge) = {}",
             hex::encode(lib_client_data_hash.as_ref())
         );
@@ -348,27 +449,29 @@ pub(crate) fn run(args: DiagArgs) -> Result<()> {
         let mut lib_message = Vec::new();
         lib_message.extend_from_slice(&assertion.auth_data);
         lib_message.extend_from_slice(lib_client_data_hash.as_ref());
-        out!("\n  Library would verify message:");
+        out!(json, "\n  Library would verify message:");
         out!(
+            json,
             "    auth_data ({} bytes) + SHA256(challenge) ({} bytes) = {} bytes",
             assertion.auth_data.len(),
             lib_client_data_hash.as_ref().len(),
             lib_message.len()
         );
-        out!("    message = {}", hex::encode(&lib_message));
+        out!(json, "    message = {}", hex::encode(&lib_message));
     }
 
     // Now verify the signature ourselves
-    out!("\n=== AWS-LC-RS VERIFICATION ===");
+    out!(json, "\n=== AWS-LC-RS VERIFICATION ===");
 
     // Build the message: authenticator_data || SHA256(raw_challenge)
     // The library uses SHA256(challenge) directly, not SHA256(clientDataJSON)
-    let challenge_hash = digest(&SHA256, &auth_challenge);
+    let challenge_hash = digest(&SHA256, &auth.challenge);
     let mut message = Vec::with_capacity(assertion.auth_data.len().saturating_add(32));
     message.extend_from_slice(&assertion.auth_data);
     message.extend_from_slice(challenge_hash.as_ref());
 
     out!(
+        json,
         "Message: {} ({} bytes)",
         hex::encode(&message),
         message.len()
@@ -377,39 +480,36 @@ pub(crate) fn run(args: DiagArgs) -> Result<()> {
     // Build SEC1 uncompressed point: 0x04 || x || y
     let mut point = Vec::with_capacity(65);
     point.push(0x04);
-    point.extend_from_slice(&x);
-    point.extend_from_slice(&y);
+    point.extend_from_slice(&reg.x);
+    point.extend_from_slice(&reg.y);
 
     out!(
+        json,
         "Public key point: {} ({} bytes)",
         hex::encode(&point),
         point.len()
     );
 
     // Also show the library's public key for comparison
+    let library_key = &reg.verify_result.credential_public_key.der;
     out!(
+        json,
         "Library public key: {} ({} bytes)",
-        hex::encode(&verify_result.credential_public_key.der),
-        verify_result.credential_public_key.der.len()
+        hex::encode(library_key),
+        library_key.len()
     );
 
     // Explicit byte-by-byte comparison
-    if point == verify_result.credential_public_key.der {
-        out!("OK Public keys are IDENTICAL (byte-by-byte)");
+    if point == *library_key {
+        out!(json, "OK Public keys are IDENTICAL (byte-by-byte)");
     } else {
-        out!("FAIL Public keys DIFFER!");
-        out!("  Our point len: {}", point.len());
-        out!(
-            "  Library len: {}",
-            verify_result.credential_public_key.der.len()
-        );
-        for (i, (a, b)) in point
-            .iter()
-            .zip(verify_result.credential_public_key.der.iter())
-            .enumerate()
-        {
+        out!(json, "FAIL Public keys DIFFER!");
+        out!(json, "  Our point len: {}", point.len());
+        out!(json, "  Library len: {}", library_key.len());
+        for (i, (a, b)) in point.iter().zip(library_key.iter()).enumerate() {
             if a != b {
                 out!(
+                    json,
                     "  First diff at byte {}: ours=0x{:02x}, lib=0x{:02x}",
                     i,
                     a,
@@ -418,8 +518,8 @@ pub(crate) fn run(args: DiagArgs) -> Result<()> {
                 break;
             }
         }
-        if point.len() != verify_result.credential_public_key.der.len() {
-            out!("  Length mismatch!");
+        if point.len() != library_key.len() {
+            out!(json, "  Length mismatch!");
         }
     }
 
@@ -428,23 +528,21 @@ pub(crate) fn run(args: DiagArgs) -> Result<()> {
 
     let aws_lc_result = public_key.verify(&message, &assertion.signature).is_ok();
     if aws_lc_result {
-        out!("\nOK aws-lc-rs verification (our point): PASSED");
+        out!(json, "\nOK aws-lc-rs verification (our point): PASSED");
     } else {
-        out!("\nFAIL aws-lc-rs verification (our point): FAILED");
+        out!(json, "\nFAIL aws-lc-rs verification (our point): FAILED");
     }
 
     // Also verify using the library's extracted public key directly
-    let public_key_lib = UnparsedPublicKey::new(
-        &ECDSA_P256_SHA256_ASN1,
-        &verify_result.credential_public_key.der,
-    );
+    let public_key_lib = UnparsedPublicKey::new(&ECDSA_P256_SHA256_ASN1, library_key);
 
     match public_key_lib.verify(&message, &assertion.signature) {
         Ok(()) => {
-            out!("OK aws-lc-rs verification (library key): PASSED");
+            out!(json, "OK aws-lc-rs verification (library key): PASSED");
         }
         Err(e) => {
             out!(
+                json,
                 "FAIL aws-lc-rs verification (library key): FAILED - {:?}",
                 e
             );
@@ -452,64 +550,107 @@ pub(crate) fn run(args: DiagArgs) -> Result<()> {
     }
 
     // Additional debug: Parse the DER signature to see r and s values
-    out!("\n=== SIGNATURE ANALYSIS ===");
+    out!(json, "\n=== SIGNATURE ANALYSIS ===");
     let sig = &assertion.signature;
     if sig.len() >= 2 && sig[0] == 0x30 {
         let seq_len = sig[1] as usize;
-        out!("DER SEQUENCE length: {}", seq_len);
+        out!(json, "DER SEQUENCE length: {}", seq_len);
         if sig.len() >= 4 && sig[2] == 0x02 {
             let r_len = sig[3] as usize;
             let r_start = 4_usize;
             let r_end = r_start.saturating_add(r_len);
             if sig.len() >= r_end {
-                out!("r ({} bytes): {}", r_len, hex::encode(&sig[r_start..r_end]));
+                out!(
+                    json,
+                    "r ({} bytes): {}",
+                    r_len,
+                    hex::encode(&sig[r_start..r_end])
+                );
                 if sig.len() > r_end.saturating_add(1) && sig[r_end] == 0x02 {
                     let s_len = sig[r_end.saturating_add(1)] as usize;
                     let s_start = r_end.saturating_add(2);
                     let s_end = s_start.saturating_add(s_len);
                     if sig.len() >= s_end {
-                        out!("s ({} bytes): {}", s_len, hex::encode(&sig[s_start..s_end]));
+                        out!(
+                            json,
+                            "s ({} bytes): {}",
+                            s_len,
+                            hex::encode(&sig[s_start..s_end])
+                        );
                     }
                 }
             }
         }
     }
 
+    Verification {
+        lib_result,
+        aws_lc_result,
+        message,
+        point,
+    }
+}
+
+/// Print the credential-ID consistency check, summary, and manual OpenSSL
+/// verification commands.
+fn print_report(
+    json: bool,
+    reg: &Registration,
+    auth: &Authentication,
+    verification: &Verification,
+) {
     // Check if credential IDs match between registration and authentication
-    out!("\n=== CREDENTIAL ID CHECK ===");
+    out!(json, "\n=== CREDENTIAL ID CHECK ===");
     out!(
+        json,
         "Registration cred_id: {}",
-        hex::encode(&verify_result.credential_id)
+        hex::encode(&reg.verify_result.credential_id)
     );
     out!(
+        json,
         "Assertion cred_id:    {}",
-        hex::encode(&assertion.credential_id)
+        hex::encode(&auth.assertion.credential_id)
     );
-    if verify_result.credential_id == assertion.credential_id {
-        out!("OK Credential IDs match");
+    if reg.verify_result.credential_id == auth.assertion.credential_id {
+        out!(json, "OK Credential IDs match");
     } else {
-        out!("FAIL Credential ID MISMATCH - authenticator used different credential!");
+        out!(
+            json,
+            "FAIL Credential ID MISMATCH - authenticator used different credential!"
+        );
     }
 
-    out!("\n=== SUMMARY ===");
-    if lib_result {
-        out!("The ctap-hid-fido2 library CAN verify the signature.");
-        out!("This suggests the issue is with how we're calling aws-lc-rs.");
+    out!(json, "\n=== SUMMARY ===");
+    if verification.lib_result {
+        out!(json, "The ctap-hid-fido2 library CAN verify the signature.");
+        out!(
+            json,
+            "This suggests the issue is with how we're calling aws-lc-rs."
+        );
     } else {
-        out!("Even the ctap-hid-fido2 library CANNOT verify the signature.");
-        out!("This suggests a fundamental issue with the YubiKey or authentication flow.");
-        out!("\nPossible causes:");
-        out!("1. YubiKey firmware bug (especially FIPS models)");
-        out!("2. Credential corruption on the YubiKey");
-        out!("3. Different key pair being used for signing vs registration");
+        out!(
+            json,
+            "Even the ctap-hid-fido2 library CANNOT verify the signature."
+        );
+        out!(
+            json,
+            "This suggests a fundamental issue with the YubiKey or authentication flow."
+        );
+        out!(json, "\nPossible causes:");
+        out!(json, "1. YubiKey firmware bug (especially FIPS models)");
+        out!(json, "2. Credential corruption on the YubiKey");
+        out!(
+            json,
+            "3. Different key pair being used for signing vs registration"
+        );
     }
 
     // Output data for manual OpenSSL verification
-    out!("\n=== OPENSSL VERIFICATION DATA ===");
-    out!("To verify with OpenSSL, run these commands:");
-    out!("");
-    out!("# Create public key PEM file");
-    out!("echo '-----BEGIN PUBLIC KEY-----' > /tmp/pubkey.pem");
+    out!(json, "\n=== OPENSSL VERIFICATION DATA ===");
+    out!(json, "To verify with OpenSSL, run these commands:");
+    out!(json, "");
+    out!(json, "# Create public key PEM file");
+    out!(json, "echo '-----BEGIN PUBLIC KEY-----' > /tmp/pubkey.pem");
 
     // Build SubjectPublicKeyInfo DER format
     // SEQUENCE { SEQUENCE { OID ecPublicKey, OID secp256r1 }, BIT STRING point }
@@ -524,105 +665,129 @@ pub(crate) fn run(args: DiagArgs) -> Result<()> {
         0x07, // OID 1.2.840.10045.3.1.7 (secp256r1)
         0x03, 0x42, 0x00, // BIT STRING, 66 bytes, 0 unused bits
     ]);
-    spki.extend_from_slice(&point);
+    spki.extend_from_slice(&verification.point);
 
     use base64::engine::general_purpose::STANDARD;
     let spki_b64 = STANDARD.encode(&spki);
     // Split into 64-char lines
     for chunk in spki_b64.as_bytes().chunks(64) {
         out!(
+            json,
             "echo '{}' >> /tmp/pubkey.pem",
             std::str::from_utf8(chunk).unwrap()
         );
     }
-    out!("echo '-----END PUBLIC KEY-----' >> /tmp/pubkey.pem");
-    out!("");
+    out!(json, "echo '-----END PUBLIC KEY-----' >> /tmp/pubkey.pem");
+    out!(json, "");
 
-    out!("# Create message file (auth_data || client_data_hash)");
     out!(
+        json,
+        "# Create message file (auth_data || client_data_hash)"
+    );
+    out!(
+        json,
         "echo -n '{}' | xxd -r -p > /tmp/message.bin",
-        hex::encode(&message)
+        hex::encode(&verification.message)
     );
-    out!("");
+    out!(json, "");
 
-    out!("# Create signature file (DER format)");
+    out!(json, "# Create signature file (DER format)");
     out!(
+        json,
         "echo -n '{}' | xxd -r -p > /tmp/signature.der",
-        hex::encode(&assertion.signature)
+        hex::encode(&auth.assertion.signature)
     );
-    out!("");
+    out!(json, "");
 
-    out!("# Verify with OpenSSL");
+    out!(json, "# Verify with OpenSSL");
     out!(
+        json,
         "openssl dgst -sha256 -verify /tmp/pubkey.pem -signature /tmp/signature.der /tmp/message.bin"
     );
 
     // Note: This test now uses non-resident credentials (no cleanup needed)
-    out!("\nNote: Non-resident credential used - no cleanup needed on YubiKey.");
+    out!(
+        json,
+        "\nNote: Non-resident credential used - no cleanup needed on YubiKey."
+    );
+}
 
-    // Extract AAGUID from auth_data (bytes 37-52 when AT flag is set)
-    let aaguid = if flags & 0x40 != 0 && auth_data.len() >= 53 {
+/// Extract the AAGUID (hex) from registration auth_data, if attested
+/// credential data is present.
+fn extract_aaguid(reg: &Registration) -> Option<String> {
+    // AAGUID lives at bytes 37-52 when the AT flag (0x40) is set
+    let auth_data = &reg.attestation.auth_data;
+    if auth_data[32] & 0x40 != 0 && auth_data.len() >= 53 {
         Some(hex::encode(&auth_data[37..53]))
     } else {
         None
-    };
+    }
+}
 
-    // Try to look up device model from AAGUID
+/// Build the JSON result summary.
+fn build_diag_json(reg: &Registration, verification: &Verification) -> DiagJson {
+    let aaguid = extract_aaguid(reg);
+    let device_model = aaguid
+        .as_ref()
+        .and_then(|aaguid_hex| vouch_common::lookup_device_model(aaguid_hex).map(String::from));
+    DiagJson {
+        // Both phases bail on failure, so reaching the report means success.
+        registration_success: true,
+        authentication_success: true,
+        library_verification: verification.lib_result,
+        aws_lc_verification: verification.aws_lc_result,
+        credential_id: hex::encode(&reg.verify_result.credential_id),
+        public_key_hex: hex::encode(&reg.verify_result.credential_public_key.der),
+        aaguid,
+        device_model,
+    }
+}
+
+/// Save the captured registration/authentication data as a test fixture.
+fn export_fixture(
+    json: bool,
+    path: &std::path::Path,
+    reg: &Registration,
+    auth: &Authentication,
+) -> Result<()> {
+    out!(json, "\n=== EXPORTING FIXTURE ===");
+
+    let aaguid = extract_aaguid(reg);
     let device_model = aaguid
         .as_ref()
         .and_then(|aaguid_hex| vouch_common::lookup_device_model(aaguid_hex).map(String::from));
 
-    // JSON output
-    if json {
-        let diag_json = DiagJson {
-            registration_success,
-            authentication_success,
-            library_verification: lib_result,
-            aws_lc_verification: aws_lc_result,
-            credential_id: hex::encode(&verify_result.credential_id),
-            public_key_hex: hex::encode(public_key_der),
-            aaguid: aaguid.clone(),
-            device_model: device_model.clone(),
-        };
-        println!("{}", serde_json::to_string_pretty(&diag_json)?);
-    }
+    let fixture = Fido2Fixture {
+        metadata: FixtureMetadata {
+            description: "YubiKey diagnostic test fixture".to_string(),
+            device_model,
+            aaguid,
+            created_at: jiff::Zoned::now().to_string(),
+            rp_id: RP_ID.to_string(),
+        },
+        registration: RegistrationFixture {
+            challenge_hex: hex::encode(&reg.challenge),
+            client_data_json: String::from_utf8_lossy(&reg.client_data_json).to_string(),
+            credential_id_hex: hex::encode(&reg.verify_result.credential_id),
+            public_key_cose_hex: hex::encode(&reg.cose_key),
+            auth_data_hex: hex::encode(&reg.attestation.auth_data),
+            attestation_object_hex: None, // Not capturing full attestation object
+            x_hex: hex::encode(&reg.x),
+            y_hex: hex::encode(&reg.y),
+        },
+        authentication: AuthenticationFixture {
+            challenge_hex: hex::encode(&auth.challenge),
+            client_data_json: String::from_utf8_lossy(&auth.client_data_json).to_string(),
+            auth_data_hex: hex::encode(&auth.assertion.auth_data),
+            signature_hex: hex::encode(&auth.assertion.signature),
+            user_handle_hex: None, // Non-resident credential doesn't have user_handle
+        },
+    };
 
-    // Export fixture if requested
-    if let Some(ref path) = args.export_fixture {
-        out!("\n=== EXPORTING FIXTURE ===");
-
-        let fixture = Fido2Fixture {
-            metadata: FixtureMetadata {
-                description: "YubiKey diagnostic test fixture".to_string(),
-                device_model,
-                aaguid,
-                created_at: jiff::Zoned::now().to_string(),
-                rp_id: rp_id.to_string(),
-            },
-            registration: RegistrationFixture {
-                challenge_hex: hex::encode(&reg_challenge),
-                client_data_json: String::from_utf8_lossy(&reg_client_data_json).to_string(),
-                credential_id_hex: hex::encode(&verify_result.credential_id),
-                public_key_cose_hex: hex::encode(cose_key_bytes),
-                auth_data_hex: hex::encode(auth_data),
-                attestation_object_hex: None, // Not capturing full attestation object
-                x_hex: hex::encode(&x),
-                y_hex: hex::encode(&y),
-            },
-            authentication: AuthenticationFixture {
-                challenge_hex: hex::encode(&auth_challenge),
-                client_data_json: String::from_utf8_lossy(&auth_client_data_json).to_string(),
-                auth_data_hex: hex::encode(&assertion.auth_data),
-                signature_hex: hex::encode(&assertion.signature),
-                user_handle_hex: None, // Non-resident credential doesn't have user_handle
-            },
-        };
-
-        fixture
-            .save_to_file(path)
-            .map_err(|e| anyhow::anyhow!("Failed to save fixture: {}", e))?;
-        out!("Fixture saved to: {}", path.display());
-    }
+    fixture
+        .save_to_file(path)
+        .map_err(|e| anyhow::anyhow!("Failed to save fixture: {}", e))?;
+    out!(json, "Fixture saved to: {}", path.display());
 
     Ok(())
 }

--- a/crates/vouch-cli/src/commands/doctor.rs
+++ b/crates/vouch-cli/src/commands/doctor.rs
@@ -64,6 +64,46 @@ pub(crate) async fn run(server: &str, quiet: bool, json: bool) -> Result<()> {
         println!("Vouch Doctor - Environment Diagnostics\n");
     }
 
+    let checks = run_checks(server, suppress).await;
+
+    let all_passed = checks.iter().all(|c| c.passed);
+
+    // JSON output
+    if json {
+        let json_output = DoctorJson {
+            checks: checks
+                .into_iter()
+                .map(|c| DoctorCheckJson {
+                    name: c.name,
+                    passed: c.passed,
+                    message: c.message,
+                })
+                .collect(),
+            all_passed,
+        };
+        println!("{}", serde_json::to_string_pretty(&json_output)?);
+    }
+
+    // Summary
+    if !suppress {
+        println!();
+    }
+    if all_passed {
+        if !suppress {
+            println!("All checks passed!");
+        }
+        Ok(())
+    } else {
+        if !suppress {
+            println!("Some checks failed. Review the issues above.");
+        }
+        bail!("doctor: one or more checks failed")
+    }
+}
+
+/// Run every diagnostic check in order, printing progress as each one
+/// completes (unless `suppress` is set), and collect the results.
+async fn run_checks(server: &str, suppress: bool) -> Vec<CheckResult> {
     let mut checks: Vec<CheckResult> = Vec::new();
 
     // Check 1: YubiKey connectivity
@@ -180,39 +220,7 @@ pub(crate) async fn run(server: &str, quiet: bool, json: bool) -> Result<()> {
     }
     checks.push(security_result);
 
-    let all_passed = checks.iter().all(|c| c.passed);
-
-    // JSON output
-    if json {
-        let json_output = DoctorJson {
-            checks: checks
-                .into_iter()
-                .map(|c| DoctorCheckJson {
-                    name: c.name,
-                    passed: c.passed,
-                    message: c.message,
-                })
-                .collect(),
-            all_passed,
-        };
-        println!("{}", serde_json::to_string_pretty(&json_output)?);
-    }
-
-    // Summary
-    if !suppress {
-        println!();
-    }
-    if all_passed {
-        if !suppress {
-            println!("All checks passed!");
-        }
-        Ok(())
-    } else {
-        if !suppress {
-            println!("Some checks failed. Review the issues above.");
-        }
-        bail!("doctor: one or more checks failed")
-    }
+    checks
 }
 
 /// Print check result with color indicators.

--- a/crates/vouch-cli/src/commands/enroll.rs
+++ b/crates/vouch-cli/src/commands/enroll.rs
@@ -55,44 +55,8 @@ pub(crate) async fn run(server: &str) -> Result<()> {
     };
 
     // Step 3: Request device code (RFC 8628 Section 3.1).
-    // Include the client_id if we registered successfully.
-    let device_request = DeviceCodeRequest {
-        client_id: pre_registered_client_id.clone(),
-        scope: None,
-    };
-
-    let device_response: DeviceCodeResponse =
-        match client.post_form("/oauth/device", &device_request).await {
-            Ok(resp) => resp,
-            Err(e) if pre_registered_client_id.is_some() => {
-                // The cached client_id may be stale (e.g. server DB was reset). Clear FAPI state, re-register, and retry once.
-                tracing::info!(
-                    "Device code request failed with cached client_id, re-registering: {e:#}"
-                );
-                if let Err(clear_err) = Config::modify(|c| {
-                    c.set_server_url(server);
-                    c.clear_fapi();
-                }) {
-                    tracing::warn!("Failed to clear stale FAPI config: {clear_err}");
-                }
-
-                let new_client_id = if let Some(ref key) = fapi_key {
-                    register_fapi_client_open(client.raw_client(), server, key).await
-                } else {
-                    None
-                };
-
-                let retry_request = DeviceCodeRequest {
-                    client_id: new_client_id,
-                    scope: None,
-                };
-                client
-                    .post_form("/oauth/device", &retry_request)
-                    .await
-                    .context("Failed to start enrollment")?
-            }
-            Err(e) => return Err(e.context("Failed to start enrollment")),
-        };
+    let device_response =
+        request_device_code(&client, server, fapi_key.as_ref(), pre_registered_client_id).await?;
 
     // Step 4: Open browser and display instructions.
     let verification_url = &device_response.verification_uri;
@@ -169,6 +133,55 @@ pub(crate) async fn run(server: &str) -> Result<()> {
     println!("  vouch login && vouch register --name \"Backup Key\"");
 
     Ok(())
+}
+
+/// Request a device code (RFC 8628 Section 3.1), including the client_id
+/// if FAPI pre-registration succeeded.
+///
+/// If the request fails with a cached client_id, the id may be stale (e.g.
+/// the server DB was reset): FAPI state is cleared, the client re-registers,
+/// and the request is retried once.
+async fn request_device_code(
+    client: &VouchClient,
+    server: &str,
+    fapi_key: Option<&vouch_cli::fapi::ClientKey>,
+    pre_registered_client_id: Option<String>,
+) -> Result<DeviceCodeResponse> {
+    let device_request = DeviceCodeRequest {
+        client_id: pre_registered_client_id.clone(),
+        scope: None,
+    };
+
+    match client.post_form("/oauth/device", &device_request).await {
+        Ok(resp) => Ok(resp),
+        Err(e) if pre_registered_client_id.is_some() => {
+            tracing::info!(
+                "Device code request failed with cached client_id, re-registering: {e:#}"
+            );
+            if let Err(clear_err) = Config::modify(|c| {
+                c.set_server_url(server);
+                c.clear_fapi();
+            }) {
+                tracing::warn!("Failed to clear stale FAPI config: {clear_err}");
+            }
+
+            let new_client_id = if let Some(key) = fapi_key {
+                register_fapi_client_open(client.raw_client(), server, key).await
+            } else {
+                None
+            };
+
+            let retry_request = DeviceCodeRequest {
+                client_id: new_client_id,
+                scope: None,
+            };
+            client
+                .post_form("/oauth/device", &retry_request)
+                .await
+                .context("Failed to start enrollment")
+        }
+        Err(e) => Err(e.context("Failed to start enrollment")),
+    }
 }
 
 /// Attempt open (unauthenticated) FAPI client registration.

--- a/crates/vouch-cli/src/commands/status.rs
+++ b/crates/vouch-cli/src/commands/status.rs
@@ -77,10 +77,52 @@ pub(crate) fn print_shell(
 }
 
 /// Run the status command.
-#[expect(clippy::too_many_lines, reason = "sequential status report output")]
 pub(crate) async fn run(server: &str, mode: OutputFormat) -> Result<()> {
-    // First, try to get session from agent (Unix only)
+    // First, try to get status from the agent (Unix only)
     #[cfg(unix)]
+    if agent_status(server, mode).await? {
+        return Ok(());
+    }
+
+    server_status(server, mode).await
+}
+
+/// Report an unauthenticated/expired session in the requested format.
+///
+/// `headline` is printed as-is in human mode, so callers style it.
+fn report_unauthenticated(
+    mode: OutputFormat,
+    agent_running: bool,
+    expires_in_seconds: Option<u64>,
+    headline: &str,
+    hint: &str,
+) {
+    match mode {
+        OutputFormat::Json => {
+            print_json(&StatusJson {
+                authenticated: false,
+                email: None,
+                expires_in_seconds,
+                agent_running,
+            });
+        }
+        OutputFormat::Shell => {
+            print_shell(false, None, None);
+        }
+        OutputFormat::Human => {
+            println!("{headline}");
+            println!("\n{}", style::dim(hint));
+        }
+    }
+}
+
+/// Report status from the agent session, if the agent answers.
+///
+/// Returns `true` when the agent gave a definitive answer (authenticated,
+/// not authenticated, or expired) and `false` when the caller should fall
+/// back to the config/server check.
+#[cfg(unix)]
+async fn agent_status(server: &str, mode: OutputFormat) -> Result<bool> {
     match get_session_from_agent().await {
         Ok(session) => {
             // Prefer the server URL from the agent (it knows the real server),
@@ -108,78 +150,52 @@ pub(crate) async fn run(server: &str, mode: OutputFormat) -> Result<()> {
                     print_all_integrations(effective_server).await;
                 }
             }
-            return Ok(());
+            Ok(true)
         }
         Err(AgentError::NotRunning) => {
             tracing::debug!("Agent not running, checking server");
+            Ok(false)
         }
         Err(AgentError::NotAuthenticated) => {
-            match mode {
-                OutputFormat::Json => {
-                    print_json(&StatusJson {
-                        authenticated: false,
-                        email: None,
-                        expires_in_seconds: None,
-                        agent_running: true,
-                    });
-                }
-                OutputFormat::Shell => {
-                    print_shell(false, None, None);
-                }
-                OutputFormat::Human => {
-                    println!("{}", style::bold_red("Not authenticated."));
-                    println!("\n{}", style::dim("Run 'vouch login' to authenticate."));
-                }
-            }
-            return Ok(());
+            report_unauthenticated(
+                mode,
+                true,
+                None,
+                &style::bold_red("Not authenticated."),
+                "Run 'vouch login' to authenticate.",
+            );
+            Ok(true)
         }
         Err(AgentError::SessionExpired) => {
-            match mode {
-                OutputFormat::Json => {
-                    print_json(&StatusJson {
-                        authenticated: false,
-                        email: None,
-                        expires_in_seconds: Some(0),
-                        agent_running: true,
-                    });
-                }
-                OutputFormat::Shell => {
-                    print_shell(false, None, None);
-                }
-                OutputFormat::Human => {
-                    println!("{}", style::bold_red("Session expired."));
-                    println!("\n{}", style::dim("Run 'vouch login' to re-authenticate."));
-                }
-            }
-            return Ok(());
+            report_unauthenticated(
+                mode,
+                true,
+                Some(0),
+                &style::bold_red("Session expired."),
+                "Run 'vouch login' to re-authenticate.",
+            );
+            Ok(true)
         }
         Err(e) => {
             tracing::debug!("Agent error: {e}, falling back to server check");
+            Ok(false)
         }
     }
+}
 
-    // Fall back to config/server check
+/// Report status from the stored token and the server's /v1/auth/status.
+async fn server_status(server: &str, mode: OutputFormat) -> Result<()> {
     let mut config = Config::load()?;
     config.set_server_url(server);
 
     if config.token().is_none() {
-        match mode {
-            OutputFormat::Json => {
-                print_json(&StatusJson {
-                    authenticated: false,
-                    email: None,
-                    expires_in_seconds: None,
-                    agent_running: false,
-                });
-            }
-            OutputFormat::Shell => {
-                print_shell(false, None, None);
-            }
-            OutputFormat::Human => {
-                println!("{}", style::bold_red("Not authenticated."));
-                println!("\n{}", style::dim("Run 'vouch login' to authenticate."));
-            }
-        }
+        report_unauthenticated(
+            mode,
+            false,
+            None,
+            &style::bold_red("Not authenticated."),
+            "Run 'vouch login' to authenticate.",
+        );
         return Ok(());
     }
 
@@ -207,54 +223,50 @@ pub(crate) async fn run(server: &str, mode: OutputFormat) -> Result<()> {
             }
             OutputFormat::Human => {
                 if status.authenticated {
-                    println!("{} ({server})", style::bold_green("Authenticated"));
-                    if let Some(email) = &status.email {
-                        println!("  {:LABEL_WIDTH$} {email}", "Email:");
-                    }
-                    if let Some(device) = &status.device_name {
-                        println!("  {:LABEL_WIDTH$} {device}", "Device:");
-                    }
-                    if let Some(expires_in) = status.expires_in_seconds {
-                        print_expiry(expires_in)?;
-                    }
-                    println!(
-                        "  {:LABEL_WIDTH$} {}",
-                        "Agent:",
-                        style::yellow("not running")
-                    );
-                    println!();
-                    print_all_integrations(server).await;
-                    println!(
-                        "\n{}",
-                        style::dim(
-                            "Hint: Start the agent for faster status checks: vouch-agent --foreground"
-                        )
-                    );
+                    print_server_session(server, &status).await?;
                 } else {
                     println!("{}", style::bold_red("Session expired."));
                     println!("\n{}", style::dim("Run 'vouch login' to re-authenticate."));
                 }
             }
         },
-        Err(e) => match mode {
-            OutputFormat::Json => {
-                print_json(&StatusJson {
-                    authenticated: false,
-                    email: None,
-                    expires_in_seconds: None,
-                    agent_running: false,
-                });
-            }
-            OutputFormat::Shell => {
-                print_shell(false, None, None);
-            }
-            OutputFormat::Human => {
-                println!("{}: {e}", style::bold_red("Session invalid"));
-                println!("\n{}", style::dim("Run 'vouch login' to re-authenticate."));
-            }
-        },
+        Err(e) => {
+            report_unauthenticated(
+                mode,
+                false,
+                None,
+                &format!("{}: {e}", style::bold_red("Session invalid")),
+                "Run 'vouch login' to re-authenticate.",
+            );
+        }
     }
 
+    Ok(())
+}
+
+/// Print a human-readable report for a server-verified session (no agent).
+async fn print_server_session(server: &str, status: &SessionStatus) -> Result<()> {
+    println!("{} ({server})", style::bold_green("Authenticated"));
+    if let Some(email) = &status.email {
+        println!("  {:LABEL_WIDTH$} {email}", "Email:");
+    }
+    if let Some(device) = &status.device_name {
+        println!("  {:LABEL_WIDTH$} {device}", "Device:");
+    }
+    if let Some(expires_in) = status.expires_in_seconds {
+        print_expiry(expires_in)?;
+    }
+    println!(
+        "  {:LABEL_WIDTH$} {}",
+        "Agent:",
+        style::yellow("not running")
+    );
+    println!();
+    print_all_integrations(server).await;
+    println!(
+        "\n{}",
+        style::dim("Hint: Start the agent for faster status checks: vouch-agent --foreground")
+    );
     Ok(())
 }
 

--- a/crates/vouch-cli/src/dns.rs
+++ b/crates/vouch-cli/src/dns.rs
@@ -12,16 +12,15 @@ use crate::config::Config;
 
 /// Initialize the process-wide DoH resolver.
 ///
-/// Reads `VOUCH_DOH` first, then `network.dns_over_https` from
-/// `~/.vouch/config.json`. Hard-fails when DoH is explicitly enabled and the
-/// resolver cannot be constructed.
+/// Reads `VOUCH_DOH` first, then `network.dns_over_https` from the supplied
+/// config (loaded once by the caller). Hard-fails when DoH is explicitly
+/// enabled and the resolver cannot be constructed.
 ///
 /// # Errors
 ///
 /// Returns an error if the configured provider is invalid.
-pub(crate) fn init() -> Result<()> {
+pub(crate) fn init(config: Option<&Config>) -> Result<()> {
     let env = std::env::var(vouch_common::dns::DOH_ENV_VAR).ok();
-    let config = Config::load().ok();
-    vouch_common::dns::init_from(env.as_deref(), config.as_ref().and_then(Config::doh))
+    vouch_common::dns::init_from(env.as_deref(), config.and_then(Config::doh))
         .context("invalid DNS-over-HTTPS configuration")
 }

--- a/crates/vouch-cli/src/main.rs
+++ b/crates/vouch-cli/src/main.rs
@@ -453,13 +453,13 @@ async fn main() -> ExitCode {
 /// (docker credential helper, git-remote-codecommit, keyring, pnpm token
 /// helper). Returns `true` if a helper handled the invocation and the
 /// process should exit.
-async fn init_and_dispatch_helper_binaries() -> Result<bool> {
+async fn init_and_dispatch_helper_binaries(config: Option<&config::Config>) -> Result<bool> {
     let argv0 = std::env::args().next().unwrap_or_default();
 
     // Initialize the process-wide DNS-over-HTTPS resolver from config + env
     // before any HTTP client is constructed (including from helper-binary
     // dispatch below). Hard-fails if DoH is configured but unavailable.
-    dns::init()?;
+    dns::init(config)?;
 
     // Register the platform-native keyring store. Non-fatal: keychain access
     // already falls back to file storage in fapi::key_store when unavailable.
@@ -487,8 +487,7 @@ async fn init_and_dispatch_helper_binaries() -> Result<bool> {
 ///
 /// Offline commands (completions, init, logout, diag) skip validation but
 /// still normalize for consistency.
-fn resolve_server_url(cli: &Cli) -> Result<server_url::ServerUrl> {
-    let config = config::Config::load()?;
+fn resolve_server_url(cli: &Cli, config: &config::Config) -> Result<server_url::ServerUrl> {
     let server_raw = cli
         .server
         .clone()
@@ -507,7 +506,9 @@ fn resolve_server_url(cli: &Cli) -> Result<server_url::ServerUrl> {
     reason = "single dispatch match over all CLI subcommands"
 )]
 async fn run() -> Result<()> {
-    if init_and_dispatch_helper_binaries().await? {
+    let config = config::Config::load();
+
+    if init_and_dispatch_helper_binaries(config.as_ref().ok()).await? {
         return Ok(());
     }
 
@@ -526,7 +527,8 @@ async fn run() -> Result<()> {
     });
     tracing_subscriber::fmt().with_env_filter(filter).init();
 
-    let server = resolve_server_url(&cli)?;
+    let config = config?;
+    let server = resolve_server_url(&cli, &config)?;
     let server = server.as_str();
 
     match cli.command {

--- a/crates/vouch-cli/src/main.rs
+++ b/crates/vouch-cli/src/main.rs
@@ -446,12 +446,14 @@ async fn main() -> ExitCode {
     }
 }
 
-/// Inner entry point that returns `anyhow::Result`.
-#[expect(
-    clippy::too_many_lines,
-    reason = "single dispatch match over all CLI subcommands"
-)]
-async fn run() -> Result<()> {
+/// Process-wide initialization plus helper-binary dispatch.
+///
+/// Initializes DNS-over-HTTPS and the keyring store, then checks whether
+/// the process was invoked via symlink as one of the helper binaries
+/// (docker credential helper, git-remote-codecommit, keyring, pnpm token
+/// helper). Returns `true` if a helper handled the invocation and the
+/// process should exit.
+async fn init_and_dispatch_helper_binaries() -> Result<bool> {
     let argv0 = std::env::args().next().unwrap_or_default();
 
     // Initialize the process-wide DNS-over-HTTPS resolver from config + env
@@ -465,17 +467,47 @@ async fn run() -> Result<()> {
         tracing::debug!("Could not initialize keyring store: {e}");
     }
 
-    // Check if invoked via symlink as a helper binary
     if check_docker_credential_invocation(&argv0).await? {
-        return Ok(());
+        return Ok(true);
     }
     if check_git_remote_codecommit_invocation(&argv0).await? {
-        return Ok(());
+        return Ok(true);
     }
     if check_keyring_invocation(&argv0).await? {
-        return Ok(());
+        return Ok(true);
     }
     if check_pnpm_tokenhelper_invocation(&argv0).await? {
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+/// Resolve the server URL from `--server`, config, or the default, and
+/// validate/normalize it.
+///
+/// Offline commands (completions, init, logout, diag) skip validation but
+/// still normalize for consistency.
+fn resolve_server_url(cli: &Cli) -> Result<server_url::ServerUrl> {
+    let config = config::Config::load()?;
+    let server_raw = cli
+        .server
+        .clone()
+        .or_else(|| config.server_url().map(String::from))
+        .unwrap_or_else(|| "https://us.vouch.sh".to_string());
+
+    Ok(server_url::ServerUrl::parse(
+        &server_raw,
+        cli.allow_insecure || !cli.command.uses_server(),
+    )?)
+}
+
+/// Inner entry point that returns `anyhow::Result`.
+#[expect(
+    clippy::too_many_lines,
+    reason = "single dispatch match over all CLI subcommands"
+)]
+async fn run() -> Result<()> {
+    if init_and_dispatch_helper_binaries().await? {
         return Ok(());
     }
 
@@ -494,20 +526,7 @@ async fn run() -> Result<()> {
     });
     tracing_subscriber::fmt().with_env_filter(filter).init();
 
-    // Load config and resolve server URL
-    let config = config::Config::load()?;
-    let server_raw = cli
-        .server
-        .or_else(|| config.server_url().map(String::from))
-        .unwrap_or_else(|| "https://us.vouch.sh".to_string());
-
-    // Validate and normalize URL for commands that contact the server.
-    // Offline commands (completions, init, logout, diag) skip validation
-    // but still normalize for consistency.
-    let server = server_url::ServerUrl::parse(
-        &server_raw,
-        cli.allow_insecure || !cli.command.uses_server(),
-    )?;
+    let server = resolve_server_url(&cli)?;
     let server = server.as_str();
 
     match cli.command {

--- a/crates/vouch-common/src/dns.rs
+++ b/crates/vouch-common/src/dns.rs
@@ -269,7 +269,7 @@ pub struct DohResolver {
     config: ResolverConfig,
     label: String,
     endpoint_url: String,
-    // FIXME: replace with `OnceLock::get_or_try_init` once stable
+    // FIXME(#467): replace with `OnceLock::get_or_try_init` once stable
     // (rust-lang/rust#109737). Until then we stringify the build error so
     // every subsequent caller sees the same message.
     inner: OnceLock<Result<hickory_resolver::TokioResolver, String>>,

--- a/crates/vouch-common/src/lib.rs
+++ b/crates/vouch-common/src/lib.rs
@@ -21,15 +21,31 @@ mod api_tests;
 mod encoding_tests;
 
 pub use encoding::{Base64Url, ConvertEncoding, Encoded, Encoding, Raw};
-pub use fido2_types::*;
+pub use fido2_types::{
+    AttestationObject, AttestationObjectData, AuthData, AuthenticatorDataMarker,
+    Base64UrlChallenge, Base64UrlCredentialId, Challenge, ChallengeData, ClientDataJson,
+    ClientDataJsonData, CoseKey, CoseKeyData, CredentialId, CredentialIdData, RawAttestationObject,
+    RawAuthData, RawChallenge, RawClientDataJson, RawCoseKey, RawCredentialId, RawSignature,
+    RawUserHandle, Signature, SignatureData, UserHandle, UserHandleData,
+};
 
 pub use aaguid::{
     AaguidPolicy, extract_aaguid_from_auth_data, extract_public_key_from_attestation,
     extract_public_key_from_auth_data, is_fips, is_yubikey_5, lookup_device_model,
 };
-pub use api::*;
+pub use api::{
+    AwsTokenResponse, BrowserLoginCompleteRequest, BrowserLoginCompleteResponse,
+    BrowserLoginStartRequest, BrowserLoginStartResponse, BrowserRegisterCompleteRequest,
+    BrowserRegisterStartRequest, BrowserRegisterStartResponse, CloudTokenResponse,
+    DeleteKeyResponse, DeviceCodeRequest, DeviceCodeResponse, DeviceTokenRequest,
+    DeviceTokenResponse, Fido2ChallengeResponse, GitHubAccountStatus, GitHubStatusResponse,
+    GitHubTokenRequest, GitHubTokenResponse, KeyInfo, ListKeysResponse, OAuthError,
+    RegisterCompleteRequest, RegisterCompleteResponse, RegisterStartRequest, RegisterStartResponse,
+    RenameKeyRequest, RenameKeyResponse, SessionStatus, SshCaPublicKeyResponse,
+    SshCertificateRequest, SshCertificateResponse, serialize_secret_string,
+};
 pub use cookie::{SessionCookie, clear_cookie, cookie_path, read_cookie, write_cookie};
-pub use error::*;
+pub use error::{ApiError, VouchError};
 pub use url::{UrlSecurity, check_url_security, is_loopback_host};
 
 /// Session cookie name with `__Host-` prefix (RFC 6265bis).

--- a/crates/vouch-server/src/config.rs
+++ b/crates/vouch-server/src/config.rs
@@ -668,27 +668,32 @@ pub enum LogFormat {
     Json,
 }
 
+/// Compute the base URL: the explicit value if provided, otherwise derived
+/// from `rp_id` (http with port for loopback development, https for
+/// production).
+fn derive_base_url(base_url: Option<String>, rp_id: &str, listen_addr: &str) -> String {
+    if let Some(url) = base_url {
+        return url;
+    }
+    let derived = if vouch_common::is_loopback_host(rp_id) {
+        // For local development (localhost/127.0.0.1), use http with port
+        let port = listen_addr.rsplit(':').next().unwrap_or("3000");
+        format!("http://{rp_id}:{port}")
+    } else {
+        // Production: use https without port (assumes standard 443)
+        format!("https://{rp_id}")
+    };
+    tracing::debug!("VOUCH_BASE_URL not set, derived from rp_id: {}", derived);
+    derived
+}
+
 impl ServerConfig {
     /// Create configuration from parsed command-line arguments.
     pub fn from_args(args: Args) -> Result<Self> {
         // Note: Validation of rp_id and jwt_secret is deferred to validate()
         // to allow these values to come from S3 config.
 
-        // Compute base URL (handles both production https and local http)
-        let base_url = if let Some(url) = args.base_url {
-            url
-        } else {
-            let derived = if vouch_common::is_loopback_host(&args.rp_id) {
-                // For local development (localhost/127.0.0.1), use http with port
-                let port = args.listen_addr.rsplit(':').next().unwrap_or("3000");
-                format!("http://{}:{}", args.rp_id, port)
-            } else {
-                // Production: use https without port (assumes standard 443)
-                format!("https://{}", args.rp_id)
-            };
-            tracing::debug!("VOUCH_BASE_URL not set, derived from rp_id: {}", derived);
-            derived
-        };
+        let base_url = derive_base_url(args.base_url, &args.rp_id, &args.listen_addr);
 
         // Parse allowed domains
         let allowed_domains = args

--- a/crates/vouch-server/src/db/config.rs
+++ b/crates/vouch-server/src/db/config.rs
@@ -81,7 +81,11 @@ impl AuthEventParams {
 }
 
 /// Insert a new authentication event via the audit store.
-pub async fn insert_auth_event(
+///
+/// Production code records events through [`spawn_audit_event`]; this is
+/// exposed to in-crate tests that need to await the write and inspect the
+/// returned event ID.
+pub(super) async fn insert_auth_event(
     audit: &AuditStore,
     params: &AuthEventParams,
     email: Option<&str>,
@@ -112,6 +116,20 @@ pub async fn insert_auth_event(
             &data_json,
         )
         .await
+}
+
+/// Record an authentication event without blocking the caller.
+///
+/// Spawns a detached task so credential flows never wait on (or fail with)
+/// the audit write; failures are logged with the event type so dropped
+/// records are visible in one consistent format.
+pub fn spawn_audit_event(audit: &AuditStore, params: AuthEventParams, email: Option<String>) {
+    let audit = audit.clone();
+    tokio::spawn(async move {
+        if let Err(e) = insert_auth_event(&audit, &params, email.as_deref()).await {
+            tracing::warn!(error = %e, event_type = ?params.event_type, "failed to record audit event");
+        }
+    });
 }
 
 /// Delete authentication events older than the specified timestamp.

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -210,8 +210,8 @@ pub use enrollment::{EnrolledUser, EnrollmentResult, enroll_user_with_org};
 
 // Re-export posture policy types and functions
 pub use posture_policies::{
-    CreateCustomPolicyParams, CustomPosturePolicy, UpdateCustomPolicyParams, count_active_policies,
-    create_custom_policy, delete_custom_policy, get_active_custom_policies,
+    CreateCustomPolicyParams, CustomPosturePolicy, FieldUpdate, UpdateCustomPolicyParams,
+    count_active_policies, create_custom_policy, delete_custom_policy, get_active_custom_policies,
     get_active_preconfigured_slugs, get_custom_policy, list_custom_policies,
     set_preconfigured_active, update_custom_policy,
 };

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -102,7 +102,7 @@ pub(crate) use device_auth::{DeviceCodeClaim, OidcStateClaim};
 pub(crate) use device_auth::get_device_auth_by_id;
 
 // Re-export config and auth event types and functions
-pub use config::{AuthEventParams, AuthEventType, delete_old_auth_events, insert_auth_event};
+pub use config::{AuthEventParams, AuthEventType, delete_old_auth_events, spawn_audit_event};
 
 // Re-export SCIM types and functions
 pub use scim::{

--- a/crates/vouch-server/src/db/posture_policies.rs
+++ b/crates/vouch-server/src/db/posture_policies.rs
@@ -159,10 +159,22 @@ pub async fn get_custom_policy(
     Ok(doc.map(CustomPosturePolicy::from))
 }
 
+/// Intent for an optional field in a PATCH-style update.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum FieldUpdate<'a> {
+    /// Leave the stored value unchanged.
+    #[default]
+    Keep,
+    /// Clear the stored value.
+    Clear,
+    /// Replace the stored value.
+    Set(&'a str),
+}
+
 /// Parameters for updating a custom posture policy.
 pub struct UpdateCustomPolicyParams<'a> {
     pub name: Option<&'a str>,
-    pub description: Option<Option<&'a str>>,
+    pub description: FieldUpdate<'a>,
     pub cel_expression: Option<&'a str>,
     pub active: Option<bool>,
 }
@@ -187,8 +199,9 @@ pub async fn update_custom_policy(
     let updated = CustomPosturePolicyDoc {
         name: params.name.map(String::from).unwrap_or(doc.data.name),
         description: match params.description {
-            Some(d) => d.map(String::from),
-            None => doc.data.description,
+            FieldUpdate::Keep => doc.data.description,
+            FieldUpdate::Clear => None,
+            FieldUpdate::Set(d) => Some(d.to_string()),
         },
         cel_expression: params
             .cel_expression

--- a/crates/vouch-server/src/db/sessions.rs
+++ b/crates/vouch-server/src/db/sessions.rs
@@ -162,6 +162,22 @@ struct CacheEntry {
     inserted_at: Instant,
 }
 
+/// Result of a cache probe, distinguishing a miss from a cached
+/// "no such session" answer (negative caching).
+#[expect(
+    clippy::large_enum_variant,
+    reason = "Hit is the common case on the auth hot path and is destructured \
+              immediately; boxing would add an allocation per lookup"
+)]
+enum CacheLookup {
+    /// No fresh entry for this key — consult the database.
+    Miss,
+    /// Cached knowledge that the database has no session for this key.
+    NegativeHit,
+    /// Cached session.
+    Hit(Session),
+}
+
 impl SessionCache {
     /// Create a new session cache.
     ///
@@ -188,8 +204,10 @@ impl SessionCache {
         store: &DocumentStore,
         token_hash: &str,
     ) -> Result<Option<Session>> {
-        if let Some(cached) = self.get(token_hash) {
-            return Ok(cached);
+        match self.get(token_hash) {
+            CacheLookup::Hit(session) => return Ok(Some(session)),
+            CacheLookup::NegativeHit => return Ok(None),
+            CacheLookup::Miss => {}
         }
         // Snapshot generation before the async DB fetch so we can
         // detect invalidations that occurred during the await.
@@ -231,16 +249,21 @@ impl SessionCache {
         map.clear();
     }
 
-    fn get(&self, key: &str) -> Option<Option<Session>> {
+    fn get(&self, key: &str) -> CacheLookup {
         let Ok(mut map) = self.entries.lock() else {
-            return None;
+            return CacheLookup::Miss;
         };
-        let entry = map.get(key)?;
+        let Some(entry) = map.get(key) else {
+            return CacheLookup::Miss;
+        };
         if entry.inserted_at.elapsed() >= self.ttl {
             map.remove(key);
-            return None;
+            return CacheLookup::Miss;
         }
-        Some(entry.value.clone())
+        match entry.value.clone() {
+            Some(session) => CacheLookup::Hit(session),
+            None => CacheLookup::NegativeHit,
+        }
     }
 
     /// Expose generation for testing the TOCTOU guard.
@@ -316,13 +339,13 @@ mod tests {
             Some(fake_session("hash-a")),
             generation,
         );
-        assert!(matches!(cache.get("hash-a"), Some(Some(_))));
+        assert!(matches!(cache.get("hash-a"), CacheLookup::Hit(_)));
     }
 
     #[test]
     fn cache_miss_returns_none() {
         let cache = SessionCache::new(100, 30);
-        assert!(cache.get("nonexistent").is_none());
+        assert!(matches!(cache.get("nonexistent"), CacheLookup::Miss));
     }
 
     #[test]
@@ -331,8 +354,8 @@ mod tests {
         let generation = cache.generation();
         cache.insert_if_valid("hash-b".to_string(), None, generation);
         assert!(
-            matches!(cache.get("hash-b"), Some(None)),
-            "cache entry should exist with None value"
+            matches!(cache.get("hash-b"), CacheLookup::NegativeHit),
+            "cache entry should exist as a negative hit"
         );
     }
 
@@ -346,7 +369,7 @@ mod tests {
             generation,
         );
         cache.invalidate("hash-c");
-        assert!(cache.get("hash-c").is_none());
+        assert!(matches!(cache.get("hash-c"), CacheLookup::Miss));
     }
 
     #[test]
@@ -364,8 +387,8 @@ mod tests {
             generation,
         );
         cache.invalidate_all();
-        assert!(cache.get("hash-d").is_none());
-        assert!(cache.get("hash-e").is_none());
+        assert!(matches!(cache.get("hash-d"), CacheLookup::Miss));
+        assert!(matches!(cache.get("hash-e"), CacheLookup::Miss));
     }
 
     /// Regression test: simulates the TOCTOU race where an invalidation
@@ -387,7 +410,7 @@ mod tests {
         );
 
         assert!(
-            cache.get("hash-f").is_none(),
+            matches!(cache.get("hash-f"), CacheLookup::Miss),
             "revoked session must not be cached"
         );
     }
@@ -417,7 +440,7 @@ mod tests {
         );
 
         assert!(
-            cache.get("hash-g").is_none(),
+            matches!(cache.get("hash-g"), CacheLookup::Miss),
             "revoked session must not be cached after invalidate_all"
         );
     }
@@ -436,7 +459,7 @@ mod tests {
             fresh_gen,
         );
 
-        assert!(matches!(cache.get("hash-h"), Some(Some(_))));
+        assert!(matches!(cache.get("hash-h"), CacheLookup::Hit(_)));
     }
 
     /// Same TOCTOU regression case for user-scoped invalidation.
@@ -454,7 +477,7 @@ mod tests {
         );
 
         assert!(
-            cache.get("hash-user").is_none(),
+            matches!(cache.get("hash-user"), CacheLookup::Miss),
             "revoked session must not be cached after invalidate_for_user"
         );
     }
@@ -469,7 +492,7 @@ mod tests {
             generation,
         );
         // With a 0s TTL the entry is immediately expired
-        assert!(cache.get("hash-i").is_none());
+        assert!(matches!(cache.get("hash-i"), CacheLookup::Miss));
     }
 
     #[test]
@@ -481,7 +504,7 @@ mod tests {
             Some(fake_session("hash-j")),
             generation,
         );
-        assert!(cache.get("hash-j").is_none());
+        assert!(matches!(cache.get("hash-j"), CacheLookup::Miss));
     }
 
     #[test]
@@ -496,7 +519,7 @@ mod tests {
             generation,
         );
         // "first" should have been evicted to make room for "second"
-        assert!(cache.get("first").is_none());
-        assert!(cache.get("second").is_some());
+        assert!(matches!(cache.get("first"), CacheLookup::Miss));
+        assert!(matches!(cache.get("second"), CacheLookup::Hit(_)));
     }
 }

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -1422,7 +1422,7 @@ async fn test_auth_event_logging() {
         .expect("Failed to create user");
 
     // Log successful login (insert_auth_event now uses AuditStore)
-    let event_id = insert_auth_event(
+    let event_id = config::insert_auth_event(
         &audit,
         &AuthEventParams {
             user_id: user_id.clone(),
@@ -1441,7 +1441,7 @@ async fn test_auth_event_logging() {
     assert!(!event_id.is_empty());
 
     // Log failed login
-    insert_auth_event(
+    config::insert_auth_event(
         &audit,
         &AuthEventParams {
             user_id: user_id.clone(),

--- a/crates/vouch-server/src/handlers/admin/policies.rs
+++ b/crates/vouch-server/src/handlers/admin/policies.rs
@@ -380,7 +380,9 @@ pub(crate) async fn update_custom_policy(
         &org_id,
         db::UpdateCustomPolicyParams {
             name: Some(&form.name),
-            description: Some(description.as_deref()),
+            description: description
+                .as_deref()
+                .map_or(db::FieldUpdate::Clear, db::FieldUpdate::Set),
             cel_expression: Some(&form.cel_expression),
             active: None,
         },
@@ -535,7 +537,7 @@ pub(crate) async fn toggle_custom_policy(
         &org_id,
         db::UpdateCustomPolicyParams {
             name: None,
-            description: None,
+            description: db::FieldUpdate::Keep,
             cel_expression: None,
             active: Some(new_active),
         },

--- a/crates/vouch-server/src/handlers/auth.rs
+++ b/crates/vouch-server/src/handlers/auth.rs
@@ -143,8 +143,6 @@ pub(crate) async fn logout(
 
                     // Fire-and-forget logout audit event
                     if let Some(session) = session_info {
-                        let audit = state.audit.clone();
-                        let user_email = session.user_email.clone();
                         let params = db::AuthEventParams {
                             user_id: session.user_id.clone(),
                             event_type: db::AuthEventType::Logout,
@@ -152,13 +150,7 @@ pub(crate) async fn logout(
                             ..Default::default()
                         }
                         .with_client_info(client_info);
-                        tokio::spawn(async move {
-                            if let Err(e) =
-                                db::insert_auth_event(&audit, &params, Some(&user_email)).await
-                            {
-                                tracing::warn!("Failed to log logout event: {}", e,);
-                            }
-                        });
+                        db::spawn_audit_event(&state.audit, params, Some(session.user_email));
                     }
                 }
             }

--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -591,12 +591,7 @@ pub(crate) async fn browser_login_complete(
             ..AuthEventParams::default()
         }
         .with_client_info(client_info.clone());
-        let audit = state.audit.clone();
-        tokio::spawn(async move {
-            if let Err(e) = db::insert_auth_event(&audit, &params, None).await {
-                tracing::warn!("Failed to log auth event: {}", e);
-            }
-        });
+        db::spawn_audit_event(&state.audit, params, None);
     };
 
     // Look up authenticator and verify ownership (single JOIN query)
@@ -738,12 +733,7 @@ pub(crate) async fn browser_login_complete(
         ..AuthEventParams::default()
     }
     .with_client_info(client_info);
-    let audit = state.audit.clone();
-    tokio::spawn(async move {
-        if let Err(e) = db::insert_auth_event(&audit, &auth_event_params, None).await {
-            tracing::warn!("Failed to log auth event: {}", e);
-        }
-    });
+    db::spawn_audit_event(&state.audit, auth_event_params, None);
 
     crate::infra::metrics::record_auth_event("browser_login_success");
 

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -1424,15 +1424,11 @@ pub(crate) async fn browser_register_complete(
         ..AuthEventParams::default()
     }
     .with_client_info(client_info);
-    let audit = state.audit.clone();
-    let user_email_for_audit = reg_state.user_email.clone();
-    tokio::spawn(async move {
-        if let Err(e) =
-            db::insert_auth_event(&audit, &auth_event_params, Some(&user_email_for_audit)).await
-        {
-            tracing::warn!("Failed to log enrollment event: {}", e);
-        }
-    });
+    db::spawn_audit_event(
+        &state.audit,
+        auth_event_params,
+        Some(reg_state.user_email.clone()),
+    );
 
     crate::infra::metrics::record_auth_event("enrollment");
 

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -683,8 +683,10 @@ async fn handle_authorization_code_grant(
     // FAPI 2.0: Require DPoP for FAPI clients (sender-constrained tokens).
     if let Err(e) = crate::services::oidc::fapi::validate_fapi_token_request(
         &authenticated_client.client,
-        dpop_proof.is_some(),
-        has_mtls_cert,
+        crate::services::oidc::fapi::SenderConstraints {
+            dpop: dpop_proof.is_some(),
+            mtls_cert: has_mtls_cert,
+        },
     ) {
         return e.into_oauth_response().into_response();
     }
@@ -1159,8 +1161,10 @@ async fn handle_fido2_assertion_grant(
     // FAPI 2.0: Require sender-constrained tokens (DPoP or mTLS)
     if let Err(e) = crate::services::oidc::fapi::validate_fapi_token_request(
         &jwt_authenticated.client,
-        dpop_proof.is_some(),
-        has_mtls_cert,
+        crate::services::oidc::fapi::SenderConstraints {
+            dpop: dpop_proof.is_some(),
+            mtls_cert: has_mtls_cert,
+        },
     ) {
         return e.into_oauth_response().into_response();
     }

--- a/crates/vouch-server/src/infra/serve.rs
+++ b/crates/vouch-server/src/infra/serve.rs
@@ -4,16 +4,28 @@
 //! Handles TLS vs non-TLS server binding, HTTP->HTTPS redirect, SIGHUP
 //! certificate hot reload, S3 config polling, and graceful shutdown.
 
+use std::sync::Arc;
+
 use anyhow::{Context, Result};
 use axum::Router;
 use axum::serve::ListenerExt;
 use axum_server::accept::NoDelayAcceptor;
 use tokio::signal;
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
+use crate::AppState;
+use crate::config::ServerConfig;
 use crate::infra::s3_config;
 
 use super::startup::ServerComponents;
+
+/// Optional S3 config source (client, source settings, initial ETag).
+type S3ConfigParts = (
+    Option<aws_sdk_s3::Client>,
+    Option<s3_config::S3ConfigSource>,
+    Option<String>,
+);
 
 /// Run the server with the given components and router.
 ///
@@ -27,10 +39,6 @@ use super::startup::ServerComponents;
 /// # Errors
 ///
 /// Returns an error if the server fails to bind or encounters a fatal error.
-#[expect(
-    clippy::too_many_lines,
-    reason = "sequential listener, TLS, and shutdown wiring"
-)]
 pub async fn serve(components: ServerComponents, app: Router) -> Result<()> {
     let ServerComponents {
         config,
@@ -42,202 +50,15 @@ pub async fn serve(components: ServerComponents, app: Router) -> Result<()> {
         cleanup_handle,
     } = components;
 
-    // S3 config polling task handle (set up after TLS config is created if needed)
-    let mut s3_poll_handle: Option<tokio::task::JoinHandle<()>> = None;
+    let s3_parts = (s3_client, s3_source, initial_etag);
 
-    // Start server with graceful shutdown
-    if config.tls_configured() {
-        let tls_config = crate::infra::tls::build_tls_config(&config)?;
-
-        // TLS mode: always listen on 443 (HTTPS) and 80 (HTTP redirect)
-        let https_addr: std::net::SocketAddr =
-            "[::]:443".parse().context("Invalid HTTPS listen address")?;
-        let http_addr: std::net::SocketAddr =
-            "[::]:80".parse().context("Invalid HTTP listen address")?;
-
-        tracing::info!(
-            "TLS enabled - listening on https://{} and http://{} (redirect)",
-            https_addr,
-            http_addr
-        );
-        tracing::info!("Send SIGHUP to reload TLS certificates");
-
-        // Create shared cancellation token for coordinated shutdown
-        let shutdown_token = CancellationToken::new();
-
-        // Spawn shutdown signal handler that cancels the token
-        let shutdown_token_for_signal = shutdown_token.clone();
-        tokio::spawn(async move {
-            shutdown_signal().await;
-            shutdown_token_for_signal.cancel();
-        });
-
-        // Start S3 config polling task if configured (with TLS config for hot reload)
-        if let (Some(client), Some(source), Some(etag)) =
-            (s3_client.clone(), s3_source.clone(), initial_etag.clone())
-        {
-            tracing::info!(
-                "Starting S3 config polling task (interval: {}s)",
-                source.poll_interval_seconds
-            );
-            s3_poll_handle = Some(s3_config::start_s3_config_task(
-                client,
-                source,
-                state.config.clone(),
-                Some(tls_config.clone()),
-                etag,
-            ));
-        }
-
-        // Clone for SIGHUP handler - read from current config (not env vars)
-        let tls_config_for_reload = tls_config.clone();
-        let config_for_sighup = state.config.clone();
-
-        // Spawn SIGHUP handler for certificate hot reload
-        tokio::spawn(async move {
-            let Ok(mut sighup) =
-                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::hangup())
-            else {
-                tracing::warn!("Failed to register SIGHUP handler, TLS hot reload disabled");
-                return;
-            };
-
-            loop {
-                sighup.recv().await;
-                tracing::info!("Received SIGHUP, reloading TLS certificates...");
-
-                // Read from current config (supports both env vars and S3 config)
-                let cfg = config_for_sighup.load();
-                match (&cfg.tls_cert, &cfg.tls_key) {
-                    (Some(cert), Some(key)) => {
-                        match crate::infra::tls::reload_tls_from_config(
-                            &tls_config_for_reload,
-                            cert,
-                            key,
-                        ) {
-                            Ok(()) => tracing::info!("TLS certificates reloaded successfully"),
-                            Err(e) => tracing::error!("Failed to reload TLS certificates: {e:#}"),
-                        }
-                    }
-                    _ => tracing::warn!("TLS not configured, nothing to reload"),
-                }
-            }
-        });
-
-        // Start mTLS listener whenever TLS is configured (mTLS port always has a value).
-        let mtls_port = config.mtls_port;
-        let mtls_addr: std::net::SocketAddr = format!("[::]:{mtls_port}")
-            .parse()
-            .context("Invalid mTLS listen address")?;
-
-        let mtls_handle: Option<tokio::task::JoinHandle<()>> = match start_mtls_listener(
-            &config,
-            mtls_addr,
-            app.clone(),
-            shutdown_token.clone(),
-        )
-        .await
-        {
-            Ok(handle) => {
-                tracing::info!("mTLS listener started on port {}", mtls_port);
-                Some(handle)
-            }
-            Err(e) => {
-                return Err(e.context("Failed to start mTLS listener"));
-            }
-        };
-
-        // Create handle for graceful shutdown of HTTPS server
-        let handle = axum_server::Handle::new();
-        let handle_for_shutdown = handle.clone();
-
-        // Spawn HTTPS shutdown handler (uses cancellation token)
-        let token_for_https = shutdown_token.clone();
-        tokio::spawn(async move {
-            token_for_https.cancelled().await;
-            tracing::info!("Initiating graceful shutdown (30s timeout)");
-            handle_for_shutdown.graceful_shutdown(Some(std::time::Duration::from_secs(30)));
-        });
-
-        // Build HTTP redirect router (with state for Host validation)
-        let redirect_app = crate::build_redirect_router(state.clone());
-
-        // Spawn HTTP redirect server (port 80) - best effort, not fatal if fails
-        let token_for_http = shutdown_token.clone();
-        let http_handle = tokio::spawn(async move {
-            match tokio::net::TcpListener::bind(http_addr).await {
-                Ok(listener) => {
-                    let listener = listener.tap_io(|tcp| {
-                        if let Err(err) = tcp.set_nodelay(true) {
-                            tracing::trace!(
-                                "failed to set TCP_NODELAY on incoming connection: {err:#}"
-                            );
-                        }
-                    });
-                    if let Err(e) = axum::serve(listener, redirect_app)
-                        .with_graceful_shutdown(token_for_http.cancelled_owned())
-                        .await
-                    {
-                        tracing::error!("HTTP redirect server error: {e}");
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "Could not bind HTTP redirect on {}: {e} (continuing without redirect)",
-                        http_addr
-                    );
-                    tracing::warn!(
-                        "Hint: Ports below 1024 require CAP_NET_BIND_SERVICE capability"
-                    );
-                }
-            }
-        });
-
-        // Run HTTPS server (port 443) - this blocks until shutdown
-        axum_server::bind_rustls(https_addr, tls_config)
-            .map(|acceptor| acceptor.acceptor(NoDelayAcceptor::new()))
-            .handle(handle)
-            .serve(app.into_make_service_with_connect_info::<std::net::SocketAddr>())
-            .await?;
-
-        // Wait for HTTP redirect server to finish; ignore JoinError on shutdown.
-        let _http = http_handle.await;
-
-        // Wait for mTLS listener to finish; ignore JoinError on shutdown.
-        if let Some(handle) = mtls_handle {
-            let _mtls = handle.await;
-        }
+    // Run until shutdown; each mode returns its S3 polling handle (if any)
+    // so cleanup stays shared below.
+    let s3_poll_handle = if config.tls_configured() {
+        serve_tls(&config, &state, app, s3_parts).await?
     } else {
-        // Start S3 config polling task if configured (no TLS)
-        if let (Some(client), Some(source), Some(etag)) = (s3_client, s3_source, initial_etag) {
-            tracing::info!(
-                "Starting S3 config polling task (interval: {}s)",
-                source.poll_interval_seconds
-            );
-            s3_poll_handle = Some(s3_config::start_s3_config_task(
-                client,
-                source,
-                state.config.clone(),
-                None, // No TLS config to reload
-                etag,
-            ));
-        }
-
-        let listener = tokio::net::TcpListener::bind(&config.listen_addr).await?;
-        tracing::info!("Listening on http://{}", config.listen_addr);
-
-        let listener = listener.tap_io(|tcp| {
-            if let Err(err) = tcp.set_nodelay(true) {
-                tracing::trace!("failed to set TCP_NODELAY on incoming connection: {err:#}");
-            }
-        });
-        axum::serve(
-            listener,
-            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
-        )
-        .with_graceful_shutdown(shutdown_signal())
-        .await?;
-    }
+        serve_plain(&config, &state, app, s3_parts).await?
+    };
 
     // Clean up background tasks
     if let Some(handle) = s3_poll_handle {
@@ -258,6 +79,216 @@ pub async fn serve(components: ServerComponents, app: Router) -> Result<()> {
 
     tracing::info!("Server shutdown complete");
     Ok(())
+}
+
+/// Start the S3 config polling task if all S3 config parts are present.
+///
+/// `tls_config` enables hot reload of certificates delivered via S3.
+fn start_s3_polling(
+    state: &Arc<AppState>,
+    s3_parts: S3ConfigParts,
+    tls_config: Option<axum_server::tls_rustls::RustlsConfig>,
+) -> Option<JoinHandle<()>> {
+    let (Some(client), Some(source), Some(etag)) = s3_parts else {
+        return None;
+    };
+    tracing::info!(
+        "Starting S3 config polling task (interval: {}s)",
+        source.poll_interval_seconds
+    );
+    Some(s3_config::start_s3_config_task(
+        client,
+        source,
+        state.config.clone(),
+        tls_config,
+        etag,
+    ))
+}
+
+/// Run in TLS mode: HTTPS on 443, HTTP redirect on 80, mTLS listener,
+/// SIGHUP certificate hot reload. Blocks until shutdown.
+///
+/// Returns the S3 config polling task handle (if S3 config is in use) so the
+/// caller can abort it during cleanup.
+async fn serve_tls(
+    config: &ServerConfig,
+    state: &Arc<AppState>,
+    app: Router,
+    s3_parts: S3ConfigParts,
+) -> Result<Option<JoinHandle<()>>> {
+    let tls_config = crate::infra::tls::build_tls_config(config)?;
+
+    // TLS mode: always listen on 443 (HTTPS) and 80 (HTTP redirect)
+    let https_addr: std::net::SocketAddr =
+        "[::]:443".parse().context("Invalid HTTPS listen address")?;
+    let http_addr: std::net::SocketAddr =
+        "[::]:80".parse().context("Invalid HTTP listen address")?;
+
+    tracing::info!(
+        "TLS enabled - listening on https://{} and http://{} (redirect)",
+        https_addr,
+        http_addr
+    );
+    tracing::info!("Send SIGHUP to reload TLS certificates");
+
+    // Create shared cancellation token for coordinated shutdown
+    let shutdown_token = CancellationToken::new();
+
+    // Spawn shutdown signal handler that cancels the token
+    let shutdown_token_for_signal = shutdown_token.clone();
+    tokio::spawn(async move {
+        shutdown_signal().await;
+        shutdown_token_for_signal.cancel();
+    });
+
+    // Start S3 config polling task if configured (with TLS config for hot reload)
+    let s3_poll_handle = start_s3_polling(state, s3_parts, Some(tls_config.clone()));
+
+    spawn_sighup_cert_reload(tls_config.clone(), state.config.clone());
+
+    // Start mTLS listener whenever TLS is configured (mTLS port always has a value).
+    let mtls_port = config.mtls_port;
+    let mtls_addr: std::net::SocketAddr = format!("[::]:{mtls_port}")
+        .parse()
+        .context("Invalid mTLS listen address")?;
+
+    let mtls_handle: Option<JoinHandle<()>> =
+        match start_mtls_listener(config, mtls_addr, app.clone(), shutdown_token.clone()).await {
+            Ok(handle) => {
+                tracing::info!("mTLS listener started on port {}", mtls_port);
+                Some(handle)
+            }
+            Err(e) => {
+                return Err(e.context("Failed to start mTLS listener"));
+            }
+        };
+
+    // Create handle for graceful shutdown of HTTPS server
+    let handle = axum_server::Handle::new();
+    let handle_for_shutdown = handle.clone();
+
+    // Spawn HTTPS shutdown handler (uses cancellation token)
+    let token_for_https = shutdown_token.clone();
+    tokio::spawn(async move {
+        token_for_https.cancelled().await;
+        tracing::info!("Initiating graceful shutdown (30s timeout)");
+        handle_for_shutdown.graceful_shutdown(Some(std::time::Duration::from_secs(30)));
+    });
+
+    // Build HTTP redirect router (with state for Host validation)
+    let redirect_app = crate::build_redirect_router(state.clone());
+
+    // Spawn HTTP redirect server (port 80) - best effort, not fatal if fails
+    let token_for_http = shutdown_token.clone();
+    let http_handle = tokio::spawn(async move {
+        match tokio::net::TcpListener::bind(http_addr).await {
+            Ok(listener) => {
+                let listener = listener.tap_io(|tcp| {
+                    if let Err(err) = tcp.set_nodelay(true) {
+                        tracing::trace!(
+                            "failed to set TCP_NODELAY on incoming connection: {err:#}"
+                        );
+                    }
+                });
+                if let Err(e) = axum::serve(listener, redirect_app)
+                    .with_graceful_shutdown(token_for_http.cancelled_owned())
+                    .await
+                {
+                    tracing::error!("HTTP redirect server error: {e}");
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Could not bind HTTP redirect on {}: {e} (continuing without redirect)",
+                    http_addr
+                );
+                tracing::warn!("Hint: Ports below 1024 require CAP_NET_BIND_SERVICE capability");
+            }
+        }
+    });
+
+    // Run HTTPS server (port 443) - this blocks until shutdown
+    axum_server::bind_rustls(https_addr, tls_config)
+        .map(|acceptor| acceptor.acceptor(NoDelayAcceptor::new()))
+        .handle(handle)
+        .serve(app.into_make_service_with_connect_info::<std::net::SocketAddr>())
+        .await?;
+
+    // Wait for HTTP redirect server to finish; ignore JoinError on shutdown.
+    let _http = http_handle.await;
+
+    // Wait for mTLS listener to finish; ignore JoinError on shutdown.
+    if let Some(handle) = mtls_handle {
+        let _mtls = handle.await;
+    }
+
+    Ok(s3_poll_handle)
+}
+
+/// Run in plain HTTP mode on the configured listen address. Blocks until
+/// shutdown.
+///
+/// Returns the S3 config polling task handle (if S3 config is in use) so the
+/// caller can abort it during cleanup.
+async fn serve_plain(
+    config: &ServerConfig,
+    state: &Arc<AppState>,
+    app: Router,
+    s3_parts: S3ConfigParts,
+) -> Result<Option<JoinHandle<()>>> {
+    // Start S3 config polling task if configured (no TLS config to reload)
+    let s3_poll_handle = start_s3_polling(state, s3_parts, None);
+
+    let listener = tokio::net::TcpListener::bind(&config.listen_addr).await?;
+    tracing::info!("Listening on http://{}", config.listen_addr);
+
+    let listener = listener.tap_io(|tcp| {
+        if let Err(err) = tcp.set_nodelay(true) {
+            tracing::trace!("failed to set TCP_NODELAY on incoming connection: {err:#}");
+        }
+    });
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+    )
+    .with_graceful_shutdown(shutdown_signal())
+    .await?;
+
+    Ok(s3_poll_handle)
+}
+
+/// Spawn the SIGHUP handler for TLS certificate hot reload.
+///
+/// Reads cert/key from the current (possibly S3-merged) config on each
+/// signal, not from the values captured at startup.
+fn spawn_sighup_cert_reload(
+    tls_config: axum_server::tls_rustls::RustlsConfig,
+    config: Arc<arc_swap::ArcSwap<ServerConfig>>,
+) {
+    tokio::spawn(async move {
+        let Ok(mut sighup) = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::hangup())
+        else {
+            tracing::warn!("Failed to register SIGHUP handler, TLS hot reload disabled");
+            return;
+        };
+
+        loop {
+            sighup.recv().await;
+            tracing::info!("Received SIGHUP, reloading TLS certificates...");
+
+            // Read from current config (supports both env vars and S3 config)
+            let cfg = config.load();
+            match (&cfg.tls_cert, &cfg.tls_key) {
+                (Some(cert), Some(key)) => {
+                    match crate::infra::tls::reload_tls_from_config(&tls_config, cert, key) {
+                        Ok(()) => tracing::info!("TLS certificates reloaded successfully"),
+                        Err(e) => tracing::error!("Failed to reload TLS certificates: {e:#}"),
+                    }
+                }
+                _ => tracing::warn!("TLS not configured, nothing to reload"),
+            }
+        }
+    });
 }
 
 /// Wait for shutdown signal (Ctrl+C or SIGTERM).

--- a/crates/vouch-server/src/infra/startup.rs
+++ b/crates/vouch-server/src/infra/startup.rs
@@ -88,87 +88,10 @@ pub async fn initialize(args: config::Args) -> Result<ServerComponents> {
         use_attestation,
     );
 
-    // AWS SDK and runtime configuration
-    let env_or = |key: &str| -> String { std::env::var(key).unwrap_or_else(|_| "(empty)".into()) };
-    tracing::info!(
-        "AWS SDK: region={}, fips={}, dualstack={}, sts_regional={}, defaults_mode={}",
-        env_or("AWS_REGION"),
-        env_or("AWS_USE_FIPS_ENDPOINT"),
-        env_or("AWS_USE_DUALSTACK_ENDPOINT"),
-        env_or("AWS_STS_REGIONAL_ENDPOINTS"),
-        env_or("AWS_DEFAULTS_MODE"),
-    );
-    tracing::info!("Logging: RUST_LOG={}", env_or("RUST_LOG"));
-
-    if !config.trusted_proxies.is_empty() {
-        let cidrs: Vec<String> = config
-            .trusted_proxies
-            .iter()
-            .map(ToString::to_string)
-            .collect();
-        tracing::warn!(
-            "Trusted proxies configured: {} -- X-Forwarded-For will be parsed for client IP",
-            cidrs.join(", "),
-        );
-    }
-
     crate::geo::warmup();
     tracing::info!("GeoIP database initialized");
 
-    // Feature status summary — one log per feature for searchable CloudWatch events
-    let pool_cfg = &config.pool_config;
-    tracing::info!(
-        "Database pool: max_connections={}, min_connections={}, idle_timeout={}s, acquire_timeout={}s",
-        pool_cfg.max_connections,
-        pool_cfg.min_connections,
-        pool_cfg.idle_timeout_secs,
-        pool_cfg.acquire_timeout_secs,
-    );
-    tracing::info!(
-        "Sessions: duration={}h, dpop_max_age={}s, cache_max_capacity={}, cache_ttl={}s",
-        config.session_hours,
-        config.dpop_max_age_seconds,
-        config.session_cache_max_capacity,
-        config.session_cache_ttl_secs,
-    );
-    tracing::info!(
-        "Device flow: code_expires={}s, poll_interval={}s",
-        config.device_code_expires_seconds,
-        config.device_poll_interval_seconds,
-    );
-
-    log_authenticator_policy(&config);
-
-    match &config.cors_origins {
-        Some(origins) => tracing::info!("CORS: origins={}", origins.join(", ")),
-        None => tracing::info!("CORS: same-origin only"),
-    }
-
-    // Warn if rp_id is localhost but TLS is configured (likely a
-    // misconfiguration: a loopback rp_id in what looks like production).
-    // WebAuthn origin relaxation is now disabled whenever TLS is configured,
-    // so origin binding is NOT weakened here — but the loopback rp_id itself
-    // is almost certainly wrong for a TLS deployment.
-    if vouch_common::is_loopback_host(&config.rp_id) && config.tls_configured() {
-        tracing::warn!(
-            target: "security",
-            "rp_id is '{}' but TLS is configured -- this looks like a production \
-             deployment with a loopback relying-party ID, which is almost \
-             certainly a misconfiguration",
-            config.rp_id,
-        );
-    }
-
-    // Loudly flag certification test mode at startup. This is a login-bypass
-    // switch (see router.rs) intended only for OpenID conformance testing.
-    if config.certification_test_token.is_some() {
-        tracing::warn!(
-            target: "security",
-            "CERTIFICATION TEST MODE is ENABLED (VOUCH_CERTIFICATION_TEST_TOKEN is \
-             set): login-bypass endpoint active, global rate limiting disabled, \
-             and the upstream-IdP requirement relaxed. MUST NOT be set in production."
-        );
-    }
+    log_startup_summary(&config);
 
     // Build AppState and start background tasks
     let state = build_app_state(&config, db.clone(), doc_keys, kms_client).await?;
@@ -747,6 +670,89 @@ async fn build_configured_idp(
                 },
             ))
         }
+    }
+}
+
+/// Log the runtime/feature configuration summary at startup — one log per
+/// feature for searchable CloudWatch events — plus security warnings for
+/// suspicious configurations.
+fn log_startup_summary(config: &config::ServerConfig) {
+    // AWS SDK and runtime configuration
+    let env_or = |key: &str| -> String { std::env::var(key).unwrap_or_else(|_| "(empty)".into()) };
+    tracing::info!(
+        "AWS SDK: region={}, fips={}, dualstack={}, sts_regional={}, defaults_mode={}",
+        env_or("AWS_REGION"),
+        env_or("AWS_USE_FIPS_ENDPOINT"),
+        env_or("AWS_USE_DUALSTACK_ENDPOINT"),
+        env_or("AWS_STS_REGIONAL_ENDPOINTS"),
+        env_or("AWS_DEFAULTS_MODE"),
+    );
+    tracing::info!("Logging: RUST_LOG={}", env_or("RUST_LOG"));
+
+    if !config.trusted_proxies.is_empty() {
+        let cidrs: Vec<String> = config
+            .trusted_proxies
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+        tracing::warn!(
+            "Trusted proxies configured: {} -- X-Forwarded-For will be parsed for client IP",
+            cidrs.join(", "),
+        );
+    }
+
+    let pool_cfg = &config.pool_config;
+    tracing::info!(
+        "Database pool: max_connections={}, min_connections={}, idle_timeout={}s, acquire_timeout={}s",
+        pool_cfg.max_connections,
+        pool_cfg.min_connections,
+        pool_cfg.idle_timeout_secs,
+        pool_cfg.acquire_timeout_secs,
+    );
+    tracing::info!(
+        "Sessions: duration={}h, dpop_max_age={}s, cache_max_capacity={}, cache_ttl={}s",
+        config.session_hours,
+        config.dpop_max_age_seconds,
+        config.session_cache_max_capacity,
+        config.session_cache_ttl_secs,
+    );
+    tracing::info!(
+        "Device flow: code_expires={}s, poll_interval={}s",
+        config.device_code_expires_seconds,
+        config.device_poll_interval_seconds,
+    );
+
+    log_authenticator_policy(config);
+
+    match &config.cors_origins {
+        Some(origins) => tracing::info!("CORS: origins={}", origins.join(", ")),
+        None => tracing::info!("CORS: same-origin only"),
+    }
+
+    // Warn if rp_id is localhost but TLS is configured (likely a
+    // misconfiguration: a loopback rp_id in what looks like production).
+    // WebAuthn origin relaxation is now disabled whenever TLS is configured,
+    // so origin binding is NOT weakened here — but the loopback rp_id itself
+    // is almost certainly wrong for a TLS deployment.
+    if vouch_common::is_loopback_host(&config.rp_id) && config.tls_configured() {
+        tracing::warn!(
+            target: "security",
+            "rp_id is '{}' but TLS is configured -- this looks like a production \
+             deployment with a loopback relying-party ID, which is almost \
+             certainly a misconfiguration",
+            config.rp_id,
+        );
+    }
+
+    // Loudly flag certification test mode at startup. This is a login-bypass
+    // switch (see router.rs) intended only for OpenID conformance testing.
+    if config.certification_test_token.is_some() {
+        tracing::warn!(
+            target: "security",
+            "CERTIFICATION TEST MODE is ENABLED (VOUCH_CERTIFICATION_TEST_TOKEN is \
+             set): login-bypass endpoint active, global rate limiting disabled, \
+             and the upstream-IdP requirement relaxed. MUST NOT be set in production."
+        );
     }
 }
 

--- a/crates/vouch-server/src/services/oidc/fapi.rs
+++ b/crates/vouch-server/src/services/oidc/fapi.rs
@@ -127,32 +127,37 @@ pub fn validate_fapi_authorization_request(
     Ok(())
 }
 
+/// Sender-constraint mechanisms present on a token request.
+///
+/// FAPI 2.0 Section 5.2.2 requires at least one of these for FAPI clients.
+#[derive(Debug, Clone, Copy)]
+pub struct SenderConstraints {
+    /// A valid DPoP proof was provided in the request.
+    pub dpop: bool,
+    /// A client mTLS certificate was presented on the connection.
+    pub mtls_cert: bool,
+}
+
 /// Validate FAPI 2.0 constraints on a token request.
 ///
-/// FAPI 2.0 Section 5.2.2 requires sender-constrained access tokens.
-/// Since we use DPoP (not mTLS), a DPoP proof is required for FAPI clients.
+/// FAPI 2.0 Section 5.2.2 requires sender-constrained access tokens,
+/// so FAPI clients must present at least one mechanism in `constraints`.
 ///
 /// Non-FAPI clients pass validation unconditionally.
-///
-/// # Arguments
-///
-/// * `client` - The OAuth client making the token request
-/// * `has_dpop` - Whether a valid DPoP proof was provided in the request
 ///
 /// # Errors
 ///
 /// Returns `ServiceError::OAuth` with `invalid_request` if constraints are violated.
 pub fn validate_fapi_token_request(
     client: &OAuthClient,
-    has_dpop: bool,
-    has_mtls_cert: bool,
+    constraints: SenderConstraints,
 ) -> ServiceResult<()> {
     if !client.is_fapi() {
         return Ok(());
     }
 
     // FAPI 2.0 Section 5.2.2: Sender-constrained tokens required (DPoP or mTLS)
-    if !has_dpop && !has_mtls_cert {
+    if !constraints.dpop && !constraints.mtls_cert {
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidRequest,
             "FAPI 2.0 requires sender-constrained access tokens (DPoP or mTLS required)",
@@ -437,16 +442,29 @@ mod tests {
     // Token Request Tests
     // =========================================================================
 
+    const NO_CONSTRAINTS: SenderConstraints = SenderConstraints {
+        dpop: false,
+        mtls_cert: false,
+    };
+    const DPOP_ONLY: SenderConstraints = SenderConstraints {
+        dpop: true,
+        mtls_cert: false,
+    };
+    const MTLS_ONLY: SenderConstraints = SenderConstraints {
+        dpop: false,
+        mtls_cert: true,
+    };
+
     #[test]
     fn test_validate_fapi_token_request_requires_sender_constraint() {
         let client = fapi_client();
-        assert!(validate_fapi_token_request(&client, false, false).is_err());
+        assert!(validate_fapi_token_request(&client, NO_CONSTRAINTS).is_err());
     }
 
     #[test]
     fn test_validate_fapi_token_request_accepts_dpop() {
         let client = fapi_client();
-        assert!(validate_fapi_token_request(&client, true, false).is_ok());
+        assert!(validate_fapi_token_request(&client, DPOP_ONLY).is_ok());
     }
 
     #[test]
@@ -454,7 +472,7 @@ mod tests {
         // mTLS certificate is a valid sender-constraint mechanism for FAPI 2.0.
         let client = fapi_client();
         assert!(
-            validate_fapi_token_request(&client, false, true).is_ok(),
+            validate_fapi_token_request(&client, MTLS_ONLY).is_ok(),
             "mTLS cert must be accepted as sender-constraint for FAPI token request"
         );
     }
@@ -462,8 +480,8 @@ mod tests {
     #[test]
     fn test_validate_fapi_token_request_skips_non_fapi() {
         let client = standard_client();
-        assert!(validate_fapi_token_request(&client, false, false).is_ok());
-        assert!(validate_fapi_token_request(&client, true, false).is_ok());
+        assert!(validate_fapi_token_request(&client, NO_CONSTRAINTS).is_ok());
+        assert!(validate_fapi_token_request(&client, DPOP_ONLY).is_ok());
     }
 
     // =========================================================================

--- a/crates/vouch-server/src/services/oidc/fido2_grant.rs
+++ b/crates/vouch-server/src/services/oidc/fido2_grant.rs
@@ -268,14 +268,7 @@ pub(crate) async fn exchange_fido2_assertion(
             ..AuthEventParams::default()
         }
         .with_client_info(failure_client_info);
-        let audit = state.audit.clone();
-        let user_email = user.email.clone();
-        tokio::spawn(async move {
-            if let Err(err) = db::insert_auth_event(&audit, &failure_event, Some(&user_email)).await
-            {
-                tracing::warn!("Failed to log auth event: {}", err);
-            }
-        });
+        db::spawn_audit_event(&state.audit, failure_event, Some(user.email.clone()));
         ServiceError::oauth(OAuthErrorCode::InvalidGrant, "Authentication failed")
     })?;
 
@@ -306,13 +299,7 @@ pub(crate) async fn exchange_fido2_assertion(
         ..AuthEventParams::default()
     }
     .with_client_info(params.client_info);
-    let audit = state.audit.clone();
-    let user_email = user.email.clone();
-    tokio::spawn(async move {
-        if let Err(e) = db::insert_auth_event(&audit, &auth_event_params, Some(&user_email)).await {
-            tracing::warn!("Failed to log auth event: {}", e);
-        }
-    });
+    db::spawn_audit_event(&state.audit, auth_event_params, Some(user.email.clone()));
 
     // 9. Validate authorization_details if provided (RFC 9396)
     let validated_ad = params

--- a/crates/vouch-server/src/services/oidc/introspection.rs
+++ b/crates/vouch-server/src/services/oidc/introspection.rs
@@ -295,7 +295,6 @@ pub async fn revoke_token(
     if revoked {
         // Fire-and-forget logout audit event
         if let Some(ref user_id) = sub {
-            let audit = state.audit.clone();
             let params = db::AuthEventParams {
                 user_id: user_id.clone(),
                 event_type: db::AuthEventType::Logout,
@@ -303,14 +302,7 @@ pub async fn revoke_token(
                 ..Default::default()
             }
             .with_client_info(client_info);
-            let email_for_audit = email.clone();
-            tokio::spawn(async move {
-                if let Err(e) =
-                    db::insert_auth_event(&audit, &params, email_for_audit.as_deref()).await
-                {
-                    tracing::warn!("Failed to log revocation logout event: {}", e);
-                }
-            });
+            db::spawn_audit_event(&state.audit, params, email.clone());
         }
 
         return RevocationResult {

--- a/crates/vouch-server/src/services/oidc/registration.rs
+++ b/crates/vouch-server/src/services/oidc/registration.rs
@@ -276,7 +276,7 @@ pub async fn register_client(
     let validated = validate_grant_and_response_types(&mut request)?;
 
     // 7. Validate redirect URIs
-    let redirect_uris = validate_redirect_uris(&mut request, validated.has_auth_code)?;
+    let redirect_uris = validate_redirect_uris(&mut request, validated.auth_code_grant)?;
 
     // 8-9. Validate JWKS and auth method
     let jwks_auth = validate_jwks_and_auth_method(&mut request, &validated.auth_method_str)?;
@@ -437,9 +437,14 @@ pub async fn register_client(
         };
 
     // 12c-2. Validate userinfo_signed_response_alg (OIDC Core Section 5.3.4).
+    let rsa_key = if state.oidc_rsa_key.is_some() {
+        RsaSigningKey::Available
+    } else {
+        RsaSigningKey::Unavailable
+    };
     let userinfo_alg = validate_userinfo_signed_response_alg(
         request.userinfo_signed_response_alg.as_deref(),
-        state.oidc_rsa_key.is_some(),
+        rsa_key,
         fapi_profile,
     )?;
 
@@ -638,13 +643,20 @@ pub async fn register_client(
 // Registration Validation Helpers
 // ============================================================================
 
+/// Whether the requested grant types include `authorization_code`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AuthorizationCodeGrant {
+    Present,
+    Absent,
+}
+
 /// Validated grant/response types and auth method from a registration request.
 #[derive(Debug)]
 struct ValidatedGrantTypes {
     grant_types: Vec<String>,
     response_types: Vec<String>,
     auth_method_str: String,
-    has_auth_code: bool,
+    auth_code_grant: AuthorizationCodeGrant,
 }
 
 /// Reject RS256 when the client is registering under any FAPI 2.0 profile.
@@ -666,12 +678,20 @@ fn reject_rs256_for_fapi(
     Ok(())
 }
 
+/// Whether the server has an RSA signing key configured (and can thus
+/// offer RS256 for signed responses).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RsaSigningKey {
+    Available,
+    Unavailable,
+}
+
 /// Validate `userinfo_signed_response_alg` — only RS256 and ES256 are accepted.
 ///
 /// Returns the parsed algorithm, or `None` if the field is absent.
 fn validate_userinfo_signed_response_alg(
     raw: Option<&str>,
-    has_rsa_key: bool,
+    rsa_key: RsaSigningKey,
     fapi_profile: FapiProfile,
 ) -> Result<Option<JwsAlgorithm>, ServiceError> {
     let Some(s) = raw else { return Ok(None) };
@@ -683,7 +703,7 @@ fn validate_userinfo_signed_response_alg(
     })?;
     reject_rs256_for_fapi(parsed, fapi_profile, "userinfo_signed_response_alg")?;
     match parsed {
-        JwsAlgorithm::Rs256 if !has_rsa_key => Err(ServiceError::oauth(
+        JwsAlgorithm::Rs256 if rsa_key == RsaSigningKey::Unavailable => Err(ServiceError::oauth(
             OAuthErrorCode::InvalidClientMetadata,
             "RS256 is not available for userinfo_signed_response_alg \
              (no RSA signing key configured)",
@@ -779,9 +799,13 @@ fn validate_grant_and_response_types(
         }
     }
 
-    let has_auth_code = grant_types.iter().any(|g| g == "authorization_code");
+    let auth_code_grant = if grant_types.iter().any(|g| g == "authorization_code") {
+        AuthorizationCodeGrant::Present
+    } else {
+        AuthorizationCodeGrant::Absent
+    };
     let has_code_response = response_types.iter().any(|r| r == "code");
-    if has_auth_code && !has_code_response {
+    if auth_code_grant == AuthorizationCodeGrant::Present && !has_code_response {
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidClientMetadata,
             "grant_types includes 'authorization_code' but response_types is missing 'code'",
@@ -792,17 +816,17 @@ fn validate_grant_and_response_types(
         grant_types,
         response_types,
         auth_method_str,
-        has_auth_code,
+        auth_code_grant,
     })
 }
 
 /// Validate redirect URIs: required for auth_code grant, cardinality, format.
 fn validate_redirect_uris(
     request: &mut RegistrationRequest,
-    has_auth_code: bool,
+    auth_code_grant: AuthorizationCodeGrant,
 ) -> Result<Vec<String>, ServiceError> {
     let redirect_uris = request.redirect_uris.take().unwrap_or_default();
-    if has_auth_code && redirect_uris.is_empty() {
+    if auth_code_grant == AuthorizationCodeGrant::Present && redirect_uris.is_empty() {
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidClientMetadata,
             "redirect_uris is required when grant_types includes 'authorization_code'",
@@ -1071,7 +1095,7 @@ pub async fn update_client_configuration(
     let validated = validate_grant_and_response_types(&mut mutable_request)?;
 
     // Validate redirect URIs (same cardinality + format rules as initial registration)
-    let redirect_uris = validate_redirect_uris(&mut mutable_request, validated.has_auth_code)?;
+    let redirect_uris = validate_redirect_uris(&mut mutable_request, validated.auth_code_grant)?;
 
     // Build updated registration metadata (cosmetic fields)
     let registration_metadata = mutable_request.registration_metadata();
@@ -1086,9 +1110,14 @@ pub async fn update_client_configuration(
     // Validate userinfo_signed_response_alg (same rules as initial registration).
     // The client's FAPI profile is immutable post-registration (RFC 7592), so we
     // re-apply the original profile's algorithm restrictions to any updates.
+    let rsa_key = if state.oidc_rsa_key.is_some() {
+        RsaSigningKey::Available
+    } else {
+        RsaSigningKey::Unavailable
+    };
     let userinfo_alg = validate_userinfo_signed_response_alg(
         mutable_request.userinfo_signed_response_alg.as_deref(),
-        state.oidc_rsa_key.is_some(),
+        rsa_key,
         client.fapi_profile,
     )?;
 
@@ -2183,7 +2212,7 @@ mod tests {
         );
         assert!(validated.response_types.contains(&"code".to_string()));
         assert_eq!(validated.auth_method_str, "client_secret_basic");
-        assert!(validated.has_auth_code);
+        assert_eq!(validated.auth_code_grant, AuthorizationCodeGrant::Present);
     }
 
     #[test]
@@ -2239,7 +2268,7 @@ mod tests {
         // Deliberately overwrite response_types to omit "code" after construction
         req.response_types = Some(vec!["token".to_string()]); // will fail earlier for "token"
         // Use a minimal non-implicit, non-code type — but those are all rejected.
-        // Instead, craft a request where has_auth_code=true but response_types != ["code"].
+        // Instead, craft a request where the authorization_code grant is present but response_types != ["code"].
         // The only allowed response type is "code", so we must test via a two-step approach:
         // Force grant_types to include authorization_code while response_types is empty.
         let mut req2 = RegistrationRequest {
@@ -2272,7 +2301,7 @@ mod tests {
             make_request_with_grant_response(Some(vec!["client_credentials"]), Some(vec!["code"]));
         let result = validate_grant_and_response_types(&mut req);
         let validated = result.expect("client_credentials + code must be valid");
-        assert!(!validated.has_auth_code);
+        assert_eq!(validated.auth_code_grant, AuthorizationCodeGrant::Absent);
         assert!(
             validated
                 .grant_types
@@ -2318,15 +2347,16 @@ mod tests {
     #[test]
     fn test_validate_redirect_uris_required_for_auth_code_empty() {
         let mut req = make_request_with_redirect_uris(None);
-        let result = validate_redirect_uris(&mut req, true);
+        let result = validate_redirect_uris(&mut req, AuthorizationCodeGrant::Present);
         assert_oauth_error(result, OAuthErrorCode::InvalidClientMetadata);
     }
 
     #[test]
     fn test_validate_redirect_uris_not_required_without_auth_code() {
         let mut req = make_request_with_redirect_uris(None);
-        let result = validate_redirect_uris(&mut req, false);
-        let uris = result.expect("Empty redirect_uris allowed when has_auth_code=false");
+        let result = validate_redirect_uris(&mut req, AuthorizationCodeGrant::Absent);
+        let uris =
+            result.expect("Empty redirect_uris allowed without the authorization_code grant");
         assert!(uris.is_empty());
     }
 
@@ -2336,7 +2366,7 @@ mod tests {
             .map(|_| "https://example.com/callback")
             .collect();
         let mut req = make_request_with_redirect_uris(Some(many));
-        let result = validate_redirect_uris(&mut req, false);
+        let result = validate_redirect_uris(&mut req, AuthorizationCodeGrant::Absent);
         assert_oauth_error(result, OAuthErrorCode::InvalidClientMetadata);
     }
 
@@ -2346,7 +2376,7 @@ mod tests {
             "https://example.com/callback",
             "http://localhost:8080/callback",
         ]));
-        let result = validate_redirect_uris(&mut req, true);
+        let result = validate_redirect_uris(&mut req, AuthorizationCodeGrant::Present);
         let uris = result.expect("Valid URIs must pass");
         assert_eq!(uris.len(), 2);
     }
@@ -2354,7 +2384,7 @@ mod tests {
     #[test]
     fn test_validate_redirect_uris_invalid_uri_rejected() {
         let mut req = make_request_with_redirect_uris(Some(vec!["not a uri !!"]));
-        let result = validate_redirect_uris(&mut req, false);
+        let result = validate_redirect_uris(&mut req, AuthorizationCodeGrant::Absent);
         assert_oauth_error(result, OAuthErrorCode::InvalidRedirectUri);
     }
 
@@ -2857,16 +2887,22 @@ mod tests {
         // Integration of reject_rs256_for_fapi into the userinfo validator.
         // Passing has_rsa_key=true isolates the FAPI rejection from the
         // "no RSA key configured" path.
-        let result =
-            validate_userinfo_signed_response_alg(Some("RS256"), true, FapiProfile::Fapi2Security);
+        let result = validate_userinfo_signed_response_alg(
+            Some("RS256"),
+            RsaSigningKey::Available,
+            FapiProfile::Fapi2Security,
+        );
         assert_rs256_fapi_error(result.map(|_| ()), "userinfo_signed_response_alg");
     }
 
     #[test]
     fn test_validate_userinfo_signed_response_alg_allows_es256_for_fapi() {
         // ES256 is allowed for FAPI clients regardless of RSA key availability.
-        let result =
-            validate_userinfo_signed_response_alg(Some("ES256"), false, FapiProfile::Fapi2Security);
+        let result = validate_userinfo_signed_response_alg(
+            Some("ES256"),
+            RsaSigningKey::Unavailable,
+            FapiProfile::Fapi2Security,
+        );
         let alg = result.expect("ES256 must be accepted for FAPI userinfo");
         assert_eq!(alg, Some(JwsAlgorithm::Es256));
     }

--- a/crates/vouch-tests/tests/db_posture_policies.rs
+++ b/crates/vouch-tests/tests/db_posture_policies.rs
@@ -12,7 +12,7 @@
     reason = "test code: panic on assertion failure is acceptable"
 )]
 
-use vouch_server::db::{self, CreateCustomPolicyParams, UpdateCustomPolicyParams};
+use vouch_server::db::{self, CreateCustomPolicyParams, FieldUpdate, UpdateCustomPolicyParams};
 use vouch_tests::TestHarness;
 
 async fn fresh_org_id(harness: &TestHarness, domain: &str) -> String {
@@ -205,7 +205,7 @@ async fn custom_policy_update_can_activate_and_rename() {
         &org_id,
         UpdateCustomPolicyParams {
             name: Some("new name"),
-            description: Some(None),
+            description: FieldUpdate::Clear,
             cel_expression: Some("device.os_version >= '14'"),
             active: Some(true),
         },
@@ -246,7 +246,7 @@ async fn custom_policy_update_refuses_cross_org_writes() {
         &org_b, // wrong org
         UpdateCustomPolicyParams {
             name: Some("hijacked"),
-            description: None,
+            description: FieldUpdate::Keep,
             cel_expression: None,
             active: None,
         },
@@ -365,7 +365,7 @@ async fn get_active_custom_policies_filters_by_flag() {
         &org_id,
         UpdateCustomPolicyParams {
             name: None,
-            description: None,
+            description: FieldUpdate::Keep,
             cel_expression: None,
             active: Some(true),
         },
@@ -431,7 +431,7 @@ async fn count_active_policies_sums_preconfigured_and_custom() {
         &org_id,
         UpdateCustomPolicyParams {
             name: None,
-            description: None,
+            description: FieldUpdate::Keep,
             cel_expression: None,
             active: Some(true),
         },


### PR DESCRIPTION
Fixes five code-quality issues, one commit per issue.

## #464 — Shared fire-and-forget audit helper
Replaces the seven copy-pasted clone/spawn/warn blocks with a single `db::spawn_audit_event(audit, params, email)` helper, so error handling and the log format for dropped audit records live in one place. `insert_auth_event` is now `pub(super)` — production code goes through the spawn helper; in-crate tests still await the insert directly to verify the returned event ID. Each call site's existing email behavior (Some vs None) is preserved.

## #465 — Explicit re-exports in vouch-common
The `api`, `error`, and `fido2_types` globs in `lib.rs` are replaced with explicit lists covering every public item, making the crate-root API surface reviewable in diffs and turning future cross-module name collisions into compile errors. Verified with `cargo check --workspace --all-targets --all-features`; the fuzz crate imports via module paths and is unaffected. The feature-gated `test_utils` glob in `vouch-cli/src/http.rs` is left as-is per the issue.

## #466 — Type-safety batch
- `validate_fapi_token_request` takes a `SenderConstraints { dpop, mtls_cert }` struct instead of two adjacent bools
- `validate_redirect_uris` takes `AuthorizationCodeGrant::Present/Absent`; `ValidatedGrantTypes` carries the enum
- `validate_userinfo_signed_response_alg` takes `RsaSigningKey::Available/Unavailable`
- `UpdateCustomPolicyParams.description` models keep/clear/set with a `FieldUpdate<'a>` enum instead of `Option<Option<&str>>`
- `SessionCache::get` returns `CacheLookup::{Miss, NegativeHit, Hit}` instead of `Option<Option<Session>>` (`Hit` left unboxed deliberately — it's the hot path; documented `#[expect]` on the variant-size lint)
- `ServerUrl::parse`'s single bool flag left as-is per the issue

## #467 — Function decomposition
Decomposed along natural phase boundaries into a few substantial helpers each — deliberately not fragmented into single-purpose micro-functions:
- `diag.rs run()` (563 lines): device/PIN setup → registration → authentication → signature verification → report → fixture export, with typed phase results (`Registration`, `Authentication`, `Verification`)
- `main.rs run()`: init + helper-binary dispatch and server-URL resolution extracted; the clap dispatch match stays
- `serve.rs serve()`: split into `serve_tls()` / `serve_plain()` along the existing branch, with shared S3-polling and SIGHUP-reload helpers
- `status.rs run()`: agent path vs server-fallback path; the four duplicated unauthenticated output blocks collapse into one `report_unauthenticated` helper
- `doctor.rs`, `credential/aws.rs`, `startup.rs`, `enroll.rs`, `config.rs`: one targeted extraction each (check runner, agent session policies, startup logging summary, device-code request with stale-client retry, base_url derivation)

Intentionally left long: `posture.rs print_text()` — a linear print sequence at a single abstraction level where per-section printers would add indirection without reducing cognitive load. `main.rs`'s dispatch match and `startup.rs build_app_state()` keep their existing `#[expect(too_many_lines)]` rationale. The `dns.rs` OnceLock FIXME now references #467.

## #468 — Idle read timeout on agent IPC
Both server-side connection loops (JSON-RPC agent socket and SSH agent socket) now read through `wire::read_message_timeout` with a 5-minute `IDLE_READ_TIMEOUT`, so abandoned or stalled clients can't pin per-connection tasks and FDs indefinitely. The timeout is a parameter, unit-tested with silent-peer, stalled-mid-message, and pass-through cases. Client-side reads (awaiting a reply to our own request) are unchanged.

## Verification
- `make lint` (clippy `-D warnings` with the workspace no-panic lint set): clean
- `cargo test --workspace` including doctests and `vouch-tests` integration suite: all passing
- `cargo check --workspace --all-targets --all-features`: clean

Fixes #464
Fixes #465
Fixes #466
Fixes #467
Fixes #468

https://claude.ai/code/session_01WrYRvGhzRmrTNVBbKvAczB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrYRvGhzRmrTNVBbKvAczB)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly structural refactors and bounded IPC reads; audit behavior is consolidated but still fire-and-forget, and AWS agent session policy logic is unchanged aside from extraction into `agent_session_policies`.
> 
> **Overview**
> This batch tightens **code quality and resource bounds** across agent IPC, server auth/audit, OIDC validation, and several CLI commands—mostly refactors with one behavioral hardening change.
> 
> **Agent IPC:** Server-side JSON-RPC and SSH agent connection loops now use `read_message_timeout` with a **5-minute** `IDLE_READ_TIMEOUT` so idle or half-open peers cannot hold connection tasks and FDs forever. Client reads stay on untimed `read_message`; new unit tests cover silent peers, stalled mid-message reads, and successful pass-through.
> 
> **Server audit:** Repeated `tokio::spawn` + `insert_auth_event` + warn blocks are replaced by **`db::spawn_audit_event`** (logout, browser login, enrollment, FIDO2 grant, introspection revocation). `insert_auth_event` is `pub(super)` for in-crate tests that need the event ID.
> 
> **Type safety / API clarity:** FAPI token checks take `SenderConstraints`; OAuth registration uses `AuthorizationCodeGrant` and `RsaSigningKey`; posture policy PATCH uses `FieldUpdate` instead of `Option<Option<&str>>`; session cache lookups return `CacheLookup` instead of nested `Option`s. **`vouch-common`** drops glob re-exports for explicit lists on `api`, `error`, and `fido2_types`.
> 
> **CLI / infra refactors:** Large `run()` paths in **diag**, **status**, **doctor**, **enroll**, **main**, and **serve** are split into phase helpers (e.g. `agent_status` / `report_unauthenticated`, `serve_tls` / `serve_plain`, `agent_session_policies` for AWS agent ReadOnlyAccess). Startup logging moves to `log_startup_summary`; base URL derivation is extracted in server config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e446bec86d07f3eabb701c995d0adc8f5737934a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->