### PR TITLE
Require RFC 9421 signatures on all /v1/* requests

### DIFF
--- a/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
+++ b/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
@@ -94,6 +94,10 @@ enroll-err-start = Failed to start enrollment
 enroll-err-key-init = Failed to initialize the hardware-backed signing key
 enroll-err-register = Failed to register client with the server (RFC 7591)
 
+## Client / session errors
+
+client-err-not-authenticated = not authenticated — run '{ -cmd } login' first
+
 ## RFC 9421 HTTP message signing errors
 
 httpsig-err-no-signature =

--- a/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
+++ b/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
@@ -91,6 +91,17 @@ enroll-err-denied = authorization was denied
 enroll-err-code-expired = The code has expired. Please try again.
 enroll-err-failed = Enrollment failed: { $reason }
 enroll-err-start = Failed to start enrollment
+enroll-err-key-init = Failed to initialize the hardware-backed signing key
+enroll-err-register = Failed to register client with the server (RFC 7591)
+
+## RFC 9421 HTTP message signing errors
+
+httpsig-err-no-signature =
+    Failed to sign request for { $path }: HTTP message signing produced no
+    signature — re-run { -cmd } enroll or unlock your keychain and try again
+httpsig-err-key-unavailable =
+    Hardware-backed signing key unavailable for { $path }: this request must be
+    signed (RFC 9421). Run { -cmd } enroll (or unlock your keychain) and try again
 
 ## FIDO2 / CTAP2 user-facing errors
 

--- a/crates/vouch-cli/src/client.rs
+++ b/crates/vouch-cli/src/client.rs
@@ -13,6 +13,7 @@ use vouch_cli::fapi::{ClientKey, DpopProofBuilder};
 use vouch_cli::http::{
     HttpClient, HttpResponse, ReqwestClient, format_http_error, parse_www_authenticate,
 };
+use vouch_cli::tr_args;
 
 /// Parameters for building RFC 9421 HTTP signature headers.
 struct SignRequestParams<'a> {
@@ -396,19 +397,17 @@ impl<H: HttpClient> VouchClient<H> {
                         });
                         if signature_required && !sig_headers.iter().any(|(k, _)| k == "Signature")
                         {
-                            return Err(anyhow::anyhow!(
-                                "failed to sign request for {path}: HTTP message signing \
-                                 produced no signature — re-run `vouch enroll` or unlock \
-                                 your keychain and try again"
-                            ));
+                            return Err(anyhow::anyhow!(tr_args!(
+                                "httpsig-err-no-signature",
+                                path = path
+                            )));
                         }
                         extra_headers.extend(sig_headers);
                     } else if signature_required {
-                        return Err(anyhow::anyhow!(
-                            "hardware-backed signing key unavailable for {path}: this \
-                             request must be signed (RFC 9421). Run `vouch enroll` (or \
-                             unlock your keychain) and try again"
-                        ));
+                        return Err(anyhow::anyhow!(tr_args!(
+                            "httpsig-err-key-unavailable",
+                            path = path
+                        )));
                     }
 
                     let extra_refs: Vec<(&str, &str)> = extra_headers

--- a/crates/vouch-cli/src/client.rs
+++ b/crates/vouch-cli/src/client.rs
@@ -13,7 +13,7 @@ use vouch_cli::fapi::{ClientKey, DpopProofBuilder};
 use vouch_cli::http::{
     HttpClient, HttpResponse, ReqwestClient, format_http_error, parse_www_authenticate,
 };
-use vouch_cli::tr_args;
+use vouch_cli::{tr, tr_args};
 
 /// Parameters for building RFC 9421 HTTP signature headers.
 struct SignRequestParams<'a> {
@@ -176,9 +176,14 @@ impl<H: HttpClient> VouchClient<H> {
 
     /// Get the stored authentication token, or error if not authenticated.
     fn token(&self) -> Result<&SecretString> {
-        self.token
-            .as_ref()
-            .context("not authenticated - run 'vouch login' first")
+        self.token.as_ref().ok_or_else(|| {
+            // Typed error so `exit_code::classify` maps it by type, not by
+            // matching the (translatable) message string.
+            crate::exit_code::CliError::NotAuthenticated {
+                reason: tr!("client-err-not-authenticated"),
+            }
+            .into()
+        })
     }
 
     /// Build the `Authorization` header value and an optional `DPoP` proof.
@@ -397,17 +402,17 @@ impl<H: HttpClient> VouchClient<H> {
                         });
                         if signature_required && !sig_headers.iter().any(|(k, _)| k == "Signature")
                         {
-                            return Err(anyhow::anyhow!(tr_args!(
-                                "httpsig-err-no-signature",
-                                path = path
-                            )));
+                            return Err(crate::exit_code::CliError::NotAuthenticated {
+                                reason: tr_args!("httpsig-err-no-signature", path = path),
+                            }
+                            .into());
                         }
                         extra_headers.extend(sig_headers);
                     } else if signature_required {
-                        return Err(anyhow::anyhow!(tr_args!(
-                            "httpsig-err-key-unavailable",
-                            path = path
-                        )));
+                        return Err(crate::exit_code::CliError::NotAuthenticated {
+                            reason: tr_args!("httpsig-err-key-unavailable", path = path),
+                        }
+                        .into());
                     }
 
                     let extra_refs: Vec<(&str, &str)> = extra_headers

--- a/crates/vouch-cli/src/client.rs
+++ b/crates/vouch-cli/src/client.rs
@@ -362,6 +362,13 @@ impl<H: HttpClient> VouchClient<H> {
         let url = self.url(path);
         tracing::debug!("{method} {url} ({auth})");
 
+        // The `/v1/*` credential and key-management endpoints require a valid
+        // RFC 9421 signature on every request (FAPI 2.0 Message Signing). The
+        // soft `/v1/auth/status` probe is exempt — it is designed to answer
+        // without authentication. For required paths we fail with a clear error
+        // rather than silently downgrading to Bearer-only.
+        let signature_required = path.starts_with("/v1/") && path != "/v1/auth/status";
+
         let mut attempt = 0;
         loop {
             let response = match auth {
@@ -377,7 +384,7 @@ impl<H: HttpClient> VouchClient<H> {
                     // Sign with RFC 9421 HTTP message signatures when FAPI key is present
                     if let Some(ref key) = self.fapi_key {
                         let nonce = self.sig_nonce.lock().ok().and_then(|g| g.clone());
-                        extra_headers.extend(Self::sign_request_headers(&SignRequestParams {
+                        let sig_headers = Self::sign_request_headers(&SignRequestParams {
                             method,
                             url: &url,
                             auth_header: &hdr,
@@ -386,7 +393,22 @@ impl<H: HttpClient> VouchClient<H> {
                             body,
                             nonce: nonce.as_deref(),
                             key,
-                        }));
+                        });
+                        if signature_required && !sig_headers.iter().any(|(k, _)| k == "Signature")
+                        {
+                            return Err(anyhow::anyhow!(
+                                "failed to sign request for {path}: HTTP message signing \
+                                 produced no signature — re-run `vouch enroll` or unlock \
+                                 your keychain and try again"
+                            ));
+                        }
+                        extra_headers.extend(sig_headers);
+                    } else if signature_required {
+                        return Err(anyhow::anyhow!(
+                            "hardware-backed signing key unavailable for {path}: this \
+                             request must be signed (RFC 9421). Run `vouch enroll` (or \
+                             unlock your keychain) and try again"
+                        ));
                     }
 
                     let extra_refs: Vec<(&str, &str)> = extra_headers

--- a/crates/vouch-cli/src/commands/enroll.rs
+++ b/crates/vouch-cli/src/commands/enroll.rs
@@ -45,7 +45,7 @@ pub(crate) async fn run(server: &str) -> Result<()> {
     // required — without it, enrollment cannot produce a client that can call
     // the credential and key-management endpoints.
     let fapi_key = vouch_cli::fapi::key_store::load_or_create_client_key()
-        .context("failed to initialize the hardware-backed signing key")?;
+        .with_context(|| tr!("enroll-err-key-init"))?;
 
     // Step 2: Register as a FAPI 2.0 client BEFORE the device code flow
     // (open registration — no auth token required).
@@ -215,7 +215,7 @@ async fn register_fapi_client_open(
     let result =
         vouch_cli::fapi::registration::register_fapi_client(http_client, base_url, None, key)
             .await
-            .context("failed to register client with the server (RFC 7591)")?;
+            .with_context(|| tr!("enroll-err-register"))?;
 
     let client_id = result.client_id.clone();
 

--- a/crates/vouch-cli/src/commands/enroll.rs
+++ b/crates/vouch-cli/src/commands/enroll.rs
@@ -40,25 +40,32 @@ pub(crate) async fn run(server: &str) -> Result<()> {
     tr_println!("enroll-starting");
     println!();
 
-    // Step 1: Generate or load the FAPI client key (for DPoP proofs).
-    let fapi_key = vouch_cli::fapi::key_store::load_or_create_client_key().ok();
+    // Step 1: Generate or load the FAPI client key. This key signs DPoP
+    // proofs and every post-enrollment `/v1/*` request (RFC 9421), so it is
+    // required — without it, enrollment cannot produce a client that can call
+    // the credential and key-management endpoints.
+    let fapi_key = vouch_cli::fapi::key_store::load_or_create_client_key()
+        .context("failed to initialize the hardware-backed signing key")?;
 
     // Step 2: Register as a FAPI 2.0 client BEFORE the device code flow
     // (open registration — no auth token required).
     //
     // This ensures we have a client_id before the device authorization
-    // request so the token will be bound to our registered client from
-    // the start. Registration is non-fatal: enrollment continues even
-    // if this step fails.
-    let pre_registered_client_id = if let Some(ref key) = fapi_key {
-        register_fapi_client_open(client.raw_client(), server, key).await
-    } else {
-        None
-    };
+    // request so the token binds to our registered client (and its JWKS)
+    // from the start. Registration is required: the post-enrollment
+    // `/v1/keys/register/*` calls are signed and the server can only verify
+    // them against the JWKS we register here.
+    let pre_registered_client_id =
+        register_fapi_client_open(client.raw_client(), server, &fapi_key).await?;
 
     // Step 3: Request device code (RFC 8628 Section 3.1).
-    let device_response =
-        request_device_code(&client, server, fapi_key.as_ref(), pre_registered_client_id).await?;
+    let device_response = request_device_code(
+        &client,
+        server,
+        Some(&fapi_key),
+        Some(pre_registered_client_id),
+    )
+    .await?;
 
     // Step 4: Open browser and display instructions.
     let verification_url = &device_response.verification_uri;
@@ -83,7 +90,7 @@ pub(crate) async fn run(server: &str) -> Result<()> {
     tr_println!("enroll-waiting");
 
     // Step 5: Poll for token (with optional DPoP proofs).
-    let token_response = poll_for_token(&client, &device_response, fapi_key.as_ref()).await?;
+    let token_response = poll_for_token(&client, &device_response, Some(&fapi_key)).await?;
 
     // Step 6: Compute expiration timestamp from expires_in.
     let expires_at = compute_session_expires_at(token_response.expires_in);
@@ -158,7 +165,7 @@ async fn request_device_code(
             }
 
             let new_client_id = if let Some(key) = fapi_key {
-                register_fapi_client_open(client.raw_client(), server, key).await
+                Some(register_fapi_client_open(client.raw_client(), server, key).await?)
             } else {
                 None
             };
@@ -183,51 +190,52 @@ async fn request_device_code(
 /// `POST /oauth/register` without a Bearer token when open registration
 /// is enabled.
 ///
-/// Returns `Some(client_id)` on success, `None` on any failure (non-fatal).
+/// Returns the registered `client_id`. Registration is required for
+/// enrollment, so any failure is returned as an error.
 async fn register_fapi_client_open(
     http_client: &reqwest::Client,
     base_url: &str,
     key: &vouch_cli::fapi::ClientKey,
-) -> Option<String> {
+) -> Result<String> {
     // If we already have a client_id in config for this server, skip.
     if let Ok(mut config) = Config::load() {
         config.set_server_url(base_url);
         if let Some(id) = config.client_id() {
             tracing::debug!("FAPI client already registered: client_id={id}");
-            return Some(id.to_string());
+            return Ok(id.to_string());
         }
     }
 
-    // Open registration — no auth token.
-    match vouch_cli::fapi::registration::register_fapi_client(http_client, base_url, None, key)
-        .await
-    {
-        Ok(result) => {
-            let client_id = result.client_id.clone();
+    // Open registration — no auth token. This is required: every `/v1/*`
+    // request the CLI makes after enrollment must carry an RFC 9421
+    // signature, and the server resolves the verifying key from the OAuth
+    // client's registered JWKS. Without a registered client_id the issued
+    // access token would not bind to our JWKS and signed requests could not
+    // be verified, so a failure here is fatal.
+    let result =
+        vouch_cli::fapi::registration::register_fapi_client(http_client, base_url, None, key)
+            .await
+            .context("failed to register client with the server (RFC 7591)")?;
 
-            // Save registration results to config.
-            let url = base_url.to_string();
-            if let Err(e) = Config::modify(|config| {
-                config.set_server_url(&url);
-                config.set_client_id(&result.client_id);
-                if let Some(ref rat) = result.registration_access_token {
-                    config.set_registration_access_token(rat);
-                }
-                if let Some(ref uri) = result.registration_client_uri {
-                    config.set_registration_client_uri(uri);
-                }
-                config.set_dpop_key_id(&result.dpop_key_id);
-            }) {
-                tracing::warn!("Failed to save FAPI registration to config: {e}");
-            }
+    let client_id = result.client_id.clone();
 
-            Some(client_id)
+    // Save registration results to config.
+    let url = base_url.to_string();
+    if let Err(e) = Config::modify(|config| {
+        config.set_server_url(&url);
+        config.set_client_id(&result.client_id);
+        if let Some(ref rat) = result.registration_access_token {
+            config.set_registration_access_token(rat);
         }
-        Err(e) => {
-            tracing::debug!("Pre-enrollment FAPI registration failed (non-fatal): {e}");
-            None
+        if let Some(ref uri) = result.registration_client_uri {
+            config.set_registration_client_uri(uri);
         }
+        config.set_dpop_key_id(&result.dpop_key_id);
+    }) {
+        tracing::warn!("Failed to save FAPI registration to config: {e}");
     }
+
+    Ok(client_id)
 }
 
 /// Poll the token endpoint until authorization is complete or timeout.

--- a/crates/vouch-cli/src/commands/enroll.rs
+++ b/crates/vouch-cli/src/commands/enroll.rs
@@ -197,12 +197,24 @@ async fn register_fapi_client_open(
     base_url: &str,
     key: &vouch_cli::fapi::ClientKey,
 ) -> Result<String> {
-    // If we already have a client_id in config for this server, skip.
+    // Reuse the cached client_id only when it was registered with the *current*
+    // signing key. If the key was rotated or recreated while a stale client_id
+    // lingers in config, the server JWKS holds the old public key and every
+    // signed `/v1/*` request would fail verification. In that case fall through
+    // and re-register so the token binds to the key we actually sign with.
     if let Ok(mut config) = Config::load() {
         config.set_server_url(base_url);
         if let Some(id) = config.client_id() {
-            tracing::debug!("FAPI client already registered: client_id={id}");
-            return Ok(id.to_string());
+            let key_matches = config
+                .dpop_key_id()
+                .is_some_and(|stored_kid| stored_kid == key.kid());
+            if key_matches {
+                tracing::debug!("FAPI client already registered: client_id={id}");
+                return Ok(id.to_string());
+            }
+            tracing::debug!(
+                "cached client_id but signing key kid changed; re-registering FAPI client"
+            );
         }
     }
 

--- a/crates/vouch-httpsig/src/middleware.rs
+++ b/crates/vouch-httpsig/src/middleware.rs
@@ -7,7 +7,7 @@
 //!
 //! ```rust,ignore
 //! use std::sync::Arc;
-//! use vouch_httpsig::middleware::{KeyResolver, verify_signature};
+//! use vouch_httpsig::middleware::{KeyResolver, require_signature};
 //!
 //! struct MyResolver { /* ... */ }
 //!
