### PR TITLE
feat(server): add cert-logout hook for RP-initiated logout testing

### DIFF
--- a/crates/vouch-server/src/handlers/oidc/logout.rs
+++ b/crates/vouch-server/src/handlers/oidc/logout.rs
@@ -626,6 +626,12 @@ mod tests {
             body.contains("</html>") || body.contains("<!DOCTYPE"),
             "expected HTML: {body}"
         );
+        // The confirmation button carries the `cert-logout` automation hook that
+        // the RP-Initiated Logout conformance suite clicks to confirm logout.
+        assert!(
+            body.contains(r#"id="cert-logout""#),
+            "confirm button must carry the cert-logout hook: {body}"
+        );
     }
 
     #[tokio::test]

--- a/crates/vouch-server/templates/logout_confirm.html
+++ b/crates/vouch-server/templates/logout_confirm.html
@@ -29,7 +29,7 @@
             {% endif %}
             <div class="flex gap-3 justify-center">
                 <a href="/" class="btn-secondary">{{ self.tr("logout-confirm-cancel") }}</a>
-                <button type="submit" class="btn-primary">{{ self.tr("logout-confirm-btn") }}</button>
+                <button type="submit" id="cert-logout" class="btn-primary">{{ self.tr("logout-confirm-btn") }}</button>
             </div>
         </form>
     </div>


### PR DESCRIPTION
## Summary

The OpenID Connect **RP-Initiated Logout** conformance suite ([vouch-sh/conformance#1](https://github.com/vouch-sh/conformance/pull/1)) drives the end-session flow with browser automation, using two identifiers:

- `cert-login` — already present (`login.html`, the `id="cert-login"` link gated by `cert_login_url`).
- `cert-logout` — **was missing**. The suite navigates to the `end_session_endpoint` (`GET /oauth/logout`), which renders the logout confirmation page, then clicks the element with `id="cert-logout"` to confirm and POST the logout.

Everything else the conformance test depends on already exists: discovery advertises `end_session_endpoint` → `<base_url>/oauth/logout` (`services/oidc/discovery.rs`), and the GET/POST handlers in `handlers/oidc/logout.rs` implement the confirmation page, session clearing, validated `post_logout_redirect_uri`, and `state` echo. The only gap was the automation hook on the confirm button.

## Changes

- `crates/vouch-server/templates/logout_confirm.html`: add `id="cert-logout"` to the confirmation submit button.
- `crates/vouch-server/src/handlers/oidc/logout.rs`: extend `test_get_logout_renders_confirmation_no_hint` to assert the page exposes `id="cert-logout"`.

The id is **unconditional**, unlike `cert-login`. The login hook exposes a FIDO2-bypass link that must never appear in production, so it is config-gated. The logout confirm button is the normal user-facing button that performs a real logout — there is no bypass path to gate, so a stable test id on it is inert in production and mirrors the always-present `id="login-btn"` on the login page.

## Testing

- `make fmt` — clean
- `cargo clippy -p vouch-server --all-targets --all-features -- -D warnings` — no warnings (no-panic gate clean)
- `cargo test -p vouch-server logout` — 27 passed, including the new `cert-logout` assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014d6YLF2MGHgGpgLQscNGkA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markup and test-only change on the existing confirmation button; no logout, session, or redirect validation logic is modified.
> 
> **Overview**
> Adds a stable **`id="cert-logout"`** on the RP-initiated logout **confirmation submit button** so the OpenID Connect conformance suite can automate clicking confirm after `GET /oauth/logout`, matching the existing **`cert-login`** pattern on the login page.
> 
> The hook is always present on the normal logout button (not config-gated like cert-login). **`test_get_logout_renders_confirmation_no_hint`** now asserts the rendered HTML includes that id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c3951b94218598e9127fd5c7079a2a136a41a2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->