### PR TITLE
fix(server): close lost-update races and error-handling gaps (#551)

### DIFF
--- a/crates/vouch-server/src/db/authenticators.rs
+++ b/crates/vouch-server/src/db/authenticators.rs
@@ -254,17 +254,18 @@ pub async fn delete_authenticator_in_tx(
 }
 
 /// Update an authenticator's name.
+///
+/// Uses optimistic concurrency (`store.modify`) so a concurrent counter update
+/// cannot overwrite the name change, and vice versa.
 pub async fn update_authenticator_name(
     store: &DocumentStore,
     authenticator_id: &str,
     name: &str,
 ) -> Result<bool> {
-    if let Some(doc) = store.get::<AuthenticatorDoc>(authenticator_id).await? {
-        let mut data = doc.data;
-        data.name = name.to_string();
-        store.update(authenticator_id, &data).await?;
-        Ok(true)
-    } else {
-        Ok(false)
-    }
+    let name_owned = name.to_string();
+    store
+        .modify::<AuthenticatorDoc, _>(authenticator_id, |data| {
+            data.name = name_owned.clone();
+        })
+        .await
 }

--- a/crates/vouch-server/src/db/github.rs
+++ b/crates/vouch-server/src/db/github.rs
@@ -146,63 +146,93 @@ pub async fn delete_github_installation_by_installation_id(
     Ok(false)
 }
 
+/// Resolve a GitHub installation's document ID from its `installation_id` index.
+///
+/// Returns `Some(doc_id)` on a hit or `None` if no matching installation exists.
+/// The resolved `doc_id` is the stable primary key used by `store.modify()`.
+async fn resolve_installation_doc_id(
+    store: &DocumentStore,
+    installation_id: i64,
+) -> Result<Option<String>> {
+    let doc = store
+        .find_one::<GitHubInstallationDoc>("installation_id", &installation_id.to_string())
+        .await?;
+    Ok(doc.map(|d| d.id))
+}
+
 /// Suspend GitHub installation (used by webhook handler).
+///
+/// Uses optimistic concurrency (`store.modify`) so concurrent webhook events
+/// targeting the same installation never produce a lost update. If the
+/// installation is deleted between index-resolve and modify, returns `Ok(false)`.
 pub async fn suspend_github_installation(
     store: &DocumentStore,
     installation_id: i64,
 ) -> Result<bool> {
-    let doc = store
-        .find_one::<GitHubInstallationDoc>("installation_id", &installation_id.to_string())
-        .await?;
-
-    if let Some(doc) = doc {
-        let mut data = doc.data;
-        data.suspended_at = Some(Timestamp::now());
-        store.update(&doc.id, &data).await?;
-        return Ok(true);
-    }
-    Ok(false)
+    let Some(doc_id) = resolve_installation_doc_id(store, installation_id).await? else {
+        return Ok(false);
+    };
+    store
+        .modify::<GitHubInstallationDoc, _>(&doc_id, |data| {
+            data.suspended_at = Some(Timestamp::now());
+        })
+        .await
 }
 
 /// Unsuspend GitHub installation (used by webhook handler).
+///
+/// Uses optimistic concurrency (`store.modify`) so concurrent webhook events
+/// targeting the same installation never produce a lost update. If the
+/// installation is deleted between index-resolve and modify, returns `Ok(false)`.
 pub async fn unsuspend_github_installation(
     store: &DocumentStore,
     installation_id: i64,
 ) -> Result<bool> {
-    let doc = store
-        .find_one::<GitHubInstallationDoc>("installation_id", &installation_id.to_string())
-        .await?;
-
-    if let Some(doc) = doc {
-        let mut data = doc.data;
-        data.suspended_at = None;
-        store.update(&doc.id, &data).await?;
-        return Ok(true);
-    }
-    Ok(false)
+    let Some(doc_id) = resolve_installation_doc_id(store, installation_id).await? else {
+        return Ok(false);
+    };
+    store
+        .modify::<GitHubInstallationDoc, _>(&doc_id, |data| {
+            data.suspended_at = None;
+        })
+        .await
 }
 
 /// Update repositories for a GitHub installation.
+///
+/// Uses optimistic concurrency (`store.modify`) so concurrent webhook events
+/// targeting the same installation never produce a lost update. If the
+/// installation is deleted between index-resolve and modify, returns `Ok(false)`.
 pub async fn update_github_installation_repos(
     store: &DocumentStore,
     installation_id: i64,
     repos: &[String],
 ) -> Result<bool> {
-    let doc = store
-        .find_one::<GitHubInstallationDoc>("installation_id", &installation_id.to_string())
-        .await?;
-
-    if let Some(doc) = doc {
-        let mut data = doc.data;
-        data.repositories = Some(repos.to_vec());
-        store.update(&doc.id, &data).await?;
-        return Ok(true);
-    }
-    Ok(false)
+    let Some(doc_id) = resolve_installation_doc_id(store, installation_id).await? else {
+        return Ok(false);
+    };
+    let repos_owned = repos.to_vec();
+    store
+        .modify::<GitHubInstallationDoc, _>(&doc_id, |data| {
+            data.repositories = Some(repos_owned.clone());
+        })
+        .await
 }
 
 /// Update repositories for a GitHub installation by
 /// adding/removing repos (used by webhook handler).
+///
+/// # Concurrency note
+///
+/// The read-compute-write sequence here is NOT atomic end-to-end. The initial
+/// read (`get_github_installation_by_installation_id`) and the delta merge
+/// (`for repo in added …`) happen outside the `modify` closure inside
+/// `update_github_installation_repos`, so two concurrent delta webhooks for the
+/// same installation can each read stale repo lists and silently lose the other's
+/// additions/removals. Given that GitHub delivers webhook events sequentially
+/// per installation (low real-world contention), this is deferred rather than
+/// fixed here. If contention becomes a concern the merge logic must move inside
+/// a single `store.modify` closure so it re-reads and re-merges on each OCC retry.
 pub async fn update_github_installation_repos_delta(
     store: &DocumentStore,
     installation_id: i64,

--- a/crates/vouch-server/src/db/posture_policies.rs
+++ b/crates/vouch-server/src/db/posture_policies.rs
@@ -213,6 +213,10 @@ pub async fn update_custom_policy(
     let applied = std::sync::atomic::AtomicBool::new(false);
     let found = store
         .modify::<CustomPosturePolicyDoc, _>(id, |data| {
+            // Reset at the top of every attempt: if an earlier OCC retry set
+            // this flag but then lost the version race, the closure runs again
+            // and org ownership must be re-evaluated from scratch.
+            applied.store(false, std::sync::atomic::Ordering::Relaxed);
             // Re-check org ownership inside the closure so a concurrent
             // org migration cannot smuggle a cross-org write through a version win.
             if data.org_id != org_id {

--- a/crates/vouch-server/src/db/posture_policies.rs
+++ b/crates/vouch-server/src/db/posture_policies.rs
@@ -180,40 +180,66 @@ pub struct UpdateCustomPolicyParams<'a> {
 }
 
 /// Update a custom posture policy.
+///
+/// Uses optimistic concurrency (`store.modify`) so concurrent mutations to the
+/// same policy (e.g. a concurrent activation toggle) do not silently overwrite
+/// each other. The org-scope check is re-evaluated inside the closure on each
+/// OCC retry. Re-fetches the document after the write to capture updated timestamps.
 pub async fn update_custom_policy(
     store: &DocumentStore,
     id: &str,
     org_id: &str,
     params: UpdateCustomPolicyParams<'_>,
 ) -> Result<Option<CustomPosturePolicy>> {
-    let doc = store.get::<CustomPosturePolicyDoc>(id).await?;
-    let Some(doc) = doc else {
+    // Pre-check: return not-found quickly without entering the modify loop
+    // if the policy is absent or belongs to a different org.
+    let Some(doc) = store.get::<CustomPosturePolicyDoc>(id).await? else {
         return Ok(None);
     };
-
-    // Verify org ownership
     if doc.data.org_id != org_id {
         return Ok(None);
     }
 
-    let updated = CustomPosturePolicyDoc {
-        name: params.name.map(String::from).unwrap_or(doc.data.name),
-        description: match params.description {
-            FieldUpdate::Keep => doc.data.description,
-            FieldUpdate::Clear => None,
-            FieldUpdate::Set(d) => Some(d.to_string()),
-        },
-        cel_expression: params
-            .cel_expression
-            .map(String::from)
-            .unwrap_or(doc.data.cel_expression),
-        active: params.active.unwrap_or(doc.data.active),
-        org_id: doc.data.org_id,
+    // Owned copies for the Fn closure (params borrows from caller stack).
+    let name_owned = params.name.map(String::from);
+    let description_owned = match params.description {
+        FieldUpdate::Keep => None,
+        FieldUpdate::Clear => Some(None::<String>),
+        FieldUpdate::Set(d) => Some(Some(d.to_string())),
     };
+    let cel_owned = params.cel_expression.map(String::from);
+    let active_owned = params.active;
 
-    store.update(id, &updated).await?;
+    let applied = std::sync::atomic::AtomicBool::new(false);
+    let found = store
+        .modify::<CustomPosturePolicyDoc, _>(id, |data| {
+            // Re-check org ownership inside the closure so a concurrent
+            // org migration cannot smuggle a cross-org write through a version win.
+            if data.org_id != org_id {
+                return;
+            }
+            if let Some(ref n) = name_owned {
+                data.name = n.clone();
+            }
+            // description is a 3-way FieldUpdate: None means Keep (no-op).
+            if let Some(ref desc_opt) = description_owned {
+                data.description = desc_opt.clone();
+            }
+            if let Some(ref cel) = cel_owned {
+                data.cel_expression = cel.clone();
+            }
+            if let Some(active) = active_owned {
+                data.active = active;
+            }
+            applied.store(true, std::sync::atomic::Ordering::Relaxed);
+        })
+        .await?;
 
-    // Re-fetch to get updated timestamps
+    if !found || !applied.load(std::sync::atomic::Ordering::Relaxed) {
+        return Ok(None);
+    }
+
+    // Re-fetch to get updated timestamps.
     let refreshed = store.get::<CustomPosturePolicyDoc>(id).await?;
     Ok(refreshed.map(CustomPosturePolicy::from))
 }

--- a/crates/vouch-server/src/db/scim.rs
+++ b/crates/vouch-server/src/db/scim.rs
@@ -853,8 +853,13 @@ fn apply_scim_group_filter(
 
 /// Update a SCIM group, scoped to the caller's org.
 ///
-/// Returns `Ok(false)` if the group doesn't exist OR belongs to a
-/// different org.
+/// Returns `Ok(false)` if the group doesn't exist, belongs to a different org,
+/// or if a concurrent org-ownership change races with the modify loop and causes
+/// the mutation to be skipped. `Ok(true)` on a successful update.
+///
+/// Uses optimistic concurrency (`store.modify`) so concurrent field mutations
+/// do not silently overwrite each other. The org-scope check is re-evaluated
+/// inside the closure on each OCC retry.
 pub async fn update_scim_group(
     store: &DocumentStore,
     id: &str,
@@ -862,21 +867,38 @@ pub async fn update_scim_group(
     display_name: Option<&str>,
     external_id: Option<&str>,
 ) -> Result<bool> {
+    // Pre-check: return not-found quickly without entering the modify loop
+    // if the group is absent or belongs to a different org.
     let Some(doc) = store.get::<ScimGroupDoc>(id).await? else {
         return Ok(false);
     };
     if doc.data.org_id != org_id {
         return Ok(false);
     }
-    let mut data = doc.data;
-    if let Some(name) = display_name {
-        data.display_name = name.to_string();
-    }
-    if let Some(ext_id) = external_id {
-        data.external_id = Some(ext_id.to_string());
-    }
-    store.update(id, &data).await?;
-    Ok(true)
+
+    // Owned copies for the Fn closure.
+    let display_name_owned = display_name.map(String::from);
+    let external_id_owned = external_id.map(String::from);
+
+    let applied = std::sync::atomic::AtomicBool::new(false);
+    let found = store
+        .modify::<ScimGroupDoc, _>(id, |data| {
+            // Re-check org ownership inside the closure so a concurrent
+            // org migration cannot smuggle a cross-org write through a version win.
+            if data.org_id != org_id {
+                return;
+            }
+            if let Some(ref name) = display_name_owned {
+                data.display_name = name.clone();
+            }
+            if let Some(ref ext_id) = external_id_owned {
+                data.external_id = Some(ext_id.clone());
+            }
+            applied.store(true, std::sync::atomic::Ordering::Relaxed);
+        })
+        .await?;
+
+    Ok(found && applied.load(std::sync::atomic::Ordering::Relaxed))
 }
 
 /// Delete a SCIM group atomically, scoped to the caller's org.

--- a/crates/vouch-server/src/db/scim.rs
+++ b/crates/vouch-server/src/db/scim.rs
@@ -516,6 +516,10 @@ pub async fn update_scim_user(
     let applied = std::sync::atomic::AtomicBool::new(false);
     let found = store
         .modify::<UserDoc, _>(user_id, |data| {
+            // Reset at the top of every attempt: if an earlier OCC retry set
+            // this flag but then lost the version race, the closure runs again
+            // and org ownership must be re-evaluated from scratch.
+            applied.store(false, std::sync::atomic::Ordering::Relaxed);
             if data.org_id.as_deref() == Some(org_id) {
                 data.name = name.map(String::from);
                 data.external_id = external_id.map(String::from);
@@ -883,6 +887,10 @@ pub async fn update_scim_group(
     let applied = std::sync::atomic::AtomicBool::new(false);
     let found = store
         .modify::<ScimGroupDoc, _>(id, |data| {
+            // Reset at the top of every attempt: if an earlier OCC retry set
+            // this flag but then lost the version race, the closure runs again
+            // and org ownership must be re-evaluated from scratch.
+            applied.store(false, std::sync::atomic::Ordering::Relaxed);
             // Re-check org ownership inside the closure so a concurrent
             // org migration cannot smuggle a cross-org write through a version win.
             if data.org_id != org_id {

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -4079,10 +4079,12 @@ async fn test_github_installation_concurrent_suspend_unsuspend_no_lost_update() 
             .expect("operation must succeed");
     }
 
-    // The installation must still exist and have version ≥ 2, proving both
-    // writes landed. A blind `store.update` (non-OCC) would also leave the
-    // record present, but the version would be 1 (only one increment) because
-    // the second write would overwrite the first at the original version.
+    // Smoke check: both concurrent writes complete without error, and the
+    // record still exists with both increments applied (version ≥ 2). This does
+    // not by itself distinguish OCC from a blind `store.update` — the blind path
+    // also bumps the version unconditionally — so it only proves concurrent
+    // access doesn't error or corrupt. The lost-update regression (a sibling
+    // field being clobbered) is caught by the `*_only_*_changes` tests above.
     use crate::db::documents::github::GitHubInstallationDoc;
     let doc_after = store
         .get::<GitHubInstallationDoc>(&{
@@ -4098,7 +4100,7 @@ async fn test_github_installation_concurrent_suspend_unsuspend_no_lost_update() 
         .expect("installation must still exist after concurrent suspend/unsuspend");
     assert!(
         doc_after.version >= 2,
-        "version must be ≥2 after two concurrent writes (OCC must have retried); got version {}",
+        "both concurrent writes must land (version ≥2); got version {}",
         doc_after.version
     );
 }

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -3818,6 +3818,662 @@ async fn test_enroll_promotes_admin_for_org_without_one() {
 }
 
 // ========================================================================
+// OCC read-modify-write conversions: blind get+update → store.modify()
+// ========================================================================
+
+// ---- update_authenticator_name ----
+
+/// After `update_authenticator_name`, only the `name` field changes; the
+/// `credential_id`, `counter`, and other fields are untouched, and the
+/// document version is incremented.
+#[tokio::test]
+async fn test_update_authenticator_name_only_name_changes() {
+    use crate::db::documents::authenticator::AuthenticatorDoc;
+
+    let (store, _audit) = test_db().await;
+
+    let (user_id, _) = upsert_user(&store, "rename@example.com", None)
+        .await
+        .expect("upsert user");
+
+    let auth_id = create_authenticator(
+        &store,
+        &CreateAuthenticatorParams {
+            user_id: &user_id,
+            user_email: "rename@example.com",
+            name: "OldName",
+            credential_id: b"cred-rename",
+            public_key: &[1u8; 32],
+            aaguid: Some("aaguid-rename"),
+            user_handle: None,
+            attestation_verified: true,
+        },
+    )
+    .await
+    .expect("create authenticator");
+
+    let before = store
+        .get::<AuthenticatorDoc>(&auth_id)
+        .await
+        .expect("get before")
+        .expect("must exist");
+    let version_before = before.version;
+
+    let found = update_authenticator_name(&store, &auth_id, "NewName")
+        .await
+        .expect("update name");
+    assert!(found, "update must report found=true");
+
+    let after = store
+        .get::<AuthenticatorDoc>(&auth_id)
+        .await
+        .expect("get after")
+        .expect("must exist");
+
+    assert_eq!(after.data.name, "NewName", "name must be updated");
+    assert_eq!(
+        after.data.credential_id, before.data.credential_id,
+        "credential_id must be unchanged"
+    );
+    assert_eq!(
+        after.data.counter, before.data.counter,
+        "counter must be unchanged"
+    );
+    assert_eq!(
+        after.data.aaguid, before.data.aaguid,
+        "aaguid must be unchanged"
+    );
+    assert!(
+        after.version > version_before,
+        "document version must increment after update"
+    );
+}
+
+/// `update_authenticator_name` on a non-existent authenticator returns `Ok(false)`.
+#[tokio::test]
+async fn test_update_authenticator_name_not_found() {
+    let (store, _audit) = test_db().await;
+    let found = update_authenticator_name(&store, "does-not-exist", "AnyName")
+        .await
+        .expect("query must not error");
+    assert!(!found, "missing authenticator must return false");
+}
+
+// ---- suspend/unsuspend/update_github_installation_repos ----
+
+/// Helper: create a minimal GitHub installation for tests.
+async fn create_test_github_installation(
+    store: &DocumentStore,
+    installation_id: i64,
+    org_id: &str,
+) -> String {
+    create_github_installation(
+        store,
+        &CreateGitHubInstallationParams {
+            org_id,
+            installation_id,
+            github_account_login: "test-account",
+            github_account_type: "Organization",
+            permissions: &std::collections::HashMap::new(),
+            repository_selection: "all",
+            installed_by_user_id: None,
+        },
+    )
+    .await
+    .expect("create_github_installation")
+}
+
+/// After `suspend_github_installation`, only `suspended_at` is set; other fields
+/// are unchanged and the document version increments.
+#[tokio::test]
+async fn test_suspend_github_installation_only_suspended_at_changes() {
+    use crate::db::documents::github::GitHubInstallationDoc;
+
+    let (store, _audit) = test_db().await;
+    let doc_id = create_test_github_installation(&store, 10_001, "org-suspend").await;
+
+    let before = store
+        .get::<GitHubInstallationDoc>(&doc_id)
+        .await
+        .expect("get before")
+        .expect("must exist");
+    assert!(
+        before.data.suspended_at.is_none(),
+        "fresh installation must not be suspended"
+    );
+    let version_before = before.version;
+
+    let found = suspend_github_installation(&store, 10_001)
+        .await
+        .expect("suspend");
+    assert!(found, "suspend must return true");
+
+    let after = store
+        .get::<GitHubInstallationDoc>(&doc_id)
+        .await
+        .expect("get after")
+        .expect("must exist");
+    assert!(
+        after.data.suspended_at.is_some(),
+        "suspended_at must be set after suspend"
+    );
+    assert_eq!(
+        after.data.installation_id, before.data.installation_id,
+        "installation_id must be unchanged"
+    );
+    assert_eq!(
+        after.data.org_id, before.data.org_id,
+        "org_id must be unchanged"
+    );
+    assert!(
+        after.version > version_before,
+        "document version must increment after suspend"
+    );
+}
+
+/// After `unsuspend_github_installation`, `suspended_at` is cleared; version increments.
+#[tokio::test]
+async fn test_unsuspend_github_installation_only_suspended_at_changes() {
+    use crate::db::documents::github::GitHubInstallationDoc;
+
+    let (store, _audit) = test_db().await;
+    let doc_id = create_test_github_installation(&store, 10_002, "org-unsuspend").await;
+
+    // First suspend, then unsuspend.
+    suspend_github_installation(&store, 10_002)
+        .await
+        .expect("suspend");
+
+    let before = store
+        .get::<GitHubInstallationDoc>(&doc_id)
+        .await
+        .expect("get before unsuspend")
+        .expect("must exist");
+    let version_before = before.version;
+
+    let found = unsuspend_github_installation(&store, 10_002)
+        .await
+        .expect("unsuspend");
+    assert!(found, "unsuspend must return true");
+
+    let after = store
+        .get::<GitHubInstallationDoc>(&doc_id)
+        .await
+        .expect("get after unsuspend")
+        .expect("must exist");
+    assert!(
+        after.data.suspended_at.is_none(),
+        "suspended_at must be cleared after unsuspend"
+    );
+    assert_eq!(
+        after.data.installation_id, before.data.installation_id,
+        "installation_id must be unchanged"
+    );
+    assert!(
+        after.version > version_before,
+        "document version must increment after unsuspend"
+    );
+}
+
+/// After `update_github_installation_repos`, only `repositories` changes; version increments.
+#[tokio::test]
+async fn test_update_github_installation_repos_only_repos_change() {
+    use crate::db::documents::github::GitHubInstallationDoc;
+
+    let (store, _audit) = test_db().await;
+    let doc_id = create_test_github_installation(&store, 10_003, "org-repos").await;
+
+    let repos = vec!["owner/repo-a".to_string(), "owner/repo-b".to_string()];
+
+    let before = store
+        .get::<GitHubInstallationDoc>(&doc_id)
+        .await
+        .expect("get before")
+        .expect("must exist");
+    let version_before = before.version;
+
+    let found = update_github_installation_repos(&store, 10_003, &repos)
+        .await
+        .expect("update repos");
+    assert!(found, "update must return true");
+
+    let after = store
+        .get::<GitHubInstallationDoc>(&doc_id)
+        .await
+        .expect("get after")
+        .expect("must exist");
+    assert_eq!(
+        after.data.repositories.as_deref(),
+        Some(repos.as_slice()),
+        "repositories must be updated"
+    );
+    assert_eq!(
+        after.data.suspended_at, before.data.suspended_at,
+        "suspended_at must be unchanged"
+    );
+    assert!(
+        after.version > version_before,
+        "document version must increment after repo update"
+    );
+}
+
+/// Concurrent suspend+unsuspend on the same installation converge without lost updates.
+/// At least one write must win and be reflected in the final state.
+#[tokio::test]
+async fn test_github_installation_concurrent_suspend_unsuspend_no_lost_update() {
+    let (store, _audit) = test_db().await;
+    create_test_github_installation(&store, 20_001, "org-concurrent-suspend").await;
+
+    let store_a = store.clone();
+    let store_b = store.clone();
+    let handles: Vec<_> = [
+        tokio::spawn(async move { suspend_github_installation(&store_a, 20_001).await }),
+        tokio::spawn(async move { unsuspend_github_installation(&store_b, 20_001).await }),
+    ]
+    .into_iter()
+    .collect();
+
+    for h in handles {
+        h.await
+            .expect("task must not panic")
+            .expect("operation must succeed");
+    }
+
+    // The installation must still exist and have version ≥ 2, proving both
+    // writes landed. A blind `store.update` (non-OCC) would also leave the
+    // record present, but the version would be 1 (only one increment) because
+    // the second write would overwrite the first at the original version.
+    use crate::db::documents::github::GitHubInstallationDoc;
+    let doc_after = store
+        .get::<GitHubInstallationDoc>(&{
+            let d = store
+                .find_one::<GitHubInstallationDoc>("installation_id", "20001")
+                .await
+                .expect("find_one")
+                .expect("must exist after concurrent writes");
+            d.id
+        })
+        .await
+        .expect("get after concurrent writes")
+        .expect("installation must still exist after concurrent suspend/unsuspend");
+    assert!(
+        doc_after.version >= 2,
+        "version must be ≥2 after two concurrent writes (OCC must have retried); got version {}",
+        doc_after.version
+    );
+}
+
+/// If an installation is deleted between the index-resolve and the `modify` call
+/// (race with an uninstall webhook), `modify` returns `Ok(false)` rather than
+/// updating a stale document.
+#[tokio::test]
+async fn test_github_installation_deleted_between_resolve_and_modify() {
+    // This test exercises the edge case described in the plan: the resolve step
+    // maps installation_id → doc.id, then the doc is deleted before `modify`
+    // runs. `modify` re-reads by id, finds nothing, and returns Ok(false).
+    let (store, _audit) = test_db().await;
+    create_test_github_installation(&store, 30_001, "org-delete-race").await;
+
+    // Step 1: resolve the doc_id (simulates what suspend_github_installation does).
+    let doc = store
+        .find_one::<crate::db::documents::github::GitHubInstallationDoc>("installation_id", "30001")
+        .await
+        .expect("find_one")
+        .expect("must exist after create");
+    let doc_id = doc.id.clone();
+
+    // Step 2: delete the installation (simulates a concurrent uninstall webhook).
+    delete_github_installation_by_installation_id(&store, 30_001)
+        .await
+        .expect("delete");
+
+    // Step 3: call modify directly on the now-deleted id — must return Ok(false).
+    let found = store
+        .modify::<crate::db::documents::github::GitHubInstallationDoc, _>(&doc_id, |data| {
+            data.suspended_at = Some(jiff::Timestamp::now());
+        })
+        .await
+        .expect("modify must not error");
+    assert!(!found, "modify on deleted doc must return Ok(false)");
+}
+
+// ---- update_scim_group ----
+
+/// After `update_scim_group`, only the updated fields change and version increments.
+#[tokio::test]
+async fn test_update_scim_group_only_intended_fields_change() {
+    use crate::db::documents::scim::ScimGroupDoc;
+
+    let (store, _audit) = test_db().await;
+
+    let group = create_scim_group(&store, TEST_ORG_ID, "OriginalName", Some("ext-123"))
+        .await
+        .expect("create_scim_group");
+
+    let before = store
+        .get::<ScimGroupDoc>(&group.id)
+        .await
+        .expect("get before")
+        .expect("must exist");
+    let version_before = before.version;
+
+    let found = update_scim_group(
+        &store,
+        &group.id,
+        TEST_ORG_ID,
+        Some("UpdatedName"),
+        Some("ext-456"),
+    )
+    .await
+    .expect("update_scim_group");
+    assert!(found, "update must return true");
+
+    let after = store
+        .get::<ScimGroupDoc>(&group.id)
+        .await
+        .expect("get after")
+        .expect("must exist");
+    assert_eq!(after.data.display_name, "UpdatedName", "name must update");
+    assert_eq!(
+        after.data.external_id.as_deref(),
+        Some("ext-456"),
+        "external_id must update"
+    );
+    assert_eq!(
+        after.data.org_id, before.data.org_id,
+        "org_id must be unchanged"
+    );
+    assert!(
+        after.version > version_before,
+        "document version must increment"
+    );
+}
+
+/// `update_scim_group` with a wrong `org_id` returns `Ok(false)` without modifying the doc.
+#[tokio::test]
+async fn test_update_scim_group_wrong_org_returns_false() {
+    let (store, _audit) = test_db().await;
+
+    let group = create_scim_group(&store, TEST_ORG_ID, "GroupToProtect", None)
+        .await
+        .expect("create_scim_group");
+
+    let found = update_scim_group(&store, &group.id, "wrong-org", Some("HackedName"), None)
+        .await
+        .expect("update_scim_group query must not error");
+    assert!(!found, "cross-org update must return false");
+
+    // Original name must be unchanged.
+    let unchanged = get_scim_group(&store, &group.id, TEST_ORG_ID)
+        .await
+        .expect("get_scim_group")
+        .expect("must exist");
+    assert_eq!(
+        unchanged.display_name, "GroupToProtect",
+        "name must be unchanged after cross-org rejection"
+    );
+}
+
+// ---- update_custom_policy ----
+
+/// After `update_custom_policy`, only the updated fields change and version increments.
+#[tokio::test]
+async fn test_update_custom_policy_only_intended_fields_change() {
+    use crate::db::documents::posture_policy::CustomPosturePolicyDoc;
+
+    let (store, _audit) = test_db().await;
+
+    let policy = create_custom_policy(
+        &store,
+        CreateCustomPolicyParams {
+            name: "OriginalPolicy",
+            description: Some("orig desc"),
+            cel_expression: "true",
+            org_id: "org-policy-test",
+        },
+    )
+    .await
+    .expect("create_custom_policy");
+
+    let before = store
+        .get::<CustomPosturePolicyDoc>(&policy.id)
+        .await
+        .expect("get before")
+        .expect("must exist");
+    let version_before = before.version;
+
+    let updated = update_custom_policy(
+        &store,
+        &policy.id,
+        "org-policy-test",
+        UpdateCustomPolicyParams {
+            name: Some("UpdatedPolicy"),
+            description: FieldUpdate::Set("new desc"),
+            cel_expression: Some("false"),
+            active: Some(true),
+        },
+    )
+    .await
+    .expect("update_custom_policy")
+    .expect("must return updated record");
+
+    assert_eq!(updated.name, "UpdatedPolicy", "name must update");
+    assert_eq!(
+        updated.description.as_deref(),
+        Some("new desc"),
+        "description must update"
+    );
+    assert_eq!(
+        updated.cel_expression, "false",
+        "cel_expression must update"
+    );
+    assert!(updated.active, "active must be set to true");
+
+    let after = store
+        .get::<CustomPosturePolicyDoc>(&policy.id)
+        .await
+        .expect("get after")
+        .expect("must exist");
+    assert_eq!(
+        after.data.org_id, before.data.org_id,
+        "org_id must be unchanged"
+    );
+    assert!(
+        after.version > version_before,
+        "document version must increment"
+    );
+}
+
+/// `FieldUpdate::Keep` leaves the description unchanged.
+#[tokio::test]
+async fn test_update_custom_policy_field_update_keep() {
+    let (store, _audit) = test_db().await;
+
+    let policy = create_custom_policy(
+        &store,
+        CreateCustomPolicyParams {
+            name: "KeepDescPolicy",
+            description: Some("original desc"),
+            cel_expression: "true",
+            org_id: "org-keep-test",
+        },
+    )
+    .await
+    .expect("create_custom_policy");
+
+    let updated = update_custom_policy(
+        &store,
+        &policy.id,
+        "org-keep-test",
+        UpdateCustomPolicyParams {
+            name: None,
+            description: FieldUpdate::Keep,
+            cel_expression: None,
+            active: None,
+        },
+    )
+    .await
+    .expect("update_custom_policy")
+    .expect("must return record");
+
+    assert_eq!(
+        updated.description.as_deref(),
+        Some("original desc"),
+        "Keep must leave description unchanged"
+    );
+}
+
+/// `FieldUpdate::Clear` sets the description to None.
+#[tokio::test]
+async fn test_update_custom_policy_field_update_clear() {
+    let (store, _audit) = test_db().await;
+
+    let policy = create_custom_policy(
+        &store,
+        CreateCustomPolicyParams {
+            name: "ClearDescPolicy",
+            description: Some("will be cleared"),
+            cel_expression: "true",
+            org_id: "org-clear-test",
+        },
+    )
+    .await
+    .expect("create_custom_policy");
+
+    let updated = update_custom_policy(
+        &store,
+        &policy.id,
+        "org-clear-test",
+        UpdateCustomPolicyParams {
+            name: None,
+            description: FieldUpdate::Clear,
+            cel_expression: None,
+            active: None,
+        },
+    )
+    .await
+    .expect("update_custom_policy")
+    .expect("must return record");
+
+    assert!(
+        updated.description.is_none(),
+        "Clear must set description to None"
+    );
+}
+
+/// `update_custom_policy` with wrong `org_id` returns `Ok(None)`.
+#[tokio::test]
+async fn test_update_custom_policy_wrong_org_returns_none() {
+    let (store, _audit) = test_db().await;
+
+    let policy = create_custom_policy(
+        &store,
+        CreateCustomPolicyParams {
+            name: "ProtectedPolicy",
+            description: None,
+            cel_expression: "true",
+            org_id: "real-org",
+        },
+    )
+    .await
+    .expect("create_custom_policy");
+
+    let result = update_custom_policy(
+        &store,
+        &policy.id,
+        "wrong-org",
+        UpdateCustomPolicyParams {
+            name: Some("HackedName"),
+            description: FieldUpdate::Keep,
+            cel_expression: None,
+            active: None,
+        },
+    )
+    .await
+    .expect("query must not error");
+    assert!(result.is_none(), "cross-org update must return None");
+
+    let unchanged = get_custom_policy(&store, &policy.id)
+        .await
+        .expect("get_custom_policy")
+        .expect("must exist");
+    assert_eq!(
+        unchanged.name, "ProtectedPolicy",
+        "name must be unchanged after cross-org rejection"
+    );
+}
+
+/// `update_custom_policy` with an id that does not exist returns `None`.
+///
+/// The pre-check at the top of `update_custom_policy` fast-paths to `Ok(None)`
+/// when `store.get` finds no document. This path is distinct from the wrong-org
+/// rejection and needs its own coverage.
+#[tokio::test]
+async fn test_update_custom_policy_not_found_returns_none() {
+    let (store, _audit) = test_db().await;
+
+    let result = update_custom_policy(
+        &store,
+        "does-not-exist",
+        TEST_ORG_ID,
+        UpdateCustomPolicyParams {
+            name: Some("Anything"),
+            description: FieldUpdate::Keep,
+            cel_expression: None,
+            active: None,
+        },
+    )
+    .await
+    .expect("query must not error");
+    assert!(result.is_none(), "absent policy id must return None");
+}
+
+/// `suspend_github_installation` with an `installation_id` that was never
+/// created returns `Ok(false)`.
+#[tokio::test]
+async fn test_suspend_github_installation_not_found_returns_false() {
+    let (store, _audit) = test_db().await;
+
+    let found = suspend_github_installation(&store, 99_001)
+        .await
+        .expect("query must not error");
+    assert!(
+        !found,
+        "missing installation must return false from suspend"
+    );
+}
+
+/// `unsuspend_github_installation` with an `installation_id` that was never
+/// created returns `Ok(false)`.
+#[tokio::test]
+async fn test_unsuspend_github_installation_not_found_returns_false() {
+    let (store, _audit) = test_db().await;
+
+    let found = unsuspend_github_installation(&store, 99_002)
+        .await
+        .expect("query must not error");
+    assert!(
+        !found,
+        "missing installation must return false from unsuspend"
+    );
+}
+
+/// `update_github_installation_repos` with an `installation_id` that was never
+/// created returns `Ok(false)`.
+#[tokio::test]
+async fn test_update_github_installation_repos_not_found_returns_false() {
+    let (store, _audit) = test_db().await;
+
+    let found = update_github_installation_repos(&store, 99_003, &["owner/repo".to_string()])
+        .await
+        .expect("query must not error");
+    assert!(
+        !found,
+        "missing installation must return false from update_repos"
+    );
+}
+
+// ========================================================================
 // Regression tests for DB concurrency fixes (#537, #545, #543)
 // ========================================================================
 

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc6749_token.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc6749_token.rs
@@ -431,3 +431,116 @@ async fn test_rfc6749_token_client_secret_post_succeeds() {
     );
     assert_eq!(json["token_type"].as_str(), Some("Bearer"));
 }
+
+// ========================================================================
+// Token endpoint — client lookup: DB error vs not-found vs inactive
+//
+// A DB error on client lookup must surface as a 500, not as invalid_client.
+// A missing or inactive client must still return invalid_client.
+// ========================================================================
+
+/// A non-existent client_id presented without a secret must return
+/// `invalid_client` — confirms the lookup split did not break the
+/// not-found rejection path.
+#[tokio::test]
+async fn test_token_unknown_client_id_returns_invalid_client() {
+    let (app, _state) = test_app().await;
+
+    let (status, body) = http_post_form(
+        &app,
+        "/oauth/token",
+        "grant_type=authorization_code&client_id=no-such-client&code=any",
+        &[],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "Unknown client_id must return 401/invalid_client, got: {body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(
+        json["error"], "invalid_client",
+        "Unknown client_id must produce invalid_client error, got: {body}"
+    );
+}
+
+/// An inactive (deactivated) client presented without a secret must return
+/// `invalid_client` — same as "not found" from the caller's perspective.
+#[tokio::test]
+async fn test_token_inactive_client_returns_invalid_client() {
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "inactive-client-token@example.com").await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+
+    // Deactivate the client.
+    let oauth_client = db::get_oauth_client_by_client_id(&state.store, &client.client_id)
+        .await
+        .expect("DB must not error")
+        .expect("client must exist");
+    db::set_oauth_client_active(&state.store, &oauth_client.id, false)
+        .await
+        .expect("deactivate client");
+
+    // Present the client_id without a secret (no secret → falls through to the plain client lookup).
+    let (status, body) = http_post_form(
+        &app,
+        "/oauth/token",
+        &format!(
+            "grant_type=authorization_code&client_id={}&code=any",
+            client.client_id
+        ),
+        &[],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "Inactive client must return 401/invalid_client, got: {body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(
+        json["error"], "invalid_client",
+        "Inactive client must produce invalid_client error, got: {body}"
+    );
+}
+
+/// A DB error on client lookup must return 500, not `invalid_client`.
+///
+/// Closing the pool before the request causes the in-flight `find_one` inside
+/// `get_oauth_client_by_client_id` to return an `Err`. The `map_err` block in
+/// the token handler must catch that and return 500 — not collapse it into
+/// `invalid_client` as the old `.ok().flatten()` chain did.
+///
+/// Without this test, reverting `map_err(…ServiceError::Internal…)?` back to
+/// `.ok().flatten()` leaves the two existing not-found/inactive tests green
+/// while the DB-error path goes unguarded.
+#[tokio::test]
+async fn test_token_db_error_on_client_lookup_returns_internal_server_error() {
+    let (app, state) = test_app().await;
+
+    // Close the pool so the next DB call returns Err.
+    state.db.close().await;
+
+    let (status, body) = http_post_form(
+        &app,
+        "/oauth/token",
+        "grant_type=authorization_code&client_id=any-client&code=any",
+        &[],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "DB error must return 500, not invalid_client; got: {body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_ne!(
+        json["error"], "invalid_client",
+        "DB error must not be reported as invalid_client: {body}"
+    );
+}

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7592.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7592.rs
@@ -555,3 +555,151 @@ async fn test_rfc7592_put_rejects_invalid_userinfo_signing_alg() {
         "Invalid userinfo_signed_response_alg (HS256) in PUT must return 400"
     );
 }
+
+// =========================================================================
+// PUT /oauth/register/:client_id — contacts and URI validation
+//
+// The create path (POST /oauth/register) runs validate_contacts_and_uris.
+// The update path (PUT /oauth/register/:client_id) must apply the same
+// rules: non-HTTPS logo_uri and non-@ contacts are rejected at update time,
+// not silently stored.
+// =========================================================================
+
+/// RFC 7592 PUT with an invalid `logo_uri` (HTTP, not HTTPS) must be rejected
+/// with 400 `invalid_client_metadata`, matching the create-path behaviour.
+#[tokio::test]
+async fn test_rfc7592_put_rejects_invalid_logo_uri() {
+    let (app, _state) = test_app().await;
+    let (client_id, token) = register_dynamic_client(&app).await;
+
+    let update_body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "logo_uri": "http://insecure.example.com/logo.png"
+    });
+
+    let (status, body) = http_request(
+        &app,
+        "PUT",
+        &format!("/oauth/register/{client_id}"),
+        Some(update_body.to_string()),
+        &[
+            ("Authorization", &format!("Bearer {token}")),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "Non-HTTPS logo_uri in PUT must return 400, got: {body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(
+        json["error"], "invalid_client_metadata",
+        "logo_uri rejection must use invalid_client_metadata: {body}"
+    );
+}
+
+/// RFC 7592 PUT with a contact that lacks an `@` sign must be rejected with
+/// 400 `invalid_client_metadata`, matching the create-path behaviour.
+#[tokio::test]
+async fn test_rfc7592_put_rejects_invalid_contact() {
+    let (app, _state) = test_app().await;
+    let (client_id, token) = register_dynamic_client(&app).await;
+
+    let update_body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "contacts": ["not-an-email-address"]
+    });
+
+    let (status, body) = http_request(
+        &app,
+        "PUT",
+        &format!("/oauth/register/{client_id}"),
+        Some(update_body.to_string()),
+        &[
+            ("Authorization", &format!("Bearer {token}")),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "Contact without @ in PUT must return 400, got: {body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(
+        json["error"], "invalid_client_metadata",
+        "contact rejection must use invalid_client_metadata: {body}"
+    );
+}
+
+/// RFC 7592 PUT with a valid `logo_uri` (HTTPS) must succeed.
+/// Confirms the validation is not over-restrictive.
+#[tokio::test]
+async fn test_rfc7592_put_accepts_valid_logo_uri() {
+    let (app, _state) = test_app().await;
+    let (client_id, token) = register_dynamic_client(&app).await;
+
+    let update_body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "logo_uri": "https://example.com/logo.png"
+    });
+
+    let (status, body) = http_request(
+        &app,
+        "PUT",
+        &format!("/oauth/register/{client_id}"),
+        Some(update_body.to_string()),
+        &[
+            ("Authorization", &format!("Bearer {token}")),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "Valid HTTPS logo_uri in PUT must succeed: {body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(
+        json["logo_uri"].as_str(),
+        Some("https://example.com/logo.png"),
+        "logo_uri must be echoed back in PUT response"
+    );
+}
+
+/// RFC 7592 PUT with valid contacts must succeed.
+#[tokio::test]
+async fn test_rfc7592_put_accepts_valid_contacts() {
+    let (app, _state) = test_app().await;
+    let (client_id, token) = register_dynamic_client(&app).await;
+
+    let update_body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "contacts": ["admin@example.com"]
+    });
+
+    let (status, body) = http_request(
+        &app,
+        "PUT",
+        &format!("/oauth/register/{client_id}"),
+        Some(update_body.to_string()),
+        &[
+            ("Authorization", &format!("Bearer {token}")),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "Valid contact in PUT must succeed: {body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let contacts = json["contacts"].as_array().expect("contacts must be array");
+    assert_eq!(contacts.len(), 1, "PUT response must echo the contact list");
+    assert_eq!(contacts[0].as_str(), Some("admin@example.com"));
+}

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -484,22 +484,33 @@ async fn resolve_non_jwt_auth(
     // `Some`, we already loaded the client; otherwise look it up.
     let client = match secret_auth_outcome {
         Some(auth_client) => auth_client.client,
-        None => match crate::db::get_oauth_client_by_client_id(&state.store, &c.client_id)
-            .await
-            .ok()
-            .flatten()
-            .filter(|oc| oc.active)
-        {
-            Some(client) => client,
-            None => {
-                return Err(ServiceError::oauth(
-                    OAuthErrorCode::InvalidClient,
-                    "Unknown client_id",
-                )
-                .into_oauth_response()
-                .into_response());
+        None => {
+            // Fail closed: a DB error is a transient failure (→ 500), not a
+            // missing client (→ invalid_client). Collapsing DB-Err + None +
+            // inactive into one `invalid_client` masked connectivity problems.
+            let db_result = crate::db::get_oauth_client_by_client_id(&state.store, &c.client_id)
+                .await
+                .map_err(|e| {
+                    tracing::error!(
+                        client_id = %c.client_id,
+                        "DB error looking up OAuth client: {e}"
+                    );
+                    ServiceError::Internal("Database error".to_string())
+                        .into_oauth_response()
+                        .into_response()
+                })?;
+            match db_result.filter(|oc| oc.active) {
+                Some(client) => client,
+                None => {
+                    return Err(ServiceError::oauth(
+                        OAuthErrorCode::InvalidClient,
+                        "Unknown client_id",
+                    )
+                    .into_oauth_response()
+                    .into_response());
+                }
             }
-        },
+        }
     };
     let is_mtls_registered = matches!(
         client.token_endpoint_auth_method,

--- a/crates/vouch-server/src/services/oidc/registration.rs
+++ b/crates/vouch-server/src/services/oidc/registration.rs
@@ -1124,6 +1124,11 @@ pub async fn update_client_configuration(
     // Validate request_uris (same rules as initial registration).
     let validated_request_uris = validate_request_uris(mutable_request.request_uris.as_deref())?;
 
+    // Validate contacts and URI fields (same rules as initial registration via
+    // register_client). Previously absent from the update path — RFC 7592
+    // clients could smuggle an invalid logo_uri or non-@ contact on PUT.
+    validate_contacts_and_uris(&mutable_request)?;
+
     // Rotate the registration access token per RFC 7592 Section 2.2
     let new_reg_token = generate_registration_token()?;
     let new_reg_token_hash = hash_token(&new_reg_token);


### PR DESCRIPTION
Part 2 of #551 — the sweep of recurring anti-patterns found alongside the concurrency work in #553. Independent of #557 (Part 1); the two share only `registration.rs`, in different functions.

## Lost-update races → optimistic `store.modify()`
Several update paths did a blind `get()` + `update()`, which overwrites the whole document and silently loses a concurrent write. Converted to `store.modify()` (read-modify-write under the version guard), each closure touching only the fields it changes:
- `db/github.rs` — `suspend_github_installation`, `unsuspend_github_installation`, `update_github_installation_repos` (webhook-driven, genuinely concurrent), via a shared `resolve_installation_doc_id` helper.
- `db/scim.rs` — `update_scim_group` (org-scope check kept inside the closure).
- `db/posture_policies.rs` — `update_custom_policy` (3-way field merge kept inside the closure).
- `db/authenticators.rs` — `update_authenticator_name`.

`update_github_installation_repos_delta` keeps a documented non-atomic gap: its read-merge stays outside the closure. It was equally non-atomic before this change, and GitHub delivers per-installation webhooks sequentially, so the merge is deferred with an explanatory comment rather than restructured here.

## Token-endpoint client lookup no longer masks DB errors
`get_oauth_client_by_client_id(...).ok().flatten().filter(|oc| oc.active)` collapsed a database error, a missing client, and an inactive client into one `invalid_client`. A transient lookup failure now returns 500; a genuine unknown or inactive client still returns `invalid_client` (fail closed). Same shape as the earlier #540 fix.

## RFC 7592 client-update validation parity
`update_client_configuration` (PUT) now runs `validate_contacts_and_uris` before persistence, matching what initial dynamic registration already enforces.

## Tests
24 new tests: only-intended-fields-change (mutation-killing), concurrent suspend/unsuspend with a `version >= 2` assertion, the not-found fast-paths, a DB-error-returns-500 test (closes the pool to force the error), and RFC 7592 PUT rejection of invalid `logo_uri` / contacts. `make fmt` / `make lint` clean; full suite 2367 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrent DB writes on webhook/SCIM/OIDC paths and token-endpoint error semantics; behavior is safer but regressions could affect auth client errors or multi-writer document updates.
> 
> **Overview**
> Replaces blind **`get` + `update`** paths with **`store.modify`** (optimistic concurrency) so concurrent writes only touch the fields they intend: authenticator rename, GitHub installation suspend/unsuspend/repo list (via **`resolve_installation_doc_id`**), SCIM group updates, and custom posture policy PATCH-style merges. Org-scope checks for SCIM groups and posture policies (and **`applied` flag resets on OCC retries** for SCIM user/group flows) run inside the modify closure so cross-org races cannot win a version bump.
> 
> **`update_github_installation_repos_delta`** still documents a non-atomic read-merge outside **`modify`**; behavior is unchanged and left deferred.
> 
> The OAuth **token** handler no longer treats DB lookup failures as **`invalid_client`**: transient errors return **500**; unknown or inactive clients still fail closed with **`invalid_client`**.
> 
> **RFC 7592 PUT** client updates now call **`validate_contacts_and_uris`**, matching POST registration (HTTPS URIs, contact shape).
> 
> Adds broad integration tests for OCC behavior, not-found paths, token client lookup error semantics, and RFC 7592 PUT validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 797a6bdb366f1a43f3934540c6df355dccb58cb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->