### PR TITLE
Remove vouch-agent's non-functional SSH cert refresh/lazy-provision

### DIFF
--- a/crates/vouch-agent/src/ssh_agent/credentials.rs
+++ b/crates/vouch-agent/src/ssh_agent/credentials.rs
@@ -7,8 +7,6 @@ use ssh_key::{PrivateKey, certificate::Certificate};
 use std::path::PathBuf;
 use zeroize::Zeroizing;
 
-use super::REFRESH_THRESHOLD_SECONDS;
-
 /// Certificate metadata for cache management.
 #[derive(Clone, Debug)]
 pub struct CertificateMetadata {
@@ -64,15 +62,6 @@ impl CertificateMetadata {
     pub fn is_expired(&self) -> bool {
         let now = Timestamp::now();
         self.expires_at < now
-    }
-
-    /// Check if the certificate is expiring soon (within threshold).
-    pub fn is_expiring_soon(&self) -> bool {
-        let now = Timestamp::now();
-        let threshold =
-            Timestamp::from_second(now.as_second().saturating_add(REFRESH_THRESHOLD_SECONDS))
-                .unwrap_or(now);
-        self.expires_at < threshold
     }
 }
 
@@ -146,19 +135,6 @@ impl SshCredentials {
     /// Check if the certificate has expired.
     pub fn is_expired(&self) -> bool {
         self.metadata.is_expired()
-    }
-
-    /// Check if the certificate is expiring soon.
-    pub fn is_expiring_soon(&self) -> bool {
-        self.metadata.is_expiring_soon()
-    }
-
-    /// Get the public key in OpenSSH format.
-    pub fn public_key_openssh(&self) -> Result<String> {
-        let pub_key = self.private_key.public_key();
-        pub_key
-            .to_openssh()
-            .map_err(|e| AgentError::Protocol(format!("failed to serialize public key: {e}")))
     }
 }
 

--- a/crates/vouch-agent/src/ssh_agent/mod.rs
+++ b/crates/vouch-agent/src/ssh_agent/mod.rs
@@ -32,12 +32,6 @@ pub(crate) const SSH_AGENT_IDENTITIES_ANSWER: u8 = 12;
 pub(crate) const SSH_AGENTC_SIGN_REQUEST: u8 = 13;
 pub(crate) const SSH_AGENT_SIGN_RESPONSE: u8 = 14;
 
-/// Refresh threshold in seconds (1 hour before expiration).
-pub(crate) use vouch_common::SSH_CERT_REFRESH_THRESHOLD_SECS as REFRESH_THRESHOLD_SECONDS;
-
-/// Minimum interval between refresh attempts (5 minutes).
-pub(crate) const MIN_REFRESH_INTERVAL_SECONDS: i64 = 5 * 60;
-
 /// Default SSH key path for lazy disk loading.
 pub(crate) const DEFAULT_KEY_NAME: &str = "id_ed25519_vouch";
 

--- a/crates/vouch-agent/src/ssh_agent/provisioning.rs
+++ b/crates/vouch-agent/src/ssh_agent/provisioning.rs
@@ -1,8 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//! SSH credential provisioning and refresh.
+//! SSH credential loading for the agent.
+//!
+//! The agent never provisions or refreshes certificates from the server itself
+//! — that path requires DPoP + RFC 9421 request signing with the FAPI private
+//! key, which lives with the CLI. Certificates are issued by the CLI's signed
+//! `vouch credential ssh` path and pushed to the agent over IPC. The agent only
+//! serves what it has in memory or can reload from disk.
 
 use crate::error::{AgentError, Result};
-use secrecy::ExposeSecret;
 use std::sync::Arc;
 use tracing::{debug, info};
 
@@ -13,7 +18,7 @@ use super::protocol::{
 };
 use super::state::SshAgentState;
 
-/// Handle SSH_AGENTC_REQUEST_IDENTITIES with lazy loading.
+/// Handle SSH_AGENTC_REQUEST_IDENTITIES.
 pub(super) async fn handle_request_identities(
     state: &Arc<SshAgentState>,
     agent_state: Option<&Arc<crate::state::AgentState>>,
@@ -25,39 +30,19 @@ pub(super) async fn handle_request_identities(
         return build_identities_response(Some(&c));
     }
 
-    // No valid credentials in memory — try lazy loading from disk
+    // No valid credentials in memory — try reloading a still-valid cert from
+    // disk (written by the CLI's `vouch credential ssh`).
     if let Some(loaded) = try_load_from_disk(state, agent_state).await {
         return build_identities_response(Some(&loaded));
     }
 
-    // No valid cert on disk either — try background provisioning
-    spawn_lazy_provision(state, agent_state);
-
-    // Return 0 identities immediately (don't block the SSH connection)
+    // Nothing to serve. Return 0 identities immediately (don't block the SSH
+    // connection); the user re-provisions with `vouch credential ssh`.
     build_identities_response(None)
 }
 
 /// Handle SSH_AGENTC_SIGN_REQUEST.
-pub(super) async fn handle_sign_request(
-    buf: &[u8],
-    state: &Arc<SshAgentState>,
-    agent_state: Option<&Arc<crate::state::AgentState>>,
-) -> Result<Vec<u8>> {
-    // Check if we need to refresh the certificate (best-effort, don't block on failure)
-    if state.needs_refresh().await
-        && state.can_attempt_refresh().await
-        && let Some(agent) = agent_state
-    {
-        // Attempt refresh in the background
-        let state_clone = Arc::clone(state);
-        let agent_clone = Arc::clone(agent);
-        tokio::spawn(async move {
-            if let Err(e) = refresh_certificate(&state_clone, &agent_clone).await {
-                debug!("Certificate refresh failed (non-fatal): {e}");
-            }
-        });
-    }
-
+pub(super) async fn handle_sign_request(buf: &[u8], state: &Arc<SshAgentState>) -> Result<Vec<u8>> {
     let creds = state
         .get_valid_credentials()
         .await
@@ -121,229 +106,4 @@ async fn try_load_from_disk(
         .await;
 
     Some(creds)
-}
-
-/// Spawn a non-blocking background task to provision SSH certificate from server.
-///
-/// This does NOT block the current SSH connection. The next identity request
-/// will pick up the newly provisioned cert.
-fn spawn_lazy_provision(
-    state: &Arc<SshAgentState>,
-    agent_state: Option<&Arc<crate::state::AgentState>>,
-) {
-    let Some(agent) = agent_state else {
-        return;
-    };
-
-    // Check for existing keypair (agent does NOT generate keypairs)
-    let home = match dirs::home_dir() {
-        Some(h) => h,
-        None => return,
-    };
-    let key_path = home.join(".ssh").join(DEFAULT_KEY_NAME);
-    let pub_path = key_path.with_added_extension("pub");
-
-    if !key_path.exists() || !pub_path.exists() {
-        debug!("No SSH keypair on disk, cannot lazy-provision");
-        return;
-    }
-
-    let state_clone = Arc::clone(state);
-    let agent_clone = Arc::clone(agent);
-
-    tokio::spawn(async move {
-        // Rate-limit provisioning attempts
-        if !state_clone.can_attempt_refresh().await {
-            debug!("Lazy provisioning rate-limited");
-            return;
-        }
-        state_clone.record_refresh_attempt().await;
-
-        // Need a valid session and server URL
-        let Some(session) = agent_clone.get_session().await else {
-            debug!("No valid session for lazy provisioning");
-            return;
-        };
-        let Some(server_url) = state_clone.get_server_url().await else {
-            debug!("No server URL for lazy provisioning");
-            return;
-        };
-
-        // Read the public key from disk
-        let pub_key_str = match std::fs::read_to_string(&pub_path) {
-            Ok(s) => s.trim().to_string(),
-            Err(e) => {
-                debug!("Failed to read public key for lazy provisioning: {e}");
-                return;
-            }
-        };
-
-        info!("Lazy-provisioning SSH certificate from {server_url}");
-
-        // Make the HTTP request with a short timeout
-        let client = match vouch_common::http::agent_client(&format!(
-            "vouch-agent/{}",
-            env!("CARGO_PKG_VERSION")
-        )) {
-            Ok(c) => c,
-            Err(e) => {
-                debug!("Failed to create HTTP client for lazy provisioning: {e}");
-                return;
-            }
-        };
-
-        let token = match agent_clone.get_token().await {
-            Some(t) => t,
-            None => {
-                debug!("No token available for lazy provisioning");
-                return;
-            }
-        };
-
-        let request = vouch_common::SshCertificateRequest {
-            public_key: pub_key_str,
-        };
-
-        let response = match client
-            .post(format!("{server_url}/v1/credentials/ssh"))
-            .bearer_auth(token.expose_secret())
-            .json(&request)
-            .send()
-            .await
-        {
-            Ok(r) => r,
-            Err(e) => {
-                debug!("Lazy provisioning request failed: {e}");
-                return;
-            }
-        };
-
-        if !response.status().is_success() {
-            debug!("Lazy provisioning returned status {}", response.status());
-            return;
-        }
-
-        let cert_response: vouch_common::SshCertificateResponse = match response.json().await {
-            Ok(r) => r,
-            Err(e) => {
-                debug!("Failed to parse lazy provisioning response: {e}");
-                return;
-            }
-        };
-
-        // Write certificate to disk atomically with 0600 permissions, so it is
-        // never briefly visible world-readable between create and chmod.
-        let cert_path = home
-            .join(".ssh")
-            .join(format!("{DEFAULT_KEY_NAME}-cert.pub"));
-        if let Err(e) = vouch_common::fs::write_secure_file(
-            &cert_path,
-            &format!("{}\n", cert_response.certificate),
-        ) {
-            debug!("Failed to write lazy-provisioned certificate: {e}");
-            return;
-        }
-
-        // Load credentials into agent state
-        match SshCredentials::load(&key_path, &cert_path) {
-            Ok(creds) => {
-                state_clone
-                    .store_credentials(creds, Some(session.expires_at), Some(server_url))
-                    .await;
-                info!(
-                    "Lazy-provisioned SSH certificate (serial: {}, valid for: {}s)",
-                    cert_response.serial, cert_response.valid_for_seconds
-                );
-            }
-            Err(e) => {
-                debug!("Failed to load lazy-provisioned credentials: {e}");
-            }
-        }
-    });
-}
-
-/// Refresh the SSH certificate from the server.
-pub(super) async fn refresh_certificate(
-    state: &Arc<SshAgentState>,
-    agent_state: &Arc<crate::state::AgentState>,
-) -> Result<()> {
-    // Record the refresh attempt
-    state.record_refresh_attempt().await;
-
-    // Get the server URL
-    let server_url = state
-        .get_server_url()
-        .await
-        .ok_or_else(|| AgentError::Protocol("no server URL configured for refresh".to_string()))?;
-
-    // Get the session token
-    let token = agent_state.get_token().await.ok_or_else(|| {
-        AgentError::Protocol("no session token available for refresh".to_string())
-    })?;
-
-    // Get the current public key
-    let creds = state
-        .get_credentials()
-        .await
-        .ok_or_else(|| AgentError::Protocol("no credentials to refresh".to_string()))?;
-
-    let public_key = creds.public_key_openssh()?;
-
-    info!("Refreshing SSH certificate from {}", server_url);
-
-    // Make the refresh request
-    let client =
-        vouch_common::http::agent_client(&format!("vouch-agent/{}", env!("CARGO_PKG_VERSION")))
-            .map_err(|e| AgentError::Protocol(format!("failed to create HTTP client: {e}")))?;
-    let request = vouch_common::SshCertificateRequest { public_key };
-
-    let response = client
-        .post(format!("{}/v1/credentials/ssh", server_url))
-        .bearer_auth(token.expose_secret())
-        .json(&request)
-        .send()
-        .await
-        .map_err(|e| AgentError::Protocol(format!("refresh request failed: {e}")))?;
-
-    if !response.status().is_success() {
-        return Err(AgentError::Protocol(format!(
-            "refresh request returned {}",
-            response.status()
-        )));
-    }
-
-    let cert_response: vouch_common::SshCertificateResponse = response
-        .json()
-        .await
-        .map_err(|e| AgentError::Protocol(format!("failed to parse refresh response: {e}")))?;
-
-    // Write the new certificate to the file
-    let cert_path = &creds.metadata.cert_path;
-    std::fs::write(cert_path, format!("{}\n", cert_response.certificate))
-        .map_err(|e| AgentError::Protocol(format!("failed to write refreshed certificate: {e}")))?;
-    // Set certificate file permissions to 0600 (owner read/write only)
-    use std::os::unix::fs::PermissionsExt;
-    std::fs::set_permissions(cert_path, std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| AgentError::Protocol(format!("failed to set certificate permissions: {e}")))?;
-
-    // Reload credentials from files
-    let new_creds = SshCredentials::load(&creds.metadata.key_path, cert_path)?;
-
-    // Get session expiration (keep existing if not available)
-    let session_expires_at = {
-        let guard = agent_state.get_session().await;
-        guard.map(|s| s.expires_at)
-    };
-
-    // Store the refreshed credentials
-    state
-        .store_credentials(new_creds, session_expires_at, Some(server_url))
-        .await;
-
-    info!(
-        "SSH certificate refreshed successfully (serial: {}, valid for: {}s)",
-        cert_response.serial, cert_response.valid_for_seconds
-    );
-
-    Ok(())
 }

--- a/crates/vouch-agent/src/ssh_agent/server.rs
+++ b/crates/vouch-agent/src/ssh_agent/server.rs
@@ -27,7 +27,8 @@ pub struct SshAgentServer {
 }
 
 impl SshAgentServer {
-    /// Create a new SSH agent server with access to the main agent state (for refresh).
+    /// Create a new SSH agent server with access to the main agent state, used
+    /// to session-gate lazy disk loading of certificates.
     pub fn with_agent_state(
         state: Arc<SshAgentState>,
         agent_state: Arc<crate::state::AgentState>,
@@ -119,9 +120,7 @@ async fn handle_ssh_connection(
             SSH_AGENTC_REQUEST_IDENTITIES => {
                 handle_request_identities(&state, agent_state.as_ref()).await
             }
-            SSH_AGENTC_SIGN_REQUEST => {
-                handle_sign_request(&buf, &state, agent_state.as_ref()).await
-            }
+            SSH_AGENTC_SIGN_REQUEST => handle_sign_request(&buf, &state).await,
             _ => {
                 debug!("Unknown SSH agent message type: {msg_type}");
                 Ok(vec![SSH_AGENT_FAILURE])

--- a/crates/vouch-agent/src/ssh_agent/state.rs
+++ b/crates/vouch-agent/src/ssh_agent/state.rs
@@ -2,9 +2,8 @@
 //! SSH Agent state management.
 //!
 //! Uses a single `RwLock<SshAgentInner>` to ensure atomic reads and writes
-//! across all state fields (credentials, session expiry, server URL, refresh timing).
+//! across all state fields (credentials, session expiry, server URL).
 
-use super::MIN_REFRESH_INTERVAL_SECONDS;
 use super::credentials::SshCredentials;
 use jiff::Timestamp;
 use std::sync::Arc;
@@ -18,10 +17,8 @@ struct SshAgentInner {
     credentials: Option<SshCredentials>,
     /// Session expiration timestamp (linked to Vouch session).
     session_expires_at: Option<Timestamp>,
-    /// Server URL for credential refresh.
+    /// Server URL the session is connected to.
     server_url: Option<String>,
-    /// Last refresh attempt timestamp (for rate limiting).
-    last_refresh_at: Option<Timestamp>,
 }
 
 /// SSH Agent state with session linkage.
@@ -71,13 +68,6 @@ impl SshAgentState {
         guard.credentials = None;
         guard.session_expires_at = None;
         guard.server_url = None;
-        guard.last_refresh_at = None;
-    }
-
-    /// Get current credentials (if any).
-    pub async fn get_credentials(&self) -> Option<SshCredentials> {
-        let guard = self.inner.read().await;
-        guard.credentials.clone()
     }
 
     /// Get valid credentials (not expired, session not expired).
@@ -110,41 +100,13 @@ impl SshAgentState {
         guard.credentials.is_some()
     }
 
-    /// Check if certificate needs refresh.
-    pub async fn needs_refresh(&self) -> bool {
-        let guard = self.inner.read().await;
-        guard
-            .credentials
-            .as_ref()
-            .is_some_and(|c| c.is_expiring_soon())
-    }
-
-    /// Check if we can attempt refresh (rate limiting).
-    pub async fn can_attempt_refresh(&self) -> bool {
-        let guard = self.inner.read().await;
-        match guard.last_refresh_at {
-            Some(last) => {
-                let now = Timestamp::now();
-                let elapsed = now.as_second().saturating_sub(last.as_second());
-                elapsed >= MIN_REFRESH_INTERVAL_SECONDS
-            }
-            None => true,
-        }
-    }
-
-    /// Record refresh attempt time.
-    pub async fn record_refresh_attempt(&self) {
-        let mut guard = self.inner.write().await;
-        guard.last_refresh_at = Some(Timestamp::now());
-    }
-
-    /// Set the server URL for credential refresh/lazy provisioning.
+    /// Set the server URL the session is connected to.
     pub async fn set_server_url(&self, url: String) {
         let mut guard = self.inner.write().await;
         guard.server_url = Some(url);
     }
 
-    /// Get the server URL for refresh.
+    /// Get the server URL the session is connected to.
     pub async fn get_server_url(&self) -> Option<String> {
         let guard = self.inner.read().await;
         guard.server_url.clone()
@@ -163,7 +125,7 @@ mod tests {
     async fn test_state_default_empty() {
         let state = make_mock_state();
         assert!(!state.has_credentials().await);
-        assert!(state.get_credentials().await.is_none());
+        assert!(state.get_valid_credentials().await.is_none());
         assert!(state.get_server_url().await.is_none());
     }
 
@@ -187,23 +149,9 @@ mod tests {
         state
             .set_server_url("https://example.com".to_string())
             .await;
-        state.record_refresh_attempt().await;
 
         state.clear_credentials().await;
 
         assert!(state.get_server_url().await.is_none());
-        assert!(state.can_attempt_refresh().await);
-    }
-
-    #[tokio::test]
-    async fn test_rate_limiting() {
-        let state = make_mock_state();
-
-        // Initially can attempt refresh
-        assert!(state.can_attempt_refresh().await);
-
-        // After recording attempt, should be rate limited
-        state.record_refresh_attempt().await;
-        assert!(!state.can_attempt_refresh().await);
     }
 }


### PR DESCRIPTION
## Summary

`vouch-agent`'s background refresh (`refresh_certificate`) and post-restart lazy-provision (`spawn_lazy_provision`) POST to `/v1/credentials/ssh` with Bearer-only auth. This path:

- **Never worked for `vouch login` (FIDO2/DPoP) sessions** — the server rejects sender-constrained tokens (`cnf.jkt` set) sent as Bearer (`handlers/session.rs`), independent of #529.
- **Is now 401'd for `vouch enroll` (device-grant) sessions** by #529's mandatory RFC 9421 signing on `/v1/credentials/*`.
- **Provides no value at current lifetimes** — the SSH cert TTL equals the session TTL (both `session_hours*3600`, `handlers/credentials.rs`), so cert and session expire together and the user must re-authenticate regardless.

Fixing it would mean sharing the FAPI signing **private key** into the long-running daemon (plus the macOS cross-binary keychain-ACL problem, since the key is migrated into the keychain and the disk copy deleted on real machines). That's a lot of new surface for a feature that never worked, so this removes it instead.

SSH certs are issued by the CLI's signed `vouch credential ssh` path, which writes to disk and pushes to the agent over IPC. After this change the agent serves an in-memory cert and reloads a still-valid cert from disk after a restart (`try_load_from_disk`, which makes **no** server call).

## Changes

Removed from `crates/vouch-agent/src/ssh_agent/`:
- `refresh_certificate`, `spawn_lazy_provision`, and the refresh-trigger block in `handle_sign_request` (`provisioning.rs`)
- Dead support: `needs_refresh`, `can_attempt_refresh`, `record_refresh_attempt`, the `last_refresh_at` field (`state.rs`); `is_expiring_soon`, `public_key_openssh` (`credentials.rs`); `REFRESH_THRESHOLD_SECONDS`, `MIN_REFRESH_INTERVAL_SECONDS` (`mod.rs`)
- `handle_sign_request` no longer takes `agent_state` (`server.rs`)

Kept: `try_load_from_disk` (no server call), the serve/sign cores, the CLI-side `SSH_CERT_REFRESH_THRESHOLD_SECS` (still used by `vouch credential ssh`), and the `SshCertProvisioned` audit event (emitted by the IPC store path).

Net: 21 insertions, 344 deletions.

## Verification

- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo test -p vouch-agent` — 75 passed
- `cargo test -p vouch-tests --test agent_ipc` — 27 passed
- `cargo fmt` — clean

Closes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SSH auth behavior when certs expire (no silent background refresh), but aligns with security model and removes non-working server calls.
> 
> **Overview**
> **Removes** the SSH agent’s ability to call `/v1/credentials/ssh` on its own. Background **refresh** on sign requests and **lazy-provision** when identities are empty are gone; those paths used Bearer-only HTTP and could not satisfy DPoP / RFC 9421 signing that the CLI holds.
> 
> The agent now **only** serves certs from memory, from CLI IPC, or via **`try_load_from_disk`** after restart (session-gated, no network). Empty identity lists mean the user runs **`vouch credential ssh`** again.
> 
> Related cleanup drops refresh thresholds, rate-limit state, `is_expiring_soon` / `public_key_openssh`, and simplifies **`handle_sign_request`** so it no longer needs main agent state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31d26f8cef8d2f5245d4b9adaa1cc3fd8b98e406. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->