### PR TITLE
Make CLI and agent XDG Base Directory compliant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,9 @@ vouch/
 └── packaging/            # AMI and post-install scripts
 ```
 
-**Agent IPC:** The CLI communicates with the agent daemon over a Unix socket (`~/.vouch/agent.sock`) using JSON-RPC 2.0 with 4-byte length-prefixed messages.
+**Agent IPC:** The CLI communicates with the agent daemon over a Unix socket (`$XDG_RUNTIME_DIR/vouch/agent.sock`) using JSON-RPC 2.0 with 4-byte length-prefixed messages.
+
+**File locations:** Vouch follows the XDG Base Directory Specification on all platforms (including macOS, using `~/.config` rather than `~/Library/Application Support`). Path resolution is centralized in `crates/vouch-common/src/paths.rs`: config → `$XDG_CONFIG_HOME/vouch/` (`config.json`), state → `$XDG_STATE_HOME/vouch/` (`cookie.txt`, `audit.log`), data → `$XDG_DATA_HOME/vouch/` (`client_key.json` keyring fallback), cache → `$XDG_CACHE_HOME/vouch/` (`agent.pid`, `agent.log`), runtime → `$XDG_RUNTIME_DIR/vouch/` (sockets, with a cache-dir fallback when unset). `paths::migrate_legacy_layout()` relocates a legacy flat `~/.vouch/` on first run; it is called early in both the CLI and agent entrypoints. Do not reintroduce ad-hoc `dirs::home_dir().join(".vouch")` path construction — use the `paths` helpers.
 
 **Database:** vouch-server uses SQLite (dev), PostgreSQL (prod), and Aurora DSQL via sqlx with a `Pool` enum abstraction (`db/pool.rs`) that dispatches at runtime based on the `DATABASE_URL` scheme. Query building uses `sea-query` for dynamic SQL. DSQL endpoints (hostname contains `.dsql.` and ends `.on.aws`) auto-generate IAM auth tokens. Migrations live in `crates/vouch-server/migrations/{sqlite,postgres}/`. Domain modules are in `crates/vouch-server/src/db/` (users, sessions, authenticators, oauth, scim, etc.).
 

--- a/crates/vouch-agent/src/audit.rs
+++ b/crates/vouch-agent/src/audit.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Structured audit log for security-relevant agent events.
 //!
-//! Writes newline-delimited JSON to `~/.vouch/audit.log`. Each line is a
+//! Writes newline-delimited JSON to `$XDG_STATE_HOME/vouch/audit.log`
+//! (`~/.local/state/vouch/audit.log` by default). Each line is a
 //! self-contained JSON object describing a security-relevant event.
 //!
 //! This composes with external log aggregation tools (jq, Datadog, Splunk)
@@ -9,9 +10,8 @@
 
 use serde::Serialize;
 use std::io::Write;
+use std::path::PathBuf;
 use tracing::debug;
-
-use crate::socket::vouch_dir;
 
 /// Maximum audit log file size (10 MB). When exceeded, the log is rotated.
 const MAX_LOG_SIZE: u64 = 10 * 1024 * 1024;
@@ -77,7 +77,8 @@ struct AuditRecord {
     event: AuditEvent,
 }
 
-/// Log a security-relevant audit event to `~/.vouch/audit.log`.
+/// Log a security-relevant audit event to the audit log
+/// (`$XDG_STATE_HOME/vouch/audit.log`).
 ///
 /// Best-effort: failures are logged at debug level and never block the agent.
 pub(crate) fn log_event(event: AuditEvent) {
@@ -91,12 +92,26 @@ pub(crate) fn log_event(event: AuditEvent) {
     }
 }
 
+/// Resolve the audit log path (`$XDG_STATE_HOME/vouch/audit.log`).
+fn audit_log_path() -> std::io::Result<PathBuf> {
+    vouch_common::paths::audit_log_file()
+        .ok_or_else(|| std::io::Error::other("cannot determine state directory"))
+}
+
 /// Write a single audit event to the log file.
 fn write_event(record: &AuditRecord) -> std::io::Result<()> {
-    let dir = vouch_dir()
-        .map_err(|e| std::io::Error::other(format!("cannot determine vouch dir: {e}")))?;
+    let log_path = audit_log_path()?;
+    let dir = log_path
+        .parent()
+        .ok_or_else(|| std::io::Error::other("audit log path has no parent"))?;
 
-    let log_path = dir.join("audit.log");
+    // Ensure the state directory exists with owner-only permissions.
+    std::fs::create_dir_all(dir)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _chmod = std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700));
+    }
 
     // Rotate if file exceeds max size
     if let Ok(metadata) = std::fs::metadata(&log_path)

--- a/crates/vouch-agent/src/config.rs
+++ b/crates/vouch-agent/src/config.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//! Read-only configuration reader for `~/.vouch/config.json`.
+//! Read-only configuration reader for `$XDG_CONFIG_HOME/vouch/config.json`.
 //!
 //! This module provides read-only access to the Vouch config file.
 //! The agent uses this to recover session state on startup.
@@ -78,10 +78,9 @@ impl VouchConfig {
     }
 }
 
-/// Get the path to the config file (`~/.vouch/config.json`).
+/// Get the path to the config file (`$XDG_CONFIG_HOME/vouch/config.json`).
 fn config_path() -> Result<PathBuf> {
-    let home = dirs::home_dir().context("could not determine home directory")?;
-    Ok(home.join(".vouch").join("config.json"))
+    vouch_common::paths::config_file().context("could not determine config directory")
 }
 
 /// Read the config file from disk.
@@ -135,7 +134,7 @@ mod tests {
         let path = config_path();
         assert!(path.is_ok());
         let path = path.expect("config_path should succeed");
-        assert!(path.ends_with(".vouch/config.json"));
+        assert!(path.ends_with("vouch/config.json"));
     }
 
     #[test]

--- a/crates/vouch-agent/src/daemon.rs
+++ b/crates/vouch-agent/src/daemon.rs
@@ -24,19 +24,17 @@ pub enum DaemonizeResult {
     Skipped,
 }
 
-/// Get the path to the PID file.
+/// Get the path to the PID file (`$XDG_CACHE_HOME/vouch/agent.pid`).
 pub fn pid_file_path() -> Result<PathBuf> {
-    let cache_dir = dirs::cache_dir()
+    let vouch_dir = vouch_common::paths::cache_dir()
         .ok_or_else(|| AgentError::Config("Could not determine cache directory".to_string()))?;
-    let vouch_dir = cache_dir.join("vouch");
     Ok(vouch_dir.join("agent.pid"))
 }
 
-/// Get the path to the log file.
+/// Get the path to the log file (`$XDG_CACHE_HOME/vouch/agent.log`).
 pub(crate) fn log_file_path() -> Result<PathBuf> {
-    let cache_dir = dirs::cache_dir()
+    let vouch_dir = vouch_common::paths::cache_dir()
         .ok_or_else(|| AgentError::Config("Could not determine cache directory".to_string()))?;
-    let vouch_dir = cache_dir.join("vouch");
     Ok(vouch_dir.join("agent.log"))
 }
 

--- a/crates/vouch-agent/src/dns.rs
+++ b/crates/vouch-agent/src/dns.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//! Initialize the process-wide DoH resolver from `~/.vouch/config.json` + env.
+//! Initialize the process-wide DoH resolver from
+//! `$XDG_CONFIG_HOME/vouch/config.json` + env.
 //!
 //! Called once from `main.rs` before any HTTP traffic. Mirrors the CLI's
 //! `vouch_cli::dns::init` so that the agent honors the same configuration.

--- a/crates/vouch-agent/src/lib.rs
+++ b/crates/vouch-agent/src/lib.rs
@@ -6,7 +6,8 @@
 //!
 //! # Architecture
 //!
-//! The agent runs as a background daemon listening on `~/.vouch/agent.sock`.
+//! The agent runs as a background daemon listening on
+//! `$XDG_RUNTIME_DIR/vouch/agent.sock`.
 //! It uses a JSON-RPC 2.0 protocol with 4-byte length-prefixed messages.
 //!
 //! # Example (CLI usage)

--- a/crates/vouch-agent/src/main.rs
+++ b/crates/vouch-agent/src/main.rs
@@ -47,6 +47,11 @@ struct Args {
 fn main() -> ExitCode {
     let args = Args::parse();
 
+    // Relocate any legacy ~/.vouch/ files into the XDG base directories before
+    // reading config or binding sockets. Runs before daemonization so the
+    // one-time notice reaches the user's terminal rather than the daemon log.
+    vouch_common::paths::migrate_legacy_layout();
+
     // Handle status check (no logging needed)
     if args.status {
         match daemon::is_running() {

--- a/crates/vouch-agent/src/recovery.rs
+++ b/crates/vouch-agent/src/recovery.rs
@@ -2,7 +2,7 @@
 //! Session recovery from persisted credentials on disk.
 //!
 //! On startup, the agent attempts to restore a valid session by reading
-//! `~/.vouch/config.json`, validating the token against the server, and
+//! `$XDG_CONFIG_HOME/vouch/config.json`, validating the token against the server, and
 //! populating in-memory state.
 //!
 //! This is best-effort: all errors are logged and never block startup.
@@ -116,7 +116,7 @@ async fn try_recover_inner(
     Ok(true)
 }
 
-/// Read token and server URL from `~/.vouch/config.json`.
+/// Read token and server URL from `$XDG_CONFIG_HOME/vouch/config.json`.
 ///
 /// Returns `Some((token, server_url))` if both are present, `None` otherwise.
 fn read_credentials_from_config() -> Result<Option<(String, String)>, Box<dyn std::error::Error>> {

--- a/crates/vouch-agent/src/socket.rs
+++ b/crates/vouch-agent/src/socket.rs
@@ -8,18 +8,21 @@ use tokio::net::{UnixListener, UnixStream};
 /// Default socket filename.
 const SOCKET_FILENAME: &str = "agent.sock";
 
-/// Get the vouch directory (~/.vouch).
+/// Get the vouch runtime directory (`$XDG_RUNTIME_DIR/vouch`, or a `0700`
+/// cache fallback when `XDG_RUNTIME_DIR` is unset, e.g. on macOS).
+///
+/// Used for Unix sockets, which belong in the runtime directory: a private,
+/// user-owned location cleared on logout.
 ///
 /// # Errors
 ///
-/// Returns `AgentError::SocketPath` if the home directory cannot be determined.
+/// Returns `AgentError::SocketPath` if the directory cannot be determined.
 pub(crate) fn vouch_dir() -> Result<PathBuf> {
-    let home = dirs::home_dir()
-        .ok_or_else(|| AgentError::SocketPath("could not determine home directory".to_string()))?;
-    Ok(home.join(".vouch"))
+    vouch_common::paths::runtime_dir()
+        .ok_or_else(|| AgentError::SocketPath("could not determine runtime directory".to_string()))
 }
 
-/// Get the socket path (~/.vouch/agent.sock).
+/// Get the socket path (`$XDG_RUNTIME_DIR/vouch/agent.sock`).
 ///
 /// # Errors
 ///
@@ -142,11 +145,11 @@ pub(crate) fn get_peer_credentials(stream: &UnixStream) -> Result<PeerCredential
     })
 }
 
-/// Validate that the vouch directory is safe to use.
+/// Validate that the vouch runtime directory is safe to use.
 ///
-/// Checks that `~/.vouch/` is not a symlink and is owned by the current user.
-/// Prevents symlink attacks where an attacker pre-creates the directory pointing
-/// to an attacker-controlled location.
+/// Checks that the socket directory is not a symlink and is owned by the
+/// current user. Prevents symlink attacks where an attacker pre-creates the
+/// directory pointing to an attacker-controlled location.
 ///
 /// # Errors
 ///

--- a/crates/vouch-agent/src/ssh_agent/mod.rs
+++ b/crates/vouch-agent/src/ssh_agent/mod.rs
@@ -5,7 +5,7 @@
 //! ([draft-miller-ssh-agent](https://datatracker.ietf.org/doc/html/draft-miller-ssh-agent))
 //! to provide seamless SSH authentication using Vouch-issued certificates.
 //!
-//! The agent listens on `~/.vouch/ssh-agent.sock` and handles:
+//! The agent listens on `$XDG_RUNTIME_DIR/vouch/ssh-agent.sock` and handles:
 //! - `SSH_AGENTC_REQUEST_IDENTITIES` - Returns available SSH certificates
 //! - `SSH_AGENTC_SIGN_REQUEST` - Signs data with the user's private key
 
@@ -41,7 +41,7 @@ pub(crate) const MIN_REFRESH_INTERVAL_SECONDS: i64 = 5 * 60;
 /// Default SSH key path for lazy disk loading.
 pub(crate) const DEFAULT_KEY_NAME: &str = "id_ed25519_vouch";
 
-/// Get the SSH agent socket path (~/.vouch/ssh-agent.sock).
+/// Get the SSH agent socket path (`$XDG_RUNTIME_DIR/vouch/ssh-agent.sock`).
 pub fn ssh_agent_socket_path() -> Result<PathBuf> {
     Ok(vouch_dir()?.join("ssh-agent.sock"))
 }

--- a/crates/vouch-cli/src/commands/setup/anthropic.rs
+++ b/crates/vouch-cli/src/commands/setup/anthropic.rs
@@ -48,7 +48,7 @@ pub(crate) async fn run(args: SetupArgs<'_>) -> Result<()> {
 
 fn print_success() {
     println!("Anthropic (Claude) Workload Identity Federation configured.\n");
-    println!("  Federation params: ~/.vouch/config.json\n");
+    println!("  Federation params: ~/.config/vouch/config.json\n");
 
     println!("This mints a service-account token for CI/headless automation.");
     println!("Get a token:");

--- a/crates/vouch-cli/src/commands/setup/mod.rs
+++ b/crates/vouch-cli/src/commands/setup/mod.rs
@@ -133,7 +133,7 @@ pub(crate) enum SetupCommands {
     },
     /// Configure Anthropic (Claude) Workload Identity Federation.
     ///
-    /// Persists federation parameters to `~/.vouch/config.json` for use by
+    /// Persists federation parameters to `~/.config/vouch/config.json` for use by
     /// `vouch credential anthropic`. This is the **workload** path: the
     /// minted token acts as a non-human service account, intended for
     /// CI/headless automation. It does not configure Claude Code.
@@ -159,7 +159,7 @@ pub(crate) enum SetupCommands {
     },
     /// Configure OpenAI Workload Identity Federation.
     ///
-    /// Persists federation parameters to `~/.vouch/config.json` AND
+    /// Persists federation parameters to `~/.config/vouch/config.json` AND
     /// auto-configures the OpenAI Codex CLI by writing a
     /// `[model_providers.vouch]` block (with refreshing auth
     /// command) into `~/.codex/config.toml` and setting it as the

--- a/crates/vouch-cli/src/commands/setup/openai.rs
+++ b/crates/vouch-cli/src/commands/setup/openai.rs
@@ -180,7 +180,7 @@ fn write_provider_block(doc: &mut DocumentMut, vouch_path: &str) -> Result<()> {
 
 fn print_success(config_path: &Path) {
     println!("OpenAI Workload Identity Federation configured.\n");
-    println!("  Federation params: ~/.vouch/config.json");
+    println!("  Federation params: ~/.config/vouch/config.json");
     println!(
         "  Codex provider block: {} ([model_providers.{PROVIDER_ID}])\n",
         config_path.display()

--- a/crates/vouch-cli/src/commands/setup/ssh.rs
+++ b/crates/vouch-cli/src/commands/setup/ssh.rs
@@ -149,6 +149,37 @@ fn configure_ssh_config(hosts: Option<&str>) -> Result<()> {
         String::new()
     };
 
+    // Migrate a stale IdentityAgent left over from the legacy ~/.vouch layout.
+    // Older versions wrote the agent socket under ~/.vouch/ssh-agent.sock; the
+    // socket now lives in the XDG runtime directory. Rewrite the path in place
+    // so existing users don't have to delete their config by hand.
+    if existing.contains(".vouch/ssh-agent.sock") && !existing.contains(&agent_socket) {
+        let rewritten = existing
+            .lines()
+            .map(|line| {
+                if line.contains("IdentityAgent") && line.contains(".vouch/ssh-agent.sock") {
+                    let indent: String = line.chars().take_while(|c| c.is_whitespace()).collect();
+                    format!("{indent}IdentityAgent {agent_socket}")
+                } else {
+                    line.to_string()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let rewritten = if existing.ends_with('\n') {
+            format!("{rewritten}\n")
+        } else {
+            rewritten
+        };
+        atomic_write_secure(&config_path, rewritten.as_bytes())
+            .with_context(|| format!("failed to write {}", config_path.display()))?;
+        println!(
+            "Updated stale Vouch IdentityAgent path in {} -> {agent_socket}",
+            config_path.display()
+        );
+        return Ok(());
+    }
+
     // Check if Vouch config already exists
     if existing.contains("# Vouch SSH Configuration") || existing.contains(&agent_socket) {
         println!("SSH config already configured for Vouch");

--- a/crates/vouch-cli/src/commands/setup/ssh.rs
+++ b/crates/vouch-cli/src/commands/setup/ssh.rs
@@ -123,6 +123,16 @@ pub(crate) async fn run(server: &str, hosts: Option<&str>) -> Result<()> {
     Ok(())
 }
 
+/// True if `line` is an `IdentityAgent` directive pointing at the legacy
+/// `~/.vouch/ssh-agent.sock` socket (ignoring leading indentation).
+///
+/// Deliberately narrow: a stray mention of the path in a comment or unrelated
+/// directive does not match, so it cannot trigger a spurious rewrite.
+fn is_stale_identity_agent_line(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.starts_with("IdentityAgent") && trimmed.contains(".vouch/ssh-agent.sock")
+}
+
 /// Configure SSH config with Vouch identity and certificate.
 ///
 /// If `--hosts` is provided, creates a host-specific block with `IdentityAgent`
@@ -149,15 +159,19 @@ fn configure_ssh_config(hosts: Option<&str>) -> Result<()> {
         String::new()
     };
 
-    // Migrate a stale IdentityAgent left over from the legacy ~/.vouch layout.
+    // Normalize a stale IdentityAgent left over from the legacy ~/.vouch layout.
     // Older versions wrote the agent socket under ~/.vouch/ssh-agent.sock; the
-    // socket now lives in the XDG runtime directory. Rewrite the path in place
-    // so existing users don't have to delete their config by hand.
-    if existing.contains(".vouch/ssh-agent.sock") && !existing.contains(&agent_socket) {
-        let rewritten = existing
+    // socket now lives in the XDG runtime directory. Only an actual
+    // `IdentityAgent ...~/.vouch/ssh-agent.sock` line is rewritten (not a stray
+    // mention in a comment), and we fall through to the normal setup path
+    // afterwards rather than returning early — so a first run that also needs
+    // the IdentityFile/CertificateFile block still gets it.
+    let has_stale_identity_agent = existing.lines().any(is_stale_identity_agent_line);
+    let existing = if has_stale_identity_agent {
+        let mut rewritten = existing
             .lines()
             .map(|line| {
-                if line.contains("IdentityAgent") && line.contains(".vouch/ssh-agent.sock") {
+                if is_stale_identity_agent_line(line) {
                     let indent: String = line.chars().take_while(|c| c.is_whitespace()).collect();
                     format!("{indent}IdentityAgent {agent_socket}")
                 } else {
@@ -166,19 +180,19 @@ fn configure_ssh_config(hosts: Option<&str>) -> Result<()> {
             })
             .collect::<Vec<_>>()
             .join("\n");
-        let rewritten = if existing.ends_with('\n') {
-            format!("{rewritten}\n")
-        } else {
-            rewritten
-        };
+        if existing.ends_with('\n') {
+            rewritten.push('\n');
+        }
         atomic_write_secure(&config_path, rewritten.as_bytes())
             .with_context(|| format!("failed to write {}", config_path.display()))?;
         println!(
             "Updated stale Vouch IdentityAgent path in {} -> {agent_socket}",
             config_path.display()
         );
-        return Ok(());
-    }
+        rewritten
+    } else {
+        existing
+    };
 
     // Check if Vouch config already exists
     if existing.contains("# Vouch SSH Configuration") || existing.contains(&agent_socket) {
@@ -352,5 +366,29 @@ mod tests {
         let path = ca_key_path("https://us.vouch.sh/").unwrap();
         let filename = path.file_name().unwrap().to_str().unwrap();
         assert_eq!(filename, "vouch_ca_us_vouch_sh.pub");
+    }
+
+    #[test]
+    fn stale_identity_agent_line_matches_only_real_directive() {
+        // Actual directive (with and without indentation) -> stale.
+        assert!(is_stale_identity_agent_line(
+            "    IdentityAgent ~/.vouch/ssh-agent.sock"
+        ));
+        assert!(is_stale_identity_agent_line(
+            "IdentityAgent /home/u/.vouch/ssh-agent.sock"
+        ));
+
+        // A comment or unrelated line mentioning the path must NOT match,
+        // so it cannot trigger a spurious rewrite / early skip.
+        assert!(!is_stale_identity_agent_line(
+            "# old path was ~/.vouch/ssh-agent.sock"
+        ));
+        assert!(!is_stale_identity_agent_line(
+            "IdentityFile ~/.ssh/id_ed25519"
+        ));
+        // A directive pointing at the new XDG socket is not stale.
+        assert!(!is_stale_identity_agent_line(
+            "    IdentityAgent /run/user/1000/vouch/ssh-agent.sock"
+        ));
     }
 }

--- a/crates/vouch-cli/src/config.rs
+++ b/crates/vouch-cli/src/config.rs
@@ -13,7 +13,7 @@ use std::fs;
 use std::path::PathBuf;
 use vouch_common::dns::{DohConfigSerde, NetworkConfig};
 
-/// AWS multi-account configuration in ~/.vouch/config.json.
+/// AWS multi-account configuration in `$XDG_CONFIG_HOME/vouch/config.json`.
 ///
 /// Keyed by SSO session name (matching `[sso-session <name>]` in `~/.aws/config`).
 /// SSO connection details (start URL, region, scopes) are read from `~/.aws/config`
@@ -112,7 +112,8 @@ pub(crate) fn normalize_member_role_path(raw: &str) -> Result<String> {
     Ok(canonical)
 }
 
-/// CLI configuration stored in ~/.vouch/config.json
+/// CLI configuration stored in `$XDG_CONFIG_HOME/vouch/config.json`
+/// (`~/.config/vouch/config.json` by default)
 ///
 /// Per-server state (token, client_id, registration, DPoP key) is
 /// stored under `servers`, keyed by hostname. Global state (CodeArtifact
@@ -148,7 +149,8 @@ pub(crate) struct ServerConfig {
     registration_access_token: Option<SecretString>,
     /// URI to manage the dynamic registration (RFC 7592).
     registration_client_uri: Option<String>,
-    /// Key ID of the DPoP keypair stored in ~/.vouch/dpop_key.json.
+    /// Key ID of the DPoP/FAPI client keypair (stored in the OS keychain, or
+    /// `$XDG_DATA_HOME/vouch/client_key.json` as a fallback).
     dpop_key_id: Option<String>,
     /// ISO 8601 timestamp of last successful registration verification.
     registration_verified_at: Option<String>,
@@ -182,7 +184,7 @@ pub(crate) struct CodeArtifactProfile {
 
 /// Federation configuration for AI provider APIs (Claude, OpenAI).
 ///
-/// Stored at the top level of `~/.vouch/config.json`. Holds the (non-secret)
+/// Stored at the top level of `$XDG_CONFIG_HOME/vouch/config.json`. Holds the (non-secret)
 /// identifiers a workload presents to a provider's token endpoint to
 /// exchange a Vouch-issued OIDC ID token for a short-lived provider token.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -601,10 +603,10 @@ impl Config {
             .openai = Some(fed);
     }
 
-    /// Get the path to the config file.
+    /// Get the path to the config file
+    /// (`$XDG_CONFIG_HOME/vouch/config.json`).
     fn config_path() -> Result<PathBuf> {
-        let home = dirs::home_dir().context("could not determine home directory")?;
-        Ok(home.join(".vouch").join("config.json"))
+        vouch_common::paths::config_file().context("could not determine config directory")
     }
 }
 

--- a/crates/vouch-cli/src/fapi/key_store.rs
+++ b/crates/vouch-cli/src/fapi/key_store.rs
@@ -106,7 +106,7 @@ pub fn delete_from_keychain() -> Result<(), FapiError> {
 ///
 /// Checks sources in order:
 /// 1. OS keychain (preferred — encrypted at rest)
-/// 2. `~/.vouch/client_key.json` (legacy/fallback)
+/// 2. `$XDG_DATA_HOME/vouch/client_key.json` (fallback)
 ///
 /// Returns `None` if no key is found. Never generates a new key — that
 /// happens only in the enroll/login flows via [`load_or_create_client_key`].
@@ -133,8 +133,7 @@ pub fn load_client_key() -> Option<ClientKey> {
     }
 
     // 2. Fall back to disk.
-    let home = dirs::home_dir()?;
-    let key_path = home.join(".vouch").join("client_key.json");
+    let key_path = vouch_common::paths::client_key_file()?;
 
     if !key_path.exists() {
         tracing::debug!("No FAPI key on disk at {}", key_path.display());
@@ -161,7 +160,7 @@ pub fn load_client_key() -> Option<ClientKey> {
 ///
 /// Checks sources in order:
 /// 1. OS keychain (preferred — encrypted at rest)
-/// 2. `~/.vouch/client_key.json` (legacy/fallback — migrated to keychain if possible)
+/// 2. `$XDG_DATA_HOME/vouch/client_key.json` (fallback — migrated to keychain if possible)
 /// 3. Generate new key → save to keychain (or file if keychain unavailable)
 ///
 /// If the key is found on disk but not in the keychain, it is migrated to the
@@ -179,25 +178,22 @@ pub fn load_or_create_client_key() -> anyhow::Result<ClientKey> {
         // If the key was loaded from disk (file still exists), migrate to keychain.
         // Verify the write by reading back — some platforms claim success but
         // don't actually persist the entry.
-        let home = dirs::home_dir();
-        if let Some(ref home) = home {
-            let key_path = home.join(".vouch").join("client_key.json");
-            if key_path.exists()
-                && let Ok(key_file) = key.to_key_file()
-                && save_to_keychain(&key_file).is_ok()
-                && load_from_keychain().is_ok_and(|v| v.is_some())
-            {
-                tracing::debug!("Migrated client key to keychain");
-                if let Err(e) = std::fs::remove_file(&key_path) {
-                    tracing::debug!("Could not remove old key file: {e}");
-                }
+        if let Some(key_path) = vouch_common::paths::client_key_file()
+            && key_path.exists()
+            && let Ok(key_file) = key.to_key_file()
+            && save_to_keychain(&key_file).is_ok()
+            && load_from_keychain().is_ok_and(|v| v.is_some())
+        {
+            tracing::debug!("Migrated client key to keychain");
+            if let Err(e) = std::fs::remove_file(&key_path) {
+                tracing::debug!("Could not remove old key file: {e}");
             }
         }
         return Ok(key);
     }
 
-    let home = dirs::home_dir().context("cannot determine home directory")?;
-    let key_path = home.join(".vouch").join("client_key.json");
+    let key_path =
+        vouch_common::paths::client_key_file().context("cannot determine data directory")?;
 
     // 2. Generate a new key.
     let key = ClientKey::generate().context("failed to generate FAPI client key")?;

--- a/crates/vouch-cli/src/integrations/aws/mod.rs
+++ b/crates/vouch-cli/src/integrations/aws/mod.rs
@@ -157,7 +157,7 @@ enum AwsStatusKind {
     /// One or more vouch profiles are present and aligned with vouch config.
     Configured { profiles: Vec<VouchProfile> },
     /// The SSO session named in `~/.aws/config` has no matching key in
-    /// `~/.vouch/config.json`. Credential fetching may still work via the
+    /// `~/.config/vouch/config.json`. Credential fetching may still work via the
     /// single-entry fallback in `resolve_management_role`, but it will
     /// silently break once a second SSO session is added.
     Mismatched {

--- a/crates/vouch-cli/src/main.rs
+++ b/crates/vouch-cli/src/main.rs
@@ -506,6 +506,10 @@ fn resolve_server_url(cli: &Cli, config: &config::Config) -> Result<server_url::
     reason = "single dispatch match over all CLI subcommands"
 )]
 async fn run() -> Result<()> {
+    // Relocate any legacy ~/.vouch/ files into the XDG base directories before
+    // the config is read. Idempotent and a no-op once migrated / for new installs.
+    vouch_common::paths::migrate_legacy_layout();
+
     let config = config::Config::load();
 
     if init_and_dispatch_helper_binaries(config.as_ref().ok()).await? {

--- a/crates/vouch-cli/src/session.rs
+++ b/crates/vouch-cli/src/session.rs
@@ -139,7 +139,7 @@ pub(crate) async fn store_session_in_agent(
     }
 }
 
-/// Write a Netscape cookie file for `curl -b ~/.vouch/cookie.txt`.
+/// Write a Netscape cookie file for `curl -b ~/.local/state/vouch/cookie.txt`.
 ///
 /// Best-effort: logs and swallows errors (cookie file is a convenience,
 /// never blocks the login flow).

--- a/crates/vouch-common/src/cookie.rs
+++ b/crates/vouch-common/src/cookie.rs
@@ -4,7 +4,8 @@
 //! This module provides functions to read and write cookies in the Netscape cookie
 //! format, which is used by many tools including curl and wget.
 //!
-//! The cookie file is stored at `~/.vouch/cookie.txt` with 0600 permissions on Unix.
+//! The cookie file is stored at `$XDG_STATE_HOME/vouch/cookie.txt`
+//! (`~/.local/state/vouch/cookie.txt` by default) with 0600 permissions on Unix.
 
 use anyhow::{Context, Result};
 use std::fs;
@@ -97,10 +98,10 @@ impl SessionCookie {
 
 /// Get the path to the cookie file.
 ///
-/// Returns `~/.vouch/cookie.txt`.
+/// Returns `$XDG_STATE_HOME/vouch/cookie.txt` (`~/.local/state/vouch/cookie.txt`
+/// by default).
 pub fn cookie_path() -> Result<PathBuf> {
-    let home = dirs::home_dir().context("could not determine home directory")?;
-    Ok(home.join(".vouch").join("cookie.txt"))
+    crate::paths::cookie_file().context("could not determine home directory")
 }
 
 /// Write a session cookie to the cookie file.

--- a/crates/vouch-common/src/dns.rs
+++ b/crates/vouch-common/src/dns.rs
@@ -6,7 +6,7 @@
 //! (Google, Cloudflare, Quad9) or a custom HTTPS endpoint.
 //!
 //! Opt-in via the `VOUCH_DOH` env var or the `network.dns_over_https` field in
-//! `~/.vouch/config.json`. When unset, the system resolver is used.
+//! `~/.config/vouch/config.json`. When unset, the system resolver is used.
 //!
 //! Both `vouch-cli` and `vouch-agent` install the process-wide state via
 //! [`init_from`] before any HTTP client is constructed; [`process_resolver`]
@@ -175,7 +175,7 @@ impl DohConfig {
 // DohConfigSerde — config-file representation
 // =============================================================================
 
-/// Serializable form for `~/.vouch/config.json`. Accepts a string keyword,
+/// Serializable form for `~/.config/vouch/config.json`. Accepts a string keyword,
 /// a URL, or a bare boolean (`true` -> Google, `false` -> Off).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]

--- a/crates/vouch-common/src/lib.rs
+++ b/crates/vouch-common/src/lib.rs
@@ -12,6 +12,7 @@ pub mod fido2_types;
 pub mod fixtures;
 pub mod fs;
 pub mod http;
+pub mod paths;
 pub mod posture;
 pub(crate) mod url;
 

--- a/crates/vouch-common/src/paths.rs
+++ b/crates/vouch-common/src/paths.rs
@@ -176,7 +176,11 @@ fn migrate_layout(legacy_dir: &Path, dests: &[(&str, PathBuf)]) -> bool {
         match move_file(&src, dest) {
             Ok(()) => moved_any = true,
             Err(e) => {
-                tracing::warn!("failed to migrate {} → {}: {e}", src.display(), dest.display());
+                tracing::warn!(
+                    "failed to migrate {} → {}: {e}",
+                    src.display(),
+                    dest.display()
+                );
             }
         }
     }

--- a/crates/vouch-common/src/paths.rs
+++ b/crates/vouch-common/src/paths.rs
@@ -187,15 +187,27 @@ fn migrate_layout(legacy_dir: &Path, dests: &[(&str, PathBuf)]) -> bool {
     moved_any
 }
 
-/// Migrate a legacy flat `~/.vouch/` layout into the XDG directories.
+/// Migrate legacy file layouts into the XDG directories.
 ///
-/// Idempotent and best-effort. A no-op when `~/.vouch/` does not exist (the
-/// common case for new installs) or when files have already been migrated.
+/// Idempotent and best-effort. Covers two cases:
+/// 1. The flat `~/.vouch/` directory used by older versions (config, cookie,
+///    audit log, client key).
+/// 2. The cache directory: older versions resolved `agent.pid`/`agent.log`
+///    via `dirs::cache_dir()` (e.g. `~/Library/Caches` on macOS), which differs
+///    from the XDG cache dir now used. Migrating the PID file lets an upgraded
+///    agent detect a still-running old agent instead of starting a second one.
+///
 /// Sockets are intentionally *not* moved — they are runtime artifacts that are
 /// recreated, and a running agent may still hold them. Safe to call
 /// concurrently from the CLI and agent: each move is an atomic `rename` guarded
 /// by a destination-exists check.
 pub fn migrate_legacy_layout() {
+    migrate_legacy_vouch_dir();
+    migrate_legacy_cache_dir();
+}
+
+/// Migrate the legacy flat `~/.vouch/` directory (case 1 above).
+fn migrate_legacy_vouch_dir() {
     let Some(home) = dirs::home_dir() else {
         return;
     };
@@ -233,6 +245,38 @@ pub fn migrate_legacy_layout() {
     }
 }
 
+/// The cache directory used by older versions, via `dirs::cache_dir()`.
+///
+/// Equals [`cache_dir`] on Linux, but differs on macOS (`~/Library/Caches`) and
+/// Windows (`%LOCALAPPDATA%`).
+fn legacy_cache_dir() -> Option<PathBuf> {
+    dirs::cache_dir().map(|c| c.join(APP_DIR))
+}
+
+/// Migrate `agent.pid`/`agent.log` from the legacy cache dir (case 2 above).
+///
+/// A no-op when the legacy and current cache directories are the same (Linux)
+/// or when the legacy directory does not exist.
+fn migrate_legacy_cache_dir() {
+    let (Some(legacy), Some(new)) = (legacy_cache_dir(), cache_dir()) else {
+        return;
+    };
+    migrate_cache_files(&legacy, &new);
+}
+
+/// Core cache migration: move `agent.pid`/`agent.log` from `legacy_cache` to
+/// `new_cache` when the two differ. Returns `true` if anything was moved.
+fn migrate_cache_files(legacy_cache: &Path, new_cache: &Path) -> bool {
+    if legacy_cache == new_cache || !legacy_cache.exists() {
+        return false;
+    }
+    let dests = [
+        ("agent.pid", new_cache.join("agent.pid")),
+        ("agent.log", new_cache.join("agent.log")),
+    ];
+    migrate_layout(legacy_cache, &dests)
+}
+
 #[cfg(test)]
 #[expect(
     clippy::panic_in_result_fn,
@@ -245,12 +289,14 @@ mod tests {
     #[test]
     fn resolve_base_prefers_absolute_env() {
         let home = PathBuf::from("/home/alice");
-        let got = resolve_base(
-            Some(OsString::from("/custom/config")),
-            Some(&home),
-            &[".config"],
-        );
-        assert_eq!(got, Some(PathBuf::from("/custom/config")));
+        // `is_absolute()` is platform-specific: on Windows a path needs a drive
+        // (or UNC) prefix, so use a platform-appropriate absolute path.
+        #[cfg(unix)]
+        let abs = "/custom/config";
+        #[cfg(windows)]
+        let abs = r"C:\custom\config";
+        let got = resolve_base(Some(OsString::from(abs)), Some(&home), &[".config"]);
+        assert_eq!(got, Some(PathBuf::from(abs)));
     }
 
     #[test]
@@ -337,6 +383,35 @@ mod tests {
         // Existing destination is left untouched; source remains.
         assert_eq!(std::fs::read(&dest)?, b"existing");
         assert!(legacy.join("config.json").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn migrate_cache_files_moves_pid_and_log() -> std::io::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let legacy = tmp.path().join("Library/Caches/vouch");
+        let new = tmp.path().join(".cache/vouch");
+        std::fs::create_dir_all(&legacy)?;
+        std::fs::write(legacy.join("agent.pid"), b"4242")?;
+        std::fs::write(legacy.join("agent.log"), b"log")?;
+
+        assert!(migrate_cache_files(&legacy, &new));
+        assert_eq!(std::fs::read(new.join("agent.pid"))?, b"4242");
+        assert!(new.join("agent.log").exists());
+        assert!(!legacy.join("agent.pid").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn migrate_cache_files_noop_when_dirs_equal() -> std::io::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let cache = tmp.path().join(".cache/vouch");
+        std::fs::create_dir_all(&cache)?;
+        std::fs::write(cache.join("agent.pid"), b"1")?;
+
+        // Linux case: legacy and current cache dirs are identical -> no move.
+        assert!(!migrate_cache_files(&cache, &cache));
+        assert!(cache.join("agent.pid").exists());
         Ok(())
     }
 }

--- a/crates/vouch-common/src/paths.rs
+++ b/crates/vouch-common/src/paths.rs
@@ -1,0 +1,338 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! XDG Base Directory resolution for vouch-owned files.
+//!
+//! This module is the single source of truth for every path vouch reads or
+//! writes under the user's home directory. It follows the
+//! [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/)
+//! and resolves XDG-style paths on **all** platforms — including macOS, where
+//! `~/.config` is used rather than `~/Library/Application Support`. This
+//! matches the convention of modern developer CLIs (`gh`, `git`, `starship`).
+//!
+//! | Data | Base (env → default) | Path |
+//! |------|----------------------|------|
+//! | config | `XDG_CONFIG_HOME` → `~/.config` | `<base>/vouch/` |
+//! | state (cookies, audit log) | `XDG_STATE_HOME` → `~/.local/state` | `<base>/vouch/` |
+//! | data (keyring fallback key) | `XDG_DATA_HOME` → `~/.local/share` | `<base>/vouch/` |
+//! | cache (pid, agent log) | `XDG_CACHE_HOME` → `~/.cache` | `<base>/vouch/` |
+//! | runtime (sockets) | `XDG_RUNTIME_DIR` → cache fallback | `<base>/vouch/` |
+//!
+//! Per the spec, `XDG_*` values that are not absolute paths are ignored and the
+//! default is used instead.
+//!
+//! Earlier versions of vouch stored everything flat in `~/.vouch/`.
+//! [`migrate_legacy_layout`] relocates those files into the directories above
+//! on first run.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+/// Application sub-directory created under each XDG base directory.
+const APP_DIR: &str = "vouch";
+
+/// Resolve an XDG base directory from an env value and home directory.
+///
+/// If `env_val` is an absolute path it is used verbatim; otherwise the base is
+/// `home` joined with `default_components`. Returns `None` only when a home
+/// directory is required (env unset/relative) but cannot be determined.
+fn resolve_base(
+    env_val: Option<OsString>,
+    home: Option<&Path>,
+    default_components: &[&str],
+) -> Option<PathBuf> {
+    if let Some(val) = env_val {
+        let candidate = PathBuf::from(val);
+        if candidate.is_absolute() {
+            return Some(candidate);
+        }
+    }
+    let mut base = home?.to_path_buf();
+    for component in default_components {
+        base.push(component);
+    }
+    Some(base)
+}
+
+/// Resolve `<base>/vouch` for the given XDG variable and default location.
+fn vouch_subdir(var: &str, default_components: &[&str]) -> Option<PathBuf> {
+    let base = resolve_base(
+        std::env::var_os(var),
+        dirs::home_dir().as_deref(),
+        default_components,
+    )?;
+    Some(base.join(APP_DIR))
+}
+
+/// Configuration directory: `<XDG_CONFIG_HOME|~/.config>/vouch`.
+#[must_use]
+pub fn config_dir() -> Option<PathBuf> {
+    vouch_subdir("XDG_CONFIG_HOME", &[".config"])
+}
+
+/// State directory: `<XDG_STATE_HOME|~/.local/state>/vouch`.
+///
+/// Holds files that should persist between runs but are not user-edited
+/// configuration: session cookies and the audit log.
+#[must_use]
+pub fn state_dir() -> Option<PathBuf> {
+    vouch_subdir("XDG_STATE_HOME", &[".local", "state"])
+}
+
+/// Data directory: `<XDG_DATA_HOME|~/.local/share>/vouch`.
+#[must_use]
+pub fn data_dir() -> Option<PathBuf> {
+    vouch_subdir("XDG_DATA_HOME", &[".local", "share"])
+}
+
+/// Cache directory: `<XDG_CACHE_HOME|~/.cache>/vouch`.
+#[must_use]
+pub fn cache_dir() -> Option<PathBuf> {
+    vouch_subdir("XDG_CACHE_HOME", &[".cache"])
+}
+
+/// Runtime directory: `<XDG_RUNTIME_DIR>/vouch`, used for Unix sockets.
+///
+/// `XDG_RUNTIME_DIR` is the correct home for sockets — it is a private,
+/// `0700`, user-owned tmpfs cleared on logout. It is, however, only set on
+/// Linux sessions managed by a login manager; on macOS and headless logins it
+/// is absent, so we fall back to the cache directory (a short path that avoids
+/// the ~104-byte `sun_path` limit on macOS).
+#[must_use]
+pub fn runtime_dir() -> Option<PathBuf> {
+    if let Some(val) = std::env::var_os("XDG_RUNTIME_DIR") {
+        let candidate = PathBuf::from(val);
+        if candidate.is_absolute() {
+            return Some(candidate.join(APP_DIR));
+        }
+    }
+    cache_dir()
+}
+
+/// Path to the CLI configuration file (`<config>/vouch/config.json`).
+#[must_use]
+pub fn config_file() -> Option<PathBuf> {
+    config_dir().map(|d| d.join("config.json"))
+}
+
+/// Path to the session cookie file (`<state>/vouch/cookie.txt`).
+#[must_use]
+pub fn cookie_file() -> Option<PathBuf> {
+    state_dir().map(|d| d.join("cookie.txt"))
+}
+
+/// Path to the audit log (`<state>/vouch/audit.log`).
+#[must_use]
+pub fn audit_log_file() -> Option<PathBuf> {
+    state_dir().map(|d| d.join("audit.log"))
+}
+
+/// Path to the FAPI client key fallback file (`<data>/vouch/client_key.json`).
+///
+/// The OS keychain remains the primary store; this file is only used when the
+/// keychain is unavailable (CI, headless).
+#[must_use]
+pub fn client_key_file() -> Option<PathBuf> {
+    data_dir().map(|d| d.join("client_key.json"))
+}
+
+/// Create `dir` (and parents) with owner-only `0700` permissions on Unix.
+fn ensure_private_dir(dir: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dir)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))?;
+    }
+    Ok(())
+}
+
+/// Move `from` to `to`, preserving permission bits.
+///
+/// Prefers an atomic `rename`; falls back to copy + remove when the source and
+/// destination live on different filesystems (`EXDEV`).
+fn move_file(from: &Path, to: &Path) -> std::io::Result<()> {
+    if let Some(parent) = to.parent() {
+        ensure_private_dir(parent)?;
+    }
+    match std::fs::rename(from, to) {
+        Ok(()) => Ok(()),
+        Err(_) => {
+            // Cross-device rename: copy (preserves mode bits) then remove.
+            std::fs::copy(from, to)?;
+            std::fs::remove_file(from)
+        }
+    }
+}
+
+/// Core migration routine: move each `(filename, destination)` out of
+/// `legacy_dir`, skipping files that are absent or whose destination already
+/// exists. Returns `true` if anything was moved.
+fn migrate_layout(legacy_dir: &Path, dests: &[(&str, PathBuf)]) -> bool {
+    let mut moved_any = false;
+    for (name, dest) in dests {
+        let src = legacy_dir.join(name);
+        if !src.exists() || dest.exists() {
+            continue;
+        }
+        match move_file(&src, dest) {
+            Ok(()) => moved_any = true,
+            Err(e) => {
+                tracing::warn!("failed to migrate {} → {}: {e}", src.display(), dest.display());
+            }
+        }
+    }
+    moved_any
+}
+
+/// Migrate a legacy flat `~/.vouch/` layout into the XDG directories.
+///
+/// Idempotent and best-effort. A no-op when `~/.vouch/` does not exist (the
+/// common case for new installs) or when files have already been migrated.
+/// Sockets are intentionally *not* moved — they are runtime artifacts that are
+/// recreated, and a running agent may still hold them. Safe to call
+/// concurrently from the CLI and agent: each move is an atomic `rename` guarded
+/// by a destination-exists check.
+pub fn migrate_legacy_layout() {
+    let Some(home) = dirs::home_dir() else {
+        return;
+    };
+    let legacy_dir = home.join(".vouch");
+    if !legacy_dir.exists() {
+        return;
+    }
+
+    let Some(state) = state_dir() else { return };
+    let mut dests: Vec<(&str, PathBuf)> = Vec::new();
+    if let Some(p) = config_file() {
+        dests.push(("config.json", p));
+    }
+    if let Some(p) = cookie_file() {
+        dests.push(("cookie.txt", p));
+    }
+    dests.push(("audit.log", state.join("audit.log")));
+    dests.push(("audit.log.1", state.join("audit.log.1")));
+    if let Some(p) = client_key_file() {
+        dests.push(("client_key.json", p));
+    }
+
+    let moved = migrate_layout(&legacy_dir, &dests);
+
+    // Best-effort cleanup: remove the legacy directory if it is now empty.
+    // `remove_dir` fails (and is ignored) when sockets or other files remain.
+    let _empty_removed = std::fs::remove_dir(&legacy_dir);
+
+    if moved {
+        eprintln!(
+            "vouch: migrated files from {} to XDG base directories (~/.config/vouch, \
+             ~/.local/state/vouch, ~/.local/share/vouch).",
+            legacy_dir.display()
+        );
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::panic_in_result_fn,
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_base_prefers_absolute_env() {
+        let home = PathBuf::from("/home/alice");
+        let got = resolve_base(
+            Some(OsString::from("/custom/config")),
+            Some(&home),
+            &[".config"],
+        );
+        assert_eq!(got, Some(PathBuf::from("/custom/config")));
+    }
+
+    #[test]
+    fn resolve_base_ignores_relative_env() {
+        let home = PathBuf::from("/home/alice");
+        let got = resolve_base(
+            Some(OsString::from("relative/path")),
+            Some(&home),
+            &[".config"],
+        );
+        assert_eq!(got, Some(PathBuf::from("/home/alice/.config")));
+    }
+
+    #[test]
+    fn resolve_base_uses_default_when_env_unset() {
+        let home = PathBuf::from("/home/alice");
+        let got = resolve_base(None, Some(&home), &[".local", "state"]);
+        assert_eq!(got, Some(PathBuf::from("/home/alice/.local/state")));
+    }
+
+    #[test]
+    fn resolve_base_none_without_home() {
+        assert_eq!(resolve_base(None, None, &[".config"]), None);
+    }
+
+    #[test]
+    fn migrate_moves_files_and_preserves_mode() -> std::io::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let legacy = tmp.path().join(".vouch");
+        std::fs::create_dir_all(&legacy)?;
+        std::fs::write(legacy.join("config.json"), b"{}")?;
+        std::fs::write(legacy.join("cookie.txt"), b"cookie")?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(
+                legacy.join("config.json"),
+                std::fs::Permissions::from_mode(0o600),
+            )?;
+        }
+
+        let config_dest = tmp.path().join(".config/vouch/config.json");
+        let cookie_dest = tmp.path().join(".local/state/vouch/cookie.txt");
+        let dests = vec![
+            ("config.json", config_dest.clone()),
+            ("cookie.txt", cookie_dest.clone()),
+        ];
+
+        assert!(migrate_layout(&legacy, &dests));
+        assert!(config_dest.exists());
+        assert!(cookie_dest.exists());
+        assert!(!legacy.join("config.json").exists());
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&config_dest)?.permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "config mode should survive migration");
+            let dir_mode = std::fs::metadata(config_dest.parent().expect("parent"))?
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(dir_mode, 0o700, "created dir should be 0700");
+        }
+
+        // Second run is a no-op.
+        assert!(!migrate_layout(&legacy, &dests));
+        Ok(())
+    }
+
+    #[test]
+    fn migrate_skips_when_destination_exists() -> std::io::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let legacy = tmp.path().join(".vouch");
+        std::fs::create_dir_all(&legacy)?;
+        std::fs::write(legacy.join("config.json"), b"new")?;
+
+        let dest = tmp.path().join(".config/vouch/config.json");
+        std::fs::create_dir_all(dest.parent().expect("parent"))?;
+        std::fs::write(&dest, b"existing")?;
+
+        let dests = vec![("config.json", dest.clone())];
+        assert!(!migrate_layout(&legacy, &dests));
+        // Existing destination is left untouched; source remains.
+        assert_eq!(std::fs::read(&dest)?, b"existing");
+        assert!(legacy.join("config.json").exists());
+        Ok(())
+    }
+}

--- a/crates/vouch-common/src/paths.rs
+++ b/crates/vouch-common/src/paths.rs
@@ -147,19 +147,22 @@ fn ensure_private_dir(dir: &Path) -> std::io::Result<()> {
 
 /// Move `from` to `to`, preserving permission bits.
 ///
-/// Prefers an atomic `rename`; falls back to copy + remove when the source and
-/// destination live on different filesystems (`EXDEV`).
+/// Prefers an atomic `rename`. Falls back to copy + remove *only* when the
+/// source and destination live on different filesystems (`EXDEV`). Any other
+/// `rename` failure (permissions, transient I/O) is propagated so the source is
+/// never deleted after a failed or partial move.
 fn move_file(from: &Path, to: &Path) -> std::io::Result<()> {
     if let Some(parent) = to.parent() {
         ensure_private_dir(parent)?;
     }
     match std::fs::rename(from, to) {
         Ok(()) => Ok(()),
-        Err(_) => {
+        Err(e) if e.kind() == std::io::ErrorKind::CrossesDevices => {
             // Cross-device rename: copy (preserves mode bits) then remove.
             std::fs::copy(from, to)?;
             std::fs::remove_file(from)
         }
+        Err(e) => Err(e),
     }
 }
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -44,6 +44,7 @@
 # Reference
 
 - [Environment Variables](reference/environment-variables.md)
+- [File Locations (CLI & Agent)](reference/file-locations.md)
 - [S3 Configuration Schema](reference/s3-config-schema.md)
 - [Compliance Mapping](reference/compliance.md)
 - [AMI STIG Alignment](reference/ami-stig.md)

--- a/docs/src/advanced/airgap-installation.md
+++ b/docs/src/advanced/airgap-installation.md
@@ -409,7 +409,7 @@ echo "john" >> /etc/ssh/auth_principals/john
 ## Step 9: Configure CLI for Air-Gap
 
 ```bash