@@ -24,7 +24,7 @@
 //!     .route("/api/resource", get(handler))
 //!     .layer(axum::middleware::from_fn_with_state(
 //!         resolver,
-//!         verify_signature::<MyResolver>,
+//!         require_signature::<MyResolver>,
 //!     ))
 //! ```
 
@@ -109,34 +109,25 @@ pub trait KeyResolver: Send + Sync + 'static {
 /// Default maximum signature age in seconds (5 minutes).
 pub const DEFAULT_MAX_AGE: i64 = 300;
 
-/// Axum middleware that verifies RFC 9421 HTTP signatures.
+/// Axum middleware that requires a valid RFC 9421 HTTP signature.
 ///
-/// If a `Signature-Input` header is present, this middleware:
+/// Every request must carry a `Signature-Input` header; an unsigned request is
+/// rejected with 401. For a signed request this middleware:
 /// 1. Extracts signature labels
 /// 2. Resolves the verifying key via the `keyid` parameter
 /// 3. Verifies the signature against the reconstructed base
-/// 4. Stores [`VerifiedSignature`] in request extensions
+/// 4. Enforces RFC 9530 `Content-Digest` integrity for request bodies
+/// 5. Stores [`VerifiedSignature`] in request extensions
 ///
-/// If no signature headers are present, the request passes through —
-/// handlers must check for the `VerifiedSignature` extension if a signature
-/// is required for their endpoint.
-///
-/// Returns 401 with a generic message if signature verification fails.
-pub async fn verify_signature<R: KeyResolver>(
+/// Used on endpoints where every request must be signed, e.g. the `/v1/*`
+/// CLI↔server channel under FAPI 2.0 Message Signing. Returns 401 with a
+/// generic message on any verification failure.
+pub async fn require_signature<R: KeyResolver>(
     State(resolver): State<Arc<R>>,
     req: Request<axum::body::Body>,
     next: Next,
 ) -> Response {
-    verify_signature_with_max_age(resolver, req, next, DEFAULT_MAX_AGE).await
-}
-
-/// Axum middleware that verifies RFC 9421 HTTP signatures with a custom max age.
-pub async fn verify_signature_with_max_age<R: KeyResolver>(
-    resolver: Arc<R>,
-    req: Request<axum::body::Body>,
-    next: Next,
-    max_age: i64,
-) -> Response {
+    let max_age = DEFAULT_MAX_AGE;
     // Trace-level logging of incoming request metadata
     tracing::trace!(
         method = %req.method(),
@@ -146,7 +137,7 @@ pub async fn verify_signature_with_max_age<R: KeyResolver>(
         "httpsig middleware"
     );
 
-    // Fetch Signature-Input once; pass through if absent.
+    // A missing Signature-Input header means the request is unsigned: reject.
     let sig_input = match req.headers().get("signature-input") {
         Some(v) => match v.to_str() {
             Ok(s) => s.to_string(),
@@ -155,7 +146,13 @@ pub async fn verify_signature_with_max_age<R: KeyResolver>(
                 return (StatusCode::UNAUTHORIZED, SIG_VERIFY_FAILED).into_response();
             }
         },
-        None => return next.run(req).await,
+        None => {
+            tracing::debug!(
+                path = %req.uri().path(),
+                "rejecting unsigned request: signature required"
+            );
+            return (StatusCode::UNAUTHORIZED, SIG_VERIFY_FAILED).into_response();
+        }
     };
 
     let labels = match extract_signature_labels(req.headers()) {
@@ -343,7 +340,7 @@ mod tests {
             .route("/test", get(ok_handler).post(ok_handler))
             .layer(axum::middleware::from_fn_with_state(
                 resolver,
-                verify_signature::<InMemoryKeyResolver>,
+                require_signature::<InMemoryKeyResolver>,
             ))
     }
 
@@ -366,7 +363,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_passthrough_without_signature() {
+    async fn test_rejects_unsigned_request() {
+        // require_signature must reject a request that carries no
+        // Signature-Input header.
         let resolver = Arc::new(InMemoryKeyResolver::new());
         let router = build_test_router(resolver);
 
@@ -379,7 +378,7 @@ mod tests {
             <Router as tower::ServiceExt<Request<axum::body::Body>>>::oneshot(router, req)
                 .await
                 .unwrap();
-        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]

--- a/crates/vouch-server/src/handlers/credentials.rs
+++ b/crates/vouch-server/src/handlers/credentials.rs
@@ -914,22 +914,26 @@ mod tests {
     async fn test_ssh_cert_requires_auth() {
         let (app, _state) = test_app().await;
 
-        // SSH CA is checked before auth in this handler, so 503 is returned
+        // /v1/* requires a valid RFC 9421 signature; the unsigned request is
+        // rejected by the signature middleware before the handler's CA check.
         let body =
             serde_json::json!({ "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI test" });
         let (status, resp_body) =
             http_post_json(&app, "/v1/credentials/ssh", &body.to_string(), &[]).await;
 
-        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
-        let error: serde_json::Value = serde_json::from_str(&resp_body).expect("Valid JSON");
-        assert_eq!(error["code"], "ssh_ca_not_configured");
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert!(
+            resp_body.contains("signature"),
+            "expected signature failure, got: {resp_body}"
+        );
     }
 
     #[tokio::test]
     async fn test_ssh_cert_rejects_invalid_token() {
         let (app, _state) = test_app().await;
 
-        // SSH CA is checked before auth, so still 503 even with a bad token
+        // The garbage token has no resolvable client, so the signature
+        // middleware rejects with 401 before the handler's CA check.
         let body =
             serde_json::json!({ "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI test" });
         let (status, resp_body) = http_post_json(
@@ -940,9 +944,11 @@ mod tests {
         )
         .await;
 
-        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
-        let error: serde_json::Value = serde_json::from_str(&resp_body).expect("Valid JSON");
-        assert_eq!(error["code"], "ssh_ca_not_configured");
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert!(
+            resp_body.contains("signature"),
+            "expected signature failure, got: {resp_body}"
+        );
     }
 
     // ========================================================================
@@ -1007,9 +1013,13 @@ mod tests {
 
         let (status, body) = http_get(&app, "/v1/credentials/aws/token", &[]).await;
 
+        // /v1/* requires a valid RFC 9421 signature; an unsigned request is
+        // rejected by the signature middleware before the handler runs.
         assert_eq!(status, StatusCode::UNAUTHORIZED);
-        let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
-        assert_eq!(error["code"], "unauthorized");
+        assert!(
+            body.contains("signature"),
+            "expected signature failure, got: {body}"
+        );
     }
 
     #[tokio::test]
@@ -1023,9 +1033,13 @@ mod tests {
         )
         .await;
 
+        // The garbage token has no resolvable client, so the signature
+        // middleware rejects the request with 401 before the handler runs.
         assert_eq!(status, StatusCode::UNAUTHORIZED);
-        let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
-        assert_eq!(error["code"], "invalid_token");
+        assert!(
+            body.contains("signature"),
+            "expected signature failure, got: {body}"
+        );
     }
 
     #[tokio::test]
@@ -1216,14 +1230,17 @@ mod tests {
     async fn test_github_token_requires_auth() {
         let (app, _state) = test_app().await;
 
-        // GitHub App config is checked before auth — 503 even without a token
+        // /v1/* requires a valid RFC 9421 signature; the unsigned request is
+        // rejected by the signature middleware before the handler's config check.
         let body = serde_json::json!({ "repositories": [] });
         let (status, resp_body) =
             http_post_json(&app, "/v1/credentials/github/token", &body.to_string(), &[]).await;
 
-        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
-        let error: serde_json::Value = serde_json::from_str(&resp_body).expect("Valid JSON");
-        assert_eq!(error["code"], "github_not_configured");
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert!(
+            resp_body.contains("signature"),
+            "expected signature failure, got: {resp_body}"
+        );
     }
 
     // ========================================================================

--- a/crates/vouch-server/src/handlers/keys.rs
+++ b/crates/vouch-server/src/handlers/keys.rs
@@ -696,7 +696,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_register_complete_invalid_state() {
-        let (app, _state) = test_app().await;
+        let (app, state) = test_app().await;
+
+        // register/complete is reached within an authenticated session, so the
+        // request must be signed (RFC 9421); the harness signs it transparently.
+        let user = create_test_user(&state.store, "invalid-state@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
 
         // All Raw fields deserialize as Vec<u8> (JSON arrays); provide empty arrays
         // so the JSON extractor succeeds, but the state JWT decode fails with 400.
@@ -707,8 +713,13 @@ mod tests {
             "attestation_object": [],
             "client_data_json": []
         }"#;
-        let (status, resp_body) =
-            http_post_json(&app, "/v1/keys/register/complete", body, &[]).await;
+        let (status, resp_body) = http_post_json(
+            &app,
+            "/v1/keys/register/complete",
+            body,
+            &[("Authorization", &format!("Bearer {token}"))],
+        )
+        .await;
 
         assert_eq!(status, StatusCode::BAD_REQUEST);
         let json: serde_json::Value = serde_json::from_str(&resp_body).expect("valid JSON");
@@ -722,6 +733,12 @@ mod tests {
     #[tokio::test]
     async fn test_register_complete_rejects_replayed_state() {
         let (app, state) = test_app().await;
+
+        // register/complete is reached within an authenticated session, so the
+        // request must be signed (RFC 9421); the harness signs it transparently.
+        let user = create_test_user(&state.store, "replay-session@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
 
         // Build a valid RegistrationState JWT with a far-future expiry.
         let signer = &state.state_signer;
@@ -757,8 +774,13 @@ mod tests {
             "attestation_object": [],
             "client_data_json": [],
         });
-        let (status, resp_body) =
-            http_post_json(&app, "/v1/keys/register/complete", &body.to_string(), &[]).await;
+        let (status, resp_body) = http_post_json(
+            &app,
+            "/v1/keys/register/complete",
+            &body.to_string(),
+            &[("Authorization", &format!("Bearer {token}"))],
+        )
+        .await;
 
         assert_eq!(status, StatusCode::BAD_REQUEST);
         let json: serde_json::Value = serde_json::from_str(&resp_body).expect("valid JSON");

--- a/crates/vouch-server/src/handlers/oidc/tests/auth_flows.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/auth_flows.rs
@@ -500,6 +500,9 @@ async fn test_revoked_token_cannot_access_resources() {
     let user = create_test_user(&state.store, "rev-d1@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
+    // The token's client must hold the shared test signing key so the
+    // transparently-signed /v1/* request verifies.
+    attach_test_signing_key(&state.store, &client.app_id).await;
 
     let (access_token, _) = issue_oauth_access_token(&app, &state, &user, &auth_id, &client).await;
 

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9449.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9449.rs
@@ -1173,6 +1173,9 @@ async fn test_dpop_resource_endpoint_post_json_without_nonce() {
     let user = create_test_user(&state.store, "dpop-post-nonce@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
+    // The DPoP-bound token's client must hold the shared test signing key so
+    // the transparently-signed POST /v1/credentials/ssh request verifies.
+    attach_test_signing_key(&state.store, &client.app_id).await;
 
     // Step 1: Get a DPoP-bound access token
     let (dpop_key, dpop_jwk) = generate_dpop_key_pair();

--- a/crates/vouch-server/src/infra/router.rs
+++ b/crates/vouch-server/src/infra/router.rs
@@ -214,7 +214,7 @@ fn build_rate_limited_routes(
         )
         .layer(axum::middleware::from_fn_with_state(
             httpsig_resolver,
-            vouch_httpsig::middleware::verify_signature::<httpsig::OAuthClientKeyResolver>,
+            vouch_httpsig::middleware::require_signature::<httpsig::OAuthClientKeyResolver>,
         ));
 
     // RFC 7592 dynamic client registration MANAGEMENT endpoints
@@ -290,7 +290,7 @@ fn build_credential_routes(
         )
         .layer(axum::middleware::from_fn_with_state(
             httpsig_resolver,
-            vouch_httpsig::middleware::verify_signature::<httpsig::OAuthClientKeyResolver>,
+            vouch_httpsig::middleware::require_signature::<httpsig::OAuthClientKeyResolver>,
         ))
         .layer(axum::middleware::from_fn_with_state(
             Arc::clone(state),
@@ -519,7 +519,7 @@ fn build_api_management_routes(
         )
         .layer(axum::middleware::from_fn_with_state(
             httpsig_resolver,
-            vouch_httpsig::middleware::verify_signature::<httpsig::OAuthClientKeyResolver>,
+            vouch_httpsig::middleware::require_signature::<httpsig::OAuthClientKeyResolver>,
         ));
 
     // RFC 9728 protected-resource endpoints in this group. Layered with

--- a/crates/vouch-server/src/test_utils.rs
+++ b/crates/vouch-server/src/test_utils.rs
@@ -150,6 +150,10 @@ pub async fn test_app_state_with_idps(
     let store = DocumentStore::new(pool.clone(), crypto.clone());
     let audit = AuditStore::new(pool.clone(), crypto);
 
+    // Register the first-party client whose JWKS holds the shared test signing
+    // key, so transparently-signed `/v1/*` test requests verify.
+    register_test_httpsig_client(&store, &config.base_url).await;
+
     Arc::new(AppState {
         db: pool,
         store,
@@ -201,6 +205,175 @@ pub async fn test_app_with_certification() -> (Router, Arc<AppState>) {
     (router, state)
 }
 
+/// Fixed `kid` for the process-wide test HTTP message-signing key.
+const TEST_HTTPSIG_KID: &str = "vouch-test-httpsig-key";
+
+/// Process-wide P-256 key used to sign `/v1/*` test requests, plus the JWKS
+/// document registered for the first-party test client.
+struct TestHttpSig {
+    signer: vouch_httpsig::algorithm::ecdsa_p256::EcdsaP256Signer,
+    jwks: serde_json::Value,
+}
+
+static TEST_HTTPSIG: std::sync::LazyLock<TestHttpSig> = std::sync::LazyLock::new(|| {
+    use base64::Engine;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use vouch_httpsig::algorithm::ecdsa_p256::EcdsaP256Signer;
+
+    let signer = EcdsaP256Signer::generate(TEST_HTTPSIG_KID).expect("generate test httpsig key");
+    // Uncompressed SEC1 point: 0x04 || x(32) || y(32).
+    let pk = signer.public_key_bytes();
+    let x = URL_SAFE_NO_PAD.encode(pk.get(1..33).expect("x coordinate"));
+    let y = URL_SAFE_NO_PAD.encode(pk.get(33..65).expect("y coordinate"));
+    let jwks = serde_json::json!({
+        "keys": [{ "kty": "EC", "crv": "P-256", "x": x, "y": y, "kid": TEST_HTTPSIG_KID }]
+    });
+    TestHttpSig { signer, jwks }
+});
+
+/// Register the first-party OAuth client used by test sessions.
+///
+/// `create_test_session*` mint tokens whose `client_id` is the server
+/// `base_url`. The `/v1/*` routes now require an RFC 9421 signature, and the
+/// server resolves the verifying key from the token client's registered JWKS.
+/// Registering a client keyed to `base_url` with the shared test signing key
+/// lets [`build_test_request`] transparently sign `/v1/*` requests so existing
+/// handler tests keep exercising the full router.
+async fn register_test_httpsig_client(store: &DocumentStore, base_url: &str) {
+    use crate::db::documents::oauth::{
+        FapiProfile, OAuthClientDoc, OAuthClientType, TokenEndpointAuthMethod,
+    };
+
+    let doc = OAuthClientDoc {
+        user_id: None,
+        client_id: base_url.to_string(),
+        name: "Test First-Party Client".to_string(),
+        description: None,
+        application_type: OAuthClientType::Native,
+        redirect_uris: Vec::new(),
+        active: true,
+        access_scope: crate::db::AccessScope::Public,
+        org_id: None,
+        resource_uris: Vec::new(),
+        jwks: Some(TEST_HTTPSIG.jwks.clone()),
+        jwks_uri: None,
+        token_endpoint_auth_method: TokenEndpointAuthMethod::default(),
+        request_object_signing_alg: None,
+        require_signed_request_object: None,
+        fapi_profile: FapiProfile::default(),
+        dpop_bound_access_tokens: false,
+        grant_types: None,
+        response_types: None,
+        software_id: None,
+        software_version: None,
+        registration_source: Some(RegistrationSource::Manual),
+        registration_access_token_hash: None,
+        registration_metadata: None,
+        id_token_signed_response_alg: JwsAlgorithm::Es256,
+        tls_client_auth_subject_dn: None,
+        tls_client_auth_san_dns: None,
+        tls_client_auth_san_uri: None,
+        tls_client_auth_san_ip: None,
+        tls_client_auth_san_email: None,
+        tls_client_certificate_bound_access_tokens: false,
+        authorization_signed_response_alg: None,
+        introspection_signed_response_alg: None,
+        userinfo_signed_response_alg: None,
+        request_uris: None,
+    };
+    store
+        .insert(&doc)
+        .await
+        .expect("register first-party test httpsig client");
+}
+
+/// Attach the shared test signing key's JWKS to an existing OAuth client.
+///
+/// Tokens issued for custom test clients (via `create_test_oauth_client`) carry
+/// that client's `client_id`. For transparently-signed `/v1/*` requests to
+/// verify, the client's registered JWKS must hold the shared test key — call
+/// this after creating a client whose token will hit a `/v1/*` endpoint.
+pub async fn attach_test_signing_key(store: &DocumentStore, app_id: &str) {
+    use crate::db::documents::oauth::OAuthClientDoc;
+    let doc = store
+        .get::<OAuthClientDoc>(app_id)
+        .await
+        .expect("get client")
+        .expect("client exists");
+    let mut data = doc.data;
+    data.jwks = Some(TEST_HTTPSIG.jwks.clone());
+    store
+        .update(app_id, &data)
+        .await
+        .expect("update client jwks");
+}
+
+/// Whether a request to `uri` carrying these `headers` should be auto-signed.
+///
+/// Signs authenticated `/v1/*` requests (those with an `Authorization` header)
+/// except the soft `/v1/auth/status` probe, mirroring the production
+/// enforcement scope so unsigned/unauthenticated tests still see their 401s.
+fn should_auto_sign(uri: &str, headers: &[(&str, &str)]) -> bool {
+    let path = uri.split('?').next().unwrap_or(uri);
+    if !path.starts_with("/v1/") || path == "/v1/auth/status" {
+        return false;
+    }
+    headers
+        .iter()
+        .any(|(k, _)| k.eq_ignore_ascii_case("authorization"))
+}
+
+/// Compute RFC 9421 signature headers for a `/v1/*` test request using the
+/// shared test signing key.
+///
+/// `uri` may be a path (`/v1/keys`) or a full URL; the signature covers
+/// `@method` and `@path` (plus `content-digest` for bodies). Exposed so the
+/// integration harness signs `/v1/*` requests with the same shared key whose
+/// JWKS is registered for the first-party test client.
+pub fn test_signature_headers(
+    method: &str,
+    uri: &str,
+    body: Option<&[u8]>,
+) -> Vec<(String, String)> {
+    let has_body = body.is_some_and(|b| !b.is_empty());
+    let body_bytes = body.unwrap_or_default();
+    let mut req = Request::builder()
+        .method(method)
+        .uri(uri)
+        .body(body_bytes.to_vec())
+        .expect("build signing request");
+
+    if has_body {
+        vouch_httpsig::digest::set_content_digest(
+            req.headers_mut(),
+            body_bytes,
+            vouch_httpsig::DigestAlgorithm::Sha256,
+        )
+        .expect("set content-digest");
+    }
+
+    let mut sig_builder = vouch_httpsig::SignatureBuilder::new("sig1")
+        .method()
+        .path()
+        .created_now();
+    if has_body {
+        sig_builder = sig_builder.field("content-digest");
+    }
+    sig_builder
+        .sign_request(&mut req, &TEST_HTTPSIG.signer)
+        .expect("sign test request");
+
+    let mut out = Vec::new();
+    for name in ["signature-input", "signature", "content-digest"] {
+        if let Some(v) = req.headers().get(name)
+            && let Ok(s) = v.to_str()
+        {
+            out.push((name.to_string(), s.to_string()));
+        }
+    }
+    out
+}
+
 /// Build a request with standard test extensions (no mTLS cert).
 fn build_test_request(
     method: &str,
@@ -211,6 +384,12 @@ fn build_test_request(
     let mut req_builder = Request::builder().method(method).uri(uri);
     for (name, value) in headers {
         req_builder = req_builder.header(*name, *value);
+    }
+    if should_auto_sign(uri, headers) {
+        let body_ref = body.as_deref().map(str::as_bytes);
+        for (name, value) in test_signature_headers(method, uri, body_ref) {
+            req_builder = req_builder.header(name, value);
+        }
     }
     let body = match body {
         Some(b) => Body::from(b),
@@ -302,6 +481,13 @@ pub async fn http_request_full(
 
     for (name, value) in headers {
         req_builder = req_builder.header(*name, *value);
+    }
+
+    if should_auto_sign(uri, headers) {
+        let body_ref = body.as_deref().map(str::as_bytes);
+        for (name, value) in test_signature_headers(method, uri, body_ref) {
+            req_builder = req_builder.header(name, value);
+        }
     }
 
     let body = match body {

--- a/crates/vouch-tests/src/harness.rs
+++ b/crates/vouch-tests/src/harness.rs
@@ -199,6 +199,26 @@ impl TestHarness {
         Ok((user, auth_id, token))
     }
 
+    /// RFC 9421 signature headers for an authenticated `/v1/*` request.
+    ///
+    /// The `/v1/*` routes require a valid signature; sessions created by this
+    /// harness use the first-party test client whose JWKS holds the shared test
+    /// signing key, so we sign with that same key here. Non-`/v1` paths and the
+    /// soft `/v1/auth/status` probe return no headers.
+    fn v1_sig_headers(
+        &self,
+        method: &str,
+        url: &str,
+        body: Option<&[u8]>,
+    ) -> Vec<(String, String)> {
+        let path = url.strip_prefix(self.base_url()).unwrap_or(url);
+        let path_only = path.split('?').next().unwrap_or(path);
+        if !path_only.starts_with("/v1/") || path_only == "/v1/auth/status" {
+            return Vec::new();
+        }
+        test_utils::test_signature_headers(method, url, body)
+    }
+
     /// Make a GET request.
     pub async fn get(&self, path: &str) -> Result<vouch_cli::HttpResponse> {
         let url = self.url(path);
@@ -235,8 +255,12 @@ impl TestHarness {
     ) -> Result<vouch_cli::HttpResponse> {
         let url = self.url(path);
         let auth = format!("Bearer {}", token);
+        let sig = self.v1_sig_headers("GET", &url, None);
+        let sig_refs: Vec<(&str, &str)> =
+            sig.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
+        let extra = (!sig_refs.is_empty()).then_some(sig_refs.as_slice());
         self.http_client
-            .request("GET", &url, None, None, Some(&auth), None)
+            .request("GET", &url, None, None, Some(&auth), extra)
             .await
     }
 
@@ -250,6 +274,10 @@ impl TestHarness {
         let url = self.url(path);
         let json = serde_json::to_vec(body)?;
         let auth = format!("Bearer {}", token);
+        let sig = self.v1_sig_headers("POST", &url, Some(&json));
+        let sig_refs: Vec<(&str, &str)> =
+            sig.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
+        let extra = (!sig_refs.is_empty()).then_some(sig_refs.as_slice());
         self.http_client
             .request(
                 "POST",
@@ -257,7 +285,7 @@ impl TestHarness {
                 Some(&json),
                 Some("application/json"),
                 Some(&auth),
-                None,
+                extra,
             )
             .await
     }
@@ -280,8 +308,12 @@ impl TestHarness {
     ) -> Result<vouch_cli::HttpResponse> {
         let url = self.url(path);
         let auth = format!("Bearer {}", token);
+        let sig = self.v1_sig_headers("DELETE", &url, None);
+        let sig_refs: Vec<(&str, &str)> =
+            sig.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
+        let extra = (!sig_refs.is_empty()).then_some(sig_refs.as_slice());
         self.http_client
-            .request("DELETE", &url, None, None, Some(&auth), None)
+            .request("DELETE", &url, None, None, Some(&auth), extra)
             .await
     }
 
@@ -295,6 +327,10 @@ impl TestHarness {
         let url = self.url(path);
         let json = serde_json::to_vec(body)?;
         let auth = format!("Bearer {}", token);
+        let sig = self.v1_sig_headers("PATCH", &url, Some(&json));
+        let sig_refs: Vec<(&str, &str)> =
+            sig.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
+        let extra = (!sig_refs.is_empty()).then_some(sig_refs.as_slice());
         self.http_client
             .request(
                 "PATCH",
@@ -302,7 +338,7 @@ impl TestHarness {
                 Some(&json),
                 Some("application/json"),
                 Some(&auth),
-                None,
+                extra,
             )
             .await
     }
@@ -317,6 +353,10 @@ impl TestHarness {
         let url = self.url(path);
         let json = serde_json::to_vec(body)?;
         let auth = format!("Bearer {}", token);
+        let sig = self.v1_sig_headers("PUT", &url, Some(&json));
+        let sig_refs: Vec<(&str, &str)> =
+            sig.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
+        let extra = (!sig_refs.is_empty()).then_some(sig_refs.as_slice());
         self.http_client
             .request(
                 "PUT",
@@ -324,7 +364,7 @@ impl TestHarness {
                 Some(&json),
                 Some("application/json"),
                 Some(&auth),
-                None,
+                extra,
             )
             .await
     }

--- a/crates/vouch-tests/tests/integration.rs
+++ b/crates/vouch-tests/tests/integration.rs
@@ -125,13 +125,14 @@ mod credentials {
             public_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITest test@example.com".to_string(),
         };
 
-        // Config check runs before auth — SSH CA not configured returns 503
+        // /v1/* requires a valid RFC 9421 signature; the unsigned request is
+        // rejected by the signature middleware before the handler's CA check.
         let response = harness
             .post_json("/v1/credentials/ssh", &request)
             .await
             .expect("Failed to post SSH cert request");
 
-        assert_eq!(response.status, 503);
+        assert_eq!(response.status, 401);
     }
 
     /// Test that authenticated users can attempt to get SSH certificates.
@@ -368,19 +369,21 @@ mod auth_security {
             public_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITest test@example.com".to_string(),
         };
 
-        // Config check runs before auth — SSH CA not configured returns 503
+        // /v1/* requires a valid RFC 9421 signature; the unsigned request is
+        // rejected by the signature middleware before the handler's CA check.
         let response = harness
             .post_json("/v1/credentials/ssh", &request)
             .await
             .expect("Failed to post SSH cert request");
-        assert_eq!(response.status, 503);
+        assert_eq!(response.status, 401);
 
-        // With invalid token — still 503 because config check runs first
+        // An invalid token resolves to no client, so the signature check
+        // rejects it with 401 before the handler runs.
         let response = harness
             .post_json_authenticated("/v1/credentials/ssh", &request, "invalid.token")
             .await
             .expect("Failed to post SSH cert request");
-        assert_eq!(response.status, 503);
+        assert_eq!(response.status, 401);
     }
 
     /// Test that AWS token endpoint requires valid session.
@@ -2757,20 +2760,49 @@ mod httpsig {
     }
 
     #[tokio::test]
-    async fn test_httpsig_unsigned_request_still_succeeds() {
-        // Verify backward compatibility: requests without signatures pass through
+    async fn test_httpsig_unsigned_request_rejected_on_v1_keys() {
+        // A signature-required /v1/* endpoint rejects an unsigned request.
+        let harness = TestHarness::new().await;
+        let (_user, _auth_id, token) = harness
+            .create_authenticated_user("unsigned-v1@example.com")
+            .await
+            .unwrap();
+
+        // Send an unsigned request by hitting the low-level client directly
+        // (the harness's authenticated helpers sign /v1/* requests).
+        let url = harness.url("/v1/keys");
+        let auth_header = format!("Bearer {token}");
+        let response = harness
+            .http_client
+            .request("GET", &url, None, None, Some(&auth_header), None)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status, 401,
+            "unsigned /v1/keys request must be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_httpsig_unsigned_auth_status_still_succeeds() {
+        // The soft /v1/auth/status probe is intentionally exempt and still
+        // answers unsigned requests.
         let harness = TestHarness::new().await;
         let key = ClientKey::generate().unwrap();
         let token = setup_user_with_httpsig_key(&harness, &key).await;
 
+        let url = harness.url("/v1/auth/status");
+        let auth_header = format!("Bearer {token}");
         let response = harness
-            .get_authenticated("/v1/auth/status", &token)
+            .http_client
+            .request("GET", &url, None, None, Some(&auth_header), None)
             .await
             .unwrap();
 
         assert_eq!(
             response.status, 200,
-            "unsigned request should still succeed"
+            "unsigned /v1/auth/status should still succeed"
         );
     }
 


### PR DESCRIPTION
Closes #526.

## What changed

#526 proposed an opt-in, per-client registration flag to require signed `/v1/*` requests. On review we dropped the flag: `vouch-httpsig` exists for FAPI 2.0 Message Signing with the CLI as the primary `/v1/*` client, and the CLI already signs **every** authenticated `/v1/*` request with the same P-256 key it registers in its JWKS at dynamic registration. Optional enforcement just left a silent Bearer-only downgrade gap. So a valid signature is now **mandatory** on `/v1/*` — no flag, no toggle.

### Production change (4 files)
- **`vouch-httpsig/middleware.rs`** — collapsed the middleware to a single `require_signature` that rejects unsigned requests. The optional `verify_signature` pass-through mode had no remaining callers, so it's gone (one public function now).
- **`vouch-server/infra/router.rs`** — applied `require_signature` to the three `/v1/*` route groups (key registration, credentials, key management).
- **`vouch-cli/client.rs`** — authenticated `/v1/*` requests now fail with a clear error instead of silently downgrading to Bearer-only when the FAPI signing key can't be loaded.
- **`vouch-cli/commands/enroll.rs`** — FAPI key creation + dynamic client registration are now mandatory, so the device-grant token always binds to a registered client whose JWKS can verify the signed `/v1/keys/register/*` calls.

### Scope / first-time setup
Enforcement is scoped to `/v1/*` only. The unauthenticated bootstrap (`/oauth/register`, `/oauth/device`, `/oauth/token`, `/oauth/fido2/challenge`) and the soft `/v1/auth/status` probe stay exempt, so first-time `vouch enroll` works: the key + registration happen before any token or `/v1/*` call.

### Tests
The vouch-server handler harness and the vouch-tests integration harness now sign `/v1/*` requests transparently with a shared test key registered to a first-party test client, so existing handler tests keep exercising the full router unchanged. A handful of tests that asserted the old unsigned/pre-auth behavior (`503`-before-auth, "unsigned still succeeds") were updated to the mandatory-signature contract. New tests cover unsigned-rejection at both the middleware and integration levels.

Full suite green: fmt + clippy clean, 3912 tests passing.

### Follow-up (not in this PR)
- Consolidating the several test-client creation paths into one signing-capable factory (deferred per discussion — kept this PR focused on getting the behavior + CI green).
- A short note in `docs/src/security/model.md` documenting the `/v1/*` mandatory-signing posture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWTZzc1mA5k4KGtgB3t5DW

---
_Generated by [Claude Code](https://claude.ai/code/session_01AWTZzc1mA5k4KGtgB3t5DW)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Mandatory message signing and stricter enrollment change the security boundary for all `/v1/*` traffic and first-time setup; misconfigured or legacy clients will fail instead of silently using Bearer-only auth.
> 
> **Overview**
> **`/v1/*` now requires a valid RFC 9421 HTTP message signature** on every request (except the soft **`/v1/auth/status`** probe). The server replaces optional signature middleware with **`require_signature`**, which returns **401** when `Signature-Input` is missing or verification fails, and wires that into the key-registration, credentials, and key-management route groups.
> 
> The **CLI** stops silently sending Bearer-only calls to protected `/v1/*` paths: missing or failed signing surfaces typed **`NotAuthenticated`** errors with new i18n strings. **`vouch enroll`** treats FAPI client key creation and **RFC 7591** dynamic registration as **mandatory**, re-registers when a cached `client_id` no longer matches the current signing key `kid`, and binds the device-grant token to JWKS the server can verify for post-enrollment signed calls.
> 
> **Tests** register a shared first-party signing key, auto-sign authenticated `/v1/*` in server and integration harnesses, and update expectations from handler-level **503** / unsigned pass-through to **401** signature failures, with new coverage for unsigned rejection while **`/v1/auth/status`** stays exempt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 067f4a737a6ae5bc3f4191b480f35b133a8fb2c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->