### PR TITLE
Add STIG-aligned kernel hardening and AMI STIG mapping doc

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -46,3 +46,4 @@
 - [Environment Variables](reference/environment-variables.md)
 - [S3 Configuration Schema](reference/s3-config-schema.md)
 - [Compliance Mapping](reference/compliance.md)
+- [AMI STIG Alignment](reference/ami-stig.md)

--- a/docs/src/reference/ami-stig.md
+++ b/docs/src/reference/ami-stig.md
@@ -1,0 +1,73 @@
+# AMI STIG Alignment
+
+This page documents how the Vouch Server **attestable AMI** aligns with the
+[DISA Security Technical Implementation Guide (STIG)](https://public.cyber.mil/stigs/)
+for its base operating system, **Amazon Linux 2023 (STIG V1R2)**.
+
+It complements the application-level [Compliance Mapping](compliance.md): that
+page covers the Vouch authentication model, while this page covers the operating
+system posture of the AMI itself.
+
+## Why Vouch does not run the AWS STIG hardening scripts
+
+AWS publishes
+[STIG hardening script bundles](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-stig-downloads.html)
+(`LinuxAWSConfigureSTIG.tgz`) that are applied to a *running, mutable* instance,
+typically through an SSM document or as EC2 Image Builder `STIG-Build-Linux`
+components.
+
+The Vouch AMI does not use them, by design:
+
+- **Immutable root filesystem.** The root partition is mounted read-only with
+  **dm-verity** and `panic-on-corruption`. Runtime remediation scripts either
+  fail to persist (writes land on an overlay tmpfs) or trip the integrity check.
+  All hardening is instead baked in at build time so it lives behind the same
+  dm-verity measurement and TPM attestation (PCR4/7/12) as the rest of the image.
+- **Minimal attack surface.** The scripts can re-enable services and install
+  third-party packages. The AMI deliberately omits SSH, the SSM agent,
+  cloud-init, and `ec2-instance-connect`; re-introducing them would weaken the
+  posture rather than strengthen it.
+- **Already met or exceeded.** As the mapping below shows, the appliance design
+  satisfies — and in several areas exceeds — the controls those scripts enforce.
+
+## Control mapping
+
+Status legend:
+
+- **Met** — satisfied by an explicit configuration in the image.
+- **Exceeded** — satisfied by a stronger mechanism than the STIG requires.
+- **N/A by design** — the control targets functionality the appliance does not
+  ship (no interactive login, no SSH, no desktop).
+- **Build-time control** — enforced via configuration baked into the image.
+
+| STIG area | Status | Mechanism (file) |
+|-----------|--------|------------------|
+| Remote access / SSH daemon hardening | **N/A by design / Exceeded** | `openssh-server` is not installed, `sshd` is masked, and any host keys are removed — there is no remote shell to harden (`appliance.kiwi`, `config.sh`) |
+| Interactive account policy (PAM, `pwquality`, `faillock`, session timeout, login banners) | **N/A by design** | No interactive user accounts exist and the root account is locked (`passwd -l root`); configuration is delivered only via AWS Parameter Store |
+| FIPS-validated cryptography | **Met** | Kernel `fips=1` plus OS crypto-policy set to FIPS (`appliance.kiwi`, `config.sh`); the server binary additionally embeds the aws-lc-rs FIPS module |
+| Boot loader integrity / boot loader password | **Exceeded** | UEFI Secure Boot with a signed Unified Kernel Image, no GRUB present, and TPM PCR measurements (PCR4/7/12) published as AMI tags for attestation |
+| File-integrity monitoring (e.g. AIDE) | **Exceeded** | dm-verity provides cryptographic, kernel-enforced integrity of the entire root filesystem with `panic-on-corruption` |
+| Filesystem mount options (`nosuid`/`nodev`/`noexec`) | **Met (partial)** | `/boot/efi` is mounted `ro,nosuid,nodev,noexec` (`fstab.script`); the root filesystem is read-only via dm-verity |
+| Kernel parameters / `sysctl` hardening | **Build-time control** | `etc/sysctl.d/90-vouch-hardening.conf` sets ASLR, `dmesg_restrict`, `kptr_restrict`, `ptrace_scope`, `suid_dumpable`, reverse-path filtering, redirect/source-route rejection, SYN cookies, and related settings |
+| Host firewall | **N/A by design** | `firewalld` is not installed; network exposure is controlled by EC2 security groups, and the only listening service is the Vouch server |
+| Time synchronization integrity | **Met** | chrony with the command port disabled (`chrony.d/10-disable-cmdport.conf`); GPS/NTP supported for air-gapped deployments |
+| Audit logging (`auditd` rules) | **Partial — see note** | Application and system logs are forwarded to CloudWatch Logs; a kernel `auditd` ruleset is not currently shipped |
+| Service / package minimization | **Met / Exceeded** | Curated minimal package set; `ec2-hibinit-agent`, `update-motd`, GRUB, and remote-access packages are explicitly excluded (`appliance.kiwi`) |
+| Process privilege restriction | **Exceeded** | The server runs as an unprivileged user under strict systemd sandboxing (`NoNewPrivileges`, `ProtectSystem=strict`, `ProtectHome`, `PrivateTmp`, `ReadWritePaths`) |
+
+## Known gap: kernel audit (`auditd`)
+
+The most material difference from a fully STIG-hardened general-purpose host is
+the absence of a kernel `auditd` ruleset. On this appliance the gap is narrow:
+
+- There are no interactive users or shells to audit, which is the primary target
+  of most STIG audit rules.
+- Application and credential-issuance events are logged by the Vouch server and
+  forwarded to CloudWatch Logs alongside system journald output.
+
+For deployments with a contractual `auditd` requirement, `auditd` and a STIG
+audit ruleset can be added to the image (package in `appliance.kiwi`, service
+enablement in `config.sh`, rules under `etc/audit/rules.d/`, and log forwarding
+in the CloudWatch agent configuration). This is not enabled by default to keep
+the image minimal and avoid a writable audit-log path on an otherwise userless
+appliance.

--- a/packaging/ami/config.sh
+++ b/packaging/ami/config.sh
@@ -90,4 +90,15 @@ if [ "$CURRENT_POLICY" != "FIPS" ]; then
     exit 1
 fi
 
+#======================================
+# Verify kernel hardening drop-in
+#======================================
+# STIG-aligned sysctl settings are provided via the root/ overlay. Values are
+# applied at boot by systemd-sysctl; here we only assert the file is present so
+# a missing overlay fails the build instead of silently shipping unhardened.
+if [ ! -f /etc/sysctl.d/90-vouch-hardening.conf ]; then
+    echo "ERROR: /etc/sysctl.d/90-vouch-hardening.conf not found"
+    exit 1
+fi
+
 echo "Vouch Server image configuration complete"

--- a/packaging/ami/root/etc/sysctl.d/90-vouch-hardening.conf
+++ b/packaging/ami/root/etc/sysctl.d/90-vouch-hardening.conf
@@ -1,0 +1,63 @@
+# Vouch Server attestable AMI - kernel hardening
+#
+# STIG-aligned sysctl settings baked into the dm-verity-measured image.
+# These mirror Amazon Linux 2023 STIG (V1R2) kernel requirements that apply
+# to a headless, single-purpose server appliance. They are applied at boot
+# and, because the file lives behind dm-verity, are covered by the image's
+# integrity guarantee.
+#
+# Settings that target interactive logins, sshd, or desktop environments are
+# intentionally omitted: the appliance ships no SSH, no interactive accounts,
+# and a locked root. See docs/src/reference/ami-stig.md for the full mapping.
+
+# Restrict access to kernel logs (hides addresses/info useful to attackers).
+kernel.dmesg_restrict = 1
+
+# Hide kernel pointers from unprivileged users in /proc and interfaces.
+kernel.kptr_restrict = 2
+
+# Restrict ptrace to child processes only (Yama LSM).
+kernel.yama.ptrace_scope = 1
+
+# Full address-space layout randomization.
+kernel.randomize_va_space = 2
+
+# Disallow unprivileged access to performance events.
+kernel.perf_event_paranoid = 2
+
+# Never create core dumps for setuid programs.
+fs.suid_dumpable = 0
+
+# Mitigate hardlink/symlink-based privilege escalation in world-writable dirs.
+fs.protected_hardlinks = 1
+fs.protected_symlinks = 1
+
+# Reverse-path filtering (anti-spoofing).
+net.ipv4.conf.all.rp_filter = 1
+net.ipv4.conf.default.rp_filter = 1
+
+# Do not accept ICMP redirects (prevents malicious routing changes).
+net.ipv4.conf.all.accept_redirects = 0
+net.ipv4.conf.default.accept_redirects = 0
+net.ipv6.conf.all.accept_redirects = 0
+net.ipv6.conf.default.accept_redirects = 0
+
+# Do not send ICMP redirects (this host is not a router).
+net.ipv4.conf.all.send_redirects = 0
+net.ipv4.conf.default.send_redirects = 0
+
+# Do not accept source-routed packets.
+net.ipv4.conf.all.accept_source_route = 0
+net.ipv4.conf.default.accept_source_route = 0
+net.ipv6.conf.all.accept_source_route = 0
+net.ipv6.conf.default.accept_source_route = 0
+
+# Log packets with impossible (martian) source addresses.
+net.ipv4.conf.all.log_martians = 1
+net.ipv4.conf.default.log_martians = 1
+
+# Ignore ICMP broadcast requests (smurf-attack mitigation).
+net.ipv4.icmp_echo_ignore_broadcasts = 1
+
+# Enable TCP SYN cookies (SYN-flood mitigation).
+net.ipv4.tcp_syncookies = 1


### PR DESCRIPTION
## Summary

Answers the question "is implementing the [AWS EC2 STIG hardening scripts](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-stig-downloads.html) worthwhile for the vouch AMI?" with the worthwhile subset of work.

Those AWS bundles (`LinuxAWSConfigureSTIG.tgz`) are designed to run on a *mutable* instance via SSM / EC2 Image Builder. The vouch AMI is an immutable **dm-verity + Secure Boot + FIPS** appliance built with KIWI-NG, with no SSH, no SSM agent, no cloud-init, and no interactive accounts — so running those scripts conflicts with the read-only root and would re-introduce removed services. Most STIG controls are already **met or exceeded** by the existing design; the real gaps are a few build-time kernel sysctls and, primarily, *compliance evidence* for the government/defense/regulated buyers the docs already target.

## Changes

- **`packaging/ami/root/etc/sysctl.d/90-vouch-hardening.conf`** (new) — STIG-aligned kernel/network sysctls baked into the dm-verity-measured image overlay: ASLR, `dmesg_restrict`, `kptr_restrict`, `ptrace_scope`, `suid_dumpable=0`, protected hard/symlinks, reverse-path filtering, ICMP redirect / source-route rejection, SYN cookies. Interactive-login/sshd controls are intentionally omitted (no SSH, no interactive users).
- **`packaging/ami/config.sh`** — assert the drop-in is present during the KIWI build, so a missing overlay fails the build instead of silently shipping unhardened (mirrors the existing FIPS assertion).
- **`docs/src/reference/ami-stig.md`** (new) + **`docs/src/SUMMARY.md`** — control mapping against Amazon Linux 2023 STIG V1R2, marking each area Met / Exceeded / N/A-by-design / build-time-control with the concrete mechanism, plus a documented rationale for not running the AWS scripts and for the `auditd` gap.

## Out of scope (documented rationale, not implemented)

- Running AWS `LinuxAWSConfigureSTIG.tgz` bundles or migrating to EC2 Image Builder.
- `auditd` + STIG audit ruleset — left as a documented gap (narrow on a userless appliance with CloudWatch logging); can be added if a customer contractually requires it.
- A machine-readable DISA `.ckl` checklist artifact.

## Verification

- `make docs-build` builds cleanly with the new page in the Reference nav (no broken-link errors).
- sysctl keys are standard for kernel 6.18 / AL2023 and don't interfere with the IMDS-over-IPv6 config fetch or chrony.
- Recommend a follow-up run of `.github/workflows/ami-test.yml` to confirm the image still boots (status checks, no kernel panic, no dm-verity corruption, FIPS on serial console) with the new overlay file present.

https://claude.ai/code/session_01TrNvnVahgc1J3qzm52tFS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01TrNvnVahgc1J3qzm52tFS9)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to AMI image overlay sysctl defaults and documentation; no application auth or runtime config paths are modified, with build failing if hardening files are absent.
> 
> **Overview**
> Adds **build-time kernel/network hardening** for the attestable AMI via a new `90-vouch-hardening.conf` sysctl drop-in (ASLR, kernel pointer/log restrictions, ptrace scope, symlink/hardlink protections, rp_filter, ICMP/source-route hardening, SYN cookies, etc.), baked into the dm-verity image overlay.
> 
> **`packaging/ami/config.sh`** now **fails the KIWI build** if that drop-in is missing, mirroring the existing FIPS policy assertion so an incomplete overlay cannot ship silently.
> 
> New reference doc **`ami-stig.md`** (linked from **`SUMMARY.md`**) explains why AWS mutable-instance STIG script bundles are not used on this immutable appliance, maps Amazon Linux 2023 STIG V1R2 areas to Met/Exceeded/N/A mechanisms, and documents the **`auditd`** gap and optional path to add it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17ba499a7d976afa40f6c8e9bb43644b3a5ebd2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->