### PR TITLE
fix: address Detail App bug reports (#570–#574)

### DIFF
--- a/crates/vouch-agent/src/expiry_monitor.rs
+++ b/crates/vouch-agent/src/expiry_monitor.rs
@@ -37,8 +37,7 @@ pub async fn run(state: Arc<AgentState>) {
     loop {
         tokio::time::sleep(tokio::time::Duration::from_secs(CHECK_INTERVAL_SECS)).await;
 
-        let session_expiry = state.current_session_expiry().await;
-        let remaining_secs = state.expires_in_seconds().await;
+        let (session_expiry, remaining_secs) = state.session_expiry_info().await;
 
         for threshold in thresholds_to_fire(
             &mut tracked_session,

--- a/crates/vouch-agent/src/state.rs
+++ b/crates/vouch-agent/src/state.rs
@@ -345,13 +345,23 @@ impl AgentState {
         guard.session.as_ref().map(|s| s.user_email().to_string())
     }
 
-    /// Get the current session's expiry timestamp, if a session is stored.
+    /// Get the current session's expiry timestamp and remaining seconds under a
+    /// single read lock.
     ///
-    /// Returned even for an expired-but-not-yet-cleared session so the expiry
+    /// Both values are read atomically so the expiry monitor never observes a
+    /// torn pair where the timestamp comes from one session and the remaining
+    /// seconds from a session that replaced it between two separate reads.
+    /// Values are returned even for an expired-but-not-yet-cleared session so the
     /// monitor can detect when a new login replaces it and re-arm its warnings.
-    pub async fn current_session_expiry(&self) -> Option<Timestamp> {
+    pub async fn session_expiry_info(&self) -> (Option<Timestamp>, Option<u64>) {
         let guard = self.inner.read().await;
-        guard.session.as_ref().map(Session::expires_at)
+        match guard.session.as_ref() {
+            Some(session) => (
+                Some(session.expires_at()),
+                Some(session.expires_in_seconds()),
+            ),
+            None => (None, None),
+        }
     }
 }
 

--- a/crates/vouch-httpsig/src/middleware.rs
+++ b/crates/vouch-httpsig/src/middleware.rs
@@ -739,11 +739,63 @@ mod tests {
         // A verified-but-under-covered signature (missing content-digest) must
         // still carry the Accept-Signature remediation hint, like base-component
         // coverage failures (#571).
-        // A missing-digest coverage failure must advertise Accept-Signature.
         let accept_sig = response.headers().get("accept-signature").unwrap();
         assert!(
             accept_sig.to_str().unwrap().contains("content-digest"),
             "Accept-Signature for a body request must advertise content-digest, got {accept_sig:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_signed_post_with_tampered_body_omits_accept_signature() {
+        // A signature that DOES cover content-digest, but whose body was altered
+        // after signing, fails with DigestMismatch (not MissingDigest). That is a
+        // tamper/corruption, not a coverage gap: the client already signed the
+        // right components, so no Accept-Signature remediation hint applies (#571).
+        let signer = EcdsaP256Signer::generate("test-key").unwrap();
+        let mut resolver = InMemoryKeyResolver::new();
+        resolver.insert("test-key".to_string(), Arc::new(signer.verifier()));
+        let router = build_test_router(Arc::new(resolver));
+
+        let original = b"{\"hello\":\"world\"}".to_vec();
+        let mut req = Request::builder()
+            .method("POST")
+            .uri("http://example.com/v1/test")
+            .body(axum::body::Body::from(original.clone()))
+            .unwrap();
+        // Digest + signature both bind the ORIGINAL body.
+        crate::digest::set_content_digest(
+            req.headers_mut(),
+            &original,
+            crate::digest::DigestAlgorithm::Sha256,
+        )
+        .unwrap();
+        SignatureBuilder::new("sig1")
+            .method()
+            .path()
+            .field("content-digest")
+            .created_now()
+            .sign_request(&mut req, &signer)
+            .unwrap();
+
+        // Swap in a different body while keeping the original digest header and
+        // signature: the signature still verifies (it covers the unchanged header
+        // value), but the body no longer matches the digest -> DigestMismatch.
+        let (mut parts, _original_body) = req.into_parts();
+        parts.uri = "/v1/test".parse().unwrap();
+        let req = Request::from_parts(
+            parts,
+            axum::body::Body::from(b"{\"hello\":\"evil\"}".to_vec()),
+        );
+
+        let response =
+            <Router as tower::ServiceExt<Request<axum::body::Body>>>::oneshot(router, req)
+                .await
+                .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert!(
+            response.headers().get("accept-signature").is_none(),
+            "DigestMismatch (tampered body) must NOT advertise Accept-Signature"
         );
     }
 }

--- a/crates/vouch-httpsig/src/middleware.rs
+++ b/crates/vouch-httpsig/src/middleware.rs
@@ -326,7 +326,16 @@ pub async fn require_signature<R: KeyResolver>(
                     error = %e,
                     "signed request body integrity check failed"
                 );
-                return (StatusCode::UNAUTHORIZED, SIG_VERIFY_FAILED).into_response();
+                let mut resp = (StatusCode::UNAUTHORIZED, SIG_VERIFY_FAILED).into_response();
+                // A coverage failure (signature verified but content-digest not
+                // covered) gets the same Accept-Signature remediation hint as the
+                // base-component coverage failure above.
+                if matches!(e, HttpSigError::MissingDigest)
+                    && let Some(accept_sig) = build_accept_signature(has_body)
+                {
+                    resp.headers_mut().insert("accept-signature", accept_sig);
+                }
+                return resp;
             }
             parts.extensions.insert(VerifiedSignature {
                 label: label.clone(),
@@ -727,5 +736,14 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        // A verified-but-under-covered signature (missing content-digest) must
+        // still carry the Accept-Signature remediation hint, like base-component
+        // coverage failures (#571).
+        // A missing-digest coverage failure must advertise Accept-Signature.
+        let accept_sig = response.headers().get("accept-signature").unwrap();
+        assert!(
+            accept_sig.to_str().unwrap().contains("content-digest"),
+            "Accept-Signature for a body request must advertise content-digest, got {accept_sig:?}"
+        );
     }
 }

--- a/crates/vouch-server/src/handlers/applications/api.rs
+++ b/crates/vouch-server/src/handlers/applications/api.rs
@@ -261,6 +261,7 @@ pub(crate) async fn create_application_api(
         fapi_profile: client.fapi_profile.as_str().to_string(),
         jwks_configured,
         jwks_uri: response_jwks_uri,
+        post_logout_redirect_uris: client.post_logout_redirect_uris,
     }))
 }
 
