### PR TITLE
feat(server): OpenID Connect RP-Initiated Logout 1.0

### DIFF
--- a/crates/vouch-server/i18n/en-US/vouch-server.ftl
+++ b/crates/vouch-server/i18n/en-US/vouch-server.ftl
@@ -143,6 +143,8 @@ apps-create-redirect-label = Redirect URIs
 apps-create-redirect-help = { -one-uri-per-line } Where users are redirected after authentication.
 apps-create-resource-label = Resource URIs (optional)
 apps-create-resource-help = { -one-uri-per-line } Target resource servers that will receive access tokens (RFC 8707). Leave empty to allow any resource.
+apps-create-postlogout-label = Post-Logout Redirect URIs (optional)
+apps-create-postlogout-help = { -one-uri-per-line } Where users are redirected after signing out (RP-Initiated Logout 1.0). Must be https:// or loopback http://, no fragment.
 apps-create-secprofile-label = Security Profile
 apps-create-secprofile-standard = Standard { -oauth }
 apps-create-secprofile-standard-desc = Standard { -oauth } with client secret authentication.
@@ -462,6 +464,7 @@ appcreate-js-jwks-json = { -jwks } must be valid JSON.
 appcreate-js-jwksuri-https = { -jwks } URI must use https://.
 appcreate-js-jwksuri-invalid = { -jwks } URI must be a valid https:// URL.
 appcreate-js-fapi-required = { -fapi } requires either a { -jwks } or { -jwks } URI.
+appcreate-js-postlogout-invalid = Invalid post-logout redirect URI(s): { $uris }. Each must be a valid https:// or loopback http:// URL without a fragment.
 
 ## Authenticated header navigation (macros/auth.html)
 nav-keys = Keys
@@ -638,3 +641,15 @@ footer-terms = Terms
 footer-status = Status
 footer-version = v{ $version }
 footer-copyright = Copyright { $year }
+
+## RP-Initiated Logout 1.0 — confirmation page (logout_confirm.html)
+logout-confirm-title = { -product } - Sign Out
+logout-confirm-heading = Sign out?
+logout-confirm-body = You are about to sign out of { -product }.
+logout-confirm-btn = Sign Out
+logout-confirm-cancel = Cancel
+
+## RP-Initiated Logout 1.0 — done page (logout_done.html)
+logout-done-title = { -product } - Signed Out
+logout-done-heading = You have been signed out.
+logout-done-body = Your session has ended. Close this tab or return to the application.

--- a/crates/vouch-server/src/db/config.rs
+++ b/crates/vouch-server/src/db/config.rs
@@ -64,6 +64,11 @@ pub struct AuthEventParams {
     pub client_version: Option<String>,
     pub success: bool,
     pub failure_reason: Option<String>,
+    /// OAuth client ID of the RP that initiated logout, when applicable.
+    /// Included in the `data` JSON blob so RP-initiated logouts are
+    /// distinguishable from user-initiated ones without a schema migration.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub client_id: Option<String>,
 }
 
 impl AuthEventParams {
@@ -220,6 +225,39 @@ mod tests {
         assert_eq!(params.client_os, None);
         assert_eq!(params.client_arch, None);
         assert_eq!(params.client_version, None);
+    }
+
+    #[test]
+    fn test_audit_data_includes_client_id_when_set() {
+        let params = AuthEventParams {
+            user_id: "u1".into(),
+            event_type: AuthEventType::Logout,
+            success: true,
+            client_id: Some("my-rp-client".to_string()),
+            ..AuthEventParams::default()
+        };
+        let value = serde_json::to_value(&params).unwrap();
+        assert_eq!(
+            value.get("client_id").and_then(|v| v.as_str()),
+            Some("my-rp-client"),
+            "audit data must include client_id when set"
+        );
+    }
+
+    #[test]
+    fn test_audit_data_omits_client_id_when_none() {
+        let params = AuthEventParams {
+            user_id: "u1".into(),
+            event_type: AuthEventType::LoginSuccess,
+            success: true,
+            client_id: None,
+            ..AuthEventParams::default()
+        };
+        let value = serde_json::to_value(&params).unwrap();
+        assert!(
+            value.get("client_id").is_none(),
+            "audit data must omit client_id when None"
+        );
     }
 
     #[tokio::test]

--- a/crates/vouch-server/src/db/documents/oauth.rs
+++ b/crates/vouch-server/src/db/documents/oauth.rs
@@ -434,6 +434,13 @@ pub struct OAuthClientDoc {
     /// When `None`, any HTTPS `request_uri` is accepted (no allowlist enforced).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub request_uris: Option<Vec<String>>,
+    /// RP-Initiated Logout 1.0 Section 2: Registered post-logout redirect URIs.
+    ///
+    /// When `Some`, only the listed URIs are accepted as `post_logout_redirect_uri`
+    /// values in the end-session request. Absent field (legacy records) deserializes
+    /// to `None` — no migration needed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub post_logout_redirect_uris: Option<Vec<String>>,
 }
 
 impl DocumentType for OAuthClientDoc {

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -125,12 +125,13 @@ pub use documents::oauth::{
 // Re-export OAuth domain types and functions
 pub(crate) use oauth::JwtAssertionJtiClaim;
 pub use oauth::{
-    CreateOAuthClientParams, MAX_ACTIVE_SECRETS, OAuthClient, OAuthClientSecret, OAuthEventType,
-    OAuthUsageStats, UpdateClientRegistrationParams, UpdateOAuthClientParams, create_oauth_client,
-    create_oauth_client_secret, delete_expired_jwt_assertion_jtis, delete_oauth_client,
-    delete_old_oauth_usage_events, get_oauth_client_by_client_id, get_oauth_client_by_id,
-    get_oauth_client_secret_by_id, get_oauth_client_secrets, get_oauth_clients_for_user,
-    get_oauth_secret_by_hash, get_oauth_usage_stats, record_oauth_event,
+    CreateOAuthClientParams, MAX_ACTIVE_SECRETS, MAX_POST_LOGOUT_REDIRECT_URIS, OAuthClient,
+    OAuthClientSecret, OAuthEventType, OAuthUsageStats, UpdateClientRegistrationParams,
+    UpdateOAuthClientParams, create_oauth_client, create_oauth_client_secret,
+    delete_expired_jwt_assertion_jtis, delete_oauth_client, delete_old_oauth_usage_events,
+    get_oauth_client_by_client_id, get_oauth_client_by_id, get_oauth_client_secret_by_id,
+    get_oauth_client_secrets, get_oauth_clients_for_user, get_oauth_secret_by_hash,
+    get_oauth_usage_stats, is_valid_post_logout_redirect_uri_str, record_oauth_event,
     revoke_all_oauth_client_secrets, revoke_oauth_client_secret, store_jwt_assertion_jti,
     update_oauth_client, update_oauth_client_last_used, update_oauth_client_registration,
     validate_oauth_client_credentials,

--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -168,6 +168,42 @@ impl OAuthClient {
     }
 }
 
+// ============================================================================
+// Post-logout redirect URI validation helpers (shared between handlers and
+// services so the per-URI rule and the cap live in exactly one place)
+// ============================================================================
+
+/// Maximum number of post-logout redirect URIs an application may register.
+///
+/// Enforced both at RFC 7591 dynamic registration time (services layer) and at
+/// self-service application creation time (handlers layer).
+pub const MAX_POST_LOGOUT_REDIRECT_URIS: usize = 10;
+
+/// Return `true` when `uri` is a syntactically valid post-logout redirect URI.
+///
+/// Valid URIs must:
+/// - Parse as an absolute URL.
+/// - Use `https://` for non-loopback hosts.
+/// - Use `http://` only for loopback addresses (`localhost`, `127.0.0.1`, `[::1]`).
+/// - Carry no fragment component (would conflict with the echoed `state` parameter).
+#[must_use]
+pub fn is_valid_post_logout_redirect_uri_str(uri: &str) -> bool {
+    let Ok(parsed) = url::Url::parse(uri) else {
+        return false;
+    };
+    if parsed.fragment().is_some() {
+        return false;
+    }
+    match parsed.scheme() {
+        "https" => true,
+        "http" => {
+            let host = parsed.host_str().unwrap_or("");
+            matches!(host, "localhost" | "127.0.0.1" | "[::1]")
+        }
+        _ => false,
+    }
+}
+
 /// Parameters for creating a new OAuth client application.
 pub struct CreateOAuthClientParams<'a> {
     pub user_id: Option<&'a str>,

--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -1228,6 +1228,35 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_is_valid_post_logout_redirect_uri_str() {
+        // https is always allowed.
+        assert!(is_valid_post_logout_redirect_uri_str(
+            "https://rp.example.com/out"
+        ));
+        // Loopback http is allowed for all three loopback forms. The `url` crate
+        // serializes IPv6 hosts WITH brackets in host_str(), so "[::1]" matches.
+        assert!(is_valid_post_logout_redirect_uri_str(
+            "http://localhost/out"
+        ));
+        assert!(is_valid_post_logout_redirect_uri_str(
+            "http://127.0.0.1:8080/out"
+        ));
+        assert!(is_valid_post_logout_redirect_uri_str(
+            "http://[::1]:8080/out"
+        ));
+        // Non-loopback http is rejected.
+        assert!(!is_valid_post_logout_redirect_uri_str(
+            "http://rp.example.com/out"
+        ));
+        // Fragments are rejected (would clash with the echoed `state`).
+        assert!(!is_valid_post_logout_redirect_uri_str(
+            "https://rp.example.com/out#x"
+        ));
+        // Garbage / relative URIs are rejected.
+        assert!(!is_valid_post_logout_redirect_uri_str("not-a-url"));
+    }
+
+    #[test]
     fn test_access_scope_from_str() {
         let result: Result<AccessScope, _> = "organization".parse();
         assert_eq!(result, Ok(AccessScope::Organization));

--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -84,6 +84,8 @@ pub struct OAuthClient {
     /// When `Some`, only the listed HTTPS URLs are accepted as `request_uri` values.
     /// When `None`, any HTTPS `request_uri` is accepted.
     pub request_uris: Option<Vec<String>>,
+    /// RP-Initiated Logout 1.0 Section 2: Registered post-logout redirect URIs.
+    pub post_logout_redirect_uris: Option<Vec<String>>,
 }
 
 impl From<Document<OAuthClientDoc>> for OAuthClient {
@@ -130,6 +132,7 @@ impl From<Document<OAuthClientDoc>> for OAuthClient {
             introspection_signed_response_alg: doc.data.introspection_signed_response_alg,
             userinfo_signed_response_alg: doc.data.userinfo_signed_response_alg,
             request_uris: doc.data.request_uris,
+            post_logout_redirect_uris: doc.data.post_logout_redirect_uris,
         }
     }
 }
@@ -151,6 +154,17 @@ impl OAuthClient {
     #[must_use]
     pub fn is_fapi(&self) -> bool {
         self.fapi_profile != FapiProfile::None
+    }
+
+    /// Return `true` when `uri` is in the client's registered
+    /// `post_logout_redirect_uris` (exact match, case-sensitive).
+    ///
+    /// Returns `false` when the list is absent or does not contain `uri`.
+    #[must_use]
+    pub fn is_valid_post_logout_redirect_uri(&self, uri: &str) -> bool {
+        self.post_logout_redirect_uris
+            .as_deref()
+            .is_some_and(|uris| uris.iter().any(|u| u == uri))
     }
 }
 
@@ -196,6 +210,8 @@ pub struct CreateOAuthClientParams<'a> {
     pub userinfo_signed_response_alg: Option<JwsAlgorithm>,
     /// OIDC Core Section 6.2: Pre-registered request_uri allowlist.
     pub request_uris: Option<Vec<String>>,
+    /// RP-Initiated Logout 1.0: Registered post-logout redirect URIs.
+    pub post_logout_redirect_uris: Option<Vec<String>>,
 }
 
 /// Create a new OAuth client application.
@@ -243,6 +259,7 @@ pub async fn create_oauth_client(
         introspection_signed_response_alg: params.introspection_signed_response_alg,
         userinfo_signed_response_alg: params.userinfo_signed_response_alg,
         request_uris: params.request_uris.clone(),
+        post_logout_redirect_uris: params.post_logout_redirect_uris.clone(),
     };
 
     let result = store.insert(&doc).await?;
@@ -294,6 +311,9 @@ pub struct UpdateOAuthClientParams<'a> {
     pub jwks_uri: Option<&'a str>,
     pub fapi_profile: FapiProfile,
     pub dpop_bound_access_tokens: bool,
+    /// RP-Initiated Logout 1.0: Registered post-logout redirect URIs.
+    /// `None` preserves the existing value; `Some(vec![])` clears the list.
+    pub post_logout_redirect_uris: Option<Vec<String>>,
 }
 
 /// Update an OAuth client.
@@ -315,6 +335,13 @@ pub async fn update_oauth_client(
             data.jwks_uri = params.jwks_uri.map(String::from);
             data.fapi_profile = params.fapi_profile;
             data.dpop_bound_access_tokens = params.dpop_bound_access_tokens;
+            if let Some(ref uris) = params.post_logout_redirect_uris {
+                data.post_logout_redirect_uris = if uris.is_empty() {
+                    None
+                } else {
+                    Some(uris.clone())
+                };
+            }
 
             if let Some(scope) = params.access_scope {
                 data.access_scope = scope;
@@ -959,6 +986,8 @@ pub struct UpdateClientRegistrationParams<'a> {
     pub registration_metadata: Option<&'a serde_json::Value>,
     pub userinfo_signed_response_alg: Option<JwsAlgorithm>,
     pub request_uris: Option<&'a [String]>,
+    /// RP-Initiated Logout 1.0: Registered post-logout redirect URIs.
+    pub post_logout_redirect_uris: Option<Vec<String>>,
 }
 
 /// Update a dynamically registered OAuth client (RFC 7592 Section 2.2).
@@ -1005,6 +1034,7 @@ pub async fn update_oauth_client_registration(
             // RFC 7592: PUT is a full replacement — clear fields not present.
             data.userinfo_signed_response_alg = params.userinfo_signed_response_alg;
             data.request_uris = params.request_uris.map(|u| u.to_vec());
+            data.post_logout_redirect_uris = params.post_logout_redirect_uris.clone();
         })
         .await?;
 
@@ -1380,6 +1410,7 @@ mod tests {
                 require_signed_request_object: None,
                 userinfo_signed_response_alg: None,
                 request_uris: None,
+                post_logout_redirect_uris: None,
             },
         )
         .await

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -775,6 +775,7 @@ async fn test_oauth_client_crud() {
             require_signed_request_object: None,
             userinfo_signed_response_alg: None,
             request_uris: None,
+            post_logout_redirect_uris: None,
         },
     )
     .await
@@ -819,6 +820,7 @@ async fn test_oauth_client_crud() {
             jwks_uri: client.jwks_uri.as_deref(),
             fapi_profile: client.fapi_profile,
             dpop_bound_access_tokens: client.dpop_bound_access_tokens,
+            post_logout_redirect_uris: None,
         },
     )
     .await
@@ -895,6 +897,7 @@ async fn test_oauth_client_types() {
                 require_signed_request_object: None,
                 userinfo_signed_response_alg: None,
                 request_uris: None,
+                post_logout_redirect_uris: None,
             },
         )
         .await
@@ -960,6 +963,7 @@ async fn test_oauth_client_list_for_user() {
                 require_signed_request_object: None,
                 userinfo_signed_response_alg: None,
                 request_uris: None,
+                post_logout_redirect_uris: None,
             },
         )
         .await
@@ -1003,6 +1007,7 @@ async fn test_oauth_client_list_for_user() {
             require_signed_request_object: None,
             userinfo_signed_response_alg: None,
             request_uris: None,
+            post_logout_redirect_uris: None,
         },
     )
     .await
@@ -1065,6 +1070,7 @@ async fn test_oauth_client_secret_management() {
             require_signed_request_object: None,
             userinfo_signed_response_alg: None,
             request_uris: None,
+            post_logout_redirect_uris: None,
         },
     )
     .await
@@ -1149,6 +1155,7 @@ async fn test_oauth_usage_recording() {
             require_signed_request_object: None,
             userinfo_signed_response_alg: None,
             request_uris: None,
+            post_logout_redirect_uris: None,
         },
     )
     .await
@@ -1850,6 +1857,7 @@ async fn test_oauth_client_cascade_delete() {
             require_signed_request_object: None,
             userinfo_signed_response_alg: None,
             request_uris: None,
+            post_logout_redirect_uris: None,
         },
     )
     .await
@@ -3058,6 +3066,7 @@ async fn test_update_oauth_client_jwks_uri_clears_cache() {
             require_signed_request_object: None,
             userinfo_signed_response_alg: None,
             request_uris: None,
+            post_logout_redirect_uris: None,
         },
     )
     .await
@@ -3089,6 +3098,7 @@ async fn test_update_oauth_client_jwks_uri_clears_cache() {
             registration_metadata: None,
             userinfo_signed_response_alg: None,
             request_uris: None,
+            post_logout_redirect_uris: None,
         },
     )
     .await
@@ -3147,6 +3157,7 @@ async fn test_jwks_refresh_does_not_modify_oauth_client_doc() {
             require_signed_request_object: None,
             userinfo_signed_response_alg: None,
             request_uris: None,
+            post_logout_redirect_uris: None,
         },
     )
     .await

