### PR TITLE
i18n: close coverage gaps and tidy server catalog

### DIFF
--- a/crates/vouch-server/i18n/en-US/vouch-server.ftl
+++ b/crates/vouch-server/i18n/en-US/vouch-server.ftl
@@ -7,6 +7,11 @@
 # This is the source-of-truth catalog for BOTH server-rendered templates and
 # the strings injected into static JS (see templates' `js_i18n` blocks).
 #
+# do-not-translate: some user-visible text is intentionally NOT in this catalog
+# because it is code, not prose — shell commands, CEL expression examples, JSON
+# and URI placeholders, and proper nouns (OS names like macOS / Debian / Ubuntu).
+# Those stay verbatim in the templates so they read identically in every locale.
+#
 # ---------------------------------------------------------------------------
 # Terms (Fluent feature: https://projectfluent.org/fluent/guide/terms.html)
 #   - Reusable nouns referenced as `{ -term-name }` from any message.
@@ -158,6 +163,22 @@ apps-list-status-active = Active
 apps-list-status-inactive = Inactive
 apps-list-never = Never
 apps-list-delete-confirm = Are you sure you want to delete this application?
+# Application type pill (applications/list.html) and the type shown on the
+# created confirmation (applications/created.html). Compact forms suit the
+# table pill and are reused on the created page.
+apps-type-web = Web
+apps-type-spa = SPA
+apps-type-native = Native
+apps-type-service = Service
+# Access scope pill plus its hover tooltip (applications/list.html). The display
+# name and its description are one conceptual pair, kept together via a Fluent
+# attribute (.desc) rather than as separate ids.
+apps-scope-organization = Organization
+    .desc = Only users in your organization can authenticate
+apps-scope-personal = Personal
+    .desc = Only you can authenticate
+apps-scope-public = Public
+    .desc = Any { -product } user can authenticate
 
 ## Security keys management (enroll_keys.html, enroll_keys_container.html)
 enroll-keys-page-title = { -product } - { -security-key }s
@@ -196,6 +217,7 @@ home-feature-phishing = Phishing-resistant
 
 ## Login (login.html)
 login-page-title = { -product } - Sign In
+login-logo-alt = Application logo
 login-title = Sign In
 # DOCUMENTED FRAGMENT: paired with a `<span class="font-semibold ...">` styled
 # client name in the template (login.html). Merging into a single message with
@@ -323,6 +345,20 @@ install-step2-title = Enroll your { -yubikey }
 install-step2-body = This opens a browser to verify your identity and register your { -yubikey }.
 install-step3-title = Daily login
 install-step3-body = After login, your identity is available to SSH, AWS, Git, and other tools automatically.
+# DOCUMENTED FRAGMENT: shell-comment annotations heading the apt/rpm code
+# blocks (install.html). The commands themselves stay English as code; only
+# these `#`-prefixed comment lines are prose. Shared across both package
+# managers where the wording is identical.
+install-comment-gpg = # Import GPG key
+install-comment-add-repo = # Add repository
+install-comment-install = # Install
+# DOCUMENTED FRAGMENT: the step-3 simulated terminal session (install.html) is
+# a stack of separately-styled <div>s interleaved with the untranslated
+# `$ vouch login` command, so each translatable line is its own id.
+install-step3-comment = # Start your day with a single touch
+install-step3-prompt-pin = Enter PIN: ****
+install-step3-prompt-touch = Touch your { -yubikey }...
+install-step3-authenticated = ✓ Authenticated for 8 hours
 
 ## Integrations (integrations.html)
 integrations-page-title = { -product } - Integrations
@@ -379,8 +415,11 @@ keys-js-delete = Delete key "{ $name }"? This action cannot be undone.
 keys-js-delete-failed = Failed to delete key
 keys-js-delete-failed-reauth = Failed to delete key after re-authentication
 keys-js-delete-failed-message = Failed to delete key: { $message }
