### PR TITLE
refactor(test): consolidate test-client creation behind one factory

### DIFF
--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -139,8 +139,7 @@ pub use oauth::{
 // Re-export test-only OAuth client helpers
 #[cfg(test)]
 pub use oauth::test_helpers::{
-    set_oauth_client_active, set_oauth_client_userinfo_alg, update_oauth_client_auth_method,
-    update_oauth_client_fapi_settings, update_oauth_client_jar_settings, update_oauth_client_jwks,
+    set_oauth_client_active, set_oauth_client_userinfo_alg, update_oauth_client_fapi_settings,
 };
 
 // Re-export JWKS cache functions

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -138,9 +138,7 @@ pub use oauth::{
 
 // Re-export test-only OAuth client helpers
 #[cfg(test)]
-pub use oauth::test_helpers::{
-    set_oauth_client_active, set_oauth_client_userinfo_alg, update_oauth_client_fapi_settings,
-};
+pub use oauth::test_helpers::{set_oauth_client_active, set_oauth_client_userinfo_alg};
 
 // Re-export JWKS cache functions
 pub use jwks_cache::{

--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -618,21 +618,6 @@ pub async fn delete_old_oauth_usage_events(audit: &AuditStore, before: Timestamp
 pub(super) mod test_helpers {
     use super::*;
 
-    pub async fn update_oauth_client_fapi_settings(
-        store: &DocumentStore,
-        id: &str,
-        fapi_profile: FapiProfile,
-        dpop_bound_access_tokens: bool,
-    ) -> Result<()> {
-        if let Some(doc) = store.get::<OAuthClientDoc>(id).await? {
-            let mut data = doc.data;
-            data.fapi_profile = fapi_profile;
-            data.dpop_bound_access_tokens = dpop_bound_access_tokens;
-            store.update(id, &data).await?;
-        }
-        Ok(())
-    }
-
     /// Set an OAuth client's `active` flag. Used to simulate deactivated clients.
     pub async fn set_oauth_client_active(
         store: &DocumentStore,

--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -618,52 +618,6 @@ pub async fn delete_old_oauth_usage_events(audit: &AuditStore, before: Timestamp
 pub(super) mod test_helpers {
     use super::*;
 
-    pub async fn update_oauth_client_jwks(
-        store: &DocumentStore,
-        id: &str,
-        jwks_value: &serde_json::Value,
-    ) -> Result<()> {
-        if let Some(doc) = store.get::<OAuthClientDoc>(id).await? {
-            let mut data = doc.data;
-            data.jwks = Some(jwks_value.clone());
-            store.update(id, &data).await?;
-        }
-        Ok(())
-    }
-
-    pub async fn update_oauth_client_auth_method(
-        store: &DocumentStore,
-        id: &str,
-        method: &str,
-    ) -> Result<()> {
-        if let Some(doc) = store.get::<OAuthClientDoc>(id).await? {
-            let mut data = doc.data;
-            data.token_endpoint_auth_method = match method {
-                "private_key_jwt" => TokenEndpointAuthMethod::PrivateKeyJwt,
-                "client_secret_post" => TokenEndpointAuthMethod::ClientSecretPost,
-                "none" => TokenEndpointAuthMethod::None,
-                _ => TokenEndpointAuthMethod::ClientSecretBasic,
-            };
-            store.update(id, &data).await?;
-        }
-        Ok(())
-    }
-
-    pub async fn update_oauth_client_jar_settings(
-        store: &DocumentStore,
-        id: &str,
-        request_object_signing_alg: Option<JwsAlgorithm>,
-        require_signed_request_object: bool,
-    ) -> Result<()> {
-        if let Some(doc) = store.get::<OAuthClientDoc>(id).await? {
-            let mut data = doc.data;
-            data.request_object_signing_alg = request_object_signing_alg;
-            data.require_signed_request_object = Some(require_signed_request_object);
-            store.update(id, &data).await?;
-        }
-        Ok(())
-    }
-
     pub async fn update_oauth_client_fapi_settings(
         store: &DocumentStore,
         id: &str,

--- a/crates/vouch-server/src/handlers/oidc/tests/auth_flows.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/auth_flows.rs
@@ -499,10 +499,15 @@ async fn test_revoked_token_cannot_access_resources() {
 
     let user = create_test_user(&state.store, "rev-d1@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let client = create_test_oauth_client(&state.store, &user.id).await;
-    // The token's client must hold the shared test signing key so the
-    // transparently-signed /v1/* request verifies.
-    attach_test_signing_key(&state.store, &client.app_id).await;
+    let client = create_test_client(
+        &state.store,
+        &user.id,
+        TestClientSpec {
+            jwks: TestJwks::Shared,
+            ..Default::default()
+        },
+    )
+    .await;
 
     let (access_token, _) = issue_oauth_access_token(&app, &state, &user, &auth_id, &client).await;
 

--- a/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
@@ -268,19 +268,12 @@ async fn create_fapi_test_client(
         TestClientSpec {
             jwks: TestJwks::Custom(jwks_value),
             token_endpoint_auth_method: Some(crate::db::TokenEndpointAuthMethod::PrivateKeyJwt),
+            fapi_profile: Some(db::FapiProfile::Fapi2Security),
+            dpop_bound_access_tokens: true,
             ..Default::default()
         },
     )
     .await;
-
-    db::update_oauth_client_fapi_settings(
-        store,
-        &client.app_id,
-        db::FapiProfile::Fapi2Security,
-        true,
-    )
-    .await
-    .expect("Failed to set FAPI profile on FAPI client");
 
     (client, pkcs8_bytes)
 }

--- a/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
@@ -260,25 +260,22 @@ async fn create_fapi_test_client(
     user_id: &str,
 ) -> (TestOAuthClient, Vec<u8>) {
     let (pkcs8_bytes, jwk) = generate_es256_signing_key();
-    let client = create_test_oauth_client(store, user_id).await;
-
-    let oauth_client = db::get_oauth_client_by_client_id(store, &client.client_id)
-        .await
-        .expect("DB error looking up client")
-        .expect("FAPI test client not found in DB");
-
     let jwks_value = serde_json::json!({ "keys": [jwk] });
-    db::update_oauth_client_jwks(store, &oauth_client.id, &jwks_value)
-        .await
-        .expect("Failed to set JWKS on FAPI client");
 
-    db::update_oauth_client_auth_method(store, &oauth_client.id, "private_key_jwt")
-        .await
-        .expect("Failed to set auth method on FAPI client");
+    let client = create_test_client(
+        store,
+        user_id,
+        TestClientSpec {
+            jwks: TestJwks::Custom(jwks_value),
+            token_endpoint_auth_method: Some(crate::db::TokenEndpointAuthMethod::PrivateKeyJwt),
+            ..Default::default()
+        },
+    )
+    .await;
 
     db::update_oauth_client_fapi_settings(
         store,
-        &oauth_client.id,
+        &client.app_id,
         db::FapiProfile::Fapi2Security,
         true,
     )

--- a/crates/vouch-server/src/handlers/oidc/tests/fido2_grant.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/fido2_grant.rs
@@ -795,46 +795,6 @@ async fn test_client_assertion_jti_committed_on_success_and_rejected_on_replay()
 // Helpers local to this module
 // ========================================================================
 
-/// Create a test OAuth client configured for `private_key_jwt` with inline JWKS.
-/// Returns (TestOAuthClient, pkcs8_bytes).
-async fn create_test_jwt_client(
-    store: &db::store::DocumentStore,
-    user_id: &str,
-) -> (TestOAuthClient, Vec<u8>) {
-    use aws_lc_rs::signature::{ECDSA_P256_SHA256_FIXED_SIGNING, EcdsaKeyPair, KeyPair};
-
-    let rng = aws_lc_rs::rand::SystemRandom::new();
-    let pkcs8 = EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &rng)
-        .expect("Failed to generate key");
-    let key_pair = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, pkcs8.as_ref())
-        .expect("Failed to parse key");
-
-    let pub_bytes = key_pair.public_key().as_ref();
-    let x = URL_SAFE_NO_PAD.encode(&pub_bytes[1..33]);
-    let y = URL_SAFE_NO_PAD.encode(&pub_bytes[33..65]);
-
-    let jwk = serde_json::json!({
-        "kty": "EC", "crv": "P-256", "x": x, "y": y,
-        "use": "sig", "alg": "ES256", "kid": "test-key-1"
-    });
-    let jwks_value = serde_json::json!({ "keys": [jwk] });
-
-    let client = create_test_oauth_client(store, user_id).await;
-    let oauth_client = db::get_oauth_client_by_client_id(store, &client.client_id)
-        .await
-        .expect("DB error")
-        .expect("Client not found");
-
-    db::update_oauth_client_jwks(store, &oauth_client.id, &jwks_value)
-        .await
-        .expect("Failed to set JWKS");
-    db::update_oauth_client_auth_method(store, &oauth_client.id, "private_key_jwt")
-        .await
-        .expect("Failed to set auth method");
-
-    (client, pkcs8.as_ref().to_vec())
-}
-
 /// Build a `private_key_jwt` client assertion for the token endpoint.
 fn build_client_assertion(
     client_id: &str,

--- a/crates/vouch-server/src/handlers/oidc/tests/helpers.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/helpers.rs
@@ -160,24 +160,18 @@ pub(super) async fn create_test_jwt_client(
     user_id: &str,
 ) -> (TestOAuthClient, Vec<u8>) {
     let (pkcs8_bytes, jwk) = generate_es256_signing_key();
+    let jwks_value = serde_json::json!({ "keys": [jwk] });
 
-    let client = create_test_oauth_client(store, user_id).await;
-
-    let oauth_client = db::get_oauth_client_by_client_id(store, &client.client_id)
-        .await
-        .expect("DB error")
-        .expect("Client not found");
-
-    let jwks_value = serde_json::json!({
-        "keys": [jwk]
-    });
-    db::update_oauth_client_jwks(store, &oauth_client.id, &jwks_value)
-        .await
-        .expect("Failed to set JWKS");
-
-    db::update_oauth_client_auth_method(store, &oauth_client.id, "private_key_jwt")
-        .await
-        .expect("Failed to set auth method");
+    let client = create_test_client(
+        store,
+        user_id,
+        TestClientSpec {
+            jwks: TestJwks::Custom(jwks_value),
+            token_endpoint_auth_method: Some(crate::db::TokenEndpointAuthMethod::PrivateKeyJwt),
+            ..Default::default()
+        },
+    )
+    .await;
 
     (client, pkcs8_bytes)
 }

--- a/crates/vouch-server/src/handlers/oidc/tests/oidc_userinfo.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/oidc_userinfo.rs
@@ -394,47 +394,19 @@ async fn test_userinfo_signed_jwt_when_es256_configured() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
 
     // Create a client with userinfo_signed_response_alg=ES256
-    let (client_doc, client_id_str) = db::create_oauth_client(
+    let client = create_test_client(
         &state.store,
-        &db::CreateOAuthClientParams {
-            user_id: Some(&user.id),
-            name: "Signed UserInfo Test Client",
-            description: None,
-            application_type: db::OAuthClientType::Web,
-            redirect_uris: &["https://example.com/callback".to_string()],
-            access_scope: db::AccessScope::Public,
-            org_id: None,
-            resource_uris: &[],
-            token_endpoint_auth_method: None,
-            jwks: None,
-            jwks_uri: None,
-            fapi_profile: None,
-            dpop_bound_access_tokens: None,
-            grant_types: None,
-            response_types: None,
-            software_id: None,
-            software_version: None,
-            registration_source: db::RegistrationSource::Manual,
-            registration_access_token_hash: None,
-            registration_metadata: None,
+        &user.id,
+        TestClientSpec {
+            name: "Signed UserInfo Test Client".to_string(),
             id_token_signed_response_alg: db::JwsAlgorithm::Es256,
-            tls_client_auth_subject_dn: None,
-            tls_client_auth_san_dns: None,
-            tls_client_auth_san_uri: None,
-            tls_client_auth_san_ip: None,
-            tls_client_auth_san_email: None,
-            tls_client_certificate_bound_access_tokens: None,
-            authorization_signed_response_alg: None,
-            introspection_signed_response_alg: None,
-            request_object_signing_alg: None,
-            require_signed_request_object: None,
             userinfo_signed_response_alg: Some(db::JwsAlgorithm::Es256),
-            request_uris: None,
+            with_secret: false,
+            ..Default::default()
         },
     )
-    .await
-    .expect("Failed to create signed-userinfo test client");
-    let _ = client_doc;
+    .await;
+    let client_id_str = client.client_id;
 
     // Token bound to this client so client_id is populated in the access token
     let token =
@@ -505,55 +477,26 @@ async fn test_userinfo_rs256_without_rsa_key_returns_500() {
 
     // Create a client with userinfo_signed_response_alg=ES256 first (valid),
     // then override it to RS256 directly via the DB to bypass registration checks.
-    let (client_doc, client_id_str) = db::create_oauth_client(
+    let client = create_test_client(
         &state.store,
-        &db::CreateOAuthClientParams {
-            user_id: Some(&user.id),
-            name: "RS256 No Key Test Client",
-            description: None,
-            application_type: db::OAuthClientType::Web,
-            redirect_uris: &["https://example.com/callback".to_string()],
-            access_scope: db::AccessScope::Public,
-            org_id: None,
-            resource_uris: &[],
-            token_endpoint_auth_method: None,
-            jwks: None,
-            jwks_uri: None,
-            fapi_profile: None,
-            dpop_bound_access_tokens: None,
-            grant_types: None,
-            response_types: None,
-            software_id: None,
-            software_version: None,
-            registration_source: db::RegistrationSource::Manual,
-            registration_access_token_hash: None,
-            registration_metadata: None,
+        &user.id,
+        TestClientSpec {
+            name: "RS256 No Key Test Client".to_string(),
             id_token_signed_response_alg: db::JwsAlgorithm::Es256,
-            tls_client_auth_subject_dn: None,
-            tls_client_auth_san_dns: None,
-            tls_client_auth_san_uri: None,
-            tls_client_auth_san_ip: None,
-            tls_client_auth_san_email: None,
-            tls_client_certificate_bound_access_tokens: None,
-            authorization_signed_response_alg: None,
-            introspection_signed_response_alg: None,
-            request_object_signing_alg: None,
-            require_signed_request_object: None,
-            userinfo_signed_response_alg: None,
-            request_uris: None,
+            with_secret: false,
+            ..Default::default()
         },
     )
-    .await
-    .expect("Failed to create RS256-no-key test client");
+    .await;
 
     // Override userinfo_signed_response_alg to RS256 directly — registration would
     // reject RS256 when no RSA key is available, but direct DB write is needed here.
-    db::set_oauth_client_userinfo_alg(&state.store, &client_doc.id, Some(db::JwsAlgorithm::Rs256))
+    db::set_oauth_client_userinfo_alg(&state.store, &client.app_id, Some(db::JwsAlgorithm::Rs256))
         .await
         .expect("Failed to set RS256 alg");
 
     let token =
-        create_test_session_for_client(&state, &user.id, &user.email, &auth_id, &client_id_str)
+        create_test_session_for_client(&state, &user.id, &user.email, &auth_id, &client.client_id)
             .await;
 
     let response = http_request_full(
@@ -591,55 +534,26 @@ async fn test_userinfo_unsupported_signing_algorithm_returns_500() {
     let user = create_test_user(&state.store, "unsupported-alg@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
 
-    let (client_doc, client_id_str) = db::create_oauth_client(
+    let client = create_test_client(
         &state.store,
-        &db::CreateOAuthClientParams {
-            user_id: Some(&user.id),
-            name: "Unsupported Alg Test Client",
-            description: None,
-            application_type: db::OAuthClientType::Web,
-            redirect_uris: &["https://example.com/callback".to_string()],
-            access_scope: db::AccessScope::Public,
-            org_id: None,
-            resource_uris: &[],
-            token_endpoint_auth_method: None,
-            jwks: None,
-            jwks_uri: None,
-            fapi_profile: None,
-            dpop_bound_access_tokens: None,
-            grant_types: None,
-            response_types: None,
-            software_id: None,
-            software_version: None,
-            registration_source: db::RegistrationSource::Manual,
-            registration_access_token_hash: None,
-            registration_metadata: None,
+        &user.id,
+        TestClientSpec {
+            name: "Unsupported Alg Test Client".to_string(),
             id_token_signed_response_alg: db::JwsAlgorithm::Es256,
-            tls_client_auth_subject_dn: None,
-            tls_client_auth_san_dns: None,
-            tls_client_auth_san_uri: None,
-            tls_client_auth_san_ip: None,
-            tls_client_auth_san_email: None,
-            tls_client_certificate_bound_access_tokens: None,
-            authorization_signed_response_alg: None,
-            introspection_signed_response_alg: None,
-            request_object_signing_alg: None,
-            require_signed_request_object: None,
-            userinfo_signed_response_alg: None,
-            request_uris: None,
+            with_secret: false,
+            ..Default::default()
         },
     )
-    .await
-    .expect("Failed to create unsupported-alg test client");
+    .await;
 
     // Inject PS256 directly — registration correctly rejects it, but a client
     // record could have it from a future schema change or manual edit.
-    db::set_oauth_client_userinfo_alg(&state.store, &client_doc.id, Some(db::JwsAlgorithm::Ps256))
+    db::set_oauth_client_userinfo_alg(&state.store, &client.app_id, Some(db::JwsAlgorithm::Ps256))
         .await
         .expect("Failed to set PS256 alg");
 
     let token =
-        create_test_session_for_client(&state, &user.id, &user.email, &auth_id, &client_id_str)
+        create_test_session_for_client(&state, &user.id, &user.email, &auth_id, &client.client_id)
             .await;
 
     let response = http_request_full(

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc6749_authorize.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc6749_authorize.rs
@@ -386,12 +386,15 @@ async fn test_rfc6749_authorize_access_denied_personal_scope() {
     // Create user who owns the app
     let owner = create_test_user(&state.store, "authorize-owner@example.com").await;
     // Create a Personal scope app
-    let client = create_test_oauth_client_with_options(
+    let client = create_test_client(
         &state.store,
         &owner.id,
-        crate::db::AccessScope::Personal,
-        None,
-        &[],
+        TestClientSpec {
+            access_scope: crate::db::AccessScope::Personal,
+            org_id: None,
+            resource_uris: vec![],
+            ..Default::default()
+        },
     )
     .await;
 
@@ -452,12 +455,15 @@ async fn test_rfc8707_authorize_invalid_resource_redirects_with_error() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
 
     // Create a client with a specific resource URI
-    let client = create_test_oauth_client_with_options(
+    let client = create_test_client(
         &state.store,
         &user.id,
-        crate::db::AccessScope::Public,
-        None,
-        &["https://api.example.com".to_string()],
+        TestClientSpec {
+            access_scope: crate::db::AccessScope::Public,
+            org_id: None,
+            resource_uris: vec!["https://api.example.com".to_string()],
+            ..Default::default()
+        },
     )
     .await;
 

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc6749_authorize.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc6749_authorize.rs
@@ -229,56 +229,27 @@ async fn test_rfc6749_authorize_missing_redirect_uri_multi_uri_shows_error_page(
 
     let user = create_test_user(&state.store, "authorize-noredir-multi@example.com").await;
     // Create a client with two redirect URIs
-    let (client_record, _) = crate::db::create_oauth_client(
+    let client = create_test_client(
         &state.store,
-        &crate::db::CreateOAuthClientParams {
-            user_id: Some(&user.id),
-            name: "Multi-URI App",
-            description: None,
-            application_type: crate::db::OAuthClientType::Web,
-            redirect_uris: &[
+        &user.id,
+        TestClientSpec {
+            name: "Multi-URI App".to_string(),
+            redirect_uris: vec![
                 "https://example.com/callback".to_string(),
                 "https://example.com/callback2".to_string(),
             ],
-            access_scope: crate::db::AccessScope::Public,
-            org_id: None,
-            resource_uris: &[],
-            token_endpoint_auth_method: None,
-            jwks: None,
-            jwks_uri: None,
-            fapi_profile: None,
-            dpop_bound_access_tokens: None,
-            grant_types: None,
-            response_types: None,
-            software_id: None,
-            software_version: None,
-            registration_source: crate::db::documents::oauth::RegistrationSource::Manual,
-            registration_access_token_hash: None,
-            registration_metadata: None,
-            id_token_signed_response_alg: crate::db::documents::oauth::JwsAlgorithm::Rs256,
-            tls_client_auth_subject_dn: None,
-            tls_client_auth_san_dns: None,
-            tls_client_auth_san_uri: None,
-            tls_client_auth_san_ip: None,
-            tls_client_auth_san_email: None,
-            tls_client_certificate_bound_access_tokens: None,
-            authorization_signed_response_alg: None,
-            introspection_signed_response_alg: None,
-            request_object_signing_alg: None,
-            require_signed_request_object: None,
-            userinfo_signed_response_alg: None,
-            request_uris: None,
+            with_secret: false,
+            ..Default::default()
         },
     )
-    .await
-    .expect("create client");
+    .await;
 
     let response = http_get_full(
         &app,
         &format!(
             "/oauth/authorize?response_type=code&client_id={}&scope=openid\
              &code_challenge=dummychallenge&code_challenge_method=S256",
-            client_record.client_id,
+            client.client_id,
         ),
         &[],
     )

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7523.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7523.rs
@@ -63,28 +63,18 @@ async fn create_test_jwt_client(
     user_id: &str,
 ) -> (TestOAuthClient, Vec<u8>) {
     let (pkcs8_bytes, jwk) = generate_es256_signing_key();
+    let jwks_value = serde_json::json!({ "keys": [jwk] });
 
-    // Create the client first
-    let client = create_test_oauth_client(store, user_id).await;
-
-    // Get the internal ID for the client
-    let oauth_client = db::get_oauth_client_by_client_id(store, &client.client_id)
-        .await
-        .expect("DB error")
-        .expect("Client not found");
-
-    // Set inline JWKS
-    let jwks_value = serde_json::json!({
-        "keys": [jwk]
-    });
-    db::update_oauth_client_jwks(store, &oauth_client.id, &jwks_value)
-        .await
-        .expect("Failed to set JWKS");
-
-    // Set auth method to private_key_jwt
-    db::update_oauth_client_auth_method(store, &oauth_client.id, "private_key_jwt")
-        .await
-        .expect("Failed to set auth method");
+    let client = create_test_client(
+        store,
+        user_id,
+        TestClientSpec {
+            jwks: TestJwks::Custom(jwks_value),
+            token_endpoint_auth_method: Some(crate::db::TokenEndpointAuthMethod::PrivateKeyJwt),
+            ..Default::default()
+        },
+    )
+    .await;
 
     (client, pkcs8_bytes)
 }

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7523.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7523.rs
@@ -690,21 +690,21 @@ async fn create_test_fapi_jwt_client(
     store: &db::store::DocumentStore,
     user_id: &str,
 ) -> (TestOAuthClient, Vec<u8>) {
-    let (client, pkcs8_bytes) = create_test_jwt_client(store, user_id).await;
+    let (pkcs8_bytes, jwk) = generate_es256_signing_key();
+    let jwks_value = serde_json::json!({ "keys": [jwk] });
 
-    let oauth_client = db::get_oauth_client_by_client_id(store, &client.client_id)
-        .await
-        .expect("DB error")
-        .expect("Client not found");
-
-    db::update_oauth_client_fapi_settings(
+    let client = create_test_client(
         store,
-        &oauth_client.id,
-        db::FapiProfile::Fapi2Security,
-        true,
+        user_id,
+        TestClientSpec {
+            jwks: TestJwks::Custom(jwks_value),
+            token_endpoint_auth_method: Some(crate::db::TokenEndpointAuthMethod::PrivateKeyJwt),
+            fapi_profile: Some(db::FapiProfile::Fapi2Security),
+            dpop_bound_access_tokens: true,
+            ..Default::default()
+        },
     )
-    .await
-    .expect("Failed to set FAPI profile");
+    .await;
 
     (client, pkcs8_bytes)
 }
@@ -1727,21 +1727,21 @@ async fn test_rfc7523_token_fapi_client_invalid_request_no_dpop_or_mtls() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "fapi-pkjwt-nosc@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let (client, pkcs8_bytes) = create_test_jwt_client(&state.store, &user.id).await;
-    let oauth = db::get_oauth_client_by_client_id(&state.store, &client.client_id)
-        .await
-        .expect("DB error")
-        .expect("client");
     // FAPI profile WITHOUT dpop_bound_access_tokens=true so the
     // FAPI sender-constraint check fires (instead of the DPoP-required check).
-    db::update_oauth_client_fapi_settings(
+    let (pkcs8_bytes, jwk) = generate_es256_signing_key();
+    let jwks_value = serde_json::json!({ "keys": [jwk] });
+    let client = create_test_client(
         &state.store,
-        &oauth.id,
-        db::FapiProfile::Fapi2Security,
-        false,
+        &user.id,
+        TestClientSpec {
+            jwks: TestJwks::Custom(jwks_value),
+            token_endpoint_auth_method: Some(crate::db::TokenEndpointAuthMethod::PrivateKeyJwt),
+            fapi_profile: Some(db::FapiProfile::Fapi2Security),
+            ..Default::default()
+        },
     )
-    .await
-    .expect("set FAPI profile");
+    .await;
 
     let code = pkjwt_issue_code(&state, &client.client_id, &user, &auth_id, None).await;
     let issuer = &state.config().base_url;

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc8705.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc8705.rs
@@ -194,6 +194,8 @@ async fn create_mtls_client_with_cert_binding(
     store: &db::store::DocumentStore,
     user_id: &str,
     subject_dn: &str,
+    fapi_profile: db::FapiProfile,
+    dpop_bound_access_tokens: bool,
 ) -> String {
     create_test_client(
         store,
@@ -204,6 +206,8 @@ async fn create_mtls_client_with_cert_binding(
             tls_client_auth_subject_dn: Some(subject_dn.to_string()),
             tls_client_certificate_bound_access_tokens: true,
             with_secret: false,
+            fapi_profile: Some(fapi_profile),
+            dpop_bound_access_tokens,
             ..Default::default()
         },
     )
@@ -261,7 +265,14 @@ async fn test_rfc8705_token_mtls_authorization_code_succeeds() {
     let subject_dn = parsed.subject_dn.expect("generated cert has subject DN");
     let thumbprint = cert_thumbprint(&cert_der);
 
-    let client_id = create_mtls_client_with_cert_binding(&state.store, &user.id, &subject_dn).await;
+    let client_id = create_mtls_client_with_cert_binding(
+        &state.store,
+        &user.id,
+        &subject_dn,
+        db::FapiProfile::None,
+        false,
+    )
+    .await;
 
     let code = issue_test_authorization_code(&state, &client_id, &user, &auth_id, None).await;
     let body = format!(
@@ -300,7 +311,14 @@ async fn test_rfc8705_token_mtls_invalid_grant_when_code_already_used() {
     let parsed = crate::services::oidc::mtls::parse_client_certificate(&cert_der)
         .expect("parse generated cert");
     let subject_dn = parsed.subject_dn.expect("subject DN");
-    let client_id = create_mtls_client_with_cert_binding(&state.store, &user.id, &subject_dn).await;
+    let client_id = create_mtls_client_with_cert_binding(
+        &state.store,
+        &user.id,
+        &subject_dn,
+        db::FapiProfile::None,
+        false,
+    )
+    .await;
 
     let code = issue_test_authorization_code(&state, &client_id, &user, &auth_id, None).await;
     let body = format!(
@@ -339,8 +357,14 @@ async fn test_rfc8705_token_mtls_invalid_client_when_cert_mismatch() {
     let parsed_a =
         crate::services::oidc::mtls::parse_client_certificate(&cert_a_der).expect("parse cert A");
     let subject_dn_a = parsed_a.subject_dn.expect("cert A has subject DN");
-    let client_id =
-        create_mtls_client_with_cert_binding(&state.store, &user.id, &subject_dn_a).await;
+    let client_id = create_mtls_client_with_cert_binding(
+        &state.store,
+        &user.id,
+        &subject_dn_a,
+        db::FapiProfile::None,
+        false,
+    )
+    .await;
 
     let code = issue_test_authorization_code(&state, &client_id, &user, &auth_id, None).await;
 
@@ -376,17 +400,14 @@ async fn test_rfc8705_token_mtls_invalid_request_when_dpop_required_but_missing(
     let parsed =
         crate::services::oidc::mtls::parse_client_certificate(&cert_der).expect("parse cert");
     let subject_dn = parsed.subject_dn.expect("subject DN");
-    let client_id = create_mtls_client_with_cert_binding(&state.store, &user.id, &subject_dn).await;
-
-    // Flip the client to require DPoP-bound tokens.
-    db::update_oauth_client_fapi_settings(
+    let client_id = create_mtls_client_with_cert_binding(
         &state.store,
-        &client_id_to_app_id(&state, &client_id).await,
+        &user.id,
+        &subject_dn,
         db::FapiProfile::Fapi2Security,
         true,
     )
-    .await
-    .expect("set dpop required");
+    .await;
 
     let code = issue_test_authorization_code(&state, &client_id, &user, &auth_id, None).await;
     let body = format!(
@@ -413,15 +434,6 @@ async fn test_rfc8705_token_mtls_invalid_request_when_dpop_required_but_missing(
     );
 }
 
-/// Look up an OAuth client's internal app_id (database PK) from its public client_id.
-async fn client_id_to_app_id(state: &std::sync::Arc<crate::AppState>, client_id: &str) -> String {
-    db::get_oauth_client_by_client_id(&state.store, client_id)
-        .await
-        .expect("DB error")
-        .expect("client not found")
-        .id
-}
-
 /// RFC 8705 §3 + RFC 9449 §5: mTLS-authenticated client with DPoP-bound and
 /// cert-bound tokens exchanges code with a matching cert + DPoP proof + nonce.
 /// Returns a DPoP-token-type access token with `cnf.jkt` (and may include
@@ -436,15 +448,14 @@ async fn test_rfc8705_token_mtls_plus_dpop_succeeds() {
     let parsed =
         crate::services::oidc::mtls::parse_client_certificate(&cert_der).expect("parse cert");
     let subject_dn = parsed.subject_dn.expect("subject DN");
-    let client_id = create_mtls_client_with_cert_binding(&state.store, &user.id, &subject_dn).await;
-    db::update_oauth_client_fapi_settings(
+    let client_id = create_mtls_client_with_cert_binding(
         &state.store,
-        &client_id_to_app_id(&state, &client_id).await,
+        &user.id,
+        &subject_dn,
         db::FapiProfile::Fapi2Security,
         true,
     )
-    .await
-    .expect("set dpop required");
+    .await;
 
     let (dpop_key, dpop_jwk) = generate_dpop_key_pair();
     let jkt = dpop_jkt(&dpop_jwk);
@@ -497,15 +508,14 @@ async fn test_rfc8705_token_mtls_plus_dpop_invalid_grant_when_jkt_mismatch() {
     let parsed =
         crate::services::oidc::mtls::parse_client_certificate(&cert_der).expect("parse cert");
     let subject_dn = parsed.subject_dn.expect("subject DN");
-    let client_id = create_mtls_client_with_cert_binding(&state.store, &user.id, &subject_dn).await;
-    db::update_oauth_client_fapi_settings(
+    let client_id = create_mtls_client_with_cert_binding(
         &state.store,
-        &client_id_to_app_id(&state, &client_id).await,
+        &user.id,
+        &subject_dn,
         db::FapiProfile::Fapi2Security,
         true,
     )
-    .await
-    .expect("set dpop required");
+    .await;
 
     // Authorization bound to key A.
     let (_key_a, jwk_a) = generate_dpop_key_pair();

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc8705.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc8705.rs
@@ -195,47 +195,20 @@ async fn create_mtls_client_with_cert_binding(
     user_id: &str,
     subject_dn: &str,
 ) -> String {
-    let (_doc, client_id) = db::create_oauth_client(
+    create_test_client(
         store,
-        &db::CreateOAuthClientParams {
-            user_id: Some(user_id),
-            name: "Test mTLS Token Client",
-            description: None,
-            application_type: db::OAuthClientType::Web,
-            redirect_uris: &["https://example.com/callback".to_string()],
-            access_scope: db::AccessScope::Public,
-            org_id: None,
-            resource_uris: &[],
+        user_id,
+        TestClientSpec {
+            name: "Test mTLS Token Client".to_string(),
             token_endpoint_auth_method: Some(db::TokenEndpointAuthMethod::TlsClientAuth),
-            jwks: None,
-            jwks_uri: None,
-            fapi_profile: None,
-            dpop_bound_access_tokens: None,
-            grant_types: None,
-            response_types: None,
-            software_id: None,
-            software_version: None,
-            registration_source: db::RegistrationSource::Manual,
-            registration_access_token_hash: None,
-            registration_metadata: None,
-            id_token_signed_response_alg: db::JwsAlgorithm::Rs256,
-            tls_client_auth_subject_dn: Some(subject_dn),
-            tls_client_auth_san_dns: None,
-            tls_client_auth_san_uri: None,
-            tls_client_auth_san_ip: None,
-            tls_client_auth_san_email: None,
-            tls_client_certificate_bound_access_tokens: Some(true),
-            authorization_signed_response_alg: None,
-            introspection_signed_response_alg: None,
-            request_object_signing_alg: None,
-            require_signed_request_object: None,
-            userinfo_signed_response_alg: None,
-            request_uris: None,
+            tls_client_auth_subject_dn: Some(subject_dn.to_string()),
+            tls_client_certificate_bound_access_tokens: true,
+            with_secret: false,
+            ..Default::default()
         },
     )
     .await
-    .expect("Failed to create mTLS test client");
-    client_id
+    .client_id
 }
 
 /// Issue an authorization code for the given client + user using standard scope.

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9101.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9101.rs
@@ -62,21 +62,17 @@ async fn create_test_jar_client(
     user_id: &str,
 ) -> (TestOAuthClient, Vec<u8>) {
     let (pkcs8_bytes, jwk) = generate_es256_signing_key();
+    let jwks_value = serde_json::json!({ "keys": [jwk] });
 
-    let client = create_test_oauth_client(store, user_id).await;
-
-    let oauth_client = db::get_oauth_client_by_client_id(store, &client.client_id)
-        .await
-        .expect("DB error")
-        .expect("Client not found");
-
-    // Set inline JWKS
-    let jwks_value = serde_json::json!({
-        "keys": [jwk]
-    });
-    db::update_oauth_client_jwks(store, &oauth_client.id, &jwks_value)
-        .await
-        .expect("Failed to set JWKS");
+    let client = create_test_client(
+        store,
+        user_id,
+        TestClientSpec {
+            jwks: TestJwks::Custom(jwks_value),
+            ..Default::default()
+        },
+    )
+    .await;
 
     (client, pkcs8_bytes)
 }
@@ -637,17 +633,20 @@ async fn test_rfc9101_require_signed_request_object_rejects_plain_params() {
 
     let user = create_test_user(&state.store, "jar-required@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let (client, _pkcs8_bytes) = create_test_jar_client(&state.store, &user.id).await;
     let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
 
-    // Set require_signed_request_object = true
-    let oauth_client = db::get_oauth_client_by_client_id(&state.store, &client.client_id)
-        .await
-        .expect("DB error")
-        .expect("Client not found");
-    db::update_oauth_client_jar_settings(&state.store, &oauth_client.id, None, true)
-        .await
-        .expect("Failed to update JAR settings");
+    let (_pkcs8_bytes, jwk) = generate_es256_signing_key();
+    let jwks_value = serde_json::json!({ "keys": [jwk] });
+    let client = create_test_client(
+        &state.store,
+        &user.id,
+        TestClientSpec {
+            jwks: TestJwks::Custom(jwks_value),
+            require_signed_request_object: Some(true),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
     let challenge = sha256_base64url(verifier);
@@ -689,17 +688,20 @@ async fn test_rfc9101_require_signed_request_object_accepts_valid_jar() {
 
     let user = create_test_user(&state.store, "jar-reqok@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let (client, pkcs8_bytes) = create_test_jar_client(&state.store, &user.id).await;
     let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
 
-    // Set require_signed_request_object = true
-    let oauth_client = db::get_oauth_client_by_client_id(&state.store, &client.client_id)
-        .await
-        .expect("DB error")
-        .expect("Client not found");
-    db::update_oauth_client_jar_settings(&state.store, &oauth_client.id, None, true)
-        .await
-        .expect("Failed to update JAR settings");
+    let (pkcs8_bytes, jwk) = generate_es256_signing_key();
+    let jwks_value = serde_json::json!({ "keys": [jwk] });
+    let client = create_test_client(
+        &state.store,
+        &user.id,
+        TestClientSpec {
+            jwks: TestJwks::Custom(jwks_value),
+            require_signed_request_object: Some(true),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let issuer = &state.config().base_url;
     let request_jwt = build_request_object(&client.client_id, issuer, &pkcs8_bytes);
@@ -896,21 +898,20 @@ async fn test_rfc9101_client_signing_alg_es256_rejects_rs256_jwt() {
 
     let user = create_test_user(&state.store, "jar-algenforce@example.com").await;
     let _auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let (client, pkcs8_bytes) = create_test_jar_client(&state.store, &user.id).await;
 
-    // Configure the client to require ES256 only
-    let oauth_client = db::get_oauth_client_by_client_id(&state.store, &client.client_id)
-        .await
-        .expect("DB error")
-        .expect("Client not found");
-    db::update_oauth_client_jar_settings(
+    let (pkcs8_bytes, jwk) = generate_es256_signing_key();
+    let jwks_value = serde_json::json!({ "keys": [jwk] });
+    let client = create_test_client(
         &state.store,
-        &oauth_client.id,
-        Some(db::JwsAlgorithm::Es256),
-        false,
+        &user.id,
+        TestClientSpec {
+            jwks: TestJwks::Custom(jwks_value),
+            request_object_signing_alg: Some(db::JwsAlgorithm::Es256),
+            require_signed_request_object: Some(false),
+            ..Default::default()
+        },
     )
-    .await
-    .expect("Failed to set request_object_signing_alg");
+    .await;
 
     // Build a JWT that claims to be RS256 in the header (but is signed with ES256 key)
     // The server should reject it because the header alg (RS256) != required alg (ES256)
@@ -968,22 +969,21 @@ async fn test_rfc9101_client_signing_alg_es256_accepts_es256_jwt() {
 
     let user = create_test_user(&state.store, "jar-algok@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let (client, pkcs8_bytes) = create_test_jar_client(&state.store, &user.id).await;
     let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
 
-    // Configure the client to require ES256 only
-    let oauth_client = db::get_oauth_client_by_client_id(&state.store, &client.client_id)
-        .await
-        .expect("DB error")
-        .expect("Client not found");
-    db::update_oauth_client_jar_settings(
+    let (pkcs8_bytes, jwk) = generate_es256_signing_key();
+    let jwks_value = serde_json::json!({ "keys": [jwk] });
+    let client = create_test_client(
         &state.store,
-        &oauth_client.id,
-        Some(db::JwsAlgorithm::Es256),
-        false,
+        &user.id,
+        TestClientSpec {
+            jwks: TestJwks::Custom(jwks_value),
+            request_object_signing_alg: Some(db::JwsAlgorithm::Es256),
+            require_signed_request_object: Some(false),
+            ..Default::default()
+        },
     )
-    .await
-    .expect("Failed to set request_object_signing_alg");
+    .await;
 
     let issuer = &state.config().base_url;
     let request_jwt = build_request_object(&client.client_id, issuer, &pkcs8_bytes);

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
@@ -1527,47 +1527,19 @@ async fn create_mtls_oauth_client(
     user_id: &str,
     subject_dn: &str,
 ) -> String {
-    let (_client_doc, client_id) = crate::db::create_oauth_client(
+    create_test_client(
         store,
-        &crate::db::CreateOAuthClientParams {
-            user_id: Some(user_id),
-            name: "Test mTLS PAR Client",
-            description: None,
-            application_type: crate::db::OAuthClientType::Web,
-            redirect_uris: &["https://example.com/callback".to_string()],
-            access_scope: crate::db::AccessScope::Public,
-            org_id: None,
-            resource_uris: &[],
-            token_endpoint_auth_method: Some(crate::db::TokenEndpointAuthMethod::TlsClientAuth),
-            jwks: None,
-            jwks_uri: None,
-            fapi_profile: None,
-            dpop_bound_access_tokens: None,
-            grant_types: None,
-            response_types: None,
-            software_id: None,
-            software_version: None,
-            registration_source: crate::db::RegistrationSource::Manual,
-            registration_access_token_hash: None,
-            registration_metadata: None,
-            id_token_signed_response_alg: crate::db::JwsAlgorithm::Rs256,
-            tls_client_auth_subject_dn: Some(subject_dn),
-            tls_client_auth_san_dns: None,
-            tls_client_auth_san_uri: None,
-            tls_client_auth_san_ip: None,
-            tls_client_auth_san_email: None,
-            tls_client_certificate_bound_access_tokens: None,
-            authorization_signed_response_alg: None,
-            introspection_signed_response_alg: None,
-            request_object_signing_alg: None,
-            require_signed_request_object: None,
-            userinfo_signed_response_alg: None,
-            request_uris: None,
+        user_id,
+        TestClientSpec {
+            name: "Test mTLS PAR Client".to_string(),
+            token_endpoint_auth_method: Some(db::TokenEndpointAuthMethod::TlsClientAuth),
+            tls_client_auth_subject_dn: Some(subject_dn.to_string()),
+            with_secret: false,
+            ..Default::default()
         },
     )
     .await
-    .expect("Failed to create mTLS test client");
-    client_id
+    .client_id
 }
 
 #[tokio::test]
@@ -1731,46 +1703,21 @@ async fn create_fapi_mtls_client(
 ) -> (String, Vec<u8>) {
     let (pkcs8_bytes, jwk) = generate_es256_signing_key();
     let jwks_value = serde_json::json!({ "keys": [jwk] });
-    let (_doc, client_id) = crate::db::create_oauth_client(
+    let client_id = create_test_client(
         store,
-        &crate::db::CreateOAuthClientParams {
-            user_id: Some(user_id),
-            name: "Test FAPI mTLS PAR Client",
-            description: None,
-            application_type: crate::db::OAuthClientType::Web,
-            redirect_uris: &["https://example.com/callback".to_string()],
-            access_scope: crate::db::AccessScope::Public,
-            org_id: None,
-            resource_uris: &[],
-            token_endpoint_auth_method: Some(crate::db::TokenEndpointAuthMethod::TlsClientAuth),
-            jwks: Some(&jwks_value),
-            jwks_uri: None,
-            fapi_profile: Some(crate::db::FapiProfile::Fapi2Security),
-            dpop_bound_access_tokens: None,
-            grant_types: None,
-            response_types: None,
-            software_id: None,
-            software_version: None,
-            registration_source: crate::db::RegistrationSource::Manual,
-            registration_access_token_hash: None,
-            registration_metadata: None,
-            id_token_signed_response_alg: crate::db::JwsAlgorithm::Rs256,
-            tls_client_auth_subject_dn: Some(subject_dn),
-            tls_client_auth_san_dns: None,
-            tls_client_auth_san_uri: None,
-            tls_client_auth_san_ip: None,
-            tls_client_auth_san_email: None,
-            tls_client_certificate_bound_access_tokens: None,
-            authorization_signed_response_alg: None,
-            introspection_signed_response_alg: None,
-            request_object_signing_alg: None,
-            require_signed_request_object: None,
-            userinfo_signed_response_alg: None,
-            request_uris: None,
+        user_id,
+        TestClientSpec {
+            name: "Test FAPI mTLS PAR Client".to_string(),
+            token_endpoint_auth_method: Some(db::TokenEndpointAuthMethod::TlsClientAuth),
+            jwks: TestJwks::Custom(jwks_value),
+            fapi_profile: Some(db::FapiProfile::Fapi2Security),
+            tls_client_auth_subject_dn: Some(subject_dn.to_string()),
+            with_secret: false,
+            ..Default::default()
         },
     )
     .await
-    .expect("Failed to create FAPI mTLS test client");
+    .client_id;
     (client_id, pkcs8_bytes)
 }
 

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
@@ -1687,10 +1687,30 @@ async fn create_fapi_jwt_client_requiring_request_object(
     store: &db::store::DocumentStore,
     user_id: &str,
 ) -> (TestOAuthClient, Vec<u8>) {
-    let (client, pkcs8_bytes) = create_fapi_jwt_client(store, user_id).await;
-    db::update_oauth_client_jar_settings(store, &client.app_id, None, true)
-        .await
-        .expect("Failed to set require_signed_request_object");
+    let (pkcs8_bytes, jwk) = generate_es256_signing_key();
+    let jwks_value = serde_json::json!({ "keys": [jwk] });
+
+    let client = create_test_client(
+        store,
+        user_id,
+        TestClientSpec {
+            jwks: TestJwks::Custom(jwks_value),
+            token_endpoint_auth_method: Some(crate::db::TokenEndpointAuthMethod::PrivateKeyJwt),
+            require_signed_request_object: Some(true),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    db::update_oauth_client_fapi_settings(
+        store,
+        &client.app_id,
+        crate::db::FapiProfile::Fapi2Security,
+        false,
+    )
+    .await
+    .expect("Failed to set FAPI profile");
+
     (client, pkcs8_bytes)
 }
 

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
@@ -1670,15 +1670,21 @@ async fn create_fapi_jwt_client(
     store: &db::store::DocumentStore,
     user_id: &str,
 ) -> (TestOAuthClient, Vec<u8>) {
-    let (client, pkcs8_bytes) = create_test_jwt_client(store, user_id).await;
-    db::update_oauth_client_fapi_settings(
+    let (pkcs8_bytes, jwk) = generate_es256_signing_key();
+    let jwks_value = serde_json::json!({ "keys": [jwk] });
+
+    let client = create_test_client(
         store,
-        &client.app_id,
-        crate::db::FapiProfile::Fapi2Security,
-        false,
+        user_id,
+        TestClientSpec {
+            jwks: TestJwks::Custom(jwks_value),
+            token_endpoint_auth_method: Some(crate::db::TokenEndpointAuthMethod::PrivateKeyJwt),
+            fapi_profile: Some(crate::db::FapiProfile::Fapi2Security),
+            ..Default::default()
+        },
     )
-    .await
-    .expect("Failed to set FAPI profile");
+    .await;
+
     (client, pkcs8_bytes)
 }
 
@@ -1696,20 +1702,12 @@ async fn create_fapi_jwt_client_requiring_request_object(
         TestClientSpec {
             jwks: TestJwks::Custom(jwks_value),
             token_endpoint_auth_method: Some(crate::db::TokenEndpointAuthMethod::PrivateKeyJwt),
+            fapi_profile: Some(crate::db::FapiProfile::Fapi2Security),
             require_signed_request_object: Some(true),
             ..Default::default()
         },
     )
     .await;
-
-    db::update_oauth_client_fapi_settings(
-        store,
-        &client.app_id,
-        crate::db::FapiProfile::Fapi2Security,
-        false,
-    )
-    .await
-    .expect("Failed to set FAPI profile");
 
     (client, pkcs8_bytes)
 }

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9449.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9449.rs
@@ -1172,10 +1172,15 @@ async fn test_dpop_resource_endpoint_post_json_without_nonce() {
 
     let user = create_test_user(&state.store, "dpop-post-nonce@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let client = create_test_oauth_client(&state.store, &user.id).await;
-    // The DPoP-bound token's client must hold the shared test signing key so
-    // the transparently-signed POST /v1/credentials/ssh request verifies.
-    attach_test_signing_key(&state.store, &client.app_id).await;
+    let client = create_test_client(
+        &state.store,
+        &user.id,
+        TestClientSpec {
+            jwks: TestJwks::Shared,
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Step 1: Get a DPoP-bound access token
     let (dpop_key, dpop_jwk) = generate_dpop_key_pair();
@@ -1407,46 +1412,19 @@ async fn test_rfc9449_token_mtls_registered_client_without_cert_rejected() {
     let subject_dn = parsed.subject_dn.expect("subject DN");
 
     // Manually create an mtls-auth client (no cert-binding required).
-    let (_doc, client_id) = db::create_oauth_client(
+    let client_id = create_test_client(
         &state.store,
-        &db::CreateOAuthClientParams {
-            user_id: Some(&user.id),
-            name: "Test mTLS Token Endpoint Client",
-            description: None,
-            application_type: db::OAuthClientType::Web,
-            redirect_uris: &["https://example.com/callback".to_string()],
-            access_scope: db::AccessScope::Public,
-            org_id: None,
-            resource_uris: &[],
+        &user.id,
+        TestClientSpec {
+            name: "Test mTLS Token Endpoint Client".to_string(),
             token_endpoint_auth_method: Some(db::TokenEndpointAuthMethod::TlsClientAuth),
-            jwks: None,
-            jwks_uri: None,
-            fapi_profile: None,
-            dpop_bound_access_tokens: None,
-            grant_types: None,
-            response_types: None,
-            software_id: None,
-            software_version: None,
-            registration_source: db::RegistrationSource::Manual,
-            registration_access_token_hash: None,
-            registration_metadata: None,
-            id_token_signed_response_alg: db::JwsAlgorithm::Rs256,
-            tls_client_auth_subject_dn: Some(&subject_dn),
-            tls_client_auth_san_dns: None,
-            tls_client_auth_san_uri: None,
-            tls_client_auth_san_ip: None,
-            tls_client_auth_san_email: None,
-            tls_client_certificate_bound_access_tokens: None,
-            authorization_signed_response_alg: None,
-            introspection_signed_response_alg: None,
-            request_object_signing_alg: None,
-            require_signed_request_object: None,
-            userinfo_signed_response_alg: None,
-            request_uris: None,
+            tls_client_auth_subject_dn: Some(subject_dn),
+            with_secret: false,
+            ..Default::default()
         },
     )
     .await
-    .expect("create mTLS-auth client");
+    .client_id;
 
     let scope = ScopeSet::parse("openid");
     let code = issue_authorization_code(

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9701.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9701.rs
@@ -2,7 +2,6 @@
 //! RFC 9701 — JWT Token Introspection Responses.
 
 use super::helpers::*;
-use crate::db::{self, CreateOAuthClientParams, JwsAlgorithm, RegistrationSource};
 
 // ============================================================================
 // Helpers
@@ -13,63 +12,17 @@ async fn create_test_client_with_introspection_jwt(
     state: &std::sync::Arc<crate::AppState>,
     user_id: &str,
 ) -> crate::test_utils::TestOAuthClient {
-    use aws_lc_rs::rand as aws_rand;
-
-    let (client, client_id) = db::create_oauth_client(
+    create_test_client(
         &state.store,
-        &CreateOAuthClientParams {
-            user_id: Some(user_id),
-            name: "JWT Introspect App",
-            description: None,
-            application_type: crate::db::OAuthClientType::Web,
-            redirect_uris: &["https://example.com/callback".to_string()],
-            access_scope: crate::db::AccessScope::Public,
-            org_id: None,
-            resource_uris: &[],
-            token_endpoint_auth_method: None,
-            jwks: None,
-            jwks_uri: None,
-            fapi_profile: None,
-            dpop_bound_access_tokens: None,
-            grant_types: None,
-            response_types: None,
-            software_id: None,
-            software_version: None,
-            registration_source: RegistrationSource::Manual,
-            registration_access_token_hash: None,
-            registration_metadata: None,
-            id_token_signed_response_alg: JwsAlgorithm::Es256,
-            tls_client_auth_subject_dn: None,
-            tls_client_auth_san_dns: None,
-            tls_client_auth_san_uri: None,
-            tls_client_auth_san_ip: None,
-            tls_client_auth_san_email: None,
-            tls_client_certificate_bound_access_tokens: None,
-            authorization_signed_response_alg: None,
-            introspection_signed_response_alg: Some(JwsAlgorithm::Es256),
-            request_object_signing_alg: None,
-            require_signed_request_object: None,
-            userinfo_signed_response_alg: None,
-            request_uris: None,
+        user_id,
+        TestClientSpec {
+            name: "JWT Introspect App".to_string(),
+            id_token_signed_response_alg: db::JwsAlgorithm::Es256,
+            introspection_signed_response_alg: Some(db::JwsAlgorithm::Es256),
+            ..Default::default()
         },
     )
     .await
-    .expect("Failed to create JWT introspect test client");
-
-    let mut secret_bytes = [0u8; 32];
-    aws_rand::fill(&mut secret_bytes).expect("RNG failure");
-    let secret = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(secret_bytes);
-    let secret_hash = crate::handlers::hash_token(&secret);
-
-    db::create_oauth_client_secret(&state.store, &client.id, &secret_hash, Some("test"), None)
-        .await
-        .expect("Failed to create test client secret");
-
-    crate::test_utils::TestOAuthClient {
-        app_id: client.id,
-        client_id,
-        client_secret: secret,
-    }
 }
 
 // ============================================================================

--- a/crates/vouch-server/src/test_utils.rs
+++ b/crates/vouch-server/src/test_utils.rs
@@ -287,27 +287,6 @@ async fn register_test_httpsig_client(store: &DocumentStore, base_url: &str) {
         .expect("register first-party test httpsig client");
 }
 
-/// Attach the shared test signing key's JWKS to an existing OAuth client.
-///
-/// Tokens issued for custom test clients (via `create_test_oauth_client`) carry
-/// that client's `client_id`. For transparently-signed `/v1/*` requests to
-/// verify, the client's registered JWKS must hold the shared test key — call
-/// this after creating a client whose token will hit a `/v1/*` endpoint.
-pub async fn attach_test_signing_key(store: &DocumentStore, app_id: &str) {
-    use crate::db::documents::oauth::OAuthClientDoc;
-    let doc = store
-        .get::<OAuthClientDoc>(app_id)
-        .await
-        .expect("get client")
-        .expect("client exists");
-    let mut data = doc.data;
-    data.jwks = Some(TEST_HTTPSIG.jwks.clone());
-    store
-        .update(app_id, &data)
-        .await
-        .expect("update client jwks");
-}
-
 /// Whether a request to `uri` carrying these `headers` should be auto-signed.
 ///
 /// Signs authenticated `/v1/*` requests (those with an `Authorization` header)
@@ -1136,6 +1115,99 @@ pub async fn create_test_scim_token(
     token
 }
 
+/// What JWKS, if any, a test OAuth client is created with.
+#[derive(Default)]
+pub enum TestJwks {
+    /// No JWKS registered (DB column stays NULL). Default — preserves the
+    /// current `create_test_oauth_client` behavior and keeps the ~4 tests
+    /// that assert `jwks IS NONE` and the ~8 private_key_jwt tests that
+    /// register their own key.
+    #[default]
+    None,
+    /// The process-wide shared test signing key (`TEST_HTTPSIG.jwks`). Opts
+    /// a custom client into transparently-signed `/v1/*` request verification.
+    /// Folds in the old `attach_test_signing_key` post-hoc patch.
+    Shared,
+    /// A caller-supplied JWKS document (e.g. a per-test `ClientKey` public JWK
+    /// for negative/key-mismatch tests).
+    Custom(serde_json::Value),
+}
+
+/// Knobs that test-client fixture sites actually vary.
+///
+/// All fields have `Default` values that reproduce the behavior of the old
+/// `create_test_oauth_client` exactly (see the mapping table in the
+/// `impl Default` below).  Use struct-update syntax to override only what the
+/// test needs:
+///
+/// ```rust,ignore
+/// create_test_client(&store, &user.id, TestClientSpec {
+///     jwks: TestJwks::Shared,
+///     ..Default::default()
+/// }).await
+/// ```
+pub struct TestClientSpec {
+    /// OAuth client display name. Default: `"Test App"`.
+    pub name: String,
+    /// Client application type. Default: `OAuthClientType::Web`.
+    pub application_type: crate::db::OAuthClientType,
+    /// Registered redirect URIs. Default: `["https://example.com/callback"]`.
+    pub redirect_uris: Vec<String>,
+    /// Access scope (Personal vs Public). Default: `AccessScope::Public`.
+    pub access_scope: crate::db::AccessScope,
+    /// Organisation the client belongs to. Default: `None`.
+    pub org_id: Option<String>,
+    /// Permitted resource URIs (RAR). Default: empty.
+    pub resource_uris: Vec<String>,
+    /// Token endpoint auth method override. Default: `None` (→ ClientSecretBasic).
+    pub token_endpoint_auth_method: Option<crate::db::TokenEndpointAuthMethod>,
+    /// JWKS to register with the client. Default: `TestJwks::None`.
+    pub jwks: TestJwks,
+    /// Require DPoP-bound access tokens. Default: `false`.
+    pub dpop_bound_access_tokens: bool,
+    /// Allowed grant types override. Default: `None`.
+    pub grant_types: Option<Vec<String>>,
+    /// FAPI security profile. Default: `None` (→ FapiProfile::None).
+    pub fapi_profile: Option<crate::db::FapiProfile>,
+    /// ID-token signing algorithm. Default: `JwsAlgorithm::Rs256`.
+    pub id_token_signed_response_alg: crate::db::JwsAlgorithm,
+    /// mTLS subject DN for `tls_client_auth`. Default: `None`.
+    pub tls_client_auth_subject_dn: Option<String>,
+    /// Bind issued tokens to the mTLS certificate. Default: `false`.
+    pub tls_client_certificate_bound_access_tokens: bool,
+    /// UserInfo JWT signing algorithm override. Default: `None`.
+    pub userinfo_signed_response_alg: Option<crate::db::JwsAlgorithm>,
+    /// Introspection JWT signing algorithm override. Default: `None`.
+    pub introspection_signed_response_alg: Option<crate::db::JwsAlgorithm>,
+    /// Whether to mint a client secret. `false` for public/SPA clients. Default: `true`.
+    pub with_secret: bool,
+}
+
+impl Default for TestClientSpec {
+    fn default() -> Self {
+        Self {
+            name: "Test App".to_string(),
+            application_type: crate::db::OAuthClientType::Web,
+            redirect_uris: vec!["https://example.com/callback".to_string()],
+            // Intentionally Public, not AccessScope::default() which is Personal.
+            access_scope: crate::db::AccessScope::Public,
+            org_id: Option::None,
+            resource_uris: vec![],
+            token_endpoint_auth_method: Option::None,
+            jwks: TestJwks::None,
+            dpop_bound_access_tokens: false,
+            grant_types: Option::None,
+            fapi_profile: Option::None,
+            id_token_signed_response_alg: crate::db::JwsAlgorithm::Rs256,
+            tls_client_auth_subject_dn: Option::None,
+            tls_client_certificate_bound_access_tokens: false,
+            userinfo_signed_response_alg: Option::None,
+            introspection_signed_response_alg: Option::None,
+            with_secret: true,
+        }
+    }
+}
+
 /// Result of creating a test OAuth client with credentials.
 pub struct TestOAuthClient {
     /// The internal application ID (database primary key).
@@ -1156,68 +1228,101 @@ impl TestOAuthClient {
     }
 }
 
-/// Create a test OAuth client with a secret for use in tests.
-pub async fn create_test_oauth_client(store: &DocumentStore, user_id: &str) -> TestOAuthClient {
+/// Create a test OAuth client from a [`TestClientSpec`].
+///
+/// This is the canonical factory. All other `create_test_*_oauth_client`
+/// helpers delegate here.
+pub async fn create_test_client(
+    store: &DocumentStore,
+    user_id: &str,
+    spec: TestClientSpec,
+) -> TestOAuthClient {
     use aws_lc_rs::rand as aws_rand;
     use base64::Engine;
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+    // Resolve the JWKS value from the spec variant.
+    let jwks_value: Option<serde_json::Value> = match spec.jwks {
+        TestJwks::None => Option::None,
+        TestJwks::Shared => Some(TEST_HTTPSIG.jwks.clone()),
+        TestJwks::Custom(v) => Some(v),
+    };
 
     let (client, client_id) = crate::db::create_oauth_client(
         store,
         &CreateOAuthClientParams {
             user_id: Some(user_id),
-            name: "Test App",
-            description: None,
-            application_type: crate::db::OAuthClientType::Web,
-            redirect_uris: &["https://example.com/callback".to_string()],
-            access_scope: crate::db::AccessScope::Public,
-            org_id: None,
-            resource_uris: &[],
-            token_endpoint_auth_method: None,
-            jwks: None,
-            jwks_uri: None,
-            fapi_profile: None,
-            dpop_bound_access_tokens: None,
-            grant_types: None,
-            response_types: None,
-            software_id: None,
-            software_version: None,
+            name: &spec.name,
+            description: Option::None,
+            application_type: spec.application_type,
+            redirect_uris: &spec.redirect_uris,
+            access_scope: spec.access_scope,
+            org_id: spec.org_id.as_deref(),
+            resource_uris: &spec.resource_uris,
+            token_endpoint_auth_method: spec.token_endpoint_auth_method,
+            jwks: jwks_value.as_ref(),
+            jwks_uri: Option::None,
+            fapi_profile: spec.fapi_profile,
+            dpop_bound_access_tokens: if spec.dpop_bound_access_tokens {
+                Some(true)
+            } else {
+                Option::None
+            },
+            grant_types: spec.grant_types.as_deref(),
+            response_types: Option::None,
+            software_id: Option::None,
+            software_version: Option::None,
             registration_source: RegistrationSource::Manual,
-            registration_access_token_hash: None,
-            registration_metadata: None,
-            id_token_signed_response_alg: JwsAlgorithm::Rs256,
-            tls_client_auth_subject_dn: None,
-            tls_client_auth_san_dns: None,
-            tls_client_auth_san_uri: None,
-            tls_client_auth_san_ip: None,
-            tls_client_auth_san_email: None,
-            tls_client_certificate_bound_access_tokens: None,
-            authorization_signed_response_alg: None,
-            introspection_signed_response_alg: None,
-            request_object_signing_alg: None,
-            require_signed_request_object: None,
-            userinfo_signed_response_alg: None,
-            request_uris: None,
+            registration_access_token_hash: Option::None,
+            registration_metadata: Option::None,
+            id_token_signed_response_alg: spec.id_token_signed_response_alg,
+            tls_client_auth_subject_dn: spec.tls_client_auth_subject_dn.as_deref(),
+            tls_client_auth_san_dns: Option::None,
+            tls_client_auth_san_uri: Option::None,
+            tls_client_auth_san_ip: Option::None,
+            tls_client_auth_san_email: Option::None,
+            tls_client_certificate_bound_access_tokens: if spec
+                .tls_client_certificate_bound_access_tokens
+            {
+                Some(true)
+            } else {
+                Option::None
+            },
+            authorization_signed_response_alg: Option::None,
+            introspection_signed_response_alg: spec.introspection_signed_response_alg,
+            request_object_signing_alg: Option::None,
+            require_signed_request_object: Option::None,
+            userinfo_signed_response_alg: spec.userinfo_signed_response_alg,
+            request_uris: Option::None,
         },
     )
     .await
     .expect("Failed to create test OAuth client");
 
-    // Generate a secret
-    let mut secret_bytes = [0u8; 32];
-    aws_rand::fill(&mut secret_bytes).expect("RNG failure");
-    let secret = URL_SAFE_NO_PAD.encode(secret_bytes);
-    let secret_hash = crate::handlers::hash_token(&secret);
-
-    crate::db::create_oauth_client_secret(store, &client.id, &secret_hash, Some("test"), None)
-        .await
-        .expect("Failed to create test OAuth client secret");
+    // Mint a client secret when requested (secret clients only).
+    let secret = if spec.with_secret {
+        let mut secret_bytes = [0u8; 32];
+        aws_rand::fill(&mut secret_bytes).expect("RNG failure");
+        let raw = URL_SAFE_NO_PAD.encode(secret_bytes);
+        let secret_hash = crate::handlers::hash_token(&raw);
+        crate::db::create_oauth_client_secret(store, &client.id, &secret_hash, Some("test"), None)
+            .await
+            .expect("Failed to create test OAuth client secret");
+        raw
+    } else {
+        String::new()
+    };
 
     TestOAuthClient {
         app_id: client.id,
         client_id,
         client_secret: secret,
     }
+}
+
+/// Create a test OAuth client with a secret for use in tests.
+pub async fn create_test_oauth_client(store: &DocumentStore, user_id: &str) -> TestOAuthClient {
+    create_test_client(store, user_id, TestClientSpec::default()).await
 }
 
 /// Create a test OAuth client with custom access scope and resource URIs.
@@ -1228,66 +1333,17 @@ pub async fn create_test_oauth_client_with_options(
     org_id: Option<&str>,
     resource_uris: &[String],
 ) -> TestOAuthClient {
-    use aws_lc_rs::rand as aws_rand;
-    use base64::Engine;
-    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-
-    let (client, client_id) = crate::db::create_oauth_client(
+    create_test_client(
         store,
-        &CreateOAuthClientParams {
-            user_id: Some(user_id),
-            name: "Test App",
-            description: None,
-            application_type: crate::db::OAuthClientType::Web,
-            redirect_uris: &["https://example.com/callback".to_string()],
+        user_id,
+        TestClientSpec {
             access_scope,
-            org_id,
-            resource_uris,
-            token_endpoint_auth_method: None,
-            jwks: None,
-            jwks_uri: None,
-            fapi_profile: None,
-            dpop_bound_access_tokens: None,
-            grant_types: None,
-            response_types: None,
-            software_id: None,
-            software_version: None,
-            registration_source: RegistrationSource::Manual,
-            registration_access_token_hash: None,
-            registration_metadata: None,
-            id_token_signed_response_alg: JwsAlgorithm::Rs256,
-            tls_client_auth_subject_dn: None,
-            tls_client_auth_san_dns: None,
-            tls_client_auth_san_uri: None,
-            tls_client_auth_san_ip: None,
-            tls_client_auth_san_email: None,
-            tls_client_certificate_bound_access_tokens: None,
-            authorization_signed_response_alg: None,
-            introspection_signed_response_alg: None,
-            request_object_signing_alg: None,
-            require_signed_request_object: None,
-            userinfo_signed_response_alg: None,
-            request_uris: None,
+            org_id: org_id.map(str::to_string),
+            resource_uris: resource_uris.to_vec(),
+            ..Default::default()
         },
     )
     .await
-    .expect("Failed to create test OAuth client");
-
-    // Generate a secret
-    let mut secret_bytes = [0u8; 32];
-    aws_rand::fill(&mut secret_bytes).expect("RNG failure");
-    let secret = URL_SAFE_NO_PAD.encode(secret_bytes);
-    let secret_hash = crate::handlers::hash_token(&secret);
-
-    crate::db::create_oauth_client_secret(store, &client.id, &secret_hash, Some("test"), None)
-        .await
-        .expect("Failed to create test OAuth client secret");
-
-    TestOAuthClient {
-        app_id: client.id,
-        client_id,
-        client_secret: secret,
-    }
 }
 
 /// Create a public OAuth client (no client secret, `token_endpoint_auth_method=none`).
@@ -1295,52 +1351,18 @@ pub async fn create_test_public_oauth_client(
     store: &DocumentStore,
     user_id: &str,
 ) -> TestOAuthClient {
-    let (client, client_id) = crate::db::create_oauth_client(
+    create_test_client(
         store,
-        &CreateOAuthClientParams {
-            user_id: Some(user_id),
-            name: "Public Test App",
-            description: None,
+        user_id,
+        TestClientSpec {
+            name: "Public Test App".to_string(),
             application_type: crate::db::OAuthClientType::Spa,
-            redirect_uris: &["https://example.com/callback".to_string()],
-            access_scope: crate::db::AccessScope::Public,
-            org_id: None,
-            resource_uris: &[],
             token_endpoint_auth_method: Some(crate::db::TokenEndpointAuthMethod::None),
-            jwks: None,
-            jwks_uri: None,
-            fapi_profile: None,
-            dpop_bound_access_tokens: None,
-            grant_types: None,
-            response_types: None,
-            software_id: None,
-            software_version: None,
-            registration_source: RegistrationSource::Manual,
-            registration_access_token_hash: None,
-            registration_metadata: None,
-            id_token_signed_response_alg: JwsAlgorithm::Rs256,
-            tls_client_auth_subject_dn: None,
-            tls_client_auth_san_dns: None,
-            tls_client_auth_san_uri: None,
-            tls_client_auth_san_ip: None,
-            tls_client_auth_san_email: None,
-            tls_client_certificate_bound_access_tokens: None,
-            authorization_signed_response_alg: None,
-            introspection_signed_response_alg: None,
-            request_object_signing_alg: None,
-            require_signed_request_object: None,
-            userinfo_signed_response_alg: None,
-            request_uris: None,
+            with_secret: false,
+            ..Default::default()
         },
     )
     .await
-    .expect("Failed to create test public OAuth client");
-
-    TestOAuthClient {
-        app_id: client.id,
-        client_id,
-        client_secret: String::new(),
-    }
 }
 
 // ============================================================================

--- a/crates/vouch-server/src/test_utils.rs
+++ b/crates/vouch-server/src/test_utils.rs
@@ -1125,8 +1125,8 @@ pub enum TestJwks {
     #[default]
     None,
     /// The process-wide shared test signing key (`TEST_HTTPSIG.jwks`). Opts
-    /// a custom client into transparently-signed `/v1/*` request verification.
-    /// Folds in the old `attach_test_signing_key` post-hoc patch.
+    /// a custom client into transparently-signed `/v1/*` request verification
+    /// using the key registered for the first-party test client.
     Shared,
     /// A caller-supplied JWKS document (e.g. a per-test `ClientKey` public JWK
     /// for negative/key-mismatch tests).
@@ -1181,6 +1181,10 @@ pub struct TestClientSpec {
     pub introspection_signed_response_alg: Option<crate::db::JwsAlgorithm>,
     /// Whether to mint a client secret. `false` for public/SPA clients. Default: `true`.
     pub with_secret: bool,
+    /// Restrict request-object signing algorithm. Default: `None`.
+    pub request_object_signing_alg: Option<crate::db::JwsAlgorithm>,
+    /// Require a signed request object (JAR). Default: `None`.
+    pub require_signed_request_object: Option<bool>,
 }
 
 impl Default for TestClientSpec {
@@ -1204,6 +1208,8 @@ impl Default for TestClientSpec {
             userinfo_signed_response_alg: Option::None,
             introspection_signed_response_alg: Option::None,
             with_secret: true,
+            request_object_signing_alg: Option::None,
+            require_signed_request_object: Option::None,
         }
     }
 }
@@ -1290,8 +1296,8 @@ pub async fn create_test_client(
             },
             authorization_signed_response_alg: Option::None,
             introspection_signed_response_alg: spec.introspection_signed_response_alg,
-            request_object_signing_alg: Option::None,
-            require_signed_request_object: Option::None,
+            request_object_signing_alg: spec.request_object_signing_alg,
+            require_signed_request_object: spec.require_signed_request_object,
             userinfo_signed_response_alg: spec.userinfo_signed_response_alg,
             request_uris: Option::None,
         },
@@ -1323,27 +1329,6 @@ pub async fn create_test_client(
 /// Create a test OAuth client with a secret for use in tests.
 pub async fn create_test_oauth_client(store: &DocumentStore, user_id: &str) -> TestOAuthClient {
     create_test_client(store, user_id, TestClientSpec::default()).await
-}
-
-/// Create a test OAuth client with custom access scope and resource URIs.
-pub async fn create_test_oauth_client_with_options(
-    store: &DocumentStore,
-    user_id: &str,
-    access_scope: crate::db::AccessScope,
-    org_id: Option<&str>,
-    resource_uris: &[String],
-) -> TestOAuthClient {
-    create_test_client(
-        store,
-        user_id,
-        TestClientSpec {
-            access_scope,
-            org_id: org_id.map(str::to_string),
-            resource_uris: resource_uris.to_vec(),
-            ..Default::default()
-        },
-    )
-    .await
 }
 
 /// Create a public OAuth client (no client secret, `token_endpoint_auth_method=none`).

--- a/crates/vouch-tests/tests/integration.rs
+++ b/crates/vouch-tests/tests/integration.rs
@@ -2632,61 +2632,37 @@ mod httpsig {
     /// Helper: create a user with an OAuth client that has JWKS containing
     /// the given ClientKey's public key, and a session bound to that client.
     async fn setup_user_with_httpsig_key(harness: &TestHarness, key: &ClientKey) -> String {
+        use vouch_server::test_utils::{TestClientSpec, TestJwks, create_test_client};
+
         let user = harness.create_user("httpsig@example.com").await.unwrap();
         let auth_id = harness.create_authenticator(&user.id).await.unwrap();
 
-        // Create OAuth client with the key's public JWK in JWKS
+        // Create OAuth client with the key's public JWK in JWKS (per-user key so
+        // the wrong-key test can register one key and sign with another).
         let public_jwk = key.public_jwk().unwrap();
         let jwks = serde_json::json!({ "keys": [public_jwk] });
 
-        let (client, client_id) = vouch_server::db::create_oauth_client(
+        let client = create_test_client(
             &harness.state.store,
-            &vouch_server::db::CreateOAuthClientParams {
-                user_id: Some(&user.id),
-                name: "Test FAPI Client",
-                description: None,
+            &user.id,
+            TestClientSpec {
+                name: "Test FAPI Client".to_string(),
                 application_type: vouch_server::db::OAuthClientType::Native,
-                redirect_uris: &[],
-                access_scope: vouch_server::db::AccessScope::Public,
-                org_id: None,
-                resource_uris: &[],
+                redirect_uris: vec![],
                 token_endpoint_auth_method: Some(
                     vouch_server::db::TokenEndpointAuthMethod::PrivateKeyJwt,
                 ),
-                jwks: Some(&jwks),
-                jwks_uri: None,
-                fapi_profile: None,
-                dpop_bound_access_tokens: Some(true),
-                grant_types: None,
-                response_types: None,
-                software_id: Some("vouch-cli"),
-                software_version: None,
-                registration_source: vouch_server::db::RegistrationSource::Dynamic,
-                registration_access_token_hash: None,
-                registration_metadata: None,
+                jwks: TestJwks::Custom(jwks),
+                dpop_bound_access_tokens: true,
                 id_token_signed_response_alg: vouch_server::db::JwsAlgorithm::Es256,
-                tls_client_auth_subject_dn: None,
-                tls_client_auth_san_dns: None,
-                tls_client_auth_san_uri: None,
-                tls_client_auth_san_ip: None,
-                tls_client_auth_san_email: None,
-                tls_client_certificate_bound_access_tokens: None,
-                authorization_signed_response_alg: None,
-                introspection_signed_response_alg: None,
-                request_object_signing_alg: None,
-                require_signed_request_object: None,
-                userinfo_signed_response_alg: None,
-                request_uris: None,
+                with_secret: false,
+                ..Default::default()
             },
         )
-        .await
-        .expect("create OAuth client");
-
-        // Ensure client_id is deterministic by reading it back
-        let _ = client;
+        .await;
 
         harness
-            .create_session_for_client(&user.id, "httpsig@example.com", &auth_id, &client_id)
+            .create_session_for_client(&user.id, "httpsig@example.com", &auth_id, &client.client_id)
             .await
             .unwrap()
     }


### PR DESCRIPTION
## What

Consolidates the fragmented test OAuth-client creation paths (issue #530) behind a single factory, then removes every post-creation client-mutation helper the factory can subsume.

### Commit 1 — one canonical factory
- Add `TestClientSpec` + `TestJwks { None | Shared | Custom }` and `create_test_client(store, user_id, spec)` in `vouch-server` `test_utils`.
- `create_test_oauth_client`, `create_test_oauth_client_with_options`, and `create_test_public_oauth_client` become thin wrappers with unchanged signatures, so the common-case call sites are untouched.
- Migrate the in-scope raw `CreateOAuthClientParams` fixtures to specs.
- Fold `attach_test_signing_key` into `TestJwks::Shared` and remove it.

### Commit 2 — remove the JWKS / auth-method / JAR mutation helpers
- Collapse the `private_key_jwt` create-then-mutate pattern (create, set JWKS, flip auth method) into a single factory call; `fido2_grant` reuses the shared helper.
- Promote `request_object_signing_alg` and `require_signed_request_object` to `TestClientSpec` (`Option`, default `None`) so JAR sites configure them at creation.
- Inline and remove `create_test_oauth_client_with_options`.
- Delete `update_oauth_client_jwks`, `update_oauth_client_auth_method`, and `update_oauth_client_jar_settings`.

### Commit 3 — remove the FAPI settings mutation helper
- Set `fapi_profile` and `dpop_bound_access_tokens` through `TestClientSpec` at creation; extend the mTLS test-client helper to take both as parameters.
- Delete `update_oauth_client_fapi_settings` and the `client_id_to_app_id` bridge it required.

After commit 3, the only remaining members of the test-only `test_helpers` module are non-creation helpers (`set_oauth_client_active`, `set_oauth_client_userinfo_alg`).

## Behavior

`TestClientSpec::default()` reproduces the old `create_test_oauth_client` field for field (secret auth, `access_scope: Public`, `id_token_signed_response_alg: Rs256`, `jwks: None`). JWKS is opt-in, so the `private_key_jwt` tests and the tests that assert `jwks` is absent are unaffected. `require_signed_request_object` is `Option<bool>` defaulting to `None`, preserving the NULL-vs-`false` distinction. `private_key_jwt` clients keep `with_secret: true` to match the old create-then-flip end state. `create_oauth_client` is a pure constructor with no field validation, so configuring FAPI/JAR/JWKS fields at creation yields the same stored client as the prior create-then-update sequences. Each migrated FAPI site keeps its exact `(fapi_profile, dpop)` pair; the FAPI sender-constraint test stays `dpop=false`.

## Scope

`register_test_httpsig_client` is kept: it registers a first-party `client_id == base_url` client that the UUID-minting factory cannot replace, and it is the verification anchor for harness auto-signing. The db-primitive sites in `db/tests.rs` / `db/oauth.rs` that test `create_oauth_client` directly stay raw, and the production client-creation handlers are out of scope. The `/v1/*` shared-key signing mechanism is unchanged.

## Tests

2322 `vouch-server` + 311 `vouch-tests` pass on each commit. `cargo clippy --all-targets --all-features -- -D warnings` clean.

Closes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production OAuth paths changed; defaults preserve prior client fixture behavior.
> 
> **Overview**
> Consolidates fragmented test OAuth client setup behind **`create_test_client`** with **`TestClientSpec`** and **`TestJwks`** (`None` | `Shared` | `Custom`) in `test_utils`, so FAPI, `private_key_jwt`, mTLS, JAR, and signed userinfo/introspection clients are configured at creation instead of create-then-mutate.
> 
> **Removes** post-creation DB test helpers (`update_oauth_client_jwks`, `update_oauth_client_auth_method`, `update_oauth_client_jar_settings`, `update_oauth_client_fapi_settings`) and **`attach_test_signing_key`**; shared `/v1/*` signing keys use **`TestJwks::Shared`**. **`create_test_oauth_client_with_options`** is dropped in favor of spec overrides; thin wrappers (`create_test_oauth_client`, `create_test_public_oauth_client`) delegate to the factory with unchanged defaults.
> 
> OIDC and integration tests are migrated from raw **`CreateOAuthClientParams`** or local helpers to **`TestClientSpec`**; duplicate **`create_test_jwt_client`** in `fido2_grant` is removed in favor of shared helpers. **`set_oauth_client_userinfo_alg`** and **`set_oauth_client_active`** remain for tests that need invalid alg injection or deactivation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6254f4d9b673d025630bb25e17ee0f0670b65cef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->