### PR TITLE
CLI and Agent i18n

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6344,6 +6344,7 @@ name = "vouch-i18n"
 version = "2026.6.3"
 dependencies = [
  "anyhow",
+ "fluent-bundle",
  "i18n-embed",
  "rust-embed",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2831,6 +2831,26 @@ dependencies = [
  "rust-embed",
  "thiserror 1.0.69",
  "unic-langid",
+ "walkdir",
+]
+
+[[package]]
+name = "i18n-embed-fl"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e598ed73b67db92f61e04672e599eef2991a262a40e1666735b8a86d2e7e9f30"
+dependencies = [
+ "find-crate",
+ "fluent",
+ "fluent-syntax",
+ "i18n-config",
+ "i18n-embed",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+ "unic-langid",
 ]
 
 [[package]]
@@ -4138,6 +4158,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5393,6 +5435,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5445,6 +5493,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -6159,20 +6216,26 @@ dependencies = [
  "clap",
  "dirs",
  "ed25519-dalek",
+ "i18n-embed",
+ "i18n-embed-fl",
  "jiff",
  "libc",
  "mimalloc",
  "reqwest",
+ "rust-embed",
  "secrecy",
  "serde",
  "serde_json",
  "ssh-key",
+ "sys-locale",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "unic-langid",
  "url",
  "vouch-common",
+ "vouch-i18n",
  "zeroize",
 ]
 
@@ -6194,6 +6257,8 @@ dependencies = [
  "gethostname",
  "hex",
  "http 1.4.2",
+ "i18n-embed",
+ "i18n-embed-fl",
  "inquire",
  "jiff",
  "jsonwebtoken",
@@ -6206,6 +6271,7 @@ dependencies = [
  "reqwest",
  "roxmltree",
  "rpassword",
+ "rust-embed",
  "rust-ini",
  "secrecy",
  "serde",
@@ -6213,6 +6279,7 @@ dependencies = [
  "serde_urlencoded",
  "serde_yaml",
  "ssh-key",
+ "sys-locale",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -6220,12 +6287,14 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
+ "unic-langid",
  "url",
  "urlencoding",
  "uuid",
  "vouch-agent",
  "vouch-common",
  "vouch-httpsig",
+ "vouch-i18n",
  "which",
  "windows",
  "windows-native-keyring-store",
@@ -6268,6 +6337,17 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
+]
+
+[[package]]
+name = "vouch-i18n"
+version = "2026.6.3"
+dependencies = [
+ "anyhow",
+ "i18n-embed",
+ "rust-embed",
+ "tracing",
+ "unic-langid",
 ]
 
 [[package]]
@@ -6349,6 +6429,7 @@ dependencies = [
  "uuid",
  "vouch-common",
  "vouch-httpsig",
+ "vouch-i18n",
  "webauthn-rs",
  "webauthn-rs-proto",
  "wiremock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,6 +158,7 @@ hex = { version = "=0.4.3", default-features = false }
 hickory-resolver = { version = "=0.26.1", default-features = false }
 http = { version = "=1.4.2", default-features = false }
 i18n-embed = { version = "=0.16.0", default-features = false }
+i18n-embed-fl = { version = "=0.10.0", default-features = false }
 idna = { version = "=1.1.0", default-features = false }
 inquire = { version = "=0.9.4", default-features = false }
 jiff = { version = "=0.2.28", default-features = false }
@@ -196,6 +197,7 @@ signature = { version = "=2.2.0", default-features = false }
 spki = { version = "=0.7.3", default-features = false }
 ssh-key = { version = "=0.6.7", default-features = false }
 subtle = { version = "=2.6.1", default-features = false }
+sys-locale = { version = "=0.3.2", default-features = false }
 tempfile = { version = "=3.27.0", default-features = false }
 thiserror = { version = "=2.0.18", default-features = false }
 time = { version = "=0.3.49", default-features = false }
@@ -216,6 +218,7 @@ uuid = { version = "=1.23.3", default-features = false }
 vouch-agent = { path = "crates/vouch-agent" }
 vouch-common = { path = "crates/vouch-common" }
 vouch-httpsig = { path = "crates/vouch-httpsig" }
+vouch-i18n = { path = "crates/vouch-i18n" }
 webauthn-rs = { version = "=0.5.5", default-features = false }
 webauthn-rs-proto = { version = "=0.5.5", default-features = false }
 which = { version = "=8.0.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,7 @@ headers = { version = "=0.4.1", default-features = false }
 hex = { version = "=0.4.3", default-features = false }
 hickory-resolver = { version = "=0.26.1", default-features = false }
 http = { version = "=1.4.2", default-features = false }
+fluent-bundle = { version = "=0.16.0", default-features = false }
 i18n-embed = { version = "=0.16.0", default-features = false }
 i18n-embed-fl = { version = "=0.10.0", default-features = false }
 idna = { version = "=1.1.0", default-features = false }

--- a/crates/vouch-agent/Cargo.toml
+++ b/crates/vouch-agent/Cargo.toml
@@ -26,19 +26,25 @@ base64 = { workspace = true, features = ["std"] }
 clap = { workspace = true, features = ["std", "derive", "env", "help", "usage", "error-context"] }
 dirs = { workspace = true }
 ed25519-dalek = { workspace = true, features = ["std"] }
+i18n-embed = { workspace = true, features = ["fluent-system", "rust-embed"] }
+i18n-embed-fl = { workspace = true }
 jiff = { workspace = true, features = ["std", "serde", "tz-system"] }
 mimalloc = { workspace = true, features = ["secure"] }
 reqwest = { workspace = true, features = ["json", "rustls", "form"] }
+rust-embed = { workspace = true }
 secrecy = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["std", "derive"] }
 serde_json = { workspace = true, features = ["std"] }
 ssh-key = { workspace = true, features = ["std", "ed25519", "encryption", "rand_core", "getrandom"] }
+sys-locale = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util", "sync", "signal", "time"] }
 tracing = { workspace = true, features = ["std"] }
 tracing-subscriber = { workspace = true, features = ["std", "fmt", "env-filter"] }
+unic-langid = { workspace = true, features = ["macros"] }
 url = { workspace = true }
 vouch-common = { path = "../vouch-common" }
+vouch-i18n = { workspace = true }
 zeroize = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/vouch-agent/i18n.toml
+++ b/crates/vouch-agent/i18n.toml
@@ -1,0 +1,4 @@
+fallback_language = "en-US"
+
+[fluent]
+assets_dir = "i18n"

--- a/crates/vouch-agent/i18n/en-US/vouch-agent.ftl
+++ b/crates/vouch-agent/i18n/en-US/vouch-agent.ftl
@@ -1,0 +1,21 @@
+# Vouch agent — en-US message catalog.
+#
+# Operator messages emitted by the agent daemon binary when invoked
+# directly. Internal `tracing` logs stay English regardless of locale —
+# they target operators/developers, not end users.
+
+agent-running = Agent is running
+agent-not-running = Agent is not running
+agent-status-err = Error checking status: { $reason }
+agent-already-running = Agent is already running. Use --stop to stop it.
+agent-check-running-err = Error checking if agent is running: { $reason }
+agent-daemonize-err = Failed to daemonize: { $reason }
+agent-pid-file-err = Error getting PID file path: { $reason }
+agent-not-running-no-pid = Agent is not running (no PID file)
+agent-pid-read-err = Failed to read PID file: { $reason }
+agent-pid-invalid = Invalid PID in file
+agent-stop-signal-sent = Sent stop signal to agent (PID { $pid })
+agent-stopped = Agent stopped
+agent-shutting-down = Agent is shutting down...
+agent-stop-signal-failed = Failed to send signal to agent (PID { $pid })
+agent-stop-unsupported = Stop command not supported on this platform

--- a/crates/vouch-agent/src/i18n.rs
+++ b/crates/vouch-agent/src/i18n.rs
@@ -117,12 +117,18 @@ macro_rules! tr {
     }};
 }
 
-/// Translate a message id with Fluent placeable arguments.
+/// Translate a message id with Fluent placeable arguments. Values are
+/// forwarded to Fluent via `Into<FluentValue>`: integer/float primitives
+/// become `FluentValue::Number` (engaging CLDR plural arms), string types
+/// (`&str`, `String`, `&String`, `Cow<str>`) become `FluentValue::String`.
+/// Anything else (`bool`, `Path::Display`, `anyhow::Error`, raw identifiers
+/// like a PID that should not be locale-grouped, …) must be stringified at
+/// the call site with `.to_string()` or `format!()`.
 #[macro_export]
 macro_rules! tr_args {
     ($id:literal, $($name:ident = $value:expr),+ $(,)?) => {{
         let __ctx = $crate::i18n::ctx();
-        ::i18n_embed_fl::fl!(__ctx.loader(), $id, $($name = ($value).to_string()),+)
+        ::i18n_embed_fl::fl!(__ctx.loader(), $id, $($name = $value),+)
     }};
 }
 

--- a/crates/vouch-agent/src/i18n.rs
+++ b/crates/vouch-agent/src/i18n.rs
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! Internationalization (i18n) for the agent daemon.
+//!
+//! Mirrors the CLI's shape (`OnceLock<I18nContext>`, `tr!()` /
+//! `tr_args!()` / `tr_println!()` / `tr_eprintln!()` macros), scoped down
+//! to the small set of operator-visible strings the agent emits when
+//! invoked directly (`--status`, `--stop`, `--foreground` errors).
+//!
+//! Background daemon `tracing` logs stay English — they target operators
+//! and developers, not end users.
+
+use std::sync::OnceLock;
+
+use i18n_embed::fluent::FluentLanguageLoader;
+use unic_langid::{LanguageIdentifier, langid};
+
+/// Embedded Fluent catalogs, one `i18n/<lang>/vouch-agent.ftl` per language.
+#[derive(rust_embed::RustEmbed)]
+#[folder = "i18n/"]
+struct Localizations;
+
+/// Process-wide loader holding every embedded catalog. Built once.
+pub(crate) static LOADER: std::sync::LazyLock<FluentLanguageLoader> =
+    std::sync::LazyLock::new(|| {
+        vouch_i18n::build_loader("vouch-agent", langid!("en-US"), &Localizations)
+    });
+
+/// Process-wide negotiated context. Installed exactly once by [`init`].
+static I18N: OnceLock<I18nContext> = OnceLock::new();
+
+/// Required message ids that must resolve at startup — packaging guard.
+const REQUIRED_IDS: &[&str] = &["agent-running", "agent-not-running"];
+
+/// Agent translation context. Wraps a selected [`FluentLanguageLoader`] and
+/// caches the negotiated BCP-47 tag.
+#[derive(Clone)]
+pub struct I18nContext {
+    loader: std::sync::Arc<FluentLanguageLoader>,
+}
+
+impl I18nContext {
+    fn from_loader(loader: FluentLanguageLoader) -> Self {
+        Self {
+            loader: std::sync::Arc::new(loader),
+        }
+    }
+
+    /// Borrow the underlying loader; used by the `tr!` / `tr_args!`
+    /// macros via [`i18n_embed_fl::fl!`]. Not a stable consumer API.
+    #[doc(hidden)]
+    pub fn loader(&self) -> &FluentLanguageLoader {
+        &self.loader
+    }
+}
+
+/// Resolve the user's preferred locale once and install it.
+///
+/// # Errors
+///
+/// Returns the underlying [`vouch_i18n::validate_startup`] error if the
+/// embedded `en-US` catalog is missing or any [`REQUIRED_IDS`] key fails to
+/// resolve.
+pub fn init() -> anyhow::Result<()> {
+    vouch_i18n::validate_startup(&LOADER, &Localizations, REQUIRED_IDS)?;
+    let lang = negotiate();
+    let langs: Vec<LanguageIdentifier> = lang.into_iter().collect();
+    let loader = vouch_i18n::select_loader(&LOADER, &langs);
+    let ctx = I18nContext::from_loader(loader);
+    if I18N.set(ctx).is_err() {
+        tracing::debug!("vouch_agent::i18n::init called more than once; ignoring later call");
+    }
+    Ok(())
+}
+
+/// Borrow the process-wide [`I18nContext`], falling back to en-US if
+/// [`init`] hasn't run yet (so panic-path `tr!()` never crashes).
+pub fn ctx() -> I18nContext {
+    if let Some(ctx) = I18N.get() {
+        return ctx.clone();
+    }
+    let loader = vouch_i18n::select_loader(&LOADER, &[]);
+    I18nContext::from_loader(loader)
+}
+
+/// Negotiate the preferred locale from environment + OS default.
+fn negotiate() -> Option<LanguageIdentifier> {
+    let env = |key: &str| std::env::var(key).ok();
+    let candidates = [
+        env("VOUCH_LANG"),
+        env("LC_ALL"),
+        env("LC_MESSAGES"),
+        env("LANG"),
+        sys_locale::get_locale(),
+    ];
+    for raw in candidates.into_iter().flatten() {
+        let trimmed = raw
+            .split(['.', '@'])
+            .next()
+            .unwrap_or(&raw)
+            .replace('_', "-");
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Ok(lang) = trimmed.parse::<LanguageIdentifier>() {
+            return Some(lang);
+        }
+    }
+    None
+}
+
+/// Translate a message id with no arguments.
+#[macro_export]
+macro_rules! tr {
+    ($id:literal) => {{
+        let __ctx = $crate::i18n::ctx();
+        ::i18n_embed_fl::fl!(__ctx.loader(), $id)
+    }};
+}
+
+/// Translate a message id with Fluent placeable arguments.
+#[macro_export]
+macro_rules! tr_args {
+    ($id:literal, $($name:ident = $value:expr),+ $(,)?) => {{
+        let __ctx = $crate::i18n::ctx();
+        ::i18n_embed_fl::fl!(__ctx.loader(), $id, $($name = ($value).to_string()),+)
+    }};
+}
+
+/// Print a translated message to stdout.
+#[macro_export]
+macro_rules! tr_println {
+    ($id:literal) => { println!("{}", $crate::tr!($id)) };
+    ($id:literal, $($name:ident = $value:expr),+ $(,)?) => {
+        println!("{}", $crate::tr_args!($id, $($name = $value),+))
+    };
+}
+
+/// Print a translated message to stderr.
+#[macro_export]
+macro_rules! tr_eprintln {
+    ($id:literal) => { eprintln!("{}", $crate::tr!($id)) };
+    ($id:literal, $($name:ident = $value:expr),+ $(,)?) => {
+        eprintln!("{}", $crate::tr_args!($id, $($name = $value),+))
+    };
+}

--- a/crates/vouch-agent/src/lib.rs
+++ b/crates/vouch-agent/src/lib.rs
@@ -37,6 +37,7 @@ pub mod dns;
 pub mod error;
 #[cfg(unix)]
 pub mod expiry_monitor;
+pub mod i18n;
 pub mod protocol;
 #[cfg(unix)]
 pub mod recovery;

--- a/crates/vouch-agent/src/main.rs
+++ b/crates/vouch-agent/src/main.rs
@@ -18,6 +18,11 @@ use vouch_agent::server::AgentServer;
 use vouch_agent::socket::remove_socket;
 use vouch_agent::ssh_agent::{SshAgentServer, SshAgentState, ssh_agent_socket_path};
 use vouch_agent::state::AgentState;
+#[expect(
+    unused_imports,
+    reason = "re-exported so dual-compiled submodules can use `crate::tr*!`"
+)]
+use vouch_agent::{tr, tr_args, tr_eprintln, tr_println};
 
 /// Vouch credential agent daemon.
 #[derive(Parser)]
@@ -52,19 +57,24 @@ fn main() -> ExitCode {
     // one-time notice reaches the user's terminal rather than the daemon log.
     vouch_common::paths::migrate_legacy_layout();
 
+    if let Err(e) = vouch_agent::i18n::init() {
+        eprintln!("Error initializing i18n: {e}");
+        return ExitCode::FAILURE;
+    }
+
     // Handle status check (no logging needed)
     if args.status {
         match daemon::is_running() {
             Ok(true) => {
-                println!("Agent is running");
+                tr_println!("agent-running");
                 return ExitCode::SUCCESS;
             }
             Ok(false) => {
-                println!("Agent is not running");
+                tr_println!("agent-not-running");
                 return ExitCode::FAILURE;
             }
             Err(e) => {
-                eprintln!("Error checking status: {e}");
+                tr_eprintln!("agent-status-err", reason = e);
                 return ExitCode::FAILURE;
             }
         }
@@ -78,12 +88,12 @@ fn main() -> ExitCode {
     // Check if already running
     match daemon::is_running() {
         Ok(true) => {
-            eprintln!("Agent is already running. Use --stop to stop it.");
+            tr_eprintln!("agent-already-running");
             return ExitCode::FAILURE;
         }
         Ok(false) => {}
         Err(e) => {
-            eprintln!("Error checking if agent is running: {e}");
+            tr_eprintln!("agent-check-running-err", reason = e);
             return ExitCode::FAILURE;
         }
     }
@@ -119,7 +129,7 @@ fn main() -> ExitCode {
                 info!("Running in foreground mode (daemonization not available)");
             }
             Err(e) => {
-                eprintln!("Failed to daemonize: {e}");
+                tr_eprintln!("agent-daemonize-err", reason = e);
                 return ExitCode::FAILURE;
             }
         }
@@ -258,20 +268,20 @@ fn stop_agent() -> ExitCode {
     let pid_path = match daemon::pid_file_path() {
         Ok(p) => p,
         Err(e) => {
-            eprintln!("Error getting PID file path: {e}");
+            tr_eprintln!("agent-pid-file-err", reason = e);
             return ExitCode::FAILURE;
         }
     };
 
     if !pid_path.exists() {
-        eprintln!("Agent is not running (no PID file)");
+        tr_eprintln!("agent-not-running-no-pid");
         return ExitCode::FAILURE;
     }
 
     let pid_str = match std::fs::read_to_string(&pid_path) {
         Ok(s) => s,
         Err(e) => {
-            eprintln!("Failed to read PID file: {e}");
+            tr_eprintln!("agent-pid-read-err", reason = e);
             return ExitCode::FAILURE;
         }
     };
@@ -279,7 +289,7 @@ fn stop_agent() -> ExitCode {
     let pid: i32 = match pid_str.trim().parse() {
         Ok(p) => p,
         Err(_) => {
-            eprintln!("Invalid PID in file");
+            tr_eprintln!("agent-pid-invalid");
             // Best-effort cleanup of the stale PID file.
             let _removed = std::fs::remove_file(&pid_path);
             return ExitCode::FAILURE;
@@ -291,22 +301,22 @@ fn stop_agent() -> ExitCode {
     {
         // SAFETY: kill() is a standard Unix API for sending signals to processes
         if unsafe { libc::kill(pid, libc::SIGTERM) } == 0 {
-            println!("Sent stop signal to agent (PID {pid})");
+            tr_println!("agent-stop-signal-sent", pid = pid);
 
             // Wait a bit and check if it stopped
             std::thread::sleep(std::time::Duration::from_millis(500));
 
             // SAFETY: kill(pid, 0) checks if process exists
             if unsafe { libc::kill(pid, 0) } != 0 {
-                println!("Agent stopped");
+                tr_println!("agent-stopped");
                 // Best-effort cleanup of the PID file.
                 let _removed = daemon::remove_pid_file();
             } else {
-                println!("Agent is shutting down...");
+                tr_println!("agent-shutting-down");
             }
             ExitCode::SUCCESS
         } else {
-            eprintln!("Failed to send signal to agent (PID {pid})");
+            tr_eprintln!("agent-stop-signal-failed", pid = pid);
             // Remove stale PID file if process doesn't exist
             // SAFETY: kill(pid, 0) checks if process exists
             if unsafe { libc::kill(pid, 0) } != 0 {
@@ -319,7 +329,7 @@ fn stop_agent() -> ExitCode {
 
     #[cfg(not(unix))]
     {
-        eprintln!("Stop command not supported on this platform");
+        tr_eprintln!("agent-stop-unsupported");
         ExitCode::FAILURE
     }
 }

--- a/crates/vouch-agent/src/main.rs
+++ b/crates/vouch-agent/src/main.rs
@@ -74,7 +74,7 @@ fn main() -> ExitCode {
                 return ExitCode::FAILURE;
             }
             Err(e) => {
-                tr_eprintln!("agent-status-err", reason = e);
+                tr_eprintln!("agent-status-err", reason = format!("{e:#}"));
                 return ExitCode::FAILURE;
             }
         }
@@ -93,7 +93,7 @@ fn main() -> ExitCode {
         }
         Ok(false) => {}
         Err(e) => {
-            tr_eprintln!("agent-check-running-err", reason = e);
+            tr_eprintln!("agent-check-running-err", reason = format!("{e:#}"));
             return ExitCode::FAILURE;
         }
     }
@@ -129,7 +129,7 @@ fn main() -> ExitCode {
                 info!("Running in foreground mode (daemonization not available)");
             }
             Err(e) => {
-                tr_eprintln!("agent-daemonize-err", reason = e);
+                tr_eprintln!("agent-daemonize-err", reason = format!("{e:#}"));
                 return ExitCode::FAILURE;
             }
         }
@@ -268,7 +268,7 @@ fn stop_agent() -> ExitCode {
     let pid_path = match daemon::pid_file_path() {
         Ok(p) => p,
         Err(e) => {
-            tr_eprintln!("agent-pid-file-err", reason = e);
+            tr_eprintln!("agent-pid-file-err", reason = format!("{e:#}"));
             return ExitCode::FAILURE;
         }
     };
@@ -281,7 +281,7 @@ fn stop_agent() -> ExitCode {
     let pid_str = match std::fs::read_to_string(&pid_path) {
         Ok(s) => s,
         Err(e) => {
-            tr_eprintln!("agent-pid-read-err", reason = e);
+            tr_eprintln!("agent-pid-read-err", reason = e.to_string());
             return ExitCode::FAILURE;
         }
     };
@@ -301,7 +301,7 @@ fn stop_agent() -> ExitCode {
     {
         // SAFETY: kill() is a standard Unix API for sending signals to processes
         if unsafe { libc::kill(pid, libc::SIGTERM) } == 0 {
-            tr_println!("agent-stop-signal-sent", pid = pid);
+            tr_println!("agent-stop-signal-sent", pid = pid.to_string());
 
             // Wait a bit and check if it stopped
             std::thread::sleep(std::time::Duration::from_millis(500));
@@ -316,7 +316,7 @@ fn stop_agent() -> ExitCode {
             }
             ExitCode::SUCCESS
         } else {
-            tr_eprintln!("agent-stop-signal-failed", pid = pid);
+            tr_eprintln!("agent-stop-signal-failed", pid = pid.to_string());
             // Remove stale PID file if process doesn't exist
             // SAFETY: kill(pid, 0) checks if process exists
             if unsafe { libc::kill(pid, 0) } != 0 {

--- a/crates/vouch-agent/src/main.rs
+++ b/crates/vouch-agent/src/main.rs
@@ -57,12 +57,12 @@ fn main() -> ExitCode {
     // one-time notice reaches the user's terminal rather than the daemon log.
     vouch_common::paths::migrate_legacy_layout();
 
-    if let Err(e) = vouch_agent::i18n::init() {
-        eprintln!("Error initializing i18n: {e}");
-        return ExitCode::FAILURE;
-    }
-
-    // Handle status check (no logging needed)
+    // `--status` and `--stop` are operator controls for an already-running
+    // daemon, so they intentionally run before i18n init: a packaging bug
+    // that corrupts the catalog must not strand the operator with no way to
+    // inspect or stop the agent. The `tr_*!` macros fall back to a fresh
+    // en-US loader when `init()` hasn't been called, so the messages still
+    // render — they just skip locale negotiation.
     if args.status {
         match daemon::is_running() {
             Ok(true) => {
@@ -80,9 +80,13 @@ fn main() -> ExitCode {
         }
     }
 
-    // Handle stop command
     if args.stop {
         return stop_agent();
+    }
+
+    if let Err(e) = vouch_agent::i18n::init() {
+        eprintln!("Error initializing i18n: {e}");
+        return ExitCode::FAILURE;
     }
 
     // Check if already running

--- a/crates/vouch-cli/Cargo.toml
+++ b/crates/vouch-cli/Cargo.toml
@@ -30,6 +30,8 @@ dirs = { workspace = true }
 gethostname = { workspace = true }
 ed25519-dalek = { workspace = true, features = ["std"] }
 hex = { workspace = true, features = ["std"] }
+i18n-embed = { workspace = true, features = ["fluent-system", "rust-embed"] }
+i18n-embed-fl = { workspace = true }
 inquire = { workspace = true, features = ["crossterm"] }
 jiff = { workspace = true, features = ["std", "serde", "tz-system"] }
 jsonwebtoken = { workspace = true, features = ["aws_lc_rs"] }
@@ -39,8 +41,10 @@ open = { workspace = true }
 reqwest = { workspace = true, features = ["json", "rustls", "form", "query"] }
 roxmltree = { workspace = true, features = ["std"] }
 rpassword = { workspace = true }
+rust-embed = { workspace = true }
 rust-ini = { workspace = true }
 secrecy = { workspace = true, features = ["serde"] }
+sys-locale = { workspace = true }
 serde = { workspace = true, features = ["std", "derive"] }
 serde_json = { workspace = true, features = ["std"] }
 serde_urlencoded = { workspace = true }
@@ -54,9 +58,11 @@ tracing = { workspace = true, features = ["std"] }
 tracing-subscriber = { workspace = true, features = ["std", "fmt", "env-filter"] }
 url = { workspace = true }
 urlencoding = { workspace = true }
+unic-langid = { workspace = true, features = ["macros"] }
 uuid = { workspace = true, features = ["v7"] }
 vouch-common = { workspace = true }
 vouch-httpsig = { workspace = true }
+vouch-i18n = { workspace = true }
 which = { workspace = true, features = ["real-sys"] }
 zeroize = { workspace = true }
 

--- a/crates/vouch-cli/i18n.toml
+++ b/crates/vouch-cli/i18n.toml
@@ -1,0 +1,4 @@
+fallback_language = "en-US"
+
+[fluent]
+assets_dir = "i18n"

--- a/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
+++ b/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
@@ -334,15 +334,37 @@ posture-label-elevated = Elevated:
 posture-label-tty = TTY:
 posture-label-parent-process = Parent process:
 posture-label-cli-version = CLI version:
-posture-val-enabled = enabled
-posture-val-disabled = disabled
+# Boolean-state value pairs. Each renders one of two arms based on a `$on`
+# (or `$b`) placeable carrying the stringified bool ("true"/"false"). State
+# pairs are kept together here so translators see both arms side-by-side and
+# can keep them consistent (capitalization, punctuation, locale-specific
+# wording). The `not-checked` plain id stays separate — it's the "we didn't
+# attempt the check" state, not a boolean arm.
+posture-val-enabled-or-missing = { $on ->
+    [true] enabled
+   *[false] not detected
+}
+posture-val-enabled-or-disabled = { $on ->
+    [true] enabled
+   *[false] disabled
+}
+posture-val-present-or-missing = { $on ->
+    [true] present
+   *[false] not detected
+}
+posture-val-enforcing-or-permissive = { $on ->
+    [true] enforcing
+   *[false] permissive/disabled
+}
+posture-val-yes-no = { $b ->
+    [true] yes
+   *[false] no
+}
+# Standalone "we checked and found nothing" / "we didn't attempt the check"
+# states — used by EDR/MDM list rendering and the disk-encryption /
+# screen-lock / firewall blocks when the underlying signal couldn't be read.
 posture-val-not-detected = not detected
 posture-val-not-checked = not checked
-posture-val-present = present
-posture-val-enforcing = enforcing
-posture-val-permissive = permissive/disabled
-posture-val-yes = yes
-posture-val-no = no
 
 # doctor command ------------------------------------------------------------
 

--- a/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
+++ b/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
@@ -1065,9 +1065,13 @@ setup-codecommit-success-block =
     Credential helper (HTTPS URLs):
 setup-codecommit-helper-line = { $indent }credential.{ $pattern }.helper = { $helper }
 setup-codecommit-http-path-line = { $indent }credential.{ $pattern }.useHttpPath = true
-setup-codecommit-remote-helper-header = Remote helper (codecommit:// URLs):
-setup-codecommit-remote-line = { $indent }{ $symlink } -> { $vouch }
-setup-codecommit-step1 = Step 1: Create symlink for codecommit:// URL support
+setup-codecommit-remote-helper-block =
+    Remote helper (codecommit:// URLs):
+      { $symlink } -> { $vouch }
+setup-codecommit-step1-block =
+    Step 1: Create symlink for codecommit:// URL support
+
+      ln -sf "{ $vouch }" "{ $symlink }"
 setup-codecommit-step2 =
     Step 2: Configure git credential helper for HTTPS URLs
 
@@ -1079,7 +1083,8 @@ setup-codecommit-tail-block =
       git ls-remote codecommit::{ $region }://YOUR-REPO
 
     To undo:
-setup-codecommit-undo-rm = { $indent }rm "{ $path }"
+      rm "{ $path }"
+# Loop body: emitted once per credential pattern after the tail block above.
 setup-codecommit-undo-config = { $indent }git config --global --remove-section credential."{ $pattern }"
 setup-codecommit-err-aws-not-configured = AWS not configured. Run '{ -cmd } setup aws --role <role-arn>' first.
 setup-codecommit-err-profile-not-found =

--- a/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
+++ b/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
@@ -1,0 +1,1151 @@
+# Vouch CLI — en-US message catalog.
+#
+# IDs follow kebab-case and are scoped by area:
+#   cli-*           - top-level command / Cli struct
+#   cmd-<sub>-*     - subcommand-level attributes
+#   arg-<scope>-*   - clap arg help / long-help
+#   fido2-err-*     - CTAP2 / WebAuthn user-facing error messages
+#   enroll-*        - enroll command output
+#
+# Translators: this file is the source of truth for runtime strings; the
+# matching English in clap derive attributes (where present) is the fallback
+# clap shows if i18n init fails. Keep them aligned for en-US.
+#
+# ---------------------------------------------------------------------------
+# Terms (Fluent feature):
+#   - Reusable nouns. Reference as { -term-name } in any message.
+#   - Translators change the noun ONCE and it propagates everywhere.
+#   - Names start with `-`. Term references survive placeable substitution.
+# ---------------------------------------------------------------------------
+
+-yubikey = YubiKey
+-product = Vouch
+-cmd = vouch
+
+cli-about = Hardware-backed identity for developers
+cli-long-about = { -product } issues short-lived credentials after FIDO2 verification with a { -yubikey }.
+    No credential issuance without human presence proof.
+cli-verbose-help = Enable verbose output
+cli-lang-help = Override the user-facing language (BCP-47, e.g. en-US, fr-FR)
+cli-server-help = { -product } server URL
+cli-color-help = Control color output
+cli-after-help =
+    Exit codes:
+      0  Success
+      1  General error
+      2  Not authenticated (session expired or missing)
+      3  Hardware key not detected
+      4  Network/server unreachable
+      5  Permission denied
+      6  Configuration error
+
+# enroll command -------------------------------------------------------------
+
+cmd-enroll-about = Enroll with browser-based OIDC + WebAuthn (recommended for new users)
+
+enroll-starting = Starting enrollment...
+enroll-waiting = Waiting for browser authorization...
+enroll-waiting-progress = Waiting for browser authorization
+enroll-registering-key = Registering your { -yubikey } with the server...
+enroll-key-registered = { -yubikey } registered! (device ID: { $device_id })
+
+# Browser opened automatically: show URL + code + fallback hint.
+enroll-browser-block =
+    Opening browser to complete enrollment...
+
+      URL:  { $url }
+      Code: { $code }
+
+    If the browser didn't open, visit the URL above and enter the code.
+
+# Browser failed to open: numbered manual fallback.
+enroll-manual-block =
+    To complete enrollment:
+
+      1. Open this URL in your browser:
+         { $url }
+
+      2. Enter this code:
+         { $code }
+
+# Success summary printed once enrollment + auto-registration finish.
+enroll-success-block =
+    Enrollment successful!
+    Enrolled as: { $email }
+
+# "Next steps" call-out shown at the very end of a successful enrollment.
+enroll-next-steps =
+    Set up integrations:
+      { -cmd } setup ssh      # SSH certificates
+      { -cmd } setup aws      # AWS credentials
+      { -cmd } setup github   # GitHub tokens
+
+    Or add a backup key:
+      { -cmd } login && { -cmd } register --name "Backup Key"
+
+enroll-err-timeout =
+    Enrollment timed out. Please try again.
+    Make sure to complete the sign-in in your browser window and enter the code shown above.
+enroll-err-denied = authorization was denied
+enroll-err-code-expired = The code has expired. Please try again.
+enroll-err-failed = Enrollment failed: { $reason }
+enroll-err-start = Failed to start enrollment
+
+# FIDO2 / CTAP2 user-facing errors -------------------------------------------
+
+fido2-err-credential-excluded = This { -yubikey } is already registered for this service.
+fido2-err-pin-invalid =
+    Incorrect PIN. Please try again.
+    Hint: Too many wrong attempts will lock your { -yubikey }.
+fido2-err-pin-blocked =
+    Your { -yubikey } PIN is blocked due to too many incorrect attempts.
+    You must reset the FIDO2 application to continue:
+
+    WARNING: This will delete all FIDO2 credentials on this { -yubikey }!
+
+    Option 1: ykman fido reset  (install: brew install ykman)
+    Option 2: Use the { -yubikey } Manager GUI app to reset FIDO2
+
+    After reset, run `{ -cmd } enroll` to re-register your { -yubikey }.
+fido2-err-pin-auth-invalid = PIN authentication failed. Please try again.
+fido2-err-pin-auth-blocked =
+    PIN authentication is temporarily blocked.
+    Please unplug your { -yubikey } and plug it back in, then try again.
+fido2-err-pin-not-set =
+    Your { -yubikey } PIN is not set.
+    This is unexpected — try running this command again.
+fido2-err-pin-required = A PIN is required for this operation.
+fido2-err-pin-policy =
+    PIN does not meet policy requirements.
+    PIN must be at least 8 characters.
+fido2-err-pin-token-expired = PIN authentication expired. Please try again.
+fido2-err-generic = { $operation } failed: { $reason }
+
+# WebAuthn (Windows) user-facing errors --------------------------------------
+
+webauthn-err-cancelled = Authentication cancelled.
+webauthn-err-device-not-found =
+    No security key found.
+    Insert your { -yubikey } and try again.
+webauthn-err-keyset-full =
+    Your { -yubikey } has no free passkey slots.
+    Delete an existing credential with `ykman fido credentials delete` and try again.
+webauthn-err-timeout =
+    Timed out waiting for { -yubikey }.
+    Insert your key and try again.
+webauthn-err-not-supported =
+    Your authenticator does not support resident keys or user verification.
+    { -cmd } requires a { -yubikey } 5 or later with PIN configured.
+webauthn-err-invalid-parameter =
+    Internal error: invalid WebAuthn parameter (HRESULT 0x{ $code }).
+    Please file a bug at https://github.com/vouch-sh/vouch/issues.
+webauthn-err-generic = { $operation } failed: 0x{ $code } { $detail }
+
+# PIN setup prompts ----------------------------------------------------------
+
+fido2-pin-prompt-new = New PIN (minimum 8 characters):
+fido2-pin-prompt-confirm = Confirm PIN:
+fido2-pin-err-too-short = PIN must be at least 8 characters.
+fido2-pin-err-too-long = PIN must be at most 63 characters.
+fido2-pin-err-mismatch = PINs do not match. Please try again.
+
+fido2-insert-prompt = Please insert your { -yubikey }...
+fido2-detected = detected!
+fido2-pin-prompt = { -yubikey } PIN:
+fido2-setup-pin-intro =
+    Your { -yubikey } does not have a PIN configured.
+    A PIN is required for FIDO2 authentication to prove you are present.
+
+    Let's set one up now.
+fido2-setting-pin = Setting PIN...
+fido2-setting-pin-done = done!
+fido2-err-insert-prompt =
+    Timed out waiting for { -yubikey } after { $timeout }s.
+    Insert your key and try again.
+fido2-err-no-device = no { -yubikey } found - please insert your { -yubikey }
+fido2-err-not-ready = { -yubikey } not ready after insertion - try removing and reinserting it
+fido2-err-pin-query = failed to query PIN status
+fido2-err-pin-unsupported = This device does not support PIN authentication
+fido2-err-pin-retries = failed to get PIN retry count
+fido2-err-pin-already-set = A PIN is already set on this { -yubikey }.
+fido2-err-pin-set-failed = Failed to set PIN: { $reason }
+fido2-err-pin-change = failed to change PIN
+fido2-err-attestation = attestation verification failed
+fido2-err-no-assertion = no assertion returned
+fido2-err-read-pin = failed to read PIN
+fido2-err-read-pin-confirmation = failed to read PIN confirmation
+fido2-pin-policy-block =
+    PIN does not meet requirements.
+    PIN must be at least 8 characters.
+fido2-err-no-credentials =
+    No credentials found for this service.
+    Have you enrolled with `{ -cmd } enroll`?
+fido2-err-not-passkey =
+    Your { -yubikey } has a credential for this service, but it was not stored as a passkey.
+    Re-enroll with `{ -cmd } enroll` to create a compatible credential.
+
+# Subcommand `about` text ----------------------------------------------------
+
+cmd-register-about = Register an additional { -yubikey } (requires login first)
+cmd-login-about = Authenticate with your { -yubikey }
+cmd-status-about = Show current session status
+cmd-logout-about = End your current session
+cmd-env-about = Output credential environment variables for `eval`
+cmd-env-long-about =
+    Usage: eval "$({ -cmd } env --type aws --shell bash --role <ARN>)"
+cmd-init-about = Output a shell hook for ambient auth status
+cmd-init-long-about = Add `eval "$({ -cmd } init bash)"` to your shell profile.
+cmd-keys-about = Manage registered security keys
+cmd-keys-long-about = Without a subcommand, opens an interactive menu.
+cmd-exec-about = Run a command with { -product }-provided credentials in the environment
+cmd-credential-about = Obtain credentials for various services
+cmd-setup-about = Configure integrations
+cmd-aws-about = AWS Identity Center commands for multi-account management
+cmd-completions-about = Generate shell completions
+cmd-doctor-about = Check your { -product } environment for common issues
+cmd-posture-about = Show device posture signals (what the CLI detects about this machine)
+cmd-diag-about = Run diagnostic test of { -yubikey } registration + authentication (bypasses server)
+cmd-diag-long-about =
+    Not available on Windows: depends on the CTAP2 protocol which Windows blocks for non-elevated processes.
+
+# Shared arg help -----------------------------------------------------------
+
+arg-register-name-help = Human-readable name for this { -yubikey } (e.g., "My { -yubikey } 5"). Defaults to "{ -yubikey }" if not specified.
+arg-register-timeout-help = Timeout in seconds for { -yubikey } detection (0 for no timeout).
+arg-login-timeout-help = Timeout in seconds for { -yubikey } detection (0 for no timeout).
+arg-status-format-help = Output format.
+arg-env-type-help = Credential type to export.
+arg-env-shell-help = Shell syntax to emit.
+arg-env-role-help = AWS IAM role ARN (required for --type aws).
+arg-init-shell-help = Shell to generate hook for.
+arg-exec-type-help = Credential type to inject.
+arg-exec-role-help = AWS IAM role ARN (required for --type aws).
+arg-exec-command-help = Command and arguments to execute.
+arg-doctor-quiet-help = Suppress output (exit code only).
+arg-doctor-json-help = Output as JSON.
+arg-posture-format-help = Output format.
+
+# Session-shared lines (reused by enroll, login, register) -------------------
+
+session-agent-ready = Your identity is now available. Check with: { -cmd } status
+session-agent-not-running = Note: Agent not running. Start it with: vouch-agent --foreground
+session-stored-locally = Your identity is stored locally. Check with: { -cmd } status
+
+# login command --------------------------------------------------------------
+
+login-starting = Logging in...
+login-contacting-server = Contacting server ({ $server })...
+login-contact-ok = ok
+login-success-as = Login successful as { $email }!
+login-success = Login successful!
+login-session-expires = Session expires: { $expiry }
+login-err-not-registered =
+    This { -yubikey } is not registered with the server.
+    Run '{ -cmd } enroll' to register it.
+login-err-invalid-client =
+    Client registration is invalid or expired.
+    The client will be re-registered on the next attempt.
+    Please run this command again. If it persists, run '{ -cmd } enroll' to start fresh.
+
+# register command ----------------------------------------------------------
+
+register-starting = Registering additional { -yubikey } '{ $name }'...
+register-contacting-server = Contacting server...
+register-contact-ok = ok
+register-completing = Completing registration...
+register-completed-ok = ok
+register-success-block =
+    Registration successful!
+    Device ID: { $device_id }
+
+    You can manage your keys with: { -cmd } keys
+register-existing-keys =
+    Note: You have { $count ->
+        [one] { $count } existing key
+       *[other] { $count } existing keys
+    } registered.
+register-not-authenticated =
+    Not authenticated.
+
+    To register your first key: { -cmd } enroll
+    To add additional keys: { -cmd } login, then { -cmd } register
+register-chrome-blocking =
+    Google Chrome is using your { -yubikey }, so we can't register it from
+    the command line. Opening your browser to finish registration there
+    instead. (Tip: quit Chrome and re-run if you'd prefer the CLI.)
+
+register-browser-block =
+    Opening browser to complete registration...
+
+      URL: { $url }
+
+    If the browser didn't open, visit the URL above. You may be
+    prompted to sign in again. After registration, run `{ -cmd } keys`
+    to verify.
+register-manual-block =
+    To complete registration:
+
+      1. Open this URL in your browser:
+         { $url }
+
+      2. Sign in (if prompted) and complete the WebAuthn ceremony.
+
+    After registration, run `{ -cmd } keys` to verify.
+
+# logout command ------------------------------------------------------------
+
+logout-success = Logged out successfully.
+logout-not-logged-in = Not currently logged in.
+
+# status command ------------------------------------------------------------
+
+status-not-authenticated = Not authenticated.
+status-session-expired = Session expired.
+status-session-invalid = Session invalid: { $reason }
+status-hint-login = Run '{ -cmd } login' to authenticate.
+status-hint-relogin = Run '{ -cmd } login' to re-authenticate.
+status-authenticated = Authenticated
+status-label-email = Email:
+status-label-device = Device:
+status-label-agent = Agent:
+status-label-expires = Expires:
+status-agent-running = running
+status-agent-not-running = not running
+status-hint-start-agent = Hint: Start the agent for faster status checks: vouch-agent --foreground
+
+# posture command -----------------------------------------------------------
+
+posture-title = Device Posture (v{ $version })
+posture-label-os = OS:
+posture-label-build = Build:
+posture-label-architecture = Architecture:
+posture-label-disk-encryption = Disk encryption:
+posture-label-screen-lock = Screen lock:
+posture-label-firewall = Firewall:
+posture-label-secure-boot = Secure boot:
+posture-label-sip = SIP:
+posture-label-tpm = TPM:
+posture-label-auto-update = Auto-update:
+posture-label-uptime = Uptime:
+posture-label-access-control = Access control:
+posture-label-edr = EDR:
+posture-label-mdm = MDM:
+posture-label-elevated = Elevated:
+posture-label-tty = TTY:
+posture-label-parent-process = Parent process:
+posture-label-cli-version = CLI version:
+posture-val-enabled = enabled
+posture-val-disabled = disabled
+posture-val-not-detected = not detected
+posture-val-not-checked = not checked
+posture-val-present = present
+posture-val-enforcing = enforcing
+posture-val-permissive = permissive/disabled
+posture-val-yes = yes
+posture-val-no = no
+
+# doctor command ------------------------------------------------------------
+
+doctor-title = { -product } Doctor - Environment Diagnostics
+doctor-all-passed = All checks passed!
+doctor-some-failed = Some checks failed. Review the issues above.
+doctor-check-yubikey-label = { -yubikey } connectivity ...
+doctor-check-agent-label = Agent running ...
+doctor-check-server-label = Server reachable ...
+doctor-check-clock-label = Clock in sync with server ...
+doctor-check-doh-label = DNS-over-HTTPS resolution ...
+doctor-check-session-label = Session valid ...
+doctor-check-ssh-label = SSH configuration ...
+doctor-check-eks-label = EKS configuration ...
+doctor-check-ssm-label = SSM configuration ...
+doctor-check-server-url-label = Server URL security ...
+doctor-doh-disabled =
+    disabled — DNS queries are visible to your local network.
+    Set VOUCH_DOH=cloudflare (or google/quad9) to encrypt them.
+
+doctor-yubikey-found = FIDO2 device found
+doctor-yubikey-not-found = No FIDO2 device found: { $reason }
+doctor-yubikey-win-api-missing = Windows WebAuthn API not available. Update to Windows 10 1903 or later.
+doctor-yubikey-win-api-available =
+    Windows WebAuthn API available (version { $version }); { -cmd } login uses the system Security dialog
+    to authenticate your { -yubikey } — no admin privileges required.
+
+doctor-agent-running-pid = Agent is running (PID { $pid })
+doctor-agent-running = Agent is running
+doctor-agent-connection-failed = Agent connection failed: { $reason }
+doctor-agent-socket-exists = Socket exists but connection failed: { $reason }
+doctor-agent-not-running = Agent not running. Start with: vouch-agent --foreground
+
+doctor-server-invalid-url = Invalid server URL: { $reason }
+doctor-server-unreachable = Server unreachable: { $reason }
+doctor-server-reachable = Server at { $server } is reachable
+doctor-server-status = Server returned status: { $status }
+
+doctor-clock-ok = System clock within { $secs }s of server
+doctor-clock-skew =
+    System clock is { $secs }s { $direction } the server.
+    Signed requests will fail once skew exceeds 300s.
+    Sync your clock (Windows: Settings → Time & Language → Date & Time → "Sync now"; macOS: `sudo sntp -sS time.apple.com`).
+doctor-clock-direction-behind = behind
+doctor-clock-direction-ahead = ahead of
+
+doctor-doh-zero-addresses = { $label }: { $host } resolved to zero addresses
+doctor-doh-resolved = { $label }: { $host } resolved to { $count } address(es)
+doctor-doh-error = { $label }: { $reason }
+
+doctor-session-valid = Session valid for { $hours }h { $mins }m ({ $email })
+doctor-session-expired = Session expired. Run: { -cmd } login
+doctor-session-none = No active session. Run: { -cmd } login
+doctor-session-no-config = No config found. Run: { -cmd } login
+doctor-session-token-only = Session token found (agent not running for full validation)
+doctor-session-no-token = No session token. Run: { -cmd } login
+
+doctor-ssh-no-home = Could not determine home directory
+doctor-ssh-key-missing = { -product } SSH key not found. Run: { -cmd } setup ssh
+doctor-ssh-config-missing-entry = No { -product } entry in SSH config. Run: { -cmd } setup ssh
+doctor-ssh-config-unreadable = Could not read SSH config
+doctor-ssh-config-not-found = SSH config not found
+doctor-ssh-configured = SSH configured for { -product }
+
+doctor-eks-no-home = Could not determine home directory
+doctor-eks-no-kubeconfig = No kubeconfig found (EKS not configured)
+doctor-eks-configured = EKS configured for { -product }
+doctor-eks-no-vouch-entry = Kubeconfig exists (no { -product } EKS integration). Run: { -cmd } setup eks --cluster <name>
+doctor-eks-unreadable = Could not read kubeconfig
+
+doctor-ssm-no-home = Could not determine home directory
+doctor-ssm-configured = SSM configured for { -product }
+doctor-ssm-plugin-found = session-manager-plugin found (not configured). Run: { -cmd } setup ssm
+doctor-ssm-plugin-missing-but-configured = SSH config references SSM but session-manager-plugin not found on PATH
+doctor-ssm-not-configured = SSM not configured (session-manager-plugin not found)
+
+doctor-server-url-insecure = Server uses plain HTTP ({ $server }). Use HTTPS or set VOUCH_ALLOW_INSECURE=1.
+doctor-server-url-secure = Server URL is secure (HTTPS or localhost)
+
+# keys command --------------------------------------------------------------
+
+keys-none = No keys registered.
+keys-prompt-select = Select a key to manage:
+keys-help-navigation = ↑↓ to move, Enter to select, Esc to exit
+keys-help-action = Select an action
+keys-help-undo = This action cannot be undone
+keys-action-exit = Exit
+keys-action-delete = Delete this key
+keys-action-back = Back to list
+keys-action-quit = Quit
+keys-marker-current = { " " }(current session)
+keys-marker-current-short = (current)
+keys-action-prompt = Key: { $name }{ $marker }
+keys-cancelled = Cancelled.
+keys-err-selection = Selection error: { $reason }
+keys-err-confirmation = Confirmation error: { $reason }
+keys-warn-current-session = WARNING: This is the key used for your current session. Your session will be invalidated.
+keys-confirm-delete = Delete key '{ $name }'?{ $warning }
+keys-step-up-needed = Fresh authentication required to delete a key.
+keys-header = Registered keys:
+keys-table-id = ID
+keys-table-name = NAME
+keys-table-model = MODEL
+keys-table-created = CREATED
+keys-table-current = CURRENT
+keys-legend = * = key used for current session
+keys-confirm-remove-line = You are about to remove the key '{ $name }' (ID: { $id }).
+keys-warn-remove-current-session =
+    WARNING: This is the key used for your current session.
+             Your session will be invalidated.
+keys-confirm-y-n = Are you sure? [y/N]
+keys-sessions-revoked =
+    { $count ->
+        [one] { $count } session revoked.
+       *[other] { $count } sessions revoked.
+    }
+keys-err-not-found = Key not found: { $id }
+keys-err-name-empty = Name cannot be empty
+keys-err-name-long = Name must be 100 characters or less
+
+# env command --------------------------------------------------------------
+
+env-err-aws-needs-role = AWS credentials require --role.
+
+# exec command -------------------------------------------------------------
+
+exec-err-no-command = No command specified.
+exec-err-no-command-short = no command specified
+exec-err-aws-needs-role = AWS credentials require --role.
+exec-err-execute-failed = failed to execute { $program }: { $reason }
+exec-err-execute-simple = failed to execute: { $program }
+exec-err-exit-status = command exited with status { $code }
+exec-err-aws-missing-key-id = AWS credentials missing AccessKeyId
+exec-err-aws-missing-secret = AWS credentials missing SecretAccessKey
+exec-err-aws-missing-token = AWS credentials missing SessionToken
+exec-err-github-missing-token = GitHub credential missing 'token' field
+exec-err-github-fetch = failed to get GitHub token from { -product } server
+exec-err-codeartifact-fetch = failed to get CodeArtifact token
+exec-err-rds-needs-hostname = RDS credentials require --rds-hostname.
+exec-err-rds-needs-username = RDS credentials require --rds-username.
+
+# diag command --------------------------------------------------------------
+
+diag-intro-block =
+    === { -yubikey } Diagnostic Test ===
+
+    This test will:
+    1. Register a new credential on your { -yubikey }
+    2. Authenticate with that credential
+    3. Verify the signature using aws-lc-rs
+diag-insert-prompt = Please insert your { -yubikey }...
+diag-detected = detected!
+diag-pin-prompt = { -yubikey } PIN:
+diag-touch-register = Touch your { -yubikey } to register...
+diag-touch-authenticate = Touch your { -yubikey } to authenticate...
+diag-registration-header = === REGISTRATION ===
+diag-authentication-header = === AUTHENTICATION ===
+diag-registration-success = Registration successful!
+diag-authentication-success = Authentication successful!
+diag-rpid-header = === RPID VERIFICATION ===
+diag-rpid-match = OK RPID hash matches
+diag-rpid-mismatch = FAIL RPID hash MISMATCH!
+diag-lib-verification-header = === LIBRARY VERIFICATION ===
+diag-lib-verification-passed = OK ctap-hid-fido2 library verification: PASSED
+diag-lib-verification-failed = FAIL ctap-hid-fido2 library verification: FAILED
+diag-aws-lc-header = === AWS-LC-RS VERIFICATION ===
+diag-keys-identical = OK Public keys are IDENTICAL (byte-by-byte)
+diag-keys-differ = FAIL Public keys DIFFER!
+diag-aws-lc-passed = OK aws-lc-rs verification ({ $kind }): PASSED
+diag-aws-lc-failed = FAIL aws-lc-rs verification ({ $kind }): FAILED
+diag-aws-lc-failed-reason = FAIL aws-lc-rs verification ({ $kind }): FAILED - { $reason }
+diag-sig-header = === SIGNATURE ANALYSIS ===
+diag-cred-id-header = === CREDENTIAL ID CHECK ===
+diag-cred-id-match = OK Credential IDs match
+diag-cred-id-mismatch = FAIL Credential ID MISMATCH - authenticator used different credential!
+diag-summary-header = === SUMMARY ===
+diag-summary-lib-ok =
+    The ctap-hid-fido2 library CAN verify the signature.
+    This suggests the issue is with how we're calling aws-lc-rs.
+diag-summary-lib-fail =
+    Even the ctap-hid-fido2 library CANNOT verify the signature.
+    This suggests a fundamental issue with the { -yubikey } or authentication flow.
+
+    Possible causes:
+    1. { -yubikey } firmware bug (especially FIPS models)
+    2. Credential corruption on the { -yubikey }
+    3. Different key pair being used for signing vs registration
+diag-openssl-header =
+    === OPENSSL VERIFICATION DATA ===
+    To verify with OpenSSL, run these commands:
+diag-no-cleanup = Note: Non-resident credential used - no cleanup needed on { -yubikey }.
+diag-export-header = === EXPORTING FIXTURE ===
+diag-fixture-saved = Fixture saved to: { $path }
+diag-err-registration = Registration failed - check PIN and touch { -yubikey }
+diag-err-attestation = Attestation verification failed!
+diag-err-no-attested-data = No attested credential data in auth_data!
+diag-err-cose-parse = Failed to parse COSE key
+diag-err-cose-not-map = COSE key is not a map
+diag-err-missing-x = Missing x coordinate
+diag-err-missing-y = Missing y coordinate
+diag-err-coord-length = Invalid coordinate lengths: x={ $x_len }, y={ $y_len }
+diag-err-authentication = Authentication failed
+diag-err-no-assertion = No assertion returned
+diag-err-fixture-save = Failed to save fixture: { $reason }
+
+# aws command --------------------------------------------------------------
+
+cmd-aws-login-about = Authenticate to AWS IAM Identity Center for account discovery
+cmd-aws-accounts-about = List AWS accounts you have access to via Identity Center
+cmd-aws-roles-about = List available roles across your AWS accounts
+cmd-aws-console-about = Open the AWS Management Console in your browser
+
+arg-aws-sso-session-help = SSO session name from ~/.aws/config (default: first found).
+arg-aws-accounts-json-help = Output as JSON.
+arg-aws-roles-account-help = Filter by account ID (show roles for a single account only).
+arg-aws-roles-json-help = Output as JSON.
+arg-aws-console-role-help = AWS IAM role ARN to assume (auto-detected from ~/.aws/config if not specified).
+
+aws-err-sso-session-not-found =
+    SSO session '{ $name }' not found in ~/.aws/config.
+    Run 'aws configure sso' or check --sso-session.
+aws-err-no-sso-session =
+    No SSO session found in ~/.aws/config.
+    Run 'aws configure sso' first.
+aws-using-sso-session = Using SSO session '{ $name }'. Specify --sso-session to use a different one.
+aws-err-sso-expired = SSO session expired or missing. Run '{ -cmd } aws login' first.
+aws-err-not-configured =
+    AWS not configured.
+    Run '{ -cmd } setup aws --role <role-arn>' first, or specify --role.
+
+aws-login-already-authenticated = Already authenticated (expires { $expires_at })
+aws-login-browser-prompt =
+    Open the following URL in your browser:
+
+      { $url }
+
+    Enter code: { $code }
+aws-login-waiting = Waiting for authorization...
+aws-login-success = Authenticated successfully. Token expires at { $expires_at }
+aws-login-err-http-client = failed to create HTTP client
+aws-login-err-register = failed to register SSO OIDC client
+aws-login-err-device-auth = failed to start device authorization
+aws-login-err-authorization = SSO authorization failed
+aws-login-err-cache-token = failed to cache SSO access token
+
+aws-accounts-table-account-id = ACCOUNT ID
+aws-accounts-table-name = NAME
+aws-accounts-table-email = EMAIL
+aws-accounts-summary =
+    { $count ->
+        [one] { $count } account
+       *[other] { $count } accounts
+    }
+aws-accounts-err-list = failed to list SSO accounts
+aws-accounts-err-serialize = failed to serialize accounts
+
+aws-roles-table-account-id = ACCOUNT ID
+aws-roles-table-account-name = ACCOUNT NAME
+aws-roles-table-role-name = ROLE NAME
+aws-roles-summary =
+    { $count ->
+        [one] { $count } role
+       *[other] { $count } roles
+    }
+aws-roles-err-list-roles = failed to list roles for account { $account_id }
+aws-roles-err-serialize = failed to serialize roles
+
+aws-console-opening = Opening AWS Console...
+aws-console-browser-failed = Could not open browser automatically. Open the URL above in your browser.
+aws-console-err-invalid-role-arn = invalid role ARN
+aws-console-err-aws-credentials = failed to get AWS credentials
+aws-console-err-serialize-session = failed to serialize session JSON
+aws-console-err-signin-request = failed to request signin token
+aws-console-err-signin-failed = federation getSigninToken failed ({ $status }): { $body }
+aws-console-err-signin-parse = failed to parse signin token response
+aws-console-err-invalid-federation-url = invalid federation endpoint URL
+
+# setup command -------------------------------------------------------------
+
+cmd-setup-aws-about = Configure AWS CLI/SDK to use { -product } credentials
+cmd-setup-ssh-about = Configure SSH to use { -product } certificates
+cmd-setup-github-about = Configure Git to use { -product } for GitHub credentials
+cmd-setup-eks-about = Configure kubectl to use { -product } credentials for Amazon EKS clusters
+cmd-setup-k8s-about = Configure kubectl to use { -product } OIDC credentials for generic Kubernetes clusters
+cmd-setup-docker-about = Configure Docker to use { -product } for container registry authentication
+cmd-setup-cargo-about = Configure Cargo to use { -product } for private registry authentication
+cmd-setup-codecommit-about = Configure Git to use { -product } for AWS CodeCommit credentials
+cmd-setup-ssm-about = Configure SSH for AWS Systems Manager Session Manager
+cmd-setup-anthropic-about = Configure Anthropic (Claude) Workload Identity Federation
+cmd-setup-anthropic-long-about =
+    Persists federation parameters to `~/.config/vouch/config.json` for use by
+    `{ -cmd } credential anthropic`. This is the workload path: the
+    minted token acts as a non-human service account, intended for
+    CI/headless automation. It does not configure Claude Code.
+cmd-setup-openai-about = Configure OpenAI Workload Identity Federation
+cmd-setup-openai-long-about =
+    Persists federation parameters to `~/.config/vouch/config.json` AND
+    auto-configures the OpenAI Codex CLI by writing a
+    `[model_providers.vouch]` block (with refreshing auth
+    command) into `~/.codex/config.toml` and setting it as the
+    top-level `model_provider`.
+
+    If Codex already has a different `model_provider` or a
+    conflicting `vouch` provider block, the command errors —
+    pass `--force` to overwrite.
+cmd-setup-codeartifact-about = Configure a package manager for AWS CodeArtifact
+
+# setup/aws arg help
+arg-setup-aws-profile-help = AWS profile name to configure. Defaults to "vouch" if not specified.
+arg-setup-aws-role-help = AWS IAM role ARN to assume. Required unless --discover is set.
+arg-setup-aws-region-help = AWS region to set in the profile.
+arg-setup-aws-discover-help = Discover accounts and roles via SSO and generate profiles automatically.
+
+# setup/ssh arg help
+arg-setup-ssh-hosts-help = Host patterns to trust with this CA (e.g., "*.example.com"). If specified, adds entry to ~/.ssh/known_hosts.
+
+# setup/github arg help
+arg-setup-github-host-help = GitHub host to configure (default: github.com).
+arg-setup-github-configure-help = Automatically configure git (otherwise just show instructions).
+
+# setup/eks arg help
+arg-setup-eks-cluster-help = EKS cluster name.
+arg-setup-eks-region-help = AWS region (auto-detected from AWS profile or environment if not specified).
+arg-setup-eks-profile-help = AWS profile to use (defaults to auto-detected { -cmd } profile).
+arg-setup-eks-kubeconfig-help = Path to kubeconfig file (defaults to ~/.kube/config).
+
+# setup/k8s arg help
+arg-setup-k8s-cluster-help = Kubernetes cluster name.
+arg-setup-k8s-server-help = Kubernetes API server URL (e.g., https://k8s.example.com:6443).
+arg-setup-k8s-ca-help = Path to the cluster's certificate authority file (PEM format).
+arg-setup-k8s-audience-help = OIDC audience (must match --oidc-client-id on the API server). Defaults to "kubernetes".
+arg-setup-k8s-kubeconfig-help = Path to kubeconfig file (defaults to ~/.kube/config).
+
+# setup/docker arg help
+arg-setup-docker-registries-help = Container registries to configure (e.g., ghcr.io).
+arg-setup-docker-configure-help = Automatically configure Docker (otherwise just show instructions).
+
+# setup/cargo arg help
+arg-setup-cargo-registry-help = Registry name to configure (if not specified, configures global provider).
+arg-setup-cargo-configure-help = Write the configuration (otherwise just show instructions).
+
+# setup/codecommit arg help
+arg-setup-codecommit-region-help = AWS region (default: wildcard matching all regions).
+arg-setup-codecommit-profile-help = AWS profile to use (defaults to auto-detected { -cmd } profile).
+arg-setup-codecommit-configure-help = Automatically configure git (otherwise just show instructions).
+
+# setup/ssm arg help
+arg-setup-ssm-profile-help = AWS profile to use (defaults to auto-detected { -cmd } profile).
+arg-setup-ssm-region-help = AWS region (auto-detected from AWS profile or environment if not specified).
+arg-setup-ssm-hosts-help = SSH host patterns for SSM proxying (i-* = EC2 instances, mi-* = managed instances).
+arg-setup-ssm-force-help = Replace existing { -product } SSM configuration if present.
+
+# setup/anthropic arg help
+arg-setup-anthropic-federation-rule-id-help = Anthropic federation rule ID (`fdrl_...`).
+arg-setup-anthropic-organization-id-help = Anthropic organization ID (UUID).
+arg-setup-anthropic-service-account-id-help = Anthropic service account ID (`svac_...`).
+arg-setup-anthropic-workspace-id-help = Anthropic workspace ID (`wrkspc_...`).
+arg-setup-anthropic-audience-help = `aud` claim to request on the assertion (optional).
+arg-setup-anthropic-token-endpoint-help = Token endpoint override (defaults to Anthropic's public endpoint).
+
+# setup/openai arg help
+arg-setup-openai-identity-provider-id-help = OpenAI Workload Identity Provider ID for the { -product } issuer.
+arg-setup-openai-service-account-id-help = OpenAI service account ID.
+arg-setup-openai-audience-help = `aud` claim to request on the assertion (matches OpenAI's configured audience for this provider).
+arg-setup-openai-token-endpoint-help = Token endpoint override (defaults to OpenAI's public endpoint).
+arg-setup-openai-force-help = Overwrite an existing Codex `model_provider` or `vouch` provider block.
+
+# setup/codeartifact arg help
+arg-setup-codeartifact-tool-help = Package manager to configure (cargo, pip, npm).
+arg-setup-codeartifact-domain-help = CodeArtifact domain name (or use --profile / saved default).
+arg-setup-codeartifact-domain-owner-help = AWS account ID that owns the domain.
+arg-setup-codeartifact-region-help = AWS region.
+arg-setup-codeartifact-repository-help = CodeArtifact repository name.
+arg-setup-codeartifact-profile-help = Named CodeArtifact profile to use / save.
+
+# Shared setup helpers ------------------------------------------------------
+
+setup-err-load-config = failed to load config - run '{ -cmd } enroll' first
+setup-err-load-vouch-config = failed to load { -product } config
+setup-err-not-configured = not configured - run '{ -cmd } enroll' first
+setup-err-anthropic-not-enrolled = not configured — run '{ -cmd } enroll' first
+setup-err-no-home = could not determine home directory
+
+# setup/anthropic ----------------------------------------------------------
+
+setup-anthropic-success-block =
+    Anthropic (Claude) Workload Identity Federation configured.
+
+      Federation params: ~/.config/vouch/config.json
+
+    This mints a service-account token for CI/headless automation.
+    Get a token:
+      { -cmd } login                 # { -yubikey } tap, once per session
+      { -cmd } credential anthropic  # prints sk-ant-oat01-...
+
+    Smoke test:
+      curl -sS https://api.anthropic.com/v1/messages \
+        -H "authorization: Bearer $({ -cmd } credential anthropic)" \
+        -H "anthropic-version: 2023-06-01" \
+        -H "content-type: application/json" \
+        -d '{"{"}"model":"claude-sonnet-4-6","max_tokens":64,"messages":[{"{"}"role":"user","content":"hi"{"}"}]{"}"}'
+
+# setup/cargo --------------------------------------------------------------
+
+setup-cargo-header =
+    Cargo Credential Provider Setup
+    ================================
+setup-cargo-already-registry = { -product } is already configured for registry '{ $name }'
+setup-cargo-already-global = { -product } is already configured as global credential provider
+setup-cargo-config-file = Configuration file: { $path }
+setup-cargo-configured-registry = Cargo configured for registry '{ $name }'
+setup-cargo-configured-global = Cargo configured with global credential provider
+setup-cargo-config-added = Configuration added to: { $path }
+setup-cargo-add-to-config = Add to ~/.cargo/config.toml:
+setup-cargo-or-run = Or run: { -cmd } setup cargo --configure
+setup-cargo-more-info =
+    For more information, see:
+      https://doc.rust-lang.org/cargo/reference/registry-authentication.html
+
+# setup/github -------------------------------------------------------------
+
+setup-github-header =
+    GitHub Credential Setup
+    =======================
+setup-github-not-configured-block =
+    GitHub App is not configured on the server.
+    Contact your administrator to enable GitHub integration.
+setup-github-org-not-connected-block =
+    Your organization has not connected GitHub.
+    An organization admin needs to visit: { $server }/github/connect
+setup-github-all-suspended-block =
+    All GitHub installations are currently suspended.
+    Contact your administrator to resolve this.
+setup-github-not-logged-in-block =
+    Login status: Not logged in
+
+    Run '{ -cmd } login' first to authenticate.
+setup-github-could-not-check = Note: Could not check GitHub status: { $reason }
+# Fluent selector: $configured is a stringified bool ("true" / "false").
+# Translators can localize the visible word without changing call sites.
+setup-github-app-configured =
+    GitHub App configured: { $configured ->
+        [true] Yes
+       *[false] No
+    }
+setup-github-org-connected =
+    Organization connected: { $connected ->
+        [true] Yes
+       *[false] No
+    }
+setup-github-accounts-header = Connected GitHub accounts:
+# $suspended is a stringified bool too — appends "(SUSPENDED)" when true.
+setup-github-account-line =
+    { $indent }- { $login } ({ $kind }){ $suspended ->
+        [true] { " " }(SUSPENDED)
+       *[false] { "" }
+    }
+setup-github-existing-warning-block =
+    Warning: Existing credential helper detected: { $existing }
+    This may conflict with { -product }.
+setup-github-err-run-config = failed to run git config
+setup-github-err-helper = failed to configure git credential helper
+setup-github-configured-block =
+    Git configured for { $host }
+
+    Configuration added:
+      { $key } = { $value }
+setup-github-add-to-gitconfig = Add to ~/.gitconfig:
+setup-github-or-run = Or run: { -cmd } setup github --configure
+setup-github-to-verify =
+    To verify, run:
+      git ls-remote https://{ $host }/YOUR-ORG/YOUR-REPO.git
+
+# setup/docker -------------------------------------------------------------
+
+setup-docker-header =
+    Docker Credential Helper Setup
+    ==============================
+setup-docker-configured = Docker credential helper configured successfully.
+setup-docker-no-registries-add =
+    To configure registries, add them to ~/.docker/config.json:
+setup-docker-configured-registries-header = Configured registries:
+setup-docker-registry-line = { $indent }- { $registry }
+setup-docker-step1-block =
+    Step 1: Create symlink for docker-credential-vouch
+
+      ln -sf "{ $vouch_path }" "{ $symlink_path }"
+setup-docker-step2-header =
+    Step 2: Configure Docker to use the credential helper
+
+      Add to ~/.docker/config.json:
+setup-docker-tail-block =
+    Or run: { -cmd } setup docker --configure [REGISTRIES...]
+
+    Examples:
+      { -cmd } setup docker --configure ghcr.io
+      { -cmd } setup docker --configure 123456789012.dkr.ecr.us-east-1.amazonaws.com
+      { -cmd } setup docker --configure 123456789012.dkr.ecr.us-west-2.amazonaws.com
+setup-docker-supported-block =
+    Supported registries:
+      - AWS ECR:     *.dkr.ecr.*.amazonaws.com
+      - GitHub:      ghcr.io
+setup-docker-updated-file = Updated: { $path }
+setup-docker-err-create-dir = failed to create { $path }
+setup-docker-err-read = failed to read { $path }
+setup-docker-err-parse = failed to parse { $path }
+setup-docker-err-serialize = failed to serialize Docker config
+setup-docker-err-write = failed to write { $path }
+
+# setup/kubernetes ---------------------------------------------------------
+
+setup-k8s-header =
+    Kubernetes OIDC Setup
+    =====================
+setup-k8s-summary =
+    Cluster:   { $cluster }
+    Server:    { $server }
+    Audience:  { $audience }
+    { -product }:     { $vouch }
+setup-k8s-updated-block =
+    Updated kubeconfig: { $kubeconfig }
+      Cluster: { $cluster } ({ $server })
+      User:    { $user_name } (via { -cmd } credential k8s)
+      Context: { $context }
+setup-k8s-tail-block =
+    To use:
+      kubectl config use-context { $context }
+      kubectl get pods
+
+    Prerequisites:
+      1. Run '{ -cmd } login' to authenticate
+      2. Kubernetes API server must be configured with --oidc-issuer-url={ $vouch } --oidc-client-id={ $audience }
+setup-k8s-err-read-ca = failed to read certificate authority file: { $path }
+
+# setup/openai -------------------------------------------------------------
+
+setup-openai-success-block =
+    OpenAI Workload Identity Federation configured.
+
+      Federation params: ~/.config/vouch/config.json
+      Codex provider block: { $config_path } ([model_providers.{ $provider_id }])
+
+    NOTE: OpenAI must onboard the { -product } issuer as a workload identity provider
+          before this works — custom OIDC issuers are not self-service. Contact
+          OpenAI to register your { -product } base URL.
+
+    Get a token:
+      { -cmd } login              # { -yubikey } tap, once per session
+      { -cmd } credential openai  # prints a short-lived OpenAI access token
+
+    Ensure OPENAI_API_KEY is UNSET in every environment Codex runs in —
+    it shadows the configured auth command.
+
+    Note: the [model_providers.vouch] block is owned by `{ -cmd } setup openai` —
+    re-running this command overwrites it. Edit the top-level `model_provider`
+    if you want to switch Codex back to a different provider.
+
+setup-openai-err-conflict =
+    Codex already has model_provider = { $existing } in { $path }.
+
+    Remove the `model_provider` entry from config.toml, or re-run
+    `{ -cmd } setup openai --force` to switch the default to `{ $provider_id }`.
+setup-openai-err-providers-not-table =
+    cannot configure OpenAI: `model_providers` exists in
+    ~/.codex/config.toml but is not a table. Remove or rename
+    the `model_providers` entry and try again.
+setup-openai-err-read = failed to read { $path }
+setup-openai-err-parse = failed to parse { $path }
+setup-openai-err-create-dir = failed to create { $path }
+setup-openai-err-write = failed to write { $path }
+
+# setup/ssh ----------------------------------------------------------------
+
+setup-ssh-downloading-ca = Downloading SSH CA public key from server...
+setup-ssh-saved-ca = Saved CA public key: { $path }
+setup-ssh-complete-block =
+    SSH CA setup complete!
+
+    To trust user certificates signed by this CA, configure your SSH servers:
+
+      1. Copy the CA public key to each server:
+         scp { $ca_path } root@server:/etc/ssh/vouch_ca.pub
+
+      2. Create /etc/ssh/sshd_config.d/99-vouch-ca.conf with:
+
+         TrustedUserCAKeys /etc/ssh/vouch_ca.pub
+
+      3. Validate the configuration and reload sshd:
+
+         sudo sshd -t && sudo systemctl reload sshd
+
+    Users can then authenticate with:
+      { -cmd } login
+      { -cmd } credential ssh
+      ssh user@server
+
+setup-ssh-stale-agent-rewrite = Updated stale { -product } IdentityAgent path in { $config_path } -> { $agent_socket }
+setup-ssh-already-configured = SSH config already configured for { -product }
+setup-ssh-updated-config = Updated SSH config: { $path }
+setup-ssh-added-host-agent = { $indent }Added { -product } IdentityAgent for specified hosts
+setup-ssh-added-identity-block =
+    { $indent }Added { -product } IdentityFile and CertificateFile
+    { $indent }Note: IdentityAgent not set globally to avoid conflicts with other SSH agents.
+    { $indent }To use the { -product } agent for specific hosts, re-run with: { -cmd } setup ssh --hosts "pattern"
+setup-ssh-ca-already-trusted = CA already trusted in known_hosts
+setup-ssh-added-ca-trust = Added CA to known_hosts for hosts: { $hosts }
+setup-ssh-err-get-ca = failed to get SSH CA public key
+setup-ssh-err-write-ca = failed to write { $path }
+setup-ssh-err-read-config = failed to read { $path }
+setup-ssh-err-write-config = failed to write { $path }
+setup-ssh-err-ca-empty = CA public key file is empty
+setup-ssh-err-ca-invalid = CA public key file does not contain a valid key
+setup-ssh-err-lock-file = failed to open lock file { $path }
+setup-ssh-err-lock-acquire = failed to acquire known_hosts lock
+
+# setup/ssm ----------------------------------------------------------------
+
+setup-ssm-err-empty = { $label } must not be empty
+setup-ssm-err-newline = { $label } must not contain newline characters
+setup-ssm-err-invalid-char =
+    { $label } contains invalid character '{ $char }'.
+    Only alphanumeric characters, spaces, underscores, hyphens, dots,
+    asterisks, and question marks are allowed.
+setup-ssm-err-plugin-missing =
+    session-manager-plugin not found on PATH.
+
+    Install it from:
+      https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html
+
+setup-ssm-header =
+    AWS SSM Setup
+    =============
+setup-ssm-summary =
+    Profile:  { $profile }
+    Region:   { $region }
+    Hosts:    { $hosts }
+
+setup-ssm-already-configured = SSH config already contains { -product } SSM configuration.
+setup-ssm-existing-profile = { $indent }Profile: { $value }
+setup-ssm-existing-region = { $indent }Region:  { $value }
+setup-ssm-existing-hosts = { $indent }Hosts:   { $value }
+setup-ssm-reconfigure-hint = To reconfigure, re-run with --force or remove the '{ $marker }' block from { $path }.
+setup-ssm-replacing = Replacing existing { -product } SSM configuration (--force).
+setup-ssm-result-block =
+    Updated SSH config: { $path }
+
+    To use:
+      { -cmd } login
+      ssh ec2-user@i-0abc123def456
+
+    Prerequisites:
+      1. Run '{ -cmd } login' to authenticate
+      2. EC2 instances must have the SSM agent installed and an IAM instance
+         profile with SSM permissions
+setup-ssm-undo =
+    To undo:
+      Remove the '{ $marker }' block from { $path }
+setup-ssm-err-read = failed to read { $path }
+setup-ssm-err-write = failed to write { $path }
+
+# setup/eks ----------------------------------------------------------------
+
+setup-eks-err-aws-not-configured = AWS not configured. Run '{ -cmd } setup aws --role <role-arn>' first.
+setup-eks-header-block =
+    Amazon EKS Setup
+    ================
+
+    Cluster:  { $cluster }
+    Region:   { $region }
+    Profile:  { $profile }
+setup-eks-fetching = Fetching cluster details...
+setup-eks-result-block =
+    Updated kubeconfig: { $kubeconfig }
+      Cluster: { $cluster } ({ $endpoint })
+      User:    { $user_name } (via { -cmd } credential eks)
+      Context: { $context }
+
+    To use:
+      kubectl config use-context { $context }
+      kubectl get pods
+
+    Prerequisites:
+      1. Run '{ -cmd } login' to authenticate
+      2. EKS Access Entry must exist for the IAM role in your AWS profile
+
+# setup/codecommit ---------------------------------------------------------
+
+setup-codecommit-header =
+    CodeCommit Credential Setup
+    ===========================
+setup-codecommit-aws-profile = AWS profile: { $profile }
+setup-codecommit-aws-role = AWS role:    { $role }
+setup-codecommit-err-helper-pattern = failed to configure git credential helper for { $pattern }
+setup-codecommit-err-http-path = failed to set useHttpPath for { $pattern }
+setup-codecommit-success-block =
+    Git configured for CodeCommit.
+
+    Credential helper (HTTPS URLs):
+setup-codecommit-helper-line = { $indent }credential.{ $pattern }.helper = { $helper }
+setup-codecommit-http-path-line = { $indent }credential.{ $pattern }.useHttpPath = true
+setup-codecommit-remote-helper-header = Remote helper (codecommit:// URLs):
+setup-codecommit-remote-line = { $indent }{ $symlink } -> { $vouch }
+setup-codecommit-step1 = Step 1: Create symlink for codecommit:// URL support
+setup-codecommit-step2 =
+    Step 2: Configure git credential helper for HTTPS URLs
+
+      Add to ~/.gitconfig:
+setup-codecommit-or-run = Or run: { -cmd } setup codecommit --configure
+setup-codecommit-tail-block =
+    To verify, run:
+      git ls-remote https://git-codecommit.{ $region }.amazonaws.com/v1/repos/YOUR-REPO
+      git ls-remote codecommit::{ $region }://YOUR-REPO
+
+    To undo:
+setup-codecommit-undo-rm = { $indent }rm "{ $path }"
+setup-codecommit-undo-config = { $indent }git config --global --remove-section credential."{ $pattern }"
+setup-codecommit-err-aws-not-configured = AWS not configured. Run '{ -cmd } setup aws --role <role-arn>' first.
+setup-codecommit-err-profile-not-found =
+    AWS profile '{ $profile }' not found in ~/.aws/config.
+    Run '{ -cmd } setup aws --role <role-arn>' first.
+setup-codecommit-err-no-vouch-profile =
+    No { -product } AWS profile found in ~/.aws/config.
+    Run '{ -cmd } setup aws --role <role-arn>' first.
+setup-codecommit-err-run-config = failed to run git config
+setup-codecommit-warn-existing-block =
+    Warning: Existing CodeCommit credential helper detected:
+      { $line }
+    This may conflict. Consider removing it.
+
+# setup/codeartifact -------------------------------------------------------
+
+setup-ca-header =
+    CodeArtifact Setup
+    ==================
+setup-ca-saved-profile = Saved CodeArtifact profile '{ $name }' to config.
+setup-ca-cargo-usage =
+    Usage:
+      cargo build --registry { $name }
+      cargo publish --registry { $name }
+
+    Cargo will automatically call { -product } to obtain a fresh CodeArtifact
+    token each time it needs to authenticate.
+setup-ca-cargo-already-block =
+    { -product } is already configured for registry '{ $name }'
+
+    Configuration file: { $path }
+setup-ca-cargo-configured-block =
+    Cargo configured for CodeArtifact registry '{ $name }'
+    Configuration written to: { $path }
+setup-ca-pip-auto-block =
+    pip will automatically call { -product } to obtain a fresh CodeArtifact
+    token each time it needs to authenticate. No more 12-hour token expiry!
+setup-ca-pip-wrote = Wrote pip config: { $path }
+setup-ca-keyring-conflict-block =
+    Note: { $path } already exists (not managed by vouch).
+    To use { -cmd } for CodeArtifact authentication, you can:
+      1. Rename the existing keyring and re-run this command:
+         mv { $path } { $path }.bak
+      2. Or manually create a symlink to vouch:
+         ln -sf "{ $vouch_path }" "{ $path }"
+setup-ca-uv-auto-block =
+    uv will automatically call { -product } to obtain a fresh CodeArtifact
+    token each time it needs to authenticate. No more 12-hour token expiry!
+
+    Note: If you also use pip, run `{ -cmd } setup codeartifact --tool pip` to
+    configure pip separately (uv does not read pip.conf).
+setup-ca-uv-wrote = Wrote uv config: { $path }
+setup-ca-npm-block =
+    Registry URL: { $url }
+
+    Note: Unlike Cargo and pip, npm does not support dynamic credential
+    helpers. The token written to ~/.npmrc expires in ~12 hours.
+    To refresh: { -cmd } setup codeartifact --tool npm --repository { $repository }
+
+    Tip: pnpm supports dynamic credential helpers. Use --tool pnpm for
+    automatic token refresh without manual re-login.
+setup-ca-npm-wrote = Wrote npm config: { $path }
+setup-ca-npmrc-conflict-block =
+    Note: ~/.npmrc has an existing { $other_tool } configuration for this registry.
+    It will be replaced. npm and pnpm use different auth mechanisms
+    (_authToken vs tokenHelper) and cannot coexist for the same registry.
+setup-ca-pnpm-auto-block =
+    pnpm will automatically call { -product } to obtain a fresh CodeArtifact
+    token each time it needs to authenticate. No more 12-hour token expiry!
+setup-ca-pnpm-conflict-block =
+    Note: { $path } already exists (not managed by vouch).
+    To use { -cmd } for pnpm CodeArtifact authentication, either:
+      1. Rename the existing file and re-run this command:
+         mv { $path } { $path }.bak
+      2. Or manually create a symlink to vouch:
+         ln -sf "{ $vouch_path }" "{ $path }"
+setup-ca-pnpm-wrote = Wrote pnpm config: { $path }
+setup-ca-refreshed-npmrc = Refreshed CodeArtifact token in ~/.npmrc
+setup-ca-err-save-profile = failed to save CodeArtifact profile
+setup-ca-err-create-dir = failed to create { $path }
+setup-ca-err-read = failed to read { $path }
+setup-ca-err-parse = failed to parse { $path }
+setup-ca-err-write = failed to write { $path }
+setup-ca-err-serialize-pip = failed to serialize pip config for { $path }
+setup-ca-err-fetch-token = failed to get CodeArtifact token
+
+# setup/kubeconfig ---------------------------------------------------------
+
+setup-kc-err-read = failed to read kubeconfig: { $path }
+setup-kc-err-parse = failed to parse kubeconfig: { $path }
+setup-kc-err-serialize = failed to serialize kubeconfig

--- a/crates/vouch-cli/src/commands/aws/accounts.rs
+++ b/crates/vouch-cli/src/commands/aws/accounts.rs
@@ -2,6 +2,7 @@
 //! `vouch aws accounts` — list AWS accounts via Identity Center.
 
 use anyhow::{Context, Result};
+use vouch_cli::{tr, tr_args};
 
 use crate::integrations::aws::config::AwsConfig;
 use crate::integrations::aws::sso::{SsoConfig, load_cached_token};
@@ -11,10 +12,10 @@ use crate::integrations::aws::sso_portal::list_accounts;
 #[derive(clap::Args)]
 pub(crate) struct AccountsArgs {
     /// SSO session name from ~/.aws/config (default: first found).
-    #[arg(long)]
+    #[arg(long, help = tr!("arg-aws-sso-session-help"))]
     pub sso_session: Option<String>,
     /// Output as JSON.
-    #[arg(long)]
+    #[arg(long, help = tr!("arg-aws-accounts-json-help"))]
     pub json: bool,
 }
 
@@ -26,17 +27,17 @@ pub(crate) async fn run(args: AccountsArgs) -> Result<()> {
 
     let token = load_cached_token(&sso_config).ok_or_else(|| {
         crate::exit_code::CliError::NotAuthenticated {
-            reason: "SSO session expired or missing. Run 'vouch aws login' first.".to_string(),
+            reason: tr!("aws-err-sso-expired"),
         }
     })?;
 
     let http_client =
         vouch_common::http::credential_client(&format!("vouch-cli/{}", env!("CARGO_PKG_VERSION")))
-            .context("failed to create HTTP client")?;
+            .with_context(|| tr!("aws-login-err-http-client"))?;
 
     let accounts = list_accounts(&http_client, &session.region, &token.token())
         .await
-        .context("failed to list SSO accounts")?;
+        .with_context(|| tr!("aws-accounts-err-list"))?;
 
     if args.json {
         let json = serde_json::to_string_pretty(
@@ -51,10 +52,15 @@ pub(crate) async fn run(args: AccountsArgs) -> Result<()> {
                 })
                 .collect::<Vec<_>>(),
         )
-        .context("failed to serialize accounts")?;
+        .with_context(|| tr!("aws-accounts-err-serialize"))?;
         println!("{json}");
     } else {
-        println!("{:<14} {:<40} EMAIL", "ACCOUNT ID", "NAME");
+        println!(
+            "{:<14} {:<40} {}",
+            tr!("aws-accounts-table-account-id"),
+            tr!("aws-accounts-table-name"),
+            tr!("aws-accounts-table-email"),
+        );
         println!("{}", "-".repeat(80));
         for account in &accounts {
             println!(
@@ -63,7 +69,10 @@ pub(crate) async fn run(args: AccountsArgs) -> Result<()> {
             );
         }
         println!();
-        println!("{} account(s)", accounts.len());
+        println!(
+            "{}",
+            tr_args!("aws-accounts-summary", count = accounts.len())
+        );
     }
 
     Ok(())

--- a/crates/vouch-cli/src/commands/aws/console.rs
+++ b/crates/vouch-cli/src/commands/aws/console.rs
@@ -7,7 +7,7 @@
 use anyhow::{Context, Result};
 use secrecy::ExposeSecret;
 use serde::Deserialize;
-use vouch_cli::{tr, tr_args};
+use vouch_cli::{tr, tr_args, tr_eprintln, tr_println};
 
 use crate::integrations::aws;
 
@@ -118,12 +118,12 @@ pub(crate) async fn run(server: &str, args: ConsoleArgs) -> Result<()> {
     let login_str = login_url.as_str();
     match open::that(login_str) {
         Ok(()) => {
-            println!("{}", tr!("aws-console-opening"));
+            tr_println!("aws-console-opening");
         }
         Err(e) => {
             tracing::debug!("failed to open browser: {e}");
             println!("{login_str}");
-            eprintln!("{}", tr!("aws-console-browser-failed"));
+            tr_eprintln!("aws-console-browser-failed");
         }
     }
 

--- a/crates/vouch-cli/src/commands/aws/console.rs
+++ b/crates/vouch-cli/src/commands/aws/console.rs
@@ -7,6 +7,7 @@
 use anyhow::{Context, Result};
 use secrecy::ExposeSecret;
 use serde::Deserialize;
+use vouch_cli::{tr, tr_args};
 
 use crate::integrations::aws;
 
@@ -15,7 +16,7 @@ use crate::integrations::aws;
 pub(crate) struct ConsoleArgs {
     /// AWS IAM role ARN to assume (auto-detected from ~/.aws/config
     /// if not specified).
-    #[arg(long)]
+    #[arg(long, help = tr!("arg-aws-console-role-help"))]
     pub role: Option<String>,
 }
 
@@ -31,17 +32,13 @@ pub(crate) async fn run(server: &str, args: ConsoleArgs) -> Result<()> {
     // 1. Resolve role ARN
     let role_arn = match args.role {
         Some(r) => r,
-        None => aws::get_local_aws_role().ok_or_else(|| {
-            anyhow::anyhow!(
-                "AWS not configured. Run 'vouch setup aws --role \
-                 <role-arn>' first, or specify --role."
-            )
-        })?,
+        None => aws::get_local_aws_role()
+            .ok_or_else(|| anyhow::anyhow!(tr!("aws-err-not-configured")))?,
     };
 
     // 2. Determine partition and federation endpoints from role ARN
-    let partition =
-        vouch_common::aws::Partition::from_arn(&role_arn).context("invalid role ARN")?;
+    let partition = vouch_common::aws::Partition::from_arn(&role_arn)
+        .with_context(|| tr!("aws-console-err-invalid-role-arn"))?;
     let federation_url = partition.federation_endpoint()?;
     let console_url = partition.console_url()?;
 
@@ -71,7 +68,7 @@ pub(crate) async fn run(server: &str, args: ConsoleArgs) -> Result<()> {
         },
     )
     .await
-    .context("failed to get AWS credentials")?;
+    .with_context(|| tr!("aws-console-err-aws-credentials"))?;
 
     let creds = &result.credentials;
 
@@ -81,7 +78,7 @@ pub(crate) async fn run(server: &str, args: ConsoleArgs) -> Result<()> {
         "sessionKey": creds.secret_access_key.expose_secret(),
         "sessionToken": creds.session_token.expose_secret(),
     }))
-    .context("failed to serialize session JSON")?;
+    .with_context(|| tr!("aws-console-err-serialize-session"))?;
 
     // 6. POST to federation endpoint for a signin token
     let resp = result
@@ -90,22 +87,26 @@ pub(crate) async fn run(server: &str, args: ConsoleArgs) -> Result<()> {
         .form(&[("Action", "getSigninToken"), ("Session", &session_encoded)])
         .send()
         .await
-        .context("failed to request signin token")?;
+        .with_context(|| tr!("aws-console-err-signin-request"))?;
 
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
-        anyhow::bail!("federation getSigninToken failed ({status}): {body}");
+        anyhow::bail!(tr_args!(
+            "aws-console-err-signin-failed",
+            status = status,
+            body = body,
+        ));
     }
 
     let token_resp: SigninTokenResponse = resp
         .json()
         .await
-        .context("failed to parse signin token response")?;
+        .with_context(|| tr!("aws-console-err-signin-parse"))?;
 
     // 7. Construct login URL using url::Url for safe encoding
-    let mut login_url =
-        url::Url::parse(federation_url).context("invalid federation endpoint URL")?;
+    let mut login_url = url::Url::parse(federation_url)
+        .with_context(|| tr!("aws-console-err-invalid-federation-url"))?;
     login_url
         .query_pairs_mut()
         .append_pair("Action", "login")
@@ -117,15 +118,12 @@ pub(crate) async fn run(server: &str, args: ConsoleArgs) -> Result<()> {
     let login_str = login_url.as_str();
     match open::that(login_str) {
         Ok(()) => {
-            println!("Opening AWS Console...");
+            println!("{}", tr!("aws-console-opening"));
         }
         Err(e) => {
             tracing::debug!("failed to open browser: {e}");
             println!("{login_str}");
-            eprintln!(
-                "Could not open browser automatically. \
-                 Open the URL above in your browser."
-            );
+            eprintln!("{}", tr!("aws-console-browser-failed"));
         }
     }
 

--- a/crates/vouch-cli/src/commands/aws/console.rs
+++ b/crates/vouch-cli/src/commands/aws/console.rs
@@ -94,7 +94,7 @@ pub(crate) async fn run(server: &str, args: ConsoleArgs) -> Result<()> {
         let body = resp.text().await.unwrap_or_default();
         anyhow::bail!(tr_args!(
             "aws-console-err-signin-failed",
-            status = status,
+            status = status.to_string(),
             body = body,
         ));
     }

--- a/crates/vouch-cli/src/commands/aws/login.rs
+++ b/crates/vouch-cli/src/commands/aws/login.rs
@@ -2,6 +2,7 @@
 //! `vouch aws login` — authenticate to AWS IAM Identity Center.
 
 use anyhow::{Context, Result};
+use vouch_cli::{tr, tr_println};
 
 use crate::integrations::aws::config::AwsConfig;
 use crate::integrations::aws::sso::{
@@ -13,7 +14,7 @@ use crate::integrations::aws::sso::{
 #[derive(clap::Args)]
 pub(crate) struct LoginArgs {
     /// SSO session name from ~/.aws/config (default: first found).
-    #[arg(long)]
+    #[arg(long, help = tr!("arg-aws-sso-session-help"))]
     pub sso_session: Option<String>,
 }
 
@@ -26,45 +27,44 @@ pub(crate) async fn run(args: LoginArgs) -> Result<()> {
     // Check if already authenticated
     if let Some(token) = load_cached_token(&sso_config) {
         let expires_at = token.expires_at.clone();
-        println!("Already authenticated (expires {expires_at})");
+        tr_println!("aws-login-already-authenticated", expires_at = expires_at);
         return Ok(());
     }
 
     let http_client =
         vouch_common::http::credential_client(&format!("vouch-cli/{}", env!("CARGO_PKG_VERSION")))
-            .context("failed to create HTTP client")?;
+            .with_context(|| tr!("aws-login-err-http-client"))?;
 
     // Register or reuse cached client
     let registration = register_client(&http_client, &sso_config)
         .await
-        .context("failed to register SSO OIDC client")?;
+        .with_context(|| tr!("aws-login-err-register"))?;
 
     // Start device authorization
     let device_auth = start_device_authorization(&http_client, &sso_config, &registration)
         .await
-        .context("failed to start device authorization")?;
+        .with_context(|| tr!("aws-login-err-device-auth"))?;
 
-    println!("Open the following URL in your browser:");
-    println!();
-    println!("  {}", device_auth.verification_uri_complete);
-    println!();
-    println!("Enter code: {}", device_auth.user_code);
-    println!();
+    tr_println!(
+        "aws-login-browser-prompt",
+        url = &device_auth.verification_uri_complete,
+        code = &device_auth.user_code,
+    );
 
     // Best-effort browser open
     if let Err(e) = open::that(&device_auth.verification_uri_complete) {
         tracing::debug!("failed to open browser: {e}");
     }
 
-    println!("Waiting for authorization...");
+    tr_println!("aws-login-waiting");
 
     let token = poll_for_token(&http_client, &sso_config, &registration, &device_auth)
         .await
-        .context("SSO authorization failed")?;
+        .with_context(|| tr!("aws-login-err-authorization"))?;
 
     let expires_at = token.expires_at.clone();
-    save_access_token(&sso_config, &token).context("failed to cache SSO access token")?;
+    save_access_token(&sso_config, &token).with_context(|| tr!("aws-login-err-cache-token"))?;
 
-    println!("Authenticated successfully. Token expires at {expires_at}");
+    tr_println!("aws-login-success", expires_at = expires_at);
     Ok(())
 }

--- a/crates/vouch-cli/src/commands/aws/login.rs
+++ b/crates/vouch-cli/src/commands/aws/login.rs
@@ -47,8 +47,8 @@ pub(crate) async fn run(args: LoginArgs) -> Result<()> {
 
     tr_println!(
         "aws-login-browser-prompt",
-        url = &device_auth.verification_uri_complete,
-        code = &device_auth.user_code,
+        url = device_auth.verification_uri_complete.as_str(),
+        code = device_auth.user_code.as_str(),
     );
 
     // Best-effort browser open

--- a/crates/vouch-cli/src/commands/aws/mod.rs
+++ b/crates/vouch-cli/src/commands/aws/mod.rs
@@ -3,6 +3,7 @@
 
 use anyhow::Result;
 use clap::Subcommand;
+use vouch_cli::{tr, tr_args};
 
 use crate::integrations::aws::config::{AwsConfig, SsoSession};
 
@@ -15,12 +16,16 @@ pub(crate) mod roles;
 #[derive(Subcommand)]
 pub(crate) enum AwsCommands {
     /// Authenticate to AWS IAM Identity Center for account discovery.
+    #[command(about = tr!("cmd-aws-login-about"))]
     Login(login::LoginArgs),
     /// List AWS accounts you have access to via Identity Center.
+    #[command(about = tr!("cmd-aws-accounts-about"))]
     Accounts(accounts::AccountsArgs),
     /// List available roles across your AWS accounts.
+    #[command(about = tr!("cmd-aws-roles-about"))]
     Roles(roles::RolesArgs),
     /// Open the AWS Management Console in your browser.
+    #[command(about = tr!("cmd-aws-console-about"))]
     Console(console::ConsoleArgs),
 }
 
@@ -40,9 +45,9 @@ pub(crate) fn resolve_sso_session(
 
     if let Some(name) = explicit {
         return aws_config.find_sso_session(Some(name)).ok_or_else(|| {
-            crate::exit_code::CliError::ConfigError(format!(
-                "SSO session '{name}' not found in ~/.aws/config. \
-                 Run 'aws configure sso' or check --sso-session."
+            crate::exit_code::CliError::ConfigError(tr_args!(
+                "aws-err-sso-session-not-found",
+                name = name,
             ))
             .into()
         });
@@ -51,18 +56,15 @@ pub(crate) fn resolve_sso_session(
     // No explicit selection — use first found, with a hint if multiple exist
     let mut all = aws_config.find_all_sso_sessions();
     if all.is_empty() {
-        return Err(crate::exit_code::CliError::ConfigError(
-            "No SSO session found in ~/.aws/config. \
-             Run 'aws configure sso' first."
-                .to_string(),
-        )
-        .into());
+        return Err(crate::exit_code::CliError::ConfigError(tr!("aws-err-no-sso-session")).into());
     }
     if all.len() > 1 {
         eprintln!(
-            "Using SSO session '{}'. \
-             Specify --sso-session to use a different one.",
-            all.first().map_or("", |s| &s.name)
+            "{}",
+            tr_args!(
+                "aws-using-sso-session",
+                name = all.first().map_or("", |s| &s.name),
+            ),
         );
     }
     Ok(all.swap_remove(0))

--- a/crates/vouch-cli/src/commands/aws/roles.rs
+++ b/crates/vouch-cli/src/commands/aws/roles.rs
@@ -2,7 +2,7 @@
 //! `vouch aws roles` — list available roles across AWS accounts.
 
 use anyhow::{Context, Result};
-use vouch_cli::{tr, tr_args};
+use vouch_cli::{tr, tr_args, tr_println};
 
 use crate::integrations::aws::config::AwsConfig;
 use crate::integrations::aws::sso::{SsoConfig, load_cached_token};
@@ -112,7 +112,7 @@ pub(crate) async fn run(args: RolesArgs) -> Result<()> {
             );
         }
         println!();
-        println!("{}", tr_args!("aws-roles-summary", count = entries.len()));
+        tr_println!("aws-roles-summary", count = entries.len());
     }
 
     Ok(())

--- a/crates/vouch-cli/src/commands/aws/roles.rs
+++ b/crates/vouch-cli/src/commands/aws/roles.rs
@@ -2,6 +2,7 @@
 //! `vouch aws roles` — list available roles across AWS accounts.
 
 use anyhow::{Context, Result};
+use vouch_cli::{tr, tr_args};
 
 use crate::integrations::aws::config::AwsConfig;
 use crate::integrations::aws::sso::{SsoConfig, load_cached_token};
@@ -11,13 +12,13 @@ use crate::integrations::aws::sso_portal::{SsoAccount, list_account_roles, list_
 #[derive(clap::Args)]
 pub(crate) struct RolesArgs {
     /// SSO session name from ~/.aws/config (default: first found).
-    #[arg(long)]
+    #[arg(long, help = tr!("arg-aws-sso-session-help"))]
     pub sso_session: Option<String>,
     /// Filter by account ID (show roles for a single account only).
-    #[arg(long)]
+    #[arg(long, help = tr!("arg-aws-roles-account-help"))]
     pub account: Option<String>,
     /// Output as JSON.
-    #[arg(long)]
+    #[arg(long, help = tr!("arg-aws-roles-json-help"))]
     pub json: bool,
 }
 
@@ -36,7 +37,7 @@ pub(crate) async fn run(args: RolesArgs) -> Result<()> {
 
     let token = load_cached_token(&sso_config).ok_or_else(|| {
         crate::exit_code::CliError::NotAuthenticated {
-            reason: "SSO session expired or missing. Run 'vouch aws login' first.".to_string(),
+            reason: tr!("aws-err-sso-expired"),
         }
     })?;
     let bearer = token.token();
@@ -44,7 +45,7 @@ pub(crate) async fn run(args: RolesArgs) -> Result<()> {
 
     let http_client =
         vouch_common::http::credential_client(&format!("vouch-cli/{}", env!("CARGO_PKG_VERSION")))
-            .context("failed to create HTTP client")?;
+            .with_context(|| tr!("aws-login-err-http-client"))?;
 
     // Determine which accounts to query
     let accounts: Vec<SsoAccount> = if let Some(ref account_id) = args.account {
@@ -57,7 +58,7 @@ pub(crate) async fn run(args: RolesArgs) -> Result<()> {
     } else {
         list_accounts(&http_client, &region, &bearer)
             .await
-            .context("failed to list SSO accounts")?
+            .with_context(|| tr!("aws-accounts-err-list"))?
     };
 
     // Collect roles for each account (O(N) sequential — acceptable for v1)
@@ -65,7 +66,9 @@ pub(crate) async fn run(args: RolesArgs) -> Result<()> {
     for account in &accounts {
         let roles = list_account_roles(&http_client, &region, &bearer, &account.account_id)
             .await
-            .with_context(|| format!("failed to list roles for account {}", account.account_id))?;
+            .with_context(|| {
+                tr_args!("aws-roles-err-list-roles", account_id = &account.account_id)
+            })?;
 
         for role in roles {
             entries.push(RoleEntry {
@@ -89,10 +92,15 @@ pub(crate) async fn run(args: RolesArgs) -> Result<()> {
                 })
                 .collect::<Vec<_>>(),
         )
-        .context("failed to serialize roles")?;
+        .with_context(|| tr!("aws-roles-err-serialize"))?;
         println!("{json}");
     } else {
-        println!("{:<14} {:<35} ROLE NAME", "ACCOUNT ID", "ACCOUNT NAME");
+        println!(
+            "{:<14} {:<35} {}",
+            tr!("aws-roles-table-account-id"),
+            tr!("aws-roles-table-account-name"),
+            tr!("aws-roles-table-role-name"),
+        );
         println!("{}", "-".repeat(80));
         for entry in &entries {
             println!(
@@ -101,7 +109,7 @@ pub(crate) async fn run(args: RolesArgs) -> Result<()> {
             );
         }
         println!();
-        println!("{} role(s)", entries.len());
+        println!("{}", tr_args!("aws-roles-summary", count = entries.len()));
     }
 
     Ok(())

--- a/crates/vouch-cli/src/commands/aws/roles.rs
+++ b/crates/vouch-cli/src/commands/aws/roles.rs
@@ -67,7 +67,10 @@ pub(crate) async fn run(args: RolesArgs) -> Result<()> {
         let roles = list_account_roles(&http_client, &region, &bearer, &account.account_id)
             .await
             .with_context(|| {
-                tr_args!("aws-roles-err-list-roles", account_id = &account.account_id)
+                tr_args!(
+                    "aws-roles-err-list-roles",
+                    account_id = account.account_id.as_str()
+                )
             })?;
 
         for role in roles {

--- a/crates/vouch-cli/src/commands/diag.rs
+++ b/crates/vouch-cli/src/commands/diag.rs
@@ -31,6 +31,7 @@ use ctap_hid_fido2::public_key_credential_user_entity::PublicKeyCredentialUserEn
 use ctap_hid_fido2::verifier;
 use ctap_hid_fido2::verifier::AttestationVerifyResult;
 use std::path::PathBuf;
+use vouch_cli::{tr, tr_args};
 use vouch_common::fixtures::{
     AuthenticationFixture, Fido2Fixture, FixtureMetadata, RegistrationFixture,
 };
@@ -119,11 +120,8 @@ struct Verification {
 pub(crate) fn run(args: DiagArgs) -> Result<()> {
     let json = args.json;
 
-    out!(json, "=== YubiKey Diagnostic Test ===\n");
-    out!(json, "This test will:");
-    out!(json, "1. Register a new credential on your YubiKey");
-    out!(json, "2. Authenticate with that credential");
-    out!(json, "3. Verify the signature using aws-lc-rs\n");
+    out!(json, "{}", tr!("diag-intro-block"));
+    out!(json, "");
 
     let (device, pin) = wait_for_device_and_pin(json)?;
 
@@ -149,7 +147,7 @@ pub(crate) fn run(args: DiagArgs) -> Result<()> {
 
 /// Wait for a YubiKey to be inserted and prompt for its PIN.
 fn wait_for_device_and_pin(json: bool) -> Result<(FidoKeyHid, String)> {
-    out_print!(json, "Please insert your YubiKey... ");
+    out_print!(json, "{} ", tr!("diag-insert-prompt"));
     if json {
         std::io::Write::flush(&mut std::io::stderr()).ok();
     } else {
@@ -159,14 +157,14 @@ fn wait_for_device_and_pin(json: bool) -> Result<(FidoKeyHid, String)> {
     let cfg = LibCfg::init();
     let device = loop {
         if let Ok(dev) = FidoKeyHidFactory::create(&cfg) {
-            out!(json, "detected!");
+            out!(json, "{}", tr!("diag-detected"));
             break dev;
         }
         std::thread::sleep(std::time::Duration::from_millis(500));
     };
 
     out!(json, "");
-    eprint!("YubiKey PIN: ");
+    eprint!("{} ", tr!("diag-pin-prompt"));
     let pin = rpassword::read_password().context("failed to read PIN")?;
     // Note: In diag mode, we keep this as a plain String for simplicity since
     // this is a debugging tool that immediately uses and discards the PIN.
@@ -194,7 +192,8 @@ fn run_registration(json: bool, device: &FidoKeyHid, pin: &str) -> Result<Regist
     let client_data_json = serde_json::to_vec(&client_data)?;
     let client_data_hash = digest(&SHA256, &client_data_json);
 
-    out!(json, "\n=== REGISTRATION ===");
+    out!(json, "");
+    out!(json, "{}", tr!("diag-registration-header"));
     out!(json, "RP ID: {}", RP_ID);
     out!(json, "Challenge: {}", hex::encode(&challenge));
     out!(
@@ -215,18 +214,19 @@ fn run_registration(json: bool, device: &FidoKeyHid, pin: &str) -> Result<Regist
         // NOT using .resident_key() - credential ID stored server-side
         .build();
 
-    out!(json, "\nTouch your YubiKey to register...");
+    out!(json, "");
+    out!(json, "{}", tr!("diag-touch-register"));
     let attestation = device
         .make_credential_with_args(&make_cred_args)
-        .context("Registration failed - check PIN and touch YubiKey")?;
+        .with_context(|| tr!("diag-err-registration"))?;
 
     // Verify attestation locally - pass raw challenge, library hashes internally
     let verify_result = verifier::verify_attestation(RP_ID, &challenge, &attestation);
     if !verify_result.is_success {
-        bail!("Attestation verification failed!");
+        bail!(tr!("diag-err-attestation"));
     }
 
-    out!(json, "Registration successful!");
+    out!(json, "{}", tr!("diag-registration-success"));
     out!(
         json,
         "Credential ID: {} ({} bytes)",
@@ -258,7 +258,7 @@ fn run_registration(json: bool, device: &FidoKeyHid, pin: &str) -> Result<Regist
     out!(json, "Flags: {:#04x}", flags);
 
     if flags & 0x40 == 0 {
-        bail!("No attested credential data in auth_data!");
+        bail!(tr!("diag-err-no-attested-data"));
     }
 
     let cred_id_len = u16::from_be_bytes([auth_data[53], auth_data[54]]) as usize;
@@ -274,9 +274,11 @@ fn run_registration(json: bool, device: &FidoKeyHid, pin: &str) -> Result<Regist
 
     // Parse COSE key to extract x and y
     let cose_val: ciborium::Value =
-        ciborium::from_reader(cose_key.as_slice()).context("Failed to parse COSE key")?;
+        ciborium::from_reader(cose_key.as_slice()).with_context(|| tr!("diag-err-cose-parse"))?;
 
-    let cose_map = cose_val.as_map().context("COSE key is not a map")?;
+    let cose_map = cose_val
+        .as_map()
+        .with_context(|| tr!("diag-err-cose-not-map"))?;
 
     let mut x: Option<Vec<u8>> = None;
     let mut y: Option<Vec<u8>> = None;
@@ -300,14 +302,18 @@ fn run_registration(json: bool, device: &FidoKeyHid, pin: &str) -> Result<Regist
     out!(json, "  kty: {:?} (should be 2 for EC2)", kty);
     out!(json, "  alg: {:?} (should be -7 for ES256)", alg);
 
-    let x = x.context("Missing x coordinate")?;
-    let y = y.context("Missing y coordinate")?;
+    let x = x.with_context(|| tr!("diag-err-missing-x"))?;
+    let y = y.with_context(|| tr!("diag-err-missing-y"))?;
 
     out!(json, "  x ({} bytes): {}", x.len(), hex::encode(&x));
     out!(json, "  y ({} bytes): {}", y.len(), hex::encode(&y));
 
     if x.len() != 32 || y.len() != 32 {
-        bail!("Invalid coordinate lengths: x={}, y={}", x.len(), y.len());
+        bail!(tr_args!(
+            "diag-err-coord-length",
+            x_len = x.len(),
+            y_len = y.len(),
+        ));
     }
 
     Ok(Registration {
@@ -329,7 +335,8 @@ fn run_authentication(
     pin: &str,
     credential_id: &[u8],
 ) -> Result<Authentication> {
-    out!(json, "\n=== AUTHENTICATION ===");
+    out!(json, "");
+    out!(json, "{}", tr!("diag-authentication-header"));
 
     let challenge: [u8; 32] = rand::random();
 
@@ -357,17 +364,18 @@ fn run_authentication(
         .add_credential_id(credential_id) // Explicitly specify which credential
         .build();
 
-    out!(json, "\nTouch your YubiKey to authenticate...");
+    out!(json, "");
+    out!(json, "{}", tr!("diag-touch-authenticate"));
     let assertions = device
         .get_assertion_with_args(&get_assertion_args)
-        .context("Authentication failed")?;
+        .with_context(|| tr!("diag-err-authentication"))?;
 
     let assertion = assertions
         .into_iter()
         .next()
-        .context("No assertion returned")?;
+        .with_context(|| tr!("diag-err-no-assertion"))?;
 
-    out!(json, "Authentication successful!");
+    out!(json, "{}", tr!("diag-authentication-success"));
     out!(
         json,
         "Credential ID: {} ({} bytes)",
@@ -388,7 +396,8 @@ fn run_authentication(
     );
 
     // Debug: Check the rpid_hash from the assertion
-    out!(json, "\n=== RPID VERIFICATION ===");
+    out!(json, "");
+    out!(json, "{}", tr!("diag-rpid-header"));
     let expected_rpid_hash = digest(&SHA256, RP_ID.as_bytes());
     out!(
         json,
@@ -401,9 +410,9 @@ fn run_authentication(
         hex::encode(&assertion.rpid_hash)
     );
     if expected_rpid_hash.as_ref() == assertion.rpid_hash.as_slice() {
-        out!(json, "OK RPID hash matches");
+        out!(json, "{}", tr!("diag-rpid-match"));
     } else {
-        out!(json, "FAIL RPID hash MISMATCH!");
+        out!(json, "{}", tr!("diag-rpid-mismatch"));
     }
 
     Ok(Authentication {
@@ -415,11 +424,16 @@ fn run_authentication(
 
 /// Verify the assertion signature two ways — via the ctap-hid-fido2 library
 /// and directly with aws-lc-rs — and dump the DER signature's r/s values.
+#[expect(
+    clippy::too_many_lines,
+    reason = "diagnostic dump of every signature-verification path"
+)]
 fn verify_signatures(json: bool, reg: &Registration, auth: &Authentication) -> Verification {
     let assertion = &auth.assertion;
 
     // First, use the library's verify_assertion function
-    out!(json, "\n=== LIBRARY VERIFICATION ===");
+    out!(json, "");
+    out!(json, "{}", tr!("diag-lib-verification-header"));
 
     // The library's verify_assertion expects raw challenge bytes (not clientDataJSON or hash)
     // It constructs clientDataJSON internally and hashes it
@@ -431,9 +445,9 @@ fn verify_signatures(json: bool, reg: &Registration, auth: &Authentication) -> V
     );
 
     if lib_result {
-        out!(json, "OK ctap-hid-fido2 library verification: PASSED");
+        out!(json, "{}", tr!("diag-lib-verification-passed"));
     } else {
-        out!(json, "FAIL ctap-hid-fido2 library verification: FAILED");
+        out!(json, "{}", tr!("diag-lib-verification-failed"));
 
         // Debug: Show what the library would compute
         // The library hashes the RAW challenge directly, not a clientDataJSON
@@ -461,7 +475,8 @@ fn verify_signatures(json: bool, reg: &Registration, auth: &Authentication) -> V
     }
 
     // Now verify the signature ourselves
-    out!(json, "\n=== AWS-LC-RS VERIFICATION ===");
+    out!(json, "");
+    out!(json, "{}", tr!("diag-aws-lc-header"));
 
     // Build the message: authenticator_data || SHA256(raw_challenge)
     // The library uses SHA256(challenge) directly, not SHA256(clientDataJSON)
@@ -501,9 +516,9 @@ fn verify_signatures(json: bool, reg: &Registration, auth: &Authentication) -> V
 
     // Explicit byte-by-byte comparison
     if point == *library_key {
-        out!(json, "OK Public keys are IDENTICAL (byte-by-byte)");
+        out!(json, "{}", tr!("diag-keys-identical"));
     } else {
-        out!(json, "FAIL Public keys DIFFER!");
+        out!(json, "{}", tr!("diag-keys-differ"));
         out!(json, "  Our point len: {}", point.len());
         out!(json, "  Library len: {}", library_key.len());
         for (i, (a, b)) in point.iter().zip(library_key.iter()).enumerate() {
@@ -527,10 +542,19 @@ fn verify_signatures(json: bool, reg: &Registration, auth: &Authentication) -> V
     let public_key = UnparsedPublicKey::new(&ECDSA_P256_SHA256_ASN1, &point);
 
     let aws_lc_result = public_key.verify(&message, &assertion.signature).is_ok();
+    out!(json, "");
     if aws_lc_result {
-        out!(json, "\nOK aws-lc-rs verification (our point): PASSED");
+        out!(
+            json,
+            "{}",
+            tr_args!("diag-aws-lc-passed", kind = "our point")
+        );
     } else {
-        out!(json, "\nFAIL aws-lc-rs verification (our point): FAILED");
+        out!(
+            json,
+            "{}",
+            tr_args!("diag-aws-lc-failed", kind = "our point")
+        );
     }
 
     // Also verify using the library's extracted public key directly
@@ -538,19 +562,28 @@ fn verify_signatures(json: bool, reg: &Registration, auth: &Authentication) -> V
 
     match public_key_lib.verify(&message, &assertion.signature) {
         Ok(()) => {
-            out!(json, "OK aws-lc-rs verification (library key): PASSED");
+            out!(
+                json,
+                "{}",
+                tr_args!("diag-aws-lc-passed", kind = "library key")
+            );
         }
         Err(e) => {
             out!(
                 json,
-                "FAIL aws-lc-rs verification (library key): FAILED - {:?}",
-                e
+                "{}",
+                tr_args!(
+                    "diag-aws-lc-failed-reason",
+                    kind = "library key",
+                    reason = format!("{e:?}"),
+                ),
             );
         }
     }
 
     // Additional debug: Parse the DER signature to see r and s values
-    out!(json, "\n=== SIGNATURE ANALYSIS ===");
+    out!(json, "");
+    out!(json, "{}", tr!("diag-sig-header"));
     let sig = &assertion.signature;
     if sig.len() >= 2 && sig[0] == 0x30 {
         let seq_len = sig[1] as usize;
@@ -600,7 +633,8 @@ fn print_report(
     verification: &Verification,
 ) {
     // Check if credential IDs match between registration and authentication
-    out!(json, "\n=== CREDENTIAL ID CHECK ===");
+    out!(json, "");
+    out!(json, "{}", tr!("diag-cred-id-header"));
     out!(
         json,
         "Registration cred_id: {}",
@@ -612,42 +646,22 @@ fn print_report(
         hex::encode(&auth.assertion.credential_id)
     );
     if reg.verify_result.credential_id == auth.assertion.credential_id {
-        out!(json, "OK Credential IDs match");
+        out!(json, "{}", tr!("diag-cred-id-match"));
     } else {
-        out!(
-            json,
-            "FAIL Credential ID MISMATCH - authenticator used different credential!"
-        );
+        out!(json, "{}", tr!("diag-cred-id-mismatch"));
     }
 
-    out!(json, "\n=== SUMMARY ===");
+    out!(json, "");
+    out!(json, "{}", tr!("diag-summary-header"));
     if verification.lib_result {
-        out!(json, "The ctap-hid-fido2 library CAN verify the signature.");
-        out!(
-            json,
-            "This suggests the issue is with how we're calling aws-lc-rs."
-        );
+        out!(json, "{}", tr!("diag-summary-lib-ok"));
     } else {
-        out!(
-            json,
-            "Even the ctap-hid-fido2 library CANNOT verify the signature."
-        );
-        out!(
-            json,
-            "This suggests a fundamental issue with the YubiKey or authentication flow."
-        );
-        out!(json, "\nPossible causes:");
-        out!(json, "1. YubiKey firmware bug (especially FIPS models)");
-        out!(json, "2. Credential corruption on the YubiKey");
-        out!(
-            json,
-            "3. Different key pair being used for signing vs registration"
-        );
+        out!(json, "{}", tr!("diag-summary-lib-fail"));
     }
 
     // Output data for manual OpenSSL verification
-    out!(json, "\n=== OPENSSL VERIFICATION DATA ===");
-    out!(json, "To verify with OpenSSL, run these commands:");
+    out!(json, "");
+    out!(json, "{}", tr!("diag-openssl-header"));
     out!(json, "");
     out!(json, "# Create public key PEM file");
     out!(json, "echo '-----BEGIN PUBLIC KEY-----' > /tmp/pubkey.pem");
@@ -706,10 +720,8 @@ fn print_report(
     );
 
     // Note: This test now uses non-resident credentials (no cleanup needed)
-    out!(
-        json,
-        "\nNote: Non-resident credential used - no cleanup needed on YubiKey."
-    );
+    out!(json, "");
+    out!(json, "{}", tr!("diag-no-cleanup"));
 }
 
 /// Extract the AAGUID (hex) from registration auth_data, if attested
@@ -750,7 +762,8 @@ fn export_fixture(
     reg: &Registration,
     auth: &Authentication,
 ) -> Result<()> {
-    out!(json, "\n=== EXPORTING FIXTURE ===");
+    out!(json, "");
+    out!(json, "{}", tr!("diag-export-header"));
 
     let aaguid = extract_aaguid(reg);
     let device_model = aaguid
@@ -786,8 +799,12 @@ fn export_fixture(
 
     fixture
         .save_to_file(path)
-        .map_err(|e| anyhow::anyhow!("Failed to save fixture: {}", e))?;
-    out!(json, "Fixture saved to: {}", path.display());
+        .map_err(|e| anyhow::anyhow!(tr_args!("diag-err-fixture-save", reason = e)))?;
+    out!(
+        json,
+        "{}",
+        tr_args!("diag-fixture-saved", path = path.display())
+    );
 
     Ok(())
 }

--- a/crates/vouch-cli/src/commands/diag.rs
+++ b/crates/vouch-cli/src/commands/diag.rs
@@ -799,11 +799,11 @@ fn export_fixture(
 
     fixture
         .save_to_file(path)
-        .map_err(|e| anyhow::anyhow!(tr_args!("diag-err-fixture-save", reason = e)))?;
+        .map_err(|e| anyhow::anyhow!(tr_args!("diag-err-fixture-save", reason = e.to_string())))?;
     out!(
         json,
         "{}",
-        tr_args!("diag-fixture-saved", path = path.display())
+        tr_args!("diag-fixture-saved", path = path.display().to_string())
     );
 
     Ok(())

--- a/crates/vouch-cli/src/commands/doctor.rs
+++ b/crates/vouch-cli/src/commands/doctor.rs
@@ -235,7 +235,10 @@ fn check_yubikey() -> CheckResult {
     let cfg = Cfg::init();
     match FidoKeyHidFactory::create(&cfg) {
         Ok(_device) => CheckResult::pass("yubikey", tr!("doctor-yubikey-found")),
-        Err(e) => CheckResult::fail("yubikey", tr_args!("doctor-yubikey-not-found", reason = e)),
+        Err(e) => CheckResult::fail(
+            "yubikey",
+            tr_args!("doctor-yubikey-not-found", reason = format!("{e:#}")),
+        ),
     }
 }
 
@@ -283,14 +286,14 @@ async fn check_agent() -> CheckResult {
                     match pid_info {
                         Some(pid) => CheckResult::pass(
                             "agent",
-                            tr_args!("doctor-agent-running-pid", pid = pid),
+                            tr_args!("doctor-agent-running-pid", pid = pid.to_string()),
                         ),
                         None => CheckResult::pass("agent", tr!("doctor-agent-running")),
                     }
                 }
                 Err(e) => CheckResult::fail(
                     "agent",
-                    tr_args!("doctor-agent-connection-failed", reason = e),
+                    tr_args!("doctor-agent-connection-failed", reason = format!("{e:#}")),
                 ),
             }
         }
@@ -301,7 +304,7 @@ async fn check_agent() -> CheckResult {
             {
                 return CheckResult::fail(
                     "agent",
-                    tr_args!("doctor-agent-socket-exists", reason = e),
+                    tr_args!("doctor-agent-socket-exists", reason = format!("{e:#}")),
                 );
             }
             CheckResult::fail("agent", tr!("doctor-agent-not-running"))
@@ -320,7 +323,10 @@ async fn check_server(server: &str) -> (CheckResult, Option<CheckResult>) {
         Ok(c) => c,
         Err(e) => {
             return (
-                CheckResult::fail("server", tr_args!("doctor-server-invalid-url", reason = e)),
+                CheckResult::fail(
+                    "server",
+                    tr_args!("doctor-server-invalid-url", reason = format!("{e:#}")),
+                ),
                 None,
             );
         }
@@ -331,7 +337,10 @@ async fn check_server(server: &str) -> (CheckResult, Option<CheckResult>) {
         Ok(resp) => resp,
         Err(e) => {
             return (
-                CheckResult::fail("server", tr_args!("doctor-server-unreachable", reason = e)),
+                CheckResult::fail(
+                    "server",
+                    tr_args!("doctor-server-unreachable", reason = format!("{e:#}")),
+                ),
                 None,
             );
         }
@@ -347,7 +356,10 @@ async fn check_server(server: &str) -> (CheckResult, Option<CheckResult>) {
     } else {
         CheckResult::fail(
             "server",
-            tr_args!("doctor-server-status", status = response.status()),
+            tr_args!(
+                "doctor-server-status",
+                status = response.status().to_string()
+            ),
         )
     };
 
@@ -444,7 +456,7 @@ async fn check_session() -> CheckResult {
                             "doctor-session-valid",
                             hours = hours,
                             mins = mins,
-                            email = &session.user_email,
+                            email = session.user_email.as_str(),
                         ),
                     )
                 } else {

--- a/crates/vouch-cli/src/commands/doctor.rs
+++ b/crates/vouch-cli/src/commands/doctor.rs
@@ -11,6 +11,7 @@ use vouch_agent::AgentClient;
 use crate::client::VouchClient;
 use crate::config::Config;
 use crate::style;
+use vouch_cli::{tr, tr_args};
 
 /// Check result with status and optional message.
 struct CheckResult {
@@ -61,7 +62,8 @@ pub(crate) async fn run(server: &str, quiet: bool, json: bool) -> Result<()> {
     let suppress = quiet || json;
 
     if !suppress {
-        println!("Vouch Doctor - Environment Diagnostics\n");
+        println!("{}", tr!("doctor-title"));
+        println!();
     }
 
     let checks = run_checks(server, suppress).await;
@@ -90,12 +92,12 @@ pub(crate) async fn run(server: &str, quiet: bool, json: bool) -> Result<()> {
     }
     if all_passed {
         if !suppress {
-            println!("All checks passed!");
+            println!("{}", tr!("doctor-all-passed"));
         }
         Ok(())
     } else {
         if !suppress {
-            println!("Some checks failed. Review the issues above.");
+            println!("{}", tr!("doctor-some-failed"));
         }
         bail!("doctor: one or more checks failed")
     }
@@ -108,7 +110,7 @@ async fn run_checks(server: &str, suppress: bool) -> Vec<CheckResult> {
 
     // Check 1: YubiKey connectivity
     if !suppress {
-        print!("YubiKey connectivity ... ");
+        print!("{} ", tr!("doctor-check-yubikey-label"));
     }
     let yubikey_result = check_yubikey();
     if !suppress {
@@ -120,7 +122,7 @@ async fn run_checks(server: &str, suppress: bool) -> Vec<CheckResult> {
     #[cfg(unix)]
     {
         if !suppress {
-            print!("Agent running ... ");
+            print!("{} ", tr!("doctor-check-agent-label"));
         }
         let agent_result = check_agent().await;
         if !suppress {
@@ -131,7 +133,7 @@ async fn run_checks(server: &str, suppress: bool) -> Vec<CheckResult> {
 
     // Check 3: Server reachable (and clock skew, derived from same response)
     if !suppress {
-        print!("Server reachable ... ");
+        print!("{} ", tr!("doctor-check-server-label"));
     }
     let (server_result, clock_result) = check_server(server).await;
     if !suppress {
@@ -140,22 +142,16 @@ async fn run_checks(server: &str, suppress: bool) -> Vec<CheckResult> {
     checks.push(server_result);
     if let Some(clock) = clock_result {
         if !suppress {
-            print!("Clock in sync with server ... ");
+            print!("{} ", tr!("doctor-check-clock-label"));
             print_result(&clock);
         }
         checks.push(clock);
     }
 
     // Check 3a: DNS-over-HTTPS resolution status.
-    //
-    // Always emit something so users discover the option. When DoH is enabled
-    // we run a real lookup through the configured provider. When disabled we
-    // print a one-line nudge — not added to `checks` so it doesn't count
-    // toward pass/fail or appear in --json output (DoH being off is a user
-    // choice, not a misconfiguration).
     if let Some(resolver) = vouch_common::dns::process_resolver() {
         if !suppress {
-            print!("DNS-over-HTTPS resolution ... ");
+            print!("{} ", tr!("doctor-check-doh-label"));
         }
         let doh_result = check_doh(&resolver, server).await;
         if !suppress {
@@ -164,15 +160,16 @@ async fn run_checks(server: &str, suppress: bool) -> Vec<CheckResult> {
         checks.push(doh_result);
     } else if !suppress {
         println!(
-            "DNS-over-HTTPS resolution ... {} disabled — DNS queries are visible to your \
-             local network. Set VOUCH_DOH=cloudflare (or google/quad9) to encrypt them.",
+            "{} {} {}",
+            tr!("doctor-check-doh-label"),
             style::yellow("[INFO]"),
+            tr!("doctor-doh-disabled"),
         );
     }
 
     // Check 4: Session valid
     if !suppress {
-        print!("Session valid ... ");
+        print!("{} ", tr!("doctor-check-session-label"));
     }
     let session_result = check_session().await;
     if !suppress {
@@ -182,7 +179,7 @@ async fn run_checks(server: &str, suppress: bool) -> Vec<CheckResult> {
 
     // Check 5: SSH config
     if !suppress {
-        print!("SSH configuration ... ");
+        print!("{} ", tr!("doctor-check-ssh-label"));
     }
     let ssh_result = check_ssh_config();
     if !suppress {
@@ -192,7 +189,7 @@ async fn run_checks(server: &str, suppress: bool) -> Vec<CheckResult> {
 
     // Check 6: EKS config
     if !suppress {
-        print!("EKS configuration ... ");
+        print!("{} ", tr!("doctor-check-eks-label"));
     }
     let eks_result = check_eks_config();
     if !suppress {
@@ -202,7 +199,7 @@ async fn run_checks(server: &str, suppress: bool) -> Vec<CheckResult> {
 
     // Check 7: SSM config
     if !suppress {
-        print!("SSM configuration ... ");
+        print!("{} ", tr!("doctor-check-ssm-label"));
     }
     let ssm_result = check_ssm_config();
     if !suppress {
@@ -212,7 +209,7 @@ async fn run_checks(server: &str, suppress: bool) -> Vec<CheckResult> {
 
     // Check 8: Server URL security
     if !suppress {
-        print!("Server URL security ... ");
+        print!("{} ", tr!("doctor-check-server-url-label"));
     }
     let security_result = check_server_url_security(server);
     if !suppress {
@@ -237,8 +234,8 @@ fn print_result(result: &CheckResult) {
 fn check_yubikey() -> CheckResult {
     let cfg = Cfg::init();
     match FidoKeyHidFactory::create(&cfg) {
-        Ok(_device) => CheckResult::pass("yubikey", "FIDO2 device found"),
-        Err(e) => CheckResult::fail("yubikey", format!("No FIDO2 device found: {e}")),
+        Ok(_device) => CheckResult::pass("yubikey", tr!("doctor-yubikey-found")),
+        Err(e) => CheckResult::fail("yubikey", tr_args!("doctor-yubikey-not-found", reason = e)),
     }
 }
 
@@ -261,18 +258,11 @@ fn check_yubikey() -> CheckResult {
     )]
     let version = unsafe { WebAuthNGetApiVersionNumber() };
     if version == 0 {
-        CheckResult::fail(
-            "yubikey",
-            "Windows WebAuthn API not available. Update to Windows 10 1903 or later.",
-        )
+        CheckResult::fail("yubikey", tr!("doctor-yubikey-win-api-missing"))
     } else {
         CheckResult::pass(
             "yubikey",
-            format!(
-                "Windows WebAuthn API available (version {version}); \
-                 vouch login uses the system Security dialog to authenticate \
-                 your YubiKey — no admin privileges required."
-            ),
+            tr_args!("doctor-yubikey-win-api-available", version = version),
         )
     }
 }
@@ -291,13 +281,17 @@ async fn check_agent() -> CheckResult {
                         .and_then(|p| std::fs::read_to_string(p).ok())
                         .and_then(|s| s.trim().parse::<u32>().ok());
                     match pid_info {
-                        Some(pid) => {
-                            CheckResult::pass("agent", format!("Agent is running (PID {pid})"))
-                        }
-                        None => CheckResult::pass("agent", "Agent is running"),
+                        Some(pid) => CheckResult::pass(
+                            "agent",
+                            tr_args!("doctor-agent-running-pid", pid = pid),
+                        ),
+                        None => CheckResult::pass("agent", tr!("doctor-agent-running")),
                     }
                 }
-                Err(e) => CheckResult::fail("agent", format!("Agent connection failed: {e}")),
+                Err(e) => CheckResult::fail(
+                    "agent",
+                    tr_args!("doctor-agent-connection-failed", reason = e),
+                ),
             }
         }
         Err(e) => {
@@ -307,13 +301,10 @@ async fn check_agent() -> CheckResult {
             {
                 return CheckResult::fail(
                     "agent",
-                    format!("Socket exists but connection failed: {e}"),
+                    tr_args!("doctor-agent-socket-exists", reason = e),
                 );
             }
-            CheckResult::fail(
-                "agent",
-                "Agent not running. Start with: vouch-agent --foreground",
-            )
+            CheckResult::fail("agent", tr!("doctor-agent-not-running"))
         }
     }
 }
@@ -329,7 +320,7 @@ async fn check_server(server: &str) -> (CheckResult, Option<CheckResult>) {
         Ok(c) => c,
         Err(e) => {
             return (
-                CheckResult::fail("server", format!("Invalid server URL: {e}")),
+                CheckResult::fail("server", tr_args!("doctor-server-invalid-url", reason = e)),
                 None,
             );
         }
@@ -340,7 +331,7 @@ async fn check_server(server: &str) -> (CheckResult, Option<CheckResult>) {
         Ok(resp) => resp,
         Err(e) => {
             return (
-                CheckResult::fail("server", format!("Server unreachable: {e}")),
+                CheckResult::fail("server", tr_args!("doctor-server-unreachable", reason = e)),
                 None,
             );
         }
@@ -349,11 +340,14 @@ async fn check_server(server: &str) -> (CheckResult, Option<CheckResult>) {
     let clock_result = build_clock_skew_result(response.headers());
 
     let server_result = if response.status().is_success() {
-        CheckResult::pass("server", format!("Server at {server} is reachable"))
+        CheckResult::pass(
+            "server",
+            tr_args!("doctor-server-reachable", server = server),
+        )
     } else {
         CheckResult::fail(
             "server",
-            format!("Server returned status: {}", response.status()),
+            tr_args!("doctor-server-status", status = response.status()),
         )
     };
 
@@ -369,18 +363,17 @@ fn build_clock_skew_result(headers: &reqwest::header::HeaderMap) -> Option<Check
     if skew_secs < vouch_cli::http::CLOCK_SKEW_THRESHOLD_SECS {
         return Some(CheckResult::pass(
             "clock_skew",
-            format!("System clock within {skew_secs}s of server"),
+            tr_args!("doctor-clock-ok", secs = skew_secs),
         ));
     }
-    let direction = if local_behind { "behind" } else { "ahead of" };
+    let direction = if local_behind {
+        tr!("doctor-clock-direction-behind")
+    } else {
+        tr!("doctor-clock-direction-ahead")
+    };
     Some(CheckResult::fail(
         "clock_skew",
-        format!(
-            "System clock is {skew_secs}s {direction} the server. \
-             Signed requests will fail once skew exceeds 300s. \
-             Sync your clock (Windows: Settings → Time & Language → Date & Time → \
-             \"Sync now\"; macOS: `sudo sntp -sS time.apple.com`)."
-        ),
+        tr_args!("doctor-clock-skew", secs = skew_secs, direction = direction),
     ))
 }
 
@@ -412,14 +405,23 @@ async fn check_doh(resolver: &vouch_common::dns::DohResolver, server: &str) -> C
         }
     };
     match resolver.lookup_ip(&host).await {
-        Ok(addrs) if addrs.is_empty() => {
-            CheckResult::fail("doh", format!("{label}: {host} resolved to zero addresses"))
-        }
+        Ok(addrs) if addrs.is_empty() => CheckResult::fail(
+            "doh",
+            tr_args!("doctor-doh-zero-addresses", label = label, host = host),
+        ),
         Ok(addrs) => CheckResult::pass(
             "doh",
-            format!("{label}: {host} resolved to {} address(es)", addrs.len()),
+            tr_args!(
+                "doctor-doh-resolved",
+                label = label,
+                host = host,
+                count = addrs.len(),
+            ),
         ),
-        Err(e) => CheckResult::fail("doh", format!("{label}: {e:#}")),
+        Err(e) => CheckResult::fail(
+            "doh",
+            tr_args!("doctor-doh-error", label = label, reason = format!("{e:#}")),
+        ),
     }
 }
 
@@ -438,32 +440,31 @@ async fn check_session() -> CheckResult {
                         .unwrap_or(0);
                     CheckResult::pass(
                         "session",
-                        format!(
-                            "Session valid for {}h {}m ({})",
-                            hours, mins, session.user_email
+                        tr_args!(
+                            "doctor-session-valid",
+                            hours = hours,
+                            mins = mins,
+                            email = &session.user_email,
                         ),
                     )
                 } else {
-                    CheckResult::fail("session", "Session expired. Run: vouch login")
+                    CheckResult::fail("session", tr!("doctor-session-expired"))
                 }
             }
-            Err(_) => CheckResult::fail("session", "No active session. Run: vouch login"),
+            Err(_) => CheckResult::fail("session", tr!("doctor-session-none")),
         };
     }
 
     // Fall back to config
     let config = match Config::load() {
         Ok(c) => c,
-        Err(_) => return CheckResult::fail("session", "No config found. Run: vouch login"),
+        Err(_) => return CheckResult::fail("session", tr!("doctor-session-no-config")),
     };
 
     if config.token().is_some() {
-        CheckResult::pass(
-            "session",
-            "Session token found (agent not running for full validation)",
-        )
+        CheckResult::pass("session", tr!("doctor-session-token-only"))
     } else {
-        CheckResult::fail("session", "No session token. Run: vouch login")
+        CheckResult::fail("session", tr!("doctor-session-no-token"))
     }
 }
 
@@ -471,37 +472,35 @@ async fn check_session() -> CheckResult {
 fn check_ssh_config() -> CheckResult {
     let home = match dirs::home_dir() {
         Some(h) => h,
-        None => return CheckResult::fail("ssh", "Could not determine home directory"),
+        None => return CheckResult::fail("ssh", tr!("doctor-ssh-no-home")),
     };
 
     let ssh_config_path = home.join(".ssh").join("config");
     let vouch_key_path = home.join(".ssh").join("id_ed25519_vouch");
 
-    let mut issues = Vec::new();
+    let mut issues: Vec<String> = Vec::new();
 
-    // Check for Vouch SSH key
     if !vouch_key_path.exists() {
-        issues.push("Vouch SSH key not found. Run: vouch setup ssh");
+        issues.push(tr!("doctor-ssh-key-missing"));
     }
 
-    // Check for SSH config entry
     if ssh_config_path.exists() {
         match std::fs::read_to_string(&ssh_config_path) {
             Ok(content) => {
                 if !content.contains("id_ed25519_vouch") && !content.contains("vouch") {
-                    issues.push("No Vouch entry in SSH config. Run: vouch setup ssh");
+                    issues.push(tr!("doctor-ssh-config-missing-entry"));
                 }
             }
             Err(_) => {
-                issues.push("Could not read SSH config");
+                issues.push(tr!("doctor-ssh-config-unreadable"));
             }
         }
     } else {
-        issues.push("SSH config not found");
+        issues.push(tr!("doctor-ssh-config-not-found"));
     }
 
     if issues.is_empty() {
-        CheckResult::pass("ssh", "SSH configured for Vouch")
+        CheckResult::pass("ssh", tr!("doctor-ssh-configured"))
     } else {
         CheckResult::fail("ssh", issues.join("; "))
     }
@@ -511,32 +510,27 @@ fn check_ssh_config() -> CheckResult {
 fn check_eks_config() -> CheckResult {
     let home = match dirs::home_dir() {
         Some(h) => h,
-        None => return CheckResult::fail("eks", "Could not determine home directory"),
+        None => return CheckResult::fail("eks", tr!("doctor-eks-no-home")),
     };
 
-    // Check KUBECONFIG env var first, then default path
     let kubeconfig_path = std::env::var("KUBECONFIG")
         .ok()
         .and_then(|k| k.split(':').next().map(std::path::PathBuf::from))
         .unwrap_or_else(|| home.join(".kube").join("config"));
 
     if !kubeconfig_path.exists() {
-        return CheckResult::pass("eks", "No kubeconfig found (EKS not configured)");
+        return CheckResult::pass("eks", tr!("doctor-eks-no-kubeconfig"));
     }
 
     match std::fs::read_to_string(&kubeconfig_path) {
         Ok(content) => {
-            // Check if there's a Vouch EKS user configured
             if content.contains("vouch-eks-") {
-                CheckResult::pass("eks", "EKS configured for Vouch")
+                CheckResult::pass("eks", tr!("doctor-eks-configured"))
             } else {
-                CheckResult::pass(
-                    "eks",
-                    "Kubeconfig exists (no Vouch EKS integration). Run: vouch setup eks --cluster <name>",
-                )
+                CheckResult::pass("eks", tr!("doctor-eks-no-vouch-entry"))
             }
         }
-        Err(_) => CheckResult::fail("eks", "Could not read kubeconfig"),
+        Err(_) => CheckResult::fail("eks", tr!("doctor-eks-unreadable")),
     }
 }
 
@@ -551,7 +545,7 @@ fn check_ssm_config() -> CheckResult {
 
     let home = match dirs::home_dir() {
         Some(h) => h,
-        None => return CheckResult::fail("ssm", "Could not determine home directory"),
+        None => return CheckResult::fail("ssm", tr!("doctor-ssm-no-home")),
     };
 
     let ssh_config_path = home.join(".ssh").join("config");
@@ -562,19 +556,10 @@ fn check_ssm_config() -> CheckResult {
         .is_some_and(|content| content.contains(SSM_MARKER));
 
     match (plugin_found, marker_found) {
-        (true, true) => CheckResult::pass("ssm", "SSM configured for Vouch"),
-        (true, false) => CheckResult::pass(
-            "ssm",
-            "session-manager-plugin found (not configured). Run: vouch setup ssm",
-        ),
-        (false, true) => CheckResult::fail(
-            "ssm",
-            "SSH config references SSM but session-manager-plugin not found on PATH",
-        ),
-        (false, false) => CheckResult::pass(
-            "ssm",
-            "SSM not configured (session-manager-plugin not found)",
-        ),
+        (true, true) => CheckResult::pass("ssm", tr!("doctor-ssm-configured")),
+        (true, false) => CheckResult::pass("ssm", tr!("doctor-ssm-plugin-found")),
+        (false, true) => CheckResult::fail("ssm", tr!("doctor-ssm-plugin-missing-but-configured")),
+        (false, false) => CheckResult::pass("ssm", tr!("doctor-ssm-not-configured")),
     }
 }
 
@@ -583,12 +568,9 @@ fn check_server_url_security(server: &str) -> CheckResult {
     if vouch_common::check_url_security(server).is_insecure() {
         CheckResult::fail(
             "server_url_security",
-            format!("Server uses plain HTTP ({server}). Use HTTPS or set VOUCH_ALLOW_INSECURE=1."),
+            tr_args!("doctor-server-url-insecure", server = server),
         )
     } else {
-        CheckResult::pass(
-            "server_url_security",
-            "Server URL is secure (HTTPS or localhost)",
-        )
+        CheckResult::pass("server_url_security", tr!("doctor-server-url-secure"))
     }
 }

--- a/crates/vouch-cli/src/commands/doctor.rs
+++ b/crates/vouch-cli/src/commands/doctor.rs
@@ -11,7 +11,7 @@ use vouch_agent::AgentClient;
 use crate::client::VouchClient;
 use crate::config::Config;
 use crate::style;
-use vouch_cli::{tr, tr_args};
+use vouch_cli::{tr, tr_args, tr_println};
 
 /// Check result with status and optional message.
 struct CheckResult {
@@ -62,7 +62,7 @@ pub(crate) async fn run(server: &str, quiet: bool, json: bool) -> Result<()> {
     let suppress = quiet || json;
 
     if !suppress {
-        println!("{}", tr!("doctor-title"));
+        tr_println!("doctor-title");
         println!();
     }
 
@@ -92,12 +92,12 @@ pub(crate) async fn run(server: &str, quiet: bool, json: bool) -> Result<()> {
     }
     if all_passed {
         if !suppress {
-            println!("{}", tr!("doctor-all-passed"));
+            tr_println!("doctor-all-passed");
         }
         Ok(())
     } else {
         if !suppress {
-            println!("{}", tr!("doctor-some-failed"));
+            tr_println!("doctor-some-failed");
         }
         bail!("doctor: one or more checks failed")
     }

--- a/crates/vouch-cli/src/commands/enroll.rs
+++ b/crates/vouch-cli/src/commands/enroll.rs
@@ -67,15 +67,15 @@ pub(crate) async fn run(server: &str) -> Result<()> {
     match open::that(verification_url) {
         Ok(()) => tr_println!(
             "enroll-browser-block",
-            url = verification_url,
-            code = &device_response.user_code,
+            url = verification_url.as_str(),
+            code = device_response.user_code.as_str(),
         ),
         Err(e) => {
             tracing::debug!("Failed to open browser: {e}");
             tr_println!(
                 "enroll-manual-block",
-                url = verification_url,
-                code = &device_response.user_code,
+                url = verification_url.as_str(),
+                code = device_response.user_code.as_str(),
             );
         }
     }
@@ -102,7 +102,10 @@ pub(crate) async fn run(server: &str) -> Result<()> {
     .await?;
 
     println!();
-    tr_println!("enroll-success-block", email = &token_response.email);
+    tr_println!(
+        "enroll-success-block",
+        email = token_response.email.as_str()
+    );
 
     // Step 8: Auto-register the inserted YubiKey if not already known.
     // The enrollment token is a full OAuth access token that can call
@@ -502,7 +505,7 @@ async fn register_current_key(server: &str, token: SecretString) -> Result<()> {
 
     tr_println!(
         "enroll-key-registered",
-        device_id = &complete_resp.device_id,
+        device_id = complete_resp.device_id.to_string(),
     );
 
     Ok(())

--- a/crates/vouch-cli/src/commands/enroll.rs
+++ b/crates/vouch-cli/src/commands/enroll.rs
@@ -13,6 +13,7 @@ use crate::client::VouchClient;
 use crate::config::Config;
 use crate::fido2::{self, FidoDevice, YubiKey};
 use crate::session;
+use vouch_cli::{tr, tr_args, tr_println};
 
 /// Response from device token endpoint.
 #[derive(serde::Deserialize)]
@@ -36,7 +37,8 @@ impl std::fmt::Debug for DeviceTokenResponse {
 pub(crate) async fn run(server: &str) -> Result<()> {
     let client = VouchClient::unauthenticated(server)?;
 
-    println!("Starting enrollment...\n");
+    tr_println!("enroll-starting");
+    println!();
 
     // Step 1: Generate or load the FAPI client key (for DPoP proofs).
     let fapi_key = vouch_cli::fapi::key_store::load_or_create_client_key().ok();
@@ -63,30 +65,22 @@ pub(crate) async fn run(server: &str) -> Result<()> {
 
     // Try to open the browser automatically
     match open::that(verification_url) {
-        Ok(()) => {
-            println!("Opening browser to complete enrollment...");
-            println!();
-            println!("  URL:  {verification_url}");
-            println!("  Code: {}", device_response.user_code);
-            println!();
-            println!(
-                "If the browser didn't open, visit the URL above \
-                 and enter the code."
-            );
-        }
+        Ok(()) => tr_println!(
+            "enroll-browser-block",
+            url = verification_url,
+            code = &device_response.user_code,
+        ),
         Err(e) => {
             tracing::debug!("Failed to open browser: {e}");
-            println!("To complete enrollment:");
-            println!();
-            println!("  1. Open this URL in your browser:");
-            println!("     {verification_url}");
-            println!();
-            println!("  2. Enter this code:");
-            println!("     {}", device_response.user_code);
+            tr_println!(
+                "enroll-manual-block",
+                url = verification_url,
+                code = &device_response.user_code,
+            );
         }
     }
     println!();
-    println!("Waiting for browser authorization...");
+    tr_println!("enroll-waiting");
 
     // Step 5: Poll for token (with optional DPoP proofs).
     let token_response = poll_for_token(&client, &device_response, fapi_key.as_ref()).await?;
@@ -107,8 +101,8 @@ pub(crate) async fn run(server: &str) -> Result<()> {
     )
     .await?;
 
-    println!("\nEnrollment successful!");
-    println!("Enrolled as: {}", token_response.email);
+    println!();
+    tr_println!("enroll-success-block", email = &token_response.email);
 
     // Step 8: Auto-register the inserted YubiKey if not already known.
     // The enrollment token is a full OAuth access token that can call
@@ -117,20 +111,15 @@ pub(crate) async fn run(server: &str) -> Result<()> {
         tracing::debug!("Auto-registration skipped: {e}");
     }
 
+    println!();
     if agent_stored {
-        println!("\nYour identity is now available. Check with: vouch status");
+        tr_println!("session-agent-ready");
     } else {
-        println!("\nNote: Agent not running. Start it with: vouch-agent --foreground");
+        tr_println!("session-agent-not-running");
     }
 
     println!();
-    println!("Set up integrations:");
-    println!("  vouch setup ssh      # SSH certificates");
-    println!("  vouch setup aws      # AWS credentials");
-    println!("  vouch setup github   # GitHub tokens");
-    println!();
-    println!("Or add a backup key:");
-    println!("  vouch login && vouch register --name \"Backup Key\"");
+    tr_println!("enroll-next-steps");
 
     Ok(())
 }
@@ -178,9 +167,9 @@ async fn request_device_code(
             client
                 .post_form("/oauth/device", &retry_request)
                 .await
-                .context("Failed to start enrollment")
+                .with_context(|| tr!("enroll-err-start"))
         }
-        Err(e) => Err(e.context("Failed to start enrollment")),
+        Err(e) => Err(e.context(tr!("enroll-err-start"))),
     }
 }
 
@@ -263,11 +252,7 @@ async fn poll_for_token(
     loop {
         // Check timeout
         if start.elapsed() > timeout {
-            anyhow::bail!(
-                "Enrollment timed out. Please try again.\n\
-                 Make sure to complete the sign-in in your \
-                 browser window and enter the code shown above."
-            );
+            anyhow::bail!(tr!("enroll-err-timeout"));
         }
 
         // Wait before polling
@@ -276,7 +261,7 @@ async fn poll_for_token(
         // Show progress (only on interactive terminals)
         if stdout().is_terminal() {
             dots = dots.saturating_add(1) % 4;
-            print!("\rWaiting for browser authorization{}", ".".repeat(dots));
+            print!("\r{}{}", tr!("enroll-waiting-progress"), ".".repeat(dots),);
             print!("{}", " ".repeat(3_usize.saturating_sub(dots)));
             stdout().flush().ok();
         }
@@ -301,18 +286,17 @@ async fn poll_for_token(
             }
             Err(PollError::Denied) => {
                 println!();
-                return Err(crate::exit_code::CliError::PermissionDenied(
-                    "authorization was denied".to_string(),
-                )
-                .into());
+                return Err(
+                    crate::exit_code::CliError::PermissionDenied(tr!("enroll-err-denied")).into(),
+                );
             }
             Err(PollError::Expired) => {
                 println!();
-                anyhow::bail!("The code has expired. Please try again.");
+                anyhow::bail!(tr!("enroll-err-code-expired"));
             }
             Err(PollError::Other(msg)) => {
                 println!();
-                anyhow::bail!("Enrollment failed: {msg}");
+                anyhow::bail!(tr_args!("enroll-err-failed", reason = msg));
             }
         }
     }
@@ -476,7 +460,8 @@ async fn register_current_key(server: &str, token: SecretString) -> Result<()> {
         return Ok(());
     }
 
-    println!("\nRegistering your YubiKey with the server...");
+    println!();
+    tr_println!("enroll-registering-key");
 
     let rp_id = start_resp.rp_id.clone();
     let rp_name = start_resp.rp_name.clone();
@@ -515,9 +500,9 @@ async fn register_current_key(server: &str, token: SecretString) -> Result<()> {
         .await
         .context("failed to complete key registration")?;
 
-    println!(
-        "YubiKey registered! (device ID: {})",
-        complete_resp.device_id
+    tr_println!(
+        "enroll-key-registered",
+        device_id = &complete_resp.device_id,
     );
 
     Ok(())

--- a/crates/vouch-cli/src/commands/env.rs
+++ b/crates/vouch-cli/src/commands/env.rs
@@ -3,6 +3,7 @@
 
 use anyhow::{Context, Result};
 use secrecy::ExposeSecret;
+use vouch_cli::tr;
 
 use super::CredentialType;
 use super::exec::{CodeArtifactOptions, RdsOptions, RedshiftOptions};
@@ -28,9 +29,7 @@ pub(crate) async fn run(
 ) -> Result<()> {
     match credential_type {
         CredentialType::Aws => {
-            let role_arn = role.context(
-                "AWS credentials require --role. Usage: vouch env --type aws --role <ARN>",
-            )?;
+            let role_arn = role.with_context(|| tr!("env-err-aws-needs-role"))?;
             print_aws_env(server, role_arn, shell).await
         }
         CredentialType::Github => print_github_env(server, shell).await,

--- a/crates/vouch-cli/src/commands/exec.rs
+++ b/crates/vouch-cli/src/commands/exec.rs
@@ -4,6 +4,7 @@
 use anyhow::{Context, Result, bail};
 use secrecy::{ExposeSecret, SecretString};
 use std::process::Command;
+use vouch_cli::{tr, tr_args};
 
 use super::CredentialType;
 use super::credential::cache;
@@ -70,18 +71,18 @@ pub(crate) async fn fetch_aws_credentials(
     let access_key_id = data
         .get("AccessKeyId")
         .and_then(|v| v.as_str())
-        .context("AWS credentials missing AccessKeyId")?
+        .with_context(|| tr!("exec-err-aws-missing-key-id"))?
         .to_string();
     let secret_access_key = SecretString::from(
         data.get("SecretAccessKey")
             .and_then(|v| v.as_str())
-            .context("AWS credentials missing SecretAccessKey")?
+            .with_context(|| tr!("exec-err-aws-missing-secret"))?
             .to_string(),
     );
     let session_token = SecretString::from(
         data.get("SessionToken")
             .and_then(|v| v.as_str())
-            .context("AWS credentials missing SessionToken")?
+            .with_context(|| tr!("exec-err-aws-missing-token"))?
             .to_string(),
     );
     let expiration = data
@@ -131,7 +132,7 @@ pub(crate) async fn fetch_github_token_cached(server: &str) -> Result<GitHubEnvT
     let token = SecretString::from(
         data.get("token")
             .and_then(serde_json::Value::as_str)
-            .context("GitHub credential missing 'token' field")?
+            .with_context(|| tr!("exec-err-github-missing-token"))?
             .to_string(),
     );
 
@@ -149,10 +150,12 @@ pub(crate) async fn run(
     rs_opts: RedshiftOptions<'_>,
 ) -> Result<()> {
     if command.is_empty() {
-        bail!("No command specified. Usage: vouch exec -- <command> [args...]");
+        bail!(tr!("exec-err-no-command"));
     }
 
-    let program = command.first().context("no command specified")?;
+    let program = command
+        .first()
+        .with_context(|| tr!("exec-err-no-command-short"))?;
     let args = command.get(1..).unwrap_or_default();
 
     let mut cmd = Command::new(program);
@@ -160,9 +163,7 @@ pub(crate) async fn run(
 
     match credential_type {
         CredentialType::Aws => {
-            let role_arn = role.context(
-                "AWS credentials require --role. Usage: vouch exec --type aws --role <ARN> -- <command>",
-            )?;
+            let role_arn = role.with_context(|| tr!("exec-err-aws-needs-role"))?;
             inject_aws_credentials(&mut cmd, server, role_arn).await?;
         }
         CredentialType::Github => {
@@ -190,18 +191,22 @@ pub(crate) async fn run(
     {
         use std::os::unix::process::CommandExt;
         let err = cmd.exec();
-        bail!("failed to execute {program}: {err}");
+        bail!(tr_args!(
+            "exec-err-execute-failed",
+            program = program,
+            reason = err
+        ));
     }
 
     #[cfg(not(unix))]
     {
         let status = cmd
             .status()
-            .with_context(|| format!("failed to execute: {program}"))?;
+            .with_context(|| tr_args!("exec-err-execute-simple", program = program))?;
 
         if !status.success() {
             let code = status.code().unwrap_or(1);
-            bail!("command exited with status {code}");
+            bail!(tr_args!("exec-err-exit-status", code = code));
         }
 
         Ok(())
@@ -282,7 +287,7 @@ pub(crate) async fn fetch_github_token(server: &str) -> Result<serde_json::Value
             &vouch_common::GitHubTokenRequest::default(),
         )
         .await
-        .context("failed to get GitHub token from Vouch server")
+        .with_context(|| tr!("exec-err-github-fetch"))
 }
 
 /// Resolve CodeArtifact parameters and fetch a token.
@@ -300,7 +305,7 @@ pub(super) async fn fetch_codeartifact_token(
 
     super::credential::codeartifact::get_token(server, &domain, &domain_owner, &region)
         .await
-        .context("failed to get CodeArtifact token")
+        .with_context(|| tr!("exec-err-codeartifact-fetch"))
 }
 
 /// Validated RDS credentials ready for environment injection.
@@ -317,14 +322,12 @@ pub(super) async fn fetch_rds_with_opts(
     role: Option<&str>,
     opts: &RdsOptions<'_>,
 ) -> Result<RdsEnvCredentials> {
-    let hostname = opts.hostname.context(
-        "RDS credentials require --rds-hostname. \
-         Usage: vouch {exec|env} --type rds --rds-hostname <host> --rds-username <user>",
-    )?;
-    let username = opts.username.context(
-        "RDS credentials require --rds-username. \
-         Usage: vouch {exec|env} --type rds --rds-hostname <host> --rds-username <user>",
-    )?;
+    let hostname = opts
+        .hostname
+        .with_context(|| tr!("exec-err-rds-needs-hostname"))?;
+    let username = opts
+        .username
+        .with_context(|| tr!("exec-err-rds-needs-username"))?;
 
     let token = super::credential::rds::fetch_rds_token(
         server,

--- a/crates/vouch-cli/src/commands/exec.rs
+++ b/crates/vouch-cli/src/commands/exec.rs
@@ -194,7 +194,7 @@ pub(crate) async fn run(
         bail!(tr_args!(
             "exec-err-execute-failed",
             program = program,
-            reason = err
+            reason = err.to_string()
         ));
     }
 

--- a/crates/vouch-cli/src/commands/keys.rs
+++ b/crates/vouch-cli/src/commands/keys.rs
@@ -13,6 +13,7 @@ use vouch_common::{
 
 use crate::client::VouchClient;
 use crate::exit_code::CliError;
+use vouch_cli::{tr, tr_args, tr_println};
 
 /// Keys subcommands.
 #[derive(Subcommand)]
@@ -49,35 +50,39 @@ pub(crate) async fn interactive(server: &str) -> Result<()> {
         let response: ListKeysResponse = client.get_authenticated("/v1/keys").await?;
 
         if response.keys.is_empty() {
-            println!("No keys registered.");
+            tr_println!("keys-none");
             return Ok(());
         }
 
         // Build display options
         let options: Vec<String> = response.keys.iter().map(format_key_for_display).collect();
+        let exit_label = tr!("keys-action-exit");
 
         // Add quit option
         let mut menu_options = options.clone();
-        menu_options.push("Exit".to_string());
+        menu_options.push(exit_label.clone());
 
         // Print prompt on its own line
-        println!("\nSelect a key to manage:\n");
+        println!();
+        tr_println!("keys-prompt-select");
+        println!();
 
         // Configure render to remove all prefixes for clean alignment
         let render_config = RenderConfig::default()
             .with_prompt_prefix(Styled::new(""))
             .with_highlighted_option_prefix(Styled::new(">"));
 
+        let nav_help = tr!("keys-help-navigation");
         // Show interactive menu (disable filtering to prevent accidental key presses)
         let selection = Select::new("\n", menu_options)
             .with_render_config(render_config)
-            .with_help_message("↑↓ to move, Enter to select, Esc to exit")
+            .with_help_message(&nav_help)
             .without_filtering()
             .prompt();
 
         match selection {
             Ok(selected) => {
-                if selected == "Exit" {
+                if selected == exit_label {
                     return Ok(());
                 }
 
@@ -101,7 +106,7 @@ pub(crate) async fn interactive(server: &str) -> Result<()> {
                 return Ok(());
             }
             Err(e) => {
-                bail!("Selection error: {e}");
+                bail!(tr_args!("keys-err-selection", reason = e));
             }
         }
     }
@@ -111,47 +116,60 @@ pub(crate) async fn interactive(server: &str) -> Result<()> {
 /// Returns false if we should exit the interactive loop.
 async fn handle_key_action(server: &str, client: &VouchClient, key: &KeyInfo) -> Result<bool> {
     let current_marker = if key.is_current_session {
-        " (current session)"
+        tr!("keys-marker-current")
     } else {
-        ""
+        String::new()
     };
 
-    let actions = vec!["Delete this key", "Back to list", "Quit"];
+    let delete_label = tr!("keys-action-delete");
+    let back_label = tr!("keys-action-back");
+    let quit_label = tr!("keys-action-quit");
+    let actions = vec![
+        delete_label.as_str(),
+        back_label.as_str(),
+        quit_label.as_str(),
+    ];
 
-    let prompt = format!("Key: {}{}", key.name, current_marker);
+    let prompt = tr_args!(
+        "keys-action-prompt",
+        name = &key.name,
+        marker = &current_marker,
+    );
+    let help = tr!("keys-help-action");
     let selection = Select::new(&prompt, actions)
-        .with_help_message("Select an action")
+        .with_help_message(&help)
         .prompt();
 
     match selection {
-        Ok("Delete this key") => {
+        Ok(choice) if choice == delete_label => {
             delete_key_interactive(server, client, key).await?;
             Ok(true) // Continue loop to refresh list
         }
-        Ok("Quit") => Ok(false),
+        Ok(choice) if choice == quit_label => Ok(false),
         Ok(_) => Ok(true), // Back to list
         Err(
             inquire::InquireError::OperationCanceled | inquire::InquireError::OperationInterrupted,
         ) => {
             Ok(true) // Back to list on Esc
         }
-        Err(e) => bail!("Selection error: {e}"),
+        Err(e) => bail!(tr_args!("keys-err-selection", reason = e)),
     }
 }
 
 /// Delete a key with confirmation.
 async fn delete_key_interactive(server: &str, client: &VouchClient, key: &KeyInfo) -> Result<()> {
     let warning = if key.is_current_session {
-        "\nWARNING: This is the key used for your current session. Your session will be invalidated."
+        format!("\n{}", tr!("keys-warn-current-session"))
     } else {
-        ""
+        String::new()
     };
 
-    let prompt = format!("Delete key '{}'?{}", key.name, warning);
+    let prompt = tr_args!("keys-confirm-delete", name = &key.name, warning = &warning);
 
+    let undo_help = tr!("keys-help-undo");
     let confirmed = Confirm::new(&prompt)
         .with_default(false)
-        .with_help_message("This action cannot be undone")
+        .with_help_message(&undo_help)
         .prompt();
 
     match confirmed {
@@ -160,19 +178,24 @@ async fn delete_key_interactive(server: &str, client: &VouchClient, key: &KeyInf
 
             println!("\n{}", response.message);
             if response.sessions_revoked > 0 {
-                println!("  {} session(s) revoked.", response.sessions_revoked);
+                println!(
+                    "  {}",
+                    tr_args!("keys-sessions-revoked", count = response.sessions_revoked),
+                );
             }
             println!();
         }
         Ok(false) => {
-            println!("Cancelled.\n");
+            tr_println!("keys-cancelled");
+            println!();
         }
         Err(
             inquire::InquireError::OperationCanceled | inquire::InquireError::OperationInterrupted,
         ) => {
-            println!("Cancelled.\n");
+            tr_println!("keys-cancelled");
+            println!();
         }
-        Err(e) => bail!("Confirmation error: {e}"),
+        Err(e) => bail!(tr_args!("keys-err-confirmation", reason = e)),
     }
 
     Ok(())
@@ -196,7 +219,8 @@ async fn delete_with_step_up(
             if let Some(cli_err) = e.downcast_ref::<CliError>()
                 && matches!(cli_err, CliError::StepUpRequired { .. })
             {
-                println!("\nFresh authentication required to delete a key.");
+                println!();
+                tr_println!("keys-step-up-needed");
                 crate::commands::login::run(server, 30)
                     .await
                     .context("step-up re-authentication failed")?;
@@ -215,9 +239,9 @@ async fn delete_with_step_up(
 /// Format a key for display in the interactive menu.
 fn format_key_for_display(key: &KeyInfo) -> String {
     let current = if key.is_current_session {
-        "(current)"
+        tr!("keys-marker-current-short")
     } else {
-        ""
+        String::new()
     };
     let created = format_timestamp(&key.created_at);
     // Show device model if available, otherwise fall back to name
@@ -239,14 +263,19 @@ pub(crate) async fn list(server: &str, json: bool) -> Result<()> {
     }
 
     if response.keys.is_empty() {
-        println!("No keys registered.");
+        tr_println!("keys-none");
         return Ok(());
     }
 
-    println!("Registered keys:\n");
+    tr_println!("keys-header");
+    println!();
     let header = format!(
         "{:<36}  {:<20}  {:<20}  {:<20}  {}",
-        "ID", "NAME", "MODEL", "CREATED", "CURRENT"
+        tr!("keys-table-id"),
+        tr!("keys-table-name"),
+        tr!("keys-table-model"),
+        tr!("keys-table-created"),
+        tr!("keys-table-current"),
     );
     println!("{header}");
     println!("{}", "-".repeat(115));
@@ -262,7 +291,8 @@ pub(crate) async fn list(server: &str, json: bool) -> Result<()> {
         );
     }
 
-    println!("\n* = key used for current session");
+    println!();
+    tr_println!("keys-legend");
 
     Ok(())
 }
@@ -278,19 +308,18 @@ pub(crate) async fn remove(server: &str, key_id: &str, force: bool) -> Result<()
     let key_name = match key {
         Some(k) => k.name.clone(),
         None => {
-            bail!("Key not found: {key_id}");
+            bail!(tr_args!("keys-err-not-found", id = key_id));
         }
     };
 
     // Prompt for confirmation unless --force is used
     if !force {
-        println!("You are about to remove the key '{key_name}' (ID: {key_id}).");
+        tr_println!("keys-confirm-remove-line", name = &key_name, id = key_id);
         if key.is_some_and(|k| k.is_current_session) {
-            println!("WARNING: This is the key used for your current session.");
-            println!("         Your session will be invalidated.");
+            tr_println!("keys-warn-remove-current-session");
         }
         println!();
-        print!("Are you sure? [y/N] ");
+        print!("{} ", tr!("keys-confirm-y-n"));
         std::io::Write::flush(&mut std::io::stdout())?;
 
         let mut input = String::new();
@@ -298,7 +327,7 @@ pub(crate) async fn remove(server: &str, key_id: &str, force: bool) -> Result<()
         let input = input.trim().to_lowercase();
 
         if input != "y" && input != "yes" {
-            println!("Cancelled.");
+            tr_println!("keys-cancelled");
             return Ok(());
         }
     }
@@ -308,7 +337,10 @@ pub(crate) async fn remove(server: &str, key_id: &str, force: bool) -> Result<()
 
     println!("{}", response.message);
     if response.sessions_revoked > 0 {
-        println!("  {} session(s) revoked.", response.sessions_revoked);
+        println!(
+            "  {}",
+            tr_args!("keys-sessions-revoked", count = response.sessions_revoked),
+        );
     }
 
     Ok(())
@@ -321,10 +353,10 @@ pub(crate) async fn rename(server: &str, key_id: &str, new_name: &str) -> Result
     // Validate name
     let new_name = new_name.trim();
     if new_name.is_empty() {
-        bail!("Name cannot be empty");
+        bail!(tr!("keys-err-name-empty"));
     }
     if new_name.len() > 100 {
-        bail!("Name must be 100 characters or less");
+        bail!(tr!("keys-err-name-long"));
     }
 
     // First, verify the key exists
@@ -332,7 +364,7 @@ pub(crate) async fn rename(server: &str, key_id: &str, new_name: &str) -> Result
     let key = keys_response.keys.iter().find(|k| k.id == key_id);
 
     if key.is_none() {
-        bail!("Key not found: {key_id}");
+        bail!(tr_args!("keys-err-not-found", id = key_id));
     }
 
     // Rename the key

--- a/crates/vouch-cli/src/commands/keys.rs
+++ b/crates/vouch-cli/src/commands/keys.rs
@@ -106,7 +106,7 @@ pub(crate) async fn interactive(server: &str) -> Result<()> {
                 return Ok(());
             }
             Err(e) => {
-                bail!(tr_args!("keys-err-selection", reason = e));
+                bail!(tr_args!("keys-err-selection", reason = e.to_string()));
             }
         }
     }
@@ -132,8 +132,8 @@ async fn handle_key_action(server: &str, client: &VouchClient, key: &KeyInfo) ->
 
     let prompt = tr_args!(
         "keys-action-prompt",
-        name = &key.name,
-        marker = &current_marker,
+        name = key.name.as_str(),
+        marker = current_marker.as_str(),
     );
     let help = tr!("keys-help-action");
     let selection = Select::new(&prompt, actions)
@@ -152,7 +152,7 @@ async fn handle_key_action(server: &str, client: &VouchClient, key: &KeyInfo) ->
         ) => {
             Ok(true) // Back to list on Esc
         }
-        Err(e) => bail!(tr_args!("keys-err-selection", reason = e)),
+        Err(e) => bail!(tr_args!("keys-err-selection", reason = e.to_string())),
     }
 }
 
@@ -164,7 +164,11 @@ async fn delete_key_interactive(server: &str, client: &VouchClient, key: &KeyInf
         String::new()
     };
 
-    let prompt = tr_args!("keys-confirm-delete", name = &key.name, warning = &warning);
+    let prompt = tr_args!(
+        "keys-confirm-delete",
+        name = key.name.as_str(),
+        warning = warning.as_str()
+    );
 
     let undo_help = tr!("keys-help-undo");
     let confirmed = Confirm::new(&prompt)
@@ -195,7 +199,7 @@ async fn delete_key_interactive(server: &str, client: &VouchClient, key: &KeyInf
             tr_println!("keys-cancelled");
             println!();
         }
-        Err(e) => bail!(tr_args!("keys-err-confirmation", reason = e)),
+        Err(e) => bail!(tr_args!("keys-err-confirmation", reason = e.to_string())),
     }
 
     Ok(())
@@ -314,7 +318,11 @@ pub(crate) async fn remove(server: &str, key_id: &str, force: bool) -> Result<()
 
     // Prompt for confirmation unless --force is used
     if !force {
-        tr_println!("keys-confirm-remove-line", name = &key_name, id = key_id);
+        tr_println!(
+            "keys-confirm-remove-line",
+            name = key_name.as_str(),
+            id = key_id
+        );
         if key.is_some_and(|k| k.is_current_session) {
             tr_println!("keys-warn-remove-current-session");
         }

--- a/crates/vouch-cli/src/commands/login.rs
+++ b/crates/vouch-cli/src/commands/login.rs
@@ -29,6 +29,7 @@ use crate::client::VouchClient;
 use crate::config::Config;
 use crate::fido2::{self, FidoDevice, YubiKey};
 use crate::session;
+use vouch_cli::{tr, tr_args, tr_println};
 
 /// Run the login command.
 ///
@@ -40,7 +41,8 @@ use crate::session;
 /// 2. All FIDO2 device work on a plain OS thread (wait, PIN, authenticate).
 /// 3. Complete authentication with the server (async).
 pub(crate) async fn run(server: &str, timeout_secs: u64) -> Result<()> {
-    println!("Logging in...\n");
+    tr_println!("login-starting");
+    println!();
 
     let client = VouchClient::unauthenticated(server)?;
 
@@ -104,7 +106,7 @@ async fn run_fapi_login(
     timeout_secs: u64,
     fapi_key: &ClientKey,
 ) -> Result<()> {
-    print!("Contacting server ({server})... ");
+    print!("{} ", tr_args!("login-contacting-server", server = server));
 
     // Step 1: Ensure the client is registered.
     let client_id = ensure_client_registered(client, fapi_key).await?;
@@ -153,7 +155,7 @@ async fn run_fapi_login(
         .await
         .context("failed to parse challenge response")?;
 
-    println!("ok");
+    tr_println!("login-contact-ok");
 
     // Step 3: Start posture collection early — it runs during the FIDO2 wait
     // (human touch takes 5-30s, posture takes 100ms-2s).
@@ -575,18 +577,19 @@ fn resolve_expiry(expires_at: Option<&str>, expires_in: u64) -> (String, jiff::T
 
 /// Print the post-login success message.
 fn finalize_login_output(email: &str, expires_at: &str, agent_stored: bool) {
-    if !email.is_empty() {
-        println!("Login successful as {email}!");
+    if email.is_empty() {
+        tr_println!("login-success");
     } else {
-        println!("Login successful!");
+        tr_println!("login-success-as", email = email);
     }
-    println!("Session expires: {}", format_expiry(expires_at));
+    tr_println!("login-session-expires", expiry = format_expiry(expires_at));
 
+    println!();
     if agent_stored {
-        println!("\nYour identity is now available. Check with: vouch status");
+        tr_println!("session-agent-ready");
     } else {
-        println!("\nNote: Agent not running. Start it with: vouch-agent --foreground");
-        println!("Your identity is stored locally. Check with: vouch status");
+        tr_println!("session-agent-not-running");
+        tr_println!("session-stored-locally");
     }
 }
 
@@ -596,17 +599,9 @@ fn finalize_login_output(email: &str, expires_at: &str, agent_stored: bool) {
 fn token_error(body: &str, status: reqwest::StatusCode) -> anyhow::Error {
     if let Ok(oauth_err) = serde_json::from_str::<vouch_common::OAuthError>(body) {
         let hint = match oauth_err.error.as_str() {
-            "invalid_grant" => {
-                "\n\nThis YubiKey is not registered with the server.\n\
-                 Run 'vouch enroll' to register it."
-            }
-            "invalid_client" => {
-                "\n\nClient registration is invalid or expired.\n\
-                 The client will be re-registered on the next \
-                 attempt.\nPlease run this command again. If it \
-                 persists, run 'vouch enroll' to start fresh."
-            }
-            _ => "",
+            "invalid_grant" => format!("\n\n{}", tr!("login-err-not-registered")),
+            "invalid_client" => format!("\n\n{}", tr!("login-err-invalid-client")),
+            _ => String::new(),
         };
         let desc = oauth_err
             .error_description

--- a/crates/vouch-cli/src/commands/logout.rs
+++ b/crates/vouch-cli/src/commands/logout.rs
@@ -7,6 +7,7 @@ use secrecy::ExposeSecret;
 use vouch_agent::{AgentClient, AgentError};
 
 use crate::config::Config;
+use vouch_cli::tr_println;
 use vouch_common::clear_cookie;
 
 /// Run the logout command.
@@ -44,9 +45,9 @@ pub(crate) async fn run(server: &str) -> Result<()> {
     };
 
     if had_token || agent_cleared || cookie_cleared {
-        println!("Logged out successfully.");
+        tr_println!("logout-success");
     } else {
-        println!("Not currently logged in.");
+        tr_println!("logout-not-logged-in");
     }
 
     Ok(())

--- a/crates/vouch-cli/src/commands/posture.rs
+++ b/crates/vouch-cli/src/commands/posture.rs
@@ -5,6 +5,7 @@
 //! Useful for debugging and verifying posture detection on a given machine.
 
 use anyhow::Result;
+use vouch_cli::{tr, tr_args};
 
 /// Output format for the posture command.
 #[derive(Debug, Default, Clone, Copy, clap::ValueEnum)]
@@ -32,8 +33,34 @@ pub(crate) fn run(format: OutputFormat) -> Result<()> {
     Ok(())
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "linear print of every posture signal — splitting would obscure the column layout"
+)]
 fn print_text(p: &vouch_common::posture::DevicePosture) {
-    println!("Device Posture (v{})", p.posture_version);
+    let enabled_or_missing = |b: bool| {
+        if b {
+            tr!("posture-val-enabled")
+        } else {
+            tr!("posture-val-not-detected")
+        }
+    };
+    let enabled_or_disabled = |b: bool| {
+        if b {
+            tr!("posture-val-enabled")
+        } else {
+            tr!("posture-val-disabled")
+        }
+    };
+    let yes_no = |b: bool| {
+        if b {
+            tr!("posture-val-yes")
+        } else {
+            tr!("posture-val-no")
+        }
+    };
+
+    println!("{}", tr_args!("posture-title", version = p.posture_version));
     println!("{}", "-".repeat(50));
 
     // OS info
@@ -41,139 +68,173 @@ fn print_text(p: &vouch_common::posture::DevicePosture) {
         let version = p.os_version.as_deref().unwrap_or("unknown");
         let distro = p.os_distribution.as_deref().unwrap_or("");
         if distro.is_empty() {
-            println!("  OS:              {os} {version}");
+            println!("  {:<16} {os} {version}", tr!("posture-label-os"));
         } else {
-            println!("  OS:              {distro} {version} ({os})");
+            println!(
+                "  {:<16} {distro} {version} ({os})",
+                tr!("posture-label-os")
+            );
         }
     }
     if let Some(ref build) = p.os_build {
-        println!("  Build:           {build}");
+        println!("  {:<16} {build}", tr!("posture-label-build"));
     }
     if let Some(ref arch) = p.arch {
-        println!("  Architecture:    {arch}");
+        println!("  {:<16} {arch}", tr!("posture-label-architecture"));
     }
     println!();
 
     // Disk encryption
     if let Some(enabled) = p.disk_encryption_enabled {
-        let status = if enabled { "enabled" } else { "not detected" };
+        let status = enabled_or_missing(enabled);
         let tech = p.disk_encryption_technology.as_deref().unwrap_or("");
         if tech.is_empty() {
-            println!("  Disk encryption: {status}");
+            println!("  {:<16} {status}", tr!("posture-label-disk-encryption"));
         } else {
-            println!("  Disk encryption: {status} ({tech})");
+            println!(
+                "  {:<16} {status} ({tech})",
+                tr!("posture-label-disk-encryption")
+            );
         }
     } else {
-        println!("  Disk encryption: not checked");
+        println!(
+            "  {:<16} {}",
+            tr!("posture-label-disk-encryption"),
+            tr!("posture-val-not-checked")
+        );
     }
 
     // Screen lock
     if let Some(enabled) = p.screen_lock_enabled {
-        let status = if enabled { "enabled" } else { "not detected" };
+        let status = enabled_or_missing(enabled);
         if let Some(timeout) = p.screen_lock_idle_timeout_secs {
-            println!("  Screen lock:     {status} (idle timeout: {timeout}s)");
+            println!(
+                "  {:<16} {status} (idle timeout: {timeout}s)",
+                tr!("posture-label-screen-lock")
+            );
         } else {
-            println!("  Screen lock:     {status}");
+            println!("  {:<16} {status}", tr!("posture-label-screen-lock"));
         }
     } else {
-        println!("  Screen lock:     not checked");
+        println!(
+            "  {:<16} {}",
+            tr!("posture-label-screen-lock"),
+            tr!("posture-val-not-checked")
+        );
     }
 
     // Firewall
     if let Some(enabled) = p.firewall_enabled {
-        let status = if enabled { "enabled" } else { "not detected" };
+        let status = enabled_or_missing(enabled);
         let tech = p.firewall_technology.as_deref().unwrap_or("");
         if tech.is_empty() {
-            println!("  Firewall:        {status}");
+            println!("  {:<16} {status}", tr!("posture-label-firewall"));
         } else {
-            println!("  Firewall:        {status} ({tech})");
+            println!("  {:<16} {status} ({tech})", tr!("posture-label-firewall"));
         }
     } else {
-        println!("  Firewall:        not checked");
+        println!(
+            "  {:<16} {}",
+            tr!("posture-label-firewall"),
+            tr!("posture-val-not-checked")
+        );
     }
 
-    // Secure boot / TPM
     if let Some(enabled) = p.secure_boot_enabled {
-        let status = if enabled { "enabled" } else { "disabled" };
-        println!("  Secure boot:     {status}");
+        let status = enabled_or_disabled(enabled);
+        println!("  {:<16} {status}", tr!("posture-label-secure-boot"));
     }
     if let Some(sip) = p.sip_enabled {
-        let status = if sip { "enabled" } else { "disabled" };
-        println!("  SIP:             {status}");
+        let status = enabled_or_disabled(sip);
+        println!("  {:<16} {status}", tr!("posture-label-sip"));
     }
     if let Some(tpm) = p.tpm_present {
-        let status = if tpm { "present" } else { "not detected" };
-        if let Some(ref ver) = p.tpm_version {
-            println!("  TPM:             {status} (v{ver})");
+        let status = if tpm {
+            tr!("posture-val-present")
         } else {
-            println!("  TPM:             {status}");
+            tr!("posture-val-not-detected")
+        };
+        if let Some(ref ver) = p.tpm_version {
+            println!("  {:<16} {status} (v{ver})", tr!("posture-label-tpm"));
+        } else {
+            println!("  {:<16} {status}", tr!("posture-label-tpm"));
         }
     }
 
-    // Auto-update
     if let Some(enabled) = p.auto_update_enabled {
-        let status = if enabled { "enabled" } else { "not detected" };
+        let status = enabled_or_missing(enabled);
         let tech = p.auto_update_technology.as_deref().unwrap_or("");
         if tech.is_empty() {
-            println!("  Auto-update:     {status}");
+            println!("  {:<16} {status}", tr!("posture-label-auto-update"));
         } else {
-            println!("  Auto-update:     {status} ({tech})");
+            println!(
+                "  {:<16} {status} ({tech})",
+                tr!("posture-label-auto-update")
+            );
         }
     }
 
-    // System uptime
     if let Some(secs) = p.uptime_secs {
         // 86400, 3600, 60 are non-zero; unwrap_or arms are unreachable.
         let days = secs.checked_div(86400).unwrap_or(0);
         let hours = (secs % 86400).checked_div(3600).unwrap_or(0);
         let mins = (secs % 3600).checked_div(60).unwrap_or(0);
-        println!("  Uptime:          {days}d {hours}h {mins}m");
+        println!(
+            "  {:<16} {days}d {hours}h {mins}m",
+            tr!("posture-label-uptime")
+        );
     }
 
-    // Access control (SELinux/AppArmor/Gatekeeper)
     if let Some(enforcing) = p.access_control_enforcing {
         let tech = p.access_control_technology.as_deref().unwrap_or("unknown");
         let status = if enforcing {
-            "enforcing"
+            tr!("posture-val-enforcing")
         } else {
-            "permissive/disabled"
+            tr!("posture-val-permissive")
         };
-        println!("  Access control:  {tech} ({status})");
+        println!(
+            "  {:<16} {tech} ({status})",
+            tr!("posture-label-access-control")
+        );
     }
 
-    // EDR agents
     if p.edr.is_empty() {
-        println!("  EDR:             not detected");
+        println!(
+            "  {:<16} {}",
+            tr!("posture-label-edr"),
+            tr!("posture-val-not-detected")
+        );
     } else {
         let names: Vec<&str> = p.edr.iter().map(|a| a.as_str()).collect();
-        println!("  EDR:             {}", names.join(", "));
+        println!("  {:<16} {}", tr!("posture-label-edr"), names.join(", "));
     }
 
-    // MDM agents
     if p.mdm.is_empty() {
-        println!("  MDM:             not detected");
+        println!(
+            "  {:<16} {}",
+            tr!("posture-label-mdm"),
+            tr!("posture-val-not-detected")
+        );
     } else {
         let names: Vec<&str> = p.mdm.iter().map(|a| a.as_str()).collect();
-        println!("  MDM:             {}", names.join(", "));
+        println!("  {:<16} {}", tr!("posture-label-mdm"), names.join(", "));
     }
 
     println!();
 
-    // Execution context
     if let Some(elevated) = p.elevated {
-        let status = if elevated { "yes" } else { "no" };
-        println!("  Elevated:        {status}");
+        let status = yes_no(elevated);
+        println!("  {:<16} {status}", tr!("posture-label-elevated"));
     }
     if let Some(tty) = p.tty {
-        let status = if tty { "yes" } else { "no" };
-        println!("  TTY:             {status}");
+        let status = yes_no(tty);
+        println!("  {:<16} {status}", tr!("posture-label-tty"));
     }
     if let Some(ref parent) = p.parent_process {
-        println!("  Parent process:  {parent}");
+        println!("  {:<16} {parent}", tr!("posture-label-parent-process"));
     }
 
-    // CLI version
     if let Some(ref ver) = p.cli_version {
-        println!("  CLI version:     {ver}");
+        println!("  {:<16} {ver}", tr!("posture-label-cli-version"));
     }
 }

--- a/crates/vouch-cli/src/commands/posture.rs
+++ b/crates/vouch-cli/src/commands/posture.rs
@@ -38,28 +38,6 @@ pub(crate) fn run(format: OutputFormat) -> Result<()> {
     reason = "linear print of every posture signal — splitting would obscure the column layout"
 )]
 fn print_text(p: &vouch_common::posture::DevicePosture) {
-    let enabled_or_missing = |b: bool| {
-        if b {
-            tr!("posture-val-enabled")
-        } else {
-            tr!("posture-val-not-detected")
-        }
-    };
-    let enabled_or_disabled = |b: bool| {
-        if b {
-            tr!("posture-val-enabled")
-        } else {
-            tr!("posture-val-disabled")
-        }
-    };
-    let yes_no = |b: bool| {
-        if b {
-            tr!("posture-val-yes")
-        } else {
-            tr!("posture-val-no")
-        }
-    };
-
     println!("{}", tr_args!("posture-title", version = p.posture_version));
     println!("{}", "-".repeat(50));
 
@@ -86,7 +64,7 @@ fn print_text(p: &vouch_common::posture::DevicePosture) {
 
     // Disk encryption
     if let Some(enabled) = p.disk_encryption_enabled {
-        let status = enabled_or_missing(enabled);
+        let status = tr_args!("posture-val-enabled-or-missing", on = enabled.to_string());
         let tech = p.disk_encryption_technology.as_deref().unwrap_or("");
         if tech.is_empty() {
             println!("  {:<16} {status}", tr!("posture-label-disk-encryption"));
@@ -106,7 +84,7 @@ fn print_text(p: &vouch_common::posture::DevicePosture) {
 
     // Screen lock
     if let Some(enabled) = p.screen_lock_enabled {
-        let status = enabled_or_missing(enabled);
+        let status = tr_args!("posture-val-enabled-or-missing", on = enabled.to_string());
         if let Some(timeout) = p.screen_lock_idle_timeout_secs {
             println!(
                 "  {:<16} {status} (idle timeout: {timeout}s)",
@@ -125,7 +103,7 @@ fn print_text(p: &vouch_common::posture::DevicePosture) {
 
     // Firewall
     if let Some(enabled) = p.firewall_enabled {
-        let status = enabled_or_missing(enabled);
+        let status = tr_args!("posture-val-enabled-or-missing", on = enabled.to_string());
         let tech = p.firewall_technology.as_deref().unwrap_or("");
         if tech.is_empty() {
             println!("  {:<16} {status}", tr!("posture-label-firewall"));
@@ -141,19 +119,15 @@ fn print_text(p: &vouch_common::posture::DevicePosture) {
     }
 
     if let Some(enabled) = p.secure_boot_enabled {
-        let status = enabled_or_disabled(enabled);
+        let status = tr_args!("posture-val-enabled-or-disabled", on = enabled.to_string());
         println!("  {:<16} {status}", tr!("posture-label-secure-boot"));
     }
     if let Some(sip) = p.sip_enabled {
-        let status = enabled_or_disabled(sip);
+        let status = tr_args!("posture-val-enabled-or-disabled", on = sip.to_string());
         println!("  {:<16} {status}", tr!("posture-label-sip"));
     }
     if let Some(tpm) = p.tpm_present {
-        let status = if tpm {
-            tr!("posture-val-present")
-        } else {
-            tr!("posture-val-not-detected")
-        };
+        let status = tr_args!("posture-val-present-or-missing", on = tpm.to_string());
         if let Some(ref ver) = p.tpm_version {
             println!("  {:<16} {status} (v{ver})", tr!("posture-label-tpm"));
         } else {
@@ -162,7 +136,7 @@ fn print_text(p: &vouch_common::posture::DevicePosture) {
     }
 
     if let Some(enabled) = p.auto_update_enabled {
-        let status = enabled_or_missing(enabled);
+        let status = tr_args!("posture-val-enabled-or-missing", on = enabled.to_string());
         let tech = p.auto_update_technology.as_deref().unwrap_or("");
         if tech.is_empty() {
             println!("  {:<16} {status}", tr!("posture-label-auto-update"));
@@ -187,11 +161,10 @@ fn print_text(p: &vouch_common::posture::DevicePosture) {
 
     if let Some(enforcing) = p.access_control_enforcing {
         let tech = p.access_control_technology.as_deref().unwrap_or("unknown");
-        let status = if enforcing {
-            tr!("posture-val-enforcing")
-        } else {
-            tr!("posture-val-permissive")
-        };
+        let status = tr_args!(
+            "posture-val-enforcing-or-permissive",
+            on = enforcing.to_string()
+        );
         println!(
             "  {:<16} {tech} ({status})",
             tr!("posture-label-access-control")
@@ -223,11 +196,11 @@ fn print_text(p: &vouch_common::posture::DevicePosture) {
     println!();
 
     if let Some(elevated) = p.elevated {
-        let status = yes_no(elevated);
+        let status = tr_args!("posture-val-yes-no", b = elevated.to_string());
         println!("  {:<16} {status}", tr!("posture-label-elevated"));
     }
     if let Some(tty) = p.tty {
-        let status = yes_no(tty);
+        let status = tr_args!("posture-val-yes-no", b = tty.to_string());
         println!("  {:<16} {status}", tr!("posture-label-tty"));
     }
     if let Some(ref parent) = p.parent_process {

--- a/crates/vouch-cli/src/commands/posture.rs
+++ b/crates/vouch-cli/src/commands/posture.rs
@@ -5,7 +5,7 @@
 //! Useful for debugging and verifying posture detection on a given machine.
 
 use anyhow::Result;
-use vouch_cli::{tr, tr_args};
+use vouch_cli::{tr, tr_args, tr_println};
 
 /// Output format for the posture command.
 #[derive(Debug, Default, Clone, Copy, clap::ValueEnum)]
@@ -38,7 +38,7 @@ pub(crate) fn run(format: OutputFormat) -> Result<()> {
     reason = "linear print of every posture signal — splitting would obscure the column layout"
 )]
 fn print_text(p: &vouch_common::posture::DevicePosture) {
-    println!("{}", tr_args!("posture-title", version = p.posture_version));
+    tr_println!("posture-title", version = p.posture_version);
     println!("{}", "-".repeat(50));
 
     // OS info

--- a/crates/vouch-cli/src/commands/register.rs
+++ b/crates/vouch-cli/src/commands/register.rs
@@ -41,10 +41,10 @@ fn browser_register_fallback(server: &str) -> Result<()> {
     tr_println!("register-chrome-blocking");
     println!();
     match open::that(&url) {
-        Ok(()) => tr_println!("register-browser-block", url = &url),
+        Ok(()) => tr_println!("register-browser-block", url = url.as_str()),
         Err(e) => {
             tracing::debug!("Failed to open browser: {e}");
-            tr_println!("register-manual-block", url = &url);
+            tr_println!("register-manual-block", url = url.as_str());
         }
     }
     Ok(())
@@ -139,7 +139,7 @@ pub(crate) async fn run(server: &str, name: Option<&str>, timeout_secs: u64) -> 
     println!();
     tr_println!(
         "register-success-block",
-        device_id = &complete_resp.device_id,
+        device_id = complete_resp.device_id.to_string(),
     );
 
     Ok(())

--- a/crates/vouch-cli/src/commands/register.rs
+++ b/crates/vouch-cli/src/commands/register.rs
@@ -14,6 +14,7 @@ use vouch_common::{
 };
 
 use crate::client::VouchClient;
+use crate::exit_code::CliError;
 use crate::fido2::{self, FidoDevice, YubiKey};
 use vouch_cli::{tr, tr_println};
 
@@ -72,9 +73,20 @@ pub(crate) async fn run(server: &str, name: Option<&str>, timeout_secs: u64) -> 
     // This fails fast if the server is unreachable or the user is not
     // authenticated, before they insert their key.
     print!("{} ", tr!("register-contacting-server"));
-    let client = VouchClient::new(server)
-        .await
-        .with_context(|| tr!("register-not-authenticated"))?;
+    // Only swap in the enroll/login guidance for a genuine missing-session
+    // error — bad URLs, HTTP client setup failures, or config corruption
+    // bubble up with their real cause instead of being mis-attributed to
+    // authentication.
+    let client = VouchClient::new(server).await.map_err(|err| {
+        if err
+            .downcast_ref::<CliError>()
+            .is_some_and(|e| matches!(e, CliError::NotAuthenticated { .. }))
+        {
+            anyhow::anyhow!(tr!("register-not-authenticated"))
+        } else {
+            err
+        }
+    })?;
     let start_resp: RegisterStartResponse = client
         .post_authenticated(
             "/v1/keys/register/start",

--- a/crates/vouch-cli/src/commands/register.rs
+++ b/crates/vouch-cli/src/commands/register.rs
@@ -15,6 +15,7 @@ use vouch_common::{
 
 use crate::client::VouchClient;
 use crate::fido2::{self, FidoDevice, YubiKey};
+use vouch_cli::{tr, tr_println};
 
 /// On macOS, Google Chrome claims YubiKeys at the USB device level the moment
 /// they enumerate (so its WebAuthn can respond instantly), which blocks every
@@ -37,33 +38,13 @@ fn is_chrome_running() -> bool {
 
 fn browser_register_fallback(server: &str) -> Result<()> {
     let url = format!("{}/enroll/keys", server.trim_end_matches('/'));
-    println!(
-        "Google Chrome is using your YubiKey, so we can't register it from\n\
-         the command line. Opening your browser to finish registration there\n\
-         instead. (Tip: quit Chrome and re-run if you'd prefer the CLI.)\n"
-    );
+    tr_println!("register-chrome-blocking");
+    println!();
     match open::that(&url) {
-        Ok(()) => {
-            println!("Opening browser to complete registration...");
-            println!();
-            println!("  URL: {url}");
-            println!();
-            println!(
-                "If the browser didn't open, visit the URL above. You may be\n\
-                 prompted to sign in again. After registration, run `vouch keys`\n\
-                 to verify."
-            );
-        }
+        Ok(()) => tr_println!("register-browser-block", url = &url),
         Err(e) => {
             tracing::debug!("Failed to open browser: {e}");
-            println!("To complete registration:");
-            println!();
-            println!("  1. Open this URL in your browser:");
-            println!("     {url}");
-            println!();
-            println!("  2. Sign in (if prompted) and complete the WebAuthn ceremony.");
-            println!();
-            println!("After registration, run `vouch keys` to verify.");
+            tr_println!("register-manual-block", url = &url);
         }
     }
     Ok(())
@@ -78,7 +59,8 @@ fn browser_register_fallback(server: &str) -> Result<()> {
 /// 3. Complete registration with the server (async)
 pub(crate) async fn run(server: &str, name: Option<&str>, timeout_secs: u64) -> Result<()> {
     let name = name.unwrap_or("YubiKey");
-    println!("Registering additional YubiKey '{name}'...\n");
+    tr_println!("register-starting", name = name);
+    println!();
 
     // Pre-flight: if Chrome is running on macOS, the CTAP-HID flow will fail
     // due to Chrome's USB device claim. Route through the browser instead.
@@ -89,12 +71,10 @@ pub(crate) async fn run(server: &str, name: Option<&str>, timeout_secs: u64) -> 
     // Step 1: Start registration with server (async, authenticated).
     // This fails fast if the server is unreachable or the user is not
     // authenticated, before they insert their key.
-    print!("Contacting server... ");
-    let client = VouchClient::new(server).await.context(
-        "Not authenticated.\n\n\
-         To register your first key: vouch enroll\n\
-         To add additional keys: vouch login, then vouch register",
-    )?;
+    print!("{} ", tr!("register-contacting-server"));
+    let client = VouchClient::new(server)
+        .await
+        .with_context(|| tr!("register-not-authenticated"))?;
     let start_resp: RegisterStartResponse = client
         .post_authenticated(
             "/v1/keys/register/start",
@@ -104,13 +84,14 @@ pub(crate) async fn run(server: &str, name: Option<&str>, timeout_secs: u64) -> 
         )
         .await
         .context("failed to start registration")?;
-    println!("ok");
+    tr_println!("register-contact-ok");
 
     // Show info about existing keys
     if !start_resp.exclude_credential_ids.is_empty() {
-        println!(
-            "\nNote: You have {} existing key(s) registered.",
-            start_resp.exclude_credential_ids.len()
+        println!();
+        tr_println!(
+            "register-existing-keys",
+            count = start_resp.exclude_credential_ids.len(),
         );
     }
 
@@ -139,7 +120,7 @@ pub(crate) async fn run(server: &str, name: Option<&str>, timeout_secs: u64) -> 
     .await?;
 
     // Step 3: Complete registration with server (async, authenticated)
-    print!("Completing registration... ");
+    print!("{} ", tr!("register-completing"));
     let complete_resp: RegisterCompleteResponse = client
         .post_authenticated(
             "/v1/keys/register/complete",
@@ -153,11 +134,13 @@ pub(crate) async fn run(server: &str, name: Option<&str>, timeout_secs: u64) -> 
         )
         .await
         .context("failed to complete registration")?;
-    println!("ok\n");
+    tr_println!("register-completed-ok");
 
-    println!("Registration successful!");
-    println!("Device ID: {}", complete_resp.device_id);
-    println!("\nYou can manage your keys with: vouch keys");
+    println!();
+    tr_println!(
+        "register-success-block",
+        device_id = &complete_resp.device_id,
+    );
 
     Ok(())
 }

--- a/crates/vouch-cli/src/commands/setup/anthropic.rs
+++ b/crates/vouch-cli/src/commands/setup/anthropic.rs
@@ -8,6 +8,7 @@
 //! Claude Code — vouch does not manage `~/.claude/settings.json`.
 
 use anyhow::{Context, Result};
+use vouch_cli::{tr, tr_println};
 
 use crate::config::{AnthropicFederation, Config};
 
@@ -27,10 +28,10 @@ pub(crate) async fn run(args: SetupArgs<'_>) -> Result<()> {
     // Config::load() succeeds on an empty file, so we have to check that a
     // server context exists. Otherwise we'd save federation params for a
     // machine that can't get a Vouch session.
-    let config = Config::load().context("failed to load Vouch config")?;
+    let config = Config::load().with_context(|| tr!("setup-err-load-vouch-config"))?;
     let _server = config
         .server_url()
-        .context("not configured — run 'vouch enroll' first")?;
+        .with_context(|| tr!("setup-err-anthropic-not-enrolled"))?;
 
     let fed = AnthropicFederation {
         federation_rule_id: args.federation_rule_id.to_string(),
@@ -47,20 +48,5 @@ pub(crate) async fn run(args: SetupArgs<'_>) -> Result<()> {
 }
 
 fn print_success() {
-    println!("Anthropic (Claude) Workload Identity Federation configured.\n");
-    println!("  Federation params: ~/.config/vouch/config.json\n");
-
-    println!("This mints a service-account token for CI/headless automation.");
-    println!("Get a token:");
-    println!("  vouch login                 # YubiKey tap, once per session");
-    println!("  vouch credential anthropic  # prints sk-ant-oat01-...\n");
-
-    println!("Smoke test:");
-    println!("  curl -sS https://api.anthropic.com/v1/messages \\");
-    println!("    -H \"authorization: Bearer $(vouch credential anthropic)\" \\");
-    println!("    -H \"anthropic-version: 2023-06-01\" \\");
-    println!("    -H \"content-type: application/json\" \\");
-    println!(
-        "    -d '{{\"model\":\"claude-sonnet-4-6\",\"max_tokens\":64,\"messages\":[{{\"role\":\"user\",\"content\":\"hi\"}}]}}'"
-    );
+    tr_println!("setup-anthropic-success-block");
 }

--- a/crates/vouch-cli/src/commands/setup/cargo.rs
+++ b/crates/vouch-cli/src/commands/setup/cargo.rs
@@ -82,13 +82,19 @@ fn configure_cargo(registry: Option<&str>, command: &[&str]) -> Result<()> {
         if config.has_registry_vouch(reg) {
             tr_println!("setup-cargo-already-registry", name = reg);
             println!();
-            tr_println!("setup-cargo-config-file", path = config.path().display());
+            tr_println!(
+                "setup-cargo-config-file",
+                path = config.path().display().to_string()
+            );
             return Ok(());
         }
     } else if config.has_global_vouch() {
         tr_println!("setup-cargo-already-global");
         println!();
-        tr_println!("setup-cargo-config-file", path = config.path().display());
+        tr_println!(
+            "setup-cargo-config-file",
+            path = config.path().display().to_string()
+        );
         return Ok(());
     }
 
@@ -104,7 +110,10 @@ fn configure_cargo(registry: Option<&str>, command: &[&str]) -> Result<()> {
     }
 
     println!();
-    tr_println!("setup-cargo-config-added", path = config.path().display());
+    tr_println!(
+        "setup-cargo-config-added",
+        path = config.path().display().to_string()
+    );
 
     Ok(())
 }

--- a/crates/vouch-cli/src/commands/setup/cargo.rs
+++ b/crates/vouch-cli/src/commands/setup/cargo.rs
@@ -4,6 +4,7 @@
 //! Configures Cargo to use Vouch for private registry authentication.
 
 use anyhow::Result;
+use vouch_cli::tr_println;
 
 use crate::install_path::resolve_install_path;
 use crate::integrations::cargo::CargoConfig;
@@ -17,8 +18,8 @@ use crate::integrations::cargo::CargoConfig;
 /// * `registry` - Optional registry name to configure (default: all registries)
 /// * `configure` - If true, automatically configure Cargo; if false, just show instructions
 pub(crate) async fn run(registry: Option<&str>, configure: bool) -> Result<()> {
-    println!("Cargo Credential Provider Setup");
-    println!("================================\n");
+    tr_println!("setup-cargo-header");
+    println!();
 
     // Get vouch binary path
     let vouch_path = resolve_install_path();
@@ -34,15 +35,15 @@ pub(crate) async fn run(registry: Option<&str>, configure: bool) -> Result<()> {
     }
 
     println!();
-    println!("For more information, see:");
-    println!("  https://doc.rust-lang.org/cargo/reference/registry-authentication.html");
+    tr_println!("setup-cargo-more-info");
 
     Ok(())
 }
 
 /// Show manual configuration instructions.
 fn show_instructions(registry: Option<&str>, command: &[&str]) {
-    println!("Add to ~/.cargo/config.toml:\n");
+    tr_println!("setup-cargo-add-to-config");
+    println!();
 
     let formatted = format_toml_array(command);
 
@@ -61,7 +62,7 @@ fn show_instructions(registry: Option<&str>, command: &[&str]) {
     }
 
     println!();
-    println!("Or run: vouch setup cargo --configure");
+    tr_println!("setup-cargo-or-run");
 }
 
 /// Format a command as a TOML array.
@@ -79,13 +80,15 @@ fn configure_cargo(registry: Option<&str>, command: &[&str]) -> Result<()> {
     // Check if already configured
     if let Some(reg) = registry {
         if config.has_registry_vouch(reg) {
-            println!("Vouch is already configured for registry '{}'\n", reg);
-            println!("Configuration file: {}", config.path().display());
+            tr_println!("setup-cargo-already-registry", name = reg);
+            println!();
+            tr_println!("setup-cargo-config-file", path = config.path().display());
             return Ok(());
         }
     } else if config.has_global_vouch() {
-        println!("Vouch is already configured as global credential provider\n");
-        println!("Configuration file: {}", config.path().display());
+        tr_println!("setup-cargo-already-global");
+        println!();
+        tr_println!("setup-cargo-config-file", path = config.path().display());
         return Ok(());
     }
 
@@ -93,15 +96,15 @@ fn configure_cargo(registry: Option<&str>, command: &[&str]) -> Result<()> {
     if let Some(reg) = registry {
         config.set_registry_provider(reg, command);
         config.save()?;
-        println!("Cargo configured for registry '{}'", reg);
+        tr_println!("setup-cargo-configured-registry", name = reg);
     } else {
         config.set_global_provider(command);
         config.save()?;
-        println!("Cargo configured with global credential provider");
+        tr_println!("setup-cargo-configured-global");
     }
 
     println!();
-    println!("Configuration added to: {}", config.path().display());
+    tr_println!("setup-cargo-config-added", path = config.path().display());
 
     Ok(())
 }

--- a/crates/vouch-cli/src/commands/setup/codeartifact.rs
+++ b/crates/vouch-cli/src/commands/setup/codeartifact.rs
@@ -57,8 +57,8 @@ pub(crate) async fn run(
     let (domain, domain_owner, region) =
         resolve_codeartifact_params(domain, domain_owner, region, profile)?;
 
-    println!("CodeArtifact Setup");
-    println!("==================\n");
+    vouch_cli::tr_println!("setup-ca-header");
+    println!();
 
     // Save profile to config (using file lock for concurrent safety)
     let profile_name = profile.unwrap_or("default");
@@ -72,9 +72,10 @@ pub(crate) async fn run(
         Config::modify(|config| {
             config.set_codeartifact_profile(&name, ca_profile);
         })
-        .context("failed to save CodeArtifact profile")?;
+        .with_context(|| vouch_cli::tr!("setup-ca-err-save-profile"))?;
     }
-    println!("Saved CodeArtifact profile '{profile_name}' to config.\n");
+    vouch_cli::tr_println!("setup-ca-saved-profile", name = profile_name);
+    println!();
 
     // Derive domain suffix from the AWS config's role ARN partition
     // to support China, GovCloud, and other partitions.
@@ -125,12 +126,7 @@ fn setup_cargo(ca_host: &str, repository: &str) -> Result<()> {
     configure_cargo_registry(&registry_name, &index_url, &vouch_path_str)?;
 
     println!();
-    println!("Usage:");
-    println!("  cargo build --registry {}", registry_name);
-    println!("  cargo publish --registry {}", registry_name);
-    println!();
-    println!("Cargo will automatically call Vouch to obtain a fresh CodeArtifact");
-    println!("token each time it needs to authenticate.");
+    vouch_cli::tr_println!("setup-ca-cargo-usage", name = &registry_name);
 
     Ok(())
 }
@@ -142,11 +138,11 @@ fn configure_cargo_registry(registry_name: &str, index_url: &str, vouch_path: &s
         .unwrap_or_else(|_| CargoConfig::empty(config_path));
 
     if config.has_registry_vouch(registry_name) {
-        println!(
-            "Vouch is already configured for registry '{}'\n",
-            registry_name
+        vouch_cli::tr_println!(
+            "setup-ca-cargo-already-block",
+            name = registry_name,
+            path = config.path().display(),
         );
-        println!("Configuration file: {}", config.path().display());
         return Ok(());
     }
 
@@ -155,11 +151,11 @@ fn configure_cargo_registry(registry_name: &str, index_url: &str, vouch_path: &s
     config.set_registry_index(registry_name, index_url);
 
     config.save()?;
-    println!(
-        "Cargo configured for CodeArtifact registry '{}'",
-        registry_name
+    vouch_cli::tr_println!(
+        "setup-ca-cargo-configured-block",
+        name = registry_name,
+        path = config.path().display(),
     );
-    println!("Configuration written to: {}", config.path().display());
 
     Ok(())
 }
@@ -176,8 +172,7 @@ fn setup_pip(ca_host: &str, repository: &str) -> Result<()> {
     install_keyring_wrapper()?;
 
     println!();
-    println!("pip will automatically call Vouch to obtain a fresh CodeArtifact");
-    println!("token each time it needs to authenticate. No more 12-hour token expiry!");
+    vouch_cli::tr_println!("setup-ca-pip-auto-block");
 
     Ok(())
 }
@@ -195,22 +190,10 @@ fn install_keyring_wrapper() -> Result<()> {
     if (keyring_path.exists() || keyring_path.is_symlink())
         && !crate::utils::is_vouch_symlink(&keyring_path)
     {
-        println!(
-            "Note: {} already exists (not managed by vouch).",
-            keyring_path.display()
-        );
-        println!("To use vouch for CodeArtifact authentication, you can:");
-        println!("  1. Rename the existing keyring and re-run this command:");
-        println!(
-            "     mv {} {}.bak",
-            keyring_path.display(),
-            keyring_path.display()
-        );
-        println!("  2. Or manually create a symlink to vouch:");
-        println!(
-            "     ln -sf \"{}\" \"{}\"",
-            vouch_path.display(),
-            keyring_path.display()
+        vouch_cli::tr_println!(
+            "setup-ca-keyring-conflict-block",
+            path = keyring_path.display(),
+            vouch_path = vouch_path.display(),
         );
         return Ok(());
     }
@@ -230,15 +213,17 @@ fn install_keyring_wrapper() -> Result<()> {
 /// with `index-url` and `keyring-provider`, preserving any other settings.
 fn write_pip_config(index_url: &str) -> Result<()> {
     let config_dir = get_pip_config_dir()?;
-    std::fs::create_dir_all(&config_dir)
-        .with_context(|| format!("failed to create {}", config_dir.display()))?;
+    std::fs::create_dir_all(&config_dir).with_context(|| {
+        vouch_cli::tr_args!("setup-ca-err-create-dir", path = config_dir.display())
+    })?;
 
     let config_path = config_dir.join("pip.conf");
 
     // Load existing config or create new
     let mut ini = if config_path.exists() {
-        ini::Ini::load_from_file(&config_path)
-            .with_context(|| format!("failed to parse {}", config_path.display()))?
+        ini::Ini::load_from_file(&config_path).with_context(|| {
+            vouch_cli::tr_args!("setup-ca-err-parse", path = config_path.display())
+        })?
     } else {
         ini::Ini::new()
     };
@@ -251,15 +236,12 @@ fn write_pip_config(index_url: &str) -> Result<()> {
     // Serialize INI to a buffer, then atomically write
     let mut buf = Vec::new();
     ini.write_to(&mut buf).with_context(|| {
-        format!(
-            "failed to serialize pip config for {}",
-            config_path.display()
-        )
+        vouch_cli::tr_args!("setup-ca-err-serialize-pip", path = config_path.display())
     })?;
     vouch_common::fs::atomic_write_secure(&config_path, &buf)
-        .with_context(|| format!("failed to write {}", config_path.display()))?;
+        .with_context(|| vouch_cli::tr_args!("setup-ca-err-write", path = config_path.display()))?;
 
-    println!("Wrote pip config: {}", config_path.display());
+    vouch_cli::tr_println!("setup-ca-pip-wrote", path = config_path.display());
 
     Ok(())
 }
@@ -274,7 +256,7 @@ fn get_pip_config_dir() -> Result<std::path::PathBuf> {
         }
     }
 
-    let home = dirs::home_dir().context("could not determine home directory")?;
+    let home = dirs::home_dir().with_context(|| vouch_cli::tr!("setup-err-no-home"))?;
     Ok(home.join(".config").join("pip"))
 }
 
@@ -292,11 +274,7 @@ fn setup_uv(ca_host: &str, repository: &str) -> Result<()> {
     install_keyring_wrapper()?;
 
     println!();
-    println!("uv will automatically call Vouch to obtain a fresh CodeArtifact");
-    println!("token each time it needs to authenticate. No more 12-hour token expiry!");
-    println!();
-    println!("Note: If you also use pip, run `vouch setup codeartifact --tool pip` to");
-    println!("configure pip separately (uv does not read pip.conf).");
+    vouch_cli::tr_println!("setup-ca-uv-auto-block");
 
     Ok(())
 }
@@ -308,22 +286,24 @@ fn setup_uv(ca_host: &str, repository: &str) -> Result<()> {
 /// updates) a CodeArtifact index entry.
 fn write_uv_config(index_url: &str, repository: &str) -> Result<()> {
     let config_dir = get_uv_config_dir()?;
-    std::fs::create_dir_all(&config_dir)
-        .with_context(|| format!("failed to create {}", config_dir.display()))?;
+    std::fs::create_dir_all(&config_dir).with_context(|| {
+        vouch_cli::tr_args!("setup-ca-err-create-dir", path = config_dir.display())
+    })?;
 
     let config_path = config_dir.join("uv.toml");
 
     // Load existing config or create new
     let content = if config_path.exists() {
-        std::fs::read_to_string(&config_path)
-            .with_context(|| format!("failed to read {}", config_path.display()))?
+        std::fs::read_to_string(&config_path).with_context(|| {
+            vouch_cli::tr_args!("setup-ca-err-read", path = config_path.display())
+        })?
     } else {
         String::new()
     };
 
     let mut doc = content
         .parse::<toml_edit::DocumentMut>()
-        .with_context(|| format!("failed to parse {}", config_path.display()))?;
+        .with_context(|| vouch_cli::tr_args!("setup-ca-err-parse", path = config_path.display()))?;
 
     // Set keyring-provider = "subprocess"
     doc.insert("keyring-provider", toml_edit::value("subprocess"));
@@ -363,9 +343,9 @@ fn write_uv_config(index_url: &str, repository: &str) -> Result<()> {
 
     let serialized = doc.to_string();
     vouch_common::fs::atomic_write_secure(&config_path, serialized.as_bytes())
-        .with_context(|| format!("failed to write {}", config_path.display()))?;
+        .with_context(|| vouch_cli::tr_args!("setup-ca-err-write", path = config_path.display()))?;
 
-    println!("Wrote uv config: {}", config_path.display());
+    vouch_cli::tr_println!("setup-ca-uv-wrote", path = config_path.display());
 
     Ok(())
 }
@@ -380,7 +360,7 @@ fn get_uv_config_dir() -> Result<std::path::PathBuf> {
         }
     }
 
-    let home = dirs::home_dir().context("could not determine home directory")?;
+    let home = dirs::home_dir().with_context(|| vouch_cli::tr!("setup-err-no-home"))?;
     Ok(home.join(".config").join("uv"))
 }
 
@@ -399,7 +379,7 @@ async fn setup_npm(
     let result =
         crate::commands::credential::codeartifact::get_token(server, domain, domain_owner, region)
             .await
-            .context("failed to get CodeArtifact token")?;
+            .with_context(|| vouch_cli::tr!("setup-ca-err-fetch-token"))?;
 
     let registry_url = format!("https://{ca_host}/npm/{repository}/");
 
@@ -410,14 +390,11 @@ async fn setup_npm(
     )?;
 
     println!();
-    println!("Registry URL: {}", registry_url);
-    println!();
-    println!("Note: Unlike Cargo and pip, npm does not support dynamic credential");
-    println!("helpers. The token written to ~/.npmrc expires in ~12 hours.");
-    println!("To refresh: vouch setup codeartifact --tool npm --repository {repository}");
-    println!();
-    println!("Tip: pnpm supports dynamic credential helpers. Use --tool pnpm for");
-    println!("automatic token refresh without manual re-login.");
+    vouch_cli::tr_println!(
+        "setup-ca-npm-block",
+        url = &registry_url,
+        repository = repository,
+    );
 
     Ok(())
 }
@@ -454,9 +431,7 @@ fn detect_npmrc_conflict<'a>(
 /// Warn if `.npmrc` has a conflicting auth mechanism for the same registry.
 fn warn_npmrc_conflict(existing: &str, ca_host: &str, repository: &str, setting_up: &str) {
     if let Some(other_tool) = detect_npmrc_conflict(existing, ca_host, repository, setting_up) {
-        println!("Note: ~/.npmrc has an existing {other_tool} configuration for this registry.");
-        println!("It will be replaced. npm and pnpm use different auth mechanisms");
-        println!("(_authToken vs tokenHelper) and cannot coexist for the same registry.");
+        vouch_cli::tr_println!("setup-ca-npmrc-conflict-block", other_tool = other_tool);
         println!();
     }
 }
@@ -466,12 +441,13 @@ fn warn_npmrc_conflict(existing: &str, ca_host: &str, repository: &str, setting_
 /// Preserves existing entries while updating/adding CodeArtifact-specific lines.
 /// Only lines matching this specific host/repo are replaced.
 fn write_npmrc(ca_host: &str, repository: &str, token: &str) -> Result<()> {
-    let home = dirs::home_dir().context("could not determine home directory")?;
+    let home = dirs::home_dir().with_context(|| vouch_cli::tr!("setup-err-no-home"))?;
     let npmrc_path = home.join(".npmrc");
 
     let existing = if npmrc_path.exists() {
-        std::fs::read_to_string(&npmrc_path)
-            .with_context(|| format!("failed to read {}", npmrc_path.display()))?
+        std::fs::read_to_string(&npmrc_path).with_context(|| {
+            vouch_cli::tr_args!("setup-ca-err-read", path = npmrc_path.display())
+        })?
     } else {
         String::new()
     };
@@ -480,9 +456,9 @@ fn write_npmrc(ca_host: &str, repository: &str, token: &str) -> Result<()> {
     let content = build_npmrc_content(&existing, ca_host, repository, token);
 
     vouch_common::fs::atomic_write_secure(&npmrc_path, content.as_bytes())
-        .with_context(|| format!("failed to write {}", npmrc_path.display()))?;
+        .with_context(|| vouch_cli::tr_args!("setup-ca-err-write", path = npmrc_path.display()))?;
 
-    println!("Wrote npm config: {}", npmrc_path.display());
+    vouch_cli::tr_println!("setup-ca-npm-wrote", path = npmrc_path.display());
 
     Ok(())
 }
@@ -498,8 +474,7 @@ fn setup_pnpm(ca_host: &str, repository: &str) -> Result<()> {
     write_npmrc_pnpm(ca_host, repository, &helper_path)?;
 
     println!();
-    println!("pnpm will automatically call Vouch to obtain a fresh CodeArtifact");
-    println!("token each time it needs to authenticate. No more 12-hour token expiry!");
+    vouch_cli::tr_println!("setup-ca-pnpm-auto-block");
 
     Ok(())
 }
@@ -517,22 +492,10 @@ fn install_pnpm_token_helper() -> Result<std::path::PathBuf> {
     if (helper_path.exists() || helper_path.is_symlink())
         && !crate::utils::is_vouch_symlink(&helper_path)
     {
-        println!(
-            "Note: {} already exists (not managed by vouch).",
-            helper_path.display()
-        );
-        println!("To use vouch for pnpm CodeArtifact authentication, either:");
-        println!("  1. Rename the existing file and re-run this command:");
-        println!(
-            "     mv {} {}.bak",
-            helper_path.display(),
-            helper_path.display()
-        );
-        println!("  2. Or manually create a symlink to vouch:");
-        println!(
-            "     ln -sf \"{}\" \"{}\"",
-            vouch_path.display(),
-            helper_path.display()
+        vouch_cli::tr_println!(
+            "setup-ca-pnpm-conflict-block",
+            path = helper_path.display(),
+            vouch_path = vouch_path.display(),
         );
         return Ok(helper_path);
     }
@@ -551,12 +514,13 @@ fn install_pnpm_token_helper() -> Result<std::path::PathBuf> {
 /// Preserves existing entries while updating/adding the `tokenHelper`
 /// directive for the given CodeArtifact registry.
 fn write_npmrc_pnpm(ca_host: &str, repository: &str, helper_path: &std::path::Path) -> Result<()> {
-    let home = dirs::home_dir().context("could not determine home directory")?;
+    let home = dirs::home_dir().with_context(|| vouch_cli::tr!("setup-err-no-home"))?;
     let npmrc_path = home.join(".npmrc");
 
     let existing = if npmrc_path.exists() {
-        std::fs::read_to_string(&npmrc_path)
-            .with_context(|| format!("failed to read {}", npmrc_path.display()))?
+        std::fs::read_to_string(&npmrc_path).with_context(|| {
+            vouch_cli::tr_args!("setup-ca-err-read", path = npmrc_path.display())
+        })?
     } else {
         String::new()
     };
@@ -565,9 +529,9 @@ fn write_npmrc_pnpm(ca_host: &str, repository: &str, helper_path: &std::path::Pa
     let content = build_npmrc_pnpm_content(&existing, ca_host, repository, helper_path);
 
     vouch_common::fs::atomic_write_secure(&npmrc_path, content.as_bytes())
-        .with_context(|| format!("failed to write {}", npmrc_path.display()))?;
+        .with_context(|| vouch_cli::tr_args!("setup-ca-err-write", path = npmrc_path.display()))?;
 
-    println!("Wrote pnpm config: {}", npmrc_path.display());
+    vouch_cli::tr_println!("setup-ca-pnpm-wrote", path = npmrc_path.display());
 
     Ok(())
 }
@@ -618,7 +582,7 @@ pub(crate) async fn auto_refresh_npmrc(server: &str) {
 /// Inner implementation for `auto_refresh_npmrc` that returns `Result`
 /// for ergonomic error handling.
 async fn try_refresh_npmrc(server: &str) -> Result<()> {
-    let home = dirs::home_dir().context("could not determine home directory")?;
+    let home = dirs::home_dir().with_context(|| vouch_cli::tr!("setup-err-no-home"))?;
     let npmrc_path = home.join(".npmrc");
 
     let content = match std::fs::read_to_string(&npmrc_path) {
@@ -682,9 +646,10 @@ async fn try_refresh_npmrc(server: &str) -> Result<()> {
     let (new_content, refreshed) = rewrite_npmrc_tokens(&content, &plain_map);
 
     if refreshed {
-        vouch_common::fs::atomic_write_secure(&npmrc_path, new_content.as_bytes())
-            .with_context(|| format!("failed to write {}", npmrc_path.display()))?;
-        println!("Refreshed CodeArtifact token in ~/.npmrc");
+        vouch_common::fs::atomic_write_secure(&npmrc_path, new_content.as_bytes()).with_context(
+            || vouch_cli::tr_args!("setup-ca-err-write", path = npmrc_path.display()),
+        )?;
+        vouch_cli::tr_println!("setup-ca-refreshed-npmrc");
     }
 
     Ok(())

--- a/crates/vouch-cli/src/commands/setup/codeartifact.rs
+++ b/crates/vouch-cli/src/commands/setup/codeartifact.rs
@@ -126,7 +126,7 @@ fn setup_cargo(ca_host: &str, repository: &str) -> Result<()> {
     configure_cargo_registry(&registry_name, &index_url, &vouch_path_str)?;
 
     println!();
-    vouch_cli::tr_println!("setup-ca-cargo-usage", name = &registry_name);
+    vouch_cli::tr_println!("setup-ca-cargo-usage", name = registry_name.as_str());
 
     Ok(())
 }
@@ -141,7 +141,7 @@ fn configure_cargo_registry(registry_name: &str, index_url: &str, vouch_path: &s
         vouch_cli::tr_println!(
             "setup-ca-cargo-already-block",
             name = registry_name,
-            path = config.path().display(),
+            path = config.path().display().to_string(),
         );
         return Ok(());
     }
@@ -154,7 +154,7 @@ fn configure_cargo_registry(registry_name: &str, index_url: &str, vouch_path: &s
     vouch_cli::tr_println!(
         "setup-ca-cargo-configured-block",
         name = registry_name,
-        path = config.path().display(),
+        path = config.path().display().to_string(),
     );
 
     Ok(())
@@ -192,8 +192,8 @@ fn install_keyring_wrapper() -> Result<()> {
     {
         vouch_cli::tr_println!(
             "setup-ca-keyring-conflict-block",
-            path = keyring_path.display(),
-            vouch_path = vouch_path.display(),
+            path = keyring_path.display().to_string(),
+            vouch_path = vouch_path.display().to_string(),
         );
         return Ok(());
     }
@@ -214,7 +214,10 @@ fn install_keyring_wrapper() -> Result<()> {
 fn write_pip_config(index_url: &str) -> Result<()> {
     let config_dir = get_pip_config_dir()?;
     std::fs::create_dir_all(&config_dir).with_context(|| {
-        vouch_cli::tr_args!("setup-ca-err-create-dir", path = config_dir.display())
+        vouch_cli::tr_args!(
+            "setup-ca-err-create-dir",
+            path = config_dir.display().to_string()
+        )
     })?;
 
     let config_path = config_dir.join("pip.conf");
@@ -222,7 +225,10 @@ fn write_pip_config(index_url: &str) -> Result<()> {
     // Load existing config or create new
     let mut ini = if config_path.exists() {
         ini::Ini::load_from_file(&config_path).with_context(|| {
-            vouch_cli::tr_args!("setup-ca-err-parse", path = config_path.display())
+            vouch_cli::tr_args!(
+                "setup-ca-err-parse",
+                path = config_path.display().to_string()
+            )
         })?
     } else {
         ini::Ini::new()
@@ -236,12 +242,22 @@ fn write_pip_config(index_url: &str) -> Result<()> {
     // Serialize INI to a buffer, then atomically write
     let mut buf = Vec::new();
     ini.write_to(&mut buf).with_context(|| {
-        vouch_cli::tr_args!("setup-ca-err-serialize-pip", path = config_path.display())
+        vouch_cli::tr_args!(
+            "setup-ca-err-serialize-pip",
+            path = config_path.display().to_string()
+        )
     })?;
-    vouch_common::fs::atomic_write_secure(&config_path, &buf)
-        .with_context(|| vouch_cli::tr_args!("setup-ca-err-write", path = config_path.display()))?;
+    vouch_common::fs::atomic_write_secure(&config_path, &buf).with_context(|| {
+        vouch_cli::tr_args!(
+            "setup-ca-err-write",
+            path = config_path.display().to_string()
+        )
+    })?;
 
-    vouch_cli::tr_println!("setup-ca-pip-wrote", path = config_path.display());
+    vouch_cli::tr_println!(
+        "setup-ca-pip-wrote",
+        path = config_path.display().to_string()
+    );
 
     Ok(())
 }
@@ -287,7 +303,10 @@ fn setup_uv(ca_host: &str, repository: &str) -> Result<()> {
 fn write_uv_config(index_url: &str, repository: &str) -> Result<()> {
     let config_dir = get_uv_config_dir()?;
     std::fs::create_dir_all(&config_dir).with_context(|| {
-        vouch_cli::tr_args!("setup-ca-err-create-dir", path = config_dir.display())
+        vouch_cli::tr_args!(
+            "setup-ca-err-create-dir",
+            path = config_dir.display().to_string()
+        )
     })?;
 
     let config_path = config_dir.join("uv.toml");
@@ -295,15 +314,21 @@ fn write_uv_config(index_url: &str, repository: &str) -> Result<()> {
     // Load existing config or create new
     let content = if config_path.exists() {
         std::fs::read_to_string(&config_path).with_context(|| {
-            vouch_cli::tr_args!("setup-ca-err-read", path = config_path.display())
+            vouch_cli::tr_args!(
+                "setup-ca-err-read",
+                path = config_path.display().to_string()
+            )
         })?
     } else {
         String::new()
     };
 
-    let mut doc = content
-        .parse::<toml_edit::DocumentMut>()
-        .with_context(|| vouch_cli::tr_args!("setup-ca-err-parse", path = config_path.display()))?;
+    let mut doc = content.parse::<toml_edit::DocumentMut>().with_context(|| {
+        vouch_cli::tr_args!(
+            "setup-ca-err-parse",
+            path = config_path.display().to_string()
+        )
+    })?;
 
     // Set keyring-provider = "subprocess"
     doc.insert("keyring-provider", toml_edit::value("subprocess"));
@@ -342,10 +367,19 @@ fn write_uv_config(index_url: &str, repository: &str) -> Result<()> {
     }
 
     let serialized = doc.to_string();
-    vouch_common::fs::atomic_write_secure(&config_path, serialized.as_bytes())
-        .with_context(|| vouch_cli::tr_args!("setup-ca-err-write", path = config_path.display()))?;
+    vouch_common::fs::atomic_write_secure(&config_path, serialized.as_bytes()).with_context(
+        || {
+            vouch_cli::tr_args!(
+                "setup-ca-err-write",
+                path = config_path.display().to_string()
+            )
+        },
+    )?;
 
-    vouch_cli::tr_println!("setup-ca-uv-wrote", path = config_path.display());
+    vouch_cli::tr_println!(
+        "setup-ca-uv-wrote",
+        path = config_path.display().to_string()
+    );
 
     Ok(())
 }
@@ -392,7 +426,7 @@ async fn setup_npm(
     println!();
     vouch_cli::tr_println!(
         "setup-ca-npm-block",
-        url = &registry_url,
+        url = registry_url.as_str(),
         repository = repository,
     );
 
@@ -446,7 +480,7 @@ fn write_npmrc(ca_host: &str, repository: &str, token: &str) -> Result<()> {
 
     let existing = if npmrc_path.exists() {
         std::fs::read_to_string(&npmrc_path).with_context(|| {
-            vouch_cli::tr_args!("setup-ca-err-read", path = npmrc_path.display())
+            vouch_cli::tr_args!("setup-ca-err-read", path = npmrc_path.display().to_string())
         })?
     } else {
         String::new()
@@ -455,10 +489,17 @@ fn write_npmrc(ca_host: &str, repository: &str, token: &str) -> Result<()> {
     warn_npmrc_conflict(&existing, ca_host, repository, "npm");
     let content = build_npmrc_content(&existing, ca_host, repository, token);
 
-    vouch_common::fs::atomic_write_secure(&npmrc_path, content.as_bytes())
-        .with_context(|| vouch_cli::tr_args!("setup-ca-err-write", path = npmrc_path.display()))?;
+    vouch_common::fs::atomic_write_secure(&npmrc_path, content.as_bytes()).with_context(|| {
+        vouch_cli::tr_args!(
+            "setup-ca-err-write",
+            path = npmrc_path.display().to_string()
+        )
+    })?;
 
-    vouch_cli::tr_println!("setup-ca-npm-wrote", path = npmrc_path.display());
+    vouch_cli::tr_println!(
+        "setup-ca-npm-wrote",
+        path = npmrc_path.display().to_string()
+    );
 
     Ok(())
 }
@@ -494,8 +535,8 @@ fn install_pnpm_token_helper() -> Result<std::path::PathBuf> {
     {
         vouch_cli::tr_println!(
             "setup-ca-pnpm-conflict-block",
-            path = helper_path.display(),
-            vouch_path = vouch_path.display(),
+            path = helper_path.display().to_string(),
+            vouch_path = vouch_path.display().to_string(),
         );
         return Ok(helper_path);
     }
@@ -519,7 +560,7 @@ fn write_npmrc_pnpm(ca_host: &str, repository: &str, helper_path: &std::path::Pa
 
     let existing = if npmrc_path.exists() {
         std::fs::read_to_string(&npmrc_path).with_context(|| {
-            vouch_cli::tr_args!("setup-ca-err-read", path = npmrc_path.display())
+            vouch_cli::tr_args!("setup-ca-err-read", path = npmrc_path.display().to_string())
         })?
     } else {
         String::new()
@@ -528,10 +569,17 @@ fn write_npmrc_pnpm(ca_host: &str, repository: &str, helper_path: &std::path::Pa
     warn_npmrc_conflict(&existing, ca_host, repository, "pnpm");
     let content = build_npmrc_pnpm_content(&existing, ca_host, repository, helper_path);
 
-    vouch_common::fs::atomic_write_secure(&npmrc_path, content.as_bytes())
-        .with_context(|| vouch_cli::tr_args!("setup-ca-err-write", path = npmrc_path.display()))?;
+    vouch_common::fs::atomic_write_secure(&npmrc_path, content.as_bytes()).with_context(|| {
+        vouch_cli::tr_args!(
+            "setup-ca-err-write",
+            path = npmrc_path.display().to_string()
+        )
+    })?;
 
-    vouch_cli::tr_println!("setup-ca-pnpm-wrote", path = npmrc_path.display());
+    vouch_cli::tr_println!(
+        "setup-ca-pnpm-wrote",
+        path = npmrc_path.display().to_string()
+    );
 
     Ok(())
 }
@@ -647,7 +695,12 @@ async fn try_refresh_npmrc(server: &str) -> Result<()> {
 
     if refreshed {
         vouch_common::fs::atomic_write_secure(&npmrc_path, new_content.as_bytes()).with_context(
-            || vouch_cli::tr_args!("setup-ca-err-write", path = npmrc_path.display()),
+            || {
+                vouch_cli::tr_args!(
+                    "setup-ca-err-write",
+                    path = npmrc_path.display().to_string()
+                )
+            },
         )?;
         vouch_cli::tr_println!("setup-ca-refreshed-npmrc");
     }

--- a/crates/vouch-cli/src/commands/setup/codecommit.rs
+++ b/crates/vouch-cli/src/commands/setup/codecommit.rs
@@ -46,20 +46,22 @@ pub(crate) async fn run(
     profile: Option<&str>,
     configure: bool,
 ) -> Result<()> {
+    use vouch_cli::{tr, tr_args, tr_println};
+
     // Load config to verify enrollment
-    let config = Config::load().context("failed to load config - run 'vouch enroll' first")?;
+    let config = Config::load().with_context(|| tr!("setup-err-load-config"))?;
     let _server = config
         .server_url()
-        .context("not configured - run 'vouch enroll' first")?;
+        .with_context(|| tr!("setup-err-not-configured"))?;
 
-    println!("CodeCommit Credential Setup");
-    println!("===========================\n");
+    tr_println!("setup-codecommit-header");
+    println!();
 
     // Check AWS configuration
     let (profile_name, role_arn) = check_aws_config(profile)?;
-    println!("AWS profile: {profile_name}");
+    tr_println!("setup-codecommit-aws-profile", profile = &profile_name);
     if let Some(ref role) = role_arn {
-        println!("AWS role:    {role}");
+        tr_println!("setup-codecommit-aws-role", role = role);
     }
     println!();
 
@@ -101,11 +103,12 @@ pub(crate) async fn run(
             let status = Command::new("git")
                 .args(["config", "--global", &config_key, &helper_command])
                 .status()
-                .context("failed to run git config")?;
+                .with_context(|| tr!("setup-codecommit-err-run-config"))?;
 
             if !status.success() {
-                return Err(crate::exit_code::CliError::ConfigError(format!(
-                    "failed to configure git credential helper for {pattern}"
+                return Err(crate::exit_code::CliError::ConfigError(tr_args!(
+                    "setup-codecommit-err-helper-pattern",
+                    pattern = pattern,
                 ))
                 .into());
             }
@@ -114,59 +117,74 @@ pub(crate) async fn run(
             let status = Command::new("git")
                 .args(["config", "--global", &use_http_path_key, "true"])
                 .status()
-                .context("failed to run git config")?;
+                .with_context(|| tr!("setup-codecommit-err-run-config"))?;
 
             if !status.success() {
-                return Err(crate::exit_code::CliError::ConfigError(format!(
-                    "failed to set useHttpPath for {pattern}"
+                return Err(crate::exit_code::CliError::ConfigError(tr_args!(
+                    "setup-codecommit-err-http-path",
+                    pattern = pattern,
                 ))
                 .into());
             }
         }
 
-        println!("\nGit configured for CodeCommit.\n");
-        println!("Credential helper (HTTPS URLs):");
+        println!();
+        tr_println!("setup-codecommit-success-block");
         for pattern in &patterns {
-            println!("  credential.{pattern}.helper = {helper_command}");
-            println!("  credential.{pattern}.useHttpPath = true");
+            tr_println!(
+                "setup-codecommit-helper-line",
+                indent = "  ",
+                pattern = pattern,
+                helper = &helper_command,
+            );
+            tr_println!(
+                "setup-codecommit-http-path-line",
+                indent = "  ",
+                pattern = pattern,
+            );
         }
         println!();
-        println!("Remote helper (codecommit:// URLs):");
-        println!("  {} -> {}", symlink_path.display(), vouch_path.display());
+        tr_println!("setup-codecommit-remote-helper-header");
+        tr_println!(
+            "setup-codecommit-remote-line",
+            indent = "  ",
+            symlink = symlink_path.display(),
+            vouch = vouch_path.display(),
+        );
     } else {
-        println!("Step 1: Create symlink for codecommit:// URL support\n");
+        tr_println!("setup-codecommit-step1");
+        println!();
         println!(
             "  ln -sf \"{}\" \"{}\"",
             vouch_path.display(),
             symlink_path.display()
         );
 
-        println!("\nStep 2: Configure git credential helper for HTTPS URLs\n");
-        println!("  Add to ~/.gitconfig:\n");
+        println!();
+        tr_println!("setup-codecommit-step2");
+        println!();
         for pattern in &patterns {
             println!("[credential \"{pattern}\"]");
             println!("    helper = {helper_command}");
             println!("    useHttpPath = true");
             println!();
         }
-        println!("Or run: vouch setup codecommit --configure");
+        tr_println!("setup-codecommit-or-run");
     }
 
     let example_region = region.unwrap_or("us-east-1");
     println!();
-    println!("To verify, run:");
-    println!(
-        "  git ls-remote https://git-codecommit.{example_region}.amazonaws.com/v1/repos/YOUR-REPO"
+    tr_println!("setup-codecommit-tail-block", region = example_region);
+    tr_println!(
+        "setup-codecommit-undo-rm",
+        indent = "  ",
+        path = symlink_path.display(),
     );
-    println!("  git ls-remote codecommit::{example_region}://YOUR-REPO");
-
-    println!();
-    println!("To undo:");
-    println!("  rm \"{}\"", symlink_path.display());
     for pattern in &patterns {
-        println!(
-            "  git config --global --remove-section credential.\"{}\"",
-            pattern
+        tr_println!(
+            "setup-codecommit-undo-config",
+            indent = "  ",
+            pattern = pattern,
         );
     }
 
@@ -175,17 +193,18 @@ pub(crate) async fn run(
 
 /// Check AWS configuration and return (profile_name, optional_role_arn).
 fn check_aws_config(profile: Option<&str>) -> Result<(String, Option<String>)> {
-    let aws_config = AwsConfig::load().map_err(|_| {
-        anyhow::anyhow!("AWS not configured. Run 'vouch setup aws --role <role-arn>' first.")
-    })?;
+    use vouch_cli::{tr, tr_args};
+
+    let aws_config = AwsConfig::load()
+        .map_err(|_| anyhow::anyhow!(tr!("setup-codecommit-err-aws-not-configured")))?;
 
     if let Some(profile_name) = profile {
         // User specified a profile — look it up
         let profile_data = aws_config.get_profile(profile_name).ok_or_else(|| {
-            anyhow::anyhow!(
-                "AWS profile '{profile_name}' not found in ~/.aws/config.\n\
-                 Run 'vouch setup aws --role <role-arn>' first."
-            )
+            anyhow::anyhow!(tr_args!(
+                "setup-codecommit-err-profile-not-found",
+                profile = profile_name,
+            ))
         })?;
         let role_arn = profile_data
             .credential_process
@@ -194,12 +213,9 @@ fn check_aws_config(profile: Option<&str>) -> Result<(String, Option<String>)> {
         Ok((profile_name.to_string(), role_arn))
     } else {
         // Auto-detect the vouch profile
-        let profile = aws_config.find_vouch_profile().ok_or_else(|| {
-            anyhow::anyhow!(
-                "No Vouch AWS profile found in ~/.aws/config.\n\
-                 Run 'vouch setup aws --role <role-arn>' first."
-            )
-        })?;
+        let profile = aws_config
+            .find_vouch_profile()
+            .ok_or_else(|| anyhow::anyhow!(tr!("setup-codecommit-err-no-vouch-profile")))?;
         let role_arn = profile
             .credential_process
             .as_deref()
@@ -224,6 +240,8 @@ fn create_remote_helper_symlink(
 
 /// Detect credential helpers that may conflict with Vouch.
 fn detect_conflicting_helpers() -> Result<()> {
+    use vouch_cli::{tr, tr_println};
+
     let output = Command::new("git")
         .args([
             "config",
@@ -232,7 +250,7 @@ fn detect_conflicting_helpers() -> Result<()> {
             r"credential.*codecommit.*helper",
         ])
         .output()
-        .context("failed to run git config")?;
+        .with_context(|| tr!("setup-codecommit-err-run-config"))?;
 
     if output.status.success() {
         let existing = String::from_utf8_lossy(&output.stdout);
@@ -244,8 +262,7 @@ fn detect_conflicting_helpers() -> Result<()> {
             if line.contains("aws codecommit credential-helper")
                 || line.contains("git-remote-codecommit")
             {
-                println!("Warning: Existing CodeCommit credential helper detected:\n  {line}");
-                println!("This may conflict. Consider removing it.\n");
+                tr_println!("setup-codecommit-warn-existing-block", line = line);
             }
         }
     }

--- a/crates/vouch-cli/src/commands/setup/codecommit.rs
+++ b/crates/vouch-cli/src/commands/setup/codecommit.rs
@@ -59,9 +59,12 @@ pub(crate) async fn run(
 
     // Check AWS configuration
     let (profile_name, role_arn) = check_aws_config(profile)?;
-    tr_println!("setup-codecommit-aws-profile", profile = &profile_name);
+    tr_println!(
+        "setup-codecommit-aws-profile",
+        profile = profile_name.as_str()
+    );
     if let Some(ref role) = role_arn {
-        tr_println!("setup-codecommit-aws-role", role = role);
+        tr_println!("setup-codecommit-aws-role", role = role.as_str());
     }
     println!();
 
@@ -134,8 +137,8 @@ pub(crate) async fn run(
             tr_println!(
                 "setup-codecommit-helper-line",
                 indent = "  ",
-                pattern = pattern,
-                helper = &helper_command,
+                pattern = pattern.as_str(),
+                helper = helper_command.as_str(),
             );
             tr_println!(
                 "setup-codecommit-http-path-line",
@@ -148,8 +151,8 @@ pub(crate) async fn run(
         tr_println!(
             "setup-codecommit-remote-line",
             indent = "  ",
-            symlink = symlink_path.display(),
-            vouch = vouch_path.display(),
+            symlink = symlink_path.display().to_string(),
+            vouch = vouch_path.display().to_string(),
         );
     } else {
         tr_println!("setup-codecommit-step1");
@@ -178,7 +181,7 @@ pub(crate) async fn run(
     tr_println!(
         "setup-codecommit-undo-rm",
         indent = "  ",
-        path = symlink_path.display(),
+        path = symlink_path.display().to_string(),
     );
     for pattern in &patterns {
         tr_println!(

--- a/crates/vouch-cli/src/commands/setup/codecommit.rs
+++ b/crates/vouch-cli/src/commands/setup/codecommit.rs
@@ -147,20 +147,16 @@ pub(crate) async fn run(
             );
         }
         println!();
-        tr_println!("setup-codecommit-remote-helper-header");
         tr_println!(
-            "setup-codecommit-remote-line",
-            indent = "  ",
+            "setup-codecommit-remote-helper-block",
             symlink = symlink_path.display().to_string(),
             vouch = vouch_path.display().to_string(),
         );
     } else {
-        tr_println!("setup-codecommit-step1");
-        println!();
-        println!(
-            "  ln -sf \"{}\" \"{}\"",
-            vouch_path.display(),
-            symlink_path.display()
+        tr_println!(
+            "setup-codecommit-step1-block",
+            vouch = vouch_path.display().to_string(),
+            symlink = symlink_path.display().to_string(),
         );
 
         println!();
@@ -177,10 +173,9 @@ pub(crate) async fn run(
 
     let example_region = region.unwrap_or("us-east-1");
     println!();
-    tr_println!("setup-codecommit-tail-block", region = example_region);
     tr_println!(
-        "setup-codecommit-undo-rm",
-        indent = "  ",
+        "setup-codecommit-tail-block",
+        region = example_region,
         path = symlink_path.display().to_string(),
     );
     for pattern in &patterns {

--- a/crates/vouch-cli/src/commands/setup/docker.rs
+++ b/crates/vouch-cli/src/commands/setup/docker.rs
@@ -6,6 +6,7 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use vouch_cli::{tr, tr_args, tr_println};
 
 use crate::config::Config;
 use crate::install_path::resolve_install_path;
@@ -32,13 +33,13 @@ struct DockerConfig {
 /// * `configure` - If true, automatically configure Docker; if false, just show instructions
 pub(crate) async fn run(registries: &[String], configure: bool) -> Result<()> {
     // Load config to verify enrollment
-    let config = Config::load().context("failed to load config - run 'vouch enroll' first")?;
+    let config = Config::load().with_context(|| tr!("setup-err-load-config"))?;
     let _server = config
         .server_url()
-        .context("not configured - run 'vouch enroll' first")?;
+        .with_context(|| tr!("setup-err-not-configured"))?;
 
-    println!("Docker Credential Helper Setup");
-    println!("==============================\n");
+    tr_println!("setup-docker-header");
+    println!();
 
     // Get vouch binary path
     let vouch_path = resolve_install_path();
@@ -55,43 +56,40 @@ pub(crate) async fn run(registries: &[String], configure: bool) -> Result<()> {
             configure_docker_config(registries)?;
         }
 
-        println!("Docker credential helper configured successfully.\n");
+        tr_println!("setup-docker-configured");
+        println!();
 
         if registries.is_empty() {
-            println!("To configure registries, add them to ~/.docker/config.json:");
+            tr_println!("setup-docker-no-registries-add");
             print_example_config();
         } else {
-            println!("Configured registries:");
+            tr_println!("setup-docker-configured-registries-header");
             for registry in registries {
-                println!("  - {registry}");
+                tr_println!(
+                    "setup-docker-registry-line",
+                    indent = "  ",
+                    registry = registry
+                );
             }
         }
     } else {
         // Show manual instructions
-        println!("Step 1: Create symlink for docker-credential-vouch\n");
-        println!(
-            "  ln -sf \"{}\" \"{}\"",
-            vouch_path.display(),
-            symlink_path.display()
+        tr_println!(
+            "setup-docker-step1-block",
+            vouch_path = vouch_path.display(),
+            symlink_path = symlink_path.display(),
         );
         println!();
 
-        println!("Step 2: Configure Docker to use the credential helper\n");
-        println!("  Add to ~/.docker/config.json:\n");
+        tr_println!("setup-docker-step2-header");
         print_example_config();
 
-        println!("\nOr run: vouch setup docker --configure [REGISTRIES...]");
         println!();
-        println!("Examples:");
-        println!("  vouch setup docker --configure ghcr.io");
-        println!("  vouch setup docker --configure 123456789012.dkr.ecr.us-east-1.amazonaws.com");
-        println!("  vouch setup docker --configure 123456789012.dkr.ecr.us-west-2.amazonaws.com");
+        tr_println!("setup-docker-tail-block");
     }
 
     println!();
-    println!("Supported registries:");
-    println!("  - AWS ECR:     *.dkr.ecr.*.amazonaws.com");
-    println!("  - GitHub:      ghcr.io");
+    tr_println!("setup-docker-supported-block");
 
     Ok(())
 }
@@ -110,15 +108,20 @@ fn create_credential_helper_symlink(
 
 /// Configure ~/.docker/config.json with the credential helper.
 fn configure_docker_config(registries: &[String]) -> Result<()> {
-    let home = dirs::home_dir().context("could not determine home directory")?;
+    let home = dirs::home_dir().with_context(|| tr!("setup-err-no-home"))?;
     let docker_config_path = home.join(".docker/config.json");
 
     // Load existing config or create new
     let mut config: DockerConfig = if docker_config_path.exists() {
-        let content = std::fs::read_to_string(&docker_config_path)
-            .with_context(|| format!("failed to read {}", docker_config_path.display()))?;
-        serde_json::from_str(&content)
-            .with_context(|| format!("failed to parse {}", docker_config_path.display()))?
+        let content = std::fs::read_to_string(&docker_config_path).with_context(|| {
+            tr_args!("setup-docker-err-read", path = docker_config_path.display())
+        })?;
+        serde_json::from_str(&content).with_context(|| {
+            tr_args!(
+                "setup-docker-err-parse",
+                path = docker_config_path.display()
+            )
+        })?
     } else {
         DockerConfig::default()
     };
@@ -135,16 +138,23 @@ fn configure_docker_config(registries: &[String]) -> Result<()> {
         && !parent.exists()
     {
         std::fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create {}", parent.display()))?;
+            .with_context(|| tr_args!("setup-docker-err-create-dir", path = parent.display()))?;
     }
 
     // Write config atomically to avoid corruption if interrupted
     let json =
-        serde_json::to_string_pretty(&config).context("failed to serialize Docker config")?;
-    vouch_common::fs::atomic_write(&docker_config_path, json.as_bytes())
-        .with_context(|| format!("failed to write {}", docker_config_path.display()))?;
+        serde_json::to_string_pretty(&config).with_context(|| tr!("setup-docker-err-serialize"))?;
+    vouch_common::fs::atomic_write(&docker_config_path, json.as_bytes()).with_context(|| {
+        tr_args!(
+            "setup-docker-err-write",
+            path = docker_config_path.display()
+        )
+    })?;
 
-    println!("Updated: {}", docker_config_path.display());
+    tr_println!(
+        "setup-docker-updated-file",
+        path = docker_config_path.display()
+    );
 
     Ok(())
 }

--- a/crates/vouch-cli/src/commands/setup/docker.rs
+++ b/crates/vouch-cli/src/commands/setup/docker.rs
@@ -76,8 +76,8 @@ pub(crate) async fn run(registries: &[String], configure: bool) -> Result<()> {
         // Show manual instructions
         tr_println!(
             "setup-docker-step1-block",
-            vouch_path = vouch_path.display(),
-            symlink_path = symlink_path.display(),
+            vouch_path = vouch_path.display().to_string(),
+            symlink_path = symlink_path.display().to_string(),
         );
         println!();
 
@@ -114,12 +114,15 @@ fn configure_docker_config(registries: &[String]) -> Result<()> {
     // Load existing config or create new
     let mut config: DockerConfig = if docker_config_path.exists() {
         let content = std::fs::read_to_string(&docker_config_path).with_context(|| {
-            tr_args!("setup-docker-err-read", path = docker_config_path.display())
+            tr_args!(
+                "setup-docker-err-read",
+                path = docker_config_path.display().to_string()
+            )
         })?;
         serde_json::from_str(&content).with_context(|| {
             tr_args!(
                 "setup-docker-err-parse",
-                path = docker_config_path.display()
+                path = docker_config_path.display().to_string()
             )
         })?
     } else {
@@ -137,8 +140,12 @@ fn configure_docker_config(registries: &[String]) -> Result<()> {
     if let Some(parent) = docker_config_path.parent()
         && !parent.exists()
     {
-        std::fs::create_dir_all(parent)
-            .with_context(|| tr_args!("setup-docker-err-create-dir", path = parent.display()))?;
+        std::fs::create_dir_all(parent).with_context(|| {
+            tr_args!(
+                "setup-docker-err-create-dir",
+                path = parent.display().to_string()
+            )
+        })?;
     }
 
     // Write config atomically to avoid corruption if interrupted
@@ -147,13 +154,13 @@ fn configure_docker_config(registries: &[String]) -> Result<()> {
     vouch_common::fs::atomic_write(&docker_config_path, json.as_bytes()).with_context(|| {
         tr_args!(
             "setup-docker-err-write",
-            path = docker_config_path.display()
+            path = docker_config_path.display().to_string()
         )
     })?;
 
     tr_println!(
         "setup-docker-updated-file",
-        path = docker_config_path.display()
+        path = docker_config_path.display().to_string()
     );
 
     Ok(())

--- a/crates/vouch-cli/src/commands/setup/eks.rs
+++ b/crates/vouch-cli/src/commands/setup/eks.rs
@@ -120,20 +120,19 @@ pub(crate) async fn run(
     // Auto-discover profile, region, and role
     let profile_name = aws::resolve_profile(profile)?;
     let region_name = aws::resolve_region(region, &profile_name)?;
-    let role_arn = aws::get_local_aws_role().ok_or_else(|| {
-        anyhow::anyhow!("AWS not configured. Run 'vouch setup aws --role <role-arn>' first.")
-    })?;
+    let role_arn = aws::get_local_aws_role()
+        .ok_or_else(|| anyhow::anyhow!(vouch_cli::tr!("setup-eks-err-aws-not-configured")))?;
 
-    println!("Amazon EKS Setup");
-    println!("================");
-    println!();
-    println!("Cluster:  {cluster_name}");
-    println!("Region:   {region_name}");
-    println!("Profile:  {profile_name}");
+    vouch_cli::tr_println!(
+        "setup-eks-header-block",
+        cluster = cluster_name,
+        region = &region_name,
+        profile = &profile_name,
+    );
     println!();
 
     // Fetch cluster info from AWS using native SigV4 API call
-    println!("Fetching cluster details...");
+    vouch_cli::tr_println!("setup-eks-fetching");
     let (endpoint, ca_data) =
         describe_cluster(server, cluster_name, &region_name, &role_arn).await?;
 
@@ -202,18 +201,14 @@ pub(crate) async fn run(
 
     // Print summary
     println!();
-    println!("Updated kubeconfig: {}", kubeconfig_path.display());
-    println!("  Cluster: {cluster_name} ({endpoint})");
-    println!("  User:    {user_name} (via vouch credential eks)");
-    println!("  Context: {context_name}");
-    println!();
-    println!("To use:");
-    println!("  kubectl config use-context {context_name}");
-    println!("  kubectl get pods");
-    println!();
-    println!("Prerequisites:");
-    println!("  1. Run 'vouch login' to authenticate");
-    println!("  2. EKS Access Entry must exist for the IAM role in your AWS profile");
+    vouch_cli::tr_println!(
+        "setup-eks-result-block",
+        kubeconfig = kubeconfig_path.display(),
+        cluster = cluster_name,
+        endpoint = &endpoint,
+        user_name = &user_name,
+        context = &context_name,
+    );
 
     Ok(())
 }

--- a/crates/vouch-cli/src/commands/setup/eks.rs
+++ b/crates/vouch-cli/src/commands/setup/eks.rs
@@ -126,8 +126,8 @@ pub(crate) async fn run(
     vouch_cli::tr_println!(
         "setup-eks-header-block",
         cluster = cluster_name,
-        region = &region_name,
-        profile = &profile_name,
+        region = region_name.as_str(),
+        profile = profile_name.as_str(),
     );
     println!();
 
@@ -203,11 +203,11 @@ pub(crate) async fn run(
     println!();
     vouch_cli::tr_println!(
         "setup-eks-result-block",
-        kubeconfig = kubeconfig_path.display(),
+        kubeconfig = kubeconfig_path.display().to_string(),
         cluster = cluster_name,
-        endpoint = &endpoint,
-        user_name = &user_name,
-        context = &context_name,
+        endpoint = endpoint.as_str(),
+        user_name = user_name.as_str(),
+        context = context_name.as_str(),
     );
 
     Ok(())

--- a/crates/vouch-cli/src/commands/setup/github.rs
+++ b/crates/vouch-cli/src/commands/setup/github.rs
@@ -63,7 +63,7 @@ pub(crate) async fn run(host: &str, configure: bool) -> Result<()> {
                 return Ok(());
             }
             // Server might not have the endpoint yet, continue with setup
-            tr_println!("setup-github-could-not-check", reason = e);
+            tr_println!("setup-github-could-not-check", reason = format!("{e:#}"));
             println!();
         }
     }
@@ -81,7 +81,10 @@ pub(crate) async fn run(host: &str, configure: bool) -> Result<()> {
     if configure {
         // Check for existing helpers that might conflict
         if let Some(existing) = detect_existing_helper(host)? {
-            tr_println!("setup-github-existing-warning-block", existing = &existing);
+            tr_println!(
+                "setup-github-existing-warning-block",
+                existing = existing.as_str()
+            );
             println!();
         }
 
@@ -100,8 +103,8 @@ pub(crate) async fn run(host: &str, configure: bool) -> Result<()> {
         tr_println!(
             "setup-github-configured-block",
             host = host,
-            key = &config_key,
-            value = &helper_command,
+            key = config_key.as_str(),
+            value = helper_command.as_str(),
         );
     } else {
         tr_println!("setup-github-add-to-gitconfig");
@@ -122,9 +125,12 @@ pub(crate) async fn run(host: &str, configure: bool) -> Result<()> {
 fn print_status(status: &GitHubStatusResponse) {
     tr_println!(
         "setup-github-app-configured",
-        configured = status.configured,
+        configured = status.configured.to_string(),
     );
-    tr_println!("setup-github-org-connected", connected = status.connected,);
+    tr_println!(
+        "setup-github-org-connected",
+        connected = status.connected.to_string(),
+    );
 
     if !status.github_accounts.is_empty() {
         tr_println!("setup-github-accounts-header");
@@ -132,9 +138,9 @@ fn print_status(status: &GitHubStatusResponse) {
             tr_println!(
                 "setup-github-account-line",
                 indent = "  ",
-                login = &account.login,
-                kind = &account.account_type,
-                suspended = account.suspended,
+                login = account.login.as_str(),
+                kind = account.account_type.as_str(),
+                suspended = account.suspended.to_string(),
             );
         }
     }

--- a/crates/vouch-cli/src/commands/setup/github.rs
+++ b/crates/vouch-cli/src/commands/setup/github.rs
@@ -5,6 +5,7 @@
 
 use anyhow::{Context, Result};
 use std::process::Command;
+use vouch_cli::{tr, tr_println};
 use vouch_common::GitHubStatusResponse;
 
 use crate::commands::credential::github::check_status;
@@ -22,13 +23,13 @@ use crate::install_path::resolve_install_path;
 /// * `configure` - If true, automatically configure git; if false, just show instructions
 pub(crate) async fn run(host: &str, configure: bool) -> Result<()> {
     // Load config to get server URL
-    let config = Config::load().context("failed to load config - run 'vouch enroll' first")?;
+    let config = Config::load().with_context(|| tr!("setup-err-load-config"))?;
     let server = config
         .server_url()
-        .context("not configured - run 'vouch enroll' first")?;
+        .with_context(|| tr!("setup-err-not-configured"))?;
 
-    println!("GitHub Credential Setup");
-    println!("=======================\n");
+    tr_println!("setup-github-header");
+    println!();
 
     // Check login status and GitHub connectivity
     match check_status(server).await {
@@ -36,17 +37,14 @@ pub(crate) async fn run(host: &str, configure: bool) -> Result<()> {
             print_status(&status);
 
             if !status.configured {
-                println!("\nGitHub App is not configured on the server.");
-                println!("Contact your administrator to enable GitHub integration.");
+                println!();
+                tr_println!("setup-github-not-configured-block");
                 return Ok(());
             }
 
             if !status.connected {
-                println!("\nYour organization has not connected GitHub.");
-                println!(
-                    "An organization admin needs to visit: {}/github/connect",
-                    server
-                );
+                println!();
+                tr_println!("setup-github-org-not-connected-block", server = server);
                 return Ok(());
             }
 
@@ -54,19 +52,18 @@ pub(crate) async fn run(host: &str, configure: bool) -> Result<()> {
             let all_suspended = !status.github_accounts.is_empty()
                 && status.github_accounts.iter().all(|a| a.suspended);
             if all_suspended {
-                println!("\nAll GitHub installations are currently suspended.");
-                println!("Contact your administrator to resolve this.");
+                println!();
+                tr_println!("setup-github-all-suspended-block");
                 return Ok(());
             }
         }
         Err(e) => {
             if e.to_string().contains("not authenticated") {
-                println!("Login status: Not logged in");
-                println!("\nRun 'vouch login' first to authenticate.");
+                tr_println!("setup-github-not-logged-in-block");
                 return Ok(());
             }
             // Server might not have the endpoint yet, continue with setup
-            println!("Note: Could not check GitHub status: {e}");
+            tr_println!("setup-github-could-not-check", reason = e);
             println!();
         }
     }
@@ -84,64 +81,60 @@ pub(crate) async fn run(host: &str, configure: bool) -> Result<()> {
     if configure {
         // Check for existing helpers that might conflict
         if let Some(existing) = detect_existing_helper(host)? {
-            println!("Warning: Existing credential helper detected: {}", existing);
-            println!("This may conflict with Vouch.\n");
+            tr_println!("setup-github-existing-warning-block", existing = &existing);
+            println!();
         }
 
         // Configure git
         let status = Command::new("git")
             .args(["config", "--global", &config_key, &helper_command])
             .status()
-            .context("failed to run git config")?;
+            .with_context(|| tr!("setup-github-err-run-config"))?;
 
         if !status.success() {
-            return Err(crate::exit_code::CliError::ConfigError(
-                "failed to configure git credential helper".to_string(),
-            )
-            .into());
+            return Err(
+                crate::exit_code::CliError::ConfigError(tr!("setup-github-err-helper")).into(),
+            );
         }
 
-        println!("Git configured for {}", host);
-        println!();
-        println!("Configuration added:");
-        println!("  {} = {}", config_key, helper_command);
+        tr_println!(
+            "setup-github-configured-block",
+            host = host,
+            key = &config_key,
+            value = &helper_command,
+        );
     } else {
-        println!("Add to ~/.gitconfig:\n");
+        tr_println!("setup-github-add-to-gitconfig");
+        println!();
         println!("[credential \"https://{}\"]", host);
         println!("    helper = {}", helper_command);
         println!();
-        println!("Or run: vouch setup github --configure");
+        tr_println!("setup-github-or-run");
     }
 
     println!();
-    println!("To verify, run:");
-    println!("  git ls-remote https://{}/YOUR-ORG/YOUR-REPO.git", host);
+    tr_println!("setup-github-to-verify", host = host);
 
     Ok(())
 }
 
 /// Print GitHub status information.
 fn print_status(status: &GitHubStatusResponse) {
-    println!(
-        "GitHub App configured: {}",
-        if status.configured { "Yes" } else { "No" }
+    tr_println!(
+        "setup-github-app-configured",
+        configured = status.configured,
     );
-    println!(
-        "Organization connected: {}",
-        if status.connected { "Yes" } else { "No" }
-    );
+    tr_println!("setup-github-org-connected", connected = status.connected,);
 
     if !status.github_accounts.is_empty() {
-        println!("Connected GitHub accounts:");
+        tr_println!("setup-github-accounts-header");
         for account in &status.github_accounts {
-            let suspended_indicator = if account.suspended {
-                " (SUSPENDED)"
-            } else {
-                ""
-            };
-            println!(
-                "  - {} ({}){}",
-                account.login, account.account_type, suspended_indicator
+            tr_println!(
+                "setup-github-account-line",
+                indent = "  ",
+                login = &account.login,
+                kind = &account.account_type,
+                suspended = account.suspended,
             );
         }
     }

--- a/crates/vouch-cli/src/commands/setup/kubeconfig.rs
+++ b/crates/vouch-cli/src/commands/setup/kubeconfig.rs
@@ -121,10 +121,12 @@ pub(crate) fn load_kubeconfig(path: &std::path::Path) -> Result<Kubeconfig> {
         });
     }
 
-    let content = std::fs::read_to_string(path)
-        .with_context(|| vouch_cli::tr_args!("setup-kc-err-read", path = path.display()))?;
-    let config: Kubeconfig = serde_yaml::from_str(&content)
-        .with_context(|| vouch_cli::tr_args!("setup-kc-err-parse", path = path.display()))?;
+    let content = std::fs::read_to_string(path).with_context(|| {
+        vouch_cli::tr_args!("setup-kc-err-read", path = path.display().to_string())
+    })?;
+    let config: Kubeconfig = serde_yaml::from_str(&content).with_context(|| {
+        vouch_cli::tr_args!("setup-kc-err-parse", path = path.display().to_string())
+    })?;
     Ok(config)
 }
 

--- a/crates/vouch-cli/src/commands/setup/kubeconfig.rs
+++ b/crates/vouch-cli/src/commands/setup/kubeconfig.rs
@@ -107,7 +107,7 @@ pub(crate) fn default_kubeconfig_path() -> Result<PathBuf> {
         return Ok(PathBuf::from(first_path));
     }
 
-    let home = dirs::home_dir().context("could not determine home directory")?;
+    let home = dirs::home_dir().with_context(|| vouch_cli::tr!("setup-err-no-home"))?;
     Ok(home.join(".kube").join("config"))
 }
 
@@ -122,9 +122,9 @@ pub(crate) fn load_kubeconfig(path: &std::path::Path) -> Result<Kubeconfig> {
     }
 
     let content = std::fs::read_to_string(path)
-        .with_context(|| format!("failed to read kubeconfig: {}", path.display()))?;
+        .with_context(|| vouch_cli::tr_args!("setup-kc-err-read", path = path.display()))?;
     let config: Kubeconfig = serde_yaml::from_str(&content)
-        .with_context(|| format!("failed to parse kubeconfig: {}", path.display()))?;
+        .with_context(|| vouch_cli::tr_args!("setup-kc-err-parse", path = path.display()))?;
     Ok(config)
 }
 
@@ -134,7 +134,8 @@ pub(crate) fn save_kubeconfig(path: &std::path::Path, config: &Kubeconfig) -> Re
         ensure_secure_dir(parent)?;
     }
 
-    let content = serde_yaml::to_string(config).context("failed to serialize kubeconfig")?;
+    let content =
+        serde_yaml::to_string(config).with_context(|| vouch_cli::tr!("setup-kc-err-serialize"))?;
     write_secure_file(path, &content)?;
     Ok(())
 }

--- a/crates/vouch-cli/src/commands/setup/kubernetes.rs
+++ b/crates/vouch-cli/src/commands/setup/kubernetes.rs
@@ -115,16 +115,16 @@ pub(crate) async fn run(
     // Print summary
     tr_println!(
         "setup-k8s-updated-block",
-        kubeconfig = kubeconfig_path.display(),
+        kubeconfig = kubeconfig_path.display().to_string(),
         cluster = cluster,
         server = k8s_server,
-        user_name = &user_name,
-        context = &context_name,
+        user_name = user_name.as_str(),
+        context = context_name.as_str(),
     );
     println!();
     tr_println!(
         "setup-k8s-tail-block",
-        context = &context_name,
+        context = context_name.as_str(),
         vouch = server,
         audience = aud,
     );

--- a/crates/vouch-cli/src/commands/setup/kubernetes.rs
+++ b/crates/vouch-cli/src/commands/setup/kubernetes.rs
@@ -8,6 +8,7 @@ use anyhow::{Context, Result};
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
 use std::path::PathBuf;
+use vouch_cli::{tr_args, tr_println};
 
 use super::kubeconfig::{
     ExecConfig, KubeconfigCluster, KubeconfigClusterData, KubeconfigContext, KubeconfigContextData,
@@ -17,7 +18,7 @@ use super::kubeconfig::{
 /// Read and base64-encode a certificate authority file.
 fn read_ca_data(ca_path: &str) -> Result<String> {
     let bytes = std::fs::read(ca_path)
-        .with_context(|| format!("failed to read certificate authority file: {ca_path}"))?;
+        .with_context(|| tr_args!("setup-k8s-err-read-ca", path = ca_path))?;
     Ok(STANDARD.encode(&bytes))
 }
 
@@ -43,13 +44,15 @@ pub(crate) async fn run(
     // Read CA data if provided
     let ca_data = ca_path.map(read_ca_data).transpose()?;
 
-    println!("Kubernetes OIDC Setup");
-    println!("=====================");
+    tr_println!("setup-k8s-header");
     println!();
-    println!("Cluster:   {cluster}");
-    println!("Server:    {k8s_server}");
-    println!("Audience:  {aud}");
-    println!("Vouch:     {server}");
+    tr_println!(
+        "setup-k8s-summary",
+        cluster = cluster,
+        server = k8s_server,
+        audience = aud,
+        vouch = server,
+    );
     println!();
 
     // Naming convention
@@ -110,20 +113,20 @@ pub(crate) async fn run(
     save_kubeconfig(&kubeconfig_path, &config)?;
 
     // Print summary
-    println!("Updated kubeconfig: {}", kubeconfig_path.display());
-    println!("  Cluster: {cluster} ({k8s_server})");
-    println!("  User:    {user_name} (via vouch credential k8s)");
-    println!("  Context: {context_name}");
+    tr_println!(
+        "setup-k8s-updated-block",
+        kubeconfig = kubeconfig_path.display(),
+        cluster = cluster,
+        server = k8s_server,
+        user_name = &user_name,
+        context = &context_name,
+    );
     println!();
-    println!("To use:");
-    println!("  kubectl config use-context {context_name}");
-    println!("  kubectl get pods");
-    println!();
-    println!("Prerequisites:");
-    println!("  1. Run 'vouch login' to authenticate");
-    println!(
-        "  2. Kubernetes API server must be configured with \
-         --oidc-issuer-url={server} --oidc-client-id={aud}"
+    tr_println!(
+        "setup-k8s-tail-block",
+        context = &context_name,
+        vouch = server,
+        audience = aud,
     );
 
     Ok(())

--- a/crates/vouch-cli/src/commands/setup/mod.rs
+++ b/crates/vouch-cli/src/commands/setup/mod.rs
@@ -2,6 +2,7 @@
 //! Setup and configuration commands.
 
 use clap::Subcommand;
+use vouch_cli::tr;
 
 pub(crate) mod anthropic;
 pub(crate) mod aws;
@@ -21,191 +22,189 @@ pub(crate) mod ssm;
 #[derive(Subcommand)]
 pub(crate) enum SetupCommands {
     /// Configure AWS CLI/SDK to use Vouch credentials.
+    #[command(about = tr!("cmd-setup-aws-about"))]
     Aws {
         /// AWS profile name to configure. Defaults to "vouch" if not specified.
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-aws-profile-help"))]
         profile: Option<String>,
         /// AWS IAM role ARN to assume. Required unless --discover is set.
-        #[arg(long, required_unless_present = "discover")]
+        #[arg(long, required_unless_present = "discover", help = tr!("arg-setup-aws-role-help"))]
         role: Option<String>,
         /// AWS region to set in the profile.
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-aws-region-help"))]
         region: Option<String>,
         /// Discover accounts and roles via SSO and generate profiles automatically.
-        #[arg(long, conflicts_with = "role")]
+        #[arg(long, conflicts_with = "role", help = tr!("arg-setup-aws-discover-help"))]
         discover: bool,
     },
     /// Configure SSH to use Vouch certificates.
+    #[command(about = tr!("cmd-setup-ssh-about"))]
     Ssh {
         /// Host patterns to trust with this CA (e.g., "*.example.com").
-        /// If specified, adds entry to ~/.ssh/known_hosts.
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-ssh-hosts-help"))]
         hosts: Option<String>,
     },
     /// Configure Git to use Vouch for GitHub credentials.
+    #[command(about = tr!("cmd-setup-github-about"))]
     Github {
         /// GitHub host to configure (default: github.com).
-        #[arg(long, default_value = "github.com")]
+        #[arg(long, default_value = "github.com", help = tr!("arg-setup-github-host-help"))]
         host: String,
         /// Automatically configure git (otherwise just show instructions).
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-github-configure-help"))]
         configure: bool,
     },
     /// Configure kubectl to use Vouch credentials for Amazon EKS clusters.
+    #[command(about = tr!("cmd-setup-eks-about"))]
     Eks {
         /// EKS cluster name.
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-eks-cluster-help"))]
         cluster: String,
         /// AWS region (auto-detected from AWS profile or environment if not specified).
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-eks-region-help"))]
         region: Option<String>,
         /// AWS profile to use (defaults to auto-detected vouch profile).
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-eks-profile-help"))]
         profile: Option<String>,
         /// Path to kubeconfig file (defaults to ~/.kube/config).
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-eks-kubeconfig-help"))]
         kubeconfig: Option<String>,
     },
     /// Configure kubectl to use Vouch OIDC credentials for generic Kubernetes clusters.
+    #[command(about = tr!("cmd-setup-k8s-about"))]
     K8s {
         /// Kubernetes cluster name.
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-k8s-cluster-help"))]
         cluster: String,
         /// Kubernetes API server URL (e.g., https://k8s.example.com:6443).
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-k8s-server-help"))]
         server: String,
         /// Path to the cluster's certificate authority file (PEM format).
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-k8s-ca-help"))]
         certificate_authority: Option<String>,
-        /// OIDC audience (must match --oidc-client-id on the API server).
-        /// Defaults to "kubernetes".
-        #[arg(long)]
+        /// OIDC audience.
+        #[arg(long, help = tr!("arg-setup-k8s-audience-help"))]
         audience: Option<String>,
         /// Path to kubeconfig file (defaults to ~/.kube/config).
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-k8s-kubeconfig-help"))]
         kubeconfig: Option<String>,
     },
     /// Configure Docker to use Vouch for container registry authentication.
+    #[command(about = tr!("cmd-setup-docker-about"))]
     Docker {
         /// Container registries to configure (e.g., ghcr.io).
-        #[arg(trailing_var_arg = true)]
+        #[arg(trailing_var_arg = true, help = tr!("arg-setup-docker-registries-help"))]
         registries: Vec<String>,
         /// Automatically configure Docker (otherwise just show instructions).
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-docker-configure-help"))]
         configure: bool,
     },
     /// Configure Cargo to use Vouch for private registry authentication.
+    #[command(about = tr!("cmd-setup-cargo-about"))]
     Cargo {
         /// Registry name to configure (if not specified, configures global provider).
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-cargo-registry-help"))]
         registry: Option<String>,
         /// Write the configuration (otherwise just show instructions).
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-cargo-configure-help"))]
         configure: bool,
     },
     /// Configure Git to use Vouch for AWS CodeCommit credentials.
+    #[command(about = tr!("cmd-setup-codecommit-about"))]
     Codecommit {
         /// AWS region (default: wildcard matching all regions).
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-codecommit-region-help"))]
         region: Option<String>,
         /// AWS profile to use (defaults to auto-detected vouch profile).
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-codecommit-profile-help"))]
         profile: Option<String>,
         /// Automatically configure git (otherwise just show instructions).
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-codecommit-configure-help"))]
         configure: bool,
     },
     /// Configure SSH for AWS Systems Manager Session Manager.
+    #[command(about = tr!("cmd-setup-ssm-about"))]
     Ssm {
         /// AWS profile to use (defaults to auto-detected vouch profile).
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-ssm-profile-help"))]
         profile: Option<String>,
-        /// AWS region (auto-detected from AWS profile or environment if not specified).
-        #[arg(long)]
+        /// AWS region.
+        #[arg(long, help = tr!("arg-setup-ssm-region-help"))]
         region: Option<String>,
-        /// SSH host patterns for SSM proxying (i-* = EC2 instances, mi-* = managed
-        /// instances).
-        #[arg(long, default_value = ssm::DEFAULT_HOST_PATTERN)]
+        /// SSH host patterns for SSM proxying.
+        #[arg(long, default_value = ssm::DEFAULT_HOST_PATTERN, help = tr!("arg-setup-ssm-hosts-help"))]
         hosts: String,
         /// Replace existing Vouch SSM configuration if present.
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-ssm-force-help"))]
         force: bool,
     },
     /// Configure Anthropic (Claude) Workload Identity Federation.
-    ///
-    /// Persists federation parameters to `~/.config/vouch/config.json` for use by
-    /// `vouch credential anthropic`. This is the **workload** path: the
-    /// minted token acts as a non-human service account, intended for
-    /// CI/headless automation. It does not configure Claude Code.
+    #[command(
+        about = tr!("cmd-setup-anthropic-about"),
+        long_about = tr!("cmd-setup-anthropic-long-about"),
+    )]
     Anthropic {
         /// Anthropic federation rule ID (`fdrl_...`).
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-anthropic-federation-rule-id-help"))]
         federation_rule_id: String,
         /// Anthropic organization ID (UUID).
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-anthropic-organization-id-help"))]
         organization_id: String,
         /// Anthropic service account ID (`svac_...`).
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-anthropic-service-account-id-help"))]
         service_account_id: String,
         /// Anthropic workspace ID (`wrkspc_...`).
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-anthropic-workspace-id-help"))]
         workspace_id: String,
         /// `aud` claim to request on the assertion (optional).
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-anthropic-audience-help"))]
         audience: Option<String>,
         /// Token endpoint override (defaults to Anthropic's public endpoint).
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-anthropic-token-endpoint-help"))]
         token_endpoint: Option<String>,
     },
     /// Configure OpenAI Workload Identity Federation.
-    ///
-    /// Persists federation parameters to `~/.config/vouch/config.json` AND
-    /// auto-configures the OpenAI Codex CLI by writing a
-    /// `[model_providers.vouch]` block (with refreshing auth
-    /// command) into `~/.codex/config.toml` and setting it as the
-    /// top-level `model_provider`.
-    ///
-    /// If Codex already has a different `model_provider` or a
-    /// conflicting `vouch` provider block, the command errors —
-    /// pass `--force` to overwrite.
+    #[command(
+        about = tr!("cmd-setup-openai-about"),
+        long_about = tr!("cmd-setup-openai-long-about"),
+    )]
     Openai {
         /// OpenAI Workload Identity Provider ID for the Vouch issuer.
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-openai-identity-provider-id-help"))]
         identity_provider_id: String,
         /// OpenAI service account ID.
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-openai-service-account-id-help"))]
         service_account_id: String,
-        /// `aud` claim to request on the assertion (matches OpenAI's
-        /// configured audience for this provider).
-        #[arg(long)]
+        /// `aud` claim to request on the assertion.
+        #[arg(long, help = tr!("arg-setup-openai-audience-help"))]
         audience: Option<String>,
         /// Token endpoint override (defaults to OpenAI's public endpoint).
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-openai-token-endpoint-help"))]
         token_endpoint: Option<String>,
-        /// Overwrite an existing Codex `model_provider` or `vouch`
-        /// provider block.
-        #[arg(long)]
+        /// Overwrite an existing Codex `model_provider` or `vouch` provider block.
+        #[arg(long, help = tr!("arg-setup-openai-force-help"))]
         force: bool,
     },
     /// Configure a package manager for AWS CodeArtifact.
+    #[command(about = tr!("cmd-setup-codeartifact-about"))]
     Codeartifact {
         /// Package manager to configure (cargo, pip, npm).
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-codeartifact-tool-help"))]
         tool: codeartifact::Tool,
         /// CodeArtifact domain name (or use --profile / saved default).
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-codeartifact-domain-help"))]
         domain: Option<String>,
         /// AWS account ID that owns the domain.
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-codeartifact-domain-owner-help"))]
         domain_owner: Option<String>,
         /// AWS region.
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-codeartifact-region-help"))]
         region: Option<String>,
         /// CodeArtifact repository name.
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-codeartifact-repository-help"))]
         repository: String,
         /// Named CodeArtifact profile to use / save.
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-setup-codeartifact-profile-help"))]
         profile: Option<String>,
     },
 }

--- a/crates/vouch-cli/src/commands/setup/openai.rs
+++ b/crates/vouch-cli/src/commands/setup/openai.rs
@@ -53,10 +53,10 @@ pub(crate) async fn run(args: SetupArgs<'_>) -> Result<()> {
     // Config::load() succeeds on an empty file, so we have to check that a
     // server context exists. Otherwise we'd happily write a Codex provider
     // block for a machine that can't get a Vouch session.
-    let config = Config::load().context("failed to load Vouch config")?;
+    let config = Config::load().with_context(|| vouch_cli::tr!("setup-err-load-vouch-config"))?;
     let _server = config
         .server_url()
-        .context("not configured — run 'vouch enroll' first")?;
+        .with_context(|| vouch_cli::tr!("setup-err-anthropic-not-enrolled"))?;
 
     let vouch_path = resolve_install_path().display().to_string();
 
@@ -80,16 +80,18 @@ pub(crate) async fn run(args: SetupArgs<'_>) -> Result<()> {
 /// has a different `model_provider` or a conflicting `vouch` provider
 /// block, unless `force` is set.
 fn configure_codex(vouch_path: &str, force: bool) -> Result<PathBuf> {
-    let home = dirs::home_dir().context("could not determine home directory")?;
+    use vouch_cli::{tr, tr_args};
+
+    let home = dirs::home_dir().with_context(|| tr!("setup-err-no-home"))?;
     let codex_dir = home.join(".codex");
     let config_path = codex_dir.join("config.toml");
 
     let mut doc: DocumentMut = if config_path.exists() {
         let content = std::fs::read_to_string(&config_path)
-            .with_context(|| format!("failed to read {}", config_path.display()))?;
+            .with_context(|| tr_args!("setup-openai-err-read", path = config_path.display()))?;
         content
             .parse()
-            .with_context(|| format!("failed to parse {}", config_path.display()))?
+            .with_context(|| tr_args!("setup-openai-err-parse", path = config_path.display()))?
     } else {
         DocumentMut::new()
     };
@@ -101,10 +103,10 @@ fn configure_codex(vouch_path: &str, force: bool) -> Result<PathBuf> {
 
     if !codex_dir.exists() {
         std::fs::create_dir_all(&codex_dir)
-            .with_context(|| format!("failed to create {}", codex_dir.display()))?;
+            .with_context(|| tr_args!("setup-openai-err-create-dir", path = codex_dir.display()))?;
     }
     vouch_common::fs::atomic_write(&config_path, doc.to_string().as_bytes())
-        .with_context(|| format!("failed to write {}", config_path.display()))?;
+        .with_context(|| tr_args!("setup-openai-err-write", path = config_path.display()))?;
 
     Ok(config_path)
 }
@@ -123,13 +125,12 @@ fn check_conflicts(doc: &DocumentMut, config_path: &Path, force: bool) -> Result
     if let Some(existing_mp) = doc.get("model_provider").and_then(Item::as_str)
         && existing_mp != PROVIDER_ID
     {
-        anyhow::bail!(
-            "Codex already has model_provider = {existing_mp:?} in {}.\n\n\
-             Remove the `model_provider` entry from config.toml, or re-run \
-             `vouch setup openai --force` to switch the default to \
-             `{PROVIDER_ID}`.",
-            config_path.display(),
-        );
+        anyhow::bail!(vouch_cli::tr_args!(
+            "setup-openai-err-conflict",
+            existing = format!("{existing_mp:?}"),
+            path = config_path.display(),
+            provider_id = PROVIDER_ID,
+        ));
     }
 
     Ok(())
@@ -163,13 +164,9 @@ fn write_provider_block(doc: &mut DocumentMut, vouch_path: &str) -> Result<()> {
     let providers = doc
         .entry("model_providers")
         .or_insert(Item::Table(Table::new()));
-    let providers_tbl = providers.as_table_mut().ok_or_else(|| {
-        anyhow::anyhow!(
-            "cannot configure OpenAI: `model_providers` exists in \
-             ~/.codex/config.toml but is not a table. Remove or rename \
-             the `model_providers` entry and try again."
-        )
-    })?;
+    let providers_tbl = providers
+        .as_table_mut()
+        .ok_or_else(|| anyhow::anyhow!(vouch_cli::tr!("setup-openai-err-providers-not-table")))?;
     // Without this the parent renders as plain `[model_providers]` instead
     // of letting the child `[model_providers.vouch]` header own the
     // section, which clutters the file.
@@ -179,27 +176,12 @@ fn write_provider_block(doc: &mut DocumentMut, vouch_path: &str) -> Result<()> {
 }
 
 fn print_success(config_path: &Path) {
-    println!("OpenAI Workload Identity Federation configured.\n");
-    println!("  Federation params: ~/.config/vouch/config.json");
-    println!(
-        "  Codex provider block: {} ([model_providers.{PROVIDER_ID}])\n",
-        config_path.display()
+    use vouch_cli::tr_println;
+    tr_println!(
+        "setup-openai-success-block",
+        config_path = config_path.display(),
+        provider_id = PROVIDER_ID,
     );
-
-    println!("NOTE: OpenAI must onboard the Vouch issuer as a workload identity provider");
-    println!("      before this works — custom OIDC issuers are not self-service. Contact");
-    println!("      OpenAI to register your Vouch base URL.\n");
-
-    println!("Get a token:");
-    println!("  vouch login              # YubiKey tap, once per session");
-    println!("  vouch credential openai  # prints a short-lived OpenAI access token\n");
-
-    println!("Ensure OPENAI_API_KEY is UNSET in every environment Codex runs in —");
-    println!("it shadows the configured auth command.\n");
-
-    println!("Note: the [model_providers.vouch] block is owned by `vouch setup openai` —");
-    println!("re-running this command overwrites it. Edit the top-level `model_provider`");
-    println!("if you want to switch Codex back to a different provider.");
 }
 
 #[cfg(test)]

--- a/crates/vouch-cli/src/commands/setup/openai.rs
+++ b/crates/vouch-cli/src/commands/setup/openai.rs
@@ -87,11 +87,18 @@ fn configure_codex(vouch_path: &str, force: bool) -> Result<PathBuf> {
     let config_path = codex_dir.join("config.toml");
 
     let mut doc: DocumentMut = if config_path.exists() {
-        let content = std::fs::read_to_string(&config_path)
-            .with_context(|| tr_args!("setup-openai-err-read", path = config_path.display()))?;
-        content
-            .parse()
-            .with_context(|| tr_args!("setup-openai-err-parse", path = config_path.display()))?
+        let content = std::fs::read_to_string(&config_path).with_context(|| {
+            tr_args!(
+                "setup-openai-err-read",
+                path = config_path.display().to_string()
+            )
+        })?;
+        content.parse().with_context(|| {
+            tr_args!(
+                "setup-openai-err-parse",
+                path = config_path.display().to_string()
+            )
+        })?
     } else {
         DocumentMut::new()
     };
@@ -102,11 +109,21 @@ fn configure_codex(vouch_path: &str, force: bool) -> Result<PathBuf> {
     doc.insert("model_provider", toml_edit::value(PROVIDER_ID));
 
     if !codex_dir.exists() {
-        std::fs::create_dir_all(&codex_dir)
-            .with_context(|| tr_args!("setup-openai-err-create-dir", path = codex_dir.display()))?;
+        std::fs::create_dir_all(&codex_dir).with_context(|| {
+            tr_args!(
+                "setup-openai-err-create-dir",
+                path = codex_dir.display().to_string()
+            )
+        })?;
     }
-    vouch_common::fs::atomic_write(&config_path, doc.to_string().as_bytes())
-        .with_context(|| tr_args!("setup-openai-err-write", path = config_path.display()))?;
+    vouch_common::fs::atomic_write(&config_path, doc.to_string().as_bytes()).with_context(
+        || {
+            tr_args!(
+                "setup-openai-err-write",
+                path = config_path.display().to_string()
+            )
+        },
+    )?;
 
     Ok(config_path)
 }
@@ -128,7 +145,7 @@ fn check_conflicts(doc: &DocumentMut, config_path: &Path, force: bool) -> Result
         anyhow::bail!(vouch_cli::tr_args!(
             "setup-openai-err-conflict",
             existing = format!("{existing_mp:?}"),
-            path = config_path.display(),
+            path = config_path.display().to_string(),
             provider_id = PROVIDER_ID,
         ));
     }
@@ -179,7 +196,7 @@ fn print_success(config_path: &Path) {
     use vouch_cli::tr_println;
     tr_println!(
         "setup-openai-success-block",
-        config_path = config_path.display(),
+        config_path = config_path.display().to_string(),
         provider_id = PROVIDER_ID,
     );
 }

--- a/crates/vouch-cli/src/commands/setup/ssh.rs
+++ b/crates/vouch-cli/src/commands/setup/ssh.rs
@@ -85,9 +85,13 @@ pub(crate) async fn run(server: &str, hosts: Option<&str>) -> Result<()> {
         ensure_secure_dir(parent)?;
     }
 
-    atomic_write(&ca_path, ca_content.as_bytes())
-        .with_context(|| tr_args!("setup-ssh-err-write-ca", path = ca_path.display()))?;
-    tr_println!("setup-ssh-saved-ca", path = ca_path.display());
+    atomic_write(&ca_path, ca_content.as_bytes()).with_context(|| {
+        tr_args!(
+            "setup-ssh-err-write-ca",
+            path = ca_path.display().to_string()
+        )
+    })?;
+    tr_println!("setup-ssh-saved-ca", path = ca_path.display().to_string());
 
     // If hosts are specified, add TrustedUserCAKeys entry to known_hosts
     if let Some(host_patterns) = hosts {
@@ -98,7 +102,10 @@ pub(crate) async fn run(server: &str, hosts: Option<&str>) -> Result<()> {
     configure_ssh_config(hosts)?;
 
     println!();
-    tr_println!("setup-ssh-complete-block", ca_path = ca_path.display());
+    tr_println!(
+        "setup-ssh-complete-block",
+        ca_path = ca_path.display().to_string()
+    );
 
     Ok(())
 }
@@ -133,8 +140,12 @@ fn configure_ssh_config(hosts: Option<&str>) -> Result<()> {
 
     // Read existing config
     let existing = if config_path.exists() {
-        fs::read_to_string(&config_path)
-            .with_context(|| tr_args!("setup-ssh-err-read-config", path = config_path.display()))?
+        fs::read_to_string(&config_path).with_context(|| {
+            tr_args!(
+                "setup-ssh-err-read-config",
+                path = config_path.display().to_string()
+            )
+        })?
     } else {
         String::new()
     };
@@ -164,12 +175,15 @@ fn configure_ssh_config(hosts: Option<&str>) -> Result<()> {
             rewritten.push('\n');
         }
         atomic_write_secure(&config_path, rewritten.as_bytes()).with_context(|| {
-            tr_args!("setup-ssh-err-write-config", path = config_path.display())
+            tr_args!(
+                "setup-ssh-err-write-config",
+                path = config_path.display().to_string()
+            )
         })?;
         tr_println!(
             "setup-ssh-stale-agent-rewrite",
-            config_path = config_path.display(),
-            agent_socket = &agent_socket,
+            config_path = config_path.display().to_string(),
+            agent_socket = agent_socket.as_str(),
         );
         rewritten
     } else {
@@ -216,10 +230,17 @@ Host *
     };
 
     let new_config = format!("{existing}{vouch_config}");
-    atomic_write_secure(&config_path, new_config.as_bytes())
-        .with_context(|| tr_args!("setup-ssh-err-write-config", path = config_path.display()))?;
+    atomic_write_secure(&config_path, new_config.as_bytes()).with_context(|| {
+        tr_args!(
+            "setup-ssh-err-write-config",
+            path = config_path.display().to_string()
+        )
+    })?;
 
-    tr_println!("setup-ssh-updated-config", path = config_path.display());
+    tr_println!(
+        "setup-ssh-updated-config",
+        path = config_path.display().to_string()
+    );
     if hosts.is_some() {
         tr_println!("setup-ssh-added-host-agent", indent = "  ");
     } else {
@@ -267,7 +288,12 @@ fn add_trusted_ca_to_known_hosts(ca_path: &std::path::Path, host_patterns: &str)
         .write(true)
         .truncate(true)
         .open(&lock_path)
-        .with_context(|| tr_args!("setup-ssh-err-lock-file", path = lock_path.display()))?;
+        .with_context(|| {
+            tr_args!(
+                "setup-ssh-err-lock-file",
+                path = lock_path.display().to_string()
+            )
+        })?;
 
     #[cfg(unix)]
     {

--- a/crates/vouch-cli/src/commands/setup/ssh.rs
+++ b/crates/vouch-cli/src/commands/setup/ssh.rs
@@ -6,6 +6,7 @@
 use anyhow::{Context, Result};
 use std::fs;
 use std::path::PathBuf;
+use vouch_cli::{tr, tr_args, tr_println};
 use vouch_common::SshCaPublicKeyResponse;
 
 use crate::client::VouchClient;
@@ -14,19 +15,19 @@ use vouch_common::fs::{atomic_write, atomic_write_secure};
 
 /// Get the SSH config path (~/.ssh/config).
 pub(crate) fn ssh_config_path() -> Result<PathBuf> {
-    let home = dirs::home_dir().context("could not determine home directory")?;
+    let home = dirs::home_dir().with_context(|| tr!("setup-err-no-home"))?;
     Ok(home.join(".ssh").join("config"))
 }
 
 /// Get the known hosts path (~/.ssh/known_hosts).
 fn known_hosts_path() -> Result<PathBuf> {
-    let home = dirs::home_dir().context("could not determine home directory")?;
+    let home = dirs::home_dir().with_context(|| tr!("setup-err-no-home"))?;
     Ok(home.join(".ssh").join("known_hosts"))
 }
 
 /// Get the CA public key path.
 fn ca_key_path(server: &str) -> Result<PathBuf> {
-    let home = dirs::home_dir().context("could not determine home directory")?;
+    let home = dirs::home_dir().with_context(|| tr!("setup-err-no-home"))?;
     // Sanitize server URL for filename: strip scheme, replace non-alphanumeric with underscores,
     // and collapse multiple underscores. e.g. "https://us.vouch.sh" → "vouch_ca_us_vouch_sh.pub"
     let safe_host = server
@@ -53,7 +54,7 @@ fn ca_key_path(server: &str) -> Result<PathBuf> {
 
 /// Get the default SSH key path (~/.ssh/id_ed25519_vouch).
 fn default_key_path() -> Result<PathBuf> {
-    let home = dirs::home_dir().context("could not determine home directory")?;
+    let home = dirs::home_dir().with_context(|| tr!("setup-err-no-home"))?;
     Ok(home.join(".ssh").join("id_ed25519_vouch"))
 }
 
@@ -69,11 +70,11 @@ pub(crate) async fn run(server: &str, hosts: Option<&str>) -> Result<()> {
     let client = VouchClient::new(server).await?;
 
     // Download CA public key
-    println!("Downloading SSH CA public key from server...");
+    tr_println!("setup-ssh-downloading-ca");
     let ca_response: SshCaPublicKeyResponse = client
         .get_authenticated("/v1/credentials/ssh/ca")
         .await
-        .context("failed to get SSH CA public key")?;
+        .with_context(|| tr!("setup-ssh-err-get-ca"))?;
 
     // Save CA public key
     let ca_path = ca_key_path(server)?;
@@ -85,8 +86,8 @@ pub(crate) async fn run(server: &str, hosts: Option<&str>) -> Result<()> {
     }
 
     atomic_write(&ca_path, ca_content.as_bytes())
-        .with_context(|| format!("failed to write {}", ca_path.display()))?;
-    println!("Saved CA public key: {}", ca_path.display());
+        .with_context(|| tr_args!("setup-ssh-err-write-ca", path = ca_path.display()))?;
+    tr_println!("setup-ssh-saved-ca", path = ca_path.display());
 
     // If hosts are specified, add TrustedUserCAKeys entry to known_hosts
     if let Some(host_patterns) = hosts {
@@ -97,28 +98,7 @@ pub(crate) async fn run(server: &str, hosts: Option<&str>) -> Result<()> {
     configure_ssh_config(hosts)?;
 
     println!();
-    println!("SSH CA setup complete!");
-    println!();
-    println!("To trust user certificates signed by this CA, configure your SSH servers:");
-    println!();
-    println!("  1. Copy the CA public key to each server:");
-    println!(
-        "     scp {} root@server:/etc/ssh/vouch_ca.pub",
-        ca_path.display()
-    );
-    println!();
-    println!("  2. Create /etc/ssh/sshd_config.d/99-vouch-ca.conf with:");
-    println!();
-    println!("     TrustedUserCAKeys /etc/ssh/vouch_ca.pub");
-    println!();
-    println!("  3. Validate the configuration and reload sshd:");
-    println!();
-    println!("     sudo sshd -t && sudo systemctl reload sshd");
-    println!();
-    println!("Users can then authenticate with:");
-    println!("  vouch login");
-    println!("  vouch credential ssh");
-    println!("  ssh user@server");
+    tr_println!("setup-ssh-complete-block", ca_path = ca_path.display());
 
     Ok(())
 }
@@ -154,7 +134,7 @@ fn configure_ssh_config(hosts: Option<&str>) -> Result<()> {
     // Read existing config
     let existing = if config_path.exists() {
         fs::read_to_string(&config_path)
-            .with_context(|| format!("failed to read {}", config_path.display()))?
+            .with_context(|| tr_args!("setup-ssh-err-read-config", path = config_path.display()))?
     } else {
         String::new()
     };
@@ -183,11 +163,13 @@ fn configure_ssh_config(hosts: Option<&str>) -> Result<()> {
         if existing.ends_with('\n') {
             rewritten.push('\n');
         }
-        atomic_write_secure(&config_path, rewritten.as_bytes())
-            .with_context(|| format!("failed to write {}", config_path.display()))?;
-        println!(
-            "Updated stale Vouch IdentityAgent path in {} -> {agent_socket}",
-            config_path.display()
+        atomic_write_secure(&config_path, rewritten.as_bytes()).with_context(|| {
+            tr_args!("setup-ssh-err-write-config", path = config_path.display())
+        })?;
+        tr_println!(
+            "setup-ssh-stale-agent-rewrite",
+            config_path = config_path.display(),
+            agent_socket = &agent_socket,
         );
         rewritten
     } else {
@@ -196,7 +178,7 @@ fn configure_ssh_config(hosts: Option<&str>) -> Result<()> {
 
     // Check if Vouch config already exists
     if existing.contains("# Vouch SSH Configuration") || existing.contains(&agent_socket) {
-        println!("SSH config already configured for Vouch");
+        tr_println!("setup-ssh-already-configured");
         return Ok(());
     }
 
@@ -235,19 +217,13 @@ Host *
 
     let new_config = format!("{existing}{vouch_config}");
     atomic_write_secure(&config_path, new_config.as_bytes())
-        .with_context(|| format!("failed to write {}", config_path.display()))?;
+        .with_context(|| tr_args!("setup-ssh-err-write-config", path = config_path.display()))?;
 
-    println!("Updated SSH config: {}", config_path.display());
+    tr_println!("setup-ssh-updated-config", path = config_path.display());
     if hosts.is_some() {
-        println!("  Added Vouch IdentityAgent for specified hosts");
+        tr_println!("setup-ssh-added-host-agent", indent = "  ");
     } else {
-        println!("  Added Vouch IdentityFile and CertificateFile");
-        println!(
-            "  Note: IdentityAgent not set globally to avoid conflicts with other SSH agents."
-        );
-        println!(
-            "  To use the Vouch agent for specific hosts, re-run with: vouch setup ssh --hosts \"pattern\""
-        );
+        tr_println!("setup-ssh-added-identity-block", indent = "  ");
     }
 
     Ok(())
@@ -265,16 +241,15 @@ fn add_trusted_ca_to_known_hosts(ca_path: &std::path::Path, host_patterns: &str)
     let ca_pub_key = ca_pub_key
         .lines()
         .next()
-        .context("CA public key file is empty")?
+        .with_context(|| tr!("setup-ssh-err-ca-empty"))?
         .split_whitespace()
         .take(2)
         .collect::<Vec<_>>()
         .join(" ");
     if ca_pub_key.is_empty() {
-        return Err(crate::exit_code::CliError::ConfigError(
-            "CA public key file does not contain a valid key".to_string(),
-        )
-        .into());
+        return Err(
+            crate::exit_code::CliError::ConfigError(tr!("setup-ssh-err-ca-invalid")).into(),
+        );
     }
 
     // Create entry
@@ -292,7 +267,7 @@ fn add_trusted_ca_to_known_hosts(ca_path: &std::path::Path, host_patterns: &str)
         .write(true)
         .truncate(true)
         .open(&lock_path)
-        .with_context(|| format!("failed to open lock file {}", lock_path.display()))?;
+        .with_context(|| tr_args!("setup-ssh-err-lock-file", path = lock_path.display()))?;
 
     #[cfg(unix)]
     {
@@ -303,7 +278,7 @@ fn add_trusted_ca_to_known_hosts(ca_path: &std::path::Path, host_patterns: &str)
 
     lock_file
         .lock()
-        .context("failed to acquire known_hosts lock")?;
+        .with_context(|| tr!("setup-ssh-err-lock-acquire"))?;
 
     // Read existing known_hosts under the lock
     let existing = if known_hosts_path.exists() {
@@ -314,7 +289,7 @@ fn add_trusted_ca_to_known_hosts(ca_path: &std::path::Path, host_patterns: &str)
 
     // Check if entry already exists
     if existing.contains(&ca_pub_key) {
-        println!("CA already trusted in known_hosts");
+        tr_println!("setup-ssh-ca-already-trusted");
         // Lock released on drop
         drop(lock_file);
         return Ok(());
@@ -327,7 +302,7 @@ fn add_trusted_ca_to_known_hosts(ca_path: &std::path::Path, host_patterns: &str)
     // Lock released on drop
     drop(lock_file);
 
-    println!("Added CA to known_hosts for hosts: {}", host_patterns);
+    tr_println!("setup-ssh-added-ca-trust", hosts = host_patterns);
 
     Ok(())
 }

--- a/crates/vouch-cli/src/commands/setup/ssm.rs
+++ b/crates/vouch-cli/src/commands/setup/ssm.rs
@@ -29,13 +29,15 @@ pub(crate) const DEFAULT_HOST_PATTERN: &str = "i-* mi-*";
 /// and question marks. This covers AWS profile names, regions, and SSH host glob
 /// patterns while rejecting shell metacharacters and SSH config injection.
 fn validate_shell_safe(value: &str, label: &str) -> Result<()> {
+    use vouch_cli::tr_args;
+
     if value.is_empty() {
-        bail!("{label} must not be empty");
+        bail!(tr_args!("setup-ssm-err-empty", label = label));
     }
 
     // Reject newlines (SSH config directive injection)
     if value.contains('\n') || value.contains('\r') {
-        bail!("{label} must not contain newline characters");
+        bail!(tr_args!("setup-ssm-err-newline", label = label));
     }
 
     // Allow only safe characters
@@ -48,11 +50,11 @@ fn validate_shell_safe(value: &str, label: &str) -> Result<()> {
             && ch != '?'
             && ch != ' '
         {
-            bail!(
-                "{label} contains invalid character '{ch}'. \
-                 Only alphanumeric characters, spaces, underscores, hyphens, dots, \
-                 asterisks, and question marks are allowed."
-            );
+            bail!(tr_args!(
+                "setup-ssm-err-invalid-char",
+                label = label,
+                char = ch
+            ));
         }
     }
 
@@ -62,11 +64,7 @@ fn validate_shell_safe(value: &str, label: &str) -> Result<()> {
 /// Check that `session-manager-plugin` is installed and on PATH.
 fn check_session_manager_plugin() -> Result<()> {
     if !ssm_integration::is_plugin_available() {
-        bail!(
-            "session-manager-plugin not found on PATH.\n\n\
-             Install it from:\n  \
-             https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html"
-        );
+        bail!(vouch_cli::tr!("setup-ssm-err-plugin-missing"));
     }
     Ok(())
 }
@@ -152,12 +150,16 @@ pub(crate) async fn run(
     validate_shell_safe(&region_name, "--region")?;
     validate_shell_safe(host_pattern, "--hosts")?;
 
-    println!("AWS SSM Setup");
-    println!("=============");
+    use vouch_cli::{tr_args, tr_println};
+
+    tr_println!("setup-ssm-header");
     println!();
-    println!("Profile:  {profile_name}");
-    println!("Region:   {region_name}");
-    println!("Hosts:    {host_pattern}");
+    tr_println!(
+        "setup-ssm-summary",
+        profile = &profile_name,
+        region = &region_name,
+        hosts = host_pattern,
+    );
     println!();
 
     // Read existing SSH config
@@ -170,7 +172,7 @@ pub(crate) async fn run(
 
     let existing = if config_path.exists() {
         fs::read_to_string(&config_path)
-            .with_context(|| format!("failed to read {}", config_path.display()))?
+            .with_context(|| tr_args!("setup-ssm-err-read", path = config_path.display()))?
     } else {
         String::new()
     };
@@ -178,7 +180,7 @@ pub(crate) async fn run(
     // Check for existing Vouch SSM configuration (idempotency)
     if existing.contains(SSM_MARKER) {
         if !force {
-            println!("SSH config already contains Vouch SSM configuration.");
+            tr_println!("setup-ssm-already-configured");
 
             // Show existing configuration details
             if let Some(proxy_line) = existing
@@ -186,10 +188,10 @@ pub(crate) async fn run(
                 .find(|l| l.contains("aws ssm start-session"))
             {
                 if let Some(p) = ssm_integration::extract_flag_value(proxy_line, "--profile") {
-                    println!("  Profile: {p}");
+                    tr_println!("setup-ssm-existing-profile", indent = "  ", value = p);
                 }
                 if let Some(r) = ssm_integration::extract_flag_value(proxy_line, "--region") {
-                    println!("  Region:  {r}");
+                    tr_println!("setup-ssm-existing-region", indent = "  ", value = r);
                 }
             }
             // Show host pattern from the Host line
@@ -198,22 +200,23 @@ pub(crate) async fn run(
                     let trimmed = rest.trim();
                     // Only show the host line that follows our marker
                     if !trimmed.is_empty() && trimmed != "*" {
-                        println!("  Hosts:   {trimmed}");
+                        tr_println!("setup-ssm-existing-hosts", indent = "  ", value = trimmed);
                         break;
                     }
                 }
             }
 
             println!();
-            println!(
-                "To reconfigure, re-run with --force or remove the '{SSM_MARKER}' block from {}.",
-                config_path.display()
+            tr_println!(
+                "setup-ssm-reconfigure-hint",
+                marker = SSM_MARKER,
+                path = config_path.display(),
             );
             return Ok(());
         }
 
         // --force: strip the existing block before appending the new one
-        println!("Replacing existing Vouch SSM configuration (--force).");
+        tr_println!("setup-ssm-replacing");
         println!();
     }
 
@@ -228,23 +231,14 @@ pub(crate) async fn run(
 
     let new_config = format!("{base}{ssm_config}");
     atomic_write_secure(&config_path, new_config.as_bytes())
-        .with_context(|| format!("failed to write {}", config_path.display()))?;
+        .with_context(|| tr_args!("setup-ssm-err-write", path = config_path.display()))?;
 
-    println!("Updated SSH config: {}", config_path.display());
+    tr_println!("setup-ssm-result-block", path = config_path.display());
     println!();
-    println!("To use:");
-    println!("  vouch login");
-    println!("  ssh ec2-user@i-0abc123def456");
-    println!();
-    println!("Prerequisites:");
-    println!("  1. Run 'vouch login' to authenticate");
-    println!("  2. EC2 instances must have the SSM agent installed and an IAM instance");
-    println!("     profile with SSM permissions");
-    println!();
-    println!("To undo:");
-    println!(
-        "  Remove the '{SSM_MARKER}' block from {}",
-        config_path.display()
+    tr_println!(
+        "setup-ssm-undo",
+        marker = SSM_MARKER,
+        path = config_path.display()
     );
 
     Ok(())

--- a/crates/vouch-cli/src/commands/setup/ssm.rs
+++ b/crates/vouch-cli/src/commands/setup/ssm.rs
@@ -53,7 +53,7 @@ fn validate_shell_safe(value: &str, label: &str) -> Result<()> {
             bail!(tr_args!(
                 "setup-ssm-err-invalid-char",
                 label = label,
-                char = ch
+                char = ch.to_string()
             ));
         }
     }
@@ -156,8 +156,8 @@ pub(crate) async fn run(
     println!();
     tr_println!(
         "setup-ssm-summary",
-        profile = &profile_name,
-        region = &region_name,
+        profile = profile_name.as_str(),
+        region = region_name.as_str(),
         hosts = host_pattern,
     );
     println!();
@@ -171,8 +171,12 @@ pub(crate) async fn run(
     }
 
     let existing = if config_path.exists() {
-        fs::read_to_string(&config_path)
-            .with_context(|| tr_args!("setup-ssm-err-read", path = config_path.display()))?
+        fs::read_to_string(&config_path).with_context(|| {
+            tr_args!(
+                "setup-ssm-err-read",
+                path = config_path.display().to_string()
+            )
+        })?
     } else {
         String::new()
     };
@@ -210,7 +214,7 @@ pub(crate) async fn run(
             tr_println!(
                 "setup-ssm-reconfigure-hint",
                 marker = SSM_MARKER,
-                path = config_path.display(),
+                path = config_path.display().to_string(),
             );
             return Ok(());
         }
@@ -230,15 +234,22 @@ pub(crate) async fn run(
     };
 
     let new_config = format!("{base}{ssm_config}");
-    atomic_write_secure(&config_path, new_config.as_bytes())
-        .with_context(|| tr_args!("setup-ssm-err-write", path = config_path.display()))?;
+    atomic_write_secure(&config_path, new_config.as_bytes()).with_context(|| {
+        tr_args!(
+            "setup-ssm-err-write",
+            path = config_path.display().to_string()
+        )
+    })?;
 
-    tr_println!("setup-ssm-result-block", path = config_path.display());
+    tr_println!(
+        "setup-ssm-result-block",
+        path = config_path.display().to_string()
+    );
     println!();
     tr_println!(
         "setup-ssm-undo",
         marker = SSM_MARKER,
-        path = config_path.display()
+        path = config_path.display().to_string()
     );
 
     Ok(())

--- a/crates/vouch-cli/src/commands/status.rs
+++ b/crates/vouch-cli/src/commands/status.rs
@@ -14,6 +14,7 @@ use crate::integrations::{
     LABEL_WIDTH, SshIntegration, SsmIntegration, print_integration_status,
 };
 use crate::style;
+use vouch_cli::{tr, tr_args};
 
 /// Output format for the status command.
 #[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
@@ -161,8 +162,8 @@ async fn agent_status(server: &str, mode: OutputFormat) -> Result<bool> {
                 mode,
                 true,
                 None,
-                &style::bold_red("Not authenticated."),
-                "Run 'vouch login' to authenticate.",
+                &style::bold_red(&tr!("status-not-authenticated")),
+                &tr!("status-hint-login"),
             );
             Ok(true)
         }
@@ -171,8 +172,8 @@ async fn agent_status(server: &str, mode: OutputFormat) -> Result<bool> {
                 mode,
                 true,
                 Some(0),
-                &style::bold_red("Session expired."),
-                "Run 'vouch login' to re-authenticate.",
+                &style::bold_red(&tr!("status-session-expired")),
+                &tr!("status-hint-relogin"),
             );
             Ok(true)
         }
@@ -193,8 +194,8 @@ async fn server_status(server: &str, mode: OutputFormat) -> Result<()> {
             mode,
             false,
             None,
-            &style::bold_red("Not authenticated."),
-            "Run 'vouch login' to authenticate.",
+            &style::bold_red(&tr!("status-not-authenticated")),
+            &tr!("status-hint-login"),
         );
         return Ok(());
     }
@@ -225,8 +226,8 @@ async fn server_status(server: &str, mode: OutputFormat) -> Result<()> {
                 if status.authenticated {
                     print_server_session(server, &status).await?;
                 } else {
-                    println!("{}", style::bold_red("Session expired."));
-                    println!("\n{}", style::dim("Run 'vouch login' to re-authenticate."));
+                    println!("{}", style::bold_red(&tr!("status-session-expired")));
+                    println!("\n{}", style::dim(&tr!("status-hint-relogin")));
                 }
             }
         },
@@ -235,8 +236,8 @@ async fn server_status(server: &str, mode: OutputFormat) -> Result<()> {
                 mode,
                 false,
                 None,
-                &format!("{}: {e}", style::bold_red("Session invalid")),
-                "Run 'vouch login' to re-authenticate.",
+                &style::bold_red(&tr_args!("status-session-invalid", reason = e)),
+                &tr!("status-hint-relogin"),
             );
         }
     }
@@ -246,27 +247,27 @@ async fn server_status(server: &str, mode: OutputFormat) -> Result<()> {
 
 /// Print a human-readable report for a server-verified session (no agent).
 async fn print_server_session(server: &str, status: &SessionStatus) -> Result<()> {
-    println!("{} ({server})", style::bold_green("Authenticated"));
+    println!(
+        "{} ({server})",
+        style::bold_green(&tr!("status-authenticated"))
+    );
     if let Some(email) = &status.email {
-        println!("  {:LABEL_WIDTH$} {email}", "Email:");
+        println!("  {:LABEL_WIDTH$} {email}", tr!("status-label-email"));
     }
     if let Some(device) = &status.device_name {
-        println!("  {:LABEL_WIDTH$} {device}", "Device:");
+        println!("  {:LABEL_WIDTH$} {device}", tr!("status-label-device"));
     }
     if let Some(expires_in) = status.expires_in_seconds {
         print_expiry(expires_in)?;
     }
     println!(
         "  {:LABEL_WIDTH$} {}",
-        "Agent:",
-        style::yellow("not running")
+        tr!("status-label-agent"),
+        style::yellow(&tr!("status-agent-not-running"))
     );
     println!();
     print_all_integrations(server).await;
-    println!(
-        "\n{}",
-        style::dim("Hint: Start the agent for faster status checks: vouch-agent --foreground")
-    );
+    println!("\n{}", style::dim(&tr!("status-hint-start-agent")));
     Ok(())
 }
 
@@ -280,10 +281,21 @@ async fn get_session_from_agent() -> vouch_agent::Result<SessionInfo> {
 /// Print session info from agent.
 #[cfg(unix)]
 fn print_agent_session(server: &str, session: &SessionInfo) -> Result<()> {
-    println!("{} ({server})", style::bold_green("Authenticated"));
-    println!("  {:LABEL_WIDTH$} {}", "Email:", session.user_email);
+    println!(
+        "{} ({server})",
+        style::bold_green(&tr!("status-authenticated"))
+    );
+    println!(
+        "  {:LABEL_WIDTH$} {}",
+        tr!("status-label-email"),
+        session.user_email
+    );
     print_expiry(session.expires_in_seconds)?;
-    println!("  {:LABEL_WIDTH$} {}", "Agent:", style::green("running"));
+    println!(
+        "  {:LABEL_WIDTH$} {}",
+        tr!("status-label-agent"),
+        style::green(&tr!("status-agent-running"))
+    );
     Ok(())
 }
 
@@ -323,7 +335,7 @@ fn print_expiry(expires_in: u64) -> Result<()> {
         );
     }
 
-    let label = "Expires:";
+    let label = tr!("status-label-expires");
 
     let color_fn: fn(&str) -> String = if expires_in > 3600 {
         style::green

--- a/crates/vouch-cli/src/commands/status.rs
+++ b/crates/vouch-cli/src/commands/status.rs
@@ -236,7 +236,10 @@ async fn server_status(server: &str, mode: OutputFormat) -> Result<()> {
                 mode,
                 false,
                 None,
-                &style::bold_red(&tr_args!("status-session-invalid", reason = e)),
+                &style::bold_red(&tr_args!(
+                    "status-session-invalid",
+                    reason = format!("{e:#}")
+                )),
                 &tr!("status-hint-relogin"),
             );
         }

--- a/crates/vouch-cli/src/fido2/unix.rs
+++ b/crates/vouch-cli/src/fido2/unix.rs
@@ -172,9 +172,10 @@ impl YubiKey {
     /// Returns immediately if a device is found, or an error if not.
     #[expect(dead_code, reason = "used by binary target, not the library")]
     pub(crate) fn discover() -> Result<Self> {
+        use crate::tr;
+
         let cfg = LibCfg::init();
-        let device = FidoKeyHidFactory::create(&cfg)
-            .context("no YubiKey found - please insert your YubiKey")?;
+        let device = FidoKeyHidFactory::create(&cfg).with_context(|| tr!("fido2-err-no-device"))?;
 
         Ok(Self { device })
     }
@@ -184,6 +185,7 @@ impl YubiKey {
     /// Prompts the user to insert their device and polls every 500ms.
     /// A `timeout_secs` of 0 means wait indefinitely.
     pub fn wait_for_device(timeout_secs: u64) -> Result<Self> {
+        use crate::{tr, tr_args};
         use std::io::{Write, stdout};
         use std::thread;
         use std::time::{Duration, Instant};
@@ -196,7 +198,7 @@ impl YubiKey {
         }
 
         // Prompt user and wait
-        print!("Please insert your YubiKey... ");
+        print!("{} ", tr!("fido2-insert-prompt"));
         stdout().flush().ok();
 
         let start = Instant::now();
@@ -210,7 +212,7 @@ impl YubiKey {
             thread::sleep(Duration::from_millis(500));
 
             if let Ok(device) = FidoKeyHidFactory::create(&cfg) {
-                println!("detected!");
+                println!("{}", tr!("fido2-detected"));
                 let key = Self { device };
                 key.wait_until_ready()?;
                 return Ok(key);
@@ -220,10 +222,7 @@ impl YubiKey {
                 && start.elapsed() >= t
             {
                 println!();
-                bail!(
-                    "Timed out waiting for YubiKey after {timeout_secs}s. \
-                     Insert your key and try again."
-                );
+                bail!(tr_args!("fido2-err-insert-prompt", timeout = timeout_secs));
             }
         }
     }
@@ -234,6 +233,7 @@ impl YubiKey {
     /// channel. This method retries a lightweight query until the device is ready
     /// rather than using a fixed delay.
     fn wait_until_ready(&self) -> Result<()> {
+        use crate::tr;
         use std::thread;
         use std::time::Duration;
 
@@ -244,7 +244,7 @@ impl YubiKey {
                 Err(_) => thread::sleep(Duration::from_millis(200)),
             }
         }
-        bail!("YubiKey not ready after insertion - try removing and reinserting it")
+        bail!(tr!("fido2-err-not-ready"))
     }
 
     /// Check if a PIN is configured on this `YubiKey`.
@@ -254,12 +254,14 @@ impl YubiKey {
     /// - `Ok(false)` if no PIN is set (user needs to create one)
     /// - `Err` if PIN is not supported or device communication failed
     pub(crate) fn is_pin_set(&self) -> Result<bool> {
+        use crate::tr;
+
         match with_suppressed_stdout(|| self.device.enable_info_option(&InfoOption::ClientPin))
-            .context("failed to query PIN status")?
+            .with_context(|| tr!("fido2-err-pin-query"))?
         {
             Some(true) => Ok(true),
             Some(false) => Ok(false),
-            None => bail!("This device does not support PIN authentication"),
+            None => bail!(tr!("fido2-err-pin-unsupported")),
         }
     }
 
@@ -268,9 +270,10 @@ impl YubiKey {
     /// Returns the count of attempts before the PIN is blocked.
     #[expect(dead_code, reason = "used by binary target, not the library")]
     pub(crate) fn pin_retries(&self) -> Result<i32> {
+        use crate::tr;
         self.device
             .get_pin_retries()
-            .context("failed to get PIN retry count")
+            .with_context(|| tr!("fido2-err-pin-retries"))
     }
 
     /// Set a new PIN on a `YubiKey` that doesn't have one configured.
@@ -278,17 +281,16 @@ impl YubiKey {
     /// # Errors
     /// Returns an error if a PIN is already set (use `change_pin` instead).
     pub(crate) fn set_new_pin(&self, pin: &str) -> Result<()> {
+        use crate::{tr, tr_args};
+
         self.device.set_new_pin(pin).map_err(|e| {
             let err_str = e.to_string();
             if err_str.contains("0x37") || err_str.contains("PIN_POLICY") {
-                anyhow::anyhow!(
-                    "PIN does not meet requirements.\n\
-                     PIN must be at least 8 characters."
-                )
+                anyhow::anyhow!(tr!("fido2-pin-policy-block"))
             } else if err_str.contains("already set") || err_str.contains("clientPin is true") {
-                anyhow::anyhow!("A PIN is already set on this YubiKey.")
+                anyhow::anyhow!(tr!("fido2-err-pin-already-set"))
             } else {
-                anyhow::anyhow!("Failed to set PIN: {e}")
+                anyhow::anyhow!(tr_args!("fido2-err-pin-set-failed", reason = e))
             }
         })
     }
@@ -296,9 +298,10 @@ impl YubiKey {
     /// Change the PIN on a `YubiKey`.
     #[expect(dead_code, reason = "used by binary target, not the library")]
     pub(crate) fn change_pin(&self, current_pin: &str, new_pin: &str) -> Result<()> {
+        use crate::tr;
         self.device
             .change_pin(current_pin, new_pin)
-            .context("failed to change PIN")
+            .with_context(|| tr!("fido2-err-pin-change"))
     }
 
     /// Perform FIDO2 registration (`make_credential`) with an explicit PIN.
@@ -354,7 +357,7 @@ impl YubiKey {
         // Verify the attestation locally
         let verify_result = verifier::verify_attestation(rp_id, &client_data_json, &attestation);
         if !verify_result.is_success {
-            bail!("attestation verification failed");
+            bail!(crate::tr!("fido2-err-attestation"));
         }
 
         Ok(RegistrationResult {
@@ -394,10 +397,7 @@ impl YubiKey {
                 // Check if it's a "no credentials" error vs a PIN error
                 let err_str = e.to_string();
                 if err_str.contains("0x2E") || err_str.contains("NO_CREDENTIALS") {
-                    anyhow::anyhow!(
-                        "No credentials found for this service.\n\
-                         Have you enrolled with `vouch enroll`?"
-                    )
+                    anyhow::anyhow!(crate::tr!("fido2-err-no-credentials"))
                 } else {
                     translate_fido2_error(e, "FIDO2 authentication")
                 }
@@ -406,16 +406,11 @@ impl YubiKey {
         let assertion = assertions
             .into_iter()
             .next()
-            .context("no assertion returned")?;
+            .with_context(|| crate::tr!("fido2-err-no-assertion"))?;
 
         // Discoverable credentials must return a user handle
         if assertion.user.id.is_empty() {
-            bail!(
-                "Your YubiKey has a credential for this service, \
-                 but it was not stored as a passkey.\n\
-                 Re-enroll with `vouch enroll` to create a \
-                 compatible credential."
-            );
+            bail!(crate::tr!("fido2-err-not-passkey"));
         }
 
         Ok(AuthenticationResult {
@@ -466,8 +461,9 @@ impl FidoDevice for YubiKey {
     reason = "used by binary target; lint fires inconsistently across compilation targets"
 )]
 fn prompt_pin() -> Result<SecretString> {
-    eprint!("YubiKey PIN: ");
-    let pin = rpassword::read_password().context("failed to read PIN")?;
+    use crate::tr;
+    eprint!("{} ", tr!("fido2-pin-prompt"));
+    let pin = rpassword::read_password().with_context(|| tr!("fido2-err-read-pin"))?;
     Ok(SecretString::from(pin))
 }
 
@@ -476,76 +472,54 @@ fn prompt_pin() -> Result<SecretString> {
 /// The ctap-hid-fido2 library returns error messages containing CTAP2 error codes.
 /// This function provides more helpful guidance for common PIN-related errors.
 fn translate_fido2_error(err: anyhow::Error, operation: &str) -> anyhow::Error {
+    use crate::{tr, tr_args};
+
     let err_str = err.to_string();
 
     // CTAP2_ERR_CREDENTIAL_EXCLUDED: authenticator already holds a
     // credential from the exclude list for this RP.
     if err_str.contains("0x19") || err_str.contains("CREDENTIAL_EXCLUDED") {
-        return anyhow::anyhow!("This YubiKey is already registered for this service.");
+        return anyhow::anyhow!(tr!("fido2-err-credential-excluded"));
     }
 
-    // Check for specific CTAP2 PIN errors in the error string
     if err_str.contains("0x31") || err_str.contains("PIN_INVALID") {
-        return anyhow::anyhow!(
-            "Incorrect PIN. Please try again.\n\
-             Hint: Too many wrong attempts will lock your YubiKey."
-        );
+        return anyhow::anyhow!(tr!("fido2-err-pin-invalid"));
     }
 
     if err_str.contains("0x32") || err_str.contains("PIN_BLOCKED") {
-        return anyhow::anyhow!(
-            "Your YubiKey PIN is blocked due to too many \
-             incorrect attempts.\n\
-             You must reset the FIDO2 application to continue:\n\
-             \n\
-             WARNING: This will delete all FIDO2 credentials \
-             on this YubiKey!\n\
-             \n\
-             Option 1: ykman fido reset  \
-             (install: brew install ykman)\n\
-             Option 2: Use the YubiKey Manager GUI app to \
-             reset FIDO2\n\
-             \n\
-             After reset, run `vouch enroll` to re-register \
-             your YubiKey."
-        );
+        return anyhow::anyhow!(tr!("fido2-err-pin-blocked"));
     }
 
     if err_str.contains("0x33") || err_str.contains("PIN_AUTH_INVALID") {
-        return anyhow::anyhow!("PIN authentication failed. Please try again.");
+        return anyhow::anyhow!(tr!("fido2-err-pin-auth-invalid"));
     }
 
     if err_str.contains("0x34") || err_str.contains("PIN_AUTH_BLOCKED") {
-        return anyhow::anyhow!(
-            "PIN authentication is temporarily blocked.\n\
-             Please unplug your YubiKey and plug it back in, then try again."
-        );
+        return anyhow::anyhow!(tr!("fido2-err-pin-auth-blocked"));
     }
 
     if err_str.contains("0x35") || err_str.contains("PIN_NOT_SET") {
-        return anyhow::anyhow!(
-            "Your YubiKey PIN is not set. \
-             This is unexpected — try running this command again."
-        );
+        return anyhow::anyhow!(tr!("fido2-err-pin-not-set"));
     }
 
     if err_str.contains("0x36") || err_str.contains("PIN_REQUIRED") {
-        return anyhow::anyhow!("A PIN is required for this operation.");
+        return anyhow::anyhow!(tr!("fido2-err-pin-required"));
     }
 
     if err_str.contains("0x37") || err_str.contains("PIN_POLICY") {
-        return anyhow::anyhow!(
-            "PIN does not meet policy requirements.\n\
-             PIN must be at least 8 characters."
-        );
+        return anyhow::anyhow!(tr!("fido2-err-pin-policy"));
     }
 
     if err_str.contains("0x38") || err_str.contains("PIN_TOKEN_EXPIRED") {
-        return anyhow::anyhow!("PIN authentication expired. Please try again.");
+        return anyhow::anyhow!(tr!("fido2-err-pin-token-expired"));
     }
 
     // Generic fallback with the operation context
-    anyhow::anyhow!("{operation} failed: {err}")
+    anyhow::anyhow!(tr_args!(
+        "fido2-err-generic",
+        operation = operation,
+        reason = err
+    ))
 }
 
 /// Prompt for a new PIN with confirmation.
@@ -560,30 +534,32 @@ fn translate_fido2_error(err: anyhow::Error, operation: &str) -> anyhow::Error {
     reason = "used by binary target; lint fires inconsistently across compilation targets"
 )]
 fn prompt_new_pin() -> Result<SecretString> {
+    use crate::tr;
     use std::io::{Write, stderr};
 
     loop {
-        eprint!("New PIN (minimum 8 characters): ");
+        eprint!("{} ", tr!("fido2-pin-prompt-new"));
         stderr().flush().ok();
-        let pin = rpassword::read_password().context("failed to read PIN")?;
+        let pin = rpassword::read_password().with_context(|| tr!("fido2-err-read-pin"))?;
 
         // Validate PIN length
         if pin.len() < 8 {
-            eprintln!("PIN must be at least 8 characters.");
+            eprintln!("{}", tr!("fido2-pin-err-too-short"));
             continue;
         }
         if pin.len() > 63 {
-            eprintln!("PIN must be at most 63 characters.");
+            eprintln!("{}", tr!("fido2-pin-err-too-long"));
             continue;
         }
 
         // Confirm PIN
-        eprint!("Confirm PIN: ");
+        eprint!("{} ", tr!("fido2-pin-prompt-confirm"));
         stderr().flush().ok();
-        let confirm = rpassword::read_password().context("failed to read PIN confirmation")?;
+        let confirm =
+            rpassword::read_password().with_context(|| tr!("fido2-err-read-pin-confirmation"))?;
 
         if pin != confirm {
-            eprintln!("PINs do not match. Please try again.\n");
+            eprintln!("{}\n", tr!("fido2-pin-err-mismatch"));
             continue;
         }
 
@@ -599,6 +575,8 @@ fn prompt_new_pin() -> Result<SecretString> {
     reason = "used by binary target; lint fires inconsistently across compilation targets"
 )]
 pub(crate) fn ensure_pin_configured(key: &YubiKey) -> Result<SecretString> {
+    use crate::{tr, tr_println};
+
     if key.is_pin_set()? {
         // PIN is already set, just prompt for it
         return prompt_pin();
@@ -606,17 +584,14 @@ pub(crate) fn ensure_pin_configured(key: &YubiKey) -> Result<SecretString> {
 
     // No PIN set - guide user through setup
     println!();
-    println!("Your YubiKey does not have a PIN configured.");
-    println!("A PIN is required for FIDO2 authentication to prove you are present.");
-    println!();
-    println!("Let's set one up now.");
+    tr_println!("fido2-setup-pin-intro");
     println!();
 
     let pin = prompt_new_pin()?;
 
-    print!("Setting PIN... ");
+    print!("{} ", tr!("fido2-setting-pin"));
     key.set_new_pin(pin.expose_secret())?;
-    println!("done!");
+    tr_println!("fido2-setting-pin-done");
     println!();
 
     Ok(pin)

--- a/crates/vouch-cli/src/fido2/unix.rs
+++ b/crates/vouch-cli/src/fido2/unix.rs
@@ -290,7 +290,10 @@ impl YubiKey {
             } else if err_str.contains("already set") || err_str.contains("clientPin is true") {
                 anyhow::anyhow!(tr!("fido2-err-pin-already-set"))
             } else {
-                anyhow::anyhow!(tr_args!("fido2-err-pin-set-failed", reason = e))
+                anyhow::anyhow!(tr_args!(
+                    "fido2-err-pin-set-failed",
+                    reason = format!("{e:#}")
+                ))
             }
         })
     }
@@ -518,7 +521,7 @@ fn translate_fido2_error(err: anyhow::Error, operation: &str) -> anyhow::Error {
     anyhow::anyhow!(tr_args!(
         "fido2-err-generic",
         operation = operation,
-        reason = err
+        reason = format!("{err:#}")
     ))
 }
 

--- a/crates/vouch-cli/src/fido2/unix.rs
+++ b/crates/vouch-cli/src/fido2/unix.rs
@@ -185,7 +185,7 @@ impl YubiKey {
     /// Prompts the user to insert their device and polls every 500ms.
     /// A `timeout_secs` of 0 means wait indefinitely.
     pub fn wait_for_device(timeout_secs: u64) -> Result<Self> {
-        use crate::{tr, tr_args};
+        use crate::{tr, tr_args, tr_println};
         use std::io::{Write, stdout};
         use std::thread;
         use std::time::{Duration, Instant};
@@ -212,7 +212,7 @@ impl YubiKey {
             thread::sleep(Duration::from_millis(500));
 
             if let Ok(device) = FidoKeyHidFactory::create(&cfg) {
-                println!("{}", tr!("fido2-detected"));
+                tr_println!("fido2-detected");
                 let key = Self { device };
                 key.wait_until_ready()?;
                 return Ok(key);
@@ -537,7 +537,7 @@ fn translate_fido2_error(err: anyhow::Error, operation: &str) -> anyhow::Error {
     reason = "used by binary target; lint fires inconsistently across compilation targets"
 )]
 fn prompt_new_pin() -> Result<SecretString> {
-    use crate::tr;
+    use crate::{tr, tr_eprintln};
     use std::io::{Write, stderr};
 
     loop {
@@ -547,11 +547,11 @@ fn prompt_new_pin() -> Result<SecretString> {
 
         // Validate PIN length
         if pin.len() < 8 {
-            eprintln!("{}", tr!("fido2-pin-err-too-short"));
+            tr_eprintln!("fido2-pin-err-too-short");
             continue;
         }
         if pin.len() > 63 {
-            eprintln!("{}", tr!("fido2-pin-err-too-long"));
+            tr_eprintln!("fido2-pin-err-too-long");
             continue;
         }
 

--- a/crates/vouch-cli/src/fido2/windows.rs
+++ b/crates/vouch-cli/src/fido2/windows.rs
@@ -494,33 +494,28 @@ const ERROR_TIMEOUT_HRESULT: u32 = 0x8007_05B4;
 
 /// Translate a WebAuthn HRESULT into a user-friendly error.
 fn translate_webauthn_error(hr: windows::core::HRESULT, op: &str) -> anyhow::Error {
+    use crate::{tr, tr_args};
+
     // Bit-pattern-preserving conversion i32 → u32 (HRESULT is wrapped i32).
     let code = u32::from_ne_bytes(hr.0.to_ne_bytes());
     let detail = webauthn_error_message(hr);
 
     match code {
-        NTE_USER_CANCELLED => anyhow::anyhow!("Authentication cancelled."),
-        NTE_DEVICE_NOT_FOUND => anyhow::anyhow!(
-            "No security key found.\n\
-             Insert your YubiKey and try again."
-        ),
-        NTE_TOKEN_KEYSET_STORAGE_FULL => anyhow::anyhow!(
-            "Your YubiKey has no free passkey slots.\n\
-             Delete an existing credential with `ykman fido credentials delete` and try again."
-        ),
-        ERROR_TIMEOUT_HRESULT => anyhow::anyhow!(
-            "Timed out waiting for YubiKey.\n\
-             Insert your key and try again."
-        ),
-        NTE_NOT_SUPPORTED => anyhow::anyhow!(
-            "Your authenticator does not support resident keys or user verification.\n\
-             vouch requires a YubiKey 5 or later with PIN configured."
-        ),
-        NTE_INVALID_PARAMETER => anyhow::anyhow!(
-            "Internal error: invalid WebAuthn parameter (HRESULT 0x{code:08x}). \
-             Please file a bug at https://github.com/vouch-sh/vouch/issues."
-        ),
-        _ => anyhow::anyhow!("{op} failed: 0x{code:08x} {detail}"),
+        NTE_USER_CANCELLED => anyhow::anyhow!(tr!("webauthn-err-cancelled")),
+        NTE_DEVICE_NOT_FOUND => anyhow::anyhow!(tr!("webauthn-err-device-not-found")),
+        NTE_TOKEN_KEYSET_STORAGE_FULL => anyhow::anyhow!(tr!("webauthn-err-keyset-full")),
+        ERROR_TIMEOUT_HRESULT => anyhow::anyhow!(tr!("webauthn-err-timeout")),
+        NTE_NOT_SUPPORTED => anyhow::anyhow!(tr!("webauthn-err-not-supported")),
+        NTE_INVALID_PARAMETER => anyhow::anyhow!(tr_args!(
+            "webauthn-err-invalid-parameter",
+            code = format!("{code:08x}"),
+        )),
+        _ => anyhow::anyhow!(tr_args!(
+            "webauthn-err-generic",
+            operation = op,
+            code = format!("{code:08x}"),
+            detail = detail,
+        )),
     }
 }
 

--- a/crates/vouch-cli/src/i18n/mod.rs
+++ b/crates/vouch-cli/src/i18n/mod.rs
@@ -1,0 +1,474 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! Internationalization (i18n) for the CLI.
+//!
+//! All `i18n-embed` / Fluent usage is confined to this module behind the
+//! [`tr!`] / [`tr_args!`] / [`tr_println!`] / [`tr_eprintln!`] macros. Call
+//! sites never reference `i18n-embed` types — keeping the translation backend
+//! swappable in one place.
+//!
+//! Locale is resolved exactly once at process start in [`init`] (which calls
+//! [`validate_startup`]) and cached in [`I18N`]. Resolution order:
+//!
+//! 1. `--lang <BCP-47>` global CLI flag
+//! 2. `VOUCH_LANG` environment variable
+//! 3. `LC_ALL` → `LC_MESSAGES` → `LANG`
+//! 4. OS default via [`sys_locale::get_locale`]
+//! 5. `en-US` fallback
+//!
+//! Because [`tr!`] expressions are embedded directly in clap derive
+//! attributes (`#[command(about = tr!(...))]`), [`init`] must run *before*
+//! `Cli::parse()`. A small [`preresolve_lang_from_argv_and_env`] pre-scan
+//! reads `--lang` straight from `argv` so the locale is known before clap
+//! does any work.
+
+use std::ffi::OsStr;
+use std::sync::OnceLock;
+
+use i18n_embed::LanguageLoader;
+use i18n_embed::fluent::FluentLanguageLoader;
+use unic_langid::{LanguageIdentifier, langid};
+
+/// Embedded Fluent catalogs, one `i18n/<lang>/vouch_cli.ftl` per language.
+#[derive(rust_embed::RustEmbed)]
+#[folder = "i18n/"]
+struct Localizations;
+
+/// Process-wide loader holding every embedded catalog. Built once; never
+/// mutated after [`init`] runs.
+pub(crate) static LOADER: std::sync::LazyLock<FluentLanguageLoader> =
+    std::sync::LazyLock::new(|| {
+        vouch_i18n::build_loader("vouch-cli", langid!("en-US"), &Localizations)
+    });
+
+/// Process-wide negotiated context. Installed exactly once by [`init`].
+static I18N: OnceLock<I18nContext> = OnceLock::new();
+
+/// Required message ids that must resolve at startup — packaging guard. Add
+/// new entries here when a new code path depends on a catalog key being
+/// present.
+const REQUIRED_IDS: &[&str] = &[
+    "cli-about",
+    "cli-long-about",
+    "cli-after-help",
+    "cli-lang-help",
+    "cli-verbose-help",
+    "cli-server-help",
+    "cli-color-help",
+];
+
+/// CLI translation context. Wraps a selected [`FluentLanguageLoader`] and
+/// caches the negotiated BCP-47 tag.
+#[derive(Clone)]
+pub struct I18nContext {
+    loader: std::sync::Arc<FluentLanguageLoader>,
+    lang: String,
+}
+
+impl I18nContext {
+    fn from_loader(loader: FluentLanguageLoader) -> Self {
+        let lang = loader.current_language().to_string();
+        Self {
+            loader: std::sync::Arc::new(loader),
+            lang,
+        }
+    }
+
+    /// Translate a message with no arguments.
+    pub fn t(&self, id: &str) -> String {
+        self.loader.get(id)
+    }
+
+    /// Translate a message with the supplied Fluent placeable arguments.
+    pub fn ta(&self, id: &str, args: &[(&str, &str)]) -> String {
+        let map: std::collections::HashMap<&str, &str> = args.iter().copied().collect();
+        self.loader.get_args(id, map)
+    }
+
+    /// BCP-47 tag of the negotiated language.
+    pub fn lang(&self) -> &str {
+        &self.lang
+    }
+
+    /// Borrow the underlying loader. Used by the [`crate::tr!`] /
+    /// [`crate::tr_args!`] macros to call [`i18n_embed_fl::fl!`] against the
+    /// negotiated locale; not a stable consumer API.
+    #[doc(hidden)]
+    pub fn loader(&self) -> &FluentLanguageLoader {
+        &self.loader
+    }
+}
+
+/// Resolve the user's preferred locale once and install it as the
+/// process-wide [`I18nContext`].
+///
+/// # Errors
+///
+/// Returns the underlying [`vouch_i18n::validate_startup`] error if the
+/// embedded `en-US` catalog is missing or any [`REQUIRED_IDS`] key fails to
+/// resolve. Safe to call only once; later calls are no-ops.
+pub fn init(requested: Option<LanguageIdentifier>) -> anyhow::Result<()> {
+    vouch_i18n::validate_startup(&LOADER, &Localizations, REQUIRED_IDS)?;
+    let langs: Vec<LanguageIdentifier> = requested.into_iter().collect();
+    let loader = vouch_i18n::select_loader(&LOADER, &langs);
+    let ctx = I18nContext::from_loader(loader);
+    // Setting the OnceLock can only fail if `init` was called twice; a benign
+    // double-init is a no-op rather than an error, so the second call drops
+    // its built context and the first context wins.
+    if I18N.set(ctx).is_err() {
+        tracing::debug!("vouch_cli::i18n::init called more than once; ignoring later call");
+    }
+    Ok(())
+}
+
+/// Borrow the process-wide [`I18nContext`], falling back to a fresh
+/// en-US-only context if [`init`] hasn't run. The fallback exists so a
+/// `tr!()` call from a panic handler or early-init path never crashes — code
+/// paths that depend on the user's negotiated locale must run after
+/// [`init`].
+pub fn ctx() -> I18nContext {
+    if let Some(ctx) = I18N.get() {
+        return ctx.clone();
+    }
+    let loader = vouch_i18n::select_loader(&LOADER, &[]);
+    I18nContext::from_loader(loader)
+}
+
+/// Negotiate the preferred locale from CLI args (the value of `--lang`) and
+/// the process environment. Pure: takes only borrowed inputs, touches no
+/// globals.
+///
+/// Resolution order matches the module-level doc comment. Returns `None`
+/// only when every source is empty or unparseable; callers fall back to the
+/// loader's `en-US` default in that case.
+pub fn negotiate(
+    cli_lang: Option<&str>,
+    env: impl Fn(&str) -> Option<String>,
+    os_locale: impl Fn() -> Option<String>,
+) -> Option<LanguageIdentifier> {
+    let candidates = [
+        cli_lang.map(str::to_owned),
+        env("VOUCH_LANG"),
+        env("LC_ALL"),
+        env("LC_MESSAGES"),
+        env("LANG"),
+        os_locale(),
+    ];
+    for raw in candidates.into_iter().flatten() {
+        // POSIX locale strings often carry `.UTF-8` or `@modifier` suffixes;
+        // strip them so `en_US.UTF-8` parses as `en-US`.
+        let trimmed = raw
+            .split(['.', '@'])
+            .next()
+            .unwrap_or(&raw)
+            .replace('_', "-");
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Ok(lang) = trimmed.parse::<LanguageIdentifier>() {
+            return Some(lang);
+        }
+    }
+    None
+}
+
+/// Pre-scan `argv` for `--lang <value>` / `--lang=<value>` and fold in the
+/// environment-based negotiation. This runs *before* `Cli::parse()` so the
+/// locale is known when clap evaluates the `tr!()` expressions inside derive
+/// attributes.
+///
+/// Only the `--lang` flag is recognized — any other argument is ignored.
+/// `--` halts scanning so `vouch -- --lang foo` (for a passthrough command)
+/// does not pick up `--lang` from the trailing args.
+pub fn preresolve_lang_from_argv_and_env() -> Option<LanguageIdentifier> {
+    let cli_lang = preresolve_cli_lang(std::env::args_os());
+    negotiate(
+        cli_lang.as_deref(),
+        |key| std::env::var(key).ok(),
+        sys_locale::get_locale,
+    )
+}
+
+fn preresolve_cli_lang<I, S>(args: I) -> Option<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let mut iter = args.into_iter();
+    // Skip the program name.
+    let _ = iter.next();
+    while let Some(raw) = iter.next() {
+        let arg = raw.as_ref().to_str()?;
+        if arg == "--" {
+            return None;
+        }
+        if let Some(value) = arg.strip_prefix("--lang=") {
+            return Some(value.to_owned());
+        }
+        if arg == "--lang" {
+            return iter
+                .next()
+                .and_then(|next| next.as_ref().to_str().map(str::to_owned));
+        }
+    }
+    None
+}
+
+/// Translate a message id with no arguments. Returns the locale-resolved
+/// `String`; safe to embed directly in `clap` derive attributes (`about =
+/// tr!("cli-about")`) because clap's `Arg::help` / `Command::about` accept
+/// `impl IntoResettable<StyledStr>`, which is implemented for `String`.
+///
+/// The id is checked at *compile time* against the `en-US` catalog
+/// (`crates/vouch-cli/i18n/en-US/vouch_cli.ftl`) via the
+/// [`i18n_embed_fl::fl!`] macro — a typo or missing key fails the build, not
+/// a startup probe. The runtime call uses the negotiated [`I18nContext`] so
+/// the user's locale is honored.
+#[macro_export]
+macro_rules! tr {
+    ($id:literal) => {{
+        let __ctx = $crate::i18n::ctx();
+        ::i18n_embed_fl::fl!(__ctx.loader(), $id)
+    }};
+}
+
+/// Translate a message id with Fluent placeable arguments. `name = value`
+/// pairs; values may be any `Display` type (`&str`, `String`, `Uuid`,
+/// integers, …) — the macro stringifies via `ToString` before handing them
+/// to Fluent so call sites stay uncluttered. Same compile-time-check
+/// guarantee as [`tr!`] for both message id and argument names.
+#[macro_export]
+macro_rules! tr_args {
+    ($id:literal, $($name:ident = $value:expr),+ $(,)?) => {{
+        let __ctx = $crate::i18n::ctx();
+        ::i18n_embed_fl::fl!(__ctx.loader(), $id, $($name = ($value).to_string()),+)
+    }};
+}
+
+/// Print a translated message to stdout.
+#[macro_export]
+macro_rules! tr_println {
+    ($id:literal) => { println!("{}", $crate::tr!($id)) };
+    ($id:literal, $($name:ident = $value:expr),+ $(,)?) => {
+        println!("{}", $crate::tr_args!($id, $($name = $value),+))
+    };
+}
+
+/// Print a translated message to stderr.
+#[macro_export]
+macro_rules! tr_eprintln {
+    ($id:literal) => { eprintln!("{}", $crate::tr!($id)) };
+    ($id:literal, $($name:ident = $value:expr),+ $(,)?) => {
+        eprintln!("{}", $crate::tr_args!($id, $($name = $value),+))
+    };
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code may panic on setup failure"
+)]
+mod tests {
+    use super::*;
+
+    fn no_env(_: &str) -> Option<String> {
+        None
+    }
+    fn no_os_locale() -> Option<String> {
+        None
+    }
+
+    #[test]
+    fn cli_lang_wins_over_env() {
+        let lang = negotiate(
+            Some("fr-FR"),
+            |k| (k == "VOUCH_LANG").then(|| "ja-JP".to_owned()),
+            no_os_locale,
+        )
+        .unwrap();
+        assert_eq!(lang.to_string(), "fr-FR");
+    }
+
+    #[test]
+    fn vouch_lang_wins_over_lc_all() {
+        let lang = negotiate(
+            None,
+            |k| match k {
+                "VOUCH_LANG" => Some("ja-JP".to_owned()),
+                "LC_ALL" => Some("fr-FR".to_owned()),
+                _ => None,
+            },
+            no_os_locale,
+        )
+        .unwrap();
+        assert_eq!(lang.to_string(), "ja-JP");
+    }
+
+    #[test]
+    fn lc_all_wins_over_lc_messages_and_lang() {
+        let lang = negotiate(
+            None,
+            |k| match k {
+                "LC_ALL" => Some("fr-FR".to_owned()),
+                "LC_MESSAGES" => Some("ja-JP".to_owned()),
+                "LANG" => Some("de-DE".to_owned()),
+                _ => None,
+            },
+            no_os_locale,
+        )
+        .unwrap();
+        assert_eq!(lang.to_string(), "fr-FR");
+    }
+
+    #[test]
+    fn lc_messages_wins_over_lang() {
+        let lang = negotiate(
+            None,
+            |k| match k {
+                "LC_MESSAGES" => Some("ja-JP".to_owned()),
+                "LANG" => Some("de-DE".to_owned()),
+                _ => None,
+            },
+            no_os_locale,
+        )
+        .unwrap();
+        assert_eq!(lang.to_string(), "ja-JP");
+    }
+
+    #[test]
+    fn lang_wins_over_os_locale() {
+        let lang = negotiate(
+            None,
+            |k| (k == "LANG").then(|| "ja-JP".to_owned()),
+            || Some("de-DE".to_owned()),
+        )
+        .unwrap();
+        assert_eq!(lang.to_string(), "ja-JP");
+    }
+
+    #[test]
+    fn os_locale_used_when_env_empty() {
+        let lang = negotiate(None, no_env, || Some("ja-JP".to_owned())).unwrap();
+        assert_eq!(lang.to_string(), "ja-JP");
+    }
+
+    #[test]
+    fn posix_locale_suffix_stripped() {
+        let lang = negotiate(None, |_| Some("en_US.UTF-8".to_owned()), no_os_locale).unwrap();
+        assert_eq!(lang.to_string(), "en-US");
+    }
+
+    #[test]
+    fn posix_locale_modifier_stripped() {
+        let lang = negotiate(None, |_| Some("ca_ES@valencia".to_owned()), no_os_locale).unwrap();
+        // unic-langid accepts ca-ES; modifier was dropped.
+        assert!(lang.to_string().starts_with("ca-ES"));
+    }
+
+    #[test]
+    fn unparseable_falls_through() {
+        let lang = negotiate(Some("not-a-locale!!!"), no_env, || Some("ja-JP".to_owned())).unwrap();
+        assert_eq!(lang.to_string(), "ja-JP");
+    }
+
+    #[test]
+    fn empty_everywhere_returns_none() {
+        assert!(negotiate(None, no_env, no_os_locale).is_none());
+    }
+
+    #[test]
+    fn preresolve_cli_lang_space_form() {
+        let argv: Vec<&OsStr> = ["vouch", "--lang", "fr-FR", "enroll"]
+            .iter()
+            .map(OsStr::new)
+            .collect();
+        assert_eq!(preresolve_cli_lang(argv), Some("fr-FR".to_owned()));
+    }
+
+    #[test]
+    fn preresolve_cli_lang_equals_form() {
+        let argv: Vec<&OsStr> = ["vouch", "--lang=fr-FR", "enroll"]
+            .iter()
+            .map(OsStr::new)
+            .collect();
+        assert_eq!(preresolve_cli_lang(argv), Some("fr-FR".to_owned()));
+    }
+
+    #[test]
+    fn preresolve_cli_lang_stops_at_double_dash() {
+        let argv: Vec<&OsStr> = ["vouch", "--", "--lang", "fr-FR"]
+            .iter()
+            .map(OsStr::new)
+            .collect();
+        assert_eq!(preresolve_cli_lang(argv), None);
+    }
+
+    #[test]
+    fn preresolve_cli_lang_absent_returns_none() {
+        let argv: Vec<&OsStr> = ["vouch", "enroll"].iter().map(OsStr::new).collect();
+        assert_eq!(preresolve_cli_lang(argv), None);
+    }
+
+    #[test]
+    fn validate_startup_passes_with_embedded_catalog() {
+        vouch_i18n::validate_startup(&LOADER, &Localizations, REQUIRED_IDS).unwrap();
+    }
+
+    #[test]
+    fn cli_about_resolves() {
+        let loader = vouch_i18n::select_loader(&LOADER, &[]);
+        let about = loader.get("cli-about");
+        assert!(
+            !about.starts_with("No localization") && about != "cli-about",
+            "cli-about should resolve to a string, got {about:?}"
+        );
+    }
+
+    /// Walk the catalog: every multi-segment lowercase kebab-case key parsed
+    /// from `vouch-cli.ftl` must resolve at startup. Mirrors the server's
+    /// `every_template_key_is_defined` test and catches typos that
+    /// [`REQUIRED_IDS`] doesn't cover. The cost is one runtime probe per id;
+    /// when the catalog grows past a thousand keys, switch this to a
+    /// compile-time check via `fl!()` only.
+    #[test]
+    fn every_catalog_key_resolves() {
+        let ftl = std::fs::read_to_string(format!(
+            "{}/i18n/en-US/vouch-cli.ftl",
+            env!("CARGO_MANIFEST_DIR")
+        ))
+        .unwrap();
+        let loader = vouch_i18n::select_loader(&LOADER, &[]);
+        for line in ftl.lines() {
+            if line.trim_start() != line {
+                continue;
+            }
+            let Some((left, _)) = line.split_once('=') else {
+                continue;
+            };
+            let id = left.trim();
+            if id.is_empty() {
+                continue;
+            }
+            // Fluent terms (e.g. `-yubikey`) start with `-` and are only
+            // reachable via `{ -term }` references inside other messages —
+            // never via `loader.get()`. Skip them.
+            if id.starts_with('-') {
+                continue;
+            }
+            if !id
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+            {
+                continue;
+            }
+            if !id.contains('-') {
+                continue;
+            }
+            let resolved = loader.get(id);
+            assert!(
+                !resolved.starts_with("No localization for id"),
+                "catalog id `{id}` does not resolve",
+            );
+        }
+    }
+}

--- a/crates/vouch-cli/src/i18n/mod.rs
+++ b/crates/vouch-cli/src/i18n/mod.rs
@@ -73,17 +73,6 @@ impl I18nContext {
         }
     }
 
-    /// Translate a message with no arguments.
-    pub fn t(&self, id: &str) -> String {
-        self.loader.get(id)
-    }
-
-    /// Translate a message with the supplied Fluent placeable arguments.
-    pub fn ta(&self, id: &str, args: &[(&str, &str)]) -> String {
-        let map: std::collections::HashMap<&str, &str> = args.iter().copied().collect();
-        self.loader.get_args(id, map)
-    }
-
     /// BCP-47 tag of the negotiated language.
     pub fn lang(&self) -> &str {
         &self.lang
@@ -232,15 +221,27 @@ macro_rules! tr {
 }
 
 /// Translate a message id with Fluent placeable arguments. `name = value`
-/// pairs; values may be any `Display` type (`&str`, `String`, `Uuid`,
-/// integers, …) — the macro stringifies via `ToString` before handing them
-/// to Fluent so call sites stay uncluttered. Same compile-time-check
-/// guarantee as [`tr!`] for both message id and argument names.
+/// pairs; each value is forwarded to Fluent via `Into<FluentValue>`, so the
+/// dispatch matches `i18n-embed-fl`'s native contract:
+///
+/// - integer and float primitives become `FluentValue::Number`, engaging CLDR
+///   plural categories so `{ $count -> [one] 1 account *[other] N accounts }`
+///   selects the singular arm when `count = 1`.
+/// - `&str`, `String`, `&String`, and `Cow<'_, str>` become
+///   `FluentValue::String`, matched by exact variant-key equality (e.g. the
+///   `[true]` / `[false]` arms used for boolean selectors).
+/// - anything else (`bool`, `Path::Display`, `anyhow::Error`,
+///   `reqwest::StatusCode`, jiff timestamps, identifiers like a PID that
+///   should not be locale-grouped) must be stringified at the call site with
+///   `.to_string()` or `format!()` — the compiler will tell you.
+///
+/// Same compile-time-check guarantee as [`tr!`] for both message id and
+/// argument names.
 #[macro_export]
 macro_rules! tr_args {
     ($id:literal, $($name:ident = $value:expr),+ $(,)?) => {{
         let __ctx = $crate::i18n::ctx();
-        ::i18n_embed_fl::fl!(__ctx.loader(), $id, $($name = ($value).to_string()),+)
+        ::i18n_embed_fl::fl!(__ctx.loader(), $id, $($name = $value),+)
     }};
 }
 
@@ -470,5 +471,37 @@ mod tests {
                 "catalog id `{id}` does not resolve",
             );
         }
+    }
+
+    /// Locks in the contract that numeric arg values flow through
+    /// `FluentValue::Number`, so CLDR plural rules pick `[one]` for count = 1
+    /// and `*[other]` for count = 2. The bug this guards against: a previous
+    /// `tr_args!` macro stringified every value, so `[one]` never matched and
+    /// summary lines always read "1 accounts".
+    #[test]
+    fn aws_accounts_summary_singular_plural() {
+        let singular = crate::tr_args!("aws-accounts-summary", count = 1_usize);
+        assert!(
+            singular.contains("1 account") && !singular.contains("accounts"),
+            "count = 1 should pick the [one] arm, got {singular:?}"
+        );
+        let plural = crate::tr_args!("aws-accounts-summary", count = 2_usize);
+        assert!(
+            plural.contains("2 accounts"),
+            "count = 2 should pick the [other] arm, got {plural:?}"
+        );
+    }
+
+    /// Locks in the contract that `bool.to_string()` produces strings that
+    /// match the FTL's explicit `[true]` / `[false]` variant arms.
+    #[test]
+    fn github_app_configured_boolean_arms() {
+        let yes = crate::tr_args!("setup-github-app-configured", configured = true.to_string());
+        assert!(yes.contains("Yes"), "true should pick [true], got {yes:?}");
+        let no = crate::tr_args!(
+            "setup-github-app-configured",
+            configured = false.to_string()
+        );
+        assert!(no.contains("No"), "false should pick [false], got {no:?}");
     }
 }

--- a/crates/vouch-cli/src/lib.rs
+++ b/crates/vouch-cli/src/lib.rs
@@ -10,6 +10,7 @@ pub(crate) mod utils;
 pub mod fapi;
 pub mod fido2;
 pub mod http;
+pub mod i18n;
 pub mod posture;
 
 // Re-export commonly used types

--- a/crates/vouch-cli/src/main.rs
+++ b/crates/vouch-cli/src/main.rs
@@ -11,6 +11,15 @@ use anyhow::Result;
 use clap::{CommandFactory, Parser, Subcommand};
 use std::process::ExitCode;
 use tracing_subscriber::EnvFilter;
+// Bring the i18n macros into the binary crate root so submodules under the
+// `vouch` binary (e.g. `fido2/unix.rs`, which is compiled into both the lib
+// and the bin) can reference them as `crate::tr!` regardless of compilation
+// context.
+#[expect(
+    unused_imports,
+    reason = "re-exported so dual-compiled submodules can use `crate::tr*!`"
+)]
+use vouch_cli::{tr, tr_args, tr_eprintln, tr_println};
 
 mod client;
 mod commands;
@@ -171,20 +180,14 @@ async fn check_pnpm_tokenhelper_invocation(argv0: &str) -> Result<bool> {
 #[derive(Parser)]
 #[command(
     name = "vouch",
-    about = "Hardware-backed identity for developers",
+    about = tr!("cli-about"),
+    long_about = tr!("cli-long-about"),
     version,
-    after_help = "Exit codes:\n  \
-        0  Success\n  \
-        1  General error\n  \
-        2  Not authenticated (session expired or missing)\n  \
-        3  Hardware key not detected\n  \
-        4  Network/server unreachable\n  \
-        5  Permission denied\n  \
-        6  Configuration error"
+    after_help = tr!("cli-after-help"),
 )]
 struct Cli {
     /// Vouch server URL.
-    #[arg(long, env = "VOUCH_SERVER", global = true)]
+    #[arg(long, env = "VOUCH_SERVER", global = true, help = tr!("cli-server-help"))]
     server: Option<String>,
 
     /// Allow insecure HTTP connections to non-localhost servers.
@@ -192,11 +195,15 @@ struct Cli {
     allow_insecure: bool,
 
     /// Enable verbose output.
-    #[arg(short, long, global = true)]
+    #[arg(short, long, global = true, help = tr!("cli-verbose-help"))]
     verbose: bool,
 
+    /// Override the user-facing language (BCP-47, e.g. en-US, fr-FR).
+    #[arg(long, env = "VOUCH_LANG", global = true, help = tr!("cli-lang-help"))]
+    lang: Option<String>,
+
     /// Control color output.
-    #[arg(long, global = true, default_value = "auto")]
+    #[arg(long, global = true, default_value = "auto", help = tr!("cli-color-help"))]
     color: style::ColorChoice,
 
     #[command(subcommand)]
@@ -294,43 +301,49 @@ impl RedshiftArgs {
 #[derive(Subcommand)]
 enum Commands {
     /// Enroll with browser-based OIDC + `WebAuthn` (recommended for new users).
+    #[command(about = tr!("cmd-enroll-about"))]
     Enroll,
     /// Register an additional `YubiKey` (requires login first).
+    #[command(about = tr!("cmd-register-about"))]
     Register {
         /// Human-readable name for this `YubiKey` (e.g., "My `YubiKey` 5").
         /// Defaults to "`YubiKey`" if not specified.
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-register-name-help"))]
         name: Option<String>,
         /// Timeout in seconds for YubiKey detection (0 for no timeout).
-        #[arg(long, default_value = "60")]
+        #[arg(long, default_value = "60", help = tr!("arg-register-timeout-help"))]
         timeout: u64,
     },
     /// Authenticate with your `YubiKey`.
+    #[command(about = tr!("cmd-login-about"))]
     Login {
         /// Timeout in seconds for YubiKey detection (0 for no timeout).
-        #[arg(long, default_value = "60")]
+        #[arg(long, default_value = "60", help = tr!("arg-login-timeout-help"))]
         timeout: u64,
     },
     /// Show current session status.
+    #[command(about = tr!("cmd-status-about"))]
     Status {
         /// Output format.
-        #[arg(long, value_enum)]
+        #[arg(long, value_enum, help = tr!("arg-status-format-help"))]
         format: Option<commands::status::OutputFormat>,
     },
     /// End your current session.
+    #[command(about = tr!("cmd-logout-about"))]
     Logout,
     /// Output credential environment variables for `eval`.
     ///
     /// Usage: `eval "$(vouch env --type aws --shell bash --role <ARN>)"`
+    #[command(about = tr!("cmd-env-about"), long_about = tr!("cmd-env-long-about"))]
     Env {
         /// Credential type to export.
-        #[arg(long = "type")]
+        #[arg(long = "type", help = tr!("arg-env-type-help"))]
         credential_type: commands::CredentialType,
         /// Shell syntax to emit.
-        #[arg(long, default_value = "bash")]
+        #[arg(long, default_value = "bash", help = tr!("arg-env-shell-help"))]
         shell: commands::env::Shell,
         /// AWS IAM role ARN (required for --type aws).
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-env-role-help"))]
         role: Option<String>,
         #[command(flatten)]
         codeartifact: CodeArtifactArgs,
@@ -342,24 +355,28 @@ enum Commands {
     /// Output a shell hook for ambient auth status.
     ///
     /// Add `eval "$(vouch init bash)"` to your shell profile.
+    #[command(about = tr!("cmd-init-about"), long_about = tr!("cmd-init-long-about"))]
     Init {
         /// Shell to generate hook for.
+        #[arg(help = tr!("arg-init-shell-help"))]
         shell: commands::init::Shell,
     },
     /// Manage registered security keys.
     ///
     /// Without a subcommand, opens an interactive menu.
+    #[command(about = tr!("cmd-keys-about"), long_about = tr!("cmd-keys-long-about"))]
     Keys {
         #[command(subcommand)]
         command: Option<KeysCommands>,
     },
     /// Run a command with Vouch-provided credentials in the environment.
+    #[command(about = tr!("cmd-exec-about"))]
     Exec {
         /// Credential type to inject.
-        #[arg(long = "type", value_enum)]
+        #[arg(long = "type", value_enum, help = tr!("arg-exec-type-help"))]
         credential_type: commands::CredentialType,
         /// AWS IAM role ARN (required for --type aws).
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-exec-role-help"))]
         role: Option<String>,
         #[command(flatten)]
         codeartifact: CodeArtifactArgs,
@@ -368,39 +385,45 @@ enum Commands {
         #[command(flatten)]
         redshift: RedshiftArgs,
         /// Command and arguments to execute.
-        #[arg(trailing_var_arg = true, required = true)]
+        #[arg(trailing_var_arg = true, required = true, help = tr!("arg-exec-command-help"))]
         command: Vec<String>,
     },
     /// Obtain credentials for various services.
+    #[command(about = tr!("cmd-credential-about"))]
     Credential {
         #[command(subcommand)]
         command: CredentialCommands,
     },
     /// Configure integrations.
+    #[command(about = tr!("cmd-setup-about"))]
     Setup {
         #[command(subcommand)]
         command: SetupCommands,
     },
     /// AWS Identity Center commands for multi-account management.
+    #[command(about = tr!("cmd-aws-about"))]
     Aws {
         #[command(subcommand)]
         command: AwsCommands,
     },
     /// Generate shell completions.
+    #[command(about = tr!("cmd-completions-about"))]
     Completions(commands::completions::CompletionsArgs),
     /// Check your Vouch environment for common issues.
+    #[command(about = tr!("cmd-doctor-about"))]
     Doctor {
         /// Suppress output (exit code only).
-        #[arg(short, long)]
+        #[arg(short, long, help = tr!("arg-doctor-quiet-help"))]
         quiet: bool,
         /// Output as JSON.
-        #[arg(long)]
+        #[arg(long, help = tr!("arg-doctor-json-help"))]
         json: bool,
     },
     /// Show device posture signals (what the CLI detects about this machine).
+    #[command(about = tr!("cmd-posture-about"))]
     Posture {
         /// Output format.
-        #[arg(long, value_enum, default_value = "text")]
+        #[arg(long, value_enum, default_value = "text", help = tr!("arg-posture-format-help"))]
         format: commands::posture::OutputFormat,
     },
     /// Run diagnostic test of YubiKey registration + authentication (bypasses server).
@@ -408,7 +431,11 @@ enum Commands {
     /// Not available on Windows: depends on the CTAP2 protocol which Windows
     /// blocks for non-elevated processes.
     #[cfg(not(target_os = "windows"))]
-    #[command(hide = true)]
+    #[command(
+        about = tr!("cmd-diag-about"),
+        long_about = tr!("cmd-diag-long-about"),
+        hide = true,
+    )]
     Diag(commands::diag::DiagArgs),
 }
 
@@ -515,6 +542,12 @@ async fn run() -> Result<()> {
     if init_and_dispatch_helper_binaries(config.as_ref().ok()).await? {
         return Ok(());
     }
+
+    // Install the negotiated locale into the OnceLock before `Cli::parse()`
+    // expands the `tr!()` calls embedded in the clap derive attributes. The
+    // pre-scan honors `--lang` from argv since clap hasn't parsed it yet.
+    let preferred = vouch_cli::i18n::preresolve_lang_from_argv_and_env();
+    vouch_cli::i18n::init(preferred)?;
 
     let cli = Cli::parse();
 

--- a/crates/vouch-cli/src/main.rs
+++ b/crates/vouch-cli/src/main.rs
@@ -15,10 +15,6 @@ use tracing_subscriber::EnvFilter;
 // `vouch` binary (e.g. `fido2/unix.rs`, which is compiled into both the lib
 // and the bin) can reference them as `crate::tr!` regardless of compilation
 // context.
-#[expect(
-    unused_imports,
-    reason = "re-exported so dual-compiled submodules can use `crate::tr*!`"
-)]
 use vouch_cli::{tr, tr_args, tr_eprintln, tr_println};
 
 mod client;

--- a/crates/vouch-i18n/Cargo.toml
+++ b/crates/vouch-i18n/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "vouch-i18n"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+description = "Locale-agnostic Fluent i18n core shared by the Vouch server, CLI, and agent"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = { workspace = true, features = ["std"] }
+i18n-embed = { workspace = true, features = ["fluent-system", "rust-embed"] }
+tracing = { workspace = true, features = ["std"] }
+unic-langid = { workspace = true, features = ["macros"] }
+
+[dev-dependencies]
+rust-embed = { workspace = true, features = ["debug-embed"] }

--- a/crates/vouch-i18n/Cargo.toml
+++ b/crates/vouch-i18n/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
+fluent-bundle = { workspace = true, features = ["default"] }
 i18n-embed = { workspace = true, features = ["fluent-system", "rust-embed"] }
 tracing = { workspace = true, features = ["std"] }
 unic-langid = { workspace = true, features = ["macros"] }

--- a/crates/vouch-i18n/src/lib.rs
+++ b/crates/vouch-i18n/src/lib.rs
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! Locale-agnostic Fluent i18n core for the Vouch workspace.
+//!
+//! Three helpers shared by the server, CLI, and agent:
+//!
+//! - [`build_loader`] constructs a [`FluentLanguageLoader`] with isolation
+//!   disabled (LTR catalogs only until an RTL language ships).
+//! - [`select_loader`] picks a sub-loader for a list of requested languages,
+//!   falling back to the loader's fallback language when none match.
+//! - [`validate_startup`] refuses to launch if the embedded fallback catalog
+//!   is missing or yields raw message ids for required keys.
+//!
+//! Each binary owns its own `Localizations` `RustEmbed` struct (one
+//! `i18n/<lang>/<domain>.ftl` per shipped language), its own process-wide
+//! `LOADER`, and its own request-scoped or process-scoped context wrapper.
+//! This crate intentionally has no Axum, no HTTP, and no global state — it
+//! plugs into whatever ambient-access pattern the binary uses (task-local,
+//! `OnceLock`, threaded parameter).
+
+use i18n_embed::I18nAssets;
+use i18n_embed::LanguageLoader;
+use i18n_embed::fluent::{FluentLanguageLoader, NegotiationStrategy};
+use unic_langid::{LanguageIdentifier, langid};
+
+pub use i18n_embed;
+pub use unic_langid;
+
+/// Build a process-wide [`FluentLanguageLoader`] for the given Fluent
+/// `domain`, loading every available catalog from `assets`.
+///
+/// Isolation is disabled: Fluent's default behavior wraps every interpolated
+/// value in invisible U+2068/U+2069 bidi marks, which leak into copy-paste
+/// and version strings for LTR-only catalogs. Re-enable when an RTL language
+/// ships and add BiDi-aware tests.
+///
+/// Catalog load failures are logged and the loader is returned with whatever
+/// catalogs did parse — startup health is verified separately by
+/// [`validate_startup`].
+pub fn build_loader(
+    domain: &'static str,
+    fallback: LanguageIdentifier,
+    assets: &dyn I18nAssets,
+) -> FluentLanguageLoader {
+    let loader = FluentLanguageLoader::new(domain, fallback);
+    if let Err(error) = loader.load_available_languages(assets) {
+        tracing::error!(%error, domain, "failed to load i18n catalogs");
+    }
+    loader.set_use_isolating(false);
+    loader
+}
+
+/// Derive a sub-loader for the requested languages from the process-wide
+/// `loader`. If `requested` is empty, the loader's fallback language is
+/// selected so callers always get a usable [`FluentLanguageLoader`].
+///
+/// The returned loader shares catalog data with `loader` via `Arc`; selecting
+/// is cheap.
+pub fn select_loader(
+    loader: &FluentLanguageLoader,
+    requested: &[LanguageIdentifier],
+) -> FluentLanguageLoader {
+    if requested.is_empty() {
+        loader.select_languages(&[loader.fallback_language().clone()])
+    } else {
+        loader.select_languages_negotiate(requested, NegotiationStrategy::Filtering)
+    }
+}
+
+/// Verify the embedded catalogs are healthy and refuse to start otherwise.
+///
+/// Catches three packaging mistakes that would otherwise let a binary boot
+/// with broken localization and render raw Fluent message ids in user-facing
+/// output:
+///
+/// 1. The fallback `en-US` catalog is missing from `assets`.
+/// 2. The fallback catalog failed to parse, so every lookup echoes the id.
+/// 3. A required message id is missing from the catalog.
+///
+/// Call this once during startup, **before** any user-facing output. Binaries
+/// pair it with their own bundle-warm-up or task-local install as needed.
+///
+/// # Errors
+///
+/// Returns `Err` when any of the conditions above are detected.
+pub fn validate_startup(
+    loader: &FluentLanguageLoader,
+    assets: &dyn I18nAssets,
+    required_ids: &[&str],
+) -> anyhow::Result<()> {
+    use anyhow::Context;
+    let available = loader
+        .available_languages(assets)
+        .context("failed to enumerate embedded i18n catalogs")?;
+    anyhow::ensure!(
+        available.contains(&langid!("en-US")),
+        "embedded i18n catalog en-US is missing; refusing to start"
+    );
+    let fallback = select_loader(loader, &[]);
+    for id in required_ids {
+        let probe = fallback.get(id);
+        // `FluentLanguageLoader::get` returns `"No localization for id:
+        // \"{id}\""` when the key is absent from every bundle and echoes the
+        // raw id when the bundle is empty — guard both.
+        anyhow::ensure!(
+            !probe.starts_with("No localization for id") && probe != *id,
+            "i18n catalog missing required key `{id}`; refusing to start"
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code may panic on setup failure"
+)]
+mod tests {
+    use super::*;
+
+    #[derive(rust_embed::RustEmbed)]
+    #[folder = "test-i18n/"]
+    struct TestAssets;
+
+    fn test_loader() -> FluentLanguageLoader {
+        build_loader("vouch_i18n", langid!("en-US"), &TestAssets)
+    }
+
+    #[test]
+    fn build_loader_loads_available_catalogs() {
+        let loader = test_loader();
+        let langs = loader.available_languages(&TestAssets).unwrap();
+        assert!(langs.contains(&langid!("en-US")));
+    }
+
+    #[test]
+    fn select_loader_with_empty_request_picks_fallback() {
+        let loader = test_loader();
+        let selected = select_loader(&loader, &[]);
+        assert_eq!(selected.current_language(), langid!("en-US"));
+    }
+
+    #[test]
+    fn select_loader_with_unknown_request_falls_back() {
+        let loader = test_loader();
+        let selected = select_loader(&loader, &[langid!("zz-ZZ")]);
+        assert_eq!(selected.current_language(), langid!("en-US"));
+    }
+
+    #[test]
+    fn validate_startup_passes_with_known_key() {
+        let loader = test_loader();
+        validate_startup(&loader, &TestAssets, &["probe-key"]).unwrap();
+    }
+
+    #[test]
+    fn validate_startup_fails_when_required_key_missing() {
+        let loader = test_loader();
+        let err = validate_startup(&loader, &TestAssets, &["does-not-exist"]).unwrap_err();
+        assert!(
+            err.to_string().contains("does-not-exist"),
+            "error should name the missing key: {err}"
+        );
+    }
+}

--- a/crates/vouch-i18n/src/lib.rs
+++ b/crates/vouch-i18n/src/lib.rs
@@ -25,6 +25,11 @@ use unic_langid::{LanguageIdentifier, langid};
 pub use i18n_embed;
 pub use unic_langid;
 
+/// Re-exported so downstream crates can build [`FluentValue`]s (for plural
+/// rules / arg dispatch) without taking on `fluent`/`fluent-bundle` as a
+/// direct dep.
+pub use fluent_bundle::FluentValue;
+
 /// Build a process-wide [`FluentLanguageLoader`] for the given Fluent
 /// `domain`, loading every available catalog from `assets`.
 ///

--- a/crates/vouch-i18n/test-i18n/en-US/vouch_i18n.ftl
+++ b/crates/vouch-i18n/test-i18n/en-US/vouch_i18n.ftl
@@ -1,0 +1,1 @@
+probe-key = Probe value

--- a/crates/vouch-server/Cargo.toml
+++ b/crates/vouch-server/Cargo.toml
@@ -96,6 +96,7 @@ urlencoding = { workspace = true }
 uuid = { workspace = true, features = ["v7", "serde", "std"] }
 vouch-common = { workspace = true }
 vouch-httpsig = { workspace = true, features = ["axum"] }
+vouch-i18n = { workspace = true }
 webauthn-rs = { workspace = true, features = ["danger-allow-state-serialisation"] }
 webauthn-rs-proto = { workspace = true }
 x509-cert = { workspace = true, features = ["std", "pem", "builder"] }

--- a/crates/vouch-server/i18n/en-US/vouch.ftl
+++ b/crates/vouch-server/i18n/en-US/vouch.ftl
@@ -6,9 +6,32 @@
 #
 # This is the source-of-truth catalog for BOTH server-rendered templates and
 # the strings injected into static JS (see templates' `js_i18n` blocks).
+#
+# ---------------------------------------------------------------------------
+# Terms (Fluent feature: https://projectfluent.org/fluent/guide/terms.html)
+#   - Reusable nouns referenced as `{ -term-name }` from any message.
+#   - Names match `crates/vouch-cli/i18n/en-US/vouch-cli.ftl` where they
+#     overlap (`-product`, `-yubikey`, `-cmd`) so translators learn one
+#     vocabulary across the CLI and server.
+#   - Changing a term changes the rendered noun everywhere it's referenced.
+# ---------------------------------------------------------------------------
+
+-product = Vouch
+-cmd = vouch
+-yubikey = YubiKey
+-security-key = security key
+-fapi = FAPI 2.0
+-github = GitHub
+-ssh = SSH
+-oauth = OAuth 2.0
+-webauthn = WebAuthn
+-jwks = JWKS
+
+# Reusable noun phrase — appears verbatim in three help texts.
+-one-uri-per-line = One URI per line.
 
 ## Common / layout
-common-app-name = vouch
+common-app-name = { -product }
 common-copy = Copy
 common-save = Save
 common-cancel = Cancel
@@ -19,7 +42,7 @@ common-client-id = Client ID
 common-client-secret = Client Secret
 
 ## Application created (applications/created.html)
-apps-created-page-title = Application Created - Vouch
+apps-created-page-title = Application Created - { -product }
 apps-created-heading = Application Created
 apps-created-save-creds = Save Your Credentials
 apps-created-secret-once = The client secret will only be shown once. Store it securely.
@@ -28,32 +51,37 @@ apps-created-view-all = View All Applications
 
 ## Application error / unauthorized / secret added
 apps-error-go-back = Go Back
-apps-unauth-page-title = Unauthorized - Vouch
+apps-unauth-page-title = Unauthorized - { -product }
 apps-unauth-heading = Sign In Required
 apps-unauth-body = You need to be signed in to manage applications.
 apps-unauth-signin = Sign In
-apps-secret-page-title = Secret Added - Vouch
+apps-secret-page-title = Secret Added - { -product }
 apps-secret-heading = Secret Added
 apps-secret-save = Save Your New Secret
 apps-secret-once = This secret will only be shown once. Copy it now and store it securely.
 apps-secret-new-label = New Client Secret
-apps-secret-back-to = Back to
+# Merged from prior `apps-secret-back-to = Back to` + plain `{{ name }}`.
+apps-secret-back-to = Back to { $name }
 
 ## Application detail (applications/detail.html)
 apps-detail-back = Back to Applications
 apps-detail-delete-confirm = Are you sure you want to delete this application? This action cannot be undone.
 apps-detail-access-scope = Access Scope
 apps-detail-auth-method = Auth Method
-apps-detail-fapi-badge = FAPI 2.0
+apps-detail-fapi-badge = { -fapi }
 apps-detail-fapi-desc = PAR + DPoP + private_key_jwt
 apps-detail-description = Description
 apps-detail-created = Created
 apps-detail-client-keys = Client Keys
-apps-detail-inline-jwks = Inline JWKS
+apps-detail-inline-jwks = Inline { -jwks }
 apps-detail-no-redirect = No redirect URIs configured
 apps-detail-resource-uris = Resource URIs
 apps-detail-client-secrets = Client Secrets
-apps-detail-secrets-suffix = of 2 active
+# Merged from prior `apps-detail-secrets-suffix = of 2 active`. The template
+# wraps this in parens. `$count` is the active-secret count, `$max` is the
+# limit (currently 2; kept as a placeable so a future limit change is a
+# one-line code edit, no catalog change).
+apps-detail-secrets-count = { $count } of { $max } active
 apps-detail-add-secret = Add Secret
 apps-detail-no-secrets = No secrets configured.
 apps-detail-secret-default = Secret
@@ -63,16 +91,16 @@ apps-detail-revoke = Revoke
 apps-detail-revoke-confirm = Revoke this secret? It will no longer be accepted for authentication.
 apps-detail-usage-stats = Usage Statistics
 apps-detail-name = Name
-apps-detail-one-uri = One URI per line
-apps-detail-resource-help = One URI per line. Target resource servers for audience-restricted tokens (RFC 8707).
+apps-detail-one-uri = { -one-uri-per-line }
+apps-detail-resource-help = { -one-uri-per-line } Target resource servers for audience-restricted tokens (RFC 8707).
 apps-detail-standard-desc = Client secret authentication.
 apps-detail-fapi-short-desc = PAR + DPoP + private_key_jwt.
 apps-detail-save-changes = Save Changes
 
 ## Application create form (applications/create.html)
-apps-create-page-title = New Application - Vouch
+apps-create-page-title = New Application - { -product }
 apps-create-heading = Register New Application
-apps-create-subtitle = Create an OAuth application to integrate with Vouch.
+apps-create-subtitle = Create an { -oauth } application to integrate with { -product }.
 apps-create-name-label = Application Name
 apps-create-name-placeholder = My Application
 apps-create-name-help = A friendly name for your application.
@@ -88,34 +116,34 @@ apps-create-type-native-desc = Desktop or mobile app. Uses PKCE, no client secre
 apps-create-type-service = Service / Machine-to-Machine
 apps-create-type-service-desc = Backend service with no user interaction. Uses client credentials.
 apps-create-redirect-label = Redirect URIs
-apps-create-redirect-help = One URI per line. Where users are redirected after authentication.
+apps-create-redirect-help = { -one-uri-per-line } Where users are redirected after authentication.
 apps-create-resource-label = Resource URIs (optional)
-apps-create-resource-help = One URI per line. Target resource servers that will receive access tokens (RFC 8707). Leave empty to allow any resource.
+apps-create-resource-help = { -one-uri-per-line } Target resource servers that will receive access tokens (RFC 8707). Leave empty to allow any resource.
 apps-create-secprofile-label = Security Profile
-apps-create-secprofile-standard = Standard OAuth 2.0
-apps-create-secprofile-standard-desc = Standard OAuth 2.0 with client secret authentication.
-apps-create-secprofile-fapi = FAPI 2.0 Security Profile
+apps-create-secprofile-standard = Standard { -oauth }
+apps-create-secprofile-standard-desc = Standard { -oauth } with client secret authentication.
+apps-create-secprofile-fapi = { -fapi } Security Profile
 apps-create-secprofile-fapi-desc = Enforces PAR, DPoP, and private_key_jwt. No client secret — authentication uses signed JWTs.
-apps-create-fapi-jwks-info = FAPI 2.0 clients authenticate using signed JWTs instead of a client secret. Provide your public keys as a JWKS (inline JSON) or a JWKS URI endpoint.
-apps-create-jwks-label = JWKS (inline JSON)
+apps-create-fapi-jwks-info = { -fapi } clients authenticate using signed JWTs instead of a client secret. Provide your public keys as a { -jwks } (inline JSON) or a { -jwks } URI endpoint.
+apps-create-jwks-label = { -jwks } (inline JSON)
 apps-create-jwks-help = JSON Web Key Set containing your public signing keys.
-apps-create-jwks-uri-label = JWKS URI
-apps-create-jwks-uri-help = HTTPS endpoint serving your JWKS.
+apps-create-jwks-uri-label = { -jwks } URI
+apps-create-jwks-uri-help = HTTPS endpoint serving your { -jwks }.
 apps-create-access-label = Who can use this application?
 apps-create-access-org = Organization members only
 apps-create-access-org-desc = Only users in your organization can authenticate with this app.
 apps-create-access-personal = Only me
 apps-create-access-personal-desc = Only you can authenticate with this app. Good for personal tools.
-apps-create-access-public = Any Vouch user
-apps-create-access-public-desc = Any authenticated Vouch user can use this app.
+apps-create-access-public = Any { -product } user
+apps-create-access-public-desc = Any authenticated { -product } user can use this app.
 
 ## Applications list (applications/list.html)
-apps-list-page-title = My Applications - Vouch
+apps-list-page-title = My Applications - { -product }
 apps-list-heading = My Applications
 apps-list-new = New Application
 apps-list-empty-heading = No applications yet
-apps-list-empty-body = Build internal tools that authenticate users via YubiKey.
-apps-list-empty-detail = Register an OAuth application to get a client ID and secret, then integrate using standard OAuth 2.0 / OIDC flows.
+apps-list-empty-body = Build internal tools that authenticate users via { -yubikey }.
+apps-list-empty-detail = Register an { -oauth } application to get a client ID and secret, then integrate using standard { -oauth } / OIDC flows.
 apps-list-create = Create Application
 apps-list-th-name = Name
 apps-list-th-type = Type
@@ -123,27 +151,37 @@ apps-list-th-scope = Scope
 apps-list-th-status = Status
 apps-list-th-last-used = Last Used
 apps-list-th-actions = Actions
+# Status pill labels are kept as separate ids per the Fluent good-practices
+# rule "Reserve Variants for Grammar/Style Only, Not UI Logic" — these are
+# distinct UI states, not grammatical variants of one message.
 apps-list-status-active = Active
 apps-list-status-inactive = Inactive
 apps-list-never = Never
 apps-list-delete-confirm = Are you sure you want to delete this application?
 
 ## Security keys management (enroll_keys.html, enroll_keys_container.html)
-enroll-keys-page-title = Vouch - Security Keys
+enroll-keys-page-title = { -product } - { -security-key }s
 enroll-keys-heading = Security Keys
 enroll-keys-cli-guidance = You can also manage keys from the command line:
 enroll-keys-empty = No security keys registered yet.
 enroll-keys-register-first = Register Your First Security Key
-enroll-keys-rename-aria = Rename key
-enroll-keys-added-prefix = Added
-enroll-keys-delete-title = Delete key
+# Fluent attribute pattern (https://projectfluent.org/fluent/guide/attributes.html):
+# the value is the action verb; the .aria-label is what a screen reader announces.
+enroll-keys-rename = Rename
+    .aria-label = Rename key
+# Merged from prior `enroll-keys-added-prefix = Added`. `$when` is a rendered
+# timestamp from the template.
+enroll-keys-added = Added { $when }
+# Value is the action; .title is the tooltip a sighted user sees on hover.
+enroll-keys-delete = Delete
+    .title = Delete key
 enroll-keys-add-another = + Add Another Security Key
 
 ## Landing / home (landing.html)
-home-page-title = Vouch - { $org }
-home-welcome = Welcome to Vouch
+home-page-title = { -product } - { $org }
+home-welcome = Welcome to { -product }
 home-tagline = { $org }'s hardware-backed authentication system
-home-subtagline = Login once with your YubiKey. SSH, AWS, and Git work for 8 hours.
+home-subtagline = Login once with your { -yubikey }. { -ssh }, AWS, and Git work for 8 hours.
 home-manage-keys = Manage Security Keys
 home-no-browser-signin = Browser sign-in is not configured. Use the CLI enrollment command below.
 home-sign-in-with = Sign in with { $provider }
@@ -157,25 +195,31 @@ home-feature-shortlived = Short-lived credentials
 home-feature-phishing = Phishing-resistant
 
 ## Login (login.html)
-login-page-title = Vouch - Sign In
+login-page-title = { -product } - Sign In
 login-title = Sign In
+# DOCUMENTED FRAGMENT: paired with a `<span class="font-semibold ...">` styled
+# client name in the template (login.html). Merging into a single message with
+# a `{ $client }` placeable would lose the visual emphasis on the client name,
+# which matters for an OAuth consent screen.
 login-continue-prefix = Sign in to continue to
-login-touch-prompt = Touch your security key to sign in
-login-status-insert = Insert your security key and touch it when it blinks.
-login-button = Sign In with Security Key
+login-touch-prompt = Touch your { -security-key } to sign in
+login-status-insert = Insert your { -security-key } and touch it when it blinks.
+login-button = Sign In with { -security-key }
 login-privacy-policy = Privacy Policy
 login-terms = Terms of Service
+# DOCUMENTED FRAGMENT: followed by an `<a>` link with the `login-enroll-now`
+# text inside (login.html). Cannot merge without losing the link element.
 login-no-account-prefix = Don't have an account?
 login-enroll-now = Enroll now
 login-cert-test-login = Certification Test Login
 login-cert-test-deny = Certification Test Deny
 
 ## Generic error page (error.html)
-error-page-title = Vouch - Error
+error-page-title = { -product } - Error
 error-back = Back
 
 ## Enrollment success (success.html)
-success-page-title = Vouch - Success
+success-page-title = { -product } - Success
 success-heading = Enrollment Complete
 success-body = You can close this window and return to your terminal.
 success-next-label = Next in your terminal
@@ -184,95 +228,112 @@ success-cmd-aws = # AWS credentials
 success-cmd-github = # GitHub tokens
 
 ## Device verification (device_verify.html)
-device-page-title = Vouch - Device Verification
+device-page-title = { -product } - Device Verification
 device-heading = Enter Your Code
 device-body = Enter the code shown in your terminal to continue.
 device-continue = Continue
 
 ## Identity provider chooser (select_idp.html)
-select-idp-page-title = Vouch - Choose Identity Provider
+select-idp-page-title = { -product } - Choose Identity Provider
 select-idp-heading = Choose your identity provider
 select-idp-body = Sign in with the identity provider your organization uses.
 
 ## OAuth authorize / consent (authorize.html)
-authorize-page-title = Sign in - Vouch
+authorize-page-title = Sign in - { -product }
 authorize-heading = Sign in to continue
 authorize-subtitle = Hardware authentication required
-authorize-wants-access = wants to access your Vouch identity
+authorize-wants-access = wants to access your { -product } identity
 authorize-org-app-for = This is an organizational application for
 authorize-org-app = This is an organizational application
-authorize-use-cli = Use the Vouch CLI to authenticate:
+authorize-use-cli = Use the { -product } CLI to authenticate:
 authorize-refresh = Then refresh this page.
 
 ## OAuth access denied (authorize_denied.html)
-authorize-denied-page-title = Access Denied - Vouch
+authorize-denied-page-title = Access Denied - { -product }
 authorize-denied-heading = Access Denied
 authorize-denied-subtitle = You cannot use this application
+# DOCUMENTED FRAGMENT: preceded by `<strong>{{ client_name }}</strong>` in
+# the template. Merging would lose the styled client name.
 authorize-denied-restricted-suffix = has restricted access.
 authorize-denied-contact = If you believe you should have access, contact the application owner.
 
 ## GitHub connect result pages (github/success.html, github/error.html)
-github-success-page-title = Vouch - GitHub Connected
-github-success-heading = GitHub Connected
+github-success-page-title = { -product } - { -github } Connected
+github-success-heading = { -github } Connected
+# DOCUMENTED FRAGMENT: followed by `<span class="text-gray-300 font-medium">`
+# styled account name. Keep split to preserve the visual emphasis.
 github-success-connected-prefix = Successfully connected to
 github-success-next-steps = Next steps for your team:
-github-success-step1 = 1. Configure Git to use Vouch:
+github-success-step1 = 1. Configure Git to use { -product }:
 github-success-step2 = 2. Test with any repository:
 github-success-close = You can close this window.
 github-error-try-again = Try Again
 
 ## GitHub connect page (github/connect.html)
-github-connect-page-title = Vouch - Connect GitHub
-github-connect-heading = Connect GitHub
-github-connect-subtitle = Connect your organization's GitHub account to enable Git credential issuance.
-github-connect-link-heading = Link Your GitHub Account
-github-connect-link-body = To reconnect existing GitHub installations, link your GitHub account to verify your access.
-github-connect-link-button = Link GitHub Account
+github-connect-page-title = { -product } - Connect { -github }
+github-connect-heading = Connect { -github }
+github-connect-subtitle = Connect your organization's { -github } account to enable Git credential issuance.
+github-connect-link-heading = Link Your { -github } Account
+github-connect-link-body = To reconnect existing { -github } installations, link your { -github } account to verify your access.
+github-connect-link-button = Link { -github } Account
 github-connect-reconnect-heading = Reconnect Existing Installations
-github-connect-reconnect-body = These GitHub accounts have the Vouch app installed and you have access to reconnect them:
+github-connect-reconnect-body = These { -github } accounts have the { -product } app installed and you have access to reconnect them:
 github-connect-linked-as = Linked as
-github-connect-connected-heading = Connected GitHub accounts:
-github-connect-connected-more = You can connect additional GitHub organizations below.
+github-connect-connected-heading = Connected { -github } accounts:
+github-connect-connected-more = You can connect additional { -github } organizations below.
 github-connect-next-heading = What happens next:
-github-connect-step1 = You'll be redirected to GitHub to install the Vouch App
-github-connect-step2 = Select which repositories Vouch can access
+github-connect-step1 = You'll be redirected to { -github } to install the { -product } App
+github-connect-step2 = Select which repositories { -product } can access
+# DOCUMENTED FRAGMENT: prefix + `<code>vouch setup github</code>` + suffix in
+# the template (github/connect.html). The `<code>` styling on the command is
+# load-bearing — keeping the command visually distinct from the surrounding
+# instructions is the point of the line.
 github-connect-step3-prefix = Team members can then use
 github-connect-step3-suffix = to configure their machines
 github-connect-perms-heading = Permissions requested:
 github-connect-perm-contents = Repository contents (read/write)
 github-connect-perm-metadata = Repository metadata (read)
-github-connect-button = Connect GitHub
-github-connect-button-another = Connect Another GitHub Account
+github-connect-button = Connect { -github }
+github-connect-button-another = Connect Another { -github } Account
 
 ## Install / developer setup (install.html)
-install-page-title = Developer Setup - Vouch
-install-heading = Get Started with Vouch
-install-subtitle = Install the CLI and enroll your YubiKey
+install-page-title = Developer Setup - { -product }
+install-heading = Get Started with { -product }
+install-subtitle = Install the CLI and enroll your { -yubikey }
 install-prereqs-label = Prerequisites
-install-prereq-key = FIDO2 security key (YubiKey 5 series recommended)
+install-prereq-key = FIDO2 { -security-key } ({ -yubikey } 5 series recommended)
+# DOCUMENTED FRAGMENT: followed by `<code>{{ server_url }}</code>)` in the
+# template — note the message ends with an open paren and the closing paren
+# lives outside `<code>` in the HTML. Splitting preserves the `<code>` style
+# on the server URL.
 install-prereq-server-prefix = Server URL from your admin (or use
 install-step1-title = Install the CLI
 install-win-limited-title = Limited Windows Support
-install-win-limited-body = The Vouch agent and SSH integration are not available on Windows. Only basic authentication and credential exchange are supported.
+install-win-limited-body = The { -product } agent and SSH integration are not available on Windows. Only basic authentication and credential exchange are supported.
+# DOCUMENTED FRAGMENT: prefix + `<a>` releases link + mid + `<code>vouch.exe</code>`
+# + suffix in install.html. The link and the `<code>` for the binary name are
+# load-bearing styling that can't move through a plain placeable.
 install-win-download-prefix = Download the Windows binary from the
 install-win-releases-link = releases page
 install-win-download-mid = , extract the zip file, and add
 install-win-download-suffix = to a directory in your PATH.
 install-win-supported-label = Supported:
 install-download-directly = Or download directly:
-install-step2-title = Enroll your YubiKey
-install-step2-body = This opens a browser to verify your identity and register your YubiKey.
+install-step2-title = Enroll your { -yubikey }
+install-step2-body = This opens a browser to verify your identity and register your { -yubikey }.
 install-step3-title = Daily login
 install-step3-body = After login, your identity is available to SSH, AWS, Git, and other tools automatically.
 
 ## Integrations (integrations.html)
-integrations-page-title = Vouch - Integrations
+integrations-page-title = { -product } - Integrations
 integrations-heading = Integrations
 integrations-subtitle = Manage server-configured integrations.
 integrations-badge-org-wide = Organization-wide
 integrations-badge-per-user = Per-user
-integrations-github-desc = Get short-lived GitHub access tokens for Git operations.
-integrations-github-not-configured = GitHub App not configured on this server.
+integrations-github-desc = Get short-lived { -github } access tokens for Git operations.
+integrations-github-not-configured = { -github } App not configured on this server.
+# DOCUMENTED FRAGMENT: prefix + `<code>VOUCH_GITHUB_APP_*</code>` + suffix in
+# integrations.html. The `<code>` style on the env-var pattern is load-bearing.
 integrations-github-requires-prefix = Requires
 integrations-github-requires-suffix = environment variables.
 integrations-requires-org = Requires organization membership.
@@ -282,18 +343,24 @@ integrations-ask-admin = Ask an org admin
 integrations-connected = Connected:
 integrations-manage = Manage
 integrations-ssh-title = SSH Certificates
-integrations-ssh-desc = Get short-lived SSH certificates signed by Vouch's CA.
+integrations-ssh-desc = Get short-lived SSH certificates signed by { -product }'s CA.
 integrations-ssh-get-cert = Get a certificate:
+# DOCUMENTED FRAGMENT: prefix + `<code>/etc/ssh/ca.pub</code>` + suffix in
+# integrations.html. `<code>` on the path is load-bearing.
 integrations-ssh-capub-prefix = CA public key (add to
 integrations-ssh-capub-suffix = on your servers):
 integrations-ssh-not-configured = SSH CA not configured on this server.
+# DOCUMENTED FRAGMENT: prefix + `<code>VOUCH_SSH_CA_KEY</code>` + mid + `<a>`
+# link + integrations-ssh-guide-link. Code + link styling is load-bearing.
 integrations-ssh-set-prefix = Set
 integrations-ssh-set-mid = to enable. See the
 integrations-ssh-guide-link = key management guide
+# DOCUMENTED FRAGMENT: prefix + `<a>` link with `integrations-setup-guide-link`
+# text. Link element prevents merge.
 integrations-more-prefix = Looking for AWS, EKS, Docker, or other integrations? See the
 integrations-setup-guide-link = setup guide
 
-## Client-side JS strings (injected via the #vouch-i18n JSON data block)
+## Client-side JS strings (injected via the /i18n.js script bundle)
 common-js-copied = Copied!
 webauthn-err-notallowed = Operation was cancelled or timed out. Please try again.
 webauthn-err-security = Security error. Please ensure you are on a secure (HTTPS) connection.
@@ -325,15 +392,18 @@ keys-js-reg-complete-failed = Failed to complete registration
 ## Application form validation — client-side JS (app-create.js, app-detail.js)
 appcreate-js-redirect-required = At least one redirect URI is required.
 appcreate-js-redirect-invalid = Invalid redirect URI(s): { $uris }. Each URI must be a valid http:// or https:// URL.
-appcreate-js-resource-toolong = ... (exceeds maximum length of 2048)
-appcreate-js-resource-fragment = {" "}(must not contain a fragment)
-appcreate-js-resource-scheme = {" "}(must be an absolute URI with a scheme)
+# Per-URI validation errors. Each takes the offending URI as a placeable so JS
+# never concatenates strings around translated text — that pattern previously
+# required a `{ " " }(reason)` leading-space hack in the catalog.
+appcreate-js-resource-fragment-uri = { $uri } must not contain a fragment.
+appcreate-js-resource-scheme-uri = { $uri } must be an absolute URI with a scheme.
+appcreate-js-resource-toolong-uri = { $uri } exceeds the maximum length of 2048 characters.
 appcreate-js-resource-invalid = Invalid resource URI(s): { $errors }.
-appcreate-js-jwks-keys = JWKS must be a JSON object with a non-empty "keys" array.
-appcreate-js-jwks-json = JWKS must be valid JSON.
-appcreate-js-jwksuri-https = JWKS URI must use https://.
-appcreate-js-jwksuri-invalid = JWKS URI must be a valid https:// URL.
-appcreate-js-fapi-required = FAPI 2.0 requires either a JWKS or JWKS URI.
+appcreate-js-jwks-keys = { -jwks } must be a JSON object with a non-empty "keys" array.
+appcreate-js-jwks-json = { -jwks } must be valid JSON.
+appcreate-js-jwksuri-https = { -jwks } URI must use https://.
+appcreate-js-jwksuri-invalid = { -jwks } URI must be a valid https:// URL.
+appcreate-js-fapi-required = { -fapi } requires either a { -jwks } or { -jwks } URI.
 
 ## Authenticated header navigation (macros/auth.html)
 nav-keys = Keys
@@ -351,7 +421,11 @@ admin-nav-domains = Email Domains
 admin-next-page = Next page
 
 ## Admin members (admin/members.html)
-admin-members-page-title = Vouch - Organization Members
+#
+# Each per-row action button uses the Fluent attribute pattern: the value is
+# the visible button label, `.title` is the hover tooltip. Translators see
+# the label and tooltip together (https://projectfluent.org/fluent/guide/attributes.html).
+admin-members-page-title = { -product } - Organization Members
 admin-members-heading = Organization Members
 admin-members-subtitle = Manage members, roles, and credentials.
 admin-members-th-email = Email
@@ -360,26 +434,31 @@ admin-members-th-keys = Keys
 admin-members-you = (you)
 admin-members-role-admin = Admin
 admin-members-role-member = Member
-admin-members-btn-demote = Demote
-admin-members-btn-promote = Promote
-admin-members-btn-deactivate = Deactivate
-admin-members-btn-activate = Activate
-admin-members-btn-revoke = Revoke Keys
-admin-members-btn-remove = Remove
-admin-members-title-demote = Demote to member
-admin-members-title-promote = Promote to admin
-admin-members-title-deactivate = Deactivate user
-admin-members-title-activate = Reactivate user
-admin-members-title-revoke = Revoke all credentials
-admin-members-title-remove = Remove from organization
+admin-members-demote = Demote
+    .title = Demote to member
+admin-members-promote = Promote
+    .title = Promote to admin
+admin-members-deactivate = Deactivate
+    .title = Deactivate user
+admin-members-activate = Activate
+    .title = Reactivate user
+admin-members-revoke = Revoke Keys
+    .title = Revoke all credentials
+admin-members-remove = Remove
+    .title = Remove from organization
 admin-members-confirm-demote = Demote this user from admin?
 admin-members-confirm-deactivate = Deactivate this user? Their sessions will be invalidated.
-admin-members-confirm-revoke = Revoke all credentials for this user? This will delete their key(s) and invalidate all sessions. The user will need to re-enroll.
+# CLDR plural selector (https://projectfluent.org/fluent/guide/selectors.html):
+# `$count` is the number of registered keys on the target user (member.key_count).
+admin-members-confirm-revoke = Revoke all credentials for this user? This will delete their { $count ->
+        [one] key
+       *[other] keys
+    } and invalidate all sessions. The user will need to re-enroll.
 admin-members-confirm-remove = Remove this user from the organization? This permanently deletes the user and all their data.
 admin-members-none = No members found.
 
 ## Admin audit log (admin/audit.html)
-admin-audit-page-title = Vouch - Audit Log
+admin-audit-page-title = { -product } - Audit Log
 admin-audit-subtitle = Security events for your organization.
 admin-audit-filter-label = Filter:
 admin-audit-filter-all = All
@@ -398,10 +477,11 @@ admin-audit-none = No audit events found.
 admin-audit-older = Older events
 
 ## Admin email domains (admin/domains.html)
-admin-domains-page-title = Vouch - Email Domains
+admin-domains-page-title = { -product } - Email Domains
 admin-domains-subtitle = Manage which email domains attach signing-in users to this organization.
-admin-domains-max-prefix = Maximum of
-admin-domains-max-suffix = additional domains reached. Remove an existing entry before adding a new one.
+# Merged from prior `admin-domains-max-prefix` + `admin-domains-max-suffix`.
+# `$count` is the remaining additional-domain capacity.
+admin-domains-max = Maximum of { $count } additional domains reached. Remove an existing entry before adding a new one.
 admin-domains-add = Add Domain
 admin-domains-domain-label = Domain (e.g. acme.co.uk)
 admin-domains-add-help = After adding, publish a TXT record to verify ownership. Only verified domains attach new users to this organization.
@@ -415,6 +495,9 @@ admin-domains-status-unverified = Unverified
 admin-domains-status-pending = Pending
 admin-domains-verify = Verify
 admin-domains-remove-confirm = Remove this domain? Existing users from it stay in the org, but new logins from this domain will no longer attach.
+# DOCUMENTED FRAGMENT: prefix + `<code>{{ row.domain }}</code>` + mid + `<em>`
+# action verb. The styled domain + emphasized action verb in the middle
+# prevent a single-message merge without losing styling.
 admin-domains-txt-prefix = Publish this TXT record on
 admin-domains-txt-mid = , then click
 admin-domains-dns-name = Name:
@@ -424,14 +507,16 @@ admin-domains-copy-token-title = Copy verification token
 admin-domains-warning = Adding a domain claims it for this organization. Anyone with a verified email in a claimed domain who signs in will be attached as a member. Only verified domains participate in login matching; pending entries do not.
 
 ## Admin device posture policies (admin/policies.html)
-admin-policies-page-title = Vouch - Device Posture Policies
+admin-policies-page-title = { -product } - Device Posture Policies
 admin-policies-heading = Device Posture Policies
 admin-policies-subtitle = Enforce device security requirements for authentication. All active policies must pass.
 admin-policies-builtin = Built-in Policies
+# Fluent attribute pattern: the value is the displayed pill label (current
+# state), the `.title` is the action invoked by clicking it (the inverse).
 admin-policies-on = On
+    .title = Click to disable
 admin-policies-off = Off
-admin-policies-title-disable = Click to disable
-admin-policies-title-enable = Click to enable
+    .title = Click to enable
 admin-policies-disk-macos = FileVault full-disk encryption
 admin-policies-disk-windows = BitLocker drive encryption
 admin-policies-disk-linux = LUKS/dm-crypt volume encryption
@@ -473,7 +558,7 @@ admin-js-cel-fails = — fails against test device
 admin-js-cel-invalid = Invalid expression
 
 ## Admin SCIM tokens (admin/scim_tokens.html)
-admin-scim-page-title = Vouch - SCIM Tokens
+admin-scim-page-title = { -product } - SCIM Tokens
 admin-scim-subtitle = Manage SCIM provisioning tokens for your identity provider.
 admin-scim-new-created = New SCIM token created. Copy it now — it won't be shown again.
 admin-scim-max = Maximum of 2 SCIM tokens reached. Revoke an existing token before creating a new one.

--- a/crates/vouch-server/src/handlers/mod.rs
+++ b/crates/vouch-server/src/handlers/mod.rs
@@ -81,29 +81,17 @@ macro_rules! impl_template_helpers {
                 fn version(&self) -> &'static str { env!("CARGO_PKG_VERSION") }
                 fn lang(&self) -> String { $crate::infra::i18n::lang() }
                 fn dir(&self) -> &'static str { $crate::infra::i18n::dir() }
-                fn tr(&self, id: &str) -> String { $crate::infra::i18n::t(id) }
-                fn tr1(&self, id: &str, name: &str, value: &str) -> String {
-                    $crate::infra::i18n::t1(id, name, value)
-                }
-                // Askama passes scalar field accesses by reference, so
-                // accept `&i64` and deref inside. `&i64` covers both
-                // `member.key_count` (an `i64` field) and explicit `&value`
-                // call sites.
-                fn tr1_num(&self, id: &str, name: &str, value: &i64) -> String {
-                    $crate::infra::i18n::t1_num(id, name, *value)
-                }
-                fn tr2(
-                    &self, id: &str,
-                    n1: &str, v1: &str,
-                    n2: &str, v2: &str,
-                ) -> String {
-                    $crate::infra::i18n::ta(id, &[(n1, v1), (n2, v2)])
-                }
-                fn tr_attr(&self, id: &str, attr: &str) -> String {
-                    $crate::infra::i18n::t_attr(id, attr)
-                }
-                fn tr_attr1(&self, id: &str, attr: &str, name: &str, value: &str) -> String {
-                    $crate::infra::i18n::t_attr1(id, attr, name, value)
+                // Single translation entry point. Returns a [`Tr`] builder
+                // that Askama Display-renders in `{{ … }}`, so call sites
+                // chain `.arg(name, value)` and `.attr(attr)` as needed:
+                //
+                //   {{ self.tr("home-tagline").arg("org", org_name.as_str()) }}
+                //   {{ self.tr("admin-members-demote").attr("title") }}
+                //   {{ self.tr("count").arg("n", member.key_count) }}
+                //
+                // Numeric values engage CLDR plural rules automatically.
+                fn tr<'a>(&self, id: &'a str) -> $crate::infra::i18n::Tr<'a> {
+                    $crate::infra::i18n::Tr::new(id)
                 }
             }
         )*

--- a/crates/vouch-server/src/handlers/mod.rs
+++ b/crates/vouch-server/src/handlers/mod.rs
@@ -67,6 +67,8 @@ macro_rules! impl_template_into_response {
 /// - **`lang`**, **`dir`**, **`tr`**, **`tr1`** — i18n helpers that forward to
 ///   the request-scoped task-local installed by
 ///   [`crate::infra::i18n::i18n_layer`].
+/// - **`tr_attr`**, **`tr_attr1`** — read Fluent message attributes
+///   (`id .attr = value`), used for paired button label + `.title` tooltip.
 #[macro_export]
 macro_rules! impl_template_helpers {
     ($($template:ty),* $(,)?) => {
@@ -82,6 +84,26 @@ macro_rules! impl_template_helpers {
                 fn tr(&self, id: &str) -> String { $crate::infra::i18n::t(id) }
                 fn tr1(&self, id: &str, name: &str, value: &str) -> String {
                     $crate::infra::i18n::t1(id, name, value)
+                }
+                // Askama passes scalar field accesses by reference, so
+                // accept `&i64` and deref inside. `&i64` covers both
+                // `member.key_count` (an `i64` field) and explicit `&value`
+                // call sites.
+                fn tr1_num(&self, id: &str, name: &str, value: &i64) -> String {
+                    $crate::infra::i18n::t1_num(id, name, *value)
+                }
+                fn tr2(
+                    &self, id: &str,
+                    n1: &str, v1: &str,
+                    n2: &str, v2: &str,
+                ) -> String {
+                    $crate::infra::i18n::ta(id, &[(n1, v1), (n2, v2)])
+                }
+                fn tr_attr(&self, id: &str, attr: &str) -> String {
+                    $crate::infra::i18n::t_attr(id, attr)
+                }
+                fn tr_attr1(&self, id: &str, attr: &str, name: &str, value: &str) -> String {
+                    $crate::infra::i18n::t_attr1(id, attr, name, value)
                 }
             }
         )*

--- a/crates/vouch-server/src/infra/i18n.rs
+++ b/crates/vouch-server/src/infra/i18n.rs
@@ -12,6 +12,7 @@
 //! `select_languages_negotiate`, so there is no shared mutable locale state.
 
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::{Arc, LazyLock};
 
 use axum::extract::FromRequestParts;
@@ -21,6 +22,7 @@ use http::{HeaderMap, StatusCode, header};
 use i18n_embed::LanguageLoader;
 use i18n_embed::fluent::FluentLanguageLoader;
 use unic_langid::{LanguageIdentifier, langid};
+use vouch_i18n::FluentValue;
 
 /// Embedded Fluent catalogs, one `i18n/<lang>/vouch.ftl` per language.
 #[derive(rust_embed::RustEmbed)]
@@ -51,58 +53,31 @@ impl I18nContext {
         negotiate(None)
     }
 
-    /// Translate a message with no arguments.
+    /// Translate a no-argument message id. Bypasses the [`Tr`] builder for
+    /// the common case where a string lookup is all the caller needs — used
+    /// by the `/i18n.js` bundle builder and unit tests. Template call sites
+    /// go through the unified [`Tr`] entry point via `self.tr("id")`.
     pub fn t(&self, id: &str) -> String {
         self.loader.get(id)
     }
 
-    /// Translate a message, substituting Fluent placeables from `args`.
-    pub fn ta(&self, id: &str, args: &[(&str, &str)]) -> String {
-        let map: HashMap<&str, &str> = args.iter().copied().collect();
-        self.loader.get_args(id, map)
-    }
-
-    /// Translate a message with a single placeable. Convenience for templates,
-    /// which cannot easily build slice literals.
-    pub fn t1(&self, id: &str, name: &str, value: &str) -> String {
-        self.ta(id, &[(name, value)])
-    }
-
-    /// Translate a message with a single **numeric** placeable.
-    ///
-    /// Distinct from [`t1`] because Fluent's CLDR plural selector
-    /// (`{ $count -> [one] … *[other] … }`, see
-    /// <https://projectfluent.org/fluent/guide/selectors.html>) only fires
-    /// when the placeable is a `FluentValue::Number`. Passing a stringified
-    /// integer through `t1` would silently take the `*[other]` branch even
-    /// when the value is `1`.
-    pub fn t1_num(&self, id: &str, name: &str, value: i64) -> String {
-        let map: HashMap<&str, i64> = std::iter::once((name, value)).collect();
-        self.loader.get_args(id, map)
-    }
-
-    /// Translate a message **attribute** (Fluent's `id .attr = value` form,
-    /// per <https://projectfluent.org/fluent/guide/attributes.html>) with no
-    /// arguments.
-    ///
-    /// Attributes pair UI-adjacent strings under a single message id — most
-    /// commonly a visible button label (the value) plus its `.title` tooltip
-    /// or `.aria-label`. Translators see them together, which preserves the
-    /// relationship the templates implied with parallel `*-btn-*` /
-    /// `*-title-*` ids.
-    pub fn t_attr(&self, id: &str, attr: &str) -> String {
-        self.loader.get_attr(id, attr)
-    }
-
-    /// Translate a message attribute with multiple placeables.
-    pub fn t_attr_args(&self, id: &str, attr: &str, args: &[(&str, &str)]) -> String {
-        let map: HashMap<&str, &str> = args.iter().copied().collect();
-        self.loader.get_attr_args(id, attr, map)
-    }
-
-    /// Translate a message attribute with a single placeable.
-    pub fn t_attr1(&self, id: &str, attr: &str, name: &str, value: &str) -> String {
-        self.t_attr_args(id, attr, &[(name, value)])
+    /// Render a [`Tr`] against this context. Handles all four shapes
+    /// (`id`, `id` + args, `id.attr`, `id.attr` + args) in one place so the
+    /// builder can stay small.
+    pub fn render(&self, tr: &Tr<'_>) -> String {
+        let no_args = tr.args.is_empty();
+        match (tr.attr, no_args) {
+            (None, true) => self.loader.get(tr.id),
+            (None, false) => {
+                let map = build_arg_map(&tr.args);
+                self.loader.get_args_concrete(tr.id, map)
+            }
+            (Some(attr), true) => self.loader.get_attr(tr.id, attr),
+            (Some(attr), false) => {
+                let map = build_arg_map(&tr.args);
+                self.loader.get_attr_args_concrete(tr.id, attr, map)
+            }
+        }
     }
 
     /// BCP-47 tag of the negotiated language, for `<html lang="...">`.
@@ -119,61 +94,80 @@ impl I18nContext {
 
 tokio::task_local! {
     /// Request-scoped translation context, installed by [`i18n_layer`] for
-    /// every request. Template shims read it via the [`t`], [`t1`], [`lang`],
-    /// and [`dir`] free functions below — handlers don't need to thread the
-    /// context themselves and templates don't need to carry any extra field.
+    /// every request. The [`Tr`] builder reads it inside its [`fmt::Display`]
+    /// impl — handlers don't thread the context and templates don't carry
+    /// any extra field.
     static REQUEST_I18N: I18nContext;
 }
 
-/// Translate a message using the request-scoped locale, falling back to
-/// `en-US` when called outside any request scope (e.g. background work or a
-/// template constructed in a unit test).
-pub(crate) fn t(id: &str) -> String {
-    REQUEST_I18N
-        .try_with(|i| i.t(id))
-        .unwrap_or_else(|_| I18nContext::fallback().t(id))
+/// Lazy translation builder.
+///
+/// Constructed by `self.tr("id")` in templates (and `Tr::new("id")` in Rust
+/// code), then chained with `.arg(name, value)` and/or `.attr(attr_name)`.
+/// Rendering happens through [`fmt::Display`] (so `{{ self.tr("id") }}` in
+/// Askama just works) and resolves against the request-scoped task-local —
+/// falling back to en-US outside any request scope.
+///
+/// Why a single builder instead of six methods (`tr` / `tr1` / `tr1_num` /
+/// `tr2` / `tr_attr` / `tr_attr1`): Askama can only call methods on `self`
+/// in `{{ … }}` expressions, so the historical method-per-arity API had to
+/// fan out. A method that returns a builder collapses every shape (no-arg,
+/// one arg, many args, with or without attribute, string or numeric value)
+/// into one call site shape, and `arg<V: Into<FluentValue<'_>>>` engages
+/// CLDR plural rules automatically when the value is numeric.
+pub struct Tr<'a> {
+    id: &'a str,
+    attr: Option<&'a str>,
+    args: Vec<(&'a str, FluentValue<'a>)>,
 }
 
-/// Translate a message with a single Fluent placeable. Same scope semantics
-/// as [`t`].
-pub(crate) fn t1(id: &str, name: &str, value: &str) -> String {
-    REQUEST_I18N
-        .try_with(|i| i.t1(id, name, value))
-        .unwrap_or_else(|_| I18nContext::fallback().t1(id, name, value))
+impl<'a> Tr<'a> {
+    /// Build a no-arg, no-attribute lookup. Chain `.arg` / `.attr` to refine.
+    pub fn new(id: &'a str) -> Self {
+        Self {
+            id,
+            attr: None,
+            args: Vec::new(),
+        }
+    }
+
+    /// Select a message attribute (Fluent's `id .attr = value` form). Pairs
+    /// with `.arg` for attributes that take placeables.
+    #[must_use]
+    pub fn attr(mut self, attr: &'a str) -> Self {
+        self.attr = Some(attr);
+        self
+    }
+
+    /// Add a Fluent placeable. Numeric `V` (`i64`, `usize`, …) flows through
+    /// `FluentValue::Number` so CLDR plural arms (`[one]` / `*[other]`) match
+    /// correctly; string `V` (`&str`, `String`, `&String`, `Cow<str>`) flows
+    /// through `FluentValue::String`. Anything else is not supported — the
+    /// compiler will tell the caller to stringify explicitly.
+    #[must_use]
+    pub fn arg<V>(mut self, name: &'a str, value: V) -> Self
+    where
+        V: Into<FluentValue<'a>>,
+    {
+        self.args.push((name, value.into()));
+        self
+    }
 }
 
-/// Translate a message with a single numeric Fluent placeable. Same scope
-/// semantics as [`t`]. Use when the catalog message branches on the value
-/// via a CLDR plural selector — passing the count as a number lets Fluent
-/// pick the correct `[one]` / `[few]` / `[other]` arm for the target locale.
-pub(crate) fn t1_num(id: &str, name: &str, value: i64) -> String {
-    REQUEST_I18N
-        .try_with(|i| i.t1_num(id, name, value))
-        .unwrap_or_else(|_| I18nContext::fallback().t1_num(id, name, value))
+impl fmt::Display for Tr<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let rendered = REQUEST_I18N
+            .try_with(|ctx| ctx.render(self))
+            .unwrap_or_else(|_| I18nContext::fallback().render(self));
+        f.write_str(&rendered)
+    }
 }
 
-/// Translate a message with multiple Fluent placeables. Same scope semantics
-/// as [`t`].
-pub(crate) fn ta(id: &str, args: &[(&str, &str)]) -> String {
-    REQUEST_I18N
-        .try_with(|i| i.ta(id, args))
-        .unwrap_or_else(|_| I18nContext::fallback().ta(id, args))
-}
-
-/// Translate a message attribute (Fluent `id .attr = value`). Same scope
-/// semantics as [`t`].
-pub(crate) fn t_attr(id: &str, attr: &str) -> String {
-    REQUEST_I18N
-        .try_with(|i| i.t_attr(id, attr))
-        .unwrap_or_else(|_| I18nContext::fallback().t_attr(id, attr))
-}
-
-/// Translate a message attribute with a single Fluent placeable. Same scope
-/// semantics as [`t`].
-pub(crate) fn t_attr1(id: &str, attr: &str, name: &str, value: &str) -> String {
-    REQUEST_I18N
-        .try_with(|i| i.t_attr1(id, attr, name, value))
-        .unwrap_or_else(|_| I18nContext::fallback().t_attr1(id, attr, name, value))
+/// Materialize the builder's arg list as the loader's expected map. Cheap
+/// for the typical 0-3 args; the FluentValues are cloned because the
+/// loader's `_concrete` entry points take ownership of the map.
+fn build_arg_map<'a>(args: &'a [(&'a str, FluentValue<'a>)]) -> HashMap<&'a str, FluentValue<'a>> {
+    args.iter().map(|(k, v)| (*k, v.clone())).collect()
 }
 
 /// BCP-47 tag of the negotiated language for `<html lang="...">`. Returns
@@ -499,7 +493,7 @@ mod tests {
     #[test]
     fn placeable_substitution() {
         let ctx = negotiate(None);
-        let rendered = ctx.t1("footer-copyright", "year", "2026");
+        let rendered = ctx.render(&Tr::new("footer-copyright").arg("year", "2026"));
         assert!(rendered.contains("2026"));
     }
 
@@ -511,7 +505,7 @@ mod tests {
         let ctx = negotiate(None);
         assert_eq!(ctx.t("admin-members-demote"), "Demote");
         assert_eq!(
-            ctx.t_attr("admin-members-demote", "title"),
+            ctx.render(&Tr::new("admin-members-demote").attr("title")),
             "Demote to member"
         );
     }
@@ -529,16 +523,36 @@ mod tests {
         );
     }
 
+    /// Display impl resolves via the request-scoped task-local — and falls
+    /// back to en-US when called outside any scope. This is the path Askama
+    /// takes when rendering `{{ self.tr(...) }}`; the templates never call
+    /// `I18nContext::render` directly.
+    #[test]
+    fn tr_display_falls_back_to_en_us_outside_scope() {
+        let rendered = Tr::new("footer-install").to_string();
+        assert_eq!(rendered, "Install");
+        let with_attr = Tr::new("admin-members-demote").attr("title").to_string();
+        assert_eq!(with_attr, "Demote to member");
+        // Numeric arg → CLDR plural dispatch through the Display path.
+        let one_arm = Tr::new("admin-members-confirm-revoke")
+            .arg("count", 1_i64)
+            .to_string();
+        assert!(
+            one_arm.contains("key ") && !one_arm.contains("keys "),
+            "Display path should engage [one] arm for count=1, got: {one_arm}"
+        );
+    }
+
     #[test]
     fn plural_selector_one_vs_other() {
         // CLDR plural selector on `admin-members-confirm-revoke`. The
         // selector picks `[one]` vs `*[other]` from a `FluentValue::Number`,
-        // so the value must go through `t1_num` (not `t1`, which would
-        // serialize as `FluentValue::String` and always fall through to
-        // `*[other]`).
+        // so the value must be passed as a numeric type — the `Tr` builder's
+        // `arg<V: Into<FluentValue>>` dispatches `i64` (and friends) through
+        // the Number arm automatically.
         let ctx = negotiate(None);
-        let one = ctx.t1_num("admin-members-confirm-revoke", "count", 1);
-        let many = ctx.t1_num("admin-members-confirm-revoke", "count", 3);
+        let one = ctx.render(&Tr::new("admin-members-confirm-revoke").arg("count", 1_i64));
+        let many = ctx.render(&Tr::new("admin-members-confirm-revoke").arg("count", 3_i64));
         assert!(one.contains("key "), "one-arm should say 'key', got: {one}");
         assert!(
             many.contains("keys "),
@@ -766,27 +780,33 @@ mod tests {
         }
 
         fn collect_keys(text: &str, keys: &mut HashSet<String>) {
-            // `self.tr("id")` / `self.tr1("id", …)` — store the bare id.
-            for marker in [".tr(\"", ".tr1(\""] {
-                for part in text.split(marker).skip(1) {
-                    if let Some(key) = part.split('"').next() {
-                        keys.insert(key.to_owned());
-                    }
+            // Template call sites have the shape `self.tr("id")` or
+            // `self.tr("id").attr("attr-name")` (plus optional `.arg(...)`
+            // chains that don't affect catalog identity). Scan for `.tr("`,
+            // capture the id, then peek at the immediately-following bytes
+            // for a `.attr("attr-name")` segment so attribute references are
+            // recorded as `id.attr` — matching what `collect_ftl_ids`
+            // produces.
+            for part in text.split(".tr(\"").skip(1) {
+                let Some(id) = part.split('"').next() else {
+                    continue;
+                };
+                if id.is_empty() {
+                    continue;
                 }
-            }
-            // `self.tr_attr("id", "attr")` / `self.tr_attr1("id", "attr", …)`
-            // — store as `id.attr` so it matches the attribute ids that
-            // `collect_ftl_ids` records.
-            for marker in [".tr_attr(\"", ".tr_attr1(\""] {
-                for part in text.split(marker).skip(1) {
-                    let mut it = part.split('"');
-                    let Some(id) = it.next() else { continue };
-                    // Skip the literal `, "` between the two string args.
-                    let _ = it.next();
-                    let Some(attr) = it.next() else { continue };
-                    if !id.is_empty() && !attr.is_empty() {
-                        keys.insert(format!("{id}.{attr}"));
-                    }
+                // The rest of the slice starts at the byte after the
+                // closing quote of the id. Look for an immediate
+                // `).attr("…")` to attach.
+                let rest_start = id.len() + 1; // +1 for the closing `"`
+                let rest = part.get(rest_start..).unwrap_or("");
+                let attr_marker = ").attr(\"";
+                if let Some(after) = rest.strip_prefix(attr_marker)
+                    && let Some(attr) = after.split('"').next()
+                    && !attr.is_empty()
+                {
+                    keys.insert(format!("{id}.{attr}"));
+                } else {
+                    keys.insert(id.to_owned());
                 }
             }
         }

--- a/crates/vouch-server/src/infra/i18n.rs
+++ b/crates/vouch-server/src/infra/i18n.rs
@@ -68,6 +68,43 @@ impl I18nContext {
         self.ta(id, &[(name, value)])
     }
 
+    /// Translate a message with a single **numeric** placeable.
+    ///
+    /// Distinct from [`t1`] because Fluent's CLDR plural selector
+    /// (`{ $count -> [one] … *[other] … }`, see
+    /// <https://projectfluent.org/fluent/guide/selectors.html>) only fires
+    /// when the placeable is a `FluentValue::Number`. Passing a stringified
+    /// integer through `t1` would silently take the `*[other]` branch even
+    /// when the value is `1`.
+    pub fn t1_num(&self, id: &str, name: &str, value: i64) -> String {
+        let map: HashMap<&str, i64> = std::iter::once((name, value)).collect();
+        self.loader.get_args(id, map)
+    }
+
+    /// Translate a message **attribute** (Fluent's `id .attr = value` form,
+    /// per <https://projectfluent.org/fluent/guide/attributes.html>) with no
+    /// arguments.
+    ///
+    /// Attributes pair UI-adjacent strings under a single message id — most
+    /// commonly a visible button label (the value) plus its `.title` tooltip
+    /// or `.aria-label`. Translators see them together, which preserves the
+    /// relationship the templates implied with parallel `*-btn-*` /
+    /// `*-title-*` ids.
+    pub fn t_attr(&self, id: &str, attr: &str) -> String {
+        self.loader.get_attr(id, attr)
+    }
+
+    /// Translate a message attribute with multiple placeables.
+    pub fn t_attr_args(&self, id: &str, attr: &str, args: &[(&str, &str)]) -> String {
+        let map: HashMap<&str, &str> = args.iter().copied().collect();
+        self.loader.get_attr_args(id, attr, map)
+    }
+
+    /// Translate a message attribute with a single placeable.
+    pub fn t_attr1(&self, id: &str, attr: &str, name: &str, value: &str) -> String {
+        self.t_attr_args(id, attr, &[(name, value)])
+    }
+
     /// BCP-47 tag of the negotiated language, for `<html lang="...">`.
     pub fn lang(&self) -> &str {
         &self.lang
@@ -103,6 +140,40 @@ pub(crate) fn t1(id: &str, name: &str, value: &str) -> String {
     REQUEST_I18N
         .try_with(|i| i.t1(id, name, value))
         .unwrap_or_else(|_| I18nContext::fallback().t1(id, name, value))
+}
+
+/// Translate a message with a single numeric Fluent placeable. Same scope
+/// semantics as [`t`]. Use when the catalog message branches on the value
+/// via a CLDR plural selector — passing the count as a number lets Fluent
+/// pick the correct `[one]` / `[few]` / `[other]` arm for the target locale.
+pub(crate) fn t1_num(id: &str, name: &str, value: i64) -> String {
+    REQUEST_I18N
+        .try_with(|i| i.t1_num(id, name, value))
+        .unwrap_or_else(|_| I18nContext::fallback().t1_num(id, name, value))
+}
+
+/// Translate a message with multiple Fluent placeables. Same scope semantics
+/// as [`t`].
+pub(crate) fn ta(id: &str, args: &[(&str, &str)]) -> String {
+    REQUEST_I18N
+        .try_with(|i| i.ta(id, args))
+        .unwrap_or_else(|_| I18nContext::fallback().ta(id, args))
+}
+
+/// Translate a message attribute (Fluent `id .attr = value`). Same scope
+/// semantics as [`t`].
+pub(crate) fn t_attr(id: &str, attr: &str) -> String {
+    REQUEST_I18N
+        .try_with(|i| i.t_attr(id, attr))
+        .unwrap_or_else(|_| I18nContext::fallback().t_attr(id, attr))
+}
+
+/// Translate a message attribute with a single Fluent placeable. Same scope
+/// semantics as [`t`].
+pub(crate) fn t_attr1(id: &str, attr: &str, name: &str, value: &str) -> String {
+    REQUEST_I18N
+        .try_with(|i| i.t_attr1(id, attr, name, value))
+        .unwrap_or_else(|_| I18nContext::fallback().t_attr1(id, attr, name, value))
 }
 
 /// BCP-47 tag of the negotiated language for `<html lang="...">`. Returns
@@ -271,10 +342,10 @@ pub(crate) const JS_I18N_KEYS: &[&str] = &[
     "appcreate-js-jwksuri-invalid",
     "appcreate-js-redirect-invalid",
     "appcreate-js-redirect-required",
-    "appcreate-js-resource-fragment",
+    "appcreate-js-resource-fragment-uri",
     "appcreate-js-resource-invalid",
-    "appcreate-js-resource-scheme",
-    "appcreate-js-resource-toolong",
+    "appcreate-js-resource-scheme-uri",
+    "appcreate-js-resource-toolong-uri",
     "common-copy",
     "common-js-copied",
     "keys-js-delete",
@@ -433,6 +504,49 @@ mod tests {
     }
 
     #[test]
+    fn attribute_resolves() {
+        // Fluent attribute pattern, per the docs at
+        // <https://projectfluent.org/fluent/guide/attributes.html>.
+        // `admin-members-demote` carries a `.title` for the button tooltip.
+        let ctx = negotiate(None);
+        assert_eq!(ctx.t("admin-members-demote"), "Demote");
+        assert_eq!(
+            ctx.t_attr("admin-members-demote", "title"),
+            "Demote to member"
+        );
+    }
+
+    #[test]
+    fn term_substitution_renders_product_name() {
+        // Terms (`-product`, `-yubikey`, …) defined at the top of vouch.ftl
+        // expand inside referencing messages. A change to the term name
+        // propagates everywhere; this test pins one representative call site.
+        let ctx = negotiate(None);
+        let rendered = ctx.t("home-welcome");
+        assert!(
+            rendered.contains("Vouch"),
+            "{{ -product }} should expand to Vouch, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn plural_selector_one_vs_other() {
+        // CLDR plural selector on `admin-members-confirm-revoke`. The
+        // selector picks `[one]` vs `*[other]` from a `FluentValue::Number`,
+        // so the value must go through `t1_num` (not `t1`, which would
+        // serialize as `FluentValue::String` and always fall through to
+        // `*[other]`).
+        let ctx = negotiate(None);
+        let one = ctx.t1_num("admin-members-confirm-revoke", "count", 1);
+        let many = ctx.t1_num("admin-members-confirm-revoke", "count", 3);
+        assert!(one.contains("key "), "one-arm should say 'key', got: {one}");
+        assert!(
+            many.contains("keys "),
+            "other-arm should say 'keys', got: {many}"
+        );
+    }
+
+    #[test]
     fn validate_startup_passes_with_embedded_catalog() {
         validate_startup().expect("embedded en-US catalog should validate");
     }
@@ -587,31 +701,91 @@ mod tests {
         use std::path::{Path, PathBuf};
 
         fn collect_ftl_ids(content: &str) -> HashSet<String> {
+            // Collect both top-level message ids (`my-msg = …`) and attribute
+            // refs (`my-msg.title`, indented under their owning message as
+            // `    .title = …`). Attribute references in templates use the
+            // `id.attr` form (e.g. `self.tr_attr("admin-members-demote",
+            // "title")`), so we register them as `my-msg.title` here.
             let mut ids = HashSet::new();
+            let mut current_owner: Option<String> = None;
             for line in content.lines() {
-                if line.trim_start() != line {
-                    continue; // indented attribute / continuation line
+                let trimmed = line.trim_start();
+                if trimmed.is_empty() || trimmed.starts_with('#') {
+                    continue;
                 }
+                let indented = trimmed.len() < line.len();
+                if indented {
+                    // Attribute line: `    .attr-name = …`. Anything else
+                    // indented (raw continuation, selector arm, etc.) is
+                    // skipped — those don't introduce new ids.
+                    if !trimmed.starts_with('.') {
+                        continue;
+                    }
+                    let Some((left, _)) = trimmed.split_once('=') else {
+                        continue;
+                    };
+                    let attr = left.trim().trim_start_matches('.');
+                    if attr.is_empty()
+                        || !attr
+                            .chars()
+                            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+                    {
+                        continue;
+                    }
+                    if let Some(owner) = current_owner.as_deref() {
+                        ids.insert(format!("{owner}.{attr}"));
+                    }
+                    continue;
+                }
+                // Top-level line: `my-msg = …`. Reset attribute ownership.
                 let Some((left, _)) = line.split_once('=') else {
+                    current_owner = None;
                     continue;
                 };
                 let id = left.trim();
+                // Skip Fluent terms (`-foo = …`) — they're not callable from
+                // templates, only referenced from other messages via
+                // `{ -foo }`. Their syntax doesn't fit our kebab-case check
+                // either (leading `-`).
+                if id.starts_with('-') {
+                    current_owner = None;
+                    continue;
+                }
                 if !id.is_empty()
                     && id
                         .chars()
                         .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
                 {
                     ids.insert(id.to_owned());
+                    current_owner = Some(id.to_owned());
+                } else {
+                    current_owner = None;
                 }
             }
             ids
         }
 
         fn collect_keys(text: &str, keys: &mut HashSet<String>) {
+            // `self.tr("id")` / `self.tr1("id", …)` — store the bare id.
             for marker in [".tr(\"", ".tr1(\""] {
                 for part in text.split(marker).skip(1) {
                     if let Some(key) = part.split('"').next() {
                         keys.insert(key.to_owned());
+                    }
+                }
+            }
+            // `self.tr_attr("id", "attr")` / `self.tr_attr1("id", "attr", …)`
+            // — store as `id.attr` so it matches the attribute ids that
+            // `collect_ftl_ids` records.
+            for marker in [".tr_attr(\"", ".tr_attr1(\""] {
+                for part in text.split(marker).skip(1) {
+                    let mut it = part.split('"');
+                    let Some(id) = it.next() else { continue };
+                    // Skip the literal `, "` between the two string args.
+                    let _ = it.next();
+                    let Some(attr) = it.next() else { continue };
+                    if !id.is_empty() && !attr.is_empty() {
+                        keys.insert(format!("{id}.{attr}"));
                     }
                 }
             }

--- a/crates/vouch-server/src/infra/i18n.rs
+++ b/crates/vouch-server/src/infra/i18n.rs
@@ -19,7 +19,7 @@ use axum::response::{IntoResponse, Response};
 use http::request::Parts;
 use http::{HeaderMap, StatusCode, header};
 use i18n_embed::LanguageLoader;
-use i18n_embed::fluent::{FluentLanguageLoader, NegotiationStrategy};
+use i18n_embed::fluent::FluentLanguageLoader;
 use unic_langid::{LanguageIdentifier, langid};
 
 /// Embedded Fluent catalogs, one `i18n/<lang>/vouch.ftl` per language.
@@ -29,19 +29,8 @@ struct Localizations;
 
 /// Process-wide loader holding every embedded catalog. Built once; never mutated
 /// after load. Per-request locale selection happens on cheap derived loaders.
-static LOADER: LazyLock<FluentLanguageLoader> = LazyLock::new(|| {
-    let loader = FluentLanguageLoader::new("vouch", langid!("en-US"));
-    if let Err(error) = loader.load_available_languages(&Localizations) {
-        tracing::error!(%error, "failed to load i18n catalogs");
-    }
-    // Disable Fluent's BiDi isolation, which otherwise wraps every interpolated
-    // value in invisible U+2068/U+2069 marks. For an LTR-only catalog those marks
-    // add nothing but leak into version strings and copy-paste. Re-enable (and add
-    // BiDi-aware tests) when an RTL language ships. The bundles are shared via Arc,
-    // so this applies to every derived loader.
-    loader.set_use_isolating(false);
-    loader
-});
+static LOADER: LazyLock<FluentLanguageLoader> =
+    LazyLock::new(|| vouch_i18n::build_loader("vouch", langid!("en-US"), &Localizations));
 
 /// Request-scoped translation handle passed into every UI template.
 ///
@@ -163,21 +152,7 @@ fn default_context() -> &'static I18nContext {
 /// Returns an error if the embedded `en-US` catalog cannot be enumerated, is
 /// missing, fails to resolve a well-known key, or yields no JS bundle entry.
 pub fn validate_startup() -> anyhow::Result<()> {
-    use anyhow::Context;
-    let available = LOADER
-        .available_languages(&Localizations)
-        .context("failed to enumerate embedded i18n catalogs")?;
-    anyhow::ensure!(
-        available.contains(&langid!("en-US")),
-        "embedded i18n catalog en-US is missing; refusing to start"
-    );
-    // Catch a parse failure that leaves the loader empty: a well-known key
-    // must resolve to a translated string, not echo its own id back.
-    let probe = DEFAULT_CONTEXT.t("common-app-name");
-    anyhow::ensure!(
-        probe != "common-app-name",
-        "i18n catalog loaded but key resolution returns raw ids; refusing to start"
-    );
+    vouch_i18n::validate_startup(&LOADER, &Localizations, &["common-app-name"])?;
     // Eagerly force the JS bundle map to build now so any render failure
     // surfaces here (not on the first `/i18n.js` request), and confirm en-US
     // is present — the handler's fallback path depends on it.
@@ -194,11 +169,7 @@ pub(crate) fn negotiate(accept_language: Option<&str>) -> I18nContext {
     let requested = accept_language
         .map(parse_accept_language)
         .unwrap_or_default();
-    let loader = if requested.is_empty() {
-        LOADER.select_languages(&[LOADER.fallback_language().clone()])
-    } else {
-        LOADER.select_languages_negotiate(&requested, NegotiationStrategy::Filtering)
-    };
+    let loader = vouch_i18n::select_loader(&LOADER, &requested);
     let lang = loader.current_language().to_string();
     I18nContext {
         loader: Arc::new(loader),

--- a/crates/vouch-server/static/js/app-create.js
+++ b/crates/vouch-server/static/js/app-create.js
@@ -73,19 +73,19 @@
                 var trimmed = uris[i].trim();
 
                 if (trimmed.length > 2048) {
-                    errors.push(trimmed.substring(0, 40) + t('appcreate-js-resource-toolong'));
+                    errors.push(t('appcreate-js-resource-toolong-uri', { uri: trimmed.substring(0, 40) }));
                     continue;
                 }
 
                 if (trimmed.indexOf('#') !== -1) {
-                    errors.push(trimmed + t('appcreate-js-resource-fragment'));
+                    errors.push(t('appcreate-js-resource-fragment-uri', { uri: trimmed }));
                     continue;
                 }
 
                 try {
                     new URL(trimmed);
                 } catch (e) {
-                    errors.push(trimmed + t('appcreate-js-resource-scheme'));
+                    errors.push(t('appcreate-js-resource-scheme-uri', { uri: trimmed }));
                 }
             }
 

--- a/crates/vouch-server/static/js/app-detail.js
+++ b/crates/vouch-server/static/js/app-detail.js
@@ -80,19 +80,19 @@
                 var trimmed = uris[i].trim();
 
                 if (trimmed.length > 2048) {
-                    errors.push(trimmed.substring(0, 40) + t('appcreate-js-resource-toolong'));
+                    errors.push(t('appcreate-js-resource-toolong-uri', { uri: trimmed.substring(0, 40) }));
                     continue;
                 }
 
                 if (trimmed.indexOf('#') !== -1) {
-                    errors.push(trimmed + t('appcreate-js-resource-fragment'));
+                    errors.push(t('appcreate-js-resource-fragment-uri', { uri: trimmed }));
                     continue;
                 }
 
                 try {
                     new URL(trimmed);
                 } catch (e) {
-                    errors.push(trimmed + t('appcreate-js-resource-scheme'));
+                    errors.push(t('appcreate-js-resource-scheme-uri', { uri: trimmed }));
                 }
             }
 

--- a/crates/vouch-server/templates/admin/domains.html
+++ b/crates/vouch-server/templates/admin/domains.html
@@ -39,7 +39,7 @@
         {% if additional_count >= max_additional %}
         {% let max_additional_str = max_additional.to_string() %}
         <div class="mb-4 px-4 py-3 rounded bg-yellow-900/30 border border-yellow-800 text-yellow-300 text-sm">
-            {{ self.tr1("admin-domains-max", "count", max_additional_str.as_str()) }}
+            {{ self.tr("admin-domains-max").arg("count", max_additional_str.as_str()) }}
         </div>
         {% else %}
         <div class="mb-6 bg-vouch-surface border border-vouch-border rounded-lg p-4">

--- a/crates/vouch-server/templates/admin/domains.html
+++ b/crates/vouch-server/templates/admin/domains.html
@@ -37,8 +37,9 @@
         {% endif %}
 
         {% if additional_count >= max_additional %}
+        {% let max_additional_str = max_additional.to_string() %}
         <div class="mb-4 px-4 py-3 rounded bg-yellow-900/30 border border-yellow-800 text-yellow-300 text-sm">
-            {{ self.tr("admin-domains-max-prefix") }} {{ max_additional }} {{ self.tr("admin-domains-max-suffix") }}
+            {{ self.tr1("admin-domains-max", "count", max_additional_str.as_str()) }}
         </div>
         {% else %}
         <div class="mb-6 bg-vouch-surface border border-vouch-border rounded-lg p-4">
@@ -99,7 +100,7 @@
                                 </form>
                                 {% endif %}
                                 <form method="POST" action="/admin/domains/{{ row.domain }}/remove" data-confirm-message="{{ self.tr("admin-domains-remove-confirm") }}">
-                                    <button type="submit" class="px-2 py-1 text-xs rounded bg-red-900/40 text-red-400 hover:bg-red-900/60">{{ self.tr("admin-members-btn-remove") }}</button>
+                                    <button type="submit" class="px-2 py-1 text-xs rounded bg-red-900/40 text-red-400 hover:bg-red-900/60">{{ self.tr("admin-members-remove") }}</button>
                                 </form>
                             </div>
                             {% endmatch %}

--- a/crates/vouch-server/templates/admin/members.html
+++ b/crates/vouch-server/templates/admin/members.html
@@ -65,35 +65,35 @@
                                 {# Promote/Demote #}
                                 {% if member.is_org_admin %}
                                 <form method="POST" action="/admin/members/{{ member.id }}/demote" data-confirm-message="{{ self.tr("admin-members-confirm-demote") }}">
-                                    <button type="submit" class="px-2 py-1 text-xs rounded bg-gray-700 text-gray-300 hover:bg-gray-600" title="{{ self.tr("admin-members-title-demote") }}">{{ self.tr("admin-members-btn-demote") }}</button>
+                                    <button type="submit" class="px-2 py-1 text-xs rounded bg-gray-700 text-gray-300 hover:bg-gray-600" title="{{ self.tr_attr("admin-members-demote", "title") }}">{{ self.tr("admin-members-demote") }}</button>
                                 </form>
                                 {% else %}
                                 <form method="POST" action="/admin/members/{{ member.id }}/promote">
-                                    <button type="submit" class="px-2 py-1 text-xs rounded bg-gray-700 text-gray-300 hover:bg-gray-600" title="{{ self.tr("admin-members-title-promote") }}">{{ self.tr("admin-members-btn-promote") }}</button>
+                                    <button type="submit" class="px-2 py-1 text-xs rounded bg-gray-700 text-gray-300 hover:bg-gray-600" title="{{ self.tr_attr("admin-members-promote", "title") }}">{{ self.tr("admin-members-promote") }}</button>
                                 </form>
                                 {% endif %}
 
                                 {# Activate/Deactivate #}
                                 {% if member.active %}
                                 <form method="POST" action="/admin/members/{{ member.id }}/deactivate" data-confirm-message="{{ self.tr("admin-members-confirm-deactivate") }}">
-                                    <button type="submit" class="px-2 py-1 text-xs rounded bg-yellow-900/40 text-yellow-400 hover:bg-yellow-900/60" title="{{ self.tr("admin-members-title-deactivate") }}">{{ self.tr("admin-members-btn-deactivate") }}</button>
+                                    <button type="submit" class="px-2 py-1 text-xs rounded bg-yellow-900/40 text-yellow-400 hover:bg-yellow-900/60" title="{{ self.tr_attr("admin-members-deactivate", "title") }}">{{ self.tr("admin-members-deactivate") }}</button>
                                 </form>
                                 {% else %}
                                 <form method="POST" action="/admin/members/{{ member.id }}/activate">
-                                    <button type="submit" class="px-2 py-1 text-xs rounded bg-green-900/40 text-green-400 hover:bg-green-900/60" title="{{ self.tr("admin-members-title-activate") }}">{{ self.tr("admin-members-btn-activate") }}</button>
+                                    <button type="submit" class="px-2 py-1 text-xs rounded bg-green-900/40 text-green-400 hover:bg-green-900/60" title="{{ self.tr_attr("admin-members-activate", "title") }}">{{ self.tr("admin-members-activate") }}</button>
                                 </form>
                                 {% endif %}
 
                                 {# Revoke Credentials #}
                                 {% if member.key_count > 0 %}
-                                <form method="POST" action="/admin/members/{{ member.id }}/revoke-credentials" data-confirm-message="{{ self.tr("admin-members-confirm-revoke") }}">
-                                    <button type="submit" class="px-2 py-1 text-xs rounded bg-red-900/40 text-red-400 hover:bg-red-900/60" title="{{ self.tr("admin-members-title-revoke") }}">{{ self.tr("admin-members-btn-revoke") }}</button>
+                                <form method="POST" action="/admin/members/{{ member.id }}/revoke-credentials" data-confirm-message="{{ self.tr1_num("admin-members-confirm-revoke", "count", member.key_count) }}">
+                                    <button type="submit" class="px-2 py-1 text-xs rounded bg-red-900/40 text-red-400 hover:bg-red-900/60" title="{{ self.tr_attr("admin-members-revoke", "title") }}">{{ self.tr("admin-members-revoke") }}</button>
                                 </form>
                                 {% endif %}
 
                                 {# Remove #}
                                 <form method="POST" action="/admin/members/{{ member.id }}/remove" data-confirm-message="{{ self.tr("admin-members-confirm-remove") }}">
-                                    <button type="submit" class="px-2 py-1 text-xs rounded bg-red-900/40 text-red-400 hover:bg-red-900/60" title="{{ self.tr("admin-members-title-remove") }}">{{ self.tr("admin-members-btn-remove") }}</button>
+                                    <button type="submit" class="px-2 py-1 text-xs rounded bg-red-900/40 text-red-400 hover:bg-red-900/60" title="{{ self.tr_attr("admin-members-remove", "title") }}">{{ self.tr("admin-members-remove") }}</button>
                                 </form>
                             </div>
                             {% endif %}

--- a/crates/vouch-server/templates/admin/members.html
+++ b/crates/vouch-server/templates/admin/members.html
@@ -65,35 +65,35 @@
                                 {# Promote/Demote #}
                                 {% if member.is_org_admin %}
                                 <form method="POST" action="/admin/members/{{ member.id }}/demote" data-confirm-message="{{ self.tr("admin-members-confirm-demote") }}">
-                                    <button type="submit" class="px-2 py-1 text-xs rounded bg-gray-700 text-gray-300 hover:bg-gray-600" title="{{ self.tr_attr("admin-members-demote", "title") }}">{{ self.tr("admin-members-demote") }}</button>
+                                    <button type="submit" class="px-2 py-1 text-xs rounded bg-gray-700 text-gray-300 hover:bg-gray-600" title="{{ self.tr("admin-members-demote").attr("title") }}">{{ self.tr("admin-members-demote") }}</button>
                                 </form>
                                 {% else %}
                                 <form method="POST" action="/admin/members/{{ member.id }}/promote">
-                                    <button type="submit" class="px-2 py-1 text-xs rounded bg-gray-700 text-gray-300 hover:bg-gray-600" title="{{ self.tr_attr("admin-members-promote", "title") }}">{{ self.tr("admin-members-promote") }}</button>
+                                    <button type="submit" class="px-2 py-1 text-xs rounded bg-gray-700 text-gray-300 hover:bg-gray-600" title="{{ self.tr("admin-members-promote").attr("title") }}">{{ self.tr("admin-members-promote") }}</button>
                                 </form>
                                 {% endif %}
 
                                 {# Activate/Deactivate #}
                                 {% if member.active %}
                                 <form method="POST" action="/admin/members/{{ member.id }}/deactivate" data-confirm-message="{{ self.tr("admin-members-confirm-deactivate") }}">
-                                    <button type="submit" class="px-2 py-1 text-xs rounded bg-yellow-900/40 text-yellow-400 hover:bg-yellow-900/60" title="{{ self.tr_attr("admin-members-deactivate", "title") }}">{{ self.tr("admin-members-deactivate") }}</button>
+                                    <button type="submit" class="px-2 py-1 text-xs rounded bg-yellow-900/40 text-yellow-400 hover:bg-yellow-900/60" title="{{ self.tr("admin-members-deactivate").attr("title") }}">{{ self.tr("admin-members-deactivate") }}</button>
                                 </form>
                                 {% else %}
                                 <form method="POST" action="/admin/members/{{ member.id }}/activate">
-                                    <button type="submit" class="px-2 py-1 text-xs rounded bg-green-900/40 text-green-400 hover:bg-green-900/60" title="{{ self.tr_attr("admin-members-activate", "title") }}">{{ self.tr("admin-members-activate") }}</button>
+                                    <button type="submit" class="px-2 py-1 text-xs rounded bg-green-900/40 text-green-400 hover:bg-green-900/60" title="{{ self.tr("admin-members-activate").attr("title") }}">{{ self.tr("admin-members-activate") }}</button>
                                 </form>
                                 {% endif %}
 
                                 {# Revoke Credentials #}
                                 {% if member.key_count > 0 %}
-                                <form method="POST" action="/admin/members/{{ member.id }}/revoke-credentials" data-confirm-message="{{ self.tr1_num("admin-members-confirm-revoke", "count", member.key_count) }}">
-                                    <button type="submit" class="px-2 py-1 text-xs rounded bg-red-900/40 text-red-400 hover:bg-red-900/60" title="{{ self.tr_attr("admin-members-revoke", "title") }}">{{ self.tr("admin-members-revoke") }}</button>
+                                <form method="POST" action="/admin/members/{{ member.id }}/revoke-credentials" data-confirm-message="{{ self.tr("admin-members-confirm-revoke").arg("count", member.key_count) }}">
+                                    <button type="submit" class="px-2 py-1 text-xs rounded bg-red-900/40 text-red-400 hover:bg-red-900/60" title="{{ self.tr("admin-members-revoke").attr("title") }}">{{ self.tr("admin-members-revoke") }}</button>
                                 </form>
                                 {% endif %}
 
                                 {# Remove #}
                                 <form method="POST" action="/admin/members/{{ member.id }}/remove" data-confirm-message="{{ self.tr("admin-members-confirm-remove") }}">
-                                    <button type="submit" class="px-2 py-1 text-xs rounded bg-red-900/40 text-red-400 hover:bg-red-900/60" title="{{ self.tr_attr("admin-members-remove", "title") }}">{{ self.tr("admin-members-remove") }}</button>
+                                    <button type="submit" class="px-2 py-1 text-xs rounded bg-red-900/40 text-red-400 hover:bg-red-900/60" title="{{ self.tr("admin-members-remove").attr("title") }}">{{ self.tr("admin-members-remove") }}</button>
                                 </form>
                             </div>
                             {% endif %}

--- a/crates/vouch-server/templates/admin/policies.html
+++ b/crates/vouch-server/templates/admin/policies.html
@@ -64,9 +64,9 @@
                             </div>
                             <form method="POST" action="/admin/policies/preconfigured/{{ policy.slug }}/toggle" class="shrink-0 policy-toggle-form">
                                 {% if policy.active %}
-                                <button type="submit" class="px-2.5 py-1 text-xs rounded bg-green-900/30 text-green-400 hover:bg-green-900/50 border border-green-800/50" title="{{ self.tr_attr("admin-policies-on", "title") }}">{{ self.tr("admin-policies-on") }}</button>
+                                <button type="submit" class="px-2.5 py-1 text-xs rounded bg-green-900/30 text-green-400 hover:bg-green-900/50 border border-green-800/50" title="{{ self.tr("admin-policies-on").attr("title") }}">{{ self.tr("admin-policies-on") }}</button>
                                 {% else %}
-                                <button type="submit" class="px-2.5 py-1 text-xs rounded bg-gray-700 text-gray-500 hover:bg-gray-600 border border-gray-600" title="{{ self.tr_attr("admin-policies-off", "title") }}">{{ self.tr("admin-policies-off") }}</button>
+                                <button type="submit" class="px-2.5 py-1 text-xs rounded bg-gray-700 text-gray-500 hover:bg-gray-600 border border-gray-600" title="{{ self.tr("admin-policies-off").attr("title") }}">{{ self.tr("admin-policies-off") }}</button>
                                 {% endif %}
                             </form>
                         </summary>
@@ -192,9 +192,9 @@
                             <div class="flex items-center gap-2 shrink-0">
                                 <form method="POST" action="/admin/policies/custom/{{ policy.id }}/toggle" class="inline">
                                     {% if policy.active %}
-                                    <button type="submit" class="px-2.5 py-1 text-xs rounded bg-green-900/30 text-green-400 hover:bg-green-900/50 border border-green-800/50" title="{{ self.tr_attr("admin-policies-on", "title") }}">{{ self.tr("admin-policies-on") }}</button>
+                                    <button type="submit" class="px-2.5 py-1 text-xs rounded bg-green-900/30 text-green-400 hover:bg-green-900/50 border border-green-800/50" title="{{ self.tr("admin-policies-on").attr("title") }}">{{ self.tr("admin-policies-on") }}</button>
                                     {% else %}
-                                    <button type="submit" class="px-2.5 py-1 text-xs rounded bg-gray-700 text-gray-500 hover:bg-gray-600 border border-gray-600" title="{{ self.tr_attr("admin-policies-off", "title") }}">{{ self.tr("admin-policies-off") }}</button>
+                                    <button type="submit" class="px-2.5 py-1 text-xs rounded bg-gray-700 text-gray-500 hover:bg-gray-600 border border-gray-600" title="{{ self.tr("admin-policies-off").attr("title") }}">{{ self.tr("admin-policies-off") }}</button>
                                     {% endif %}
                                 </form>
                                 <button type="button" class="btn-edit-policy p-1 text-gray-500 hover:text-vouch-accent transition-colors"

--- a/crates/vouch-server/templates/admin/policies.html
+++ b/crates/vouch-server/templates/admin/policies.html
@@ -64,9 +64,9 @@
                             </div>
                             <form method="POST" action="/admin/policies/preconfigured/{{ policy.slug }}/toggle" class="shrink-0 policy-toggle-form">
                                 {% if policy.active %}
-                                <button type="submit" class="px-2.5 py-1 text-xs rounded bg-green-900/30 text-green-400 hover:bg-green-900/50 border border-green-800/50" title="{{ self.tr("admin-policies-title-disable") }}">{{ self.tr("admin-policies-on") }}</button>
+                                <button type="submit" class="px-2.5 py-1 text-xs rounded bg-green-900/30 text-green-400 hover:bg-green-900/50 border border-green-800/50" title="{{ self.tr_attr("admin-policies-on", "title") }}">{{ self.tr("admin-policies-on") }}</button>
                                 {% else %}
-                                <button type="submit" class="px-2.5 py-1 text-xs rounded bg-gray-700 text-gray-500 hover:bg-gray-600 border border-gray-600" title="{{ self.tr("admin-policies-title-enable") }}">{{ self.tr("admin-policies-off") }}</button>
+                                <button type="submit" class="px-2.5 py-1 text-xs rounded bg-gray-700 text-gray-500 hover:bg-gray-600 border border-gray-600" title="{{ self.tr_attr("admin-policies-off", "title") }}">{{ self.tr("admin-policies-off") }}</button>
                                 {% endif %}
                             </form>
                         </summary>
@@ -192,9 +192,9 @@
                             <div class="flex items-center gap-2 shrink-0">
                                 <form method="POST" action="/admin/policies/custom/{{ policy.id }}/toggle" class="inline">
                                     {% if policy.active %}
-                                    <button type="submit" class="px-2.5 py-1 text-xs rounded bg-green-900/30 text-green-400 hover:bg-green-900/50 border border-green-800/50" title="{{ self.tr("admin-policies-title-disable") }}">{{ self.tr("admin-policies-on") }}</button>
+                                    <button type="submit" class="px-2.5 py-1 text-xs rounded bg-green-900/30 text-green-400 hover:bg-green-900/50 border border-green-800/50" title="{{ self.tr_attr("admin-policies-on", "title") }}">{{ self.tr("admin-policies-on") }}</button>
                                     {% else %}
-                                    <button type="submit" class="px-2.5 py-1 text-xs rounded bg-gray-700 text-gray-500 hover:bg-gray-600 border border-gray-600" title="{{ self.tr("admin-policies-title-enable") }}">{{ self.tr("admin-policies-off") }}</button>
+                                    <button type="submit" class="px-2.5 py-1 text-xs rounded bg-gray-700 text-gray-500 hover:bg-gray-600 border border-gray-600" title="{{ self.tr_attr("admin-policies-off", "title") }}">{{ self.tr("admin-policies-off") }}</button>
                                     {% endif %}
                                 </form>
                                 <button type="button" class="btn-edit-policy p-1 text-gray-500 hover:text-vouch-accent transition-colors"

--- a/crates/vouch-server/templates/applications/detail.html
+++ b/crates/vouch-server/templates/applications/detail.html
@@ -165,7 +165,7 @@
                     {% let secrets_count_str = secrets_count.to_string() %}
                     <div>
                         <label class="text-sm text-gray-400">{{ self.tr("apps-detail-client-secrets") }}</label>
-                        <span class="text-xs text-gray-500 ml-2">({{ self.tr2("apps-detail-secrets-count", "count", secrets_count_str.as_str(), "max", "2") }})</span>
+                        <span class="text-xs text-gray-500 ml-2">({{ self.tr("apps-detail-secrets-count").arg("count", secrets_count_str.as_str()).arg("max", "2") }})</span>
                     </div>
                     {% if secrets_count < 2 %}
                     <form action="/applications/{{ app.id }}/secrets" method="POST">

--- a/crates/vouch-server/templates/applications/detail.html
+++ b/crates/vouch-server/templates/applications/detail.html
@@ -162,9 +162,10 @@
             {% if (app.application_type == "web" || app.application_type == "service") && app.fapi_profile != "fapi2_security" %}
             <div class="border-t border-vouch-border pt-4">
                 <div class="flex items-center justify-between mb-3">
+                    {% let secrets_count_str = secrets_count.to_string() %}
                     <div>
                         <label class="text-sm text-gray-400">{{ self.tr("apps-detail-client-secrets") }}</label>
-                        <span class="text-xs text-gray-500 ml-2">({{ secrets_count }} {{ self.tr("apps-detail-secrets-suffix") }})</span>
+                        <span class="text-xs text-gray-500 ml-2">({{ self.tr2("apps-detail-secrets-count", "count", secrets_count_str.as_str(), "max", "2") }})</span>
                     </div>
                     {% if secrets_count < 2 %}
                     <form action="/applications/{{ app.id }}/secrets" method="POST">

--- a/crates/vouch-server/templates/applications/secret_added.html
+++ b/crates/vouch-server/templates/applications/secret_added.html
@@ -57,7 +57,7 @@
 
         <div class="mt-8 flex justify-center">
             <a href="/applications/{{ app_id }}" class="px-6 py-2 bg-vouch-accent hover:bg-vouch-accent-hover text-[#0a0a0a] rounded-md text-sm font-medium transition-colors">
-                {{ self.tr("apps-secret-back-to") }} {{ name }}
+                {{ self.tr1("apps-secret-back-to", "name", name.as_str()) }}
             </a>
         </div>
     </div>

--- a/crates/vouch-server/templates/applications/secret_added.html
+++ b/crates/vouch-server/templates/applications/secret_added.html
@@ -57,7 +57,7 @@
 
         <div class="mt-8 flex justify-center">
             <a href="/applications/{{ app_id }}" class="px-6 py-2 bg-vouch-accent hover:bg-vouch-accent-hover text-[#0a0a0a] rounded-md text-sm font-medium transition-colors">
-                {{ self.tr1("apps-secret-back-to", "name", name.as_str()) }}
+                {{ self.tr("apps-secret-back-to").arg("name", name.as_str()) }}
             </a>
         </div>
     </div>

--- a/crates/vouch-server/templates/base.html
+++ b/crates/vouch-server/templates/base.html
@@ -60,8 +60,8 @@
         <span class="mx-2">&middot;</span>
         <a href="https://vouch-sh.statuspage.io/" target="_blank" rel="noopener noreferrer" class="text-vouch-accent hover:text-vouch-accent-hover">{{ self.tr("footer-status") }}</a>
         <span class="mx-2">&middot;</span>
-        <a href="https://github.com/vouch-sh/vouch/releases/tag/v{{ self.version() }}" target="_blank" rel="noopener noreferrer" class="text-vouch-accent hover:text-vouch-accent-hover">{{ self.tr1("footer-version", "version", self.version()) }}</a>
-        <div class="mt-2">{{ self.tr1("footer-copyright", "year", "2026") }} <a href="https://smoketurner.com" target="_blank" rel="noopener noreferrer" class="hover:underline">Smoke Turner, LLC</a></div>
+        <a href="https://github.com/vouch-sh/vouch/releases/tag/v{{ self.version() }}" target="_blank" rel="noopener noreferrer" class="text-vouch-accent hover:text-vouch-accent-hover">{{ self.tr("footer-version").arg("version", self.version()) }}</a>
+        <div class="mt-2">{{ self.tr("footer-copyright").arg("year", "2026") }} <a href="https://smoketurner.com" target="_blank" rel="noopener noreferrer" class="hover:underline">Smoke Turner, LLC</a></div>
     </footer>
     <script src="/i18n.js"></script>
     {% block scripts %}{% endblock %}

--- a/crates/vouch-server/templates/enroll_keys_container.html
+++ b/crates/vouch-server/templates/enroll_keys_container.html
@@ -15,7 +15,7 @@
             <div class="flex-1 min-w-0 mr-4">
                 <div class="key-name-display-row flex items-center gap-1 mb-1">
                     <span class="key-name-display font-medium text-gray-200 truncate">{{ key.name }}</span>
-                    <button type="button" data-action="rename" aria-label="{{ self.tr_attr("enroll-keys-rename", "aria-label") }}"
+                    <button type="button" data-action="rename" aria-label="{{ self.tr("enroll-keys-rename").attr("aria-label") }}"
                             class="shrink-0 text-gray-500 hover:text-vouch-accent transition-colors p-1">
                         <svg class="w-4 h-4 pointer-events-none" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125"/></svg>
                     </button>
@@ -31,12 +31,12 @@
                 </form>
                 <div class="text-sm text-gray-500">
                     {% match key.device_model %}{% when Some with (model) %}<span class="mr-3">{{ model }}</span>{% when None %}{% endmatch %}
-                    <span>{{ self.tr1("enroll-keys-added", "when", key.created_at.as_str()) }}</span>
+                    <span>{{ self.tr("enroll-keys-added").arg("when", key.created_at.as_str()) }}</span>
                 </div>
             </div>
             {% if can_delete %}
             <button type="button" data-action="delete" data-key-id="{{ key.id }}" data-key-name="{{ key.name }}"
-                    class="text-gray-500 hover:text-vouch-error p-1" title="{{ self.tr_attr("enroll-keys-delete", "title") }}">
+                    class="text-gray-500 hover:text-vouch-error p-1" title="{{ self.tr("enroll-keys-delete").attr("title") }}">
                 <svg class="w-5 h-5 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" /></svg>
             </button>
             {% endif %}

--- a/crates/vouch-server/templates/enroll_keys_container.html
+++ b/crates/vouch-server/templates/enroll_keys_container.html
@@ -15,7 +15,7 @@
             <div class="flex-1 min-w-0 mr-4">
                 <div class="key-name-display-row flex items-center gap-1 mb-1">
                     <span class="key-name-display font-medium text-gray-200 truncate">{{ key.name }}</span>
-                    <button type="button" data-action="rename" aria-label="{{ self.tr("enroll-keys-rename-aria") }}"
+                    <button type="button" data-action="rename" aria-label="{{ self.tr_attr("enroll-keys-rename", "aria-label") }}"
                             class="shrink-0 text-gray-500 hover:text-vouch-accent transition-colors p-1">
                         <svg class="w-4 h-4 pointer-events-none" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125"/></svg>
                     </button>
@@ -31,12 +31,12 @@
                 </form>
                 <div class="text-sm text-gray-500">
                     {% match key.device_model %}{% when Some with (model) %}<span class="mr-3">{{ model }}</span>{% when None %}{% endmatch %}
-                    <span>{{ self.tr("enroll-keys-added-prefix") }} {{ key.created_at }}</span>
+                    <span>{{ self.tr1("enroll-keys-added", "when", key.created_at.as_str()) }}</span>
                 </div>
             </div>
             {% if can_delete %}
             <button type="button" data-action="delete" data-key-id="{{ key.id }}" data-key-name="{{ key.name }}"
-                    class="text-gray-500 hover:text-vouch-error p-1" title="{{ self.tr("enroll-keys-delete-title") }}">
+                    class="text-gray-500 hover:text-vouch-error p-1" title="{{ self.tr_attr("enroll-keys-delete", "title") }}">
                 <svg class="w-5 h-5 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" /></svg>
             </button>
             {% endif %}

--- a/crates/vouch-server/templates/landing.html
+++ b/crates/vouch-server/templates/landing.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% import "macros/auth.html" as auth_macros %}
 
-{% block title %}{{ self.tr1("home-page-title", "org", org_name.as_str()) }}{% endblock %}
+{% block title %}{{ self.tr("home-page-title").arg("org", org_name.as_str()) }}{% endblock %}
 
 {% block header_right %}
 {{ auth_macros::header_auth(auth, self) }}
@@ -12,7 +12,7 @@
     <div class="card max-w-xl w-full">
         <svg class="w-8 h-8 text-vouch-accent mx-auto mb-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"/></svg>
         <h1 class="text-3xl font-bold text-gray-200 mb-2">{{ self.tr("home-welcome") }}</h1>
-        <p class="text-gray-400 text-lg mb-2">{{ self.tr1("home-tagline", "org", org_name.as_str()) }}</p>
+        <p class="text-gray-400 text-lg mb-2">{{ self.tr("home-tagline").arg("org", org_name.as_str()) }}</p>
         <p class="text-gray-500 text-sm mb-8">{{ self.tr("home-subtagline") }}</p>
 
         <!-- Browser-based enrollment or authenticated state -->
@@ -37,7 +37,7 @@
             <a href="/enroll/start{% if !entry.id.is_empty() %}?provider={{ entry.id }}{% endif %}"
                class="w-full flex items-center justify-center gap-3 bg-vouch-surface border border-vouch-border text-gray-300 font-medium py-3 px-6 rounded-lg hover:bg-vouch-raised transition-colors">
                 {{ entry.svg_icon|safe }}
-                {{ self.tr1("home-sign-in-with", "provider", entry.display_name.as_str()) }}
+                {{ self.tr("home-sign-in-with").arg("provider", entry.display_name.as_str()) }}
             </a>
             {% endfor %}
             </div>

--- a/crates/vouch-server/templates/select_idp.html
+++ b/crates/vouch-server/templates/select_idp.html
@@ -16,7 +16,7 @@
                 <button type="submit" name="provider" value="{{ entry.id }}"
                         class="w-full flex items-center justify-center gap-3 bg-vouch-surface border border-vouch-border text-gray-300 font-medium py-3 px-6 rounded-lg hover:bg-vouch-raised transition-colors">
                     {{ entry.svg_icon|safe }}
-                    {{ self.tr1("home-sign-in-with", "provider", entry.display_name.as_str()) }}
+                    {{ self.tr("home-sign-in-with").arg("provider", entry.display_name.as_str()) }}
                 </button>
                 {% endfor %}
             </div>
@@ -27,7 +27,7 @@
             <a href="{{ action }}?provider={{ entry.id }}"
                class="w-full flex items-center justify-center gap-3 bg-vouch-surface border border-vouch-border text-gray-300 font-medium py-3 px-6 rounded-lg hover:bg-vouch-raised transition-colors">
                 {{ entry.svg_icon|safe }}
-                {{ self.tr1("home-sign-in-with", "provider", entry.display_name.as_str()) }}
+                {{ self.tr("home-sign-in-with").arg("provider", entry.display_name.as_str()) }}
             </a>
             {% endfor %}
         </div>

--- a/deny.toml
+++ b/deny.toml
@@ -16,7 +16,14 @@ targets = [
 ]
 
 [advisories]
-ignore = []
+ignore = [
+    # proc-macro-error2 is unmaintained, but pulled in transitively by
+    # `i18n-embed-fl` v0.10.0. No safe upgrade is available upstream; the
+    # advisory is informational only (no known vulnerability). Re-evaluate
+    # when `i18n-embed-fl` drops the dependency or a maintained fork lands.
+    # https://rustsec.org/advisories/RUSTSEC-2026-0173
+    "RUSTSEC-2026-0173",
+]
 
 [licenses]
 confidence-threshold = 0.8

--- a/docs/src/reference/environment-variables.md
+++ b/docs/src/reference/environment-variables.md
@@ -164,3 +164,21 @@ These optional variables configure download links displayed in the server UI.
 | `VOUCH_CLI_DOWNLOAD_MACOS` | No | _(none)_ | CLI download URL for macOS, displayed in the server UI. |
 | `VOUCH_CLI_DOWNLOAD_LINUX` | No | _(none)_ | CLI download URL for Linux, displayed in the server UI. |
 | `VOUCH_CLI_DOWNLOAD_WINDOWS` | No | _(none)_ | CLI download URL for Windows, displayed in the server UI. |
+
+## CLI Localization
+
+The Vouch CLI resolves its user-facing language once at startup. Resolution checks the following sources in order; the first that parses as a [BCP 47](https://www.rfc-editor.org/rfc/rfc5646) language tag wins.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `--lang <BCP-47>` | No | _(none)_ | Global CLI flag (highest priority). Example: `vouch --lang en-US enroll`. |
+| `VOUCH_LANG` | No | _(none)_ | Explicit CLI locale override. Example: `VOUCH_LANG=en-US`. |
+| `LC_ALL` | No | _(POSIX)_ | Standard POSIX locale variable; overrides every other `LC_*`. |
+| `LC_MESSAGES` | No | _(POSIX)_ | Standard POSIX locale variable for message translations. |
+| `LANG` | No | _(POSIX)_ | Standard POSIX locale variable used when `LC_*` are unset. |
+
+If none of the above resolve, the CLI falls through to the operating system's default locale via [`sys-locale`](https://crates.io/crates/sys-locale). When that is also unavailable (e.g., a minimal container with no locale configured), the CLI falls back to `en-US`. POSIX-style locale strings (`en_US.UTF-8`, `ca_ES@valencia`) are normalized by stripping the `.<codeset>` and `@<modifier>` suffixes and replacing `_` with `-`.
+
+Machine-readable output (`vouch status --json`, `vouch status --shell`, `vouch env`, credential helpers) is **never** affected by the locale — those payloads are consumed by other tools and remain stable across locales. Only human-facing prompts, success/failure messages, and `--help` text honor the negotiated locale.
+
+This release ships `en-US` only; the catalog scaffolding lets translations land in isolated PRs without changing the CLI surface.


### PR DESCRIPTION
Follow-on to https://github.com/vouch-sh/vouch/pull/485 (vouch-server)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly user-visible string and help text changes; auth and credential logic are unchanged aside from error message wording.
> 
> **Overview**
> Extends the **Fluent / `vouch-i18n` stack** (already used on the server) to **`vouch-cli`** and **`vouch-agent`**, with embedded catalogs and shared loader helpers from the new **`vouch-i18n`** workspace crate.
> 
> **CLI** gets a large **`en-US/vouch-cli.ftl`** catalog and **`tr!` / `tr_args!` / `tr_println!`** wiring across commands (enroll, login, doctor, setup, AWS, keys, etc.). **Clap** help and errors move onto translated ids where applicable; locale is chosen via **`--lang`**, **`VOUCH_LANG`**, standard **`LANG`/`LC_*`**, or OS default, with **early argv pre-scan** so derive attributes resolve before **`Cli::parse()`**. **`tracing`** logs stay English.
> 
> **Agent** adds a smaller catalog for **operator-facing** stdout/stderr (`--status`, `--stop`, daemonize errors). **`--status` / `--stop` run before `i18n::init()`** so a broken catalog cannot block stopping the daemon; macros still fall back to **en-US**.
> 
> Workspace **`Cargo.toml`** pins **`i18n-embed`**, **`fluent-bundle`**, **`sys-locale`**, and related crates; **`vouch-server`** picks up **`vouch-i18n`** as a dependency in the lockfile (aligning with the server i18n follow-on).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31638f62dd03c4d6e1ef3a868d368bb0d5b73e66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->