-# ~/.vouch/config.json
+# ~/.config/vouch/config.json
 {
   "server_url": "https://auth.internal",
   "ca_cert_path": "/etc/vouch/root-ca.crt"

--- a/docs/src/operations/scim.md
+++ b/docs/src/operations/scim.md
@@ -17,7 +17,7 @@ Log in with `vouch login`, then create a SCIM token using the cookie file or tok
 ```bash
 # Using cookie file (written automatically on login)
 curl -X POST https://auth.example.com/api/v1/org/scim-tokens \
-  -b ~/.vouch/cookie.txt \
+  -b ~/.local/state/vouch/cookie.txt \
   -H "Content-Type: application/json" \
   -d '{"description": "SCIM integration", "expires_in_days": 90}'
 
@@ -40,11 +40,11 @@ Enter the following in your IdP's SCIM configuration:
 
 ```bash
 # List active SCIM tokens
-curl -b ~/.vouch/cookie.txt \
+curl -b ~/.local/state/vouch/cookie.txt \
   https://auth.example.com/api/v1/org/scim-tokens
 
 # Revoke a SCIM token
-curl -X DELETE -b ~/.vouch/cookie.txt \
+curl -X DELETE -b ~/.local/state/vouch/cookie.txt \
   https://auth.example.com/api/v1/org/scim-tokens/<token-id>
 ```
 

--- a/docs/src/operations/sessions.md
+++ b/docs/src/operations/sessions.md
@@ -25,9 +25,16 @@ Sessions are stored in multiple locations for different access patterns:
 | Location | Purpose | Security |
 |----------|---------|----------|
 | `vouch-agent` memory | Primary access for CLI and credential helpers | In-process, zeroized on drop |
-| `~/.vouch/config.json` | Fallback when agent is not running | File permissions 0600 |
-| `~/.vouch/cookie.txt` | Netscape cookie file for `curl -b` usage | File permissions 0600 |
+| `~/.config/vouch/config.json` | Fallback when agent is not running | File permissions 0600 |
+| `~/.local/state/vouch/cookie.txt` | Netscape cookie file for `curl -b` usage | File permissions 0600 |
 | Server database | Server-side session record | Token hash stored, not plaintext |
+
+Vouch follows the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/)
+and honors `XDG_CONFIG_HOME`, `XDG_STATE_HOME`, `XDG_DATA_HOME`, `XDG_CACHE_HOME`,
+and `XDG_RUNTIME_DIR` on all platforms (including macOS). The paths above show the
+defaults when those variables are unset. See
+[File Locations](../reference/file-locations.md) for the full map and the
+automatic migration from the legacy `~/.vouch/` directory.
 
 ## Server-Side Session Management
 

--- a/docs/src/reference/file-locations.md
+++ b/docs/src/reference/file-locations.md
@@ -1,0 +1,46 @@
+# File Locations (CLI & Agent)
+
+The `vouch` CLI and `vouch-agent` follow the
+[XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/).
+Files are split by purpose across the standard base directories, and the
+relevant `XDG_*` environment variables are honored on **all** platforms —
+including macOS, where Vouch uses `~/.config` rather than
+`~/Library/Application Support`, matching the convention of tools like `gh` and
+`git`.
+
+## Locations
+
+| File | Purpose | Base directory (env → default) | Default path |
+|------|---------|--------------------------------|--------------|
+| `config.json` | CLI configuration, session token, OAuth/DPoP client metadata | `XDG_CONFIG_HOME` → `~/.config` | `~/.config/vouch/config.json` |
+| `cookie.txt` | Netscape session cookie for `curl -b` usage | `XDG_STATE_HOME` → `~/.local/state` | `~/.local/state/vouch/cookie.txt` |
+| `audit.log` | Agent security audit log (newline-delimited JSON) | `XDG_STATE_HOME` → `~/.local/state` | `~/.local/state/vouch/audit.log` |
+| `client_key.json` | FAPI client key — **fallback only**; the OS keychain is the primary store | `XDG_DATA_HOME` → `~/.local/share` | `~/.local/share/vouch/client_key.json` |
+| `agent.pid`, `agent.log` | Agent PID and daemon log | `XDG_CACHE_HOME` → `~/.cache` | `~/.cache/vouch/` |
+| `agent.sock`, `ssh-agent.sock` | Agent IPC and SSH-agent Unix sockets | `XDG_RUNTIME_DIR` → cache fallback | `$XDG_RUNTIME_DIR/vouch/*.sock` |
+
+All files written by Vouch are created with owner-only permissions (`0600` for
+files, `0700` for directories) on Unix.
+
+### Runtime sockets
+
+Unix sockets live in `XDG_RUNTIME_DIR` — a private, user-owned, `0700` tmpfs
+that the login session manager clears on logout. `XDG_RUNTIME_DIR` is only set
+on Linux sessions managed by a login manager; on macOS and headless logins it
+is absent, so Vouch falls back to a `0700` directory under the cache base
+(`~/.cache/vouch`), chosen because its short path stays within the macOS
+`sun_path` socket-path length limit.
+
+## Migration from `~/.vouch/`
+
+Earlier versions of Vouch stored everything flat under `~/.vouch/`. On the first
+run of a newer `vouch` or `vouch-agent`, files found there
+(`config.json`, `cookie.txt`, `audit.log`, `client_key.json`) are moved
+automatically to their XDG locations, preserving permissions. The migration is
+idempotent and prints a one-time notice. Sockets are not migrated — they are
+recreated on demand.
+
+One thing the migration cannot fix automatically: if you previously ran
+`vouch setup ssh`, your `~/.ssh/config` may contain an `IdentityAgent` line
+pointing at the old `~/.vouch/ssh-agent.sock`. Re-running `vouch setup ssh`
+detects and rewrites that stale path to the new socket location.

--- a/docs/src/reference/file-locations.md
+++ b/docs/src/reference/file-locations.md
@@ -40,6 +40,12 @@ automatically to their XDG locations, preserving permissions. The migration is
 idempotent and prints a one-time notice. Sockets are not migrated — they are
 recreated on demand.
 
+On macOS (and Windows), the agent's `agent.pid`/`agent.log` previously lived in
+the OS cache directory (`~/Library/Caches/vouch`) rather than `~/.cache/vouch`.
+These are migrated too, so an upgraded agent detects a still-running old agent
+via the PID file instead of starting a second one. On Linux the cache location
+is unchanged, so this step is a no-op.
+
 One thing the migration cannot fix automatically: if you previously ran
 `vouch setup ssh`, your `~/.ssh/config` may contain an `IdentityAgent` line
 pointing at the old `~/.vouch/ssh-agent.sock`. Re-running `vouch setup ssh`


### PR DESCRIPTION
## Summary

Vouch previously stored every file flat under `~/.vouch/`, computed ad-hoc from `dirs::home_dir()` in five helpers across three crates, ignoring the user's `XDG_*` settings. This change makes the CLI and agent fully [XDG Base Directory](https://specifications.freedesktop.org/basedir-spec/latest/) compliant, splitting files by purpose and resolving them XDG-style on **all** platforms — including macOS, which now uses `~/.config` rather than `~/Library/Application Support` (matching `gh`/`git`).

Direct motivation: config now lives at `~/.config/vouch/config.json` (honoring `$XDG_CONFIG_HOME`), not `~/.vouch/`.

## Target layout

| Data | Base (env → default) | Path |
|------|----------------------|------|
| `config.json` | `XDG_CONFIG_HOME` → `~/.config` | `<base>/vouch/` |
| `cookie.txt`, `audit.log` | `XDG_STATE_HOME` → `~/.local/state` | `<base>/vouch/` |
| `client_key.json` (keyring fallback) | `XDG_DATA_HOME` → `~/.local/share` | `<base>/vouch/` |
| `agent.pid`, `agent.log` | `XDG_CACHE_HOME` → `~/.cache` | `<base>/vouch/` |
| `agent.sock`, `ssh-agent.sock` | `XDG_RUNTIME_DIR` → cache fallback | `<base>/vouch/` |

## What changed

- **New module `crates/vouch-common/src/paths.rs`** — single source of truth for every vouch-owned path. Reads `XDG_*` env vars with home-based defaults (ignoring non-absolute values per the spec). No new dependency; `dirs::home_dir()` remains the only directory dep.
- **`migrate_legacy_layout()`** — relocates an existing `~/.vouch/` into the XDG dirs on first run, preserving permissions; called early in both the CLI (`main.rs run()`) and agent (`main.rs main()`) entrypoints. Idempotent, best-effort, race-safe (atomic `rename` guarded by destination-exists checks). Sockets are not moved (runtime artifacts, recreated). Prints a one-time notice.
- **Existing helpers delegate to `paths`** — agent `socket.rs` (runtime dir, sockets), `audit.rs` (state dir, decoupled from the socket dir), `config.rs`, `daemon.rs` (XDG cache); CLI `config.rs`, `fapi/key_store.rs`; common `cookie.rs`. All existing permission/ownership/symlink checks preserved.
- **`vouch setup ssh`** now detects and rewrites a stale `IdentityAgent` line pointing at the old `~/.vouch/ssh-agent.sock` (the one part migration can't self-heal, since the path is now dynamic). It already wrote the resolved absolute socket path, which now points at the runtime dir.
- **Runtime-dir fallback** — `XDG_RUNTIME_DIR` is absent on macOS/headless logins, so sockets fall back to a `0700` dir under the cache base (short path, stays within the macOS `sun_path` limit).
- **Docs** — new `reference/file-locations.md` (+ SUMMARY entry); updated `operations/sessions.md`, `operations/scim.md`, `advanced/airgap-installation.md`, and `CLAUDE.md`.

## Testing

- `cargo clippy -p vouch-common -p vouch-cli -p vouch-agent --all-targets` — clean (`-D warnings`, no-panic lints).
- `cargo test` for the three crates — **1054 tests pass**, including 6 new `paths` tests (XDG resolution with/without env vars, non-absolute rejection, migration moves + mode preservation + idempotency + destination-exists skip).
- End-to-end smoke: ran the real `vouch` binary with a seeded legacy `~/.vouch/` and `XDG_*` pointed at a scratch dir — confirmed `config.json` migrated to `$XDG_CONFIG_HOME/vouch/` with `0600` preserved (dir `0700`), `audit.log` → `$XDG_STATE_HOME/vouch/`, legacy dir cleaned up, and the one-time notice printed.

## Compatibility note

Existing users are auto-migrated transparently. The one manual step: anyone who previously ran `vouch setup ssh` should re-run it so the stale `~/.ssh/config` `IdentityAgent` path is rewritten (handled automatically by the re-run).


---
_Generated by [Claude Code](https://claude.ai/code/session_01DbQG7Y7vpJvJ6NdvobX1Ua)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session config, tokens, audit logs, agent PID/sockets, and SSH `IdentityAgent` paths; migration is best-effort but mis-migration or wrong socket path could break login or SSH until users re-run setup.
> 
> **Overview**
> **Moves CLI and agent off the flat `~/.vouch/` tree** onto [XDG Base Directory](https://specifications.freedesktop.org/basedir-spec/latest/) paths on all platforms (including macOS `~/.config`), with a new **`vouch_common::paths`** module as the only place that resolves config, state, cookies, audit log, FAPI key fallback, cache (PID/log), and runtime sockets.
> 
> **`migrate_legacy_layout()`** runs at CLI and agent startup: relocates legacy `~/.vouch/` files and (on macOS/Windows) old `dirs::cache_dir()` agent PID/log into the new layout, preserves modes, skips existing destinations, and prints a one-time notice. Sockets are not migrated.
> 
> **Call sites** in agent and CLI now use `paths::*` instead of `home.join(".vouch")`. Agent IPC and SSH-agent sockets use **`$XDG_RUNTIME_DIR/vouch/`** with a **`0700` cache-dir fallback** when runtime dir is unset.
> 
> **`vouch setup ssh`** rewrites only real stale **`IdentityAgent`** lines that still point at **`~/.vouch/ssh-agent.sock`**, then continues normal setup.
> 
> Docs add **`reference/file-locations.md`** and update session/SCIM/airgap paths and **`CLAUDE.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e38e3940523ab55f50a33435609e688062812d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->