### PR TITLE
feat(ui): localize timestamp display in applications and admin UI

### DIFF
--- a/crates/vouch-server/src/db/audit.rs
+++ b/crates/vouch-server/src/db/audit.rs
@@ -7,7 +7,8 @@
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+use jiff::Timestamp;
 use sea_query::{Expr, ExprTrait, Iden, Order, Query};
 
 use super::pool::Pool;
@@ -64,8 +65,8 @@ pub struct AuditEvent {
     pub email_hmac: Option<String>,
     /// JSON event data.
     pub data: String,
-    /// ISO 8601 creation timestamp.
-    pub created_at: String,
+    /// Creation timestamp (parsed from the stored RFC 3339 string).
+    pub created_at: Timestamp,
 }
 
 /// Filter criteria for querying audit events.
@@ -214,7 +215,7 @@ impl AuditStore {
 
         let mut events = Vec::with_capacity(rows.len());
         for row in rows {
-            events.push(raw_to_audit_event(row));
+            events.push(raw_to_audit_event(row)?);
         }
         Ok(events)
     }
@@ -288,16 +289,20 @@ fn extract_domain(email: &str) -> Option<String> {
 }
 
 /// Convert a raw row to an `AuditEvent`.
-fn raw_to_audit_event(row: RawAuditRow) -> AuditEvent {
-    AuditEvent {
+fn raw_to_audit_event(row: RawAuditRow) -> Result<AuditEvent> {
+    let created_at: Timestamp = row
+        .created_at
+        .parse()
+        .context("failed to parse audit event created_at timestamp")?;
+    Ok(AuditEvent {
         id: row.id,
         event_type: row.event_type,
         user_id: row.user_id,
         email_domain: row.email_domain,
         email_hmac: row.email_hmac,
         data: row.data,
-        created_at: row.created_at,
-    }
+        created_at,
+    })
 }
 
 // ============================================================================

--- a/crates/vouch-server/src/filters.rs
+++ b/crates/vouch-server/src/filters.rs
@@ -4,8 +4,12 @@
 //! To use these filters in a template, add `use crate::filters;` to the
 //! module that defines the template struct.
 
-/// Format a `jiff::Timestamp` as "Mar 1, 2026" (English, UTC).
+/// Format a `jiff::Timestamp` as "Mar 1, 2026, 17:43 UTC" (24-hour, UTC).
+///
+/// Used as the no-JS fallback inside `<time data-localize-time>` elements;
+/// client-side JS (`static/js/common.js`) upgrades it to the viewer's locale
+/// and timezone. The `UTC` label keeps the server-rendered time unambiguous.
 #[askama::filter_fn]
-pub fn humandate(ts: &jiff::Timestamp, _env: &dyn askama::Values) -> askama::Result<String> {
-    Ok(ts.strftime("%b %-d, %Y").to_string())
+pub fn humandatetime(ts: &jiff::Timestamp, _env: &dyn askama::Values) -> askama::Result<String> {
+    Ok(ts.strftime("%b %-d, %Y, %H:%M UTC").to_string())
 }

--- a/crates/vouch-server/src/handlers/admin/audit.rs
+++ b/crates/vouch-server/src/handlers/admin/audit.rs
@@ -14,7 +14,7 @@ use jiff::Timestamp;
 use serde::Deserialize;
 use std::sync::Arc;
 
-use super::format_timestamp;
+use crate::filters;
 use crate::handlers::session::{AuthContext, get_resource_auth_context};
 
 /// Page size for the audit log.
@@ -47,7 +47,9 @@ pub(crate) struct AuditRow {
     pub event_type: String,
     pub email_domain: Option<String>,
     pub data: String,
-    pub created_at: String,
+    /// Event timestamp, rendered client-side in the viewer's locale and
+    /// timezone (`humandatetime` is the no-JS fallback).
+    pub created_at: Timestamp,
     /// Pre-formatted IP cell text, e.g. "🇺🇸 8.8.8.8" or "-".
     pub ip_display: String,
     /// Tooltip for the IP cell with country code and ASN.
@@ -129,16 +131,12 @@ pub(crate) async fn admin_audit_page(
         .iter()
         .map(|e| {
             let geo = GeoFields::from_json(&e.data);
-            let created_at = e
-                .created_at
-                .parse::<Timestamp>()
-                .map_or_else(|_| e.created_at.clone(), |ts| format_timestamp(&ts));
             AuditRow {
                 id: e.id.clone(),
                 event_type: e.event_type.clone(),
                 email_domain: e.email_domain.clone(),
                 data: e.data.clone(),
-                created_at,
+                created_at: e.created_at,
                 ip_display: geo.ip_display(),
                 ip_title: geo.ip_title(),
             }

--- a/crates/vouch-server/src/handlers/admin/domains.rs
+++ b/crates/vouch-server/src/handlers/admin/domains.rs
@@ -7,6 +7,7 @@
 
 use crate::AppState;
 use crate::db;
+use crate::filters;
 use crate::handlers::admin::flash;
 use crate::handlers::browser_login::validate_origin;
 use crate::handlers::session::{AuthContext, extract_org_admin, get_resource_auth_context};
@@ -18,6 +19,7 @@ use axum::extract::{OriginalUri, Path, State};
 use axum::http::{HeaderMap, Method};
 use axum::response::{IntoResponse, Redirect, Response};
 use axum_extra::extract::cookie::CookieJar;
+use jiff::Timestamp;
 use serde::Deserialize;
 use std::sync::Arc;
 
@@ -46,7 +48,10 @@ pub(crate) struct DomainRow {
     pub unicode: Option<String>,
     pub status: DomainRowStatus,
     pub verification_token: Option<String>,
-    pub added_at: Option<String>,
+    /// When the domain was added — `org.created_at` for the primary domain,
+    /// `ad.added_at` for additional domains. Rendered client-side in the
+    /// viewer's locale and timezone (`humandatetime` is the no-JS fallback).
+    pub added_at: Timestamp,
     /// Email of the admin who added this domain. `None` for the primary
     /// (provisioned at org creation).
     pub added_by: Option<String>,
@@ -96,7 +101,7 @@ fn build_rows(org: &db::Organization) -> Vec<DomainRow> {
         unicode: db::unicode_form(&org.domain),
         status: DomainRowStatus::Primary,
         verification_token: None,
-        added_at: None,
+        added_at: org.created_at,
         added_by: None,
     });
     for ad in &org.additional_domains {
@@ -117,7 +122,7 @@ fn build_rows(org: &db::Organization) -> Vec<DomainRow> {
             unicode: db::unicode_form(&ad.domain),
             status,
             verification_token,
-            added_at: Some(ad.added_at.strftime("%Y-%m-%d %H:%M UTC").to_string()),
+            added_at: ad.added_at,
             added_by: Some(ad.added_by_email.clone()),
         });
     }

--- a/crates/vouch-server/src/handlers/admin/mod.rs
+++ b/crates/vouch-server/src/handlers/admin/mod.rs
@@ -88,11 +88,6 @@ pub(crate) fn compute_token_expiry(days: i64) -> Result<Timestamp, ServiceError>
     })
 }
 
-/// Format a `jiff::Timestamp` as a date string for display.
-pub(crate) fn format_timestamp(ts: &Timestamp) -> String {
-    ts.strftime("%Y-%m-%d %H:%M UTC").to_string()
-}
-
 /// Helper: extract org admin from cookie, verify target is in same org.
 pub(crate) async fn extract_admin_and_target(
     state: &AppState,

--- a/crates/vouch-server/src/handlers/admin/scim_tokens.rs
+++ b/crates/vouch-server/src/handlers/admin/scim_tokens.rs
@@ -17,7 +17,8 @@ use secrecy::ExposeSecret;
 use serde::Deserialize;
 use std::sync::Arc;
 
-use super::{MAX_SCIM_TOKENS, compute_token_expiry, format_timestamp, generate_scim_token};
+use super::{MAX_SCIM_TOKENS, compute_token_expiry, generate_scim_token};
+use crate::filters;
 use crate::handlers::browser_login::validate_origin;
 use crate::handlers::session::{AuthContext, extract_org_admin, get_resource_auth_context};
 use crate::handlers::{ValidPath, ValidUuid};
@@ -236,12 +237,16 @@ pub(crate) async fn delete_scim_token(
 // ============================================================================
 
 /// Display row for SCIM tokens in the template.
+///
+/// Timestamps are passed through as `jiff::Timestamp` and rendered client-side
+/// in the viewer's locale and timezone (see `static/js/common.js`), with the
+/// `humandatetime` filter as the no-JS fallback.
 pub(crate) struct ScimTokenRow {
     pub id: String,
     pub description: Option<String>,
-    pub created_at: String,
-    pub last_used_at: Option<String>,
-    pub expires_at: Option<String>,
+    pub created_at: Timestamp,
+    pub last_used_at: Option<Timestamp>,
+    pub expires_at: Option<Timestamp>,
 }
 
 /// SCIM tokens page template.
@@ -309,9 +314,9 @@ pub(crate) async fn admin_scim_tokens_page(
         .map(|t| ScimTokenRow {
             id: t.id,
             description: t.description,
-            created_at: format_timestamp(&t.created_at),
-            last_used_at: t.last_used_at.as_ref().map(format_timestamp),
-            expires_at: t.expires_at.as_ref().map(format_timestamp),
+            created_at: t.created_at,
+            last_used_at: t.last_used_at,
+            expires_at: t.expires_at,
         })
         .collect();
 
@@ -424,9 +429,9 @@ pub(crate) async fn admin_create_scim_token(
         .map(|t| ScimTokenRow {
             id: t.id,
             description: t.description,
-            created_at: format_timestamp(&t.created_at),
-            last_used_at: t.last_used_at.as_ref().map(format_timestamp),
-            expires_at: t.expires_at.as_ref().map(format_timestamp),
+            created_at: t.created_at,
+            last_used_at: t.last_used_at,
+            expires_at: t.expires_at,
         })
         .collect();
 

--- a/crates/vouch-server/static/js/common.js
+++ b/crates/vouch-server/static/js/common.js
@@ -2,7 +2,38 @@
 // Attach behavior via data-* attributes — no inline handlers needed.
 
 (function() {
+    // Render <time data-localize-time> elements in the viewer's locale and
+    // local timezone. The server emits the full UTC instant in the datetime
+    // attribute plus a no-JS fallback in the element body; here we upgrade it.
+    function localizeTimes() {
+        if (!('DateTimeFormat' in Intl)) return;
+        var locale = document.documentElement.lang || undefined;
+        // Explicit components (not dateStyle/timeStyle, which can't carry
+        // timeZoneName) so the rendered time always names its timezone —
+        // a bare "13:43" is ambiguous without it. hour12:false forces 24-hour
+        // time regardless of the locale's default convention.
+        var fmt = new Intl.DateTimeFormat(locale, {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+            hour12: false,
+            timeZoneName: 'short'
+        });
+        var els = document.querySelectorAll('time[data-localize-time]');
+        for (var i = 0; i < els.length; i++) {
+            var iso = els[i].getAttribute('datetime');
+            if (!iso) continue;
+            var date = new Date(iso);
+            if (isNaN(date.getTime())) continue;
+            els[i].textContent = fmt.format(date);
+        }
+    }
+
     document.addEventListener('DOMContentLoaded', function() {
+        localizeTimes();
+
         // Copy to clipboard: any element with data-copy-text
         document.addEventListener('click', function(event) {
             var btn = event.target.closest('[data-copy-text]');

--- a/crates/vouch-server/templates/admin/audit.html
+++ b/crates/vouch-server/templates/admin/audit.html
@@ -50,7 +50,7 @@
                 <tbody>
                     {% for event in events %}
                     <tr class="border-b border-vouch-border last:border-b-0">
-                        <td class="px-4 py-3 text-gray-400 whitespace-nowrap">{{ event.created_at }}</td>
+                        <td class="px-4 py-3 text-gray-400 whitespace-nowrap"><time datetime="{{ event.created_at }}" data-localize-time>{{ event.created_at|humandatetime }}</time></td>
                         <td class="px-4 py-3 text-gray-400 whitespace-nowrap text-xs font-mono" title="{{ event.ip_title }}">{{ event.ip_display }}</td>
                         <td class="px-4 py-3">
                             <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium
@@ -88,4 +88,8 @@
         {% endif %}
     </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script src="/static/js/common.js"></script>
 {% endblock %}

--- a/crates/vouch-server/templates/admin/domains.html
+++ b/crates/vouch-server/templates/admin/domains.html
@@ -87,7 +87,7 @@
                             <span class="px-2 py-0.5 rounded bg-yellow-900/40 text-yellow-300 text-xs">{{ self.tr("admin-domains-status-pending") }}</span>
                             {% endmatch %}
                         </td>
-                        <td class="px-4 py-3 text-gray-400 whitespace-nowrap">{{ row.added_at.as_deref().unwrap_or("—") }}</td>
+                        <td class="px-4 py-3 text-gray-400 whitespace-nowrap"><time datetime="{{ row.added_at }}" data-localize-time>{{ row.added_at|humandatetime }}</time></td>
                         <td class="px-4 py-3 text-gray-400 whitespace-nowrap">{{ row.added_by.as_deref().unwrap_or("—") }}</td>
                         <td class="px-4 py-3 text-right whitespace-nowrap">
                             {% match row.status %}

--- a/crates/vouch-server/templates/admin/scim_tokens.html
+++ b/crates/vouch-server/templates/admin/scim_tokens.html
@@ -81,9 +81,9 @@
                     {% for token in tokens %}
                     <tr class="border-b border-vouch-border last:border-b-0">
                         <td class="px-4 py-3 text-gray-200 max-w-xs truncate" title="{{ token.description.as_deref().unwrap_or("") }}">{{ token.description.as_deref().unwrap_or("—") }}</td>
-                        <td class="px-4 py-3 text-gray-400 whitespace-nowrap">{{ token.created_at }}</td>
-                        <td class="px-4 py-3 text-gray-400 whitespace-nowrap">{% match token.last_used_at %}{% when Some with (v) %}{{ v }}{% when None %}{{ self.tr("apps-list-never") }}{% endmatch %}</td>
-                        <td class="px-4 py-3 text-gray-400 whitespace-nowrap">{% match token.expires_at %}{% when Some with (v) %}{{ v }}{% when None %}{{ self.tr("apps-list-never") }}{% endmatch %}</td>
+                        <td class="px-4 py-3 text-gray-400 whitespace-nowrap"><time datetime="{{ token.created_at }}" data-localize-time>{{ token.created_at|humandatetime }}</time></td>
+                        <td class="px-4 py-3 text-gray-400 whitespace-nowrap">{% match token.last_used_at %}{% when Some with (v) %}<time datetime="{{ v }}" data-localize-time>{{ v|humandatetime }}</time>{% when None %}{{ self.tr("apps-list-never") }}{% endmatch %}</td>
+                        <td class="px-4 py-3 text-gray-400 whitespace-nowrap">{% match token.expires_at %}{% when Some with (v) %}<time datetime="{{ v }}" data-localize-time>{{ v|humandatetime }}</time>{% when None %}{{ self.tr("apps-list-never") }}{% endmatch %}</td>
                         <td class="px-4 py-3 text-right">
                             <form method="POST" action="/admin/scim-tokens/{{ token.id }}/revoke" data-confirm-message="{{ self.tr("admin-scim-revoke-confirm") }}">
                                 <button type="submit" class="px-2 py-1 text-xs rounded bg-red-900/40 text-red-400 hover:bg-red-900/60">{{ self.tr("apps-detail-revoke") }}</button>
@@ -108,5 +108,6 @@
 {% endblock %}
 
 {% block scripts %}
+<script src="/static/js/common.js"></script>
 <script src="/static/js/admin.js"></script>
 {% endblock %}

--- a/crates/vouch-server/templates/applications/detail.html
+++ b/crates/vouch-server/templates/applications/detail.html
@@ -103,10 +103,10 @@
                 {% endmatch %}
 
                 <dt class="text-gray-400">{{ self.tr("apps-detail-created") }}</dt>
-                <dd class="text-gray-200">{{ app.created_at|humandate }}</dd>
+                <dd class="text-gray-200"><time datetime="{{ app.created_at }}" data-localize-time>{{ app.created_at|humandatetime }}</time></dd>
 
                 <dt class="text-gray-400">{{ self.tr("apps-list-th-last-used") }}</dt>
-                <dd class="text-gray-200">{% match app.last_used_at %}{% when Some with (date) %}{{ date|humandate }}{% when None %}{{ self.tr("apps-list-never") }}{% endmatch %}</dd>
+                <dd class="text-gray-200">{% match app.last_used_at %}{% when Some with (date) %}<time datetime="{{ date }}" data-localize-time>{{ date|humandatetime }}</time>{% when None %}{{ self.tr("apps-list-never") }}{% endmatch %}</dd>
             </dl>
 
             <!-- JWKS / JWKS URI (for FAPI clients) -->
@@ -189,7 +189,7 @@
                             {% else %}
                             <span class="ml-2 px-1.5 inline-flex text-xs leading-5 font-semibold rounded bg-vouch-error-bg text-vouch-error">{{ self.tr("apps-detail-secret-revoked") }}</span>
                             {% endif %}
-                            <span class="ml-2 text-xs text-gray-500">{{ self.tr("apps-detail-created") }} {{ secret.created_at|humandate }}</span>
+                            <span class="ml-2 text-xs text-gray-500">{{ self.tr("apps-detail-created") }} <time datetime="{{ secret.created_at }}" data-localize-time>{{ secret.created_at|humandatetime }}</time></span>
                         </div>
                         {% if secret.active && secrets_count > 1 %}
                         <form action="/applications/{{ app.id }}/secrets/{{ secret.id }}/delete" method="POST">

--- a/crates/vouch-server/templates/applications/list.html
+++ b/crates/vouch-server/templates/applications/list.html
@@ -99,7 +99,7 @@
                     </td>
                     <td class="px-3 py-4 whitespace-nowrap text-sm text-gray-500">
                         {% match app.last_used_at %}
-                            {% when Some with (date) %}{{ date }}{% when None %}{{ self.tr("apps-list-never") }}{% endmatch %}
+                            {% when Some with (date) %}<time datetime="{{ date }}" data-localize-time>{{ date|humandatetime }}</time>{% when None %}{{ self.tr("apps-list-never") }}{% endmatch %}
                     </td>
                     <td class="px-4 py-4 whitespace-nowrap text-right">
                         <div class="flex items-center justify-end gap-3">


### PR DESCRIPTION
## What

Timestamps in the web UI were shown as raw ISO strings (e.g. `2026-06-22T15:04:29.257530261Z`) or fixed UTC strings (e.g. `2026-06-22 17:43 UTC`). This renders them in the viewer's locale, local timezone, and 24-hour time instead.

The server emits a `<time datetime="…Z" data-localize-time>` element carrying the absolute UTC instant, plus a no-JS fallback in the element text. `static/js/common.js` upgrades the text on load using `Intl.DateTimeFormat`, keyed off `<html lang>` so the date language tracks the page locale. Because conversion happens in the browser, timestamps follow the laptop's configured timezone as the user travels (updated on page load); the server stays entirely in UTC.

| Path | Renders |
|------|---------|
| No-JS fallback (server) | `Jun 22, 2026, 17:43 UTC` |
| JS (normal) | `Jun 22, 2026, 13:43 EDT` (locale + local zone + 24h) |

## Changes

- Apply the shared `<time data-localize-time>` pattern to the applications list/detail pages and the admin SCIM tokens, audit log, and domains pages. Load `common.js` on the admin SCIM-tokens and audit pages (audit had no scripts block before).
- Replace the date-only `humandate` filter with `humandatetime` (date + 24-hour time + `UTC` label) and remove the now-unused admin `format_timestamp` helper.
- Use `org.created_at` for the domains primary-domain row instead of a `—` placeholder; `DomainRow.added_at` becomes non-optional.
- Make `AuditEvent.created_at` a `jiff::Timestamp` (parsed at the row-mapping boundary like the document store) instead of a `String`, removing the per-row raw fallback. The `created_at` column stays `TEXT`; only the Rust type changes. A genuinely unparseable value now fails the query (logged → 500) rather than rendering raw, matching how the document store treats a corrupt timestamp.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test -p vouch-server` — 2376 passed
- `make fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-layer and timestamp typing changes only; audit log may 500 on corrupt `created_at` instead of degrading to raw text.
> 
> **Overview**
> **Timestamps** across applications and admin pages now use a shared **`<time datetime="…" data-localize-time>`** pattern: the server keeps UTC in `datetime`, shows a **`humandatetime`** no-JS fallback (`Jun 22, 2026, 17:43 UTC`), and **`common.js`** rewrites visible text with **`Intl.DateTimeFormat`** (page `lang`, viewer timezone, 24-hour + short zone name).
> 
> Handlers stop pre-formatting times as strings: **`format_timestamp`** is removed; audit, SCIM token, and domain rows pass **`jiff::Timestamp`** into templates. **`AuditEvent.created_at`** is parsed to **`Timestamp`** at row mapping (bad DB values fail the query → 500 instead of showing raw strings). The domains primary row shows **`org.created_at`** instead of `—`; **`added_at`** is always set.
> 
> **`humandate`** is replaced by **`humandatetime`**. Admin audit and SCIM pages load **`common.js`** where it was missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44eb7634e93996da4127db3b40d167be13a4ff7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->