### PR TITLE
chore(doc): fix dsql comment

### DIFF
--- a/crates/vouch-server/src/db/dsql.rs
+++ b/crates/vouch-server/src/db/dsql.rs
@@ -157,7 +157,9 @@ pub(crate) enum DsqlEndpoint {
         region: String,
         /// DSQL cluster ID (from `dsql_cluster_id` query parameter)
         cluster_id: String,
-        /// Hostname for IAM token generation (e.g., `cluster_id.dsql.region.on.aws`)
+        /// Hostname for IAM token generation. Reuses the PrivateLink service
+        /// identifier from the VPC endpoint FQDN, not the public `dsql` label
+        /// (e.g., `cluster_id.dsql-fnh4.region.on.aws`).
         auth_hostname: String,
     },
 }
@@ -250,8 +252,12 @@ impl DsqlEndpoint {
     /// The hostname to use for IAM token generation.
     ///
     /// For direct connections this is the same as `connect_hostname()`.
-    /// For VPC endpoints this is the cluster's public hostname
-    /// (e.g., `cluster_id.dsql.region.on.aws`).
+    /// For VPC endpoints this reuses the PrivateLink service identifier from the
+    /// endpoint FQDN — `{cluster_id}.{service_id}.{region}.on.aws` (e.g.
+    /// `cluster_id.dsql-fnh4.region.on.aws`), not the public `dsql` hostname. The
+    /// cluster is identified by the `amzn-cluster-id` connection option (from the
+    /// `dsql_cluster_id` URL param), so the service-identifier label is not used
+    /// for cluster routing — which is why this form still authenticates.
     #[must_use]
     pub(crate) fn token_hostname(&self) -> &str {
         match self {


### PR DESCRIPTION
Related to #549 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change with no effect on authentication or connection logic.
> 
> **Overview**
> **Documentation-only** update in `dsql.rs` for Aurora DSQL VPC PrivateLink connections.
> 
> Rustdoc on `VpcEndpoint::auth_hostname` and `token_hostname()` no longer describes IAM tokens as using the cluster’s **public** `*.dsql.*` hostname. The comments now state that token generation uses `{cluster_id}.{service_id}.{region}.on.aws`, where `service_id` comes from the PrivateLink VPC endpoint FQDN (e.g. `dsql-fnh4`), and explain that cluster selection still relies on `amzn-cluster-id` / `dsql_cluster_id`, not the service-identifier label in the hostname.
> 
> **No runtime or connection behavior changes**—only comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3d00aef870e276cd480deb27219d87630550552. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->