### PR TITLE
Add manually-dispatched test AMI build workflow

### DIFF
--- a/.github/workflows/ami-test.yml
+++ b/.github/workflows/ami-test.yml
@@ -89,6 +89,16 @@ jobs:
           role-session-name: test-ami-build-${{ inputs.arch }}
           mask-aws-account-id: true
 
+      - name: Clean up artifacts from previous run attempts
+        env:
+          S3_BUCKET: ${{ vars.AMI_BUILD_BUCKET }}
+          S3_PREFIX: ami-test-builds/${{ github.run_id }}
+        run: |
+          # Re-runs keep the same run_id; stale build-status.txt/snapshot-id.txt
+          # from a previous attempt would otherwise satisfy the polling below
+          echo "Removing stale artifacts at s3://${S3_BUCKET}/${S3_PREFIX}/"
+          aws s3 rm "s3://${S3_BUCKET}/${S3_PREFIX}/" --recursive 2>/dev/null || true
+
       - name: Upload AMI files to S3
         env:
           S3_BUCKET: ${{ vars.AMI_BUILD_BUCKET }}

--- a/.github/workflows/ami-test.yml
+++ b/.github/workflows/ami-test.yml
@@ -1,0 +1,448 @@
+name: Test AMI Build
+
+# Builds a test AMI from the packaging/ami files on the dispatched branch and
+# boot-verifies it (FIPS mode, no kernel panic) via the serial console. Unlike
+# the release "Build AMI" workflow this does not require a release tag for the
+# AMI itself: the vouch-server binary is borrowed from an existing release,
+# while the image definition comes from the branch under test. No region
+# copies and no SSM parameter updates are performed, and the test AMI is
+# deleted after verification unless keep_ami is set.
+
+on:
+  workflow_dispatch:
+    inputs:
+      binary_tag:
+        description: 'Existing release tag whose vouch-server RPM to use (e.g., v0.1.0)'
+        required: true
+        type: string
+      arch:
+        description: 'Architecture to build and boot-test'
+        required: true
+        type: choice
+        default: x86_64
+        options:
+          - x86_64
+          - arm64
+      keep_ami:
+        description: 'Keep the test AMI and snapshot after verification'
+        required: false
+        type: boolean
+        default: false
+
+permissions: {}
+
+env:
+  AWS_REGION: us-east-1
+
+jobs:
+  build:
+    name: Build test AMI (${{ inputs.arch }})
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      ami_id: ${{ steps.register.outputs.ami_id }}
+      snapshot_id: ${{ steps.build.outputs.snapshot_id }}
+      instance_type: ${{ steps.version.outputs.instance_type }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          sparse-checkout: packaging/ami
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Validate inputs
+        id: version
+        env:
+          TAG: ${{ inputs.binary_tag }}
+          ARCH: ${{ inputs.arch }}
+          SHA: ${{ github.sha }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          # Validate tag format (must be vX.Y.Z or vX.Y.Z-suffix)
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "ERROR: Invalid tag format '${TAG}'. Must be a semantic version tag (e.g., v1.0.0 or v1.0.0-beta.1)"
+            exit 1
+          fi
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+          # Test AMI name: unique per run, never collides with release AMI names
+          echo "ami_name=vouch-server-test-${RUN_ID}-${ARCH}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+          if [ "$ARCH" = "x86_64" ]; then
+            echo "instance_type=m5.xlarge" >> "$GITHUB_OUTPUT"
+          else
+            echo "instance_type=m6g.xlarge" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "Building test AMI from $(git rev-parse HEAD 2>/dev/null || echo "$SHA") with vouch-server ${TAG}"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: ${{ vars.ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: test-ami-build-${{ inputs.arch }}
+          mask-aws-account-id: true
+
+      - name: Upload AMI files to S3
+        env:
+          S3_BUCKET: ${{ vars.AMI_BUILD_BUCKET }}
+          S3_PREFIX: ami-test-builds/${{ github.run_id }}
+          SECUREBOOT_DB_KEY: ${{ secrets.SECUREBOOT_DB_KEY }}
+        run: |
+          tar -czf /tmp/ami-files.tar.gz -C packaging/ami .
+          aws s3 cp /tmp/ami-files.tar.gz "s3://${S3_BUCKET}/${S3_PREFIX}/ami-files.tar.gz"
+
+          SB_PREFIX="${S3_PREFIX}/secureboot"
+          printf '%s' "$SECUREBOOT_DB_KEY" > /tmp/DB.key
+          aws s3 cp /tmp/DB.key "s3://${S3_BUCKET}/${SB_PREFIX}/DB.key"
+          aws s3 cp packaging/ami/secureboot/DB.crt "s3://${S3_BUCKET}/${SB_PREFIX}/DB.crt"
+          shred -u /tmp/DB.key 2>/dev/null || rm -f /tmp/DB.key
+
+      - name: Get latest AL2023 AMI
+        id: ami
+        env:
+          ARCH: ${{ inputs.arch }}
+        run: |
+          AMI_ID=$(aws ssm get-parameter \
+            --name "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.18-${ARCH}" \
+            --query 'Parameter.Value' \
+            --output text)
+          echo "base_ami=${AMI_ID}" >> "$GITHUB_OUTPUT"
+
+      - name: Launch build instance
+        id: instance
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          S3_BUCKET: ${{ vars.AMI_BUILD_BUCKET }}
+          S3_PREFIX: ami-test-builds/${{ github.run_id }}/${{ inputs.arch }}
+          S3_PARENT_PREFIX: ami-test-builds/${{ github.run_id }}
+          SB_KEY_S3_PATH: s3://${{ vars.AMI_BUILD_BUCKET }}/ami-test-builds/${{ github.run_id }}/secureboot
+          BASE_AMI: ${{ steps.ami.outputs.base_ami }}
+          INSTANCE_TYPE: ${{ steps.version.outputs.instance_type }}
+          SUBNET_ID: ${{ vars.AMI_BUILD_SUBNET_ID }}
+          ARCH: ${{ inputs.arch }}
+        run: |
+          # Generate user-data from template
+          # envsubst needs literal $VAR names, not shell expansion
+          # shellcheck disable=SC2016
+          envsubst '$VERSION $AWS_REGION $S3_BUCKET $S3_PREFIX $S3_PARENT_PREFIX $SB_KEY_S3_PATH' < packaging/ami/user-data.sh.tpl > /tmp/user-data.sh
+
+          INSTANCE_ID=$(aws ec2 run-instances \
+            --image-id "${BASE_AMI}" \
+            --instance-type "${INSTANCE_TYPE}" \
+            --subnet-id "${SUBNET_ID}" \
+            --iam-instance-profile Name=VouchAMIBuilder \
+            --block-device-mappings '[{"DeviceName":"/dev/xvda","Ebs":{"VolumeSize":30,"VolumeType":"gp3","DeleteOnTermination":true}}]' \
+            --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=vouch-ami-test-builder-${ARCH}}]" \
+            --user-data file:///tmp/user-data.sh \
+            --query 'Instances[0].InstanceId' \
+            --output text)
+
+          echo "instance_id=${INSTANCE_ID}" >> "$GITHUB_OUTPUT"
+          echo "Launched build instance: ${INSTANCE_ID}"
+
+          aws ec2 wait instance-running --instance-ids "${INSTANCE_ID}"
+          echo "Instance is running, build started via user-data"
+
+      - name: Wait for build to complete
+        id: build
+        env:
+          S3_BUCKET: ${{ vars.AMI_BUILD_BUCKET }}
+          S3_PREFIX: ami-test-builds/${{ github.run_id }}/${{ inputs.arch }}
+        run: |
+          echo "Waiting for build to complete (polling S3 for status)..."
+
+          # Poll for build-status.txt (max 1 hour)
+          for attempt in {1..120}; do
+            if aws s3 ls "s3://${S3_BUCKET}/${S3_PREFIX}/build-status.txt" >/dev/null 2>&1; then
+              echo "Build status file found"
+              break
+            fi
+
+            if [ "$attempt" -eq 120 ]; then
+              echo "Build timed out after 1 hour"
+              aws s3 cp "s3://${S3_BUCKET}/${S3_PREFIX}/build.log" /tmp/build.log 2>/dev/null && cat /tmp/build.log || true
+              exit 1
+            fi
+
+            echo "Build in progress (attempt $attempt/120)..."
+            sleep 30
+          done
+
+          aws s3 cp "s3://${S3_BUCKET}/${S3_PREFIX}/build-status.txt" /tmp/build-status.txt
+          STATUS=$(cat /tmp/build-status.txt)
+          echo "Build status: ${STATUS}"
+
+          echo "=== Build Log ==="
+          aws s3 cp "s3://${S3_BUCKET}/${S3_PREFIX}/build.log" /tmp/build.log 2>/dev/null && cat /tmp/build.log || echo "No build log found"
+
+          if [ "$STATUS" != "SUCCESS" ]; then
+            echo "Build failed"
+            exit 1
+          fi
+
+          aws s3 cp "s3://${S3_BUCKET}/${S3_PREFIX}/snapshot-id.txt" /tmp/snapshot-id.txt
+          SNAPSHOT_ID=$(cat /tmp/snapshot-id.txt)
+          echo "snapshot_id=${SNAPSHOT_ID}" >> "$GITHUB_OUTPUT"
+
+      - name: Register test AMI
+        id: register
+        env:
+          AMI_NAME: ${{ steps.version.outputs.ami_name }}
+          SNAPSHOT_ID: ${{ steps.build.outputs.snapshot_id }}
+          ARCH: ${{ inputs.arch }}
+          BINARY_TAG: ${{ inputs.binary_tag }}
+          REPOSITORY: ${{ github.repository }}
+          COMMIT_SHA: ${{ github.sha }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          echo "Waiting for snapshot ${SNAPSHOT_ID} to be available..."
+          aws ec2 wait snapshot-completed --snapshot-ids "${SNAPSHOT_ID}"
+
+          # Load UEFI variable store with Secure Boot keys
+          UEFI_DATA=""
+          UEFI_VARS_FILE="packaging/ami/secureboot/uefi-vars.b64"
+          if [ -f "$UEFI_VARS_FILE" ]; then
+            UEFI_DATA=$(cat "$UEFI_VARS_FILE")
+            echo "Loaded UEFI variable store for Secure Boot"
+          else
+            echo "WARNING: No UEFI variable store found at ${UEFI_VARS_FILE}"
+          fi
+
+          REGISTER_ARGS=(
+            --name "${AMI_NAME}"
+            --description "Vouch Server TEST AMI (branch ${BRANCH}, binary ${BINARY_TAG}) - not for release"
+            --virtualization-type hvm
+            --boot-mode uefi
+            --architecture "${ARCH}"
+            --root-device-name /dev/xvda
+            --block-device-mappings "DeviceName=/dev/xvda,Ebs={SnapshotId=${SNAPSHOT_ID},VolumeType=gp3,DeleteOnTermination=true}"
+            --tpm-support v2.0
+            --ena-support
+            --query 'ImageId'
+            --output text
+          )
+
+          if [ -n "$UEFI_DATA" ]; then
+            REGISTER_ARGS+=(--uefi-data "$UEFI_DATA")
+          fi
+
+          AMI_ID=$(aws ec2 register-image "${REGISTER_ARGS[@]}")
+
+          echo "ami_id=${AMI_ID}" >> "$GITHUB_OUTPUT"
+          echo "Registered test AMI: ${AMI_ID}"
+
+          aws ec2 create-tags --resources "${AMI_ID}" "${SNAPSHOT_ID}" --tags \
+            "Key=Name,Value=${AMI_NAME}" \
+            "Key=Test,Value=true" \
+            "Key=BinaryTag,Value=${BINARY_TAG}" \
+            "Key=Branch,Value=${BRANCH}" \
+            "Key=Repository,Value=${REPOSITORY}" \
+            "Key=Commit,Value=${COMMIT_SHA}"
+
+      - name: Tag AMI with PCR measurements
+        env:
+          S3_BUCKET: ${{ vars.AMI_BUILD_BUCKET }}
+          S3_PREFIX: ami-test-builds/${{ github.run_id }}/${{ inputs.arch }}
+          AMI_ID: ${{ steps.register.outputs.ami_id }}
+        run: |
+          if aws s3 cp "s3://${S3_BUCKET}/${S3_PREFIX}/pcr_measurements.json" /tmp/pcr_measurements.json 2>/dev/null; then
+            echo "PCR measurements downloaded"
+            cat /tmp/pcr_measurements.json
+
+            TAG_ARGS=()
+            for PCR in PCR4 PCR7 PCR12; do
+              VALUE=$(python3 -c "import json,sys; d=json.load(open('/tmp/pcr_measurements.json')); print(d.get('$PCR', ''))")
+              if [ -n "$VALUE" ]; then
+                TAG_ARGS+=("Key=${PCR},Value=${VALUE}")
+                echo "${PCR}: ${VALUE}"
+              fi
+            done
+
+            if [ ${#TAG_ARGS[@]} -gt 0 ]; then
+              aws ec2 create-tags --resources "${AMI_ID}" --tags "${TAG_ARGS[@]}"
+              echo "PCR tags applied to AMI ${AMI_ID}"
+            fi
+          else
+            echo "WARNING: Could not download PCR measurements from S3"
+          fi
+
+      - name: Cleanup build instance
+        if: always()
+        env:
+          INSTANCE_ID: ${{ steps.instance.outputs.instance_id }}
+        run: |
+          if [ -n "${INSTANCE_ID}" ]; then
+            aws ec2 terminate-instances --instance-ids "${INSTANCE_ID}" || true
+          fi
+
+  boot-verify:
+    name: Boot-verify FIPS mode (${{ inputs.arch }})
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: ${{ vars.ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: test-ami-verify-${{ inputs.arch }}
+          mask-aws-account-id: true
+
+      - name: Launch test instance
+        id: instance
+        env:
+          AMI_ID: ${{ needs.build.outputs.ami_id }}
+          INSTANCE_TYPE: ${{ needs.build.outputs.instance_type }}
+          SUBNET_ID: ${{ vars.AMI_BUILD_SUBNET_ID }}
+          ARCH: ${{ inputs.arch }}
+        run: |
+          INSTANCE_ID=$(aws ec2 run-instances \
+            --image-id "${AMI_ID}" \
+            --instance-type "${INSTANCE_TYPE}" \
+            --subnet-id "${SUBNET_ID}" \
+            --metadata-options 'HttpTokens=required,InstanceMetadataTags=enabled' \
+            --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=vouch-ami-test-verify-${ARCH}}]" \
+            --query 'Instances[0].InstanceId' \
+            --output text)
+
+          echo "instance_id=${INSTANCE_ID}" >> "$GITHUB_OUTPUT"
+          echo "Launched test instance ${INSTANCE_ID} from ${AMI_ID}"
+
+      - name: Wait for boot and verify FIPS via serial console
+        env:
+          INSTANCE_ID: ${{ steps.instance.outputs.instance_id }}
+        run: |
+          # The image has no SSH/SSM by design; verification relies on the
+          # serial console (console=ttyS0) and EC2 reachability checks.
+          BOOT_OK=true
+          if ! aws ec2 wait instance-status-ok --instance-ids "${INSTANCE_ID}"; then
+            echo "WARNING: instance did not reach status-ok within the waiter timeout"
+            BOOT_OK=false
+          fi
+
+          # Console output can lag behind boot; poll until it has content
+          CONSOLE_FILE=/tmp/console.txt
+          for attempt in {1..20}; do
+            aws ec2 get-console-output \
+              --instance-id "${INSTANCE_ID}" \
+              --latest \
+              --query 'Output' \
+              --output text > "$CONSOLE_FILE" 2>/dev/null || true
+
+            if [ -s "$CONSOLE_FILE" ] && ! grep -qx 'None' "$CONSOLE_FILE"; then
+              break
+            fi
+            echo "Console output not available yet (attempt $attempt/20)..."
+            sleep 15
+          done
+
+          echo "=== Console output ==="
+          cat "$CONSOLE_FILE"
+          echo "=== End console output ==="
+
+          FAILED=0
+
+          if [ "$BOOT_OK" != "true" ]; then
+            echo "FAIL: instance did not pass EC2 status checks"
+            FAILED=1
+          fi
+
+          if grep -qi 'kernel panic' "$CONSOLE_FILE"; then
+            echo "FAIL: kernel panic found in console output"
+            FAILED=1
+          fi
+
+          if grep -qi 'verification failure\|verity.*corruption' "$CONSOLE_FILE"; then
+            echo "FAIL: dm-verity corruption reported in console output"
+            FAILED=1
+          fi
+
+          if grep -qi 'fips mode: enabled' "$CONSOLE_FILE"; then
+            echo "PASS: kernel reports FIPS mode enabled"
+          else
+            echo "FAIL: 'fips mode: enabled' not found in console output"
+            FAILED=1
+          fi
+
+          if [ "$FAILED" -ne 0 ]; then
+            echo "Boot verification FAILED"
+            exit 1
+          fi
+
+          echo "Boot verification PASSED: instance boots with FIPS mode enabled"
+
+      - name: Cleanup test instance
+        if: always()
+        env:
+          INSTANCE_ID: ${{ steps.instance.outputs.instance_id }}
+        run: |
+          if [ -n "${INSTANCE_ID}" ]; then
+            aws ec2 terminate-instances --instance-ids "${INSTANCE_ID}" || true
+          fi
+
+  cleanup:
+    name: Cleanup and summary
+    runs-on: ubuntu-latest
+    needs: [build, boot-verify]
+    permissions:
+      id-token: write
+    if: always() && needs.build.outputs.ami_id != ''
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: ${{ vars.ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: test-ami-cleanup
+          mask-aws-account-id: true
+
+      - name: Deregister test AMI
+        if: ${{ !inputs.keep_ami }}
+        env:
+          AMI_ID: ${{ needs.build.outputs.ami_id }}
+          SNAPSHOT_ID: ${{ needs.build.outputs.snapshot_id }}
+        run: |
+          echo "Deregistering test AMI ${AMI_ID}"
+          aws ec2 deregister-image --image-id "${AMI_ID}" || true
+
+          if [ -n "${SNAPSHOT_ID}" ]; then
+            echo "Deleting snapshot ${SNAPSHOT_ID}"
+            aws ec2 delete-snapshot --snapshot-id "${SNAPSHOT_ID}" || true
+          fi
+
+      - name: Generate summary
+        env:
+          AMI_ID: ${{ needs.build.outputs.ami_id }}
+          ARCH: ${{ inputs.arch }}
+          BINARY_TAG: ${{ inputs.binary_tag }}
+          BRANCH: ${{ github.ref_name }}
+          KEEP_AMI: ${{ inputs.keep_ami }}
+          VERIFY_RESULT: ${{ needs.boot-verify.result }}
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" << EOF
+          ## Test AMI Build Summary
+
+          | | |
+          |---|---|
+          | **Branch** | ${BRANCH} |
+          | **Binary** | vouch-server ${BINARY_TAG} |
+          | **Architecture** | ${ARCH} |
+          | **AMI ID** | \`${AMI_ID}\` |
+          | **Boot verification** | ${VERIFY_RESULT} |
+          | **AMI retained** | ${KEEP_AMI} |
+
+          Boot verification checks: EC2 status checks pass, no kernel panic,
+          no dm-verity corruption, and the kernel reports \`fips mode: enabled\`
+          on the serial console.
+          EOF


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ami-test.yml`, a `workflow_dispatch`-only workflow that builds a **test AMI** from the `packaging/ami/` files on the dispatched branch and boot-verifies it via the EC2 serial console (FIPS mode indication, no kernel panic, instance reaches status-ok).

Unlike the release `Build AMI` workflow it:
- needs no release tag for the AMI — the `vouch-server` RPM is borrowed from an existing release (`binary_tag` input), while the image definition comes from the branch under test
- builds a single arch (`arch` input, default `x86_64`)
- names the AMI `vouch-server-test-<short-sha>-<arch>` so it can never collide with immutable release AMIs
- performs **no** region copies and **no** SSM parameter updates
- deregisters the test AMI and deletes its snapshot after verification unless `keep_ami` is set

## Why a separate PR

GitHub only registers `workflow_dispatch` workflows that exist on the default branch, so this must land on `main` before it can be dispatched against feature branches. It is inert on `main` (manual dispatch only, no automatic triggers).

First consumer: the FIPS crypto-policy AMI change in #480 — once this merges, dispatch with `--ref claude/fips-crypto-policy-ami-it3acg -f binary_tag=v2026.6.1` to verify that branch's image boots in FIPS mode.

https://claude.ai/code/session_01TaHFHq3h66Gwnc8BXciPT3

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaHFHq3h66Gwnc8BXciPT3)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Manual-only but assumes the same AWS role, S3 bucket, subnet, and Secure Boot secret as release AMI builds; mis-dispatch could incur EC2/S3 cost or briefly register non-release AMIs (mitigated by test naming, tags, and default cleanup).
> 
> **Overview**
> Adds **`.github/workflows/ami-test.yml`**, a **`workflow_dispatch`-only** pipeline to build and validate AMI packaging from a branch without a release AMI tag.
> 
> Operators supply an existing **`binary_tag`** (RPM from a release) and **`arch`**; the workflow checks out **`packaging/ami`** from the dispatched ref, uploads build artifacts to a run-scoped S3 prefix (`ami-test-builds/`), launches an EC2 builder like the release flow, registers a **test** AMI named `vouch-server-test-<run_id>-<arch>` (tagged `Test=true`), and optionally applies PCR tags. It **does not** copy AMIs across regions or update SSM.
> 
> A **`boot-verify`** job boots the test AMI and asserts EC2 status checks, no kernel panic / dm-verity failures, and **`fips mode: enabled`** on the serial console. **`cleanup`** deregisters the AMI and deletes the snapshot unless **`keep_ami`** is set, and writes a job summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a28309a1ed448ed239115d6d6c456d1b738b3bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->