### PR TITLE
Fix Detail bug reports: registration origin gate, SSRF doc claim, SSH pub-key migration

### DIFF
--- a/crates/vouch-cli/src/commands/credential/ssh.rs
+++ b/crates/vouch-cli/src/commands/credential/ssh.rs
@@ -49,6 +49,26 @@ pub(crate) fn default_key_path() -> Result<PathBuf> {
 pub(crate) fn ensure_keypair(key_path: &Path) -> Result<KeypairAction> {
     let pub_path = key_path.with_added_extension("pub");
 
+    // Releases <= v2026.6.1 wrote the public key with the final extension
+    // replaced (`prod_key.pem` -> `prod_key.pub`) rather than appended
+    // (`prod_key.pem.pub`). Migrate it so the lookup below finds the existing
+    // keypair instead of regenerating — and overwriting — the private key.
+    let old_pub_path = key_path.with_extension("pub");
+    if key_path.exists() && !pub_path.exists() && old_pub_path.exists() {
+        tracing::info!(
+            old_path = %old_pub_path.display(),
+            new_path = %pub_path.display(),
+            "Migrating SSH public key to new location"
+        );
+        std::fs::rename(&old_pub_path, &pub_path).with_context(|| {
+            format!(
+                "failed to migrate public key {} to {}",
+                old_pub_path.display(),
+                pub_path.display()
+            )
+        })?;
+    }
+
     if key_path.exists() && pub_path.exists() {
         // Load existing public key
         let pub_key_str = std::fs::read_to_string(&pub_path)
@@ -574,6 +594,64 @@ mod tests {
 
         let result = check_existing_certificate(&key_path);
         assert!(result.is_none(), "expected None when cert file is missing");
+    }
+
+    /// Write a keypair to disk, returning the generated key. The public key
+    /// is written to `pub_path`, letting tests choose the old (replaced
+    /// extension) or new (appended extension) location.
+    fn write_test_keypair(key_path: &Path, pub_path: &Path) -> PrivateKey {
+        let key = PrivateKey::random(&mut OsRng, Algorithm::Ed25519).unwrap();
+        let key_str = key.to_openssh(LineEnding::LF).unwrap();
+        std::fs::write(key_path, key_str.as_bytes()).unwrap();
+        let pub_str = key.public_key().to_openssh().unwrap();
+        std::fs::write(pub_path, format!("{pub_str}\n")).unwrap();
+        key
+    }
+
+    #[test]
+    fn test_ensure_keypair_migrates_old_style_pub_path() {
+        // Releases <= v2026.6.1 wrote `prod_key.pub` for `prod_key.pem`.
+        // ensure_keypair must find it, migrate it to `prod_key.pem.pub`,
+        // and load the existing keypair instead of regenerating.
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("prod_key.pem");
+        let old_pub_path = dir.path().join("prod_key.pub");
+        let new_pub_path = dir.path().join("prod_key.pem.pub");
+
+        let key = write_test_keypair(&key_path, &old_pub_path);
+        let private_before = std::fs::read(&key_path).unwrap();
+
+        let action = ensure_keypair(&key_path).unwrap();
+
+        assert!(
+            matches!(action, KeypairAction::Loaded(_)),
+            "expected existing keypair to be loaded, not regenerated"
+        );
+        assert_eq!(action.public_key(), key.public_key());
+        assert_eq!(
+            std::fs::read(&key_path).unwrap(),
+            private_before,
+            "private key must not be overwritten"
+        );
+        assert!(new_pub_path.exists(), "public key migrated to new location");
+        assert!(!old_pub_path.exists(), "old public key location removed");
+    }
+
+    #[test]
+    fn test_ensure_keypair_loads_new_style_pub_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("prod_key.pem");
+        let pub_path = dir.path().join("prod_key.pem.pub");
+
+        let key = write_test_keypair(&key_path, &pub_path);
+        let private_before = std::fs::read(&key_path).unwrap();
+
+        let action = ensure_keypair(&key_path).unwrap();
+
+        assert!(matches!(action, KeypairAction::Loaded(_)));
+        assert_eq!(action.public_key(), key.public_key());
+        assert_eq!(std::fs::read(&key_path).unwrap(), private_before);
+        assert!(pub_path.exists());
     }
 
     #[test]

--- a/crates/vouch-server/src/crypto/webauthn_verify.rs
+++ b/crates/vouch-server/src/crypto/webauthn_verify.rs
@@ -393,6 +393,11 @@ pub struct RegistrationVerificationResult {
 /// 5. For `fmt="none"`: accept (no attestation statement)
 ///
 /// Returns the server-verified credential ID, public key, and AAGUID.
+///
+/// `allow_localhost_origin` gates the loopback origin-variation relaxation:
+/// it must be `true` only in development (no TLS). Production threads `false`
+/// so an origin mismatch is always rejected even on a misconfigured loopback
+/// `rp_id`.
 pub fn verify_registration(
     attestation_object: &[u8],
     client_data_json: &[u8],
@@ -400,6 +405,7 @@ pub fn verify_registration(
     expected_challenge: &str,
     expected_origin: &str,
     require_user_verification: bool,
+    allow_localhost_origin: bool,
 ) -> Result<RegistrationVerificationResult, VerifyError> {
     verify_registration_with_verifier(
         attestation_object,
@@ -408,6 +414,7 @@ pub fn verify_registration(
         expected_challenge,
         expected_origin,
         require_user_verification,
+        allow_localhost_origin,
         &RealCoseVerifier,
     )
 }
@@ -415,6 +422,10 @@ pub fn verify_registration(
 /// Verify a WebAuthn registration with a custom COSE verifier.
 ///
 /// This is the testable version of [`verify_registration`].
+#[expect(
+    clippy::too_many_arguments,
+    reason = "mirrors verify_registration; a params struct would churn all callers"
+)]
 pub fn verify_registration_with_verifier<V: CoseVerifier>(
     attestation_object: &[u8],
     client_data_json: &[u8],
@@ -422,6 +433,7 @@ pub fn verify_registration_with_verifier<V: CoseVerifier>(
     expected_challenge: &str,
     expected_origin: &str,
     require_user_verification: bool,
+    allow_localhost_origin: bool,
     verifier: &V,
 ) -> Result<RegistrationVerificationResult, VerifyError> {
     // 1. Parse attestation_object CBOR
@@ -553,11 +565,15 @@ pub fn verify_registration_with_verifier<V: CoseVerifier>(
             .and_then(|u| u.host_str().map(String::from))
             .is_some_and(|h| vouch_common::is_loopback_host(&h));
 
-        if expected_is_local && origin_is_local {
-            tracing::debug!(
+        let is_localhost_match = allow_localhost_origin && expected_is_local && origin_is_local;
+
+        if is_localhost_match {
+            tracing::warn!(
+                target: "security",
                 expected = %expected_origin,
                 actual = %client_data.origin,
-                "Allowing localhost origin variation for registration (development mode)"
+                "Allowing localhost origin variation for registration (development mode) -- \
+                 this relaxation is disabled when TLS is configured"
             );
         } else {
             return Err(VerifyError::InvalidOrigin);
@@ -2234,6 +2250,7 @@ mod tests {
             challenge,
             origin,
             true,
+            true,
             &TestCoseVerifier::always_succeed(),
         )
         .unwrap_err();
@@ -2261,6 +2278,7 @@ mod tests {
             challenge,
             origin,
             true,
+            true,
             &TestCoseVerifier::always_succeed(),
         )
         .unwrap_err();
@@ -2269,5 +2287,56 @@ mod tests {
             matches!(err, VerifyError::InvalidAuthDataLength),
             "got {err:?}"
         );
+    }
+
+    #[test]
+    fn test_registration_localhost_origin_relaxation_allowed_when_enabled() {
+        // With relaxation enabled (development), a loopback origin variation
+        // (localhost vs 127.0.0.1, differing ports) is accepted.
+        let rp_id = "localhost";
+        let challenge = "test-challenge";
+        let cose_key = make_eddsa_cose_key(&[0u8; 32]);
+        let auth_data = make_registration_auth_data(rp_id, [1; 16], b"cred-id", &cose_key);
+        let attestation = make_attestation_object_none(&auth_data);
+        let client_data =
+            make_client_data_json("webauthn.create", challenge, "http://127.0.0.1:9000");
+
+        let result = verify_registration_with_verifier(
+            &attestation,
+            &client_data,
+            rp_id,
+            challenge,
+            "http://localhost:8080",
+            true,
+            true,
+            &TestCoseVerifier::always_succeed(),
+        );
+        assert!(result.is_ok(), "expected ok, got {result:?}");
+    }
+
+    #[test]
+    fn test_registration_localhost_origin_relaxation_rejected_when_disabled() {
+        // With relaxation disabled (production), the same loopback origin
+        // variation is rejected: production must never weaken origin binding,
+        // even on a misconfigured loopback rp_id.
+        let rp_id = "localhost";
+        let challenge = "test-challenge";
+        let cose_key = make_eddsa_cose_key(&[0u8; 32]);
+        let auth_data = make_registration_auth_data(rp_id, [1; 16], b"cred-id", &cose_key);
+        let attestation = make_attestation_object_none(&auth_data);
+        let client_data =
+            make_client_data_json("webauthn.create", challenge, "http://127.0.0.1:9000");
+
+        let result = verify_registration_with_verifier(
+            &attestation,
+            &client_data,
+            rp_id,
+            challenge,
+            "http://localhost:8080",
+            true,
+            false,
+            &TestCoseVerifier::always_succeed(),
+        );
+        assert!(matches!(result, Err(VerifyError::InvalidOrigin)));
     }
 }

--- a/crates/vouch-server/src/crypto/webauthn_verify.rs
+++ b/crates/vouch-server/src/crypto/webauthn_verify.rs
@@ -226,6 +226,50 @@ pub fn verify_assertion_with_verifier<V: CoseVerifier>(
     verify_assertion_inner(params, verifier)
 }
 
+/// Verify the client-data origin for both assertion and registration flows.
+///
+/// `allow_localhost_origin` gates the loopback origin-variation relaxation
+/// (e.g. `localhost` ↔ `127.0.0.1`): it must be `true` only in development
+/// (no TLS). Production threads `false` so an origin mismatch is always
+/// rejected even on a misconfigured loopback `rp_id`.
+///
+/// Note: the relaxation intentionally does not compare ports — the server
+/// may listen on one port while the browser constructs an origin with a
+/// different one.
+fn verify_origin(
+    presented_origin: &str,
+    expected_origin: &str,
+    allow_localhost_origin: bool,
+    flow: &str,
+) -> Result<(), VerifyError> {
+    if presented_origin == expected_origin {
+        return Ok(());
+    }
+
+    let expected_is_local = url::Url::parse(expected_origin)
+        .ok()
+        .and_then(|u| u.host_str().map(String::from))
+        .is_some_and(|h| vouch_common::is_loopback_host(&h));
+    let origin_is_local = url::Url::parse(presented_origin)
+        .ok()
+        .and_then(|u| u.host_str().map(String::from))
+        .is_some_and(|h| vouch_common::is_loopback_host(&h));
+
+    if allow_localhost_origin && expected_is_local && origin_is_local {
+        tracing::warn!(
+            target: "security",
+            flow,
+            expected = %expected_origin,
+            actual = %presented_origin,
+            "Allowing localhost origin variation (development mode) -- \
+             this relaxation is disabled when TLS is configured"
+        );
+        Ok(())
+    } else {
+        Err(VerifyError::InvalidOrigin)
+    }
+}
+
 /// Core WebAuthn assertion verification.
 ///
 /// `params.allow_localhost_origin` gates the loopback origin-variation
@@ -322,32 +366,12 @@ fn verify_assertion_inner<V: CoseVerifier>(
     }
 
     // Verify origin
-    if client_data.origin != expected_origin {
-        // Allow localhost variations for development (e.g. localhost ↔ 127.0.0.1).
-        // Note: this intentionally does not compare ports — the server may listen
-        // on one port while the browser constructs an origin with a different one.
-        let expected_is_local = url::Url::parse(expected_origin)
-            .ok()
-            .and_then(|u| u.host_str().map(String::from))
-            .is_some_and(|h| vouch_common::is_loopback_host(&h));
-        let origin_is_local = url::Url::parse(&client_data.origin)
-            .ok()
-            .and_then(|u| u.host_str().map(String::from))
-            .is_some_and(|h| vouch_common::is_loopback_host(&h));
-        let is_localhost_match = allow_localhost_origin && expected_is_local && origin_is_local;
-
-        if is_localhost_match {
-            tracing::warn!(
-                target: "security",
-                expected = %expected_origin,
-                actual = %client_data.origin,
-                "Allowing localhost origin variation (development mode) -- \
-                 this relaxation is disabled when TLS is configured"
-            );
-        } else {
-            return Err(VerifyError::InvalidOrigin);
-        }
-    }
+    verify_origin(
+        &client_data.origin,
+        expected_origin,
+        allow_localhost_origin,
+        "assertion",
+    )?;
 
     // 7. Build signed data: authenticator_data || SHA-256(client_data_json)
     let client_data_hash = digest::digest(&SHA256, client_data_json);
@@ -383,6 +407,30 @@ pub struct RegistrationVerificationResult {
     pub attestation_verified: bool,
 }
 
+/// Parameters for WebAuthn registration (attestation) verification
+/// (WebAuthn Level 2 §7.1).
+///
+/// Named fields prevent the positional byte-slice/string swaps an 8-argument
+/// signature would invite.
+#[derive(Debug, Clone, Copy)]
+pub struct RegistrationParams<'a> {
+    /// Raw attestation object bytes (CBOR).
+    pub attestation_object: &'a [u8],
+    /// Raw client data JSON bytes.
+    pub client_data_json: &'a [u8],
+    /// The expected relying party ID.
+    pub expected_rp_id: &'a str,
+    /// The expected challenge (base64url encoded).
+    pub expected_challenge: &'a str,
+    /// The expected origin URL.
+    pub expected_origin: &'a str,
+    /// Whether to require the UV flag.
+    pub require_user_verification: bool,
+    /// Whether to tolerate loopback origin variations. Development only; pass
+    /// `false` in production so an origin mismatch is always rejected.
+    pub allow_localhost_origin: bool,
+}
+
 /// Verify a WebAuthn registration (attestation) response.
 ///
 /// Implements WebAuthn Level 2 Section 7.1 verification steps:
@@ -393,21 +441,20 @@ pub struct RegistrationVerificationResult {
 /// 5. For `fmt="none"`: accept (no attestation statement)
 ///
 /// Returns the server-verified credential ID, public key, and AAGUID.
-///
-/// `allow_localhost_origin` gates the loopback origin-variation relaxation:
-/// it must be `true` only in development (no TLS). Production threads `false`
-/// so an origin mismatch is always rejected even on a misconfigured loopback
-/// `rp_id`.
 pub fn verify_registration(
-    attestation_object: &[u8],
-    client_data_json: &[u8],
-    expected_rp_id: &str,
-    expected_challenge: &str,
-    expected_origin: &str,
-    require_user_verification: bool,
-    allow_localhost_origin: bool,
+    params: &RegistrationParams<'_>,
 ) -> Result<RegistrationVerificationResult, VerifyError> {
-    verify_registration_with_verifier(
+    verify_registration_with_verifier(params, &RealCoseVerifier)
+}
+
+/// Verify a WebAuthn registration with a custom COSE verifier.
+///
+/// This is the testable version of [`verify_registration`].
+pub fn verify_registration_with_verifier<V: CoseVerifier>(
+    params: &RegistrationParams<'_>,
+    verifier: &V,
+) -> Result<RegistrationVerificationResult, VerifyError> {
+    let &RegistrationParams {
         attestation_object,
         client_data_json,
         expected_rp_id,
@@ -415,27 +462,8 @@ pub fn verify_registration(
         expected_origin,
         require_user_verification,
         allow_localhost_origin,
-        &RealCoseVerifier,
-    )
-}
+    } = params;
 
-/// Verify a WebAuthn registration with a custom COSE verifier.
-///
-/// This is the testable version of [`verify_registration`].
-#[expect(
-    clippy::too_many_arguments,
-    reason = "mirrors verify_registration; a params struct would churn all callers"
-)]
-pub fn verify_registration_with_verifier<V: CoseVerifier>(
-    attestation_object: &[u8],
-    client_data_json: &[u8],
-    expected_rp_id: &str,
-    expected_challenge: &str,
-    expected_origin: &str,
-    require_user_verification: bool,
-    allow_localhost_origin: bool,
-    verifier: &V,
-) -> Result<RegistrationVerificationResult, VerifyError> {
     // 1. Parse attestation_object CBOR
     let att_obj: ciborium::Value = ciborium::from_reader(attestation_object)
         .map_err(|e| VerifyError::InvalidClientData(format!("Invalid attestation CBOR: {e}")))?;
@@ -554,31 +582,13 @@ pub fn verify_registration_with_verifier<V: CoseVerifier>(
         return Err(VerifyError::ChallengeMismatch);
     }
 
-    // Verify origin (reuse the same localhost relaxation logic as assertion)
-    if client_data.origin != expected_origin {
-        let expected_is_local = url::Url::parse(expected_origin)
-            .ok()
-            .and_then(|u| u.host_str().map(String::from))
-            .is_some_and(|h| vouch_common::is_loopback_host(&h));
-        let origin_is_local = url::Url::parse(&client_data.origin)
-            .ok()
-            .and_then(|u| u.host_str().map(String::from))
-            .is_some_and(|h| vouch_common::is_loopback_host(&h));
-
-        let is_localhost_match = allow_localhost_origin && expected_is_local && origin_is_local;
-
-        if is_localhost_match {
-            tracing::warn!(
-                target: "security",
-                expected = %expected_origin,
-                actual = %client_data.origin,
-                "Allowing localhost origin variation for registration (development mode) -- \
-                 this relaxation is disabled when TLS is configured"
-            );
-        } else {
-            return Err(VerifyError::InvalidOrigin);
-        }
-    }
+    // Verify origin (same localhost relaxation gating as assertion)
+    verify_origin(
+        &client_data.origin,
+        expected_origin,
+        allow_localhost_origin,
+        "registration",
+    )?;
 
     // 4. Verify attestation statement based on format
     let mut attestation_verified = false;
@@ -2244,13 +2254,15 @@ mod tests {
         let client_data = make_client_data_json("webauthn.create", challenge, origin);
 
         let err = verify_registration_with_verifier(
-            &attestation,
-            &client_data,
-            rp_id,
-            challenge,
-            origin,
-            true,
-            true,
+            &RegistrationParams {
+                attestation_object: &attestation,
+                client_data_json: &client_data,
+                expected_rp_id: rp_id,
+                expected_challenge: challenge,
+                expected_origin: origin,
+                require_user_verification: true,
+                allow_localhost_origin: true,
+            },
             &TestCoseVerifier::always_succeed(),
         )
         .unwrap_err();
@@ -2272,13 +2284,15 @@ mod tests {
         let client_data = make_client_data_json("webauthn.create", challenge, origin);
 
         let err = verify_registration_with_verifier(
-            &attestation,
-            &client_data,
-            rp_id,
-            challenge,
-            origin,
-            true,
-            true,
+            &RegistrationParams {
+                attestation_object: &attestation,
+                client_data_json: &client_data,
+                expected_rp_id: rp_id,
+                expected_challenge: challenge,
+                expected_origin: origin,
+                require_user_verification: true,
+                allow_localhost_origin: true,
+            },
             &TestCoseVerifier::always_succeed(),
         )
         .unwrap_err();
@@ -2302,13 +2316,15 @@ mod tests {
             make_client_data_json("webauthn.create", challenge, "http://127.0.0.1:9000");
 
         let result = verify_registration_with_verifier(
-            &attestation,
-            &client_data,
-            rp_id,
-            challenge,
-            "http://localhost:8080",
-            true,
-            true,
+            &RegistrationParams {
+                attestation_object: &attestation,
+                client_data_json: &client_data,
+                expected_rp_id: rp_id,
+                expected_challenge: challenge,
+                expected_origin: "http://localhost:8080",
+                require_user_verification: true,
+                allow_localhost_origin: true,
+            },
             &TestCoseVerifier::always_succeed(),
         );
         assert!(result.is_ok(), "expected ok, got {result:?}");
@@ -2328,13 +2344,15 @@ mod tests {
             make_client_data_json("webauthn.create", challenge, "http://127.0.0.1:9000");
 
         let result = verify_registration_with_verifier(
-            &attestation,
-            &client_data,
-            rp_id,
-            challenge,
-            "http://localhost:8080",
-            true,
-            false,
+            &RegistrationParams {
+                attestation_object: &attestation,
+                client_data_json: &client_data,
+                expected_rp_id: rp_id,
+                expected_challenge: challenge,
+                expected_origin: "http://localhost:8080",
+                require_user_verification: true,
+                allow_localhost_origin: false,
+            },
             &TestCoseVerifier::always_succeed(),
         );
         assert!(matches!(result, Err(VerifyError::InvalidOrigin)));

--- a/crates/vouch-server/src/handlers/keys.rs
+++ b/crates/vouch-server/src/handlers/keys.rs
@@ -248,17 +248,17 @@ pub(crate) async fn register_complete(
     let config = state.config();
     let challenge_b64 =
         base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(reg_state.challenge.as_bytes());
-    let verified = webauthn_verify::verify_registration(
-        req.attestation_object.as_bytes(),
-        req.client_data_json.as_bytes(),
-        &reg_state.rp_id,
-        &challenge_b64,
-        &config.base_url,
-        true, // require user verification
+    let verified = webauthn_verify::verify_registration(&webauthn_verify::RegistrationParams {
+        attestation_object: req.attestation_object.as_bytes(),
+        client_data_json: req.client_data_json.as_bytes(),
+        expected_rp_id: &reg_state.rp_id,
+        expected_challenge: &challenge_b64,
+        expected_origin: &config.base_url,
+        require_user_verification: true,
         // Loopback origin relaxation is development-only: disabled as soon
         // as TLS is configured, matching assertion verification.
-        !config.tls_configured(),
-    )
+        allow_localhost_origin: !config.tls_configured(),
+    })
     .map_err(|e| {
         tracing::warn!("Registration attestation verification failed: {e}");
         ServiceError::api(

--- a/crates/vouch-server/src/handlers/keys.rs
+++ b/crates/vouch-server/src/handlers/keys.rs
@@ -255,6 +255,9 @@ pub(crate) async fn register_complete(
         &challenge_b64,
         &config.base_url,
         true, // require user verification
+        // Loopback origin relaxation is development-only: disabled as soon
+        // as TLS is configured, matching assertion verification.
+        !config.tls_configured(),
     )
     .map_err(|e| {
         tracing::warn!("Registration attestation verification failed: {e}");

--- a/crates/vouch-server/src/infra/dns.rs
+++ b/crates/vouch-server/src/infra/dns.rs
@@ -44,10 +44,12 @@ fn resolver() -> Result<&'static TokioResolver> {
 /// process-wide system resolver.
 ///
 /// Used by the SSRF egress guard ([`crate::infra::ssrf`]) to vet
-/// client-controlled fetch destinations before they are requested. The same
-/// system resolver backs the server's `reqwest` client (no DoH override is
-/// installed server-side), so the addresses returned here are the ones the
-/// HTTP client will dial.
+/// client-controlled fetch destinations before they are requested. Note that
+/// `reqwest` builds its own resolver with an independent cache (the server
+/// does not install a shared process resolver), so the addresses returned
+/// here are not guaranteed to be the ones the HTTP client dials — a record
+/// change between check and fetch can diverge. The guard is a best-effort
+/// pre-flight check; TLS validation protects the subsequent fetch.
 ///
 /// # Errors
 ///


### PR DESCRIPTION
Fixes the three bugs reported by Detail.

## #478 — WebAuthn registration missing `allow_localhost_origin` gate

The loopback origin-variation relaxation in `verify_registration_with_verifier` was left ungated when commit 5767254 gated the identical logic for assertion verification. Registration now takes an `allow_localhost_origin` parameter and applies the same `is_localhost_match` check (with the same `warn!(target: "security", ...)` log) as `verify_assertion_inner`. The CLI registration handler (`handlers/keys.rs`) threads `!config.tls_configured()`, matching `fido2_grant.rs` and `browser_login.rs`, so production deployments always reject origin mismatches.

New tests mirror the assertion pair: loopback variation accepted with the flag enabled, rejected with `VerifyError::InvalidOrigin` when disabled.

## #477 — False security claim in SSRF egress guard doc comment

`resolve_host_ips` claimed the addresses it returns "are the ones the HTTP client will dial", but `reqwest` builds its own resolver with an independent cache (vouch-server installs no shared process resolver). The comment now states the guard is a best-effort pre-flight check whose results can diverge from what reqwest dials, with TLS validation protecting the subsequent fetch. Doc-only change.

## #476 — Upgrading regenerates SSH keys for custom key paths with extensions

Releases ≤ v2026.6.1 wrote the public key with the final extension replaced (`prod_key.pem` → `prod_key.pub`); main switched to `with_added_extension` (`prod_key.pem.pub`), so `ensure_keypair` missed the old file and silently regenerated the keypair, **overwriting the existing private key**. `ensure_keypair` now renames the old-style public key to the new location before the existence check. The default key name (`id_ed25519_vouch`, no extension) produces identical old/new paths, so default setups are unaffected and the agent's read-only check needs no change.

Tests cover migration from the old-style path (keypair loaded, private key bytes untouched, pub file relocated) and the new-style path.

## Verification

- `make lint` (clippy, all targets/features, `-D warnings`) — clean
- `make fmt` — applied
- `make test` — 31 suites, 0 failures, including the 4 new tests

Fixes #476
Fixes #477
Fixes #478

https://claude.ai/code/session_01QKcwA3oZp4jqmZNC39np2J

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKcwA3oZp4jqmZNC39np2J)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WebAuthn origin binding and SSH key persistence on upgrade; behavior changes are intentional security and data-loss fixes with new tests, but registration and credential paths warrant careful review.
> 
> **Overview**
> Fixes three Detail-reported issues across CLI SSH provisioning, WebAuthn registration verification, and SSRF documentation.
> 
> **SSH (`ensure_keypair`)** — Before checking for an existing keypair, the CLI **renames** legacy public-key paths (`prod_key.pub`) to the current layout (`prod_key.pem.pub`) so upgrades do not miss the old `.pub` file and **regenerate/overwrite** the private key. Tests cover migration and the new-style path.
> 
> **WebAuthn registration** — Registration verification now uses a shared **`verify_origin`** helper and a **`RegistrationParams`** struct (including **`allow_localhost_origin`**). Loopback origin relaxation for registration is **gated the same way as assertions** (only when allowed); **`register_complete`** passes **`!config.tls_configured()`**, closing a gap where registration could accept origin mismatches in production. New tests mirror the assertion enable/disable behavior.
> 
> **SSRF DNS docs** — **`resolve_host_ips`** documentation no longer claims DNS results always match what **`reqwest`** dials; it describes a best-effort pre-flight check with possible check/fetch divergence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25a3b5b2811623db5758a29046bb5cdfd0c46873. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->