### PR TITLE
fix(server): enforce OAuth secret cap/floor under concurrency (#551)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,6 +267,7 @@ cargo test --features yubikey-tests -- --ignored
 7. **Don't use `chrono`** — Use `jiff` for time
 8. **Don't use `ring`** — Use `aws-lc-rs` for crypto
 9. **Don't blind-write documents after a read** — For any document that can be mutated concurrently (users, authenticators, OAuth secrets, etc.), use `store.modify()` (optimistic concurrency) rather than `store.get()` + `store.update()`. A blind `store.update()` overwrites the whole document and silently loses concurrent writes (lost-update race).
+10. **Cross-row invariants (cap ≤N, floor ≥1, monotonic) → one transaction that version-bumps the owning doc via `compare_and_update`, wrapped in `with_dsql_retry!`** (the single OCC-aware bounded retry; model the conflict as `ServiceError::OccConflict` — the only variant that `is_retryable()` returns `true` for). DSQL is OCC-only (no `SELECT … FOR UPDATE`); forcing concurrent writers to collide on the owner doc's row is what makes the guard atomic on every backend. **Never hand-roll a retry loop.** (A deterministic-PK-slot design can make a true cap *conflict-free*, but we don't use it here — it would cost a new doc type or a re-keying migration; OCC reuses the existing types and the one shared macro.)
 
 ## File Locations
 

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -125,8 +125,8 @@ pub use documents::oauth::{
 // Re-export OAuth domain types and functions
 pub(crate) use oauth::JwtAssertionJtiClaim;
 pub use oauth::{
-    CreateOAuthClientParams, OAuthClient, OAuthClientSecret, OAuthEventType, OAuthUsageStats,
-    UpdateClientRegistrationParams, UpdateOAuthClientParams, create_oauth_client,
+    CreateOAuthClientParams, MAX_ACTIVE_SECRETS, OAuthClient, OAuthClientSecret, OAuthEventType,
+    OAuthUsageStats, UpdateClientRegistrationParams, UpdateOAuthClientParams, create_oauth_client,
     create_oauth_client_secret, delete_expired_jwt_assertion_jtis, delete_oauth_client,
     delete_old_oauth_usage_events, get_oauth_client_by_client_id, get_oauth_client_by_id,
     get_oauth_client_secret_by_id, get_oauth_client_secrets, get_oauth_clients_for_user,

--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -615,8 +615,11 @@ pub async fn get_oauth_client_secret_by_id(
 /// 2. Short-circuits with a terminal "not found" if the secret is already revoked.
 /// 3. Loads the `OAuthClientDoc` to record its `version` (the serialization point
 ///    for all secret-set mutations on this client).
-/// 4. Counts currently-active secrets (filter, not SQL COUNT — soft-deleted rows
-///    are retained).  If only one remains, returns a terminal 409 `last_secret`.
+/// 4. Counts the *other* active secrets — those that would remain after this
+///    revoke, excluding the target row itself (filter, not SQL COUNT — soft-deleted
+///    rows are retained).  If none remain, returns a terminal 409 `last_secret`.
+///    Excluding the target matters when it is expired-but-unrevoked: revoking it
+///    must still be allowed while a different valid secret exists.
 /// 5. Soft-deletes the secret (`revoked_at`) inside the transaction.
 /// 6. Bumps the client version via `compare_and_update`.  If another concurrent
 ///    revoke committed between our read and our commit, the version won't match
@@ -695,9 +698,15 @@ pub async fn revoke_oauth_client_secret(
             .await
             .map_err(|e| map_db_err(e, "Failed to list secrets for revoke"))?;
 
-        let active_count = all_secrets
+        // Count the *other* active secrets — exclude the target row itself, so a
+        // revoke that leaves a valid secret behind is allowed even when the target
+        // is expired-but-unrevoked.  Mirrors the handler's pre-flight check.
+        let other_active_count = all_secrets
             .iter()
             .filter(|s| {
+                if s.id == secret_id {
+                    return false;
+                }
                 if s.data.revoked_at.is_some() {
                     return false;
                 }
@@ -710,8 +719,8 @@ pub async fn revoke_oauth_client_secret(
             })
             .count();
 
-        // Floor guard: must retain at least one active secret.
-        if active_count <= 1 {
+        // Floor guard: at least one *other* active secret must remain.
+        if other_active_count == 0 {
             return Err(ServiceError::api(
                 StatusCode::CONFLICT,
                 "last_secret",

--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -10,8 +10,18 @@ use super::documents::oauth::{
     RegistrationSource, TokenEndpointAuthMethod,
 };
 use super::store::DocumentStore;
+use crate::services::error::ServiceError;
 use anyhow::Result;
+use axum::http::StatusCode;
 use jiff::Timestamp;
+
+/// Maximum number of active (non-revoked, non-expired) secrets per OAuth client.
+///
+/// Enforced inside `create_oauth_client_secret` via an OCC-guarded transaction
+/// that version-bumps the owning `OAuthClientDoc`.  Both the guard and the secret
+/// insert happen atomically, so concurrent adds collide on the client row and the
+/// loser re-reads the updated count before deciding whether to insert or reject.
+pub const MAX_ACTIVE_SECRETS: usize = 2;
 
 // ============================================================================
 // OAuth Client
@@ -389,23 +399,164 @@ impl OAuthClientSecret {
     }
 }
 
-/// Create a new client secret.
+/// Create a new client secret, enforcing the ≤`MAX_ACTIVE_SECRETS` cap.
+///
+/// The entire operation runs inside a single transaction wrapped in
+/// `with_dsql_retry!`.  The transaction:
+///
+/// 1. Loads the `OAuthClientDoc` and records its `version` — this is the
+///    deliberate serialization point for all secret-set mutations on this client.
+/// 2. Counts currently-valid (non-revoked, non-expired) secrets.
+/// 3. If the count is already at the cap, returns a terminal 409 error that
+///    is **not** retried (business logic, not a transient conflict).
+/// 4. Inserts the new secret inside the transaction.
+/// 5. Bumps the client doc version via `compare_and_update`.  If another writer
+///    committed a secret-set mutation between our read and our commit, the version
+///    won't match and `compare_and_update` returns `Ok(false)` — we surface this
+///    as `ServiceError::OccConflict` so `with_dsql_retry!` re-runs the whole
+///    block (re-counting, possibly rejecting at the cap on the second attempt).
+///
+/// This approach is correct on Aurora DSQL where the reverted #547 fix was not:
+/// the reverted fix relied on snapshot isolation to reject a second concurrent
+/// insert, but two adds write *distinct* rows and neither `SELECT FOR UPDATE` nor
+/// `SERIALIZABLE` caught them.  Here, both writers also update the **same** client
+/// row via `compare_and_update`, causing a write-write conflict (DSQL OC000) that
+/// the loser retries at the application level.
+///
+/// Note: because this function version-bumps the `OAuthClientDoc`, concurrent
+/// client metadata updates (e.g. `update_oauth_client`) may incur OCC retries
+/// while a secret add is in flight, and vice versa.
+///
+/// # Errors
+///
+/// - `ServiceError::NotFound` — client does not exist.
+/// - `ServiceError::Api(409 "max_secrets_reached")` — cap already reached (terminal).
+/// - `ServiceError::Api(409 "conflict")` — OCC retry budget exhausted; caller may retry.
+/// - `ServiceError::Internal` — unexpected database or serialization error.
 pub async fn create_oauth_client_secret(
     store: &DocumentStore,
     oauth_client_id: &str,
     secret_hash: &str,
     description: Option<&str>,
     expires_at: Option<Timestamp>,
-) -> Result<OAuthClientSecret> {
-    let doc = OAuthClientSecretDoc {
-        oauth_client_id: oauth_client_id.to_string(),
-        secret_hash: secret_hash.to_string(),
-        description: description.map(String::from),
-        expires_at,
-        revoked_at: None,
+) -> Result<OAuthClientSecret, ServiceError> {
+    // Capture parameters as owned values so the async block (re-run on retry) can
+    // borrow them without lifetime conflicts.
+    let oauth_client_id = oauth_client_id.to_string();
+    let secret_hash = secret_hash.to_string();
+    let description = description.map(String::from);
+
+    // Map a DB error from any tx operation into either an OccConflict (if it
+    // signals writer contention — Postgres serialization failure, Aurora DSQL
+    // OC000/OC001, SQLite BUSY/LOCKED) or a generic 500.
+    // OccConflict is retried by with_dsql_retry!; the 500 path propagates.
+    let map_db_err = |e: anyhow::Error, msg: &'static str| -> ServiceError {
+        tracing::error!("{msg}: {e}");
+        if crate::db::pool::is_retryable_db_error(&e) {
+            ServiceError::OccConflict
+        } else {
+            ServiceError::Internal(msg.to_string())
+        }
     };
-    let result = store.insert(&doc).await?;
-    Ok(OAuthClientSecret::from(result))
+
+    crate::with_dsql_retry!(async {
+        let mut tx = store.begin().await.map_err(|e| {
+            map_db_err(
+                e,
+                "Failed to begin transaction for create_oauth_client_secret",
+            )
+        })?;
+
+        // Load the client doc.  Its version is the serialization point — a
+        // concurrent secret-set mutation that commits between our read and our
+        // compare_and_update will change the version and trigger a retry.
+        let client_doc = tx
+            .get::<OAuthClientDoc>(&oauth_client_id)
+            .await
+            .map_err(|e| map_db_err(e, "Failed to load OAuthClientDoc for secret create"))?
+            .ok_or(ServiceError::NotFound("OAuth client"))?;
+
+        // Count currently-active secrets by filtering (not SQL COUNT) because
+        // soft-deleted rows are retained and a COUNT(*) would include them.
+        let now = Timestamp::now();
+        let all_secrets = tx
+            .find_all::<OAuthClientSecretDoc>("oauth_client_id", &oauth_client_id)
+            .await
+            .map_err(|e| map_db_err(e, "Failed to list secrets for secret create"))?;
+
+        // Filter directly on the doc fields to avoid a needless From conversion.
+        // Mirrors the `is_valid` predicate: not revoked, not expired.
+        let active_count = all_secrets
+            .iter()
+            .filter(|s| {
+                if s.data.revoked_at.is_some() {
+                    return false;
+                }
+                if let Some(exp) = s.data.expires_at
+                    && exp <= now
+                {
+                    return false;
+                }
+                true
+            })
+            .count();
+
+        if active_count >= MAX_ACTIVE_SECRETS {
+            // Terminal business error — do not retry.
+            return Err(ServiceError::api(
+                axum::http::StatusCode::CONFLICT,
+                "max_secrets_reached",
+                "Maximum of 2 active secrets allowed",
+            ));
+        }
+
+        // Insert the new secret inside the transaction.
+        let new_secret_doc = OAuthClientSecretDoc {
+            oauth_client_id: oauth_client_id.clone(),
+            secret_hash: secret_hash.clone(),
+            description: description.clone(),
+            expires_at,
+            revoked_at: None,
+        };
+        let inserted = tx
+            .insert(&new_secret_doc)
+            .await
+            .map_err(|e| map_db_err(e, "Failed to insert secret"))?;
+
+        // Version-bump the client doc.  This is the OCC serialization point:
+        // any concurrent secret-set mutation on this client will have bumped the
+        // version, causing compare_and_update to return Ok(false).
+        let ok = tx
+            .compare_and_update::<OAuthClientDoc>(
+                &oauth_client_id,
+                client_doc.version,
+                &client_doc.data,
+            )
+            .await
+            .map_err(|e| map_db_err(e, "Failed to version-bump client for secret create"))?;
+
+        if !ok {
+            // OCC conflict — another writer beat us to the client row.  Signal
+            // with_dsql_retry! to re-run the entire block.
+            return Err(ServiceError::OccConflict);
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| map_db_err(e, "Failed to commit create_oauth_client_secret"))?;
+
+        Ok(OAuthClientSecret::from(inserted))
+    })
+    // `with_dsql_retry!` exhausts OccConflict after MAX_DSQL_RETRIES attempts.
+    // Surface as 409 "conflict" (not 500) — mirrors the delete_key precedent.
+    .map_err(|e| match e {
+        ServiceError::OccConflict => ServiceError::api(
+            axum::http::StatusCode::CONFLICT,
+            "conflict",
+            "Secret creation conflicted with a concurrent operation. Please retry.",
+        ),
+        other => other,
+    })
 }
 
 /// Get all secrets for an OAuth client.
@@ -455,15 +606,154 @@ pub async fn get_oauth_client_secret_by_id(
     Ok(doc.map(OAuthClientSecret::from))
 }
 
-/// Revoke a single secret (soft-delete).
+/// Revoke a single secret (soft-delete), enforcing the ≥1 active floor.
 ///
-/// Returns `true` if the secret was found and updated, `false` if not found.
-pub async fn revoke_oauth_client_secret(store: &DocumentStore, id: &str) -> Result<bool> {
-    store
-        .modify::<OAuthClientSecretDoc, _>(id, |data| {
-            data.revoked_at = Some(Timestamp::now());
-        })
-        .await
+/// The entire operation runs inside a single transaction wrapped in
+/// `with_dsql_retry!`.  The transaction:
+///
+/// 1. Verifies the secret exists and belongs to the given client.
+/// 2. Short-circuits with a terminal "not found" if the secret is already revoked.
+/// 3. Loads the `OAuthClientDoc` to record its `version` (the serialization point
+///    for all secret-set mutations on this client).
+/// 4. Counts currently-active secrets (filter, not SQL COUNT — soft-deleted rows
+///    are retained).  If only one remains, returns a terminal 409 `last_secret`.
+/// 5. Soft-deletes the secret (`revoked_at`) inside the transaction.
+/// 6. Bumps the client version via `compare_and_update`.  If another concurrent
+///    revoke committed between our read and our commit, the version won't match
+///    and we surface `ServiceError::OccConflict` so the macro retries.  The
+///    retried attempt re-counts and returns `last_secret` if appropriate.
+///
+/// Note: because this function version-bumps the `OAuthClientDoc`, concurrent
+/// client metadata updates (e.g. `update_oauth_client`) may incur OCC retries
+/// while a secret revocation is in flight, and vice versa.
+///
+/// # Errors
+///
+/// - `ServiceError::NotFound("Secret")` — secret does not exist, does not belong
+///   to the given client, or is already revoked.
+/// - `ServiceError::NotFound("OAuth client")` — the owning client does not exist.
+/// - `ServiceError::Api(409 "last_secret")` — would leave zero active secrets (terminal).
+/// - `ServiceError::Api(409 "conflict")` — OCC retry budget exhausted; caller may retry.
+/// - `ServiceError::Internal` — unexpected database or serialization error.
+pub async fn revoke_oauth_client_secret(
+    store: &DocumentStore,
+    secret_id: &str,
+    oauth_client_id: &str,
+) -> Result<(), ServiceError> {
+    let secret_id = secret_id.to_string();
+    let oauth_client_id = oauth_client_id.to_string();
+
+    // Map a DB error from any tx operation into either an OccConflict (if it
+    // signals writer contention — Postgres serialization failure, Aurora DSQL
+    // OC000/OC001, SQLite BUSY/LOCKED) or a generic 500.
+    // OccConflict is retried by with_dsql_retry!; the 500 path propagates.
+    let map_db_err = |e: anyhow::Error, msg: &'static str| -> ServiceError {
+        tracing::error!("{msg}: {e}");
+        if crate::db::pool::is_retryable_db_error(&e) {
+            ServiceError::OccConflict
+        } else {
+            ServiceError::Internal(msg.to_string())
+        }
+    };
+
+    crate::with_dsql_retry!(async {
+        let mut tx = store.begin().await.map_err(|e| {
+            map_db_err(
+                e,
+                "Failed to begin transaction for revoke_oauth_client_secret",
+            )
+        })?;
+
+        // Verify the secret exists and belongs to this client.
+        let secret_doc = tx
+            .get::<OAuthClientSecretDoc>(&secret_id)
+            .await
+            .map_err(|e| map_db_err(e, "Failed to load secret for revoke"))?
+            .ok_or(ServiceError::NotFound("Secret"))?;
+
+        if secret_doc.data.oauth_client_id != oauth_client_id {
+            return Err(ServiceError::NotFound("Secret"));
+        }
+
+        // Already revoked — idempotent short-circuit; caller should treat as not-found.
+        if secret_doc.data.revoked_at.is_some() {
+            return Err(ServiceError::NotFound("Secret"));
+        }
+
+        // Load the client doc — its version is the serialization point for all
+        // secret-set mutations on this client.
+        let client_doc = tx
+            .get::<OAuthClientDoc>(&oauth_client_id)
+            .await
+            .map_err(|e| map_db_err(e, "Failed to load OAuthClientDoc for revoke"))?
+            .ok_or(ServiceError::NotFound("OAuth client"))?;
+
+        // Count active secrets (filter, not SQL COUNT — soft-deleted rows are retained).
+        let now = Timestamp::now();
+        let all_secrets = tx
+            .find_all::<OAuthClientSecretDoc>("oauth_client_id", &oauth_client_id)
+            .await
+            .map_err(|e| map_db_err(e, "Failed to list secrets for revoke"))?;
+
+        let active_count = all_secrets
+            .iter()
+            .filter(|s| {
+                if s.data.revoked_at.is_some() {
+                    return false;
+                }
+                if let Some(exp) = s.data.expires_at
+                    && exp <= now
+                {
+                    return false;
+                }
+                true
+            })
+            .count();
+
+        // Floor guard: must retain at least one active secret.
+        if active_count <= 1 {
+            return Err(ServiceError::api(
+                StatusCode::CONFLICT,
+                "last_secret",
+                "Cannot delete the last active secret",
+            ));
+        }
+
+        // Soft-delete: set revoked_at on the target secret.
+        let mut updated_data = secret_doc.data.clone();
+        updated_data.revoked_at = Some(now);
+        tx.update(&secret_id, &updated_data)
+            .await
+            .map_err(|e| map_db_err(e, "Failed to soft-delete secret"))?;
+
+        // Version-bump the client doc.  This is the OCC serialization point.
+        let ok = tx
+            .compare_and_update::<OAuthClientDoc>(
+                &oauth_client_id,
+                client_doc.version,
+                &client_doc.data,
+            )
+            .await
+            .map_err(|e| map_db_err(e, "Failed to version-bump client for revoke"))?;
+
+        if !ok {
+            return Err(ServiceError::OccConflict);
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| map_db_err(e, "Failed to commit revoke_oauth_client_secret"))
+    })
+    // `with_dsql_retry!` exhausts OccConflict after MAX_DSQL_RETRIES attempts.
+    // Surface as 409 "conflict" (not 500) — mirrors the delete_key precedent.
+    .map_err(|e| match e {
+        ServiceError::OccConflict => ServiceError::api(
+            axum::http::StatusCode::CONFLICT,
+            "conflict",
+            "Secret revocation conflicted with a concurrent operation. Please retry.",
+        ),
+        other => other,
+    })
 }
 
 // ============================================================================
@@ -1133,14 +1423,24 @@ mod tests {
     #[tokio::test]
     async fn test_revoke_secret_sets_revoked_at() {
         let store = test_store().await;
-        let (_client, secret, _hash) = create_client_and_secret(&store).await;
+        let (client, secret, _hash) = create_client_and_secret(&store).await;
 
         assert!(secret.revoked_at.is_none());
 
-        let updated = revoke_oauth_client_secret(&store, &secret.id)
+        // Need a second active secret so the floor guard passes.
+        let _second = create_oauth_client_secret(
+            &store,
+            &client.id,
+            "hash_second_for_revoke_test",
+            None,
+            None,
+        )
+        .await
+        .expect("create second secret");
+
+        revoke_oauth_client_secret(&store, &secret.id, &client.id)
             .await
             .expect("revoke");
-        assert!(updated);
 
         let fetched = get_oauth_client_secret_by_id(&store, &secret.id)
             .await
@@ -1166,9 +1466,20 @@ mod tests {
     #[tokio::test]
     async fn test_secret_is_valid_revoked() {
         let store = test_store().await;
-        let (_client, secret, _hash) = create_client_and_secret(&store).await;
+        let (client, secret, _hash) = create_client_and_secret(&store).await;
 
-        revoke_oauth_client_secret(&store, &secret.id)
+        // Need a second active secret so the floor guard passes.
+        let _second = create_oauth_client_secret(
+            &store,
+            &client.id,
+            "hash_second_for_valid_test",
+            None,
+            None,
+        )
+        .await
+        .expect("create second secret");
+
+        revoke_oauth_client_secret(&store, &secret.id, &client.id)
             .await
             .expect("revoke");
 
@@ -1260,7 +1571,18 @@ mod tests {
         let store = test_store().await;
         let (client, secret, hash) = create_client_and_secret(&store).await;
 
-        revoke_oauth_client_secret(&store, &secret.id)
+        // Need a second active secret so the floor guard passes.
+        let _second = create_oauth_client_secret(
+            &store,
+            &client.id,
+            "hash_second_revoke_validate",
+            None,
+            None,
+        )
+        .await
+        .expect("create second secret");
+
+        revoke_oauth_client_secret(&store, &secret.id, &client.id)
             .await
             .expect("revoke");
 

--- a/crates/vouch-server/src/db/pool.rs
+++ b/crates/vouch-server/src/db/pool.rs
@@ -430,11 +430,34 @@ impl From<sqlx::postgres::PgQueryResult> for QueryResult {
     }
 }
 
-/// Retry an async block on transient DSQL errors.
+/// Trait for errors that signal a transient conflict worth retrying.
+///
+/// Implemented for `anyhow::Error` (delegates to `is_retryable_db_error`) and for
+/// `ServiceError` (only the dedicated `OccConflict` variant is retryable).  The
+/// `with_dsql_retry!` macro calls `e.is_retryable()` instead of the old
+/// `is_retryable_db_error(&e)` so that OCC version-bump conflicts from
+/// `compare_and_update` are retried through the same bounded loop as DSQL
+/// network-level serialization failures, without any change to the ~11 existing
+/// non-transactional call sites (their error type is still `anyhow::Error`).
+pub(crate) trait RetryableError {
+    fn is_retryable(&self) -> bool;
+}
+
+impl RetryableError for anyhow::Error {
+    fn is_retryable(&self) -> bool {
+        is_retryable_db_error(self)
+    }
+}
+
+/// Retry an async block on transient DSQL errors or OCC version conflicts.
 ///
 /// Re-evaluates the body on each attempt (creating a fresh future),
 /// so the operation is fully retried from scratch. Non-retryable
 /// errors and successes pass through immediately.
+///
+/// The error type returned by `$body` must implement [`RetryableError`].
+/// For `anyhow::Error` this is equivalent to the old `is_retryable_db_error`
+/// check.  For `ServiceError`, only the `OccConflict` variant retries.
 ///
 /// Usage: `with_dsql_retry!(async { ... }).await`
 #[macro_export]
@@ -445,13 +468,13 @@ macro_rules! with_dsql_retry {
             match $body.await {
                 Ok(val) => break Ok(val),
                 Err(e)
-                    if $crate::db::pool::is_retryable_db_error(&e)
+                    if $crate::db::pool::RetryableError::is_retryable(&e)
                         && __attempt < $crate::db::pool::MAX_DSQL_RETRIES =>
                 {
                     tracing::warn!(
                         attempt = __attempt,
                         error = %e,
-                        "transient DSQL error, retrying"
+                        "transient DSQL/OCC conflict, retrying"
                     );
                     tokio::time::sleep(
                         $crate::db::pool::retry_backoff(__attempt),
@@ -1037,5 +1060,131 @@ mod tests {
         assert!(d0.as_millis() <= 200);
         assert!(d1.as_millis() <= 400);
         assert!(d2.as_millis() <= 800);
+    }
+
+    // ========================================================================
+    // RetryableError trait and with_dsql_retry! OCC tests
+    // ========================================================================
+
+    /// A minimal error type for testing with_dsql_retry! with a custom retryable variant.
+    #[derive(Debug, PartialEq)]
+    enum TestError {
+        /// Retryable OCC conflict signal.
+        OccConflict,
+        /// Non-retryable business error.
+        BusinessError(String),
+    }
+
+    impl std::fmt::Display for TestError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::OccConflict => write!(f, "OCC conflict"),
+                Self::BusinessError(msg) => write!(f, "business error: {msg}"),
+            }
+        }
+    }
+
+    impl RetryableError for TestError {
+        fn is_retryable(&self) -> bool {
+            matches!(self, Self::OccConflict)
+        }
+    }
+
+    /// Body returning OccConflict retries up to MAX_DSQL_RETRIES, then succeeds on
+    /// a later attempt.
+    #[tokio::test]
+    async fn test_with_dsql_retry_occ_conflict_retries_then_succeeds() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        let call_count = Arc::new(AtomicU32::new(0));
+        let call_count2 = call_count.clone();
+
+        // Fail with OccConflict on the first attempt, succeed on the second.
+        let result: Result<u32, TestError> = crate::with_dsql_retry!(async {
+            let n = call_count2.fetch_add(1, Ordering::SeqCst);
+            if n == 0 {
+                Err(TestError::OccConflict)
+            } else {
+                Ok(42)
+            }
+        });
+
+        assert_eq!(result, Ok(42));
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            2,
+            "must retry exactly once"
+        );
+    }
+
+    /// Body returning a non-retryable BusinessError propagates immediately without retry.
+    #[tokio::test]
+    async fn test_with_dsql_retry_business_error_no_retry() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        let call_count = Arc::new(AtomicU32::new(0));
+        let call_count2 = call_count.clone();
+
+        let result: Result<u32, TestError> = crate::with_dsql_retry!(async {
+            call_count2.fetch_add(1, Ordering::SeqCst);
+            Err(TestError::BusinessError("limit reached".to_string()))
+        });
+
+        assert_eq!(
+            result,
+            Err(TestError::BusinessError("limit reached".to_string()))
+        );
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "must not retry on business error"
+        );
+    }
+
+    /// anyhow::Error path: non-DB error is not retryable and propagates immediately.
+    #[tokio::test]
+    async fn test_with_dsql_retry_anyhow_non_retryable_propagates() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        let call_count = Arc::new(AtomicU32::new(0));
+        let call_count2 = call_count.clone();
+
+        let result: Result<u32, anyhow::Error> = crate::with_dsql_retry!(async {
+            call_count2.fetch_add(1, Ordering::SeqCst);
+            Err(anyhow::anyhow!("some non-DB error"))
+        });
+
+        assert!(result.is_err());
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "must not retry on non-retryable anyhow error"
+        );
+    }
+
+    /// OccConflict that never succeeds exhausts the retry budget and returns the error.
+    #[tokio::test]
+    async fn test_with_dsql_retry_occ_exhausts_budget() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        let call_count = Arc::new(AtomicU32::new(0));
+        let call_count2 = call_count.clone();
+
+        let result: Result<u32, TestError> = crate::with_dsql_retry!(async {
+            call_count2.fetch_add(1, Ordering::SeqCst);
+            Err(TestError::OccConflict)
+        });
+
+        assert_eq!(result, Err(TestError::OccConflict));
+        // Initial attempt + MAX_DSQL_RETRIES retries = MAX_DSQL_RETRIES + 1 total calls.
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            MAX_DSQL_RETRIES.saturating_add(1),
+            "must attempt exactly MAX_DSQL_RETRIES + 1 times"
+        );
     }
 }

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -4271,3 +4271,47 @@ async fn test_revoke_last_secret_rejected() {
         "revoking the last secret must fail with last_secret; got: {result:?}"
     );
 }
+
+/// Revoking an expired-but-unrevoked secret must succeed while another valid
+/// secret remains: the floor counts *other* active secrets, not the target.
+/// Without excluding the target, the expired row drops `active_count` to 1 and
+/// the revoke is wrongly rejected with `last_secret` (PR #557 review finding).
+#[tokio::test]
+async fn test_revoke_expired_secret_allowed_when_valid_remains() {
+    let (store, _audit) = test_db().await;
+    let app_id = create_test_client(
+        &store,
+        "occ-test-user",
+        TestClientSpec {
+            with_secret: false,
+            ..Default::default()
+        },
+    )
+    .await
+    .app_id;
+
+    // One valid secret (no expiry) plus one expired-but-unrevoked secret.
+    let _valid = create_oauth_client_secret(&store, &app_id, "hash_valid", None, None)
+        .await
+        .expect("create valid secret");
+    let past: jiff::Timestamp = "2020-01-01T00:00:00Z".parse().unwrap();
+    let expired = create_oauth_client_secret(&store, &app_id, "hash_expired", None, Some(past))
+        .await
+        .expect("create expired secret");
+
+    // Revoking the expired secret must be allowed — a valid secret still remains.
+    revoke_oauth_client_secret(&store, &expired.id, &app_id)
+        .await
+        .expect("revoking an expired secret must succeed while a valid secret remains");
+
+    // The valid secret is untouched and still active.
+    let now = jiff::Timestamp::now();
+    let secrets = get_oauth_client_secrets(&store, &app_id)
+        .await
+        .expect("list secrets");
+    let active = secrets.iter().filter(|s| s.is_valid(&now)).count();
+    assert_eq!(
+        active, 1,
+        "the valid secret must remain active; got {active}"
+    );
+}

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -17,6 +17,7 @@ use super::*;
 use crate::crypto::document_crypto::PlaintextDocumentCrypto;
 use crate::db::audit::AuditStore;
 use crate::db::store::DocumentStore;
+use crate::test_utils::{TestClientSpec, create_test_client};
 
 /// Create an in-memory SQLite database for testing.
 ///
@@ -4051,56 +4052,8 @@ async fn test_delete_authenticator_clears_device_auth_reference() {
 }
 
 // ============================================================================
-// PR-A OCC Invariant Tests — secret cap (≤2) and floor (≥1)
+// OAuth secret cap (≤2) / floor (≥1) OCC invariant tests (#551)
 // ============================================================================
-
-/// Helper: create an OAuth client with no initial secret (to control secrets precisely).
-async fn make_client(store: &DocumentStore) -> OAuthClient {
-    use crate::db::oauth::CreateOAuthClientParams;
-    use crate::db::{AccessScope, FapiProfile, JwsAlgorithm, OAuthClientType, RegistrationSource};
-
-    let (client, _client_id) = crate::db::oauth::create_oauth_client(
-        store,
-        &CreateOAuthClientParams {
-            user_id: Some("occ-test-user"),
-            name: "OCC Test App",
-            description: None,
-            application_type: OAuthClientType::Web,
-            redirect_uris: &["https://example.com/callback".to_string()],
-            access_scope: AccessScope::Public,
-            org_id: None,
-            resource_uris: &[],
-            token_endpoint_auth_method: None,
-            jwks: None,
-            jwks_uri: None,
-            fapi_profile: Some(FapiProfile::None),
-            dpop_bound_access_tokens: None,
-            grant_types: None,
-            response_types: None,
-            software_id: None,
-            software_version: None,
-            registration_source: RegistrationSource::Manual,
-            registration_access_token_hash: None,
-            registration_metadata: None,
-            id_token_signed_response_alg: JwsAlgorithm::Rs256,
-            tls_client_auth_subject_dn: None,
-            tls_client_auth_san_dns: None,
-            tls_client_auth_san_uri: None,
-            tls_client_auth_san_ip: None,
-            tls_client_auth_san_email: None,
-            tls_client_certificate_bound_access_tokens: None,
-            authorization_signed_response_alg: None,
-            introspection_signed_response_alg: None,
-            request_object_signing_alg: None,
-            require_signed_request_object: None,
-            userinfo_signed_response_alg: None,
-            request_uris: None,
-        },
-    )
-    .await
-    .expect("create oauth client");
-    client
-}
 
 /// 4 concurrent adds → exactly 2 `Ok`, rest `409 max_secrets_reached`.
 /// Mirrors `test_update_authenticator_counter_high_concurrency_no_lost_update`.
@@ -4110,8 +4063,16 @@ async fn make_client(store: &DocumentStore) -> OAuthClient {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_concurrent_secret_add_never_exceeds_two() {
     let (store, _audit) = test_db().await;
-    let client = make_client(&store).await;
-    let app_id = client.id.clone();
+    let app_id = create_test_client(
+        &store,
+        "occ-test-user",
+        TestClientSpec {
+            with_secret: false,
+            ..Default::default()
+        },
+    )
+    .await
+    .app_id;
 
     let handles: Vec<_> = (0_u8..4)
         .map(|i| {
@@ -4161,8 +4122,16 @@ async fn test_concurrent_secret_add_never_exceeds_two() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_concurrent_secret_revoke_never_drops_below_one() {
     let (store, _audit) = test_db().await;
-    let client = make_client(&store).await;
-    let app_id = client.id.clone();
+    let app_id = create_test_client(
+        &store,
+        "occ-test-user",
+        TestClientSpec {
+            with_secret: false,
+            ..Default::default()
+        },
+    )
+    .await
+    .app_id;
 
     // Seed exactly 2 active secrets.
     let s1 = create_oauth_client_secret(&store, &app_id, "hash_s1", None, None)
@@ -4217,8 +4186,16 @@ async fn test_concurrent_secret_revoke_never_drops_below_one() {
 #[tokio::test]
 async fn test_revoke_then_add_back_to_two() {
     let (store, _audit) = test_db().await;
-    let client = make_client(&store).await;
-    let app_id = client.id.clone();
+    let app_id = create_test_client(
+        &store,
+        "occ-test-user",
+        TestClientSpec {
+            with_secret: false,
+            ..Default::default()
+        },
+    )
+    .await
+    .app_id;
 
     // Seed 2 active secrets.
     let s1 = create_oauth_client_secret(&store, &app_id, "hash_rtb_s1", None, None)
@@ -4269,13 +4246,22 @@ async fn test_revoke_then_add_back_to_two() {
 #[tokio::test]
 async fn test_revoke_last_secret_rejected() {
     let (store, _audit) = test_db().await;
-    let client = make_client(&store).await;
+    let app_id = create_test_client(
+        &store,
+        "occ-test-user",
+        TestClientSpec {
+            with_secret: false,
+            ..Default::default()
+        },
+    )
+    .await
+    .app_id;
 
-    let secret = create_oauth_client_secret(&store, &client.id, "hash_only_one", None, None)
+    let secret = create_oauth_client_secret(&store, &app_id, "hash_only_one", None, None)
         .await
         .expect("create sole secret");
 
-    let result = revoke_oauth_client_secret(&store, &secret.id, &client.id).await;
+    let result = revoke_oauth_client_secret(&store, &secret.id, &app_id).await;
 
     assert!(
         matches!(

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -7,6 +7,7 @@
     clippy::indexing_slicing,
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss,
+    clippy::panic,
     reason = "test code: panic on assertion failure is acceptable; cast bounds are obvious in test fixtures"
 )]
 
@@ -4046,5 +4047,241 @@ async fn test_delete_authenticator_clears_device_auth_reference() {
     assert!(
         after.authenticator_id.is_none(),
         "authenticator_id must be cleared by cascade delete"
+    );
+}
+
+// ============================================================================
+// PR-A OCC Invariant Tests — secret cap (≤2) and floor (≥1)
+// ============================================================================
+
+/// Helper: create an OAuth client with no initial secret (to control secrets precisely).
+async fn make_client(store: &DocumentStore) -> OAuthClient {
+    use crate::db::oauth::CreateOAuthClientParams;
+    use crate::db::{AccessScope, FapiProfile, JwsAlgorithm, OAuthClientType, RegistrationSource};
+
+    let (client, _client_id) = crate::db::oauth::create_oauth_client(
+        store,
+        &CreateOAuthClientParams {
+            user_id: Some("occ-test-user"),
+            name: "OCC Test App",
+            description: None,
+            application_type: OAuthClientType::Web,
+            redirect_uris: &["https://example.com/callback".to_string()],
+            access_scope: AccessScope::Public,
+            org_id: None,
+            resource_uris: &[],
+            token_endpoint_auth_method: None,
+            jwks: None,
+            jwks_uri: None,
+            fapi_profile: Some(FapiProfile::None),
+            dpop_bound_access_tokens: None,
+            grant_types: None,
+            response_types: None,
+            software_id: None,
+            software_version: None,
+            registration_source: RegistrationSource::Manual,
+            registration_access_token_hash: None,
+            registration_metadata: None,
+            id_token_signed_response_alg: JwsAlgorithm::Rs256,
+            tls_client_auth_subject_dn: None,
+            tls_client_auth_san_dns: None,
+            tls_client_auth_san_uri: None,
+            tls_client_auth_san_ip: None,
+            tls_client_auth_san_email: None,
+            tls_client_certificate_bound_access_tokens: None,
+            authorization_signed_response_alg: None,
+            introspection_signed_response_alg: None,
+            request_object_signing_alg: None,
+            require_signed_request_object: None,
+            userinfo_signed_response_alg: None,
+            request_uris: None,
+        },
+    )
+    .await
+    .expect("create oauth client");
+    client
+}
+
+/// 4 concurrent adds → exactly 2 `Ok`, rest `409 max_secrets_reached`.
+/// Mirrors `test_update_authenticator_counter_high_concurrency_no_lost_update`.
+/// Uses multi_thread for defensive OS-level parallelism; busy_timeout waits happen
+/// inside sqlx-sqlite's dedicated OS thread and do not block tokio worker threads,
+/// so a single-thread runtime would also work correctly here.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_concurrent_secret_add_never_exceeds_two() {
+    let (store, _audit) = test_db().await;
+    let client = make_client(&store).await;
+    let app_id = client.id.clone();
+
+    let handles: Vec<_> = (0_u8..4)
+        .map(|i| {
+            let store = store.clone();
+            let app_id = app_id.clone();
+            tokio::spawn(async move {
+                create_oauth_client_secret(
+                    &store,
+                    &app_id,
+                    &format!("hash_concurrent_{i}"),
+                    None,
+                    None,
+                )
+                .await
+            })
+        })
+        .collect();
+
+    let mut ok_count: usize = 0;
+    let mut max_reached_count: usize = 0;
+    for h in handles {
+        match h.await.expect("task must not panic") {
+            Ok(_) => ok_count = ok_count.saturating_add(1),
+            Err(crate::services::error::ServiceError::Api { ref code, .. })
+                if code == "max_secrets_reached" =>
+            {
+                max_reached_count = max_reached_count.saturating_add(1);
+            }
+            Err(e) => panic!("unexpected error: {e}"),
+        }
+    }
+
+    assert_eq!(ok_count, 2, "exactly 2 adds must succeed");
+    assert_eq!(max_reached_count, 2, "exactly 2 adds must be rejected");
+
+    // Verify at the DB level.
+    let now = jiff::Timestamp::now();
+    let secrets = get_oauth_client_secrets(&store, &app_id)
+        .await
+        .expect("list secrets");
+    let active = secrets.iter().filter(|s| s.is_valid(&now)).count();
+    assert_eq!(active, 2, "exactly 2 active secrets must exist");
+}
+
+/// Seed 2 active secrets, 4 concurrent revokes → at least 1 active always remains.
+/// Uses multi_thread for defensive OS-level parallelism (see add test for rationale).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_concurrent_secret_revoke_never_drops_below_one() {
+    let (store, _audit) = test_db().await;
+    let client = make_client(&store).await;
+    let app_id = client.id.clone();
+
+    // Seed exactly 2 active secrets.
+    let s1 = create_oauth_client_secret(&store, &app_id, "hash_s1", None, None)
+        .await
+        .expect("seed s1");
+    let s2 = create_oauth_client_secret(&store, &app_id, "hash_s2", None, None)
+        .await
+        .expect("seed s2");
+
+    let secret_ids = [s1.id, s2.id];
+
+    // 4 concurrent revoke attempts on s1 and s2 (two each).
+    let handles: Vec<_> = secret_ids
+        .iter()
+        .flat_map(|sid| [sid.clone(), sid.clone()])
+        .map(|sid| {
+            let store = store.clone();
+            let app_id = app_id.clone();
+            tokio::spawn(async move { revoke_oauth_client_secret(&store, &sid, &app_id).await })
+        })
+        .collect();
+
+    for h in handles {
+        let result = h.await.expect("task must not panic");
+        // Acceptable outcomes: Ok (revoked), last_secret (floor guard),
+        // ServiceError::NotFound (already revoked — idempotent path),
+        // or conflict (exhausted OCC budget).  Anything else is a bug.
+        // Note: the already-revoked path returns ServiceError::NotFound, not
+        // ServiceError::Api { code: "not_found" }, so there is no Api "not_found" arm.
+        match result {
+            Ok(()) => {}
+            Err(crate::services::error::ServiceError::Api { ref code, .. })
+                if code == "last_secret" || code == "conflict" => {}
+            Err(crate::services::error::ServiceError::NotFound(_)) => {}
+            Err(e) => panic!("unexpected error from concurrent revoke: {e}"),
+        }
+    }
+
+    // Invariant: at least 1 active secret must remain.
+    let now = jiff::Timestamp::now();
+    let secrets = get_oauth_client_secrets(&store, &app_id)
+        .await
+        .expect("list secrets");
+    let active = secrets.iter().filter(|s| s.is_valid(&now)).count();
+    assert!(
+        active >= 1,
+        "at least 1 active secret must remain; got {active}"
+    );
+}
+
+/// Revoke 1 of 2, then add back to 2, confirming the cap counts `is_valid` not total rows.
+#[tokio::test]
+async fn test_revoke_then_add_back_to_two() {
+    let (store, _audit) = test_db().await;
+    let client = make_client(&store).await;
+    let app_id = client.id.clone();
+
+    // Seed 2 active secrets.
+    let s1 = create_oauth_client_secret(&store, &app_id, "hash_rtb_s1", None, None)
+        .await
+        .expect("seed s1");
+    let _s2 = create_oauth_client_secret(&store, &app_id, "hash_rtb_s2", None, None)
+        .await
+        .expect("seed s2");
+
+    // Revoke s1 (1 active remains).
+    revoke_oauth_client_secret(&store, &s1.id, &app_id)
+        .await
+        .expect("revoke s1");
+
+    // Now 1 active, 1 soft-deleted row.  A new add should succeed (not
+    // triggered by the soft-deleted row's count).
+    let _s3 = create_oauth_client_secret(&store, &app_id, "hash_rtb_s3", None, None)
+        .await
+        .expect("add s3 after revoke");
+
+    // Now 2 active (s2 + s3).  A further add must be rejected.
+    let cap_result = create_oauth_client_secret(&store, &app_id, "hash_rtb_s4", None, None).await;
+    assert!(
+        matches!(
+            cap_result,
+            Err(crate::services::error::ServiceError::Api { ref code, .. }) if code == "max_secrets_reached"
+        ),
+        "third add must fail with max_secrets_reached; got: {cap_result:?}"
+    );
+
+    // Verify counts at DB level.
+    let now = jiff::Timestamp::now();
+    let secrets = get_oauth_client_secrets(&store, &app_id)
+        .await
+        .expect("list secrets");
+    let total = secrets.len();
+    let active = secrets.iter().filter(|s| s.is_valid(&now)).count();
+    assert_eq!(active, 2, "exactly 2 active secrets; got {active}");
+    assert_eq!(
+        total, 3,
+        "3 total rows (1 soft-deleted, 2 active); got {total}"
+    );
+}
+
+/// Revoking the sole active secret returns `Api(409 "last_secret")`.
+/// Complements the handler-layer `test_delete_last_secret_rejected` with a
+/// faster, db-level signal that the floor guard fires.
+#[tokio::test]
+async fn test_revoke_last_secret_rejected() {
+    let (store, _audit) = test_db().await;
+    let client = make_client(&store).await;
+
+    let secret = create_oauth_client_secret(&store, &client.id, "hash_only_one", None, None)
+        .await
+        .expect("create sole secret");
+
+    let result = revoke_oauth_client_secret(&store, &secret.id, &client.id).await;
+
+    assert!(
+        matches!(
+            result,
+            Err(crate::services::error::ServiceError::Api { ref code, .. }) if code == "last_secret"
+        ),
+        "revoking the last secret must fail with last_secret; got: {result:?}"
     );
 }

--- a/crates/vouch-server/src/handlers/applications/api.rs
+++ b/crates/vouch-server/src/handlers/applications/api.rs
@@ -19,6 +19,7 @@ use axum::{
 use axum_extra::extract::cookie::CookieJar;
 use std::sync::Arc;
 
+use super::generate_client_secret;
 use super::types::{
     AddSecretRequest, AddSecretResponse, ApplicationResponse, CreateApplicationRequest,
     CreateApplicationResponse, ListApplicationsResponse, ListSecretsResponse, SecretInfo,
@@ -28,7 +29,6 @@ use super::validate::{
     CreateAppInput, UpdateAppInput, validate_create_application, validate_update_fapi,
     validate_update_format,
 };
-use super::{MAX_ACTIVE_SECRETS, generate_client_secret};
 use crate::handlers::extractors::OptionalClientCert;
 use crate::handlers::hash_token;
 use crate::handlers::session::extract_resource_token;
@@ -74,10 +74,6 @@ pub(crate) async fn list_applications_api(
 
 /// Create a new application (API).
 /// POST /api/v1/applications
-#[expect(
-    clippy::too_many_lines,
-    reason = "dominated by the exhaustive CreateOAuthClientParams literal"
-)]
 pub(crate) async fn create_application_api(
     method: Method,
     uri: OriginalUri,
@@ -230,15 +226,7 @@ pub(crate) async fn create_application_api(
             Some("Initial secret"),
             None,
         )
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to create client secret: {e}");
-            ServiceError::api(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "db_error",
-                "Internal database error",
-            )
-        })?;
+        .await?;
 
         Some(secret)
     } else {
@@ -666,30 +654,13 @@ pub(crate) async fn add_secret_api(
         ));
     }
 
-    let now = jiff::Timestamp::now();
-    let secrets = db::get_oauth_client_secrets(&state.store, &app_id)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to get secrets: {e}");
-            ServiceError::api(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "db_error",
-                "Internal database error",
-            )
-        })?;
-
-    let active_count = secrets.iter().filter(|s| s.is_valid(&now)).count();
-    if active_count >= MAX_ACTIVE_SECRETS {
-        return Err(ServiceError::api(
-            StatusCode::CONFLICT,
-            "max_secrets_reached",
-            "Maximum of 2 active secrets allowed",
-        ));
-    }
-
     let secret = generate_client_secret();
     let secret_hash = hash_token(&secret);
 
+    // The cap guard (≤ MAX_ACTIVE_SECRETS) is enforced inside
+    // create_oauth_client_secret via an OCC-guarded transaction — the
+    // pre-flight count that was here has been dropped because the in-tx guard
+    // is authoritative and works correctly under concurrent adds on all backends.
     let record = db::create_oauth_client_secret(
         &state.store,
         &app_id,
@@ -697,15 +668,7 @@ pub(crate) async fn add_secret_api(
         req.description.as_deref(),
         None,
     )
-    .await
-    .map_err(|e| {
-        tracing::error!("Failed to create secret: {e}");
-        ServiceError::api(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "db_error",
-            "Internal database error",
-        )
-    })?;
+    .await?;
 
     if let Err(e) = db::record_oauth_event(
         &state.audit,
@@ -901,16 +864,10 @@ pub(crate) async fn delete_secret_api(
         ));
     }
 
-    db::revoke_oauth_client_secret(&state.store, &secret_id)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to revoke secret: {e}");
-            ServiceError::api(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "db_error",
-                "Internal database error",
-            )
-        })?;
+    // The floor guard (≥1 active) is enforced atomically inside
+    // revoke_oauth_client_secret via an OCC-guarded transaction.  The pre-flight
+    // count above remains as a fast-path for the common non-concurrent case.
+    db::revoke_oauth_client_secret(&state.store, &secret_id, &app_id).await?;
 
     if let Err(e) = db::record_oauth_event(
         &state.audit,

--- a/crates/vouch-server/src/handlers/applications/mod.rs
+++ b/crates/vouch-server/src/handlers/applications/mod.rs
@@ -19,9 +19,6 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use super::extract_session_from_cookie;
 use super::session::AuthContext;
 
-/// Maximum number of active secrets per application.
-pub(crate) const MAX_ACTIVE_SECRETS: usize = 2;
-
 // Re-export handler functions used by the router.
 pub(crate) use api::{
     add_secret_api, create_application_api, delete_application_api, delete_secret_api,

--- a/crates/vouch-server/src/handlers/applications/web.rs
+++ b/crates/vouch-server/src/handlers/applications/web.rs
@@ -28,8 +28,7 @@ use super::validate::{
     validate_update_fapi, validate_update_format,
 };
 use super::{
-    MAX_ACTIVE_SECRETS, extract_auth_from_cookie, generate_client_secret, parse_redirect_uris,
-    parse_resource_uris,
+    extract_auth_from_cookie, generate_client_secret, parse_redirect_uris, parse_resource_uris,
 };
 use crate::handlers::hash_token;
 use crate::infra::i18n::Tr;
@@ -234,6 +233,7 @@ pub(crate) async fn create_application_form(
         )
         .await
         {
+            // ServiceError does not implement std::error::Error but does impl Display.
             tracing::error!("Failed to create client secret: {}", e);
             // Clean up the client
             if let Err(cleanup_err) = db::delete_oauth_client(&state.store, &client.id).await {
@@ -589,35 +589,25 @@ pub(crate) async fn add_secret_form(
         );
     }
 
-    let now = jiff::Timestamp::now();
-    let secrets = match db::get_oauth_client_secrets(&state.store, &app_id).await {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::error!("Failed to get secrets: {e}");
-            return error_page(
-                Tr::new("apps-error-title-error"),
-                Tr::new("apps-error-secret-add-failed"),
-                format!("/applications/{app_id}"),
-            );
-        }
-    };
-
-    let active_count = secrets.iter().filter(|s| s.is_valid(&now)).count();
-    if active_count >= MAX_ACTIVE_SECRETS {
-        return error_page(
-            Tr::new("apps-error-title-error"),
-            Tr::new("apps-error-secret-max"),
-            format!("/applications/{app_id}"),
-        );
-    }
-
     let secret = generate_client_secret();
     let secret_hash = hash_token(&secret);
 
+    // Cap guard (≤ MAX_ACTIVE_SECRETS) is enforced atomically inside
+    // create_oauth_client_secret — the pre-flight count has been dropped because
+    // the in-tx OCC guard is authoritative on all backends.
     let record =
         match db::create_oauth_client_secret(&state.store, &app_id, &secret_hash, None, None).await
         {
             Ok(r) => r,
+            Err(crate::services::error::ServiceError::Api { ref code, .. })
+                if code == "max_secrets_reached" =>
+            {
+                return error_page(
+                    Tr::new("apps-error-title-error"),
+                    Tr::new("apps-error-secret-max"),
+                    format!("/applications/{app_id}"),
+                );
+            }
             Err(e) => {
                 tracing::error!("Failed to create secret: {e}");
                 return error_page(
@@ -701,11 +691,24 @@ pub(crate) async fn delete_secret_form(
         );
     }
 
-    if let Err(e) = db::revoke_oauth_client_secret(&state.store, &secret_id).await {
-        tracing::error!("Failed to revoke secret: {e}");
+    // Floor guard (≥1 active) is enforced atomically inside
+    // revoke_oauth_client_secret — the pre-flight count above remains as a
+    // fast-path for the common non-concurrent case.  A concurrent revoke may
+    // still race us to the last secret and return last_secret 409; show the
+    // specific message rather than the generic delete-failed page.
+    if let Err(e) = db::revoke_oauth_client_secret(&state.store, &secret_id, &app_id).await {
+        let msg = match &e {
+            crate::services::error::ServiceError::Api { code, .. } if code == "last_secret" => {
+                Tr::new("apps-error-secret-last-active")
+            }
+            _ => {
+                tracing::error!("Failed to revoke secret: {e}");
+                Tr::new("apps-error-secret-delete-failed")
+            }
+        };
         return error_page(
             Tr::new("apps-error-title-error"),
-            Tr::new("apps-error-secret-delete-failed"),
+            msg,
             format!("/applications/{app_id}"),
         );
     }

--- a/crates/vouch-server/src/services/error.rs
+++ b/crates/vouch-server/src/services/error.rs
@@ -86,6 +86,17 @@ pub enum ServiceError {
         max_age: Option<u64>,
     },
 
+    /// OCC version-conflict signal.
+    ///
+    /// Returned by transactional operations when `compare_and_update` returns
+    /// `Ok(false)` — meaning another writer already bumped the owning document's
+    /// version between our read and our commit.  This is the **only** `ServiceError`
+    /// variant that `with_dsql_retry!` will re-run the enclosing async block for;
+    /// business-logic 409s (e.g. `max_secrets_reached`, `last_secret`) are
+    /// distinct variants and are **not** retried.
+    #[error("OCC version conflict; retry the transaction")]
+    OccConflict,
+
     /// Database error.
     #[error("database error: {0}")]
     Database(#[from] sqlx::Error),
@@ -98,6 +109,17 @@ pub enum ServiceError {
 impl From<anyhow::Error> for ServiceError {
     fn from(err: anyhow::Error) -> Self {
         Self::Internal(err.to_string())
+    }
+}
+
+impl crate::db::pool::RetryableError for ServiceError {
+    /// Only `OccConflict` triggers a retry.
+    ///
+    /// Business-logic errors (max_secrets_reached, last_secret, last_key, …)
+    /// use dedicated `ServiceError::Api` or `ServiceError::NotFound` variants and
+    /// must propagate immediately — retrying them would loop forever.
+    fn is_retryable(&self) -> bool {
+        matches!(self, Self::OccConflict)
     }
 }
 
@@ -485,7 +507,7 @@ impl ServiceError {
                 )
                     .into_response();
             }
-            Self::Database(_) | Self::Internal(_) => (
+            Self::Database(_) | Self::Internal(_) | Self::OccConflict => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "internal_error",
                 "Internal error".to_string(),

--- a/crates/vouch-server/src/services/keys.rs
+++ b/crates/vouch-server/src/services/keys.rs
@@ -193,10 +193,12 @@ pub(crate) async fn rename_key(
 ///
 /// Each attempt runs inside a single transaction with a delete-then-check guard
 /// and a `compare_and_update` version bump on the User doc, so two concurrent
-/// deletes against the same user serialise on a write-write conflict. The loser
-/// is retried with backoff; once a sibling delete has committed, its retry
-/// re-evaluates the last-key guard and returns 400 `last_key`, so exactly one
-/// of two concurrent deletes succeeds.
+/// deletes against the same user serialise on a write-write conflict.  The loser
+/// is retried by `with_dsql_retry!` (up to `MAX_DSQL_RETRIES = 3` times, down from
+/// the old hand-rolled loop's 5 attempts — accepted behaviour change under heavy
+/// contention); once a sibling delete has committed, the retry re-evaluates the
+/// last-key guard and returns 400 `last_key`, so exactly one of two concurrent
+/// deletes succeeds.
 ///
 /// # Errors
 ///
@@ -204,47 +206,9 @@ pub(crate) async fn rename_key(
 /// - `ServiceError::NotFound` if the key (or user) does not exist.
 /// - `ServiceError::Forbidden` if the key does not belong to the user.
 /// - `ServiceError::Api(400 "last_key")` if this is the user's last key.
-/// - `ServiceError::Api(409 "conflict")` if concurrent deletes keep conflicting
-///   on the User doc's optimistic-concurrency version past the retry budget.
+/// - `ServiceError::Api(409 "conflict")` if the retry budget is exhausted.
 /// - `ServiceError::Internal` on database errors.
 pub(crate) async fn delete_key(
-    store: &DocumentStore,
-    user_id: &str,
-    key_id: &str,
-) -> Result<(String, u64), ServiceError> {
-    // Concurrent deletes against the same user contend on the User-doc version
-    // bump (and, on SQLite, on the write lock). A losing attempt surfaces as a
-    // 409 "conflict" — either a retryable DB error mapped to 409, or the
-    // version-bump conflict. Retry so exactly one delete wins and the rest
-    // re-evaluate the last-key guard (returning 400 "last_key") instead of all
-    // failing with 409 and leaving the key undeleted (flaky on SQLite under
-    // write contention).
-    const MAX_ATTEMPTS: u32 = 5;
-    for attempt in 1..=MAX_ATTEMPTS {
-        match delete_key_once(store, user_id, key_id).await {
-            Ok(result) => return Ok(result),
-            Err(e) => {
-                let is_conflict = match &e {
-                    ServiceError::Api { status, .. } => *status == axum::http::StatusCode::CONFLICT,
-                    _ => false,
-                };
-                if is_conflict && attempt < MAX_ATTEMPTS {
-                    tokio::time::sleep(crate::db::pool::retry_backoff(attempt)).await;
-                    continue;
-                }
-                return Err(e);
-            }
-        }
-    }
-    // The loop returns on the final attempt; this point is unreachable.
-    Err(ServiceError::Internal(
-        "key deletion retry loop exhausted".to_string(),
-    ))
-}
-
-/// A single attempt at the transactional key deletion. [`delete_key`] retries
-/// this on a 409 conflict (write-write contention on the User doc).
-async fn delete_key_once(
     store: &DocumentStore,
     user_id: &str,
     key_id: &str,
@@ -256,121 +220,127 @@ async fn delete_key_once(
         ));
     }
 
-    // Map a DB error from any tx operation into either a 409 conflict (if it
+    // Map a DB error from any tx operation into either an OccConflict (if it
     // signals contention with a concurrent writer — Postgres serialization
     // failure, Aurora DSQL OC000/OC001, SQLite BUSY/LOCKED) or a generic 500.
-    // The contention case is the loser of the same race that the version
-    // bump below would catch on commit — it just surfaces earlier.
+    // OccConflict is retried by with_dsql_retry!; the 500 path propagates.
     let map_db_err = |e: anyhow::Error, msg: &'static str| -> ServiceError {
         tracing::error!("{msg}: {e}");
         if crate::db::pool::is_retryable_db_error(&e) {
-            ServiceError::api(
-                axum::http::StatusCode::CONFLICT,
-                "conflict",
-                "Key deletion conflicted with a concurrent operation. Please retry.",
-            )
+            ServiceError::OccConflict
         } else {
             ServiceError::Internal(msg.to_string())
         }
     };
 
-    let mut tx = store
-        .begin()
-        .await
-        .map_err(|e| map_db_err(e, "Failed to start transaction"))?;
+    let result = crate::with_dsql_retry!(async {
+        let mut tx = store
+            .begin()
+            .await
+            .map_err(|e| map_db_err(e, "Failed to start transaction"))?;
 
-    // Load the User doc with its version. The version is bumped at the end of
-    // the transaction so that two concurrent deletes against the same user
-    // serialise on a write-write conflict (needed for PostgreSQL READ COMMITTED;
-    // SQLite and Aurora DSQL are already safe via writer serialisation and
-    // SERIALIZABLE isolation respectively).
-    let user_doc = tx
-        .get::<UserDoc>(user_id)
-        .await
-        .map_err(|e| map_db_err(e, "Failed to load user"))?
-        .ok_or(ServiceError::NotFound("User"))?;
+        // Load the User doc with its version. The version is bumped at the end of
+        // the transaction so that two concurrent deletes against the same user
+        // serialise on a write-write conflict (needed for PostgreSQL READ COMMITTED;
+        // SQLite and Aurora DSQL are already safe via writer serialisation and
+        // SERIALIZABLE isolation respectively).
+        let user_doc = tx
+            .get::<UserDoc>(user_id)
+            .await
+            .map_err(|e| map_db_err(e, "Failed to load user"))?
+            .ok_or(ServiceError::NotFound("User"))?;
 
-    // Load the authenticator and verify ownership within the transaction.
-    let auth_doc = tx
-        .get::<AuthenticatorDoc>(key_id)
-        .await
-        .map_err(|e| map_db_err(e, "Failed to retrieve key"))?
-        .ok_or(ServiceError::NotFound("Key"))?;
+        // Load the authenticator and verify ownership within the transaction.
+        let auth_doc = tx
+            .get::<AuthenticatorDoc>(key_id)
+            .await
+            .map_err(|e| map_db_err(e, "Failed to retrieve key"))?
+            .ok_or(ServiceError::NotFound("Key"))?;
 
-    if auth_doc.data.user_id != user_id {
-        return Err(ServiceError::api(
-            axum::http::StatusCode::FORBIDDEN,
-            "forbidden",
-            "Key does not belong to this user",
-        ));
-    }
-    let key_name = auth_doc.data.name.clone();
+        if auth_doc.data.user_id != user_id {
+            return Err(ServiceError::api(
+                axum::http::StatusCode::FORBIDDEN,
+                "forbidden",
+                "Key does not belong to this user",
+            ));
+        }
+        let key_name = auth_doc.data.name.clone();
 
-    // Pre-flight "last key" guard — fast-paths the common single-request case
-    // and preserves the 400 / "last_key" response semantics. The count
-    // includes the key about to be deleted, so `<= 1` means "this is the only
-    // key the user owns."
-    let count_before = tx
-        .count::<AuthenticatorDoc>("user_id", user_id)
-        .await
-        .map_err(|e| map_db_err(e, "Failed to check key count"))?;
-    if count_before <= 1 {
-        return Err(ServiceError::api(
-            axum::http::StatusCode::BAD_REQUEST,
-            "last_key",
-            "Cannot delete your last key. Register another key first.",
-        ));
-    }
+        // Pre-flight "last key" guard — fast-paths the common single-request case
+        // and preserves the 400 / "last_key" response semantics. The count
+        // includes the key about to be deleted, so `<= 1` means "this is the only
+        // key the user owns."
+        let count_before = tx
+            .count::<AuthenticatorDoc>("user_id", user_id)
+            .await
+            .map_err(|e| map_db_err(e, "Failed to check key count"))?;
+        if count_before <= 1 {
+            return Err(ServiceError::api(
+                axum::http::StatusCode::BAD_REQUEST,
+                "last_key",
+                "Cannot delete your last key. Register another key first.",
+            ));
+        }
 
-    // Count sessions to report in the response payload. Snapshot taken before
-    // the cascade — represents the sessions that will be revoked.
-    let sessions_revoked = tx
-        .count::<SessionDoc>("authenticator_id", key_id)
-        .await
-        .map_err(|e| map_db_err(e, "Failed to count sessions"))?;
+        // Count sessions to report in the response payload. Snapshot taken before
+        // the cascade — represents the sessions that will be revoked.
+        let sessions_revoked = tx
+            .count::<SessionDoc>("authenticator_id", key_id)
+            .await
+            .map_err(|e| map_db_err(e, "Failed to count sessions"))?;
 
-    // Cascade-delete the authenticator (device_auth refs, sessions, doc).
-    db::delete_authenticator_in_tx(&mut tx, key_id)
-        .await
-        .map_err(|e| map_db_err(e, "Failed to delete key"))?;
+        // Cascade-delete the authenticator (device_auth refs, sessions, doc).
+        db::delete_authenticator_in_tx(&mut tx, key_id)
+            .await
+            .map_err(|e| map_db_err(e, "Failed to delete key"))?;
 
-    // Post-delete invariant. Under PostgreSQL READ COMMITTED both concurrent
-    // transactions would still see count_after == 1 (each observes the other's
-    // uncommitted key), so this guard only catches SQLite/DSQL races; the
-    // version bump below is what serialises PostgreSQL.
-    let count_after = tx
-        .count::<AuthenticatorDoc>("user_id", user_id)
-        .await
-        .map_err(|e| map_db_err(e, "Failed to verify key count"))?;
-    if count_after < 1 {
-        return Err(ServiceError::api(
-            axum::http::StatusCode::BAD_REQUEST,
-            "last_key",
-            "Cannot delete your last key. Register another key first.",
-        ));
-    }
+        // Post-delete invariant. Under PostgreSQL READ COMMITTED both concurrent
+        // transactions would still see count_after == 1 (each observes the other's
+        // uncommitted key), so this guard only catches SQLite/DSQL races; the
+        // version bump below is what serialises PostgreSQL.
+        let count_after = tx
+            .count::<AuthenticatorDoc>("user_id", user_id)
+            .await
+            .map_err(|e| map_db_err(e, "Failed to verify key count"))?;
+        if count_after < 1 {
+            return Err(ServiceError::api(
+                axum::http::StatusCode::BAD_REQUEST,
+                "last_key",
+                "Cannot delete your last key. Register another key first.",
+            ));
+        }
 
-    // Version-bump the User doc to serialise concurrent deletes on the user row.
-    let ok = tx
-        .compare_and_update::<UserDoc>(user_id, user_doc.version, &user_doc.data)
-        .await
-        .map_err(|e| map_db_err(e, "Failed to commit key deletion"))?;
-    if !ok {
-        return Err(ServiceError::api(
+        // Version-bump the User doc to serialise concurrent deletes on the user row.
+        let ok = tx
+            .compare_and_update::<UserDoc>(user_id, user_doc.version, &user_doc.data)
+            .await
+            .map_err(|e| map_db_err(e, "Failed to version-bump user doc"))?;
+        if !ok {
+            // OCC conflict — another writer beat us to the User doc.  Signal
+            // with_dsql_retry! to re-run the entire block.
+            return Err(ServiceError::OccConflict);
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| map_db_err(e, "Failed to commit key deletion"))?;
+
+        let sessions = u64::try_from(sessions_revoked).unwrap_or_default();
+        tracing::info!("Deleted key {key_id} for user {user_id}, revoked {sessions} sessions");
+
+        Ok::<(String, u64), ServiceError>((key_name, sessions))
+    });
+
+    // `with_dsql_retry!` exhausts OccConflict after MAX_DSQL_RETRIES attempts.
+    // If the final attempt also conflicts, surface as a 409 to the caller.
+    result.map_err(|e| match e {
+        ServiceError::OccConflict => ServiceError::api(
             axum::http::StatusCode::CONFLICT,
             "conflict",
             "Key deletion conflicted with a concurrent operation. Please retry.",
-        ));
-    }
-
-    tx.commit()
-        .await
-        .map_err(|e| map_db_err(e, "Failed to commit key deletion"))?;
-
-    let sessions = u64::try_from(sessions_revoked).unwrap_or_default();
-    tracing::info!("Deleted key {key_id} for user {user_id}, revoked {sessions} sessions");
-
-    Ok((key_name, sessions))
+        ),
+        other => other,
+    })
 }
 
 #[cfg(test)]

--- a/crates/vouch-server/src/services/oidc/registration.rs
+++ b/crates/vouch-server/src/services/oidc/registration.rs
@@ -560,11 +560,7 @@ pub async fn register_client(
             Some("Dynamic registration"),
             None,
         )
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to create client secret for dynamic registration: {e}");
-            ServiceError::Internal("Failed to create client secret".to_string())
-        })?;
+        .await?;
 
         Some(secret)
     } else {


### PR DESCRIPTION
Part 1 of #551. Closes the live gap where the ≤2 active OAuth client-secret cap was unenforced on Postgres/Aurora DSQL after the interim #547 fix was reverted in #553.

## Problem
Two concurrent secret adds insert distinct `documents` rows with no shared write, so neither OCC nor snapshot isolation detects a conflict — both commit, and the cap is bypassed on Postgres/DSQL. (SQLite happened to serialize, which is why the reverted fix looked correct in dev.)

## Change
Both the ≤2 cap (`create_oauth_client_secret`) and the ≥1 floor (`revoke_oauth_client_secret`) run as a single transaction that version-bumps the owning `OAuthClientDoc` via `compare_and_update`. Concurrent writers collide on that one row, so the loser re-runs the whole transaction and re-checks the guard against fresh data. This makes the invariants hold on SQLite, Postgres, and DSQL.

`with_dsql_retry!` is made OCC-aware rather than adding a second retry construct:
- A `RetryableError` trait generalizes its predicate; the `anyhow::Error` impl delegates to the existing `is_retryable_db_error`, so the existing call sites are unchanged.
- A dedicated `ServiceError::OccConflict` is the only retryable `ServiceError`. A conflict is modelled as a retryable error (not `Ok(false)`), unifying SQLite's `Ok(false)` and DSQL's `Err(40001)` into one retry path. An exhausted retry budget surfaces as 409 `conflict`, consistent with `delete_key`.

`delete_key`'s hand-rolled retry loop is collapsed onto the macro; the retry budget is unified to `MAX_DSQL_RETRIES`.

Reuses `OAuthClientSecretDoc` unchanged — no new document type and no database migration. Secrets keep random ids and soft-delete retention; the auth-time `secret_hash` lookup is untouched.

A `CLAUDE.md` principle (item #10) records the pattern: cross-row invariants → one transaction that version-bumps the owning doc, wrapped in `with_dsql_retry!`.

## Tests
- `test_concurrent_secret_add_never_exceeds_two`, `test_concurrent_secret_revoke_never_drops_below_one` — 4 concurrent tasks; assert the ≤2 / ≥1 invariants hold.
- `test_revoke_then_add_back_to_two`, `test_revoke_last_secret_rejected` — sequential cap/floor behavior.
- Four `with_dsql_retry!` OCC unit tests (retry-then-succeed, non-retryable propagation, exhaustion, anyhow path unchanged).
- `make fmt` / `make lint` clean; full suite 2351 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes OAuth client-secret lifecycle and concurrency control on credential storage; incorrect OCC or floor logic could block secret rotation or briefly allow invariant violations under race.
> 
> **Overview**
> Closes the gap where concurrent OAuth client-secret **adds** could exceed the **≤2 active** cap on Postgres/Aurora DSQL (distinct secret rows did not share a serialization point). **Creates** and **revokes** now run in one transaction that counts `is_valid` secrets, mutates the secret row, and **version-bumps the owning `OAuthClientDoc`** via `compare_and_update`, wrapped in **`with_dsql_retry!`**. Losers retry and re-check caps/floors; terminal **`max_secrets_reached`**, **`last_secret`**, and exhausted OCC map to **409** API errors.
> 
> **`with_dsql_retry!`** gains a **`RetryableError`** trait so **`ServiceError::OccConflict`** retries alongside transient DB errors; business 409s do not. **`delete_key`** drops its hand-rolled retry loop in favor of the same macro (budget aligned to **`MAX_DSQL_RETRIES`**). **`MAX_ACTIVE_SECRETS`** lives in the DB layer; API/web handlers remove duplicate pre-flight cap checks and propagate **`ServiceError`** from **`create_oauth_client_secret`** / **`revoke_oauth_client_secret`** (revoke now takes **`oauth_client_id`**). **`CLAUDE.md`** documents the cross-row invariant pattern.
> 
> Adds concurrent and sequential DB tests for cap/floor behavior plus **`with_dsql_retry!`** OCC unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32ff53375d9a82b191dbf49fbe9201242bafe445. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->