### PR TITLE
docs(server): fix stale WebauthnChallengeClaim comment references

### DIFF
--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -452,7 +452,7 @@ pub(crate) async fn browser_login_complete(
 
     // ── Phase 3b: Atomic single-use challenge consume ─────────────────────
     // Mark the authentication state JWT consumed before any side effects.
-    // The returned `WebauthnChallengeClaim` witness is the structural proof
+    // The returned `ChallengeStateClaim` witness is the structural proof
     // threaded into the TokenIssuanceProof below — the only path to
     // `GrantProof::BrowserLogin`. Two concurrent requests with the same
     // state JWT collide on the deterministic PRIMARY KEY; only one wins.

--- a/crates/vouch-server/src/services/oidc/fido2_grant.rs
+++ b/crates/vouch-server/src/services/oidc/fido2_grant.rs
@@ -195,7 +195,7 @@ pub(crate) async fn exchange_fido2_assertion(
 
     // 5. Mark challenge used + look up authenticator in parallel
     //    (independent DB operations on different tables). The returned
-    //    `WebauthnChallengeClaim` witness is the structural proof threaded
+    //    `ChallengeStateClaim` witness is the structural proof threaded
     //    into the TokenIssuanceProof below — the only path to
     //    `GrantProof::Fido2Assertion`.
     let (challenge_claim_result, lookup_result) = tokio::try_join!(


### PR DESCRIPTION
## What changed

Two comments referenced `WebauthnChallengeClaim`, a type name that does not exist — the witness was renamed to `ChallengeStateClaim` during the evolution of #409:

- `crates/vouch-server/src/handlers/browser_login.rs` (browser-login consume step)
- `crates/vouch-server/src/services/oidc/fido2_grant.rs` (FIDO2 assertion grant consume step)

Both now name the actual type. Comment-only change; no code, behavior, or test impact.

## Why

Found during a review of the typestate witness / token-issuance chokepoint work from #409 (`TokenIssuanceProof` / `GrantProof` / `ClientAuthProof` and the `*Claim` witnesses). The review verified the witnesses are sealed (constructible only by their atomic consume operations), the chokepoint has no bypasses (`db::create_session` and `sign_access_token_jwt` are only reachable through `create_oauth_access_token`), test-only escape hatches are cfg-gated with a `compile_error!` guard for release builds, and the concurrent-replay regression tests from #407 still pin the original #391 race. These stale comments were the only defect found.

## Reviewer notes

`rg -n "WebauthnChallengeClaim" crates/` returns no matches after this change; `cargo fmt --check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only comment fixes with zero runtime or behavioral impact.
> 
> **Overview**
> Updates two inline comments so they reference **`ChallengeStateClaim`**, the actual witness type returned by `try_consume_challenge_state`, instead of the obsolete name **`WebauthnChallengeClaim`**.
> 
> The edits are in the browser-login complete handler (Phase 3b consume step) and the FIDO2 assertion grant exchange (parallel consume + lookup). **Comment-only** — no logic, types, or tests change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdace2ea6cee13d5908c15fa0d3560f93fdd18a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->