### PR TITLE
Wire audit events + Content-Digest enforcement; drop unused PIN methods

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,7 +242,6 @@ let result = key.authenticate(&rp_id, &challenge, &pin)?;
 **PIN Handling:**
 - `key.is_pin_set()` — Check if PIN is configured
 - `key.set_new_pin(&pin)` — Set initial PIN (8+ characters required)
-- `key.change_pin(&current, &new)` — Change existing PIN
 - `ensure_pin_configured(&key)` — Detect missing PIN and guide user through setup
 - `translate_fido2_error()` — Convert CTAP2 errors to user-friendly messages
 

--- a/crates/vouch-agent/src/client.rs
+++ b/crates/vouch-agent/src/client.rs
@@ -346,4 +346,3 @@ impl AgentClient {
         Ok(())
     }
 }
-

--- a/crates/vouch-agent/src/expiry_monitor.rs
+++ b/crates/vouch-agent/src/expiry_monitor.rs
@@ -4,6 +4,7 @@
 //! Runs as a background task in the agent, checking session expiry at regular
 //! intervals and sending desktop notifications at configurable thresholds.
 
+use jiff::Timestamp;
 use std::sync::Arc;
 use tracing::{debug, info};
 
@@ -24,29 +25,28 @@ const CHECK_INTERVAL_SECS: u64 = 60;
 /// This task checks the session state periodically and sends desktop
 /// notifications when the session is about to expire.
 pub async fn run(state: Arc<AgentState>) {
-    // Track which thresholds have already fired to avoid duplicate notifications
+    // Thresholds already fired for the current session, to avoid duplicate
+    // notifications.
     let mut fired_thresholds: Vec<u64> = Vec::new();
+    // Identity of the session those thresholds were recorded against (its
+    // expiry timestamp). A new login changes this — even one that replaces an
+    // already-expired session without an intervening logout — so the warnings
+    // re-arm for the new session.
+    let mut tracked_session: Option<Timestamp> = None;
 
     loop {
         tokio::time::sleep(tokio::time::Duration::from_secs(CHECK_INTERVAL_SECS)).await;
 
-        // Check if we have an active session
-        let remaining_secs = match state.expires_in_seconds().await {
-            Some(secs) => secs,
-            None => {
-                // No session — reset fired thresholds for next login
-                if !fired_thresholds.is_empty() {
-                    fired_thresholds.clear();
-                    debug!("Session cleared, reset expiry notifications");
-                }
-                continue;
-            }
-        };
+        let session_expiry = state.current_session_expiry().await;
+        let remaining_secs = state.expires_in_seconds().await;
 
-        // Session already expired
-        if remaining_secs == 0 {
-            if !fired_thresholds.contains(&0) {
-                fired_thresholds.push(0);
+        for threshold in thresholds_to_fire(
+            &mut tracked_session,
+            &mut fired_thresholds,
+            session_expiry,
+            remaining_secs,
+        ) {
+            if threshold == 0 {
                 info!("Session has expired");
                 let email = state.current_user_email().await;
                 crate::audit::log_event(crate::audit::AuditEvent::SessionExpired { email });
@@ -54,14 +54,7 @@ pub async fn run(state: Arc<AgentState>) {
                     "Vouch session expired",
                     "Your session has expired. Run 'vouch login' to re-authenticate.",
                 );
-            }
-            continue;
-        }
-
-        // Check each threshold
-        for &threshold in WARN_THRESHOLDS_SECS {
-            if remaining_secs <= threshold && !fired_thresholds.contains(&threshold) {
-                fired_thresholds.push(threshold);
+            } else {
                 // 60 is non-zero; unwrap_or arm is unreachable.
                 let mins = threshold.checked_div(60).unwrap_or(0);
                 let message = format!(
@@ -74,6 +67,48 @@ pub async fn run(state: Arc<AgentState>) {
             }
         }
     }
+}
+
+/// Compute which expiry thresholds should fire on a single monitor tick.
+///
+/// Resets `fired_thresholds` whenever the active session changes — keyed on the
+/// session's expiry timestamp, so a new login that replaces an already-expired
+/// session (without an intervening logout) re-arms the warnings. Returns the
+/// thresholds crossed this tick that have not fired yet — `0` means the session
+/// has expired — and marks them fired.
+fn thresholds_to_fire(
+    tracked_session: &mut Option<Timestamp>,
+    fired_thresholds: &mut Vec<u64>,
+    session_expiry: Option<Timestamp>,
+    remaining_secs: Option<u64>,
+) -> Vec<u64> {
+    if session_expiry != *tracked_session {
+        *tracked_session = session_expiry;
+        fired_thresholds.clear();
+    }
+
+    let Some(remaining) = remaining_secs else {
+        return Vec::new();
+    };
+
+    let mut fired_now = Vec::new();
+
+    if remaining == 0 {
+        if !fired_thresholds.contains(&0) {
+            fired_thresholds.push(0);
+            fired_now.push(0);
+        }
+        return fired_now;
+    }
+
+    for &threshold in WARN_THRESHOLDS_SECS {
+        if remaining <= threshold && !fired_thresholds.contains(&threshold) {
+            fired_thresholds.push(threshold);
+            fired_now.push(threshold);
+        }
+    }
+
+    fired_now
 }
 
 /// Send a desktop notification using platform-native commands.
@@ -134,5 +169,77 @@ fn send_notification(title: &str, body: &str) {
     {
         let _ = (title, body);
         debug!("Desktop notifications not supported on this platform");
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
+mod tests {
+    use super::*;
+
+    fn ts(secs: i64) -> Timestamp {
+        Timestamp::from_second(secs).unwrap()
+    }
+
+    #[test]
+    fn re_login_re_arms_expiry_warnings() {
+        let mut tracked = None;
+        let mut fired = Vec::new();
+
+        // Session A expires → the expired threshold fires once.
+        assert_eq!(
+            thresholds_to_fire(&mut tracked, &mut fired, Some(ts(1000)), Some(0)),
+            vec![0]
+        );
+        // Same expired session next tick → no duplicate.
+        assert!(thresholds_to_fire(&mut tracked, &mut fired, Some(ts(1000)), Some(0)).is_empty());
+
+        // A new login replaces the still-stored expired session without ever
+        // passing through "no session" — thresholds must reset.
+        assert!(
+            thresholds_to_fire(&mut tracked, &mut fired, Some(ts(40000)), Some(8 * 3600))
+                .is_empty()
+        );
+        assert!(fired.is_empty(), "thresholds reset on session change");
+
+        // When session B expires, the audit/notification must fire again.
+        assert_eq!(
+            thresholds_to_fire(&mut tracked, &mut fired, Some(ts(40000)), Some(0)),
+            vec![0],
+            "expiry must fire for the new session"
+        );
+    }
+
+    #[test]
+    fn warn_thresholds_fire_once_each() {
+        let mut tracked = None;
+        let mut fired = Vec::new();
+        let expiry = Some(ts(99999));
+
+        // 25 minutes left crosses the 30-minute threshold.
+        assert_eq!(
+            thresholds_to_fire(&mut tracked, &mut fired, expiry, Some(25 * 60)),
+            vec![30 * 60]
+        );
+        // Still 25 minutes → no re-fire.
+        assert!(thresholds_to_fire(&mut tracked, &mut fired, expiry, Some(25 * 60)).is_empty());
+        // 4 minutes left crosses the 5-minute threshold.
+        assert_eq!(
+            thresholds_to_fire(&mut tracked, &mut fired, expiry, Some(4 * 60)),
+            vec![5 * 60]
+        );
+    }
+
+    #[test]
+    fn no_session_clears_tracking() {
+        let mut tracked = Some(ts(1000));
+        let mut fired = vec![0_u64];
+
+        assert!(thresholds_to_fire(&mut tracked, &mut fired, None, None).is_empty());
+        assert_eq!(tracked, None);
+        assert!(fired.is_empty());
     }
 }

--- a/crates/vouch-agent/src/expiry_monitor.rs
+++ b/crates/vouch-agent/src/expiry_monitor.rs
@@ -48,6 +48,8 @@ pub async fn run(state: Arc<AgentState>) {
             if !fired_thresholds.contains(&0) {
                 fired_thresholds.push(0);
                 info!("Session has expired");
+                let email = state.current_user_email().await;
+                crate::audit::log_event(crate::audit::AuditEvent::SessionExpired { email });
                 send_notification(
                     "Vouch session expired",
                     "Your session has expired. Run 'vouch login' to re-authenticate.",

--- a/crates/vouch-agent/src/ssh_agent/provisioning.rs
+++ b/crates/vouch-agent/src/ssh_agent/provisioning.rs
@@ -70,6 +70,8 @@ pub(super) async fn handle_sign_request(
     // Sign the data (returns encoded signature blob)
     let sig_blob = sign_data(&creds.private_key, &data)?;
 
+    crate::audit::log_event(crate::audit::AuditEvent::SshSigning);
+
     build_sign_response(&sig_blob)
 }
 

--- a/crates/vouch-agent/src/state.rs
+++ b/crates/vouch-agent/src/state.rs
@@ -344,6 +344,15 @@ impl AgentState {
         let guard = self.inner.read().await;
         guard.session.as_ref().map(|s| s.user_email().to_string())
     }
+
+    /// Get the current session's expiry timestamp, if a session is stored.
+    ///
+    /// Returned even for an expired-but-not-yet-cleared session so the expiry
+    /// monitor can detect when a new login replaces it and re-arm its warnings.
+    pub async fn current_session_expiry(&self) -> Option<Timestamp> {
+        let guard = self.inner.read().await;
+        guard.session.as_ref().map(Session::expires_at)
+    }
 }
 
 #[cfg(test)]

--- a/crates/vouch-agent/src/state.rs
+++ b/crates/vouch-agent/src/state.rs
@@ -335,6 +335,15 @@ impl AgentState {
             _ => None,
         }
     }
+
+    /// Get the current session's email, if a session is stored.
+    ///
+    /// Returns the email even when the session has expired so that the expiry
+    /// monitor can attribute an `AuditEvent::SessionExpired` to the user.
+    pub async fn current_user_email(&self) -> Option<String> {
+        let guard = self.inner.read().await;
+        guard.session.as_ref().map(|s| s.user_email().to_string())
+    }
 }
 
 #[cfg(test)]
@@ -492,6 +501,32 @@ mod tests {
         // Expired session should not be returned
         assert!(state.get_session().await.is_none());
         assert!(state.get_token().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_current_user_email_available_for_expired_session() {
+        let state = AgentState::new();
+
+        // No session yet.
+        assert!(state.current_user_email().await.is_none());
+
+        // An expired session still yields the email so the expiry monitor can
+        // attribute the SessionExpired audit event to the user.
+        let session = Session::new(
+            SecretString::from("test_token"),
+            "user@example.com".to_string(),
+            past_timestamp(100),
+        );
+        state.store_session(session).await;
+
+        assert!(
+            state.get_session().await.is_none(),
+            "expired session hidden"
+        );
+        assert_eq!(
+            state.current_user_email().await.as_deref(),
+            Some("user@example.com")
+        );
     }
 
     // --- CachedCredential tests ---

--- a/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
+++ b/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
@@ -166,14 +166,11 @@ fido2-setting-pin-done = done!
 fido2-err-insert-prompt =
     Timed out waiting for { -yubikey } after { $timeout }s.
     Insert your key and try again.
-fido2-err-no-device = no { -yubikey } found - please insert your { -yubikey }
 fido2-err-not-ready = { -yubikey } not ready after insertion - try removing and reinserting it
 fido2-err-pin-query = failed to query PIN status
 fido2-err-pin-unsupported = This device does not support PIN authentication
-fido2-err-pin-retries = failed to get PIN retry count
 fido2-err-pin-already-set = A PIN is already set on this { -yubikey }.
 fido2-err-pin-set-failed = Failed to set PIN: { $reason }
-fido2-err-pin-change = failed to change PIN
 fido2-err-attestation = attestation verification failed
 fido2-err-no-assertion = no assertion returned
 fido2-err-read-pin = failed to read PIN

--- a/crates/vouch-cli/src/fido2/unix.rs
+++ b/crates/vouch-cli/src/fido2/unix.rs
@@ -167,19 +167,6 @@ fn build_attestation_object(attestation: &Attestation) -> Result<Vec<u8>> {
 }
 
 impl YubiKey {
-    /// Discover and connect to a `YubiKey`.
-    ///
-    /// Returns immediately if a device is found, or an error if not.
-    #[expect(dead_code, reason = "used by binary target, not the library")]
-    pub(crate) fn discover() -> Result<Self> {
-        use crate::tr;
-
-        let cfg = LibCfg::init();
-        let device = FidoKeyHidFactory::create(&cfg).with_context(|| tr!("fido2-err-no-device"))?;
-
-        Ok(Self { device })
-    }
-
     /// Wait for a `YubiKey` to be inserted, polling until one is found or timeout.
     ///
     /// Prompts the user to insert their device and polls every 500ms.
@@ -265,21 +252,10 @@ impl YubiKey {
         }
     }
 
-    /// Get the number of PIN retry attempts remaining.
-    ///
-    /// Returns the count of attempts before the PIN is blocked.
-    #[expect(dead_code, reason = "used by binary target, not the library")]
-    pub(crate) fn pin_retries(&self) -> Result<i32> {
-        use crate::tr;
-        self.device
-            .get_pin_retries()
-            .with_context(|| tr!("fido2-err-pin-retries"))
-    }
-
     /// Set a new PIN on a `YubiKey` that doesn't have one configured.
     ///
     /// # Errors
-    /// Returns an error if a PIN is already set (use `change_pin` instead).
+    /// Returns an error if a PIN is already set.
     pub(crate) fn set_new_pin(&self, pin: &str) -> Result<()> {
         use crate::{tr, tr_args};
 
@@ -296,15 +272,6 @@ impl YubiKey {
                 ))
             }
         })
-    }
-
-    /// Change the PIN on a `YubiKey`.
-    #[expect(dead_code, reason = "used by binary target, not the library")]
-    pub(crate) fn change_pin(&self, current_pin: &str, new_pin: &str) -> Result<()> {
-        use crate::tr;
-        self.device
-            .change_pin(current_pin, new_pin)
-            .with_context(|| tr!("fido2-err-pin-change"))
     }
 
     /// Perform FIDO2 registration (`make_credential`) with an explicit PIN.

--- a/crates/vouch-httpsig/src/middleware.rs
+++ b/crates/vouch-httpsig/src/middleware.rs
@@ -38,6 +38,8 @@ use axum::{
 };
 
 use crate::algorithm::VerifyingAlgorithm;
+use crate::digest::verify_content_digest;
+use crate::error::HttpSigError;
 use crate::signature_params::SignatureParams;
 use crate::verify::{extract_signature_labels, validate_coverage, verify_request_signature};
 
@@ -46,6 +48,12 @@ use crate::verify::{extract_signature_labels, validate_coverage, verify_request_
 /// Ensures signatures protect the request method and target, preventing
 /// replay attacks where an attacker moves a signature to a different endpoint.
 const REQUIRED_COVERAGE: &[&str] = &["@method", "@path"];
+
+/// Maximum signed request body buffered for Content-Digest verification.
+///
+/// Signed `/v1/*` payloads are small JSON documents; 1 MiB is a generous cap
+/// that bounds memory use while never rejecting a legitimate request.
+const MAX_SIGNED_BODY: usize = 1024 * 1024;
 
 /// Generic error response to avoid leaking verification details to attackers.
 const SIG_VERIFY_FAILED: &str = "signature verification failed";
@@ -125,7 +133,7 @@ pub async fn verify_signature<R: KeyResolver>(
 /// Axum middleware that verifies RFC 9421 HTTP signatures with a custom max age.
 pub async fn verify_signature_with_max_age<R: KeyResolver>(
     resolver: Arc<R>,
-    mut req: Request<axum::body::Body>,
+    req: Request<axum::body::Body>,
     next: Next,
     max_age: i64,
 ) -> Response {
@@ -194,10 +202,30 @@ pub async fn verify_signature_with_max_age<R: KeyResolver>(
                 alg = ?params.alg,
                 "HTTP signature verified"
             );
-            req.extensions_mut().insert(VerifiedSignature {
+            // Enforce RFC 9530 body integrity for signed requests that carry a
+            // body, then rebuild the request for the downstream handler.
+            let (mut parts, body) = req.into_parts();
+            let bytes = match axum::body::to_bytes(body, MAX_SIGNED_BODY).await {
+                Ok(bytes) => bytes,
+                Err(e) => {
+                    tracing::debug!(error = %e, "failed to buffer signed request body");
+                    return (StatusCode::UNAUTHORIZED, SIG_VERIFY_FAILED).into_response();
+                }
+            };
+            if let Err(e) = enforce_body_digest(&params, &parts.headers, &bytes) {
+                tracing::debug!(
+                    label = %label,
+                    keyid = %keyid,
+                    error = %e,
+                    "signed request body integrity check failed"
+                );
+                return (StatusCode::UNAUTHORIZED, SIG_VERIFY_FAILED).into_response();
+            }
+            parts.extensions.insert(VerifiedSignature {
                 label: label.clone(),
                 params,
             });
+            let req = Request::from_parts(parts, axum::body::Body::from(bytes));
             let mut response = next.run(req).await;
 
             // Issue a fresh nonce for the client's next request
@@ -219,6 +247,38 @@ pub async fn verify_signature_with_max_age<R: KeyResolver>(
             (StatusCode::UNAUTHORIZED, SIG_VERIFY_FAILED).into_response()
         }
     }
+}
+
+/// Enforce RFC 9530 Content-Digest integrity for a signed request body.
+///
+/// A signed request that carries a non-empty body MUST cover `content-digest`
+/// in its signature and present a matching `Content-Digest` header. Coverage is
+/// required because an unsigned digest header could be swapped alongside the
+/// body. Empty bodies (GET and bodyless POST requests) are exempt.
+///
+/// # Errors
+///
+/// Returns [`HttpSigError::MissingDigest`] when the body is not bound by a
+/// covered, present `Content-Digest`, or [`HttpSigError::DigestMismatch`] when
+/// the digest does not match the body.
+fn enforce_body_digest(
+    params: &SignatureParams,
+    headers: &http::HeaderMap,
+    body: &[u8],
+) -> Result<(), HttpSigError> {
+    if body.is_empty() {
+        return Ok(());
+    }
+
+    validate_coverage(params, &["content-digest"]).map_err(|_| HttpSigError::MissingDigest)?;
+
+    let header = headers
+        .get("content-digest")
+        .ok_or(HttpSigError::MissingDigest)?
+        .to_str()
+        .map_err(|e| HttpSigError::SfvParse(format!("Content-Digest: {e}")))?;
+
+    verify_content_digest(header, body)
 }
 
 /// Extract the `keyid` parameter from a Signature-Input header value for a given label.
@@ -280,11 +340,29 @@ mod tests {
 
     fn build_test_router(resolver: Arc<InMemoryKeyResolver>) -> Router {
         Router::new()
-            .route("/test", get(ok_handler))
+            .route("/test", get(ok_handler).post(ok_handler))
             .layer(axum::middleware::from_fn_with_state(
                 resolver,
                 verify_signature::<InMemoryKeyResolver>,
             ))
+    }
+
+    fn params_covering(components: Vec<crate::ComponentIdentifier>) -> SignatureParams {
+        SignatureParams {
+            components,
+            alg: None,
+            keyid: None,
+            created: None,
+            expires: None,
+            nonce: None,
+            tag: None,
+        }
+    }
+
+    fn digest_header(body: &[u8]) -> http::HeaderValue {
+        crate::digest::content_digest(body, crate::digest::DigestAlgorithm::Sha256)
+            .parse()
+            .unwrap()
     }
 
     #[tokio::test]
@@ -401,6 +479,130 @@ mod tests {
         parts
             .headers
             .insert("signature", "sig1=:dGFtcGVyZWQ=:".parse().unwrap());
+        let req = Request::from_parts(parts, body);
+
+        let response =
+            <Router as tower::ServiceExt<Request<axum::body::Body>>>::oneshot(router, req)
+                .await
+                .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn test_enforce_body_digest_empty_body_is_exempt() {
+        let params = params_covering(vec![]);
+        let headers = http::HeaderMap::new();
+        enforce_body_digest(&params, &headers, b"").unwrap();
+    }
+
+    #[test]
+    fn test_enforce_body_digest_valid() {
+        let body = b"{\"x\":1}";
+        let params = params_covering(vec![
+            crate::ComponentIdentifier::method(),
+            crate::ComponentIdentifier::field("content-digest"),
+        ]);
+        let mut headers = http::HeaderMap::new();
+        headers.insert("content-digest", digest_header(body));
+        enforce_body_digest(&params, &headers, body).unwrap();
+    }
+
+    #[test]
+    fn test_enforce_body_digest_missing_header() {
+        let body = b"body";
+        let params = params_covering(vec![crate::ComponentIdentifier::field("content-digest")]);
+        let headers = http::HeaderMap::new();
+        assert!(matches!(
+            enforce_body_digest(&params, &headers, body),
+            Err(HttpSigError::MissingDigest)
+        ));
+    }
+
+    #[test]
+    fn test_enforce_body_digest_not_covered() {
+        let body = b"body";
+        let params = params_covering(vec![crate::ComponentIdentifier::method()]);
+        let mut headers = http::HeaderMap::new();
+        headers.insert("content-digest", digest_header(body));
+        assert!(matches!(
+            enforce_body_digest(&params, &headers, body),
+            Err(HttpSigError::MissingDigest)
+        ));
+    }
+
+    #[test]
+    fn test_enforce_body_digest_mismatch() {
+        let params = params_covering(vec![crate::ComponentIdentifier::field("content-digest")]);
+        let mut headers = http::HeaderMap::new();
+        headers.insert("content-digest", digest_header(b"other body"));
+        assert!(matches!(
+            enforce_body_digest(&params, &headers, b"body"),
+            Err(HttpSigError::DigestMismatch(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_signed_post_with_valid_digest_succeeds() {
+        let signer = EcdsaP256Signer::generate("test-key").unwrap();
+        let mut resolver = InMemoryKeyResolver::new();
+        resolver.insert("test-key".to_string(), Arc::new(signer.verifier()));
+        let router = build_test_router(Arc::new(resolver));
+
+        let body = b"{\"hello\":\"world\"}".to_vec();
+        let mut req = Request::builder()
+            .method("POST")
+            .uri("http://example.com/test")
+            .body(axum::body::Body::from(body.clone()))
+            .unwrap();
+        crate::digest::set_content_digest(
+            req.headers_mut(),
+            &body,
+            crate::digest::DigestAlgorithm::Sha256,
+        )
+        .unwrap();
+
+        SignatureBuilder::new("sig1")
+            .method()
+            .path()
+            .field("content-digest")
+            .created_now()
+            .sign_request(&mut req, &signer)
+            .unwrap();
+
+        let (mut parts, body) = req.into_parts();
+        parts.uri = "/test".parse().unwrap();
+        let req = Request::from_parts(parts, body);
+
+        let response =
+            <Router as tower::ServiceExt<Request<axum::body::Body>>>::oneshot(router, req)
+                .await
+                .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_signed_post_without_digest_is_rejected() {
+        let signer = EcdsaP256Signer::generate("test-key").unwrap();
+        let mut resolver = InMemoryKeyResolver::new();
+        resolver.insert("test-key".to_string(), Arc::new(signer.verifier()));
+        let router = build_test_router(Arc::new(resolver));
+
+        // A signed POST whose signature does not cover the body via Content-Digest.
+        let mut req = Request::builder()
+            .method("POST")
+            .uri("http://example.com/test")
+            .body(axum::body::Body::from(b"{\"hello\":\"world\"}".to_vec()))
+            .unwrap();
+
+        SignatureBuilder::new("sig1")
+            .method()
+            .path()
+            .created_now()
+            .sign_request(&mut req, &signer)
+            .unwrap();
+
+        let (mut parts, body) = req.into_parts();
+        parts.uri = "/test".parse().unwrap();
         let req = Request::from_parts(parts, body);
 
         let response =


### PR DESCRIPTION
Follow-up to the Detail dead-code cleanup (#501–#524). Three of those PRs (#501, #513, #522/#523) removed code that was dead only because a feature was never wired up. This wires the worthwhile ones and removes the genuinely-unneeded one. Each is a separate commit.

## Audit SSH signing and session-expiry events (replaces #501)
The agent detected session expiry and performed SSH signing but never wrote the matching audit events. Emit `AuditEvent::SshSigning` on each SSH signing operation and `AuditEvent::SessionExpired { email }` when a session lapses. Adds `AgentState::current_user_email` so the expired session can still attribute the event.

## Enforce Content-Digest integrity for signed /v1 bodies (replaces #522, #523)
A signed `/v1/*` request carrying a non-empty body must now cover and present a `Content-Digest` header whose value matches the body (RFC 9530). The middleware buffers the body, verifies the digest, and returns 401 on a missing, uncovered, or mismatched digest. This consumes the previously-unused `VerifiedSignature` request extension and `MissingDigest` error variant, and matches the CLI, which already signs and covers `content-digest` for bodied requests.

This is internal `/v1/*` hardening between the CLI and server. It is not exercised by the OpenID FAPI conformance suite, which signs JAR/JARM with ES256 over `/oauth/*`. Optional per-client "all /v1/* requests must be signed" enforcement is tracked in #526.

## Remove unused YubiKey PIN methods (replaces #513)
`change_pin`, `discover`, and `pin_retries` have no caller. First-time PIN setup is handled inline by `ensure_pin_configured` during `register`/`login`, and no vouch flow changes an existing PIN. Removes them, their orphaned i18n keys, the stale `dead_code` expectations, and the phantom `change_pin` reference in `CLAUDE.md`.

## Validation
- `make lint` (clippy `-D warnings`, all targets and features): clean
- `make test`: pass (0 failures)
- `cargo test -p vouch-httpsig --all-features` (incl. new digest tests) and the server httpsig integration tests: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Content-Digest enforcement changes auth behavior for signed POSTs to `/v1/*` (intentional hardening); agent audit and expiry-monitor changes are localized with tests.
> 
> **Overview**
> **Agent audit and session expiry** — SSH agent sign requests now emit `AuditEvent::SshSigning`. When a session lapses, the expiry monitor logs `AuditEvent::SessionExpired { email }` and still notifies the user. `AgentState` gains `current_user_email` and `current_session_expiry` (including expired-but-not-cleared sessions) so expiry can be attributed and **re-login re-arms** warning thresholds; logic is extracted into `thresholds_to_fire` with unit tests.
> 
> **HTTP signature hardening** — After a valid RFC 9421 signature, `vouch-httpsig` middleware buffers the body (up to 1 MiB) and requires non-empty bodies to include a signature-covered `Content-Digest` that matches the payload (RFC 9530); failures return 401. Empty bodies stay exempt. New unit and integration tests cover digest enforcement.
> 
> **CLI cleanup** — Removes unused `YubiKey::discover`, `change_pin`, and `pin_retries`, related i18n strings, and the stale `change_pin` note in `CLAUDE.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff8665cb44ee168f371b6972d43d3fe886ef845b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->