-keys-js-stepup-1 = Deleting a key requires recent authentication.
-keys-js-stepup-2 = Please touch your security key when prompted.
+# Single multiline message (newline preserved between lines) so translators see
+# the full prompt as one block rather than two concatenated fragments.
+keys-js-stepup =
+    Deleting a key requires recent authentication.
+    Please touch your { -security-key } when prompted.
 keys-js-reauth-start-failed = Failed to start re-authentication
 keys-js-reauth-complete-failed = Failed to complete re-authentication
 keys-js-reg-starting = Starting registration...

--- a/crates/vouch-server/src/infra/i18n.rs
+++ b/crates/vouch-server/src/infra/i18n.rs
@@ -18,7 +18,7 @@ use std::sync::{Arc, LazyLock};
 use axum::extract::FromRequestParts;
 use axum::response::{IntoResponse, Response};
 use http::request::Parts;
-use http::{HeaderMap, StatusCode, header};
+use http::{HeaderMap, HeaderValue, StatusCode, header};
 use i18n_embed::LanguageLoader;
 use i18n_embed::fluent::FluentLanguageLoader;
 use unic_langid::{LanguageIdentifier, langid};
@@ -245,7 +245,9 @@ pub(crate) fn negotiate(accept_language: Option<&str>) -> I18nContext {
 /// Parse an `Accept-Language` header into language identifiers, highest quality
 /// first. Malformed entries and the `*` wildcard are skipped.
 fn parse_accept_language(header: &str) -> Vec<LanguageIdentifier> {
-    let mut weighted: Vec<(f32, LanguageIdentifier)> = Vec::new();
+    // Browsers typically send a handful of languages; preallocate to skip the
+    // early reallocations.
+    let mut weighted: Vec<(f32, LanguageIdentifier)> = Vec::with_capacity(4);
     for entry in header.split(',') {
         let mut segments = entry.trim().split(';');
         let Some(tag) = segments.next() else {
@@ -353,8 +355,7 @@ pub(crate) const JS_I18N_KEYS: &[&str] = &[
     "keys-js-reg-start-failed",
     "keys-js-reg-starting",
     "keys-js-reg-touch",
-    "keys-js-stepup-1",
-    "keys-js-stepup-2",
+    "keys-js-stepup",
     "login-js-complete-failed",
     "login-js-error",
     "login-js-signed-in",
@@ -412,17 +413,31 @@ fn etag_for(body: &str) -> String {
 /// instead of a fresh JSON serialization plus SHA-256 per page navigation.
 /// `en-US` is the guaranteed fallback (verified by [`validate_startup`]); new
 /// languages are added inside [`build_js_bundles`] as their catalogs land.
-static JS_BUNDLES: LazyLock<HashMap<String, (String, String)>> = LazyLock::new(build_js_bundles);
+/// A pre-rendered client bundle: the JS body, its ETag string (for comparing
+/// against `If-None-Match`), and that ETag pre-parsed as a `HeaderValue` so the
+/// response path neither re-parses nor heap-allocates it per request.
+type Bundle = (String, String, HeaderValue);
 
-fn build_js_bundles() -> HashMap<String, (String, String)> {
+static JS_BUNDLES: LazyLock<HashMap<String, Bundle>> = LazyLock::new(build_js_bundles);
+
+fn build_js_bundles() -> HashMap<String, Bundle> {
     let mut bundles = HashMap::new();
     let body = render_i18n_js(default_context());
     let etag = etag_for(&body);
-    bundles.insert("en-US".to_owned(), (body, etag));
+    // `etag_for` emits `"<hex>"`, always a valid header value; the fallback only
+    // keeps this panic-free.
+    let etag_value =
+        HeaderValue::from_str(&etag).unwrap_or_else(|_| HeaderValue::from_static("\"i18n\""));
+    bundles.insert("en-US".to_owned(), (body, etag, etag_value));
     // Additional language bundles land here as their catalogs ship: build an
     // `I18nContext` for the tag via `negotiate(Some(tag))` and insert.
     bundles
 }
+
+const I18N_JS_CONTENT_TYPE: HeaderValue =
+    HeaderValue::from_static("text/javascript; charset=utf-8");
+const I18N_JS_CACHE_CONTROL: HeaderValue = HeaderValue::from_static("no-cache");
+const I18N_JS_VARY: HeaderValue = HeaderValue::from_static("Accept-Language");
 
 /// Serve the negotiated locale's client-side translation bundle.
 ///
@@ -437,7 +452,7 @@ pub(crate) async fn i18n_js_handler(ctx: I18nContext, headers: HeaderMap) -> Res
     let bundle = JS_BUNDLES
         .get(ctx.lang())
         .or_else(|| JS_BUNDLES.get("en-US"));
-    let Some((body, etag)) = bundle else {
+    let Some((body, etag, etag_value)) = bundle else {
         tracing::error!("i18n bundle map is empty; serving 500");
         return StatusCode::INTERNAL_SERVER_ERROR.into_response();
     };
@@ -449,9 +464,9 @@ pub(crate) async fn i18n_js_handler(ctx: I18nContext, headers: HeaderMap) -> Res
         return (
             StatusCode::NOT_MODIFIED,
             [
-                (header::ETAG, etag.clone()),
-                (header::CACHE_CONTROL, "no-cache".to_owned()),
-                (header::VARY, "Accept-Language".to_owned()),
+                (header::ETAG, etag_value.clone()),
+                (header::CACHE_CONTROL, I18N_JS_CACHE_CONTROL),
+                (header::VARY, I18N_JS_VARY),
             ],
         )
             .into_response();
@@ -459,13 +474,10 @@ pub(crate) async fn i18n_js_handler(ctx: I18nContext, headers: HeaderMap) -> Res
 
     (
         [
-            (
-                header::CONTENT_TYPE,
-                "text/javascript; charset=utf-8".to_owned(),
-            ),
-            (header::CACHE_CONTROL, "no-cache".to_owned()),
-            (header::VARY, "Accept-Language".to_owned()),
-            (header::ETAG, etag.clone()),
+            (header::CONTENT_TYPE, I18N_JS_CONTENT_TYPE),
+            (header::CACHE_CONTROL, I18N_JS_CACHE_CONTROL),
+            (header::VARY, I18N_JS_VARY),
+            (header::ETAG, etag_value.clone()),
         ],
         body.clone(),
     )
@@ -570,7 +582,7 @@ mod tests {
         let fresh = render_i18n_js(default_context());
         let cached = JS_BUNDLES
             .get("en-US")
-            .map(|(body, _)| body.clone())
+            .map(|(body, ..)| body.clone())
             .expect("en-US bundle should be present");
         assert_eq!(
             cached, fresh,
@@ -930,6 +942,37 @@ mod tests {
         assert!(
             missing.is_empty(),
             "i18n keys missing from catalog: {missing:?}"
+        );
+
+        // Reverse direction: every catalog id should be referenced by some
+        // template/JS/Rust call site, otherwise it is dead weight. A message
+        // whose attribute is referenced (e.g. used only via `.attr("title")`)
+        // counts as live. Terms (`-foo`) are already excluded from `defined`.
+        //
+        // A few ids are intentionally present without a `tr()` render site:
+        // `common-app-name` is the canary `validate_startup` probes (passed as a
+        // required-id literal) to confirm the catalog resolves terms.
+        const NON_RENDERED_IDS: &[&str] = &["common-app-name"];
+        let used_roots: HashSet<&str> = used
+            .iter()
+            .map(|key| key.split('.').next().unwrap_or(key))
+            .collect();
+        let is_dead = |id: &String| {
+            if used.contains(id) || NON_RENDERED_IDS.contains(&id.as_str()) {
+                return false;
+            }
+            // Attribute entries (`id.attr`) must be referenced directly.
+            if id.contains('.') {
+                return true;
+            }
+            // A bare message id is live if any of its attributes is used.
+            !used_roots.contains(&id.as_str())
+        };
+        let mut dead: Vec<&String> = defined.iter().filter(|id| is_dead(id)).collect();
+        dead.sort();
+        assert!(
+            dead.is_empty(),
+            "i18n catalog ids defined but never referenced by any call site: {dead:?}"
         );
     }
 }

--- a/crates/vouch-server/static/js/keys.js
+++ b/crates/vouch-server/static/js/keys.js
@@ -166,7 +166,7 @@
     // RFC 9470: Perform inline FIDO2 re-authentication to get a fresh session.
     // Calls the same WebAuthn assertion endpoints as the login page.
     async function stepUpReauth() {
-        alert(t('keys-js-stepup-1') + '\n' + t('keys-js-stepup-2'));
+        alert(t('keys-js-stepup'));
 
         var startResp = await fetch('/login/webauthn/start', {
             method: 'POST',

--- a/crates/vouch-server/templates/applications/created.html
+++ b/crates/vouch-server/templates/applications/created.html
@@ -73,7 +73,13 @@
 
             <div>
                 <label class="block text-sm font-medium text-gray-300 mb-1">{{ self.tr("apps-create-type-label") }}</label>
-                <p class="text-sm text-gray-200">{{ application_type }}</p>
+                <p class="text-sm text-gray-200">
+                    {% if application_type == "web" %}{{ self.tr("apps-type-web") }}
+                    {% elif application_type == "native" %}{{ self.tr("apps-type-native") }}
+                    {% elif application_type == "spa" %}{{ self.tr("apps-type-spa") }}
+                    {% elif application_type == "service" %}{{ self.tr("apps-type-service") }}
+                    {% else %}{{ application_type }}{% endif %}
+                </p>
             </div>
         </div>
 

--- a/crates/vouch-server/templates/applications/list.html
+++ b/crates/vouch-server/templates/applications/list.html
@@ -58,7 +58,11 @@
                             {% elif app.application_type == "native" %}bg-vouch-success-bg text-vouch-success
                             {% elif app.application_type == "spa" %}bg-vouch-warning-bg text-vouch-warning
                             {% else %}bg-[#1f0d2d] text-[#a78bfa]{% endif %}">
-                            {{ app.application_type }}
+                            {% if app.application_type == "web" %}{{ self.tr("apps-type-web") }}
+                            {% elif app.application_type == "native" %}{{ self.tr("apps-type-native") }}
+                            {% elif app.application_type == "spa" %}{{ self.tr("apps-type-spa") }}
+                            {% elif app.application_type == "service" %}{{ self.tr("apps-type-service") }}
+                            {% else %}{{ app.application_type }}{% endif %}
                         </span>
                     </td>
                     <td class="px-3 py-4 whitespace-nowrap">
@@ -68,9 +72,17 @@
                             {% when crate::db::AccessScope::Personal %}bg-[#2d1f0d] text-[#fbbf24]
                             {% when crate::db::AccessScope::Public %}bg-[#0d2d1f] text-[#3ecf8e]
                             {% endmatch %}">
-                            {{ app.access_scope.display_name() }}
+                            {% match app.access_scope %}
+                            {% when crate::db::AccessScope::Organization %}{{ self.tr("apps-scope-organization") }}
+                            {% when crate::db::AccessScope::Personal %}{{ self.tr("apps-scope-personal") }}
+                            {% when crate::db::AccessScope::Public %}{{ self.tr("apps-scope-public") }}
+                            {% endmatch %}
                             <span class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2 py-1 text-xs text-gray-200 bg-gray-800 rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10">
-                                {{ app.access_scope.description() }}
+                                {% match app.access_scope %}
+                                {% when crate::db::AccessScope::Organization %}{{ self.tr("apps-scope-organization").attr("desc") }}
+                                {% when crate::db::AccessScope::Personal %}{{ self.tr("apps-scope-personal").attr("desc") }}
+                                {% when crate::db::AccessScope::Public %}{{ self.tr("apps-scope-public").attr("desc") }}
+                                {% endmatch %}
                             </span>
                         </span>
                     </td>

--- a/crates/vouch-server/templates/install.html
+++ b/crates/vouch-server/templates/install.html
@@ -45,21 +45,21 @@
 
                 <div id="apt-tab" class="tab-content hidden">
                     <div class="code-block text-sm space-y-1">
-                        <div class="text-gray-500"># Import GPG key</div>
+                        <div class="text-gray-500">{{ self.tr("install-comment-gpg") }}</div>
                         <div>curl -fsSL https://packages.vouch.sh/gpg/vouch.asc \</div>
                         <div class="pl-4">| gpg --dearmor \</div>
                         <div class="pl-4">| sudo tee /usr/share/keyrings/vouch-archive-keyring.gpg &gt; /dev/null</div>
-                        <div class="mt-2 text-gray-500"># Add repository</div>
+                        <div class="mt-2 text-gray-500">{{ self.tr("install-comment-add-repo") }}</div>
                         <div>echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/vouch-archive-keyring.gpg] https://packages.vouch.sh/apt stable main" \</div>
                         <div class="pl-4">| sudo tee /etc/apt/sources.list.d/vouch.list &gt; /dev/null</div>
-                        <div class="mt-2 text-gray-500"># Install</div>
+                        <div class="mt-2 text-gray-500">{{ self.tr("install-comment-install") }}</div>
                         <div>sudo apt-get update &amp;&amp; sudo apt-get install -y vouch</div>
                     </div>
                 </div>
 
                 <div id="rpm-tab" class="tab-content hidden">
                     <div class="code-block text-sm space-y-1">
-                        <div class="text-gray-500"># Add repository</div>
+                        <div class="text-gray-500">{{ self.tr("install-comment-add-repo") }}</div>
                         <div>sudo tee /etc/yum.repos.d/vouch.repo &lt;&lt; 'EOF'</div>
                         <div>[vouch]</div>
                         <div>name=Vouch</div>
@@ -68,7 +68,7 @@
                         <div>gpgkey=https://packages.vouch.sh/gpg/vouch.asc</div>
                         <div>enabled=1</div>
                         <div>EOF</div>
-                        <div class="mt-2 text-gray-500"># Install</div>
+                        <div class="mt-2 text-gray-500">{{ self.tr("install-comment-install") }}</div>
                         <div>sudo dnf install -y vouch</div>
                     </div>
                 </div>
@@ -148,11 +148,11 @@
             </div>
             <div class="ml-11">
                 <div class="code-block">
-                    <div class="text-gray-500"># Start your day with a single touch</div>
+                    <div class="text-gray-500">{{ self.tr("install-step3-comment") }}</div>
                     <div><span class="text-gray-500">$</span> <span id="step3-command">vouch login</span></div>
-                    <div>Enter PIN: ****</div>
-                    <div>Touch your YubiKey...</div>
-                    <div class="text-vouch-accent">&#x2713; Authenticated for 8 hours</div>
+                    <div>{{ self.tr("install-step3-prompt-pin") }}</div>
+                    <div>{{ self.tr("install-step3-prompt-touch") }}</div>
+                    <div class="text-vouch-accent">{{ self.tr("install-step3-authenticated") }}</div>
                 </div>
                 <p class="mt-2 text-sm text-gray-400">{{ self.tr("install-step3-body") }}</p>
             </div>

--- a/crates/vouch-server/templates/login.html
+++ b/crates/vouch-server/templates/login.html
@@ -9,7 +9,7 @@
             <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 5.25a3 3 0 0 1 3 3m3 0a6 6 0 0 1-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1 1 21.75 8.25Z"/>
         </svg>
         {% if let Some(logo) = logo_uri %}
-        <img src="{{ logo }}" alt="Application logo" class="w-12 h-12 mx-auto mb-4 rounded" referrerpolicy="no-referrer">
+        <img src="{{ logo }}" alt="{{ self.tr("login-logo-alt") }}" class="w-12 h-12 mx-auto mb-4 rounded" referrerpolicy="no-referrer">
         {% endif %}
         <h1 class="text-2xl font-bold text-gray-200 mb-2">{{ self.tr("login-title") }}</h1>
         {% if client_name.is_some() %}


### PR DESCRIPTION
## Summary

A follow-up review of the recently-shipped i18n work (#485, #489). The verdict: the **infrastructure is solid** — the shared `vouch-i18n` crate, per-request `Accept-Language` negotiation, no-panic fallbacks, and the completeness tests all hold up and need no refactoring. What remained were a handful of **user-facing coverage gaps** plus a few consistency/polish items. This PR addresses those; it does **not** add a new language or change the architecture.

## What changed

**Internationalize strings that slipped through**
- `login.html` — the logo `alt` text (accessibility) → `login-logo-alt`.
- `applications/list.html` + `applications/created.html` — the application-type pill and the access-scope badge were rendering raw English enum output (`app.application_type`, `AccessScope::display_name()`/`description()`), bypassing i18n. Now mapped template-side to catalog ids so the completeness test still sees literal keys. The scope **display name and its tooltip description are kept together as one message with a Fluent `.desc` attribute** (matching the existing `.title`/`.aria-label` pattern).
- `install.html` — the apt/rpm shell-comment annotations and the simulated step-3 terminal session prose.
- Code/proper-noun text (shell commands, CEL/JSON/URI examples, OS names like macOS / Debian / Ubuntu) is **intentionally left verbatim**, now documented by a `do-not-translate` note in the catalog header.

**Consistency**
- `keys.js` built its step-up alert by concatenating two translated strings with `'\n'`, which breaks word order in other locales. Collapsed into a single multiline Fluent message (`keys-js-stepup`); dropped the now-unused `keys-js-stepup-{1,2}`.

**Infra polish** (`infra/i18n.rs`)
- `/i18n.js` handler now serves constant headers as static `HeaderValue`s and a pre-parsed ETag `HeaderValue` instead of allocating them on every request; `parse_accept_language` preallocates its buffer.

**Test**
- Extended `every_template_key_is_defined` with the reverse check: flag catalog ids that are **defined but never referenced** by any template/JS/Rust call site (a message whose attribute is used counts as live; the `common-app-name` startup canary is allowlisted). The catalog was already clean apart from that canary.

## Testing
- `cargo test -p vouch-server` — **2322 passed**, including the parity + new dead-key checks.
- `cargo clippy -p vouch-server --all-targets --all-features` — clean (no-panic lints enforced).
- `cargo fmt` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Li2x7SsuZWAeCTYEnV5F3a)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI copy and i18n test/perf polish only; no auth, OAuth, or data-path changes.
> 
> **Overview**
> Closes **user-facing i18n gaps** that still rendered hard-coded English: login logo `alt`, application **type** and **access scope** pills (with scope tooltips via Fluent `.desc`), install-page shell comments and step-3 demo terminal lines. Documents in the catalog which strings stay **verbatim** (commands, OS names, code).
> 
> **`keys-js-stepup`** replaces two JS strings concatenated with `\n` so locales can control the full step-up alert in one message.
> 
> **`/i18n.js`** now reuses static `HeaderValue`s and a pre-parsed ETag; **`parse_accept_language`** preallocates its vector.
> 
> **`every_template_key_is_defined`** gains a reverse check for catalog ids never referenced (with an allowlist for the startup canary).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63e68f90192a3de1dfd048f2049189512bac5b72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->