### PR TITLE
feat(cli): pre-fill device code

### DIFF
--- a/crates/vouch-cli/src/commands/enroll.rs
+++ b/crates/vouch-cli/src/commands/enroll.rs
@@ -68,10 +68,16 @@ pub(crate) async fn run(server: &str) -> Result<()> {
     .await?;
 
     // Step 4: Open browser and display instructions.
+    // Prefer the RFC 8628 §3.3.1 verification_uri_complete (embeds user_code) so the
+    // /device form is pre-filled; fall back to the plain verification_uri.
+    let open_url = device_response
+        .verification_uri_complete
+        .as_deref()
+        .unwrap_or(&device_response.verification_uri);
     let verification_url = &device_response.verification_uri;
 
     // Try to open the browser automatically
-    match open::that(verification_url) {
+    match open::that(open_url) {
         Ok(()) => tr_println!(
             "enroll-browser-block",
             url = verification_url.as_str(),


### PR DESCRIPTION
Related to https://github.com/vouch-sh/vouch/pull/564/changes/581b8e95c26b2d9f6e9658317eb33c1a3da4f4f7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX-only change in browser URL selection with a safe fallback when `verification_uri_complete` is absent.
> 
> **Overview**
> **`vouch enroll`** now opens **`verification_uri_complete`** from the device authorization response when the server provides it, so the browser lands on `/device` with the user code already filled in (RFC 8628 §3.3.1). If that field is missing, behavior is unchanged: it opens the plain **`verification_uri`**.
> 
> Printed enrollment instructions still use **`verification_uri`** and the separate **`user_code`** for manual copy/paste when auto-open fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93aa51e2bde5e1260b4df67fc930bfbb9f7bfee5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->