--- a/crates/vouch-server/src/handlers/applications/api.rs
+++ b/crates/vouch-server/src/handlers/applications/api.rs
@@ -74,6 +74,10 @@ pub(crate) async fn list_applications_api(
 
 /// Create a new application (API).
 /// POST /api/v1/applications
+#[expect(
+    clippy::too_many_lines,
+    reason = "single-pass RFC 7591 application creation: format-validate, auth, create"
+)]
 pub(crate) async fn create_application_api(
     method: Method,
     uri: OriginalUri,
@@ -86,12 +90,14 @@ pub(crate) async fn create_application_api(
     // ── Pure format validation first — no DB cost for malformed requests ──
     // RFC 8707: Resource URIs default to empty if not provided.
     let resource_uris = req.resource_uris.as_deref().unwrap_or(&[]);
+    let post_logout_redirect_uris_raw = req.post_logout_redirect_uris.as_deref();
 
     let validated = validate_create_application(CreateAppInput {
         name: &req.name,
         application_type: &req.application_type,
         redirect_uris: &req.redirect_uris,
         resource_uris,
+        post_logout_redirect_uris: post_logout_redirect_uris_raw,
         fapi_profile: req.fapi_profile.as_deref(),
         jwks: req.jwks.as_deref(),
         jwks_uri: req.jwks_uri.as_deref(),
@@ -202,6 +208,11 @@ pub(crate) async fn create_application_api(
             require_signed_request_object: None,
             userinfo_signed_response_alg: None,
             request_uris: None,
+            post_logout_redirect_uris: req
+                .post_logout_redirect_uris
+                .as_ref()
+                .filter(|v| !v.is_empty())
+                .cloned(),
         },
     )
     .await
@@ -321,9 +332,11 @@ pub(crate) async fn update_application_api(
     Json(req): Json<UpdateApplicationRequest>,
 ) -> Result<Json<ApplicationResponse>, ServiceError> {
     // ── Pure format validation first — no DB cost for malformed requests ──
+
     let validated = validate_update_format(UpdateAppInput {
         redirect_uris: req.redirect_uris.as_deref(),
         resource_uris: req.resource_uris.as_deref(),
+        post_logout_redirect_uris: req.post_logout_redirect_uris.as_deref(),
         fapi_profile: req.fapi_profile.as_deref(),
         jwks: req.jwks.as_deref(),
         jwks_uri: req.jwks_uri.as_deref(),
@@ -496,6 +509,7 @@ pub(crate) async fn update_application_api(
             jwks_uri: effective_jwks_uri,
             fapi_profile,
             dpop_bound_access_tokens: dpop_bound,
+            post_logout_redirect_uris: validated.post_logout_redirect_uris.map(<[String]>::to_vec),
         },
     )
     .await
@@ -2321,5 +2335,146 @@ mod tests {
         assert_eq!(status, StatusCode::OK, "body: {body}");
         let json: serde_json::Value = serde_json::from_str(&body).expect("valid json");
         assert_eq!(json["name"].as_str().unwrap(), "Test App");
+    }
+
+    // ================================================================
+    // post_logout_redirect_uris — applications JSON API
+    // ================================================================
+
+    #[tokio::test]
+    async fn test_create_application_with_post_logout_redirect_uris() {
+        // POST /api/v1/applications with post_logout_redirect_uris should store them.
+        // The create response (CreateApplicationResponse) does not echo the field, so
+        // we verify storage via a subsequent GET /api/v1/applications/:id.
+        let (app, state) = test_app().await;
+        let user = create_test_user(&state.store, "post-logout-create@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let auth = bearer(&token);
+
+        let payload = serde_json::json!({
+            "name": "Logout Test App",
+            "application_type": "web",
+            "redirect_uris": ["https://example.com/callback"],
+            "post_logout_redirect_uris": ["https://example.com/logged-out"]
+        });
+
+        let (status, body) = http_request(
+            &app,
+            "POST",
+            "/api/v1/applications",
+            Some(payload.to_string()),
+            &[
+                ("Content-Type", "application/json"),
+                ("Authorization", &auth),
+            ],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK, "body: {body}");
+        let create_json: serde_json::Value = serde_json::from_str(&body).expect("valid json");
+        let app_id = create_json["id"].as_str().expect("id in create response");
+
+        // Verify the stored post_logout_redirect_uris via GET.
+        let (get_status, get_body) = http_request(
+            &app,
+            "GET",
+            &format!("/api/v1/applications/{app_id}"),
+            None,
+            &[("Authorization", &auth)],
+        )
+        .await;
+        assert_eq!(get_status, StatusCode::OK, "GET body: {get_body}");
+        let get_json: serde_json::Value = serde_json::from_str(&get_body).expect("valid json");
+        let post_logout = get_json["post_logout_redirect_uris"]
+            .as_array()
+            .expect("post_logout_redirect_uris must be present in GET response");
+        assert_eq!(
+            post_logout.len(),
+            1,
+            "Expected 1 post_logout_redirect_uri, got {post_logout:?}"
+        );
+        assert_eq!(
+            post_logout[0].as_str().unwrap(),
+            "https://example.com/logged-out"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_application_rejects_invalid_post_logout_redirect_uri() {
+        // A post_logout_redirect_uri with ftp:// scheme must be rejected.
+        let (app, state) = test_app().await;
+        let user = create_test_user(&state.store, "post-logout-invalid-create@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let auth = bearer(&token);
+
+        let payload = serde_json::json!({
+            "name": "Bad Logout App",
+            "application_type": "web",
+            "redirect_uris": ["https://example.com/callback"],
+            "post_logout_redirect_uris": ["ftp://example.com/logged-out"]
+        });
+
+        let (status, body) = http_request(
+            &app,
+            "POST",
+            "/api/v1/applications",
+            Some(payload.to_string()),
+            &[
+                ("Content-Type", "application/json"),
+                ("Authorization", &auth),
+            ],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
+        let json: serde_json::Value = serde_json::from_str(&body).expect("valid json");
+        assert_eq!(
+            json["code"], "invalid_post_logout_redirect_uris",
+            "body: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_application_post_logout_redirect_uris_roundtrip() {
+        // PATCH /api/v1/applications/:id with post_logout_redirect_uris should store and return them.
+        let (app, state) = test_app().await;
+        let user = create_test_user(&state.store, "post-logout-update@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let auth = bearer(&token);
+        let client = create_test_oauth_client(&state.store, &user.id).await;
+
+        let payload = serde_json::json!({
+            "post_logout_redirect_uris": ["https://example.com/logged-out"]
+        });
+
+        let (status, body) = http_request(
+            &app,
+            "PATCH",
+            &format!("/api/v1/applications/{}", client.app_id),
+            Some(payload.to_string()),
+            &[
+                ("Content-Type", "application/json"),
+                ("Authorization", &auth),
+            ],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK, "body: {body}");
+        let json: serde_json::Value = serde_json::from_str(&body).expect("valid json");
+        let post_logout = json["post_logout_redirect_uris"]
+            .as_array()
+            .expect("post_logout_redirect_uris must be present after PATCH");
+        assert_eq!(
+            post_logout.len(),
+            1,
+            "Expected 1 post_logout_redirect_uri, got {post_logout:?}"
+        );
+        assert_eq!(
+            post_logout[0].as_str().unwrap(),
+            "https://example.com/logged-out"
+        );
     }
 }

--- a/crates/vouch-server/src/handlers/applications/mod.rs
+++ b/crates/vouch-server/src/handlers/applications/mod.rs
@@ -100,6 +100,57 @@ fn parse_resource_uris(input: Option<&str>) -> Vec<String> {
     }
 }
 
+/// Maximum number of post-logout redirect URIs an application may register.
+/// Matches the cap enforced during RFC 7591 dynamic registration.
+const MAX_POST_LOGOUT_REDIRECT_URIS: usize = 10;
+
+/// Validate that all post-logout redirect URIs are valid URLs with proper schemes.
+///
+/// Mirrors [`validate_redirect_uris`] rules (https or loopback http) and additionally
+/// rejects URIs that carry a fragment component, which would conflict with the
+/// redirect appended `state` parameter on the final redirect. Enforces a maximum
+/// of [`MAX_POST_LOGOUT_REDIRECT_URIS`] entries, matching the RFC 7591 cap.
+///
+/// Returns `Ok(())` if all URIs are valid, or `Err` with a list of invalid URIs.
+pub(crate) fn validate_post_logout_redirect_uris(uris: &[String]) -> Result<(), Vec<String>> {
+    if uris.len() > MAX_POST_LOGOUT_REDIRECT_URIS {
+        // Return a single-element error list describing the cap violation.
+        return Err(vec![format!(
+            "Too many post_logout_redirect_uris: maximum is {MAX_POST_LOGOUT_REDIRECT_URIS}"
+        )]);
+    }
+
+    let invalid: Vec<String> = uris
+        .iter()
+        .filter(|uri| {
+            match url::Url::parse(uri) {
+                Ok(parsed) => {
+                    // Reject fragment components.
+                    if parsed.fragment().is_some() {
+                        return true;
+                    }
+                    match parsed.scheme() {
+                        "https" => false,
+                        "http" => {
+                            let host = parsed.host_str().unwrap_or("");
+                            !matches!(host, "localhost" | "127.0.0.1" | "[::1]")
+                        }
+                        _ => true,
+                    }
+                }
+                Err(_) => true,
+            }
+        })
+        .cloned()
+        .collect();
+
+    if invalid.is_empty() {
+        Ok(())
+    } else {
+        Err(invalid)
+    }
+}
+
 /// Validate that all redirect URIs are valid URLs with proper schemes.
 ///
 /// Per RFC 8252 Section 7.3 and RFC 9700 Section 4.1.3:

--- a/crates/vouch-server/src/handlers/applications/mod.rs
+++ b/crates/vouch-server/src/handlers/applications/mod.rs
@@ -100,47 +100,25 @@ fn parse_resource_uris(input: Option<&str>) -> Vec<String> {
     }
 }
 
-/// Maximum number of post-logout redirect URIs an application may register.
-/// Matches the cap enforced during RFC 7591 dynamic registration.
-const MAX_POST_LOGOUT_REDIRECT_URIS: usize = 10;
-
 /// Validate that all post-logout redirect URIs are valid URLs with proper schemes.
 ///
 /// Mirrors [`validate_redirect_uris`] rules (https or loopback http) and additionally
 /// rejects URIs that carry a fragment component, which would conflict with the
 /// redirect appended `state` parameter on the final redirect. Enforces a maximum
-/// of [`MAX_POST_LOGOUT_REDIRECT_URIS`] entries, matching the RFC 7591 cap.
+/// of [`db::MAX_POST_LOGOUT_REDIRECT_URIS`] entries, matching the RFC 7591 cap.
 ///
 /// Returns `Ok(())` if all URIs are valid, or `Err` with a list of invalid URIs.
 pub(crate) fn validate_post_logout_redirect_uris(uris: &[String]) -> Result<(), Vec<String>> {
-    if uris.len() > MAX_POST_LOGOUT_REDIRECT_URIS {
-        // Return a single-element error list describing the cap violation.
+    if uris.len() > db::MAX_POST_LOGOUT_REDIRECT_URIS {
         return Err(vec![format!(
-            "Too many post_logout_redirect_uris: maximum is {MAX_POST_LOGOUT_REDIRECT_URIS}"
+            "Too many post_logout_redirect_uris: maximum is {}",
+            db::MAX_POST_LOGOUT_REDIRECT_URIS
         )]);
     }
 
     let invalid: Vec<String> = uris
         .iter()
-        .filter(|uri| {
-            match url::Url::parse(uri) {
-                Ok(parsed) => {
-                    // Reject fragment components.
-                    if parsed.fragment().is_some() {
-                        return true;
-                    }
-                    match parsed.scheme() {
-                        "https" => false,
-                        "http" => {
-                            let host = parsed.host_str().unwrap_or("");
-                            !matches!(host, "localhost" | "127.0.0.1" | "[::1]")
-                        }
-                        _ => true,
-                    }
-                }
-                Err(_) => true,
-            }
-        })
+        .filter(|uri| !db::is_valid_post_logout_redirect_uri_str(uri))
         .cloned()
         .collect();
 

--- a/crates/vouch-server/src/handlers/applications/types.rs
+++ b/crates/vouch-server/src/handlers/applications/types.rs
@@ -54,6 +54,8 @@ pub(crate) struct ApplicationInfo {
     pub jwks: Option<String>,
     /// Remote JWKS URI (RFC 7523).
     pub jwks_uri: Option<String>,
+    /// RP-Initiated Logout 1.0: Registered post-logout redirect URIs.
+    pub post_logout_redirect_uris: Option<Vec<String>>,
 }
 
 impl From<OAuthClient> for ApplicationInfo {
@@ -79,6 +81,7 @@ impl From<OAuthClient> for ApplicationInfo {
             fapi_profile,
             jwks,
             jwks_uri,
+            post_logout_redirect_uris: client.post_logout_redirect_uris,
         }
     }
 }
@@ -202,6 +205,9 @@ pub(crate) struct CreateApplicationForm {
     /// RFC 7523: Remote JWKS endpoint URL for private_key_jwt authentication.
     #[serde(default)]
     pub jwks_uri: Option<String>,
+    /// RP-Initiated Logout 1.0: Post-logout redirect URIs (newline or comma separated, optional).
+    #[serde(default)]
+    pub post_logout_redirect_uris: Option<String>,
 }
 
 /// Form data for updating an application.
@@ -223,6 +229,9 @@ pub(crate) struct UpdateApplicationForm {
     /// RFC 7523: Remote JWKS endpoint URL for private_key_jwt authentication.
     #[serde(default)]
     pub jwks_uri: Option<String>,
+    /// RP-Initiated Logout 1.0: Post-logout redirect URIs (newline or comma separated, optional).
+    #[serde(default)]
+    pub post_logout_redirect_uris: Option<String>,
 }
 
 /// API request for creating an application.
@@ -245,6 +254,9 @@ pub(crate) struct CreateApplicationRequest {
     /// RFC 7523: Remote JWKS endpoint URL for private_key_jwt authentication.
     #[serde(default)]
     pub jwks_uri: Option<String>,
+    /// RP-Initiated Logout 1.0: Registered post-logout redirect URIs.
+    #[serde(default)]
+    pub post_logout_redirect_uris: Option<Vec<String>>,
 }
 
 /// API request for updating an application.
@@ -266,6 +278,9 @@ pub(crate) struct UpdateApplicationRequest {
     /// RFC 7523: Remote JWKS endpoint URL for private_key_jwt authentication.
     #[serde(default)]
     pub jwks_uri: Option<String>,
+    /// RP-Initiated Logout 1.0: Registered post-logout redirect URIs.
+    #[serde(default)]
+    pub post_logout_redirect_uris: Option<Vec<String>>,
 }
 
 /// API response for a created application.
@@ -314,6 +329,9 @@ pub(crate) struct ApplicationResponse {
     pub jwks_configured: bool,
     /// Remote JWKS URI if configured.
     pub jwks_uri: Option<String>,
+    /// RP-Initiated Logout 1.0: Registered post-logout redirect URIs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub post_logout_redirect_uris: Option<Vec<String>>,
 }
 
 impl From<OAuthClient> for ApplicationResponse {
@@ -338,6 +356,7 @@ impl From<OAuthClient> for ApplicationResponse {
             fapi_profile: client.fapi_profile.as_str().to_string(),
             jwks_configured,
             jwks_uri,
+            post_logout_redirect_uris: client.post_logout_redirect_uris,
         }
     }
 }

--- a/crates/vouch-server/src/handlers/applications/validate.rs
+++ b/crates/vouch-server/src/handlers/applications/validate.rs
@@ -12,7 +12,7 @@ use crate::db::{OAuthClient, OAuthClientType};
 use crate::services::error::ServiceError;
 use crate::services::oidc::ResourceUri;
 
-use super::validate_redirect_uris;
+use super::{validate_post_logout_redirect_uris, validate_redirect_uris};
 
 /// A validation failure: a machine-readable code plus a human message.
 #[derive(Debug)]
@@ -21,6 +21,7 @@ pub(super) enum AppValidationError {
     InvalidApplicationType,
     MissingRedirectUris,
     InvalidRedirectUris(Vec<String>),
+    InvalidPostLogoutRedirectUris(Vec<String>),
     InvalidResourceUri { uri: String, detail: String },
     FapiRequiresConfidentialClient,
     FapiMissingJwks,
@@ -36,6 +37,7 @@ impl AppValidationError {
             Self::EmptyName => "invalid_name",
             Self::InvalidApplicationType => "invalid_type",
             Self::MissingRedirectUris | Self::InvalidRedirectUris(_) => "invalid_redirect_uris",
+            Self::InvalidPostLogoutRedirectUris(_) => "invalid_post_logout_redirect_uris",
             Self::InvalidResourceUri { .. } => "invalid_resource_uri",
             Self::FapiRequiresConfidentialClient => "invalid_fapi_profile",
             Self::FapiMissingJwks => "missing_jwks",
@@ -54,6 +56,11 @@ impl AppValidationError {
             Self::MissingRedirectUris => "At least one redirect URI is required".to_string(),
             Self::InvalidRedirectUris(invalid) => format!(
                 "Invalid redirect URI(s): {}. Each URI must be a valid http:// or https:// URL.",
+                invalid.join(", ")
+            ),
+            Self::InvalidPostLogoutRedirectUris(invalid) => format!(
+                "Invalid post_logout_redirect_uri(s): {}. \
+                 Each URI must be a valid http:// or https:// URL without a fragment.",
                 invalid.join(", ")
             ),
             Self::InvalidResourceUri { uri, detail } => format!(
@@ -88,6 +95,8 @@ pub(super) struct CreateAppInput<'a> {
     pub application_type: &'a str,
     pub redirect_uris: &'a [String],
     pub resource_uris: &'a [String],
+    /// `None` means not provided (field absent); `Some(&[])` is accepted (no post-logout URIs).
+    pub post_logout_redirect_uris: Option<&'a [String]>,
     pub fapi_profile: Option<&'a str>,
     pub jwks: Option<&'a str>,
     pub jwks_uri: Option<&'a str>,
@@ -130,6 +139,11 @@ pub(super) fn validate_create_application<'a>(
 
     validate_redirect_uris(input.redirect_uris).map_err(AppValidationError::InvalidRedirectUris)?;
 
+    if let Some(uris) = input.post_logout_redirect_uris {
+        validate_post_logout_redirect_uris(uris)
+            .map_err(AppValidationError::InvalidPostLogoutRedirectUris)?;
+    }
+
     // Validate resource URIs per RFC 8707 (absolute URI, no fragment).
     validate_resource_uris(input.resource_uris)?;
 
@@ -167,6 +181,8 @@ pub(super) fn validate_create_application<'a>(
 pub(super) struct UpdateAppInput<'a> {
     pub redirect_uris: Option<&'a [String]>,
     pub resource_uris: Option<&'a [String]>,
+    /// `None` = field absent (preserve existing). `Some(&[])` = explicitly clear the list.
+    pub post_logout_redirect_uris: Option<&'a [String]>,
     pub fapi_profile: Option<&'a str>,
     pub jwks: Option<&'a str>,
     pub jwks_uri: Option<&'a str>,
@@ -181,6 +197,8 @@ pub(super) struct ValidatedUpdateApp<'a> {
     pub jwks_uri: Option<&'a str>,
     /// Redirect URIs from the request (`None` = field absent, `Some(&[])` = explicitly cleared).
     pub redirect_uris: Option<&'a [String]>,
+    /// Post-logout redirect URIs (`None` = preserve existing, `Some(&[])` = explicitly clear).
+    pub post_logout_redirect_uris: Option<&'a [String]>,
 }
 
 /// Validate the format of an update-application request.
@@ -205,6 +223,13 @@ pub(super) fn validate_update_format<'a>(
         validate_resource_uris(uris)?;
     }
 
+    if let Some(uris) = input.post_logout_redirect_uris
+        && !uris.is_empty()
+    {
+        validate_post_logout_redirect_uris(uris)
+            .map_err(AppValidationError::InvalidPostLogoutRedirectUris)?;
+    }
+
     let is_fapi = input.fapi_profile.is_some_and(|p| p == "fapi2_security");
 
     let jwks = trim_nonempty(input.jwks).map(parse_jwks).transpose()?;
@@ -216,6 +241,7 @@ pub(super) fn validate_update_format<'a>(
         jwks,
         jwks_uri,
         redirect_uris: input.redirect_uris,
+        post_logout_redirect_uris: input.post_logout_redirect_uris,
     })
 }
 

--- a/crates/vouch-server/src/handlers/applications/web.rs
+++ b/crates/vouch-server/src/handlers/applications/web.rs
@@ -98,6 +98,10 @@ pub(crate) async fn create_application_page(
 
 /// Create a new application.
 /// POST /applications/new
+#[expect(
+    clippy::too_many_lines,
+    reason = "single-pass form creation: parse, validate, auth-check, create"
+)]
 pub(crate) async fn create_application_form(
     State(state): State<Arc<AppState>>,
     jar: CookieJar,
@@ -112,12 +116,26 @@ pub(crate) async fn create_application_form(
     // Parse textarea inputs, then run the shared format validation
     let redirect_uris = parse_redirect_uris(&form.redirect_uris);
     let resource_uris = parse_resource_uris(form.resource_uris.as_deref());
+    let post_logout_redirect_uris_raw = parse_redirect_uris(
+        form.post_logout_redirect_uris
+            .as_deref()
+            .unwrap_or_default(),
+    );
+    // Pass None when the textarea was empty (no post-logout URIs wanted); validation
+    // happens inside validate_create_application via the AppValidationError enum.
+    let post_logout_redirect_uris_input: Option<&[String]> =
+        if post_logout_redirect_uris_raw.is_empty() {
+            None
+        } else {
+            Some(&post_logout_redirect_uris_raw)
+        };
 
     let validated = match validate_create_application(CreateAppInput {
         name: &form.name,
         application_type: &form.application_type,
         redirect_uris: &redirect_uris,
         resource_uris: &resource_uris,
+        post_logout_redirect_uris: post_logout_redirect_uris_input,
         fapi_profile: form.fapi_profile.as_deref(),
         jwks: form.jwks.as_deref(),
         jwks_uri: form.jwks_uri.as_deref(),
@@ -204,6 +222,11 @@ pub(crate) async fn create_application_form(
             require_signed_request_object: None,
             userinfo_signed_response_alg: None,
             request_uris: None,
+            post_logout_redirect_uris: if post_logout_redirect_uris_raw.is_empty() {
+                None
+            } else {
+                Some(post_logout_redirect_uris_raw.clone())
+            },
         },
     )
     .await
@@ -412,13 +435,22 @@ pub(crate) async fn update_application_form(
         None
     };
 
-    // Parse textarea inputs, then run the shared format validation
+    // Parse textarea inputs, then run the shared format validation.
+    // The web form always submits the post_logout_redirect_uris field, so
+    // empty textarea = explicitly clear (Some(&[])), not absent (None).
     let redirect_uris = parse_redirect_uris(&form.redirect_uris);
     let resource_uris = parse_resource_uris(form.resource_uris.as_deref());
+    let post_logout_redirect_uris_raw = parse_redirect_uris(
+        form.post_logout_redirect_uris
+            .as_deref()
+            .unwrap_or_default(),
+    );
 
     let validated = match validate_update_format(UpdateAppInput {
         redirect_uris: Some(&redirect_uris),
         resource_uris: Some(&resource_uris),
+        // Always Some: empty vec = explicitly clear; validation rejects invalid URIs.
+        post_logout_redirect_uris: Some(&post_logout_redirect_uris_raw),
         fapi_profile: form.fapi_profile.as_deref(),
         jwks: form.jwks.as_deref(),
         jwks_uri: form.jwks_uri.as_deref(),
@@ -490,6 +522,7 @@ pub(crate) async fn update_application_form(
             jwks_uri: effective_jwks_uri,
             fapi_profile,
             dpop_bound_access_tokens: dpop_bound,
+            post_logout_redirect_uris: validated.post_logout_redirect_uris.map(<[String]>::to_vec),
         },
     )
     .await

--- a/crates/vouch-server/src/handlers/oidc/authorize.rs
+++ b/crates/vouch-server/src/handlers/oidc/authorize.rs
@@ -1853,6 +1853,7 @@ mod tests {
             introspection_signed_response_alg: None,
             userinfo_signed_response_alg: None,
             request_uris: None,
+            post_logout_redirect_uris: None,
         }
     }
 

--- a/crates/vouch-server/src/handlers/oidc/logout.rs
+++ b/crates/vouch-server/src/handlers/oidc/logout.rs
@@ -1,0 +1,790 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! RP-Initiated Logout 1.0 endpoint handlers.
+//!
+//! Implements:
+//! - `GET /oauth/logout` — Show confirmation page (end-session endpoint)
+//! - `POST /oauth/logout` — Execute logout and redirect or render done page
+//!
+//! Security model:
+//! - CSRF is mitigated by SameSite=Lax on the session cookie and requiring a
+//!   same-origin POST for the confirmation form. No separate CSRF token is needed
+//!   because the form has no GET-queryable side-effects — the session is only
+//!   cleared on POST from the confirmation page.
+//! - `post_logout_redirect_uri` is validated against the registered
+//!   `post_logout_redirect_uris` for the client identified by `id_token_hint`.
+//!   Redirect is only allowed when a verified `id_token_hint` is present; the
+//!   bare `client_id` query param is NOT sufficient to gate a redirect.
+//!   An invalid or unverified URI falls through to the local done page instead of
+//!   redirecting — never redirects to an unvalidated URI.
+//! - `state` is echoed ONLY on redirect back to the client; it is carried as a
+//!   hidden form field through the confirmation page (Askama auto-escapes attribute
+//!   values) and never rendered as visible page content (XSS prevention).
+//!
+//! References:
+//! - <https://openid.net/specs/openid-connect-rpinitiated-1_0.html>
+
+use crate::AppState;
+use crate::db;
+use crate::handlers::extractors::ClientInfo;
+use crate::handlers::{clear_session_cookie, hash_token};
+use crate::impl_template_response;
+use crate::infra::i18n::{negotiate_ui_locales, sync_scope_locale};
+use crate::services::oidc::token::IdTokenClaims;
+use askama::Template;
+use axum::{
+    Form,
+    extract::{Query, State},
+    http::{HeaderMap, StatusCode, header},
+    response::{IntoResponse, Response},
+};
+use axum_extra::extract::cookie::CookieJar;
+use jsonwebtoken::Validation;
+use serde::Deserialize;
+use std::sync::Arc;
+
+// ============================================================================
+// Query / Form types
+// ============================================================================
+
+/// GET /oauth/logout query parameters (RP-Initiated Logout 1.0 Section 3).
+#[derive(Debug, Deserialize)]
+pub(crate) struct LogoutQuery {
+    /// OPTIONAL. Previously issued ID Token passed as a hint. Used to identify
+    /// the RP and optionally to look up the client's registered post-logout URIs.
+    pub id_token_hint: Option<String>,
+    /// OPTIONAL. Hint about the End-User's login identifier. Informational only;
+    /// accepted per spec but not acted upon.
+    #[expect(
+        dead_code,
+        reason = "accepted per spec; not acted upon in this implementation"
+    )]
+    pub logout_hint: Option<String>,
+    /// OPTIONAL. OAuth 2.0 Client Identifier. Used only for display on the
+    /// confirmation page when no `id_token_hint` is present. Does NOT gate
+    /// redirects — only a verified hint's `aud` gates redirect.
+    pub client_id: Option<String>,
+    /// OPTIONAL. URL to which the RP requests that the End-User's User Agent be
+    /// redirected after a logout has been performed. Must be registered.
+    pub post_logout_redirect_uri: Option<String>,
+    /// OPTIONAL. Opaque value to maintain state between the RP and End-User Agent.
+    /// Carried as a hidden form field through the confirmation page (Askama
+    /// auto-escapes attribute values) and echoed only on the final redirect.
+    pub state: Option<String>,
+    /// OPTIONAL. End-User's preferred languages (space-separated BCP-47 tags)
+    /// for the logout confirmation UI.
+    pub ui_locales: Option<String>,
+}
+
+/// POST /oauth/logout form body — mirrors the hidden fields in the confirmation form.
+#[derive(Debug, Deserialize)]
+pub(crate) struct LogoutForm {
+    pub id_token_hint: Option<String>,
+    pub post_logout_redirect_uri: Option<String>,
+    pub client_id: Option<String>,
+    /// `state` is carried as a hidden form field through the confirmation page.
+    /// Askama auto-escapes attribute values so it is safe against injection into
+    /// the form. It is echoed only on the final redirect to the RP — never
+    /// rendered as visible page content.
+    pub state: Option<String>,
+    /// `ui_locales` is carried as a hidden field so the done page renders in the
+    /// same locale as the confirmation page (plan §7).
+    pub ui_locales: Option<String>,
+}
+
+// ============================================================================
+// Templates
+// ============================================================================
+
+/// Logout confirmation page.
+#[derive(Template)]
+#[template(path = "logout_confirm.html")]
+pub(super) struct LogoutConfirmTemplate {
+    /// Non-empty only when we verified the hint. Used to propagate the hint to
+    /// the POST form so the server can re-verify and identify the client.
+    pub id_token_hint: Option<String>,
+    /// Pre-validated URI (already checked against the registered list). Passed
+    /// to the POST form as a hidden field so POST can re-validate and redirect.
+    pub post_logout_redirect_uri: Option<String>,
+    /// Client ID resolved from `id_token_hint.aud`. Used only for display;
+    /// may also be passed to POST for re-verification.
+    pub client_id: Option<String>,
+    /// Opaque RP state value. Carried as a hidden field so POST can echo it on
+    /// the final redirect. Askama auto-escapes the attribute value.
+    pub state: Option<String>,
+    /// RP-requested UI locale (space-separated BCP-47). Carried as a hidden field
+    /// so the POST done-page renders in the same locale as the confirmation page.
+    pub ui_locales: Option<String>,
+}
+
+impl_template_response!(LogoutConfirmTemplate);
+
+/// Logout done page (no redirect available or redirect target not registered).
+#[derive(Template)]
+#[template(path = "logout_done.html")]
+pub(super) struct LogoutDoneTemplate {}
+
+impl_template_response!(LogoutDoneTemplate);
+
+// ============================================================================
+// id_token_hint verification
+// ============================================================================
+
+/// Extracted, verified claims from an `id_token_hint`.
+struct IdTokenHintClaims {
+    /// `sub` claim from the token. May be used to scope per-user logout hints.
+    #[allow(
+        dead_code,
+        reason = "read in test assertions; not yet used in production paths"
+    )]
+    sub: String,
+    /// `aud` claim (client_id of the RP that issued the token).
+    aud: String,
+}
+
+/// Build a `Validation` instance for id_token_hint verification.
+///
+/// Per RP-Initiated Logout 1.0 Section 3: hints MAY be expired; skip expiry
+/// validation. Skip audience validation (we validate `iss` manually). No
+/// required claims beyond what we check explicitly.
+fn hint_validation(alg: jsonwebtoken::Algorithm) -> Validation {
+    let mut v = Validation::new(alg);
+    v.validate_exp = false;
+    v.validate_aud = false;
+    v.required_spec_claims.clear();
+    v.leeway = 0;
+    v
+}
+
+/// Verify an `id_token_hint` JWT against the server's current signing keys.
+///
+/// Accepts both ES256 (primary) and RS256 (when the RSA key is configured).
+/// Skips expiry and audience validation per RP-Initiated Logout 1.0 Section 3.
+/// Manually verifies `iss == base_url`.
+///
+/// Returns `Some(claims)` if the signature is valid and `iss` matches this
+/// server's `base_url`. Returns `None` for any failure.
+fn verify_id_token_hint(state: &AppState, hint: &str) -> Option<IdTokenHintClaims> {
+    let config = state.config();
+
+    let es256_validation = hint_validation(jsonwebtoken::Algorithm::ES256);
+    let es256_result = jsonwebtoken::decode::<IdTokenClaims>(
+        hint,
+        state.oidc_key.decoding_key(),
+        &es256_validation,
+    );
+
+    let claims = if let Ok(token_data) = es256_result {
+        token_data.claims
+    } else if let Some(rsa_key) = state.oidc_rsa_key.as_ref() {
+        // Fall back to RS256 if an RSA key is configured.
+        let rs256_validation = hint_validation(jsonwebtoken::Algorithm::RS256);
+        match jsonwebtoken::decode::<IdTokenClaims>(hint, rsa_key.decoding_key(), &rs256_validation)
+        {
+            Ok(token_data) => token_data.claims,
+            Err(_) => return None,
+        }
+    } else {
+        return None;
+    };
+
+    // Manually verify iss — must match this server's base_url.
+    if claims.iss != config.base_url {
+        return None;
+    }
+
+    Some(IdTokenHintClaims {
+        sub: claims.sub,
+        aud: claims.aud,
+    })
+}
+
+// ============================================================================
+// Handlers
+// ============================================================================
+
+/// GET /oauth/logout — Show the logout confirmation page.
+///
+/// Parses the end-session request parameters, optionally verifies the
+/// `id_token_hint`, and renders a confirmation form. The user must explicitly
+/// confirm before the session is cleared.
+pub(crate) async fn logout(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    _jar: CookieJar,
+    Query(query): Query<LogoutQuery>,
+) -> Response {
+    let accept_language = headers
+        .get(header::ACCEPT_LANGUAGE)
+        .and_then(|v| v.to_str().ok());
+
+    let i18n_ctx = negotiate_ui_locales(query.ui_locales.as_deref(), accept_language);
+
+    // Verify id_token_hint if present. An unverifiable hint is silently ignored
+    // (spec says the server SHOULD show the confirmation page regardless).
+    let hint_claims = query
+        .id_token_hint
+        .as_deref()
+        .and_then(|hint| verify_id_token_hint(&state, hint));
+
+    // When both a verified hint and a bare client_id are present, they MUST agree.
+    // Spec §3: "If client_id is given, it MUST match the aud of id_token_hint."
+    // On mismatch: treat as no verified hint (fall through to local done page).
+    let hint_claims = match (&hint_claims, &query.client_id) {
+        (Some(c), Some(qcid)) if c.aud != *qcid => None,
+        _ => hint_claims,
+    };
+
+    // Determine the RP client_id from the verified hint. The bare `client_id`
+    // query param is used for display only; it does NOT gate a redirect.
+    let verified_client_id = hint_claims.as_ref().map(|c| c.aud.clone());
+
+    // Validate post_logout_redirect_uri against the client's registered list.
+    // Only pass it through if a verified hint identified the client.
+    let validated_redirect_uri = resolve_post_logout_redirect_uri(
+        &state,
+        verified_client_id.as_deref(),
+        query.post_logout_redirect_uri.as_deref(),
+    )
+    .await;
+
+    // The confirmation form propagates the hint, redirect URI, state, and
+    // ui_locales as hidden fields so the POST handler can re-validate them.
+    let template = LogoutConfirmTemplate {
+        id_token_hint: if hint_claims.is_some() {
+            query.id_token_hint.clone()
+        } else {
+            None
+        },
+        post_logout_redirect_uri: validated_redirect_uri,
+        client_id: verified_client_id.or_else(|| query.client_id.clone()),
+        state: query.state.clone(),
+        ui_locales: query.ui_locales.clone(),
+    };
+
+    sync_scope_locale(i18n_ctx, || template.into_response())
+}
+
+/// POST /oauth/logout — Execute logout.
+///
+/// Clears the browser session (cookie + DB record + audit event) and then either
+/// redirects to the validated `post_logout_redirect_uri` (with `state` echoed as
+/// a query parameter) or renders the local done page.
+pub(crate) async fn logout_post(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    jar: CookieJar,
+    Form(form): Form<LogoutForm>,
+) -> Response {
+    let hint_claims = form
+        .id_token_hint
+        .as_deref()
+        .and_then(|hint| verify_id_token_hint(&state, hint));
+
+    // Enforce client_id == hint.aud on the POST leg as well.
+    let hint_claims = match (&hint_claims, &form.client_id) {
+        (Some(c), Some(fcid)) if c.aud != *fcid => None,
+        _ => hint_claims,
+    };
+
+    let verified_client_id = hint_claims.as_ref().map(|c| c.aud.clone());
+
+    // Re-validate the post_logout_redirect_uri. The POST handler must NOT trust
+    // the form field without re-checking — the form is same-origin but the
+    // hidden field value could be tampered with.
+    let validated_redirect_uri = resolve_post_logout_redirect_uri(
+        &state,
+        verified_client_id.as_deref(),
+        form.post_logout_redirect_uri.as_deref(),
+    )
+    .await;
+
+    // Clear the browser session (DB deletion + cache invalidation + audit event).
+    clear_user_session(&state, &jar, &headers, verified_client_id.as_deref()).await;
+
+    let clear_cookie = clear_session_cookie().to_string();
+
+    match validated_redirect_uri {
+        Some(redirect_uri) => {
+            // Append `state` if the RP provided it — echo only on redirect.
+            let location = if let Some(ref state_param) = form.state {
+                match url::Url::parse(&redirect_uri) {
+                    Ok(mut url) => {
+                        url.query_pairs_mut().append_pair("state", state_param);
+                        url.to_string()
+                    }
+                    Err(_) => redirect_uri,
+                }
+            } else {
+                redirect_uri
+            };
+
+            Response::builder()
+                .status(StatusCode::SEE_OTHER)
+                .header(header::LOCATION, location)
+                .header(header::SET_COOKIE, clear_cookie)
+                .body(axum::body::Body::empty())
+                .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
+        }
+        None => {
+            let accept_language = headers
+                .get(header::ACCEPT_LANGUAGE)
+                .and_then(|v| v.to_str().ok());
+            let i18n_ctx = negotiate_ui_locales(form.ui_locales.as_deref(), accept_language);
+
+            // Render the done template, then prepend the Set-Cookie header to
+            // clear the session cookie in the browser.
+            let inner_response =
+                sync_scope_locale(i18n_ctx, || LogoutDoneTemplate {}.into_response());
+
+            let (mut parts, body) = inner_response.into_parts();
+            if let Ok(cookie_value) = clear_cookie.parse() {
+                parts.headers.insert(header::SET_COOKIE, cookie_value);
+            }
+            Response::from_parts(parts, body)
+        }
+    }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Look up the client and validate `post_logout_redirect_uri` against its
+/// registered list. Returns `Some(uri)` only when the URI is registered.
+///
+/// Redirect is only permitted when a verified `id_token_hint` supplied `client_id`
+/// — the caller must pass `None` when no hint was verified.
+async fn resolve_post_logout_redirect_uri(
+    state: &AppState,
+    client_id: Option<&str>,
+    post_logout_redirect_uri: Option<&str>,
+) -> Option<String> {
+    let uri = post_logout_redirect_uri?;
+    let cid = client_id?;
+
+    let client = db::get_oauth_client_by_client_id(&state.store, cid)
+        .await
+        .ok()
+        .flatten()?;
+
+    if client.is_valid_post_logout_redirect_uri(uri) {
+        Some(uri.to_string())
+    } else {
+        None
+    }
+}
+
+/// Delete the session associated with the current browser cookie, invalidate
+/// the in-process cache, and fire an audit event.
+///
+/// The `rp_client_id` is the `aud` from the verified `id_token_hint`, included
+/// in the audit event to distinguish RP-initiated logouts from user-initiated ones.
+async fn clear_user_session(
+    state: &AppState,
+    jar: &CookieJar,
+    headers: &HeaderMap,
+    rp_client_id: Option<&str>,
+) {
+    let Some(token) = jar
+        .get(vouch_common::SESSION_COOKIE_NAME)
+        .map(|c| c.value().to_string())
+    else {
+        return;
+    };
+
+    let token_hash = hash_token(&token);
+
+    let session_info = state
+        .session_cache
+        .get_session_by_token_hash(&state.store, &token_hash)
+        .await
+        .ok()
+        .flatten();
+
+    match db::delete_session_by_token_hash(&state.store, &token_hash).await {
+        Ok(deleted) => {
+            if deleted {
+                state.session_cache.invalidate(&token_hash);
+                tracing::info!(
+                    rp_client_id = rp_client_id,
+                    "Session cleared during RP-Initiated Logout"
+                );
+
+                if let Some(session) = session_info {
+                    let client_info = ClientInfo::from(headers);
+                    let params = db::AuthEventParams {
+                        user_id: session.user_id.clone(),
+                        event_type: db::AuthEventType::Logout,
+                        success: true,
+                        ..Default::default()
+                    }
+                    .with_client_info(client_info);
+                    db::spawn_audit_event(&state.audit, params, Some(session.user_email));
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!("Failed to delete session during RP-Initiated Logout: {e}");
+        }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
+mod tests {
+    use super::*;
+    use crate::db::CreateOAuthClientParams;
+    use crate::services::oidc::token::IdTokenClaims;
+    use crate::test_utils::{
+        create_test_authenticator, create_test_session, create_test_user, http_get, http_post_form,
+        test_app, test_app_state, test_app_state_with_rsa_key,
+    };
+
+    /// Build a minimal `IdTokenClaims` for signing in tests.
+    fn test_id_token_claims(iss: &str, sub: &str, aud: &str, exp: i64) -> IdTokenClaims {
+        IdTokenClaims {
+            iss: iss.to_string(),
+            sub: sub.to_string(),
+            aud: aud.to_string(),
+            exp,
+            iat: 0,
+            auth_time: None,
+            nonce: None,
+            email: None,
+            email_verified: None,
+            hardware_verified: None,
+            hardware_aaguid: None,
+            cnf: None,
+            amr: None,
+            acr: None,
+            at_hash: None,
+        }
+    }
+
+    // ====================================================================
+    // verify_id_token_hint — unit tests
+    // ====================================================================
+
+    #[tokio::test]
+    async fn test_verify_id_token_hint_rejects_garbage() {
+        let state = test_app_state().await;
+        assert!(verify_id_token_hint(&state, "not.a.jwt").is_none());
+        assert!(verify_id_token_hint(&state, "").is_none());
+        assert!(verify_id_token_hint(&state, "abc").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_verify_id_token_hint_rejects_wrong_issuer() {
+        let state = test_app_state().await;
+
+        // Sign with the state's key but use a wrong issuer.
+        let claims = test_id_token_claims(
+            "https://evil.example.com",
+            "user-123",
+            "client-abc",
+            9_999_999_999,
+        );
+        let token = state.oidc_key.sign_jwt(&claims).await.unwrap();
+        assert!(verify_id_token_hint(&state, &token).is_none());
+    }
+
+    #[tokio::test]
+    async fn test_verify_id_token_hint_accepts_valid_token() {
+        let state = test_app_state().await;
+        let base_url = state.config().base_url.clone();
+
+        let claims = test_id_token_claims(&base_url, "user-123", "client-abc", 9_999_999_999);
+        let token = state.oidc_key.sign_jwt(&claims).await.unwrap();
+
+        let result = verify_id_token_hint(&state, &token);
+        assert!(result.is_some());
+        let c = result.unwrap();
+        assert_eq!(c.sub, "user-123");
+        assert_eq!(c.aud, "client-abc");
+    }
+
+    #[tokio::test]
+    async fn test_verify_id_token_hint_accepts_expired_token() {
+        let state = test_app_state().await;
+        let base_url = state.config().base_url.clone();
+
+        // exp in the past — should still verify (validate_exp = false).
+        let claims = test_id_token_claims(&base_url, "user-456", "client-xyz", 1);
+        let token = state.oidc_key.sign_jwt(&claims).await.unwrap();
+
+        let result = verify_id_token_hint(&state, &token);
+        assert!(result.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_verify_id_token_hint_accepts_rs256_token() {
+        // An id_token_hint signed with RS256 (the fallback key) must be accepted
+        // when the server has an RSA key configured.
+        let state = test_app_state_with_rsa_key().await;
+        let base_url = state.config().base_url.clone();
+
+        let rsa_key = state.oidc_rsa_key.as_ref().unwrap();
+        let claims = test_id_token_claims(&base_url, "user-rs256", "client-rs256", 9_999_999_999);
+        let token = rsa_key.sign_jwt(&claims).await.unwrap();
+
+        let result = verify_id_token_hint(&state, &token);
+        assert!(result.is_some(), "RS256-signed hint must be accepted");
+        let c = result.unwrap();
+        assert_eq!(c.aud, "client-rs256");
+    }
+
+    #[tokio::test]
+    async fn test_verify_id_token_hint_rs256_rejected_without_rsa_key() {
+        // A RS256-signed hint must be rejected when the server has no RSA key.
+        // (The ES256 decode will fail, and there's no RSA fallback.)
+        let state_with_rsa = test_app_state_with_rsa_key().await;
+        let base_url = state_with_rsa.config().base_url.clone();
+
+        let rsa_key = state_with_rsa.oidc_rsa_key.as_ref().unwrap();
+        let claims = test_id_token_claims(&base_url, "user-no-rsa", "client-no-rsa", 9_999_999_999);
+        let token = rsa_key.sign_jwt(&claims).await.unwrap();
+
+        // Now verify against a state that has NO RSA key.
+        let state_no_rsa = test_app_state().await;
+        // We need the same base_url for the issuer check to pass.
+        // Both states use test_config() so base_url matches — only the key differs.
+        let result = verify_id_token_hint(&state_no_rsa, &token);
+        assert!(
+            result.is_none(),
+            "RS256 hint must be rejected without RSA key"
+        );
+    }
+
+    // ====================================================================
+    // HTTP-level endpoint tests
+    // ====================================================================
+
+    /// Build a signed id_token_hint for the given app state and client_id.
+    async fn make_hint(state: &crate::AppState, client_id: &str) -> String {
+        let base_url = state.config().base_url.clone();
+        let claims = test_id_token_claims(&base_url, "user-1", client_id, 9_999_999_999);
+        state.oidc_key.sign_jwt(&claims).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_get_logout_renders_confirmation_no_hint() {
+        // GET /oauth/logout without any hint always renders 200 HTML confirmation.
+        let (app, _state) = test_app().await;
+        let (status, body) = http_get(&app, "/oauth/logout", &[]).await;
+        assert_eq!(status, axum::http::StatusCode::OK, "body: {body}");
+        assert!(
+            body.contains("</html>") || body.contains("<!DOCTYPE"),
+            "expected HTML: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_logout_renders_confirmation_with_valid_hint() {
+        // GET /oauth/logout with a valid hint renders the confirmation page (200 HTML).
+        let (app, state) = test_app().await;
+        let hint = make_hint(&state, "test-client").await;
+        let url = format!("/oauth/logout?id_token_hint={}", urlencoding::encode(&hint));
+        let (status, body) = http_get(&app, &url, &[]).await;
+        assert_eq!(status, axum::http::StatusCode::OK, "body: {body}");
+        assert!(
+            body.contains("</html>") || body.contains("<!DOCTYPE"),
+            "expected HTML: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_logout_renders_confirmation_without_session_cookie() {
+        // GET /oauth/logout without a session cookie still renders 200 (not 401).
+        // The logout endpoint must not require authentication.
+        let (app, _state) = test_app().await;
+        let (status, _body) = http_get(&app, "/oauth/logout", &[]).await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_post_logout_clears_session_and_redirects_with_state() {
+        // POST /oauth/logout with a valid hint + registered redirect URI should:
+        // 1. Clear the session (Set-Cookie: clear)
+        // 2. 303 redirect to the registered URI with `state` echoed.
+        let (app, state) = test_app().await;
+
+        // Create a user + session.
+        let user = create_test_user(&state.store, "logout-redirect@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+
+        // Create an OAuth client with a registered post_logout_redirect_uri.
+        let post_logout_uri = "https://rp.example.com/logged-out";
+        let client_record = crate::db::create_oauth_client(
+            &state.store,
+            &CreateOAuthClientParams {
+                user_id: Some(&user.id),
+                name: "Logout Test App",
+                description: None,
+                application_type: crate::db::OAuthClientType::Web,
+                redirect_uris: &["https://rp.example.com/callback".to_string()],
+                access_scope: crate::db::AccessScope::Personal,
+                org_id: None,
+                resource_uris: &[],
+                token_endpoint_auth_method: None,
+                jwks: None,
+                jwks_uri: None,
+                fapi_profile: None,
+                dpop_bound_access_tokens: None,
+                grant_types: None,
+                response_types: None,
+                software_id: None,
+                software_version: None,
+                registration_source: crate::db::RegistrationSource::Manual,
+                registration_access_token_hash: None,
+                registration_metadata: None,
+                id_token_signed_response_alg: crate::db::JwsAlgorithm::Rs256,
+                tls_client_auth_subject_dn: None,
+                tls_client_auth_san_dns: None,
+                tls_client_auth_san_uri: None,
+                tls_client_auth_san_ip: None,
+                tls_client_auth_san_email: None,
+                tls_client_certificate_bound_access_tokens: None,
+                authorization_signed_response_alg: None,
+                introspection_signed_response_alg: None,
+                request_object_signing_alg: None,
+                require_signed_request_object: None,
+                userinfo_signed_response_alg: None,
+                request_uris: None,
+                post_logout_redirect_uris: Some(vec![post_logout_uri.to_string()]),
+            },
+        )
+        .await
+        .unwrap();
+        let (_, client_id) = client_record;
+
+        let hint = make_hint(&state, &client_id).await;
+        let form_body = format!(
+            "id_token_hint={}&client_id={}&post_logout_redirect_uri={}&state=my-opaque-state",
+            urlencoding::encode(&hint),
+            urlencoding::encode(&client_id),
+            urlencoding::encode(post_logout_uri),
+        );
+
+        let (status, body) = http_post_form(
+            &app,
+            "/oauth/logout",
+            &form_body,
+            &[("Cookie", &format!("__Host-vouch_session={session_token}"))],
+        )
+        .await;
+
+        assert_eq!(
+            status,
+            axum::http::StatusCode::SEE_OTHER,
+            "expected 303 redirect; body: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_post_logout_tampered_hint_renders_done_page() {
+        // A tampered / wrong-issuer hint must NOT redirect. Instead render done page locally.
+        let (app, _state) = test_app().await;
+
+        let form_body = "id_token_hint=garbage.garbage.garbage&post_logout_redirect_uri=https://evil.example.com/";
+
+        let (status, body) = http_post_form(&app, "/oauth/logout", form_body, &[]).await;
+
+        // Must NOT redirect to the evil URI.
+        assert_ne!(
+            status,
+            axum::http::StatusCode::SEE_OTHER,
+            "must not redirect with tampered hint; body: {body}"
+        );
+        // Must render done page HTML.
+        assert!(
+            body.contains("</html>") || body.contains("<!DOCTYPE"),
+            "expected done-page HTML: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_post_logout_unregistered_redirect_uri_renders_done_page() {
+        // A valid hint but an unregistered redirect URI must NOT redirect.
+        let (app, state) = test_app().await;
+        let hint = make_hint(&state, "no-such-client").await;
+        let form_body = format!(
+            "id_token_hint={}&post_logout_redirect_uri=https://unregistered.example.com/",
+            urlencoding::encode(&hint),
+        );
+
+        let (status, body) = http_post_form(&app, "/oauth/logout", &form_body, &[]).await;
+        assert_ne!(
+            status,
+            axum::http::StatusCode::SEE_OTHER,
+            "must not redirect to unregistered URI; body: {body}"
+        );
+        assert!(
+            body.contains("</html>") || body.contains("<!DOCTYPE"),
+            "expected done-page HTML: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_post_logout_client_id_mismatch_renders_done_page() {
+        // When client_id != hint.aud the hint is discarded → no redirect.
+        let (app, state) = test_app().await;
+        let hint = make_hint(&state, "real-client").await;
+        let form_body = format!(
+            "id_token_hint={}&client_id=different-client&post_logout_redirect_uri=https://rp.example.com/",
+            urlencoding::encode(&hint),
+        );
+
+        let (status, body) = http_post_form(&app, "/oauth/logout", &form_body, &[]).await;
+        assert_ne!(
+            status,
+            axum::http::StatusCode::SEE_OTHER,
+            "client_id mismatch must discard hint; body: {body}"
+        );
+        assert!(
+            body.contains("</html>") || body.contains("<!DOCTYPE"),
+            "expected done-page HTML: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_post_logout_no_hint_renders_done_page() {
+        // POST without any hint and with a redirect URI must NOT redirect.
+        // Redirect is gated on a verified hint — bare client_id is not enough.
+        let (app, _state) = test_app().await;
+        let form_body = "post_logout_redirect_uri=https://rp.example.com/";
+
+        let (status, body) = http_post_form(&app, "/oauth/logout", form_body, &[]).await;
+        assert_ne!(
+            status,
+            axum::http::StatusCode::SEE_OTHER,
+            "no hint must not redirect; body: {body}"
+        );
+        assert!(
+            body.contains("</html>") || body.contains("<!DOCTYPE"),
+            "expected done-page HTML: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_post_logout_set_cookie_clears_session() {
+        // POST must always return a Set-Cookie header that clears the session,
+        // regardless of whether a redirect URI is available.
+        let (app, _state) = test_app().await;
+        let (status, _body) = http_post_form(&app, "/oauth/logout", "", &[]).await;
+
+        // 200 (done page) or 303 (redirect) — both must have cleared the cookie.
+        // We verify the response is well-formed (not an error).
+        assert!(
+            status == axum::http::StatusCode::OK || status == axum::http::StatusCode::SEE_OTHER,
+            "unexpected status: {status}"
+        );
+    }
+}

--- a/crates/vouch-server/src/handlers/oidc/logout.rs
+++ b/crates/vouch-server/src/handlers/oidc/logout.rs
@@ -256,12 +256,19 @@ pub(crate) async fn logout(
 
     // Validate post_logout_redirect_uri against the client's registered list.
     // Only pass it through if a verified hint identified the client.
-    let validated_redirect_uri = resolve_post_logout_redirect_uri(
+    let validated_redirect_uri = match resolve_post_logout_redirect_uri(
         &state,
         verified_client_id.as_deref(),
         query.post_logout_redirect_uri.as_deref(),
     )
-    .await;
+    .await
+    {
+        Ok(uri) => uri,
+        Err(e) => {
+            tracing::error!(error = %e, "logout: failed to resolve post_logout_redirect_uri");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
 
     // The confirmation form propagates the hint, redirect URI, state, and
     // ui_locales as hidden fields so the POST handler can re-validate them.
@@ -301,20 +308,35 @@ pub(crate) async fn logout_post(
 
     let verified_client_id = hint_claims.as_ref().map(|c| c.aud.clone());
 
+    // Clear the browser session first (DB deletion + cache invalidation + audit
+    // event). The user asked to log out, so a later redirect-validation database
+    // error must not prevent logout.
+    clear_user_session(&state, &jar, &headers, verified_client_id.as_deref()).await;
+
+    let clear_cookie = clear_session_cookie().to_string();
+
     // Re-validate the post_logout_redirect_uri. The POST handler must NOT trust
     // the form field without re-checking — the form is same-origin but the
     // hidden field value could be tampered with.
-    let validated_redirect_uri = resolve_post_logout_redirect_uri(
+    let validated_redirect_uri = match resolve_post_logout_redirect_uri(
         &state,
         verified_client_id.as_deref(),
         form.post_logout_redirect_uri.as_deref(),
     )
-    .await;
-
-    // Clear the browser session (DB deletion + cache invalidation + audit event).
-    clear_user_session(&state, &jar, &headers, verified_client_id.as_deref()).await;
-
-    let clear_cookie = clear_session_cookie().to_string();
+    .await
+    {
+        Ok(uri) => uri,
+        Err(e) => {
+            tracing::error!(error = %e, "logout: failed to resolve post_logout_redirect_uri");
+            // The session is already cleared; surface the server fault rather
+            // than silently skipping the redirect.
+            return Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .header(header::SET_COOKIE, clear_cookie)
+                .body(axum::body::Body::empty())
+                .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response());
+        }
+    };
 
     match validated_redirect_uri {
         Some(redirect_uri) => {
@@ -363,7 +385,10 @@ pub(crate) async fn logout_post(
 // ============================================================================
 
 /// Look up the client and validate `post_logout_redirect_uri` against its
-/// registered list. Returns `Some(uri)` only when the URI is registered.
+/// registered list. Returns `Ok(Some(uri))` only when the URI is registered for
+/// an active client, `Ok(None)` when there is no valid redirect target, and
+/// `Err` when the client lookup fails — the caller surfaces that as a server
+/// error rather than silently skipping the redirect.
 ///
 /// Redirect is only permitted when a verified `id_token_hint` supplied `client_id`
 /// — the caller must pass `None` when no hint was verified.
@@ -371,20 +396,24 @@ async fn resolve_post_logout_redirect_uri(
     state: &AppState,
     client_id: Option<&str>,
     post_logout_redirect_uri: Option<&str>,
-) -> Option<String> {
-    let uri = post_logout_redirect_uri?;
-    let cid = client_id?;
+) -> anyhow::Result<Option<String>> {
+    let (Some(uri), Some(cid)) = (post_logout_redirect_uri, client_id) else {
+        return Ok(None);
+    };
 
-    let client = db::get_oauth_client_by_client_id(&state.store, cid)
-        .await
-        .ok()
-        .flatten()?;
+    let Some(client) = db::get_oauth_client_by_client_id(&state.store, cid).await? else {
+        return Ok(None);
+    };
 
-    if client.is_valid_post_logout_redirect_uri(uri) {
-        Some(uri.to_string())
-    } else {
-        None
+    // Deactivated clients cannot receive a post-logout redirect, consistent with
+    // the authorize flow which rejects inactive clients.
+    if !client.active {
+        return Ok(None);
     }
+
+    Ok(client
+        .is_valid_post_logout_redirect_uri(uri)
+        .then(|| uri.to_string()))
 }
 
 /// Delete the session associated with the current browser cookie, invalidate
@@ -699,6 +728,91 @@ mod tests {
             status,
             axum::http::StatusCode::SEE_OTHER,
             "expected 303 redirect; body: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_post_logout_inactive_client_renders_done_page() {
+        // A deactivated client must NOT receive a post-logout redirect, even with
+        // a valid hint and a registered URI — consistent with the authorize flow.
+        let (app, state) = test_app().await;
+
+        let user = create_test_user(&state.store, "logout-inactive@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+
+        let post_logout_uri = "https://rp.example.com/logged-out";
+        let (client_oid, client_id) = crate::db::create_oauth_client(
+            &state.store,
+            &CreateOAuthClientParams {
+                user_id: Some(&user.id),
+                name: "Inactive Logout App",
+                description: None,
+                application_type: crate::db::OAuthClientType::Web,
+                redirect_uris: &["https://rp.example.com/callback".to_string()],
+                access_scope: crate::db::AccessScope::Personal,
+                org_id: None,
+                resource_uris: &[],
+                token_endpoint_auth_method: None,
+                jwks: None,
+                jwks_uri: None,
+                fapi_profile: None,
+                dpop_bound_access_tokens: None,
+                grant_types: None,
+                response_types: None,
+                software_id: None,
+                software_version: None,
+                registration_source: crate::db::RegistrationSource::Manual,
+                registration_access_token_hash: None,
+                registration_metadata: None,
+                id_token_signed_response_alg: crate::db::JwsAlgorithm::Rs256,
+                tls_client_auth_subject_dn: None,
+                tls_client_auth_san_dns: None,
+                tls_client_auth_san_uri: None,
+                tls_client_auth_san_ip: None,
+                tls_client_auth_san_email: None,
+                tls_client_certificate_bound_access_tokens: None,
+                authorization_signed_response_alg: None,
+                introspection_signed_response_alg: None,
+                request_object_signing_alg: None,
+                require_signed_request_object: None,
+                userinfo_signed_response_alg: None,
+                request_uris: None,
+                post_logout_redirect_uris: Some(vec![post_logout_uri.to_string()]),
+            },
+        )
+        .await
+        .unwrap();
+
+        // Deactivate the client after creation.
+        crate::db::set_oauth_client_active(&state.store, &client_oid.id, false)
+            .await
+            .unwrap();
+
+        let hint = make_hint(&state, &client_id).await;
+        let form_body = format!(
+            "id_token_hint={}&client_id={}&post_logout_redirect_uri={}&state=opaque",
+            urlencoding::encode(&hint),
+            urlencoding::encode(&client_id),
+            urlencoding::encode(post_logout_uri),
+        );
+
+        let (status, body) = http_post_form(
+            &app,
+            "/oauth/logout",
+            &form_body,
+            &[("Cookie", &format!("__Host-vouch_session={session_token}"))],
+        )
+        .await;
+
+        assert_ne!(
+            status,
+            axum::http::StatusCode::SEE_OTHER,
+            "deactivated client must not receive a redirect; body: {body}"
+        );
+        assert!(
+            body.contains("</html>") || body.contains("<!DOCTYPE"),
+            "expected done-page HTML: {body}"
         );
     }
 

--- a/crates/vouch-server/src/handlers/oidc/logout.rs
+++ b/crates/vouch-server/src/handlers/oidc/logout.rs
@@ -199,6 +199,25 @@ fn verify_id_token_hint(state: &AppState, hint: &str) -> Option<IdTokenHintClaim
 }
 
 // ============================================================================
+// Helpers for hint/client_id consistency
+// ============================================================================
+
+/// Enforce the `client_id == hint.aud` constraint from RP-Initiated Logout 1.0 §3.
+///
+/// When both a verified hint and an explicit `client_id` are present they MUST agree.
+/// On mismatch, the hint is discarded so the request falls through to the local done
+/// page — never redirecting to an unvalidated URI.
+fn filter_hint_by_client_id(
+    hint: Option<IdTokenHintClaims>,
+    client_id: Option<&str>,
+) -> Option<IdTokenHintClaims> {
+    match (&hint, client_id) {
+        (Some(c), Some(cid)) if c.aud != cid => None,
+        _ => hint,
+    }
+}
+
+// ============================================================================
 // Handlers
 // ============================================================================
 
@@ -229,10 +248,7 @@ pub(crate) async fn logout(
     // When both a verified hint and a bare client_id are present, they MUST agree.
     // Spec §3: "If client_id is given, it MUST match the aud of id_token_hint."
     // On mismatch: treat as no verified hint (fall through to local done page).
-    let hint_claims = match (&hint_claims, &query.client_id) {
-        (Some(c), Some(qcid)) if c.aud != *qcid => None,
-        _ => hint_claims,
-    };
+    let hint_claims = filter_hint_by_client_id(hint_claims, query.client_id.as_deref());
 
     // Determine the RP client_id from the verified hint. The bare `client_id`
     // query param is used for display only; it does NOT gate a redirect.
@@ -281,10 +297,7 @@ pub(crate) async fn logout_post(
         .and_then(|hint| verify_id_token_hint(&state, hint));
 
     // Enforce client_id == hint.aud on the POST leg as well.
-    let hint_claims = match (&hint_claims, &form.client_id) {
-        (Some(c), Some(fcid)) if c.aud != *fcid => None,
-        _ => hint_claims,
-    };
+    let hint_claims = filter_hint_by_client_id(hint_claims, form.client_id.as_deref());
 
     let verified_client_id = hint_claims.as_ref().map(|c| c.aud.clone());
 
@@ -416,6 +429,7 @@ async fn clear_user_session(
                         user_id: session.user_id.clone(),
                         event_type: db::AuthEventType::Logout,
                         success: true,
+                        client_id: rp_client_id.map(str::to_string),
                         ..Default::default()
                     }
                     .with_client_info(client_info);

--- a/crates/vouch-server/src/handlers/oidc/logout.rs
+++ b/crates/vouch-server/src/handlers/oidc/logout.rs
@@ -255,20 +255,20 @@ pub(crate) async fn logout(
     let verified_client_id = hint_claims.as_ref().map(|c| c.aud.clone());
 
     // Validate post_logout_redirect_uri against the client's registered list.
-    // Only pass it through if a verified hint identified the client.
-    let validated_redirect_uri = match resolve_post_logout_redirect_uri(
+    // Only pass it through if a verified hint identified the client. A transient
+    // client-lookup failure degrades to "no redirect target" (logged, not
+    // silently dropped) — the same outcome as an unregistered URI — rather than
+    // blocking the confirmation page with a 500.
+    let validated_redirect_uri = resolve_post_logout_redirect_uri(
         &state,
         verified_client_id.as_deref(),
         query.post_logout_redirect_uri.as_deref(),
     )
     .await
-    {
-        Ok(uri) => uri,
-        Err(e) => {
-            tracing::error!(error = %e, "logout: failed to resolve post_logout_redirect_uri");
-            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
-        }
-    };
+    .unwrap_or_else(|e| {
+        tracing::warn!(error = %e, "logout: post_logout_redirect_uri resolution failed; not redirecting");
+        None
+    });
 
     // The confirmation form propagates the hint, redirect URI, state, and
     // ui_locales as hidden fields so the POST handler can re-validate them.
@@ -317,26 +317,19 @@ pub(crate) async fn logout_post(
 
     // Re-validate the post_logout_redirect_uri. The POST handler must NOT trust
     // the form field without re-checking — the form is same-origin but the
-    // hidden field value could be tampered with.
-    let validated_redirect_uri = match resolve_post_logout_redirect_uri(
+    // hidden field value could be tampered with. A transient client-lookup
+    // failure degrades to "no redirect" (logged): the session is already
+    // cleared, so logout still succeeds and we fall through to the done page.
+    let validated_redirect_uri = resolve_post_logout_redirect_uri(
         &state,
         verified_client_id.as_deref(),
         form.post_logout_redirect_uri.as_deref(),
     )
     .await
-    {
-        Ok(uri) => uri,
-        Err(e) => {
-            tracing::error!(error = %e, "logout: failed to resolve post_logout_redirect_uri");
-            // The session is already cleared; surface the server fault rather
-            // than silently skipping the redirect.
-            return Response::builder()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .header(header::SET_COOKIE, clear_cookie)
-                .body(axum::body::Body::empty())
-                .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response());
-        }
-    };
+    .unwrap_or_else(|e| {
+        tracing::warn!(error = %e, "logout: post_logout_redirect_uri resolution failed; not redirecting");
+        None
+    });
 
     match validated_redirect_uri {
         Some(redirect_uri) => {
@@ -436,12 +429,19 @@ async fn clear_user_session(
 
     let token_hash = hash_token(&token);
 
-    let session_info = state
+    let session_info = match state
         .session_cache
         .get_session_by_token_hash(&state.store, &token_hash)
         .await
-        .ok()
-        .flatten();
+    {
+        Ok(info) => info,
+        Err(e) => {
+            // Don't silently drop the error: log it and proceed. The session is
+            // still deleted below; only the audit event's user context is lost.
+            tracing::warn!(error = %e, "RP-Initiated Logout: session lookup for audit failed");
+            None
+        }
+    };
 
     match db::delete_session_by_token_hash(&state.store, &token_hash).await {
         Ok(deleted) => {

--- a/crates/vouch-server/src/handlers/oidc/logout.rs
+++ b/crates/vouch-server/src/handlers/oidc/logout.rs
@@ -483,11 +483,11 @@ async fn clear_user_session(
 )]
 mod tests {
     use super::*;
-    use crate::db::CreateOAuthClientParams;
     use crate::services::oidc::token::IdTokenClaims;
     use crate::test_utils::{
-        create_test_authenticator, create_test_session, create_test_user, http_get, http_post_form,
-        test_app, test_app_state, test_app_state_with_rsa_key,
+        TestClientSpec, create_test_authenticator, create_test_client, create_test_session,
+        create_test_user, http_get, http_post_form, test_app, test_app_state,
+        test_app_state_with_rsa_key,
     };
 
     /// Build a minimal `IdTokenClaims` for signing in tests.
@@ -665,48 +665,17 @@ mod tests {
 
         // Create an OAuth client with a registered post_logout_redirect_uri.
         let post_logout_uri = "https://rp.example.com/logged-out";
-        let client_record = crate::db::create_oauth_client(
+        let client = create_test_client(
             &state.store,
-            &CreateOAuthClientParams {
-                user_id: Some(&user.id),
-                name: "Logout Test App",
-                description: None,
-                application_type: crate::db::OAuthClientType::Web,
-                redirect_uris: &["https://rp.example.com/callback".to_string()],
-                access_scope: crate::db::AccessScope::Personal,
-                org_id: None,
-                resource_uris: &[],
-                token_endpoint_auth_method: None,
-                jwks: None,
-                jwks_uri: None,
-                fapi_profile: None,
-                dpop_bound_access_tokens: None,
-                grant_types: None,
-                response_types: None,
-                software_id: None,
-                software_version: None,
-                registration_source: crate::db::RegistrationSource::Manual,
-                registration_access_token_hash: None,
-                registration_metadata: None,
-                id_token_signed_response_alg: crate::db::JwsAlgorithm::Rs256,
-                tls_client_auth_subject_dn: None,
-                tls_client_auth_san_dns: None,
-                tls_client_auth_san_uri: None,
-                tls_client_auth_san_ip: None,
-                tls_client_auth_san_email: None,
-                tls_client_certificate_bound_access_tokens: None,
-                authorization_signed_response_alg: None,
-                introspection_signed_response_alg: None,
-                request_object_signing_alg: None,
-                require_signed_request_object: None,
-                userinfo_signed_response_alg: None,
-                request_uris: None,
-                post_logout_redirect_uris: Some(vec![post_logout_uri.to_string()]),
+            &user.id,
+            TestClientSpec {
+                name: "Logout Test App".to_string(),
+                post_logout_redirect_uris: vec![post_logout_uri.to_string()],
+                ..Default::default()
             },
         )
-        .await
-        .unwrap();
-        let (_, client_id) = client_record;
+        .await;
+        let client_id = client.client_id;
 
         let hint = make_hint(&state, &client_id).await;
         let form_body = format!(
@@ -742,50 +711,20 @@ mod tests {
         let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
 
         let post_logout_uri = "https://rp.example.com/logged-out";
-        let (client_oid, client_id) = crate::db::create_oauth_client(
+        let client = create_test_client(
             &state.store,
-            &CreateOAuthClientParams {
-                user_id: Some(&user.id),
-                name: "Inactive Logout App",
-                description: None,
-                application_type: crate::db::OAuthClientType::Web,
-                redirect_uris: &["https://rp.example.com/callback".to_string()],
-                access_scope: crate::db::AccessScope::Personal,
-                org_id: None,
-                resource_uris: &[],
-                token_endpoint_auth_method: None,
-                jwks: None,
-                jwks_uri: None,
-                fapi_profile: None,
-                dpop_bound_access_tokens: None,
-                grant_types: None,
-                response_types: None,
-                software_id: None,
-                software_version: None,
-                registration_source: crate::db::RegistrationSource::Manual,
-                registration_access_token_hash: None,
-                registration_metadata: None,
-                id_token_signed_response_alg: crate::db::JwsAlgorithm::Rs256,
-                tls_client_auth_subject_dn: None,
-                tls_client_auth_san_dns: None,
-                tls_client_auth_san_uri: None,
-                tls_client_auth_san_ip: None,
-                tls_client_auth_san_email: None,
-                tls_client_certificate_bound_access_tokens: None,
-                authorization_signed_response_alg: None,
-                introspection_signed_response_alg: None,
-                request_object_signing_alg: None,
-                require_signed_request_object: None,
-                userinfo_signed_response_alg: None,
-                request_uris: None,
-                post_logout_redirect_uris: Some(vec![post_logout_uri.to_string()]),
+            &user.id,
+            TestClientSpec {
+                name: "Inactive Logout App".to_string(),
+                post_logout_redirect_uris: vec![post_logout_uri.to_string()],
+                ..Default::default()
             },
         )
-        .await
-        .unwrap();
+        .await;
+        let client_id = client.client_id;
 
         // Deactivate the client after creation.
-        crate::db::set_oauth_client_active(&state.store, &client_oid.id, false)
+        crate::db::set_oauth_client_active(&state.store, &client.app_id, false)
             .await
             .unwrap();
 

--- a/crates/vouch-server/src/handlers/oidc/logout.rs
+++ b/crates/vouch-server/src/handlers/oidc/logout.rs
@@ -266,7 +266,7 @@ pub(crate) async fn logout(
     )
     .await
     .unwrap_or_else(|e| {
-        tracing::warn!(error = %e, "logout: post_logout_redirect_uri resolution failed; not redirecting");
+        tracing::error!(error = %e, "logout: post_logout_redirect_uri resolution failed; not redirecting");
         None
     });
 
@@ -327,7 +327,7 @@ pub(crate) async fn logout_post(
     )
     .await
     .unwrap_or_else(|e| {
-        tracing::warn!(error = %e, "logout: post_logout_redirect_uri resolution failed; not redirecting");
+        tracing::error!(error = %e, "logout: post_logout_redirect_uri resolution failed; not redirecting");
         None
     });
 

--- a/crates/vouch-server/src/handlers/oidc/mod.rs
+++ b/crates/vouch-server/src/handlers/oidc/mod.rs
@@ -14,6 +14,7 @@
 //! - `GET /oauth/userinfo` — OIDC Core 1.0 Section 5.3 (UserInfo Endpoint)
 //! - `POST /oauth/revoke` — RFC 7009 Section 2 (Token Revocation)
 //! - `POST /oauth/introspect` — RFC 7662 Section 2 (Token Introspection)
+//! - `GET|POST /oauth/logout` — RP-Initiated Logout 1.0
 //!
 //! ## Token Claims
 //!
@@ -27,6 +28,7 @@ pub(crate) mod client_auth;
 mod discovery;
 mod fido2_challenge;
 mod introspect;
+mod logout;
 mod par;
 mod protected_resource;
 mod register;
@@ -87,6 +89,7 @@ pub(crate) use authorize::{authorize, authorize_post};
 pub(crate) use discovery::{discovery, jwks};
 pub(crate) use fido2_challenge::fido2_challenge;
 pub(crate) use introspect::{introspect, revoke};
+pub(crate) use logout::{logout, logout_post};
 pub(crate) use par::par;
 pub(crate) use protected_resource::{
     protected_resource_metadata_root, protected_resource_metadata_subpath,

--- a/crates/vouch-server/src/handlers/oidc/tests/oidc_discovery.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/oidc_discovery.rs
@@ -314,6 +314,30 @@ async fn test_oidc_discovery_userinfo_signing_alg_values_supported() {
 }
 
 #[tokio::test]
+async fn test_oidc_discovery_end_session_endpoint_present() {
+    // RP-Initiated Logout 1.0 §4: end_session_endpoint must be advertised.
+    let (app, state) = test_app().await;
+
+    let (status, body) = http_get(&app, "/.well-known/openid-configuration", &[]).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let discovery: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+
+    let end_session_endpoint = discovery["end_session_endpoint"]
+        .as_str()
+        .expect("end_session_endpoint must be present and a string in OIDC discovery document");
+    let expected = format!("{}/oauth/logout", state.config().base_url);
+    assert_eq!(
+        end_session_endpoint, expected,
+        "end_session_endpoint must equal <base_url>/oauth/logout"
+    );
+    assert!(
+        end_session_endpoint.starts_with("https://"),
+        "end_session_endpoint must be an absolute HTTPS URL, got: {end_session_endpoint}"
+    );
+}
+
+#[tokio::test]
 async fn test_oidc_discovery_hardware_claims_not_in_claims_supported() {
     // OIDC compliance: hardware_verified and hardware_aaguid must not appear in
     // claims_supported after removal from standard OIDC id_tokens.

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7591.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7591.rs
@@ -1164,3 +1164,104 @@ async fn test_rfc7591_e2e_registered_client_auth_code_flow() {
         serde_json::from_str(&userinfo_body).expect("Valid JSON userinfo");
     assert_eq!(userinfo["email"], "e2e-dynamic-user@example.com");
 }
+
+// ========================================================================
+// RP-Initiated Logout 1.0 — post_logout_redirect_uris registration
+// ========================================================================
+
+#[tokio::test]
+async fn test_rfc7591_post_logout_redirect_uris_roundtrip() {
+    // RFC 7591: post_logout_redirect_uris must be echoed back in the registration response.
+    let (app, _state) = test_app().await;
+
+    let body = serde_json::json!({
+        "redirect_uris": ["https://rp.example.com/callback"],
+        "post_logout_redirect_uris": ["https://rp.example.com/logged-out"]
+    });
+
+    let (status, resp) = http_post_json(&app, "/oauth/register", &body.to_string(), &[]).await;
+    assert_eq!(status, StatusCode::CREATED, "Registration failed: {resp}");
+
+    let json: serde_json::Value = serde_json::from_str(&resp).expect("Valid JSON");
+    let post_logout = json
+        .get("post_logout_redirect_uris")
+        .and_then(|v| v.as_array())
+        .expect("post_logout_redirect_uris must be echoed in the registration response");
+    assert_eq!(
+        post_logout.len(),
+        1,
+        "Expected 1 post_logout_redirect_uri, got {post_logout:?}"
+    );
+    assert_eq!(
+        post_logout[0].as_str().unwrap(),
+        "https://rp.example.com/logged-out"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc7591_post_logout_redirect_uris_invalid_scheme_rejected() {
+    // A post_logout_redirect_uri with an invalid scheme (ftp://) must be rejected.
+    let (app, _state) = test_app().await;
+
+    let body = serde_json::json!({
+        "redirect_uris": ["https://rp.example.com/callback"],
+        "post_logout_redirect_uris": ["ftp://rp.example.com/logged-out"]
+    });
+
+    let (status, resp) = http_post_json(&app, "/oauth/register", &body.to_string(), &[]).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "ftp:// post_logout_redirect_uri must be rejected: {resp}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&resp).expect("Valid JSON");
+    // RFC 7591 §3.2.2: registration errors use `invalid_client_metadata`.
+    assert_eq!(json["error"], "invalid_client_metadata");
+}
+
+#[tokio::test]
+async fn test_rfc7591_post_logout_redirect_uris_fragment_rejected() {
+    // A post_logout_redirect_uri carrying a fragment must be rejected.
+    let (app, _state) = test_app().await;
+
+    let body = serde_json::json!({
+        "redirect_uris": ["https://rp.example.com/callback"],
+        "post_logout_redirect_uris": ["https://rp.example.com/logged-out#section"]
+    });
+
+    let (status, resp) = http_post_json(&app, "/oauth/register", &body.to_string(), &[]).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "fragment in post_logout_redirect_uri must be rejected: {resp}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&resp).expect("Valid JSON");
+    // RFC 7591 §3.2.2: registration errors use `invalid_client_metadata`.
+    assert_eq!(json["error"], "invalid_client_metadata");
+}
+
+#[tokio::test]
+async fn test_rfc7591_post_logout_redirect_uris_loopback_http_allowed() {
+    // Loopback http:// is allowed for native app testing.
+    let (app, _state) = test_app().await;
+
+    let body = serde_json::json!({
+        "redirect_uris": ["http://localhost:3000/callback"],
+        "post_logout_redirect_uris": ["http://localhost:3000/logged-out"]
+    });
+
+    let (status, resp) = http_post_json(&app, "/oauth/register", &body.to_string(), &[]).await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "loopback http:// post_logout_redirect_uri must be accepted: {resp}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&resp).expect("Valid JSON");
+    let post_logout = json["post_logout_redirect_uris"]
+        .as_array()
+        .expect("post_logout_redirect_uris present");
+    assert_eq!(
+        post_logout[0].as_str().unwrap(),
+        "http://localhost:3000/logged-out"
+    );
+}

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7592.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7592.rs
@@ -703,3 +703,148 @@ async fn test_rfc7592_put_accepts_valid_contacts() {
     assert_eq!(contacts.len(), 1, "PUT response must echo the contact list");
     assert_eq!(contacts[0].as_str(), Some("admin@example.com"));
 }
+
+// ========================================================================
+// RP-Initiated Logout 1.0 — post_logout_redirect_uris management
+// ========================================================================
+
+#[tokio::test]
+async fn test_rfc7592_put_post_logout_redirect_uris_roundtrip() {
+    // PUT must accept post_logout_redirect_uris and echo them in the response.
+    let (app, _state) = test_app().await;
+    let (client_id, token) = register_dynamic_client(&app).await;
+
+    let update_body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "post_logout_redirect_uris": ["https://example.com/logged-out"]
+    });
+
+    let (status, body) = http_request(
+        &app,
+        "PUT",
+        &format!("/oauth/register/{client_id}"),
+        Some(update_body.to_string()),
+        &[
+            ("Authorization", &format!("Bearer {token}")),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "PUT with post_logout_redirect_uris must succeed: {body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let post_logout = json["post_logout_redirect_uris"]
+        .as_array()
+        .expect("post_logout_redirect_uris must be echoed in PUT response");
+    assert_eq!(
+        post_logout.len(),
+        1,
+        "Expected 1 post_logout_redirect_uri, got {post_logout:?}"
+    );
+    assert_eq!(
+        post_logout[0].as_str().unwrap(),
+        "https://example.com/logged-out"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc7592_put_post_logout_redirect_uris_clears_on_omit() {
+    // A PUT without post_logout_redirect_uris must clear the field (full-replacement semantics).
+    // Note: RFC 7592 §3 says PUT may rotate registration_access_token. We read the new
+    // token from the first PUT response and use it for the second PUT.
+    let (app, _state) = test_app().await;
+    let (client_id, token) = register_dynamic_client(&app).await;
+
+    // First PUT: set post_logout_redirect_uris; read back the (possibly rotated) token.
+    let set_body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "post_logout_redirect_uris": ["https://example.com/logged-out"]
+    });
+    let (status, first_resp) = http_request(
+        &app,
+        "PUT",
+        &format!("/oauth/register/{client_id}"),
+        Some(set_body.to_string()),
+        &[
+            ("Authorization", &format!("Bearer {token}")),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "First PUT must succeed: {first_resp}"
+    );
+
+    // Extract the possibly-rotated token from the response.
+    let first_json: serde_json::Value =
+        serde_json::from_str(&first_resp).expect("Valid JSON from first PUT");
+    let token2 = first_json["registration_access_token"]
+        .as_str()
+        .unwrap_or(&token)
+        .to_string();
+
+    // Second PUT: omit post_logout_redirect_uris → field should be cleared.
+    let clear_body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"]
+    });
+    let (status, body) = http_request(
+        &app,
+        "PUT",
+        &format!("/oauth/register/{client_id}"),
+        Some(clear_body.to_string()),
+        &[
+            ("Authorization", &format!("Bearer {token2}")),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "Second PUT must succeed: {body}");
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let post_logout = json.get("post_logout_redirect_uris");
+    // Field should be absent or null/empty after full-replacement without it.
+    assert!(
+        post_logout.is_none()
+            || post_logout.is_some_and(|v| v.is_null() || v == &serde_json::json!([])),
+        "post_logout_redirect_uris must be cleared when omitted from PUT: {json}"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc7592_put_post_logout_redirect_uris_invalid_rejected() {
+    // PUT with an invalid post_logout_redirect_uri must be rejected with 400.
+    let (app, _state) = test_app().await;
+    let (client_id, token) = register_dynamic_client(&app).await;
+
+    let update_body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "post_logout_redirect_uris": ["ftp://not-allowed.example.com/"]
+    });
+
+    let (status, body) = http_request(
+        &app,
+        "PUT",
+        &format!("/oauth/register/{client_id}"),
+        Some(update_body.to_string()),
+        &[
+            ("Authorization", &format!("Bearer {token}")),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "Invalid post_logout_redirect_uri must be rejected: {body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    // RFC 7591/7592: registration management errors use `invalid_client_metadata`.
+    assert_eq!(
+        json["error"], "invalid_client_metadata",
+        "Error code must be invalid_client_metadata: {json}"
+    );
+}

--- a/crates/vouch-server/src/infra/i18n.rs
+++ b/crates/vouch-server/src/infra/i18n.rs
@@ -229,6 +229,45 @@ pub fn validate_startup() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Negotiate an [`I18nContext`] giving precedence to `ui_locales` (RP-Initiated Logout 1.0
+/// Section 3, space-separated BCP-47 tags) over `Accept-Language`.
+///
+/// If `ui_locales` is `Some` and non-empty, its tags are tried first. If none match an
+/// installed locale, fall back to `accept_language` as normal.
+pub(crate) fn negotiate_ui_locales(
+    ui_locales: Option<&str>,
+    accept_language: Option<&str>,
+) -> I18nContext {
+    if let Some(raw) = ui_locales {
+        let mut requested: Vec<LanguageIdentifier> = raw
+            .split_whitespace()
+            .filter_map(|tag| tag.parse::<LanguageIdentifier>().ok())
+            .collect();
+        if !requested.is_empty() {
+            // Append Accept-Language languages as lower-priority fallbacks.
+            if let Some(al) = accept_language {
+                requested.extend(parse_accept_language(al));
+            }
+            let loader = vouch_i18n::select_loader(&LOADER, &requested);
+            let lang = loader.current_language().to_string();
+            return I18nContext {
+                loader: Arc::new(loader),
+                lang,
+            };
+        }
+    }
+    negotiate(accept_language)
+}
+
+/// Run `f` inside the [`REQUEST_I18N`] scope of `ctx`.
+///
+/// Used by the logout handler to honour `ui_locales` for page rendering without
+/// changing the handler signature — templates pick up the locale via the
+/// task-local just as they do under [`i18n_layer`].
+pub(crate) fn sync_scope_locale<R>(ctx: I18nContext, f: impl FnOnce() -> R) -> R {
+    REQUEST_I18N.sync_scope(ctx, f)
+}
+
 /// Negotiate an [`I18nContext`] from an optional `Accept-Language` header value.
 pub(crate) fn negotiate(accept_language: Option<&str>) -> I18nContext {
     let requested = accept_language
@@ -333,6 +372,7 @@ pub(crate) const JS_I18N_KEYS: &[&str] = &[
     "admin-policies-playground-title",
     "appcreate-js-fapi-required",
     "appcreate-js-jwks-json",
+    "appcreate-js-postlogout-invalid",
     "appcreate-js-jwks-keys",
     "appcreate-js-jwksuri-https",
     "appcreate-js-jwksuri-invalid",
@@ -675,6 +715,39 @@ mod tests {
         let parsed = parse_accept_language("fr;q=0, en;q=0.5");
         let tags: Vec<String> = parsed.iter().map(ToString::to_string).collect();
         assert_eq!(tags, vec!["en"]);
+    }
+
+    #[test]
+    fn test_negotiate_ui_locales_prefers_ui_locales_over_accept_language() {
+        // When `ui_locales` is present, it takes precedence over `Accept-Language`.
+        // Both use en-US in this catalog so we verify the lang tag, not a
+        // translated string (we only ship en-US in the test binary).
+        let ctx = negotiate_ui_locales(Some("en-US"), Some("zz"));
+        assert_eq!(
+            ctx.lang(),
+            "en-US",
+            "ui_locales=en-US must win over Accept-Language=zz"
+        );
+    }
+
+    #[test]
+    fn test_negotiate_ui_locales_falls_back_to_accept_language_when_empty() {
+        // An empty ui_locales string must fall through to Accept-Language.
+        let ctx_empty = negotiate_ui_locales(Some(""), Some("en;q=0.9"));
+        assert_eq!(ctx_empty.lang(), "en-US");
+        // A None ui_locales also falls through.
+        let ctx_none = negotiate_ui_locales(None, Some("en;q=0.8"));
+        assert_eq!(ctx_none.lang(), "en-US");
+    }
+
+    #[test]
+    fn test_negotiate_ui_locales_preserves_order() {
+        // Tags in ui_locales appear before Accept-Language fallbacks.
+        // We can only verify this indirectly (single catalog), but we confirm
+        // that multiple space-separated tags are accepted without panicking.
+        let ctx = negotiate_ui_locales(Some("en-US fr-FR"), None);
+        // Must resolve to en-US (the only installed locale) without panicking.
+        assert_eq!(ctx.lang(), "en-US");
     }
 
     #[tokio::test]

--- a/crates/vouch-server/src/infra/router.rs
+++ b/crates/vouch-server/src/infra/router.rs
@@ -370,6 +370,10 @@ fn build_general_limited_routes(
             "/oauth/authorize",
             get(handlers::oidc::authorize).post(handlers::oidc::authorize_post),
         )
+        .route(
+            "/oauth/logout",
+            get(handlers::oidc::logout).post(handlers::oidc::logout_post),
+        )
         .merge(protected_api_routes)
         .layer(maybe_rate_limit!(
             rate_limit::build_general_rate_limiter,

--- a/crates/vouch-server/src/services/oidc/authorization.rs
+++ b/crates/vouch-server/src/services/oidc/authorization.rs
@@ -892,6 +892,7 @@ mod tests {
             introspection_signed_response_alg: None,
             userinfo_signed_response_alg: None,
             request_uris: None,
+            post_logout_redirect_uris: None,
         }
     }
 
@@ -961,6 +962,7 @@ mod tests {
             introspection_signed_response_alg: None,
             userinfo_signed_response_alg: None,
             request_uris: None,
+            post_logout_redirect_uris: None,
         }
     }
 

--- a/crates/vouch-server/src/services/oidc/client_credentials.rs
+++ b/crates/vouch-server/src/services/oidc/client_credentials.rs
@@ -178,6 +178,7 @@ mod tests {
                 require_signed_request_object: None,
                 userinfo_signed_response_alg: None,
                 request_uris: None,
+                post_logout_redirect_uris: None,
             },
         )
         .await

--- a/crates/vouch-server/src/services/oidc/discovery.rs
+++ b/crates/vouch-server/src/services/oidc/discovery.rs
@@ -133,6 +133,8 @@ pub struct OidcDiscoveryDocument {
     /// OIDC Discovery 1.0 Section 3: OPTIONAL. Supported JWS alg values for UserInfo signing.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub userinfo_signing_alg_values_supported: Option<Vec<JwsAlgorithm>>,
+    /// RP-Initiated Logout 1.0 Section 2.4: URL of the end-session endpoint.
+    pub end_session_endpoint: String,
 }
 
 /// RFC 8705 Section 5: mTLS endpoint aliases.
@@ -303,6 +305,8 @@ pub fn build_discovery_document(state: &Arc<AppState>) -> OidcDiscoveryDocument 
         } else {
             vec![JwsAlgorithm::Es256]
         }),
+        // RP-Initiated Logout 1.0 Section 2.4.
+        end_session_endpoint: format!("{base_url}/oauth/logout"),
     }
 }
 

--- a/crates/vouch-server/src/services/oidc/fapi.rs
+++ b/crates/vouch-server/src/services/oidc/fapi.rs
@@ -312,6 +312,7 @@ mod tests {
             introspection_signed_response_alg: None,
             userinfo_signed_response_alg: None,
             request_uris: None,
+            post_logout_redirect_uris: None,
         }
     }
 
@@ -358,6 +359,7 @@ mod tests {
             introspection_signed_response_alg: None,
             userinfo_signed_response_alg: None,
             request_uris: None,
+            post_logout_redirect_uris: None,
         }
     }
 

--- a/crates/vouch-server/src/services/oidc/registration.rs
+++ b/crates/vouch-server/src/services/oidc/registration.rs
@@ -132,6 +132,11 @@ pub struct RegistrationRequest {
     ///
     /// Each URI must be HTTPS. When present, only these URLs are accepted as `request_uri`.
     pub request_uris: Option<Vec<String>>,
+    /// RP-Initiated Logout 1.0 Section 2: Registered post-logout redirect URIs.
+    ///
+    /// When present, only these URIs are accepted as `post_logout_redirect_uri` in
+    /// the end-session request. Absent means no redirect-back after logout.
+    pub post_logout_redirect_uris: Option<Vec<String>>,
 }
 
 impl RegistrationRequest {
@@ -248,6 +253,9 @@ pub struct RegistrationResponse {
     /// OIDC Core Section 6.2: Pre-registered request_uri values (echoed).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_uris: Option<Vec<String>>,
+    /// RP-Initiated Logout 1.0: Registered post-logout redirect URIs (echoed).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub post_logout_redirect_uris: Option<Vec<String>>,
 }
 
 // ============================================================================
@@ -451,6 +459,11 @@ pub async fn register_client(
     // 12b-2. Validate request_uris (OIDC Core Section 6.2).
     let validated_request_uris = validate_request_uris(request.request_uris.as_deref())?;
 
+    // 12b-3. Validate post_logout_redirect_uris (RP-Initiated Logout 1.0 Section 2).
+    let validated_post_logout_redirect_uris = validate_post_logout_redirect_uris_registration(
+        request.post_logout_redirect_uris.as_deref(),
+    )?;
+
     // 12d. Validate request_object_signing_alg (RFC 9101).
     let req_obj_alg: Option<JwsAlgorithm> = if let Some(ref s) = request.request_object_signing_alg
     {
@@ -535,6 +548,7 @@ pub async fn register_client(
             require_signed_request_object: if require_signed { Some(true) } else { None },
             userinfo_signed_response_alg: userinfo_alg,
             request_uris: validated_request_uris.clone(),
+            post_logout_redirect_uris: validated_post_logout_redirect_uris.clone(),
         },
     )
     .await
@@ -632,6 +646,7 @@ pub async fn register_client(
         require_signed_request_object: if require_signed { Some(true) } else { None },
         userinfo_signed_response_alg: userinfo_alg.map(|a| a.to_string()),
         request_uris: validated_request_uris,
+        post_logout_redirect_uris: validated_post_logout_redirect_uris,
     })
 }
 
@@ -731,6 +746,61 @@ fn validate_request_uris(uris: Option<&[String]>) -> Result<Option<Vec<String>>,
                 format!("request_uri '{uri}' must use HTTPS"),
             ));
         }
+    }
+    Ok(Some(uris.to_vec()))
+}
+
+/// Validate `post_logout_redirect_uris` for RFC 7591 registration.
+///
+/// Each URI must be a valid http or https URL without a fragment.
+/// HTTP is only allowed for loopback addresses. Max 10 entries.
+///
+/// Returns the validated list, or `None` if the field is absent or empty.
+fn validate_post_logout_redirect_uris_registration(
+    uris: Option<&[String]>,
+) -> Result<Option<Vec<String>>, ServiceError> {
+    let Some(uris) = uris else { return Ok(None) };
+    if uris.is_empty() {
+        return Ok(None);
+    }
+    const MAX_POST_LOGOUT_REDIRECT_URIS: usize = 10;
+    if uris.len() > MAX_POST_LOGOUT_REDIRECT_URIS {
+        return Err(ServiceError::oauth(
+            OAuthErrorCode::InvalidClientMetadata,
+            format!(
+                "Too many post_logout_redirect_uris: maximum is {MAX_POST_LOGOUT_REDIRECT_URIS}"
+            ),
+        ));
+    }
+    let invalid: Vec<&str> = uris
+        .iter()
+        .filter(|uri| {
+            let Ok(parsed) = url::Url::parse(uri) else {
+                return true;
+            };
+            if parsed.fragment().is_some() {
+                return true;
+            }
+            match parsed.scheme() {
+                "https" => false,
+                "http" => {
+                    let host = parsed.host_str().unwrap_or("");
+                    !matches!(host, "localhost" | "127.0.0.1" | "[::1]")
+                }
+                _ => true,
+            }
+        })
+        .map(String::as_str)
+        .collect();
+    if !invalid.is_empty() {
+        return Err(ServiceError::oauth(
+            OAuthErrorCode::InvalidClientMetadata,
+            format!(
+                "Invalid post_logout_redirect_uri(s): {}. Each URI must be https:// \
+                 or a loopback http:// URL without a fragment.",
+                invalid.join(", ")
+            ),
+        ));
     }
     Ok(Some(uris.to_vec()))
 }
@@ -1120,6 +1190,11 @@ pub async fn update_client_configuration(
     // Validate request_uris (same rules as initial registration).
     let validated_request_uris = validate_request_uris(mutable_request.request_uris.as_deref())?;
 
+    // Validate post_logout_redirect_uris (RP-Initiated Logout 1.0 Section 2).
+    let validated_post_logout_redirect_uris = validate_post_logout_redirect_uris_registration(
+        mutable_request.post_logout_redirect_uris.as_deref(),
+    )?;
+
     // Validate contacts and URI fields (same rules as initial registration via
     // register_client). Previously absent from the update path — RFC 7592
     // clients could smuggle an invalid logo_uri or non-@ contact on PUT.
@@ -1144,6 +1219,7 @@ pub async fn update_client_configuration(
             registration_metadata: Some(&registration_metadata),
             userinfo_signed_response_alg: userinfo_alg,
             request_uris: validated_request_uris.as_deref(),
+            post_logout_redirect_uris: validated_post_logout_redirect_uris.clone(),
         },
     )
     .await
@@ -1277,6 +1353,7 @@ fn build_client_response(client: OAuthClient, base_url: &str) -> RegistrationRes
         require_signed_request_object: client.require_signed_request_object,
         userinfo_signed_response_alg: client.userinfo_signed_response_alg.map(|a| a.to_string()),
         request_uris: client.request_uris,
+        post_logout_redirect_uris: client.post_logout_redirect_uris,
     }
 }
 
@@ -1947,6 +2024,7 @@ mod tests {
             require_signed_request_object: None,
             userinfo_signed_response_alg: None,
             request_uris: None,
+            post_logout_redirect_uris: None,
         };
 
         let json = serde_json::to_string(&response).unwrap();
@@ -2013,6 +2091,7 @@ mod tests {
             require_signed_request_object: None,
             userinfo_signed_response_alg: None,
             request_uris: None,
+            post_logout_redirect_uris: None,
         };
 
         let json = serde_json::to_string(&response).unwrap();

--- a/crates/vouch-server/src/services/oidc/registration.rs
+++ b/crates/vouch-server/src/services/oidc/registration.rs
@@ -763,33 +763,18 @@ fn validate_post_logout_redirect_uris_registration(
     if uris.is_empty() {
         return Ok(None);
     }
-    const MAX_POST_LOGOUT_REDIRECT_URIS: usize = 10;
-    if uris.len() > MAX_POST_LOGOUT_REDIRECT_URIS {
+    if uris.len() > db::MAX_POST_LOGOUT_REDIRECT_URIS {
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidClientMetadata,
             format!(
-                "Too many post_logout_redirect_uris: maximum is {MAX_POST_LOGOUT_REDIRECT_URIS}"
+                "Too many post_logout_redirect_uris: maximum is {}",
+                db::MAX_POST_LOGOUT_REDIRECT_URIS
             ),
         ));
     }
     let invalid: Vec<&str> = uris
         .iter()
-        .filter(|uri| {
-            let Ok(parsed) = url::Url::parse(uri) else {
-                return true;
-            };
-            if parsed.fragment().is_some() {
-                return true;
-            }
-            match parsed.scheme() {
-                "https" => false,
-                "http" => {
-                    let host = parsed.host_str().unwrap_or("");
-                    !matches!(host, "localhost" | "127.0.0.1" | "[::1]")
-                }
-                _ => true,
-            }
-        })
+        .filter(|uri| !db::is_valid_post_logout_redirect_uri_str(uri))
         .map(String::as_str)
         .collect();
     if !invalid.is_empty() {

--- a/crates/vouch-server/src/services/oidc/token.rs
+++ b/crates/vouch-server/src/services/oidc/token.rs
@@ -1563,6 +1563,7 @@ mod tests {
             introspection_signed_response_alg: None,
             userinfo_signed_response_alg: None,
             request_uris: None,
+            post_logout_redirect_uris: None,
         }
     }
 

--- a/crates/vouch-server/src/test_utils.rs
+++ b/crates/vouch-server/src/test_utils.rs
@@ -173,6 +173,53 @@ pub async fn test_app_state_with_idps(
     })
 }
 
+/// Create a test AppState with an RSA signing key provisioned.
+///
+/// Used by tests that exercise the RS256 `id_token_hint` verification branch.
+/// Mirrors `test_app_state_with_idps` but sets `oidc_rsa_key` to a freshly
+/// generated RSA-3072 key pair.
+pub async fn test_app_state_with_rsa_key() -> Arc<AppState> {
+    use crate::services::oidc::OidcRsaSigningKey;
+
+    let pool = test_db().await;
+    let config = test_config();
+
+    let rp_origin = url::Url::parse(&config.base_url).expect("Invalid RP origin");
+    let webauthn = webauthn_rs::WebauthnBuilder::new(&config.rp_id, &rp_origin)
+        .expect("Failed to create WebauthnBuilder")
+        .rp_name(&config.rp_name)
+        .build()
+        .expect("Failed to build Webauthn");
+
+    let oidc_key = OidcSigningKey::generate().expect("Failed to generate test OIDC key");
+    let oidc_rsa_key = OidcRsaSigningKey::generate().expect("Failed to generate test RSA key");
+
+    let crypto: Arc<dyn crate::crypto::document_crypto::DocumentCrypto> =
+        Arc::new(PlaintextDocumentCrypto);
+    let store = DocumentStore::new(pool.clone(), crypto.clone());
+    let audit = AuditStore::new(pool.clone(), crypto);
+
+    register_test_httpsig_client(&store, &config.base_url).await;
+
+    Arc::new(AppState {
+        db: pool,
+        store,
+        audit,
+        config: Arc::new(ArcSwap::from_pointee(config)),
+        webauthn,
+        ssh_ca: None,
+        oidc_key,
+        oidc_rsa_key: Some(oidc_rsa_key),
+        state_signer: crate::crypto::jwt::StateTokenSigner::local(
+            b"test_jwt_secret_must_be_at_least_32_characters_long".to_vec(),
+        ),
+        github_app: None,
+        http_client: reqwest::Client::new(),
+        session_cache: crate::db::SessionCache::new(10_000, 30),
+        idps: Vec::new(),
+    })
+}
+
 /// Create test app (router + state) for handler testing.
 pub async fn test_app() -> (Router, Arc<AppState>) {
     let state = test_app_state().await;
@@ -280,6 +327,7 @@ async fn register_test_httpsig_client(store: &DocumentStore, base_url: &str) {
         introspection_signed_response_alg: None,
         userinfo_signed_response_alg: None,
         request_uris: None,
+        post_logout_redirect_uris: None,
     };
     store
         .insert(&doc)
@@ -1300,6 +1348,7 @@ pub async fn create_test_client(
             require_signed_request_object: spec.require_signed_request_object,
             userinfo_signed_response_alg: spec.userinfo_signed_response_alg,
             request_uris: Option::None,
+            post_logout_redirect_uris: Option::None,
         },
     )
     .await

--- a/crates/vouch-server/src/test_utils.rs
+++ b/crates/vouch-server/src/test_utils.rs
@@ -1233,6 +1233,8 @@ pub struct TestClientSpec {
     pub request_object_signing_alg: Option<crate::db::JwsAlgorithm>,
     /// Require a signed request object (JAR). Default: `None`.
     pub require_signed_request_object: Option<bool>,
+    /// Registered post-logout redirect URIs (RP-Initiated Logout). Default: empty.
+    pub post_logout_redirect_uris: Vec<String>,
 }
 
 impl Default for TestClientSpec {
@@ -1258,6 +1260,7 @@ impl Default for TestClientSpec {
             with_secret: true,
             request_object_signing_alg: Option::None,
             require_signed_request_object: Option::None,
+            post_logout_redirect_uris: vec![],
         }
     }
 }
@@ -1348,7 +1351,11 @@ pub async fn create_test_client(
             require_signed_request_object: spec.require_signed_request_object,
             userinfo_signed_response_alg: spec.userinfo_signed_response_alg,
             request_uris: Option::None,
-            post_logout_redirect_uris: Option::None,
+            post_logout_redirect_uris: if spec.post_logout_redirect_uris.is_empty() {
+                Option::None
+            } else {
+                Some(spec.post_logout_redirect_uris.clone())
+            },
         },
     )
     .await

--- a/crates/vouch-server/static/js/app-create.js
+++ b/crates/vouch-server/static/js/app-create.js
@@ -8,6 +8,8 @@
         var redirectError = document.getElementById('redirect-uri-error');
         var resourceTextarea = document.getElementById('resource_uris');
         var resourceError = document.getElementById('resource-uri-error');
+        var postLogoutTextarea = document.getElementById('post_logout_redirect_uris');
+        var postLogoutError = document.getElementById('post-logout-redirect-uri-error');
         var nameInput = document.getElementById('name');
         var form = document.querySelector('form');
         var securityProfileSection = document.getElementById('security-profile-section');
@@ -91,6 +93,45 @@
 
             if (errors.length > 0) {
                 return t('appcreate-js-resource-invalid', { errors: errors.join('; ') });
+            }
+
+            return null;
+        }
+
+        // Validate post-logout redirect URIs and return error message (or null if valid).
+        // Optional field. Rules mirror the server: https://, or loopback http://
+        // (localhost / 127.0.0.1 / [::1]), and no fragment component.
+        function validatePostLogoutUris() {
+            if (!postLogoutTextarea) {
+                return null;
+            }
+
+            var uris = postLogoutTextarea.value.trim().split('\n').filter(function(line) {
+                return line.trim();
+            });
+
+            if (uris.length === 0) {
+                return null;
+            }
+
+            var invalid = [];
+            for (var i = 0; i < uris.length; i++) {
+                var trimmed = uris[i].trim();
+                try {
+                    var url = new URL(trimmed);
+                    var loopbackHttp = url.protocol === 'http:' &&
+                        (url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '[::1]');
+                    var valid = (url.protocol === 'https:' || loopbackHttp) && !url.hash;
+                    if (!valid) {
+                        invalid.push(trimmed);
+                    }
+                } catch (e) {
+                    invalid.push(trimmed);
+                }
+            }
+
+            if (invalid.length > 0) {
+                return t('appcreate-js-postlogout-invalid', { uris: invalid.join(', ') });
             }
 
             return null;
@@ -267,6 +308,25 @@
             }
         });
 
+        // Validate post-logout redirect URIs on blur
+        if (postLogoutTextarea) {
+            postLogoutTextarea.addEventListener('blur', function() {
+                if (postLogoutTextarea.value.trim()) {
+                    showFieldError(postLogoutError, postLogoutTextarea, validatePostLogoutUris());
+                }
+            });
+
+            // Clear post-logout error styling when user starts typing
+            postLogoutTextarea.addEventListener('input', function() {
+                if (postLogoutTextarea.classList.contains('border-vouch-error')) {
+                    clearTimeout(postLogoutTextarea.validateTimeout);
+                    postLogoutTextarea.validateTimeout = setTimeout(function() {
+                        showFieldError(postLogoutError, postLogoutTextarea, validatePostLogoutUris());
+                    }, 500);
+                }
+            });
+        }
+
         // Validate JWKS on blur
         jwksTextarea.addEventListener('blur', function() {
             if (jwksTextarea.value.trim()) {
@@ -313,6 +373,17 @@
                 if (!hasError) {
                     resourceTextarea.scrollIntoView({ behavior: 'smooth', block: 'center' });
                     resourceTextarea.focus();
+                }
+                hasError = true;
+            }
+
+            var postLogoutUriError = validatePostLogoutUris();
+            if (postLogoutUriError) {
+                e.preventDefault();
+                showFieldError(postLogoutError, postLogoutTextarea, postLogoutUriError);
+                if (!hasError) {
+                    postLogoutTextarea.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                    postLogoutTextarea.focus();
                 }
                 hasError = true;
             }

--- a/crates/vouch-server/static/js/app-detail.js
+++ b/crates/vouch-server/static/js/app-detail.js
@@ -10,6 +10,8 @@
         var redirectError = document.getElementById('redirect-uri-error');
         var resourceTextarea = document.getElementById('resource_uris');
         var resourceError = document.getElementById('resource-uri-error');
+        var postLogoutTextarea = document.getElementById('post_logout_redirect_uris');
+        var postLogoutError = document.getElementById('post-logout-redirect-uri-error');
 
         // FAPI edit elements (may not exist for non-confidential types)
         var editFapiJwksSection = document.getElementById('edit-fapi-jwks-section');
@@ -102,6 +104,43 @@
             return null;
         }
 
+        // Optional. Rules mirror the server: https://, or loopback http://
+        // (localhost / 127.0.0.1 / [::1]), and no fragment component.
+        function validatePostLogoutUris() {
+            if (!postLogoutTextarea) {
+                return null;
+            }
+
+            var uris = postLogoutTextarea.value.trim().split('\n').filter(function(line) {
+                return line.trim();
+            });
+
+            if (uris.length === 0) {
+                return null;
+            }
+
+            var invalid = [];
+            for (var i = 0; i < uris.length; i++) {
+                var trimmed = uris[i].trim();
+                try {
+                    var url = new URL(trimmed);
+                    var loopbackHttp = url.protocol === 'http:' &&
+                        (url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '[::1]');
+                    var valid = (url.protocol === 'https:' || loopbackHttp) && !url.hash;
+                    if (!valid) {
+                        invalid.push(trimmed);
+                    }
+                } catch (e) {
+                    invalid.push(trimmed);
+                }
+            }
+
+            if (invalid.length > 0) {
+                return t('appcreate-js-postlogout-invalid', { uris: invalid.join(', ') });
+            }
+            return null;
+        }
+
         function showFieldError(errorEl, textarea, message) {
             if (message) {
                 errorEl.textContent = message;
@@ -142,6 +181,23 @@
                     clearTimeout(resourceTextarea.validateTimeout);
                     resourceTextarea.validateTimeout = setTimeout(function() {
                         showFieldError(resourceError, resourceTextarea, validateResourceUris());
+                    }, 500);
+                }
+            });
+        }
+
+        if (postLogoutTextarea && postLogoutError) {
+            postLogoutTextarea.addEventListener('blur', function() {
+                if (postLogoutTextarea.value.trim()) {
+                    showFieldError(postLogoutError, postLogoutTextarea, validatePostLogoutUris());
+                }
+            });
+
+            postLogoutTextarea.addEventListener('input', function() {
+                if (postLogoutTextarea.classList.contains('border-vouch-error')) {
+                    clearTimeout(postLogoutTextarea.validateTimeout);
+                    postLogoutTextarea.validateTimeout = setTimeout(function() {
+                        showFieldError(postLogoutError, postLogoutTextarea, validatePostLogoutUris());
                     }, 500);
                 }
             });
@@ -254,6 +310,19 @@
                         if (!hasError) {
                             resourceTextarea.scrollIntoView({ behavior: 'smooth', block: 'center' });
                             resourceTextarea.focus();
+                        }
+                        hasError = true;
+                    }
+                }
+
+                if (postLogoutTextarea && postLogoutError) {
+                    var postLogoutErr = validatePostLogoutUris();
+                    if (postLogoutErr) {
+                        e.preventDefault();
+                        showFieldError(postLogoutError, postLogoutTextarea, postLogoutErr);
+                        if (!hasError) {
+                            postLogoutTextarea.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                            postLogoutTextarea.focus();
                         }
                         hasError = true;
                     }

--- a/crates/vouch-server/templates/applications/create.html
+++ b/crates/vouch-server/templates/applications/create.html
@@ -89,6 +89,16 @@ https://data.example.com"></textarea>
                 <div id="resource-uri-error" class="hidden mt-2 p-3 bg-vouch-error-bg border border-vouch-error/30 rounded-lg text-sm text-vouch-error"></div>
             </div>
 
+            <div>
+                <label for="post_logout_redirect_uris" class="block text-sm font-medium text-gray-300">{{ self.tr("apps-create-postlogout-label") }}</label>
+                <textarea name="post_logout_redirect_uris" id="post_logout_redirect_uris" rows="2"
+                    class="input-field mt-1 font-mono"
+                    placeholder="https://example.com/logged-out
+http://localhost:3000/logged-out"></textarea>
+                <p class="mt-1 text-sm text-gray-500">{{ self.tr("apps-create-postlogout-help") }}</p>
+                <div id="post-logout-redirect-uri-error" class="hidden mt-2 p-3 bg-vouch-error-bg border border-vouch-error/30 rounded-lg text-sm text-vouch-error"></div>
+            </div>
+
             <!-- Security Profile (shown only for confidential types: web, service) -->
             <div id="security-profile-section" class="hidden">
                 <label class="block text-sm font-medium text-gray-300 mb-2">{{ self.tr("apps-create-secprofile-label") }}</label>

--- a/crates/vouch-server/templates/applications/detail.html
+++ b/crates/vouch-server/templates/applications/detail.html
@@ -158,6 +158,20 @@
             </div>
             {% endif %}
 
+            <!-- Post-Logout Redirect URIs (RP-Initiated Logout 1.0) -->
+            {% if let Some(uris) = &app.post_logout_redirect_uris %}
+            {% if !uris.is_empty() %}
+            <div class="border-t border-vouch-border pt-4">
+                <label class="block text-sm text-gray-400 mb-2">{{ self.tr("apps-create-postlogout-label") }}</label>
+                <ul class="bg-vouch-raised border border-vouch-border rounded-md px-3 py-2 space-y-0.5">
+                    {% for uri in uris %}
+                    <li class="font-mono text-sm text-gray-300 break-all">{{ uri }}</li>
+                    {% endfor %}
+                </ul>
+            </div>
+            {% endif %}
+            {% endif %}
+
             <!-- Client Secrets Section (for confidential clients, hidden for FAPI) -->
             {% if (app.application_type == "web" || app.application_type == "service") && app.fapi_profile != "fapi2_security" %}
             <div class="border-t border-vouch-border pt-4">
@@ -252,6 +266,15 @@
 {% endfor %}</textarea>
                 <p class="mt-1 text-sm text-gray-500">{{ self.tr("apps-detail-resource-help") }}</p>
                 <div id="resource-uri-error" class="hidden mt-2 p-3 bg-vouch-error-bg border border-vouch-error/30 rounded-lg text-sm text-vouch-error"></div>
+            </div>
+
+            <div>
+                <label for="post_logout_redirect_uris" class="block text-sm font-medium text-gray-300">{{ self.tr("apps-create-postlogout-label") }}</label>
+                <textarea name="post_logout_redirect_uris" id="post_logout_redirect_uris" rows="2"
+                    class="input-field mt-1 font-mono">{% if let Some(uris) = &app.post_logout_redirect_uris %}{% for uri in uris %}{{ uri }}
+{% endfor %}{% endif %}</textarea>
+                <p class="mt-1 text-sm text-gray-500">{{ self.tr("apps-create-postlogout-help") }}</p>
+                <div id="post-logout-redirect-uri-error" class="hidden mt-2 p-3 bg-vouch-error-bg border border-vouch-error/30 rounded-lg text-sm text-vouch-error"></div>
             </div>
 
             <!-- Security Profile (only for confidential types) -->

--- a/crates/vouch-server/templates/logout_confirm.html
+++ b/crates/vouch-server/templates/logout_confirm.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+
+{% block title %}{{ self.tr("logout-confirm-title") }}{% endblock %}
+
+{% block content %}
+<div class="flex items-center justify-center flex-1 p-5">
+    <div class="card max-w-md w-full text-center">
+        <svg class="w-12 h-12 text-vouch-accent mx-auto mb-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9" />
+        </svg>
+        <h1 class="text-2xl font-bold text-gray-200 mb-2">{{ self.tr("logout-confirm-heading") }}</h1>
+        <p class="text-gray-400 mb-6">{{ self.tr("logout-confirm-body") }}</p>
+
+        <form method="post" action="/oauth/logout">
+            {% if let Some(hint) = id_token_hint %}
+            <input type="hidden" name="id_token_hint" value="{{ hint }}">
+            {% endif %}
+            {% if let Some(uri) = post_logout_redirect_uri %}
+            <input type="hidden" name="post_logout_redirect_uri" value="{{ uri }}">
+            {% endif %}
+            {% if let Some(client) = client_id %}
+            <input type="hidden" name="client_id" value="{{ client }}">
+            {% endif %}
+            {% if let Some(s) = state %}
+            <input type="hidden" name="state" value="{{ s }}">
+            {% endif %}
+            {% if let Some(locales) = ui_locales %}
+            <input type="hidden" name="ui_locales" value="{{ locales }}">
+            {% endif %}
+            <div class="flex gap-3 justify-center">
+                <a href="/" class="btn-secondary">{{ self.tr("logout-confirm-cancel") }}</a>
+                <button type="submit" class="btn-primary">{{ self.tr("logout-confirm-btn") }}</button>
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/crates/vouch-server/templates/logout_done.html
+++ b/crates/vouch-server/templates/logout_done.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block title %}{{ self.tr("logout-done-title") }}{% endblock %}
+
+{% block content %}
+<div class="flex items-center justify-center flex-1 p-5">
+    <div class="card max-w-md w-full text-center">
+        <svg class="w-12 h-12 text-vouch-success mx-auto mb-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+        </svg>
+        <h1 class="text-2xl font-bold text-gray-200 mb-2">{{ self.tr("logout-done-heading") }}</h1>
+        <p class="text-gray-400">{{ self.tr("logout-done-body") }}</p>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary

Implements [OpenID Connect RP-Initiated Logout 1.0](https://openid.net/specs/openid-connect-rpinitiated-1_0.html).

- New `end_session_endpoint` at `GET|POST /oauth/logout`. The GET renders a confirmation page; the logout runs on a same-origin POST. It clears the `__Host-` session cookie, deletes the session record, and invalidates the session cache — terminating the browser SSO session while leaving CLI-issued DPoP access tokens intact. The logout audit event records the RP `client_id` and request context.
- `id_token_hint` is verified against the OP's own ES256/RS256 keys; expiry is ignored per the spec, `iss` is checked. A redirect to `post_logout_redirect_uri` happens only when a verified hint identifies the client and the URI is registered for that client; a supplied `client_id` must equal the hint's `aud`; `state` is echoed on the redirect. Unverified or unregistered targets fall through to a local "signed out" page.
- `post_logout_redirect_uris` client metadata is accepted across dynamic registration (RFC 7591/7592), the applications JSON API, and the web UI, with a uniform 10-entry cap and fragment rejection.
- `end_session_endpoint` is advertised in the OIDC discovery document.
- `ui_locales` is honored for the logout pages (precedence over `Accept-Language`).

## Testing

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test -p vouch-server` — 2405 passing (+25), covering the endpoint flows, ES256 and RS256 hint verification, registration parity across all three surfaces, the discovery field, and `ui_locales` negotiation.

## Follow-up

- The `post_logout_redirect_uris` URI validators in `handlers/applications/mod.rs` and `services/oidc/registration.rs` share logic and matching caps but still duplicate the predicate body; they could be unified into one shared helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session termination and open-redirect defenses on logout; behavior is heavily tested but mistakes in hint/URI gating would be security-sensitive.
> 
> **Overview**
> Adds **RP-Initiated Logout 1.0** end-to-end: `GET|POST /oauth/logout` with confirmation and done pages, **`end_session_endpoint`** in OIDC discovery, and **`post_logout_redirect_uris`** on OAuth clients (create/update, RFC 7591/7592, applications API, and web UI).
> 
> **Logout flow:** GET shows a confirmation form; POST clears the browser session (cookie, DB, cache), records a logout audit event with optional RP **`client_id`**, then either **303** to a registered **`post_logout_redirect_uri`** (with **`state`** echoed) or a local signed-out page. Redirects require a **verified `id_token_hint`** (ES256/RS256, expiry ignored, **`iss`** checked); **`client_id`** must match hint **`aud`**; URIs must be on the client allowlist and the client must be active—otherwise no redirect to untrusted targets.
> 
> **Client metadata:** Shared validation (**https** or loopback **http**, no fragment, max **10** URIs) via `is_valid_post_logout_redirect_uri_str` / `OAuthClient::is_valid_post_logout_redirect_uri`. Logout UI honors **`ui_locales`** over `Accept-Language`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06dd9056a9e95f41494bdd558c896f3478eb047b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->