@@ -2343,9 +2344,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_application_with_post_logout_redirect_uris() {
-        // POST /api/v1/applications with post_logout_redirect_uris should store them.
-        // The create response (CreateApplicationResponse) does not echo the field, so
-        // we verify storage via a subsequent GET /api/v1/applications/:id.
+        // POST /api/v1/applications with post_logout_redirect_uris should store them
+        // and echo them back in the create response, mirroring resource_uris.
         let (app, state) = test_app().await;
         let user = create_test_user(&state.store, "post-logout-create@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
@@ -2374,6 +2374,20 @@ mod tests {
         assert_eq!(status, StatusCode::OK, "body: {body}");
         let create_json: serde_json::Value = serde_json::from_str(&body).expect("valid json");
         let app_id = create_json["id"].as_str().expect("id in create response");
+
+        // The create response itself must echo post_logout_redirect_uris (#574).
+        let created_post_logout = create_json["post_logout_redirect_uris"]
+            .as_array()
+            .expect("post_logout_redirect_uris must be present in create response");
+        assert_eq!(
+            created_post_logout.len(),
+            1,
+            "Expected 1 post_logout_redirect_uri in create response, got {created_post_logout:?}"
+        );
+        assert_eq!(
+            created_post_logout[0].as_str().unwrap(),
+            "https://example.com/logged-out"
+        );
 
         // Verify the stored post_logout_redirect_uris via GET.
         let (get_status, get_body) = http_request(

--- a/crates/vouch-server/src/handlers/applications/types.rs
+++ b/crates/vouch-server/src/handlers/applications/types.rs
@@ -302,6 +302,9 @@ pub(crate) struct CreateApplicationResponse {
     pub jwks_configured: bool,
     /// Remote JWKS URI if configured.
     pub jwks_uri: Option<String>,
+    /// RP-Initiated Logout 1.0: Registered post-logout redirect URIs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub post_logout_redirect_uris: Option<Vec<String>>,
 }
 
 /// API response for application details.

--- a/crates/vouch-server/src/handlers/oidc/introspect.rs
+++ b/crates/vouch-server/src/handlers/oidc/introspect.rs
@@ -7,7 +7,7 @@
 
 use crate::AppState;
 use crate::handlers::extractors::ClientInfo;
-use crate::services::error::{OAuthErrorResponse, ServiceError};
+use crate::services::error::ServiceError;
 use crate::services::oidc::introspection::{
     introspect_token as svc_introspect, revoke_token as svc_revoke, sign_introspection_jwt,
 };
@@ -215,7 +215,7 @@ pub(crate) async fn introspect(
         Ok(r) => r,
         Err(e) => {
             tracing::error!("Introspection failed: {e}");
-            return e.into_oauth_response().into_response();
+            return introspect_error_response(e);
         }
     };
 
@@ -245,12 +245,25 @@ pub(crate) async fn introspect(
     }
 }
 
+/// Render any introspection-endpoint `ServiceError` as an RFC 6749 §5.2 OAuth
+/// error response (e.g. `{"error": "server_error", ...}`).
+///
+/// Both error-producing paths in this endpoint — the introspection-service
+/// failure (store/DB errors) and the JWT-signing failure — funnel through this
+/// helper so the endpoint can never emit two different error shapes for the same
+/// `ServiceError` (issue #572). Do not hand-roll an error response here; route it
+/// through `ServiceError::into_oauth_response`.
+fn introspect_error_response(e: ServiceError) -> Response {
+    e.into_oauth_response().into_response()
+}
+
 /// Map a signed-introspection-JWT result to an HTTP response.
 ///
 /// Returns 200 with Content-Type `application/token-introspection+jwt` on success
-/// (RFC 9701 §5). On signing failure, returns 500 `server_error` and logs the
-/// underlying error — never `{"active": false}`, which would misrepresent a
-/// validated active token as inactive (issue #396).
+/// (RFC 9701 §5). On signing failure, returns the OAuth `server_error` response
+/// (via [`introspect_error_response`]) and logs the underlying error — never
+/// `{"active": false}`, which would misrepresent a validated active token as
+/// inactive (issue #396).
 fn jwt_introspect_response(jwt_result: Result<String, ServiceError>) -> Response {
     match jwt_result {
         Ok(jwt) => (
@@ -264,15 +277,7 @@ fn jwt_introspect_response(jwt_result: Result<String, ServiceError>) -> Response
             .into_response(),
         Err(e) => {
             tracing::error!("Failed to sign introspection JWT: {e}");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(OAuthErrorResponse {
-                    error: "server_error".to_string(),
-                    error_description: Some("Failed to sign introspection response".to_string()),
-                    error_uri: None,
-                }),
-            )
-                .into_response()
+            introspect_error_response(e)
         }
     }
 }
@@ -328,6 +333,35 @@ mod tests {
             "Response must NOT contain 'active' field — that would leak \
              the buggy inactive payload (issue #396): {body}"
         );
+    }
+
+    /// Regression guard for issue #572: every `ServiceError` from this endpoint
+    /// — whether from the introspection service (store/DB) or JWT signing — must
+    /// render as an RFC 6749 §5.2 OAuth error (`{"error": "server_error"}`),
+    /// never the API error envelope (`{"code": ..., "message": ...}`). Both arms
+    /// funnel through `introspect_error_response`, so testing it pins the single
+    /// rendering contract the two paths share.
+    #[tokio::test]
+    async fn test_introspect_error_response_uses_oauth_error_shape() {
+        for err in [
+            ServiceError::Internal("simulated store failure".to_string()),
+            ServiceError::OccConflict,
+        ] {
+            let response = introspect_error_response(err);
+            let (status, _content_type, body) = read_body(response).await;
+            assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR, "body: {body}");
+
+            let json: serde_json::Value =
+                serde_json::from_str(&body).expect("Body must be JSON OAuth error");
+            assert_eq!(
+                json["error"], "server_error",
+                "Must use OAuth 'error' field per RFC 6749 §5.2, not API 'code': {body}"
+            );
+            assert!(
+                json.get("code").is_none() && json.get("message").is_none(),
+                "Must NOT use the API error envelope ({{code, message}}): {body}"
+            );
+        }
     }
 
     /// Happy path: signed JWT is returned verbatim with the RFC 9701

--- a/crates/vouch-server/src/handlers/oidc/introspect.rs
+++ b/crates/vouch-server/src/handlers/oidc/introspect.rs
@@ -215,7 +215,7 @@ pub(crate) async fn introspect(
         Ok(r) => r,
         Err(e) => {
             tracing::error!("Introspection failed: {e}");
-            return e.into_response();
+            return e.into_oauth_response().into_response();
         }
     };
 

--- a/crates/vouch-server/templates/admin/policies.html
+++ b/crates/vouch-server/templates/admin/policies.html
@@ -102,7 +102,7 @@
                             </div>
                             {% else if policy.slug == "os_recency" %}
                             <div class="text-xs text-gray-500 space-y-1">
-                                <p class="flex items-center gap-1.5">{{ os::apple("w-3.5 h-3.5 text-gray-500 shrink-0") }} semver(os_version) &ge; semver("25.0.0") (Sequoia+)</p>
+                                <p class="flex items-center gap-1.5">{{ os::apple("w-3.5 h-3.5 text-gray-500 shrink-0") }} semver(os_version) &ge; semver("14.0.0") (Sonoma+)</p>
                                 <p class="flex items-center gap-1.5">{{ os::windows("w-3.5 h-3.5 text-gray-500 shrink-0") }} semver(os_version) &ge; semver("10.0.26100") (24H2+)</p>
                                 <p class="flex items-center gap-1.5">{{ os::linux("w-3.5 h-3.5 text-gray-500 shrink-0") }} {{ self.tr("admin-policies-osrecency-linux") }}</p>
                                 <p class="mt-1 text-gray-600"><span class="font-mono">semver()</span> {{ self.tr("admin-policies-semver-explain") }} (<span class="font-mono">"9" &lt; "14"</span>)</p>


### PR DESCRIPTION
Fixes the five open Detail App bug reports. Each is a small, isolated correctness/consistency fix; one commit per issue.

## Fixes

- **#574 — `fix(server)`**: `POST /api/v1/applications` accepted and stored `post_logout_redirect_uris` but `CreateApplicationResponse` omitted it (unlike `ApplicationResponse` and the echoed `resource_uris`). Added the field and populate it from the stored client. Extended the existing round-trip test to assert the create response now echoes it.
- **#573 — `fix(agent)`**: The expiry monitor read `current_session_expiry()` and `expires_in_seconds()` under two separate `RwLock` acquisitions, allowing a torn read (expiry from session A, remaining from session B) that silently dropped the `SessionExpired` audit event when a login replaced an expired session at the boundary. Replaced both reads with a single `session_expiry_info()` accessor under one read lock.
- **#572 — `fix(server)`**: `/oauth/introspect` returned the API error envelope (`{"code","message"}`) on store/DB failures, while the JWT-signing path on the same endpoint returns the RFC 6749 OAuth error (`{"error","..."}`). Switched the DB-error path to `into_oauth_response()` for a consistent shape.
- **#571 — `fix(httpsig)`**: A verified signature covering `@method`/`@path` but not `content-digest` failed with a bare 401, while base-component coverage failures return `Accept-Signature` guidance. Emit the same hint for `MissingDigest` coverage failures, reusing the computed `has_body`. Extended the existing rejection test to assert the header is present.
- **#570 — `fix(ui)`**: The admin policies template showed `semver("25.0.0") (Sequoia+)` for the macOS OS-recency policy, but enforcement and the remediation text use `14.0.0` (Sonoma). Corrected the guidance text.

## Verification

- `make fmt` clean.
- `cargo clippy -p vouch-httpsig -p vouch-agent -p vouch-server --all-targets --all-features -- -D warnings` — clean (no-panic policy enforced).
- Targeted tests pass:
  - `vouch-httpsig` (`--features axum`): `test_signed_post_without_digest_is_rejected` now asserts `Accept-Signature` is emitted.
  - `vouch-agent`: `expiry_monitor::tests` (3 tests).
  - `vouch-server`: `test_create_application_with_post_logout_redirect_uris` asserts the field round-trips in the create response.

Closes #570
Closes #571
Closes #572
Closes #573
Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHozCR4fa5Adj5Z94ZGR4T)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized bug fixes with regression tests; no auth model or data-migration changes beyond consistent error JSON and API field echoing.
> 
> **Overview**
> This PR bundles five small correctness fixes (one per issue #570–#574).
> 
> The **vouch-agent** expiry monitor now calls **`session_expiry_info()`** once under a single read lock instead of separate **`current_session_expiry()`** and **`expires_in_seconds()`** calls, avoiding torn reads that could skip **`SessionExpired`** audit when a new login replaces an expired session.
> 
> **`/oauth/introspect`** routes store/DB failures through **`introspect_error_response`** → **`into_oauth_response()`**, matching the JWT-signing error shape (RFC 6749 OAuth **`{"error": ...}`**, not the API **`code`/`message`** envelope).
> 
> **vouch-httpsig** middleware adds **`Accept-Signature`** (including **`content-digest`**) on **`MissingDigest`** body-coverage failures, but not on **`DigestMismatch`** (tampered body); tests cover both.
> 
> **`POST /api/v1/applications`** **`CreateApplicationResponse`** now echoes **`post_logout_redirect_uris`** like GET/PATCH.
> 
> The admin **policies** template corrects macOS OS-recency guidance from Sequoia **`25.0.0`** to Sonoma **`14.0.0`** to match enforcement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4a88257189d259a506477335a6fed6fa954b142. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->