### PR TITLE
feat(aws): unify credential/setup commands across STS and Identity Center

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "apple-native-keyring-store"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6307,7 +6307,6 @@ dependencies = [
  "tracing-subscriber",
  "unic-langid",
  "url",
- "urlencoding",
  "uuid",
  "vouch-agent",
  "vouch-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ allow_attributes_without_reason = "deny"
 # pedantic = { level = "warn", priority = -1 }
 
 [workspace.dependencies]
-anyhow = { version = "=1.0.102", default-features = false }
+anyhow = { version = "=1.0.103", default-features = false }
 apple-native-keyring-store = { version = "=1.0.0", default-features = false }
 arc-swap = { version = "=1.9.1", default-features = false }
 askama = { version = "=0.16.0", default-features = false }

--- a/crates/vouch-cli/Cargo.toml
+++ b/crates/vouch-cli/Cargo.toml
@@ -57,7 +57,6 @@ toml_edit = { workspace = true, features = ["parse", "display"] }
 tracing = { workspace = true, features = ["std"] }
 tracing-subscriber = { workspace = true, features = ["std", "fmt", "env-filter"] }
 url = { workspace = true }
-urlencoding = { workspace = true }
 unic-langid = { workspace = true, features = ["macros"] }
 uuid = { workspace = true, features = ["v7"] }
 vouch-common = { workspace = true }

--- a/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
+++ b/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
@@ -620,6 +620,10 @@ aws-err-sso-expired = SSO session expired or missing. Run '{ -cmd } aws login' f
 aws-err-not-configured =
     AWS not configured.
     Run '{ -cmd } setup aws --role <role-arn>' first, or specify --role.
+aws-err-agent-idc-readonly-unsupported =
+    Coding agent detected ({ $source }): Identity Center portal credentials
+    (--account) cannot be restricted to ReadOnlyAccess, unlike the STS --role path.
+    Use an STS role (--role <arn>) or a dedicated read-only permission set instead.
 
 aws-login-already-authenticated = Already authenticated (expires { $expires_at })
 aws-login-browser-prompt =

--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -533,25 +533,38 @@ async fn run_identity_center(
     let session = crate::commands::aws::resolve_sso_session(&aws_config, sso_session)?;
     let region = session.region.clone();
 
-    let http_client =
-        vouch_common::http::credential_client(&format!("vouch-cli/{}", env!("CARGO_PKG_VERSION")))
-            .context("failed to create HTTP client")?;
+    // Cache the credential_process output keyed by SSO session + target account +
+    // permission set, mirroring the STS `--role` path: repeated AWS CLI refreshes
+    // reuse credentials until expiry (instead of repeating web identity → RS256 →
+    // CreateTokenWithIAM → GetRoleCredentials every time) and fall back to the
+    // cached entry on network errors. Coding agents fail closed above and never
+    // reach this cache.
+    let cache_key = format!("aws:idc:{}:{account_id}:{role_name}", session.name);
+    super::cache::get_or_fetch(&cache_key, "AWS credentials", || async move {
+        let http_client = vouch_common::http::credential_client(&format!(
+            "vouch-cli/{}",
+            env!("CARGO_PKG_VERSION")
+        ))
+        .context("failed to create HTTP client")?;
 
-    let bearer = resolve_bearer_token(server, &session, &region).await?;
-    let creds = get_role_credentials(&http_client, &region, &bearer, account_id, role_name)
-        .await
-        .with_context(|| {
-            format!("failed to get role credentials for account {account_id} role {role_name}")
-        })?;
+        let bearer = resolve_bearer_token(server, &session, &region).await?;
+        let creds = get_role_credentials(&http_client, &region, &bearer, account_id, role_name)
+            .await
+            .with_context(|| {
+                format!("failed to get role credentials for account {account_id} role {role_name}")
+            })?;
 
-    let output = CredentialProcessOutput {
-        version: 1,
-        access_key_id: creds.access_key_id,
-        secret_access_key: creds.secret_access_key,
-        session_token: creds.session_token,
-        expiration: creds.expiration.to_string(),
-    };
-    Ok(output.to_json())
+        let output = CredentialProcessOutput {
+            version: 1,
+            access_key_id: creds.access_key_id,
+            secret_access_key: creds.secret_access_key,
+            session_token: creds.session_token,
+            expiration: creds.expiration.to_string(),
+        };
+        let expires_at = output.expiration.clone();
+        Ok((output.to_json(), expires_at))
+    })
+    .await
 }
 
 /// Look up the per-session Vouch config for a resolved `[sso-session]` name.

--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -11,6 +11,11 @@ use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 
 use crate::client::VouchClient;
+use crate::config::SsoSessionConfig;
+use crate::integrations::aws::config::SsoSession;
+use crate::integrations::aws::identity_center::create_token_with_iam;
+use crate::integrations::aws::sso::{SsoConfig, load_cached_token};
+use crate::integrations::aws::sso_portal::get_role_credentials;
 
 /// AWS credential process output format.
 /// See: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html
@@ -474,15 +479,158 @@ pub(crate) async fn get_aws_credentials(server: &str, role_arn: &str) -> Result<
     .await
 }
 
-/// Run the AWS credential command.
+/// Run the AWS credential command (a non-interactive `credential_process` helper).
+///
+/// Serves all three access patterns from one command, selected by the target
+/// form:
+/// - `--role <arn>` (no `--account`) → STS `AssumeRoleWithWebIdentity`, chaining
+///   through the management role when configured (patterns 1 & 2).
+/// - `--account <id> --role <permission-set>` → IAM Identity Center portal
+///   `GetRoleCredentials` (pattern 3).
 ///
 /// Outputs AWS credential_process JSON to stdout.
-pub(crate) async fn run(server: &str, role_arn: &str) -> Result<()> {
-    let data = get_aws_credentials(server, role_arn).await?;
+pub(crate) async fn run(
+    server: &str,
+    role: &str,
+    account: Option<&str>,
+    sso_session: Option<&str>,
+) -> Result<()> {
+    let data = if let Some(account_id) = account {
+        // IdC portal: `role` is a permission-set name.
+        run_identity_center(server, account_id, role, sso_session).await?
+    } else {
+        // STS web-identity: `role` is a role ARN.
+        get_aws_credentials(server, role).await?
+    };
     let json = serde_json::to_string(&data).context("failed to serialize credentials")?;
     // Machine-readable JSON output: stays English (consumed by AWS CLI).
     println!("{json}");
     Ok(())
+}
+
+/// Pattern 3: issue credentials for a permission-set role via the IAM Identity
+/// Center portal `GetRoleCredentials`.
+async fn run_identity_center(
+    server: &str,
+    account_id: &str,
+    role_name: &str,
+    sso_session: Option<&str>,
+) -> Result<serde_json::Value> {
+    let aws_config = crate::integrations::aws::config::AwsConfig::load()?;
+    let session = crate::commands::aws::resolve_sso_session(&aws_config, sso_session)?;
+    let region = session.region.clone();
+
+    let http_client =
+        vouch_common::http::credential_client(&format!("vouch-cli/{}", env!("CARGO_PKG_VERSION")))
+            .context("failed to create HTTP client")?;
+
+    let bearer = resolve_bearer_token(server, &session, &region).await?;
+    let creds = get_role_credentials(&http_client, &region, &bearer, account_id, role_name)
+        .await
+        .with_context(|| {
+            format!("failed to get role credentials for account {account_id} role {role_name}")
+        })?;
+
+    let output = CredentialProcessOutput {
+        version: 1,
+        access_key_id: creds.access_key_id,
+        secret_access_key: creds.secret_access_key,
+        session_token: creds.session_token,
+        expiration: creds.expiration.to_string(),
+    };
+    Ok(output.to_json())
+}
+
+/// Resolve the Identity Center bearer token for an SSO session: trusted-token-
+/// issuer exchange when configured, otherwise the cached `vouch aws login`
+/// device token.
+///
+/// Shared with `vouch setup aws`, which uses it to enumerate accounts and roles
+/// during IdC profile discovery.
+pub(crate) async fn resolve_bearer_token(
+    server: &str,
+    session: &SsoSession,
+    region: &str,
+) -> Result<SecretString> {
+    let vouch_config = crate::config::Config::load().ok();
+    let ic_session = vouch_config
+        .as_ref()
+        .and_then(|c| c.aws())
+        .and_then(|a| a.sso_sessions.get(&session.name))
+        .filter(|c| {
+            c.identity_center_application_arn.is_some() && c.identity_center_audience.is_some()
+        });
+
+    if let Some(cfg) = ic_session {
+        obtain_identity_center_token(server, cfg, region).await
+    } else {
+        let sso_config = SsoConfig::from_session(session);
+        let token = load_cached_token(&sso_config).ok_or_else(|| {
+            crate::exit_code::CliError::NotAuthenticated {
+                reason: "SSO session expired or missing. Run 'vouch aws login' first.".to_string(),
+            }
+        })?;
+        Ok(token.token())
+    }
+}
+
+/// Obtain an Identity Center access token via the trusted-token-issuer exchange.
+///
+/// 1. Assume the management role via `AssumeRoleWithWebIdentity` — the SigV4
+///    caller for `CreateTokenWithIAM`. No AI-agent `ReadOnlyAccess` restriction
+///    is applied here (the caller only needs `sso-oauth:CreateTokenWithIAM`,
+///    which `ReadOnlyAccess` would strip); agent attribution still flows via
+///    the RS256 token's session tags.
+/// 2. Fetch the RS256 assertion token from Vouch (`audience` = the app's Aud
+///    claim), carrying agent attribution when running inside a coding agent.
+/// 3. Exchange the assertion for an Identity Center access token.
+async fn obtain_identity_center_token(
+    server: &str,
+    cfg: &SsoSessionConfig,
+    region: &str,
+) -> Result<SecretString> {
+    let application_arn = cfg
+        .identity_center_application_arn
+        .as_deref()
+        .context("identity_center_application_arn not configured")?;
+    let audience = cfg
+        .identity_center_audience
+        .as_deref()
+        .context("identity_center_audience not configured")?;
+
+    let mgmt = exchange_for_sts_credentials(StsRequest {
+        server,
+        role_arn: &cfg.management_role,
+        region,
+        management_role: None,
+        agent_source: None,
+    })
+    .await
+    .context("failed to assume management role for Identity Center token exchange")?;
+
+    let mut client = VouchClient::new(server).await?;
+    let agent_source = detect_agent_source();
+    if let Some(src) = agent_source.as_deref() {
+        client.set_dpop_source(src);
+    }
+
+    let path = format!(
+        "/v1/credentials/aws/sso/token?audience={}",
+        urlencoding::encode(audience)
+    );
+    let assertion: OidcTokenResponse = client
+        .get_authenticated(&path)
+        .await
+        .context("failed to get Identity Center assertion token from Vouch server")?;
+
+    create_token_with_iam(
+        &mgmt.http_client,
+        region,
+        application_arn,
+        assertion.id_token.expose_secret(),
+        &mgmt.credentials,
+    )
+    .await
 }
 
 /// Fetch an OIDC token and exchange it for STS credentials.

--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -546,7 +546,7 @@ async fn run_identity_center(
 /// Mirrors [`resolve_management_role`]'s fallback: if there is no exact key
 /// match but exactly one `sso_sessions` entry is configured, use it (so a lone
 /// Identity Center block under a differently-named key is still honored).
-fn resolve_session_config<'a>(
+pub(crate) fn resolve_session_config<'a>(
     aws: &'a crate::config::AwsMultiAccountConfig,
     session_name: &str,
 ) -> Option<&'a SsoSessionConfig> {

--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -618,11 +618,15 @@ async fn obtain_identity_center_token(
         .as_deref()
         .context("identity_center_audience not configured")?;
 
+    // Assume *this* session's management role directly via web identity — it is
+    // the SigV4 caller for CreateTokenWithIAM. Set `management_role` equal to the
+    // target so no chaining hop is added and the role is not re-resolved from the
+    // first `~/.aws/config` session (which may belong to a different org).
     let mgmt = exchange_for_sts_credentials(StsRequest {
         server,
         role_arn: &cfg.management_role,
         region,
-        management_role: None,
+        management_role: Some(cfg.management_role.as_str()),
         agent_source: None,
     })
     .await

--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -567,21 +567,6 @@ async fn run_identity_center(
     .await
 }
 
-/// Look up the per-session Vouch config for a resolved `[sso-session]` name.
-///
-/// Requires an exact match between the AWS `[sso-session]` name and the
-/// `sso_sessions` key. There is deliberately no single-entry fallback: with
-/// several `~/.aws/config` sessions, honoring a lone Vouch entry under a
-/// mismatched key would apply one org's `identity_center_application_arn` /
-/// `management_role` to a different org's session. On a miss the caller falls
-/// back to its non-IdC path (device token / STS).
-pub(crate) fn resolve_session_config<'a>(
-    aws: &'a crate::config::AwsMultiAccountConfig,
-    session_name: &str,
-) -> Option<&'a SsoSessionConfig> {
-    aws.sso_sessions.get(session_name)
-}
-
 /// Resolve the Identity Center bearer token for an SSO session: trusted-token-
 /// issuer exchange when configured, otherwise the cached `vouch aws login`
 /// device token.
@@ -597,9 +582,11 @@ pub(crate) async fn resolve_bearer_token(
     // `Config::default()` (no `aws` block) rather than an error, so the device
     // fallback below still applies for users without Vouch config.
     let vouch_config = crate::config::Config::load()?;
+    // Exact `[sso-session]`-name → key match, no fallback: a lone Vouch entry
+    // under a mismatched key must not apply one org's config to another's session.
     let ic_session = vouch_config
         .aws()
-        .and_then(|a| resolve_session_config(a, &session.name))
+        .and_then(|a| a.sso_sessions.get(&session.name))
         .filter(|c| c.identity_center_application_arn.is_some());
 
     if let Some(cfg) = ic_session {
@@ -945,20 +932,5 @@ mod tests {
         let b = build_cache_key(ROLE, Some(MGMT), Some("claude-code"));
         assert_eq!(a, b);
         assert_eq!(a, format!("aws:chain:{MGMT}:{ROLE}:agent:claude-code"));
-    }
-
-    /// `resolve_session_config` requires an exact `[sso-session]`-name → key
-    /// match. A single configured entry must NOT be applied to a different
-    /// session name (regression guard against the cross-org lone-entry fallback).
-    #[test]
-    fn test_resolve_session_config_requires_exact_match() {
-        let mut aws = crate::config::AwsMultiAccountConfig::default();
-        aws.sso_sessions
-            .insert("orgA".to_string(), SsoSessionConfig::default());
-
-        // Exact match resolves.
-        assert!(resolve_session_config(&aws, "orgA").is_some());
-        // A mismatched session name does NOT fall back to the lone entry.
-        assert!(resolve_session_config(&aws, "orgB").is_none());
     }
 }

--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -577,9 +577,7 @@ pub(crate) async fn resolve_bearer_token(
     let ic_session = vouch_config
         .aws()
         .and_then(|a| resolve_session_config(a, &session.name))
-        .filter(|c| {
-            c.identity_center_application_arn.is_some() && c.identity_center_audience.is_some()
-        });
+        .filter(|c| c.identity_center_application_arn.is_some());
 
     if let Some(cfg) = ic_session {
         obtain_identity_center_token(server, cfg, region).await
@@ -601,8 +599,8 @@ pub(crate) async fn resolve_bearer_token(
 ///    is applied here (the caller only needs `sso-oauth:CreateTokenWithIAM`,
 ///    which `ReadOnlyAccess` would strip); agent attribution still flows via
 ///    the RS256 token's session tags.
-/// 2. Fetch the RS256 assertion token from Vouch (`audience` = the app's Aud
-///    claim), carrying agent attribution when running inside a coding agent.
+/// 2. Fetch the RS256 assertion token from Vouch (its `aud` is the Vouch server
+///    URL), carrying agent attribution when running inside a coding agent.
 /// 3. Exchange the assertion for an Identity Center access token.
 async fn obtain_identity_center_token(
     server: &str,
@@ -613,10 +611,6 @@ async fn obtain_identity_center_token(
         .identity_center_application_arn
         .as_deref()
         .context("identity_center_application_arn not configured")?;
-    let audience = cfg
-        .identity_center_audience
-        .as_deref()
-        .context("identity_center_audience not configured")?;
 
     // Assume *this* session's management role directly via web identity — it is
     // the SigV4 caller for CreateTokenWithIAM. Set `management_role` equal to the
@@ -638,12 +632,8 @@ async fn obtain_identity_center_token(
         client.set_dpop_source(src);
     }
 
-    let path = format!(
-        "/v1/credentials/aws/sso/token?audience={}",
-        urlencoding::encode(audience)
-    );
     let assertion: OidcTokenResponse = client
-        .get_authenticated(&path)
+        .get_authenticated("/v1/credentials/aws/sso/token")
         .await
         .context("failed to get Identity Center assertion token from Vouch server")?;
 

--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -569,20 +569,17 @@ async fn run_identity_center(
 
 /// Look up the per-session Vouch config for a resolved `[sso-session]` name.
 ///
-/// Mirrors [`resolve_management_role`]'s fallback: if there is no exact key
-/// match but exactly one `sso_sessions` entry is configured, use it (so a lone
-/// Identity Center block under a differently-named key is still honored).
+/// Requires an exact match between the AWS `[sso-session]` name and the
+/// `sso_sessions` key. There is deliberately no single-entry fallback: with
+/// several `~/.aws/config` sessions, honoring a lone Vouch entry under a
+/// mismatched key would apply one org's `identity_center_application_arn` /
+/// `management_role` to a different org's session. On a miss the caller falls
+/// back to its non-IdC path (device token / STS).
 pub(crate) fn resolve_session_config<'a>(
     aws: &'a crate::config::AwsMultiAccountConfig,
     session_name: &str,
 ) -> Option<&'a SsoSessionConfig> {
-    aws.sso_sessions.get(session_name).or_else(|| {
-        if aws.sso_sessions.len() == 1 {
-            aws.sso_sessions.values().next()
-        } else {
-            None
-        }
-    })
+    aws.sso_sessions.get(session_name)
 }
 
 /// Resolve the Identity Center bearer token for an SSO session: trusted-token-
@@ -948,5 +945,20 @@ mod tests {
         let b = build_cache_key(ROLE, Some(MGMT), Some("claude-code"));
         assert_eq!(a, b);
         assert_eq!(a, format!("aws:chain:{MGMT}:{ROLE}:agent:claude-code"));
+    }
+
+    /// `resolve_session_config` requires an exact `[sso-session]`-name → key
+    /// match. A single configured entry must NOT be applied to a different
+    /// session name (regression guard against the cross-org lone-entry fallback).
+    #[test]
+    fn test_resolve_session_config_requires_exact_match() {
+        let mut aws = crate::config::AwsMultiAccountConfig::default();
+        aws.sso_sessions
+            .insert("orgA".to_string(), SsoSessionConfig::default());
+
+        // Exact match resolves.
+        assert!(resolve_session_config(&aws, "orgA").is_some());
+        // A mismatched session name does NOT fall back to the lone entry.
+        assert!(resolve_session_config(&aws, "orgB").is_none());
     }
 }

--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -541,6 +541,24 @@ async fn run_identity_center(
     Ok(output.to_json())
 }
 
+/// Look up the per-session Vouch config for a resolved `[sso-session]` name.
+///
+/// Mirrors [`resolve_management_role`]'s fallback: if there is no exact key
+/// match but exactly one `sso_sessions` entry is configured, use it (so a lone
+/// Identity Center block under a differently-named key is still honored).
+fn resolve_session_config<'a>(
+    aws: &'a crate::config::AwsMultiAccountConfig,
+    session_name: &str,
+) -> Option<&'a SsoSessionConfig> {
+    aws.sso_sessions.get(session_name).or_else(|| {
+        if aws.sso_sessions.len() == 1 {
+            aws.sso_sessions.values().next()
+        } else {
+            None
+        }
+    })
+}
+
 /// Resolve the Identity Center bearer token for an SSO session: trusted-token-
 /// issuer exchange when configured, otherwise the cached `vouch aws login`
 /// device token.
@@ -552,11 +570,13 @@ pub(crate) async fn resolve_bearer_token(
     session: &SsoSession,
     region: &str,
 ) -> Result<SecretString> {
-    let vouch_config = crate::config::Config::load().ok();
+    // Propagate a genuine config read/parse error; a missing config file yields
+    // `Config::default()` (no `aws` block) rather than an error, so the device
+    // fallback below still applies for users without Vouch config.
+    let vouch_config = crate::config::Config::load()?;
     let ic_session = vouch_config
-        .as_ref()
-        .and_then(|c| c.aws())
-        .and_then(|a| a.sso_sessions.get(&session.name))
+        .aws()
+        .and_then(|a| resolve_session_config(a, &session.name))
         .filter(|c| {
             c.identity_center_application_arn.is_some() && c.identity_center_audience.is_some()
         });

--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -6,6 +6,7 @@
 use anyhow::{Context, Result};
 use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
+use vouch_cli::tr_args;
 
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -516,6 +517,18 @@ async fn run_identity_center(
     role_name: &str,
     sso_session: Option<&str>,
 ) -> Result<serde_json::Value> {
+    // Fail closed for coding agents: the SSO portal's `GetRoleCredentials` returns
+    // the permission set's full access and accepts no inline session policy, so we
+    // cannot apply the `ReadOnlyAccess` downscoping the STS `--role` path uses
+    // (issue #398). Refuse rather than silently hand an agent unrestricted creds.
+    if let Some(source) = detect_agent_source() {
+        return Err(crate::exit_code::CliError::ConfigError(tr_args!(
+            "aws-err-agent-idc-readonly-unsupported",
+            source = source,
+        ))
+        .into());
+    }
+
     let aws_config = crate::integrations::aws::config::AwsConfig::load()?;
     let session = crate::commands::aws::resolve_sso_session(&aws_config, sso_session)?;
     let region = session.region.clone();

--- a/crates/vouch-cli/src/commands/credential/mod.rs
+++ b/crates/vouch-cli/src/commands/credential/mod.rs
@@ -27,10 +27,22 @@ pub(crate) mod wif;
 #[derive(Subcommand)]
 pub(crate) enum CredentialCommands {
     /// Obtain temporary AWS credentials.
+    ///
+    /// `--role <arn>` uses STS `AssumeRoleWithWebIdentity` (chaining through the
+    /// configured management role when set). `--account <id> --role <name>`
+    /// instead uses the IAM Identity Center portal for a permission-set role
+    /// (no role chaining, no per-role IAM trust). Invoked non-interactively as
+    /// an AWS `credential_process`; configure it with `vouch setup aws`.
     Aws {
-        /// AWS IAM role ARN to assume.
+        /// STS role ARN, or the permission-set role name when `--account` is set.
         #[arg(long)]
         role: String,
+        /// AWS account ID — switches to the Identity Center portal for `--role`.
+        #[arg(long)]
+        account: Option<String>,
+        /// SSO session name from ~/.aws/config (Identity Center mode).
+        #[arg(long)]
+        sso_session: Option<String>,
     },
     /// Obtain an SSH certificate.
     Ssh {

--- a/crates/vouch-cli/src/commands/setup/aws.rs
+++ b/crates/vouch-cli/src/commands/setup/aws.rs
@@ -44,26 +44,34 @@ fn sanitize_profile_name(name: &str) -> String {
     result.trim_matches('-').to_string()
 }
 
-/// Run the AWS setup command with an explicit role ARN.
+/// Run the AWS setup command. Writes AWS profiles to `~/.aws/config` whose
+/// `credential_process` invokes `vouch credential aws`.
 ///
-/// Automatically adds a vouch profile to ~/.aws/config with smart naming:
-/// - If `--profile` is given, uses that name (exits early if it already exists).
-/// - Otherwise, checks existing vouch profiles for a role match (exits early if found),
-///   then picks the next available name: "vouch", "vouch-2", "vouch-3", etc.
+/// - `--discover` → discover accounts/roles via SSO and write a profile each.
+///   Uses the IAM Identity Center portal (writing `--account/--role` process
+///   lines) when the session has Identity Center configured, otherwise STS
+///   role-chaining (writing `--role <arn>` lines).
+/// - `--role <arn>` → write a single STS profile for that role ARN.
+/// - neither → interactive single-account Identity Center setup (pick account +
+///   permission-set), when the session has Identity Center configured.
 pub(crate) async fn run(
+    server: &str,
     profile: Option<&str>,
     role_arn: Option<&str>,
     region: Option<&str>,
     discover: bool,
 ) -> Result<()> {
     if discover {
-        return run_discover(profile, region).await;
+        return run_discover(server, profile, region).await;
     }
+    match role_arn {
+        Some(role_arn) => run_explicit_role(profile, role_arn, region),
+        None => run_interactive_identity_center(server, profile, region).await,
+    }
+}
 
-    let role_arn = role_arn.ok_or_else(|| {
-        crate::exit_code::CliError::ConfigError(tr!("setup-aws-err-role-required"))
-    })?;
-
+/// Write a single STS profile for an explicit role ARN (patterns 1 & 2).
+fn run_explicit_role(profile: Option<&str>, role_arn: &str, region: Option<&str>) -> Result<()> {
     let vouch_path = resolve_install_path();
 
     let config_path = AwsConfig::default_path()?;
@@ -122,7 +130,14 @@ pub(crate) async fn run(
 }
 
 /// Discover AWS accounts/roles via SSO and create profiles automatically.
-async fn run_discover(profile_prefix: Option<&str>, region: Option<&str>) -> Result<()> {
+///
+/// Uses the IAM Identity Center portal (permission-set profiles) when the
+/// session has Identity Center configured, otherwise STS role-chaining.
+async fn run_discover(
+    server: &str,
+    profile_prefix: Option<&str>,
+    region: Option<&str>,
+) -> Result<()> {
     use crate::integrations::aws::config::AwsConfig as AwsCliConfig;
     use crate::integrations::aws::sso::{SsoConfig, load_cached_token};
     use crate::integrations::aws::sso_portal::{list_account_roles, list_accounts};
@@ -139,6 +154,13 @@ async fn run_discover(profile_prefix: Option<&str>, region: Option<&str>) -> Res
         .and_then(|a| a.sso_sessions.get(&session.name))
         .cloned()
         .unwrap_or_default();
+
+    // Identity Center configured → portal discovery (permission-set profiles).
+    if session_cfg.identity_center_application_arn.is_some()
+        && session_cfg.identity_center_audience.is_some()
+    {
+        return discover_identity_center(server, &session, profile_prefix, region).await;
+    }
 
     let sso_region = session.region.clone();
     let sso_config = SsoConfig::from_session(&session);
@@ -236,6 +258,278 @@ async fn run_discover(profile_prefix: Option<&str>, region: Option<&str>) -> Res
         skipped = skipped_count
     );
     Ok(())
+}
+
+/// An account choice shown in the interactive picker.
+struct AccountChoice {
+    id: String,
+    name: String,
+}
+
+impl std::fmt::Display for AccountChoice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} ({})", self.name, self.id)
+    }
+}
+
+/// Build the `credential_process` line for an Identity Center permission-set
+/// profile: `vouch credential aws --sso-session <name> --account <id> --role <ps>`.
+fn idc_credential_process(
+    vouch_path: &std::path::Path,
+    session_name: &str,
+    account_id: &str,
+    role_name: &str,
+) -> String {
+    format!(
+        "{} credential aws --sso-session {session_name} --account {account_id} --role {role_name}",
+        vouch_path.display()
+    )
+}
+
+/// Discover accounts/permission-sets via the Identity Center portal and write a
+/// profile per account+role (`vouch setup aws --discover` with IdC configured).
+async fn discover_identity_center(
+    server: &str,
+    session: &crate::integrations::aws::config::SsoSession,
+    profile_prefix: Option<&str>,
+    region: Option<&str>,
+) -> Result<()> {
+    use crate::integrations::aws::sso_portal::{list_account_roles, list_accounts};
+
+    let sso_region = session.region.clone();
+    let bearer =
+        crate::commands::credential::aws::resolve_bearer_token(server, session, &sso_region)
+            .await?;
+
+    let http_client =
+        vouch_common::http::credential_client(&format!("vouch-cli/{}", env!("CARGO_PKG_VERSION")))
+            .context("failed to create HTTP client")?;
+
+    let accounts = list_accounts(&http_client, &sso_region, &bearer)
+        .await
+        .context("failed to list SSO accounts")?;
+
+    let vouch_path = resolve_install_path();
+    let config_path = AwsConfig::default_path()?;
+    let aws_dir = dirs::home_dir()
+        .context("could not determine home directory")?
+        .join(".aws");
+    ensure_secure_dir(&aws_dir)?;
+    let mut config =
+        AwsConfig::load_from(config_path.clone()).unwrap_or_else(|_| AwsConfig::empty(config_path));
+
+    let mut created_count: u32 = 0;
+    let mut skipped_count: u32 = 0;
+
+    for account in &accounts {
+        let roles = list_account_roles(&http_client, &sso_region, &bearer, &account.account_id)
+            .await
+            .with_context(|| format!("failed to list roles for account {}", account.account_id))?;
+
+        let safe_account = sanitize_profile_name(&account.account_name);
+        let account_part = if safe_account.is_empty() {
+            account.account_id.clone()
+        } else {
+            safe_account
+        };
+
+        for role in &roles {
+            let role_part = sanitize_profile_name(&role.role_name);
+            let base = format!("{account_part}-{role_part}");
+            let profile_name = match profile_prefix {
+                Some(prefix) => format!("{prefix}-{base}"),
+                None => format!("vouch-sso-{base}"),
+            };
+
+            if config.profile_exists(&profile_name) {
+                tr_println!(
+                    "setup-aws-discover-skipped",
+                    profile = profile_name.as_str()
+                );
+                skipped_count = skipped_count.saturating_add(1);
+                continue;
+            }
+
+            config.set_profile(&AwsProfile {
+                name: profile_name.clone(),
+                credential_process: Some(idc_credential_process(
+                    &vouch_path,
+                    &session.name,
+                    &account.account_id,
+                    &role.role_name,
+                )),
+                region: region
+                    .map(str::to_string)
+                    .or_else(|| Some(sso_region.clone())),
+                output: Some("json".to_string()),
+            });
+
+            tr_println!(
+                "setup-aws-discover-added",
+                profile = profile_name.as_str(),
+                role_arn = role.role_name.as_str()
+            );
+            created_count = created_count.saturating_add(1);
+        }
+    }
+
+    if created_count > 0 {
+        config.save()?;
+    }
+
+    println!();
+    tr_println!(
+        "setup-aws-discover-summary",
+        created = created_count,
+        skipped = skipped_count
+    );
+    Ok(())
+}
+
+/// Interactive single-account Identity Center setup: pick an account and
+/// permission-set role, then write one profile (`vouch setup aws` with no
+/// `--role`/`--discover`). Requires the session to have Identity Center
+/// configured.
+async fn run_interactive_identity_center(
+    server: &str,
+    profile: Option<&str>,
+    region: Option<&str>,
+) -> Result<()> {
+    use crate::integrations::aws::sso_portal::{list_account_roles, list_accounts};
+
+    let aws_cli_config = AwsConfig::load()?;
+    let session = aws_cli_config.find_sso_session(None).ok_or_else(|| {
+        crate::exit_code::CliError::ConfigError(tr!("setup-aws-err-no-sso-session"))
+    })?;
+
+    // Interactive setup only applies to the Identity Center route; without it,
+    // an explicit `--role <arn>` (or `--discover`) is required.
+    let vouch_config = crate::config::Config::load()?;
+    let has_idc = vouch_config
+        .aws()
+        .and_then(|a| a.sso_sessions.get(&session.name))
+        .is_some_and(|c| {
+            c.identity_center_application_arn.is_some() && c.identity_center_audience.is_some()
+        });
+    if !has_idc {
+        return Err(
+            crate::exit_code::CliError::ConfigError(tr!("setup-aws-err-role-required")).into(),
+        );
+    }
+
+    require_terminal()?;
+
+    let sso_region = session.region.clone();
+    let bearer =
+        crate::commands::credential::aws::resolve_bearer_token(server, &session, &sso_region)
+            .await?;
+    let http_client =
+        vouch_common::http::credential_client(&format!("vouch-cli/{}", env!("CARGO_PKG_VERSION")))
+            .context("failed to create HTTP client")?;
+
+    // Pick account.
+    let accounts = list_accounts(&http_client, &sso_region, &bearer)
+        .await
+        .context("failed to list SSO accounts")?;
+    if accounts.is_empty() {
+        anyhow::bail!("no AWS accounts are assigned to you via Identity Center");
+    }
+    let account_choices: Vec<AccountChoice> = accounts
+        .into_iter()
+        .map(|a| AccountChoice {
+            id: a.account_id,
+            name: a.account_name,
+        })
+        .collect();
+    let account = prompt_select("Select an AWS account", account_choices)?;
+
+    // Pick permission-set role.
+    let roles = list_account_roles(&http_client, &sso_region, &bearer, &account.id)
+        .await
+        .with_context(|| format!("failed to list roles for account {}", account.id))?;
+    if roles.is_empty() {
+        anyhow::bail!("no roles are assigned to you in account {}", account.id);
+    }
+    let role_names: Vec<String> = roles.into_iter().map(|r| r.role_name).collect();
+    let role_name = prompt_select("Select a role", role_names)?;
+
+    // Write the profile.
+    let profile_name = match profile {
+        Some(p) => p.to_string(),
+        None => {
+            let safe_account = sanitize_profile_name(&account.name);
+            let account_part = if safe_account.is_empty() {
+                account.id.clone()
+            } else {
+                safe_account
+            };
+            format!(
+                "vouch-sso-{account_part}-{}",
+                sanitize_profile_name(&role_name)
+            )
+        }
+    };
+
+    let config_path = AwsConfig::default_path()?;
+    let aws_dir = dirs::home_dir()
+        .context("could not determine home directory")?
+        .join(".aws");
+    ensure_secure_dir(&aws_dir)?;
+    let mut config =
+        AwsConfig::load_from(config_path.clone()).unwrap_or_else(|_| AwsConfig::empty(config_path));
+
+    if config.profile_exists(&profile_name) {
+        tr_println!(
+            "setup-aws-profile-already-exists",
+            profile = profile_name.as_str()
+        );
+        return Ok(());
+    }
+
+    let vouch_path = resolve_install_path();
+    config.set_profile(&AwsProfile {
+        name: profile_name.clone(),
+        credential_process: Some(idc_credential_process(
+            &vouch_path,
+            &session.name,
+            &account.id,
+            &role_name,
+        )),
+        region: region.map(str::to_string).or(Some(sso_region)),
+        output: Some("json".to_string()),
+    });
+    config.save()?;
+
+    tr_println!(
+        "setup-aws-added-profile-block",
+        profile = profile_name.as_str(),
+    );
+    Ok(())
+}
+
+/// Error out when stdin is not a terminal (interactive selection impossible).
+fn require_terminal() -> Result<()> {
+    use std::io::IsTerminal;
+    if std::io::stdin().is_terminal() {
+        return Ok(());
+    }
+    Err(crate::exit_code::CliError::ConfigError(
+        "run interactively, or pass --role <arn> / --discover".to_string(),
+    )
+    .into())
+}
+
+/// Show an interactive single-select prompt, mapping cancellation to a clean error.
+fn prompt_select<T: std::fmt::Display>(prompt: &str, options: Vec<T>) -> Result<T> {
+    inquire::Select::new(prompt, options)
+        .prompt()
+        .map_err(|e| match e {
+            inquire::InquireError::OperationCanceled
+            | inquire::InquireError::OperationInterrupted => {
+                crate::exit_code::CliError::ConfigError("selection cancelled".to_string()).into()
+            }
+            other => anyhow::anyhow!("selection failed: {other}"),
+        })
 }
 
 #[cfg(test)]

--- a/crates/vouch-cli/src/commands/setup/aws.rs
+++ b/crates/vouch-cli/src/commands/setup/aws.rs
@@ -274,6 +274,10 @@ impl std::fmt::Display for AccountChoice {
 
 /// Build the `credential_process` line for an Identity Center permission-set
 /// profile: `vouch credential aws --sso-session <name> --account <id> --role <ps>`.
+///
+/// The session and permission-set names are double-quoted so values containing
+/// spaces are passed as single argv tokens (AWS parses `credential_process`
+/// with shell-like tokenization that respects quotes).
 fn idc_credential_process(
     vouch_path: &std::path::Path,
     session_name: &str,
@@ -281,7 +285,7 @@ fn idc_credential_process(
     role_name: &str,
 ) -> String {
     format!(
-        "{} credential aws --sso-session {session_name} --account {account_id} --role {role_name}",
+        "{} credential aws --sso-session \"{session_name}\" --account {account_id} --role \"{role_name}\"",
         vouch_path.display()
     )
 }

--- a/crates/vouch-cli/src/commands/setup/aws.rs
+++ b/crates/vouch-cli/src/commands/setup/aws.rs
@@ -156,9 +156,7 @@ async fn run_discover(
         .unwrap_or_default();
 
     // Identity Center configured → portal discovery (permission-set profiles).
-    if session_cfg.identity_center_application_arn.is_some()
-        && session_cfg.identity_center_audience.is_some()
-    {
+    if session_cfg.identity_center_application_arn.is_some() {
         return discover_identity_center(server, &session, profile_prefix, region).await;
     }
 
@@ -412,9 +410,7 @@ async fn run_interactive_identity_center(
     let has_idc = vouch_config
         .aws()
         .and_then(|a| crate::commands::credential::aws::resolve_session_config(a, &session.name))
-        .is_some_and(|c| {
-            c.identity_center_application_arn.is_some() && c.identity_center_audience.is_some()
-        });
+        .is_some_and(|c| c.identity_center_application_arn.is_some());
     if !has_idc {
         return Err(
             crate::exit_code::CliError::ConfigError(tr!("setup-aws-err-role-required")).into(),

--- a/crates/vouch-cli/src/commands/setup/aws.rs
+++ b/crates/vouch-cli/src/commands/setup/aws.rs
@@ -113,7 +113,7 @@ fn run_explicit_role(profile: Option<&str>, role_arn: &str, region: Option<&str>
     config.set_profile(&AwsProfile {
         name: profile_name.clone(),
         credential_process: Some(format!(
-            "{} credential aws --role {role_arn}",
+            "\"{}\" credential aws --role {role_arn}",
             vouch_path.display()
         )),
         region: region.map(str::to_string),
@@ -230,7 +230,7 @@ async fn run_discover(
         config.set_profile(&AwsProfile {
             name: profile_name.clone(),
             credential_process: Some(format!(
-                "{} credential aws --role {role_arn}",
+                "\"{}\" credential aws --role {role_arn}",
                 vouch_path.display()
             )),
             region: region.map(str::to_string),
@@ -273,9 +273,9 @@ impl std::fmt::Display for AccountChoice {
 /// Build the `credential_process` line for an Identity Center permission-set
 /// profile: `vouch credential aws --sso-session <name> --account <id> --role <ps>`.
 ///
-/// The session and permission-set names are double-quoted so values containing
-/// spaces are passed as single argv tokens (AWS parses `credential_process`
-/// with shell-like tokenization that respects quotes).
+/// The binary path, session name, and permission-set name are double-quoted so
+/// values containing spaces are passed as single argv tokens (AWS parses
+/// `credential_process` with shell-like tokenization that respects quotes).
 fn idc_credential_process(
     vouch_path: &std::path::Path,
     session_name: &str,
@@ -283,7 +283,7 @@ fn idc_credential_process(
     role_name: &str,
 ) -> String {
     format!(
-        "{} credential aws --sso-session \"{session_name}\" --account {account_id} --role \"{role_name}\"",
+        "\"{}\" credential aws --sso-session \"{session_name}\" --account {account_id} --role \"{role_name}\"",
         vouch_path.display()
     )
 }

--- a/crates/vouch-cli/src/commands/setup/aws.rs
+++ b/crates/vouch-cli/src/commands/setup/aws.rs
@@ -151,7 +151,7 @@ async fn run_discover(
     let session = crate::commands::aws::resolve_sso_session(&aws_cli_config, None)?;
     let session_cfg = vouch_config
         .aws()
-        .and_then(|a| crate::commands::credential::aws::resolve_session_config(a, &session.name))
+        .and_then(|a| a.sso_sessions.get(&session.name))
         .cloned()
         .unwrap_or_default();
 
@@ -409,7 +409,7 @@ async fn run_interactive_identity_center(
     let vouch_config = crate::config::Config::load()?;
     let has_idc = vouch_config
         .aws()
-        .and_then(|a| crate::commands::credential::aws::resolve_session_config(a, &session.name))
+        .and_then(|a| a.sso_sessions.get(&session.name))
         .is_some_and(|c| c.identity_center_application_arn.is_some());
     if !has_idc {
         return Err(

--- a/crates/vouch-cli/src/commands/setup/aws.rs
+++ b/crates/vouch-cli/src/commands/setup/aws.rs
@@ -146,9 +146,9 @@ async fn run_discover(
     let vouch_config = crate::config::Config::load()?;
     let aws_cli_config = AwsCliConfig::load()?;
 
-    let session = aws_cli_config.find_sso_session(None).ok_or_else(|| {
-        crate::exit_code::CliError::ConfigError(tr!("setup-aws-err-no-sso-session"))
-    })?;
+    // Mirror `vouch credential aws`: honor a single session silently, but emit a
+    // stderr hint naming the auto-selected session when several are configured.
+    let session = crate::commands::aws::resolve_sso_session(&aws_cli_config, None)?;
     let session_cfg = vouch_config
         .aws()
         .and_then(|a| crate::commands::credential::aws::resolve_session_config(a, &session.name))
@@ -400,9 +400,9 @@ async fn run_interactive_identity_center(
     use crate::integrations::aws::sso_portal::{list_account_roles, list_accounts};
 
     let aws_cli_config = AwsConfig::load()?;
-    let session = aws_cli_config.find_sso_session(None).ok_or_else(|| {
-        crate::exit_code::CliError::ConfigError(tr!("setup-aws-err-no-sso-session"))
-    })?;
+    // Mirror `vouch credential aws`: honor a single session silently, but emit a
+    // stderr hint naming the auto-selected session when several are configured.
+    let session = crate::commands::aws::resolve_sso_session(&aws_cli_config, None)?;
 
     // Interactive setup only applies to the Identity Center route; without it,
     // an explicit `--role <arn>` (or `--discover`) is required.

--- a/crates/vouch-cli/src/commands/setup/aws.rs
+++ b/crates/vouch-cli/src/commands/setup/aws.rs
@@ -151,7 +151,7 @@ async fn run_discover(
     })?;
     let session_cfg = vouch_config
         .aws()
-        .and_then(|a| a.sso_sessions.get(&session.name))
+        .and_then(|a| crate::commands::credential::aws::resolve_session_config(a, &session.name))
         .cloned()
         .unwrap_or_default();
 
@@ -411,7 +411,7 @@ async fn run_interactive_identity_center(
     let vouch_config = crate::config::Config::load()?;
     let has_idc = vouch_config
         .aws()
-        .and_then(|a| a.sso_sessions.get(&session.name))
+        .and_then(|a| crate::commands::credential::aws::resolve_session_config(a, &session.name))
         .is_some_and(|c| {
             c.identity_center_application_arn.is_some() && c.identity_center_audience.is_some()
         });

--- a/crates/vouch-cli/src/commands/setup/mod.rs
+++ b/crates/vouch-cli/src/commands/setup/mod.rs
@@ -27,8 +27,10 @@ pub(crate) enum SetupCommands {
         /// AWS profile name to configure. Defaults to "vouch" if not specified.
         #[arg(long, help = tr!("arg-setup-aws-profile-help"))]
         profile: Option<String>,
-        /// AWS IAM role ARN to assume. Required unless --discover is set.
-        #[arg(long, required_unless_present = "discover", help = tr!("arg-setup-aws-role-help"))]
+        /// AWS IAM role ARN to assume. When omitted (and not --discover),
+        /// an interactive Identity Center setup runs if the session is
+        /// configured for it.
+        #[arg(long, help = tr!("arg-setup-aws-role-help"))]
         role: Option<String>,
         /// AWS region to set in the profile.
         #[arg(long, help = tr!("arg-setup-aws-region-help"))]

--- a/crates/vouch-cli/src/config.rs
+++ b/crates/vouch-cli/src/config.rs
@@ -41,6 +41,19 @@ pub(crate) struct SsoSessionConfig {
         deserialize_with = "deserialize_member_role_path"
     )]
     pub member_role_path: String,
+    /// IAM Identity Center customer-managed application ARN (the `clientId`
+    /// for `sso-oidc:CreateTokenWithIAM`). When set together with
+    /// `identity_center_audience`, `credential aws --account/--role` exchanges a
+    /// Vouch RS256 token for an Identity Center token instead of requiring a
+    /// separate `vouch aws login` — reaching any assigned account with no role
+    /// chaining and no per-role IAM trust policy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity_center_application_arn: Option<String>,
+    /// Aud claim configured on the customer-managed application's trusted token
+    /// issuer. Requested as the `audience` on the Vouch RS256 token so AWS
+    /// accepts it during the exchange.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity_center_audience: Option<String>,
 }
 
 impl Default for SsoSessionConfig {
@@ -49,6 +62,8 @@ impl Default for SsoSessionConfig {
             management_role: String::new(),
             member_role_name: default_member_role_name(),
             member_role_path: default_member_role_path(),
+            identity_center_application_arn: None,
+            identity_center_audience: None,
         }
     }
 }

--- a/crates/vouch-cli/src/config.rs
+++ b/crates/vouch-cli/src/config.rs
@@ -42,18 +42,14 @@ pub(crate) struct SsoSessionConfig {
     )]
     pub member_role_path: String,
     /// IAM Identity Center customer-managed application ARN (the `clientId`
-    /// for `sso-oidc:CreateTokenWithIAM`). When set together with
-    /// `identity_center_audience`, `credential aws --account/--role` exchanges a
-    /// Vouch RS256 token for an Identity Center token instead of requiring a
-    /// separate `vouch aws login` — reaching any assigned account with no role
-    /// chaining and no per-role IAM trust policy.
+    /// for `sso-oidc:CreateTokenWithIAM`). When set, `credential aws
+    /// --account/--role` exchanges a Vouch RS256 token for an Identity Center
+    /// token instead of requiring a separate `vouch aws login` — reaching any
+    /// assigned account with no role chaining and no per-role IAM trust policy.
+    /// The token's `aud` is the Vouch server URL, so the customer-managed
+    /// application's Aud claim must be set to that same URL.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identity_center_application_arn: Option<String>,
-    /// Aud claim configured on the customer-managed application's trusted token
-    /// issuer. Requested as the `audience` on the Vouch RS256 token so AWS
-    /// accepts it during the exchange.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub identity_center_audience: Option<String>,
 }
 
 impl Default for SsoSessionConfig {
@@ -63,7 +59,6 @@ impl Default for SsoSessionConfig {
             member_role_name: default_member_role_name(),
             member_role_path: default_member_role_path(),
             identity_center_application_arn: None,
-            identity_center_audience: None,
         }
     }
 }

--- a/crates/vouch-cli/src/integrations/aws/identity_center.rs
+++ b/crates/vouch-cli/src/integrations/aws/identity_center.rs
@@ -38,7 +38,7 @@ struct CreateTokenResponse {
 ///
 /// `application_arn` is the customer-managed application's ARN (the `clientId`).
 /// `assertion_jwt` is the RS256 token from
-/// `GET /v1/credentials/aws/sso/token?audience=<aud>`. `caller_creds` are the
+/// `GET /v1/credentials/aws/sso/token`. `caller_creds` are the
 /// SigV4 caller credentials (the management role, assumed via web identity,
 /// which must hold `sso-oauth:CreateTokenWithIAM`).
 pub(crate) async fn create_token_with_iam(

--- a/crates/vouch-cli/src/integrations/aws/identity_center.rs
+++ b/crates/vouch-cli/src/integrations/aws/identity_center.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! AWS IAM Identity Center trusted-token-issuer exchange.
+//!
+//! Implements `sso-oidc:CreateTokenWithIAM` with the `jwt-bearer` grant: a
+//! Vouch-issued **RS256** JWT (the trusted token issuer's signed token) is
+//! exchanged for an Identity Center access token. That token then drives the
+//! SSO Portal (`ListAccounts`/`ListAccountRoles`/`GetRoleCredentials`) to reach
+//! every account+permission-set the user is assigned to — no role chaining and
+//! no per-role IAM trust policy.
+//!
+//! Unlike the device-authorization flow in [`super::sso`], this requires no
+//! interactive AWS login: the user authenticates once with Vouch (FIDO2), and
+//! the management role (assumed via `AssumeRoleWithWebIdentity`) is the SigV4
+//! caller for the exchange.
+
+use anyhow::{Context, Result};
+use secrecy::SecretString;
+use serde::Deserialize;
+use vouch_common::aws::Partition;
+
+use super::sigv4::sign_and_send_json_post;
+use super::sts::StsCredentials;
+
+/// OAuth 2.0 JWT bearer grant type (RFC 7523).
+const JWT_BEARER_GRANT: &str = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+
+/// Subset of the `CreateTokenWithIAM` response we consume.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateTokenResponse {
+    /// The Identity Center access token (presented to the SSO Portal via the
+    /// `x-amz-sso_bearer_token` header).
+    access_token: String,
+}
+
+/// Exchange a Vouch RS256 JWT for an IAM Identity Center access token via
+/// `sso-oidc:CreateTokenWithIAM` (`jwt-bearer` grant).
+///
+/// `application_arn` is the customer-managed application's ARN (the `clientId`).
+/// `assertion_jwt` is the RS256 token from
+/// `GET /v1/credentials/aws/sso/token?audience=<aud>`. `caller_creds` are the
+/// SigV4 caller credentials (the management role, assumed via web identity,
+/// which must hold `sso-oauth:CreateTokenWithIAM`).
+pub(crate) async fn create_token_with_iam(
+    http_client: &reqwest::Client,
+    region: &str,
+    application_arn: &str,
+    assertion_jwt: &str,
+    caller_creds: &StsCredentials,
+) -> Result<SecretString> {
+    let partition = Partition::from_region(region);
+    let endpoint = partition.sso_oidc_endpoint(region);
+
+    let body = serde_json::json!({
+        "clientId": application_arn,
+        "grantType": JWT_BEARER_GRANT,
+        "assertion": assertion_jwt,
+    });
+
+    // CreateTokenWithIAM is POST /token?aws_iam=t, signed for the `sso-oauth`
+    // service (SigV4). The `aws_iam=t` query param selects the IAM-authenticated
+    // variant of CreateToken.
+    let response = sign_and_send_json_post(
+        http_client,
+        &endpoint,
+        "/token",
+        &[("aws_iam", "t")],
+        "sso-oauth",
+        region,
+        caller_creds,
+        &body,
+    )
+    .await
+    .context("CreateTokenWithIAM exchange failed")?;
+
+    let parsed: CreateTokenResponse =
+        serde_json::from_str(&response).context("failed to parse CreateTokenWithIAM response")?;
+
+    Ok(SecretString::from(parsed.access_token))
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_token_response_deserialization() {
+        // CreateTokenWithIAM returns additional fields (tokenType, expiresIn,
+        // refreshToken, idToken) we ignore; only accessToken is required.
+        let json = r#"{
+            "accessToken": "ic-access-token-value",
+            "tokenType": "Bearer",
+            "expiresIn": 3600,
+            "refreshToken": "ic-refresh-token",
+            "idToken": "ic-id-token"
+        }"#;
+
+        let parsed: CreateTokenResponse = serde_json::from_str(json).expect("valid JSON");
+        assert_eq!(parsed.access_token, "ic-access-token-value");
+    }
+
+    #[test]
+    fn test_jwt_bearer_grant_constant() {
+        // The grant type must match RFC 7523 exactly — AWS rejects any other value.
+        assert_eq!(
+            JWT_BEARER_GRANT,
+            "urn:ietf:params:oauth:grant-type:jwt-bearer"
+        );
+    }
+}

--- a/crates/vouch-cli/src/integrations/aws/identity_center.rs
+++ b/crates/vouch-cli/src/integrations/aws/identity_center.rs
@@ -102,13 +102,4 @@ mod tests {
         let parsed: CreateTokenResponse = serde_json::from_str(json).expect("valid JSON");
         assert_eq!(parsed.access_token, "ic-access-token-value");
     }
-
-    #[test]
-    fn test_jwt_bearer_grant_constant() {
-        // The grant type must match RFC 7523 exactly — AWS rejects any other value.
-        assert_eq!(
-            JWT_BEARER_GRANT,
-            "urn:ietf:params:oauth:grant-type:jwt-bearer"
-        );
-    }
 }

--- a/crates/vouch-cli/src/integrations/aws/mod.rs
+++ b/crates/vouch-cli/src/integrations/aws/mod.rs
@@ -7,6 +7,7 @@
 pub(crate) mod codeartifact;
 pub(crate) mod codecommit;
 pub(crate) mod config;
+pub(crate) mod identity_center;
 pub(crate) mod redshift;
 pub(crate) mod sigv4;
 pub(crate) mod sso;

--- a/crates/vouch-cli/src/integrations/aws/sigv4.rs
+++ b/crates/vouch-cli/src/integrations/aws/sigv4.rs
@@ -361,6 +361,117 @@ pub(crate) async fn sign_and_send_form_post(
         .context("failed to read AWS API response body")
 }
 
+/// Send a SigV4-signed POST request with a JSON body to a REST-style AWS
+/// endpoint that uses a path and query string (not JSON-RPC `X-Amz-Target`).
+///
+/// Used for IAM Identity Center `sso-oidc:CreateTokenWithIAM`, which is
+/// `POST /token?aws_iam=t` with a `application/json` body, signed for the
+/// `sso-oauth` service.
+///
+/// # Arguments
+/// * `endpoint` - Base URL (e.g., `https://oidc.us-east-1.amazonaws.com`)
+/// * `path` - URI path (e.g., `/token`)
+/// * `query_params` - Query parameters (e.g., `&[("aws_iam", "t")]`)
+/// * `service` - AWS service name for signing (e.g., `sso-oauth`)
+/// * `region` - AWS region
+/// * `creds` - Temporary AWS credentials (SigV4 caller identity)
+/// * `body` - JSON request body
+#[expect(
+    clippy::too_many_arguments,
+    reason = "AWS SigV4 JSON POST requires all listed parameters"
+)]
+pub(crate) async fn sign_and_send_json_post(
+    http_client: &reqwest::Client,
+    endpoint: &str,
+    path: &str,
+    query_params: &[(&str, &str)],
+    service: &str,
+    region: &str,
+    creds: &StsCredentials,
+    body: &serde_json::Value,
+) -> Result<String> {
+    let host = endpoint
+        .strip_prefix("https://")
+        .unwrap_or(endpoint)
+        .trim_end_matches('/');
+
+    let mut sorted_params: Vec<(&str, &str)> = query_params.to_vec();
+    sorted_params.sort_by(|a, b| a.0.cmp(b.0));
+    let canonical_query_string: String = sorted_params
+        .iter()
+        .map(|(k, v)| format!("{}={}", uri_encode(k), uri_encode(v)))
+        .collect::<Vec<_>>()
+        .join("&");
+
+    let body_str = body.to_string();
+    let now = jiff::Timestamp::now();
+    let amz_date = format_amz_date(now);
+    let date_stamp = format_date_stamp(now);
+
+    let payload_hash = sha256_hex(body_str.as_bytes());
+
+    let canonical_headers = format!(
+        "content-type:application/json\n\
+         host:{host}\nx-amz-date:{amz_date}\n\
+         x-amz-security-token:{}\n",
+        creds.session_token.expose_secret()
+    );
+    let signed_headers = "content-type;host;x-amz-date;x-amz-security-token";
+
+    let canonical_request = format!(
+        "POST\n{path}\n{canonical_query_string}\n\
+         {canonical_headers}\n{signed_headers}\n{payload_hash}"
+    );
+
+    let algorithm = "AWS4-HMAC-SHA256";
+    let credential_scope = format!("{date_stamp}/{region}/{service}/aws4_request");
+    let canonical_request_hash = sha256_hex(canonical_request.as_bytes());
+
+    let string_to_sign =
+        format!("{algorithm}\n{amz_date}\n{credential_scope}\n{canonical_request_hash}");
+
+    let k_signing = derive_signing_key(&creds.secret_access_key, &date_stamp, region, service);
+    let signature = hex::encode(hmac_sha256(&k_signing, string_to_sign.as_bytes()));
+
+    let authorization = format!(
+        "{algorithm} Credential={}/{credential_scope}, \
+         SignedHeaders={signed_headers}, Signature={signature}",
+        creds.access_key_id
+    );
+
+    let url = if canonical_query_string.is_empty() {
+        format!("{endpoint}{path}")
+    } else {
+        format!("{endpoint}{path}?{canonical_query_string}")
+    };
+
+    let response = http_client
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .header("X-Amz-Date", &amz_date)
+        .header("X-Amz-Security-Token", creds.session_token.expose_secret())
+        .header("Authorization", &authorization)
+        .body(body_str)
+        .send()
+        .await
+        .context("failed to send AWS API request")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let response_body = response.text().await.unwrap_or_default();
+        let truncated = truncate_error_body(&response_body, 500);
+        return Err(crate::exit_code::CliError::NetworkError(format!(
+            "{service} returned error {status}: {truncated}"
+        ))
+        .into());
+    }
+
+    response
+        .text()
+        .await
+        .context("failed to read AWS API response body")
+}
+
 /// Parameters for building a SigV4 presigned URL.
 pub(crate) struct PresignedUrlParams<'a> {
     /// HTTP method (typically "GET").

--- a/crates/vouch-cli/src/integrations/aws/sso_portal.rs
+++ b/crates/vouch-cli/src/integrations/aws/sso_portal.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//! AWS SSO Portal API for listing accounts and roles.
+//! AWS SSO Portal API for listing accounts and roles and retrieving role
+//! credentials.
 //!
 //! Uses Bearer token auth via the `x-amz-sso_bearer_token` header (not
 //! standard `Authorization: Bearer` — this is what the AWS SDK uses).
@@ -8,6 +9,8 @@ use anyhow::{Context, Result};
 use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use vouch_common::aws::Partition;
+
+use super::sts::StsCredentials;
 
 /// An AWS account the user has access to via SSO.
 #[derive(Debug, Clone, Deserialize)]
@@ -187,6 +190,93 @@ pub(crate) async fn list_account_roles(
     Ok(roles)
 }
 
+/// AWS SSO Portal `GetRoleCredentials` response envelope.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RoleCredentialsResponse {
+    role_credentials: PortalRoleCredentials,
+}
+
+/// Temporary role credentials returned by the SSO Portal `GetRoleCredentials`
+/// API. `expiration` is Unix epoch **milliseconds** (not seconds).
+///
+/// The secret fields are deserialized as plain `String` (the workspace builds
+/// `secrecy` without its `serde` feature, so `SecretString` is not
+/// `Deserialize`) and wrapped into `SecretString` in [`get_role_credentials`].
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PortalRoleCredentials {
+    access_key_id: String,
+    secret_access_key: String,
+    session_token: String,
+    /// Expiry as Unix epoch milliseconds.
+    expiration: i64,
+}
+
+/// Retrieve temporary AWS credentials for a permission-set role in a specific
+/// account, on behalf of the SSO-authenticated user.
+///
+/// This is the credential-issuing counterpart to [`list_accounts`] /
+/// [`list_account_roles`]: given an account and a role name from those
+/// listings, it returns STS-equivalent credentials directly from the SSO
+/// Portal — no `AssumeRole` chaining and no per-role IAM trust policy. Access
+/// is governed entirely by the user's IAM Identity Center permission-set
+/// assignments.
+///
+/// `role_name` is the permission-set name (as returned by
+/// [`list_account_roles`]); the portal resolves it to the corresponding
+/// `AWSReservedSSO_*` role in `account_id`.
+pub(crate) async fn get_role_credentials(
+    http_client: &reqwest::Client,
+    region: &str,
+    access_token: &SecretString,
+    account_id: &str,
+    role_name: &str,
+) -> Result<StsCredentials> {
+    let partition = Partition::from_region(region);
+    let base_url = partition.sso_portal_endpoint(region);
+    let url = format!("{base_url}/federation/credentials");
+
+    let response = http_client
+        .get(&url)
+        .header("x-amz-sso_bearer_token", access_token.expose_secret())
+        .query(&[("account_id", account_id), ("role_name", role_name)])
+        .send()
+        .await
+        .context("failed to call SSO Portal get role credentials")?;
+
+    if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+        return Err(crate::exit_code::CliError::NotAuthenticated {
+            reason: "SSO token is invalid or expired. Run 'vouch aws login' first.".to_string(),
+        }
+        .into());
+    }
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(crate::exit_code::CliError::NetworkError(format!(
+            "SSO Portal get role credentials failed {status}: {text}"
+        ))
+        .into());
+    }
+
+    let resp: RoleCredentialsResponse = response
+        .json()
+        .await
+        .context("failed to parse SSO Portal role credentials response")?;
+
+    let expiration = jiff::Timestamp::from_millisecond(resp.role_credentials.expiration)
+        .context("SSO Portal returned an out-of-range credential expiration")?;
+
+    Ok(StsCredentials {
+        access_key_id: resp.role_credentials.access_key_id,
+        secret_access_key: SecretString::from(resp.role_credentials.secret_access_key),
+        session_token: SecretString::from(resp.role_credentials.session_token),
+        expiration,
+    })
+}
+
 #[cfg(test)]
 #[expect(
     clippy::expect_used,
@@ -195,6 +285,26 @@ pub(crate) async fn list_account_roles(
 )]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_role_credentials_response_deserialization() {
+        // `expiration` is Unix epoch milliseconds in the SSO Portal response.
+        let json = r#"{
+            "roleCredentials": {
+                "accessKeyId": "ASIAEXAMPLE",
+                "secretAccessKey": "secretkeyexample",
+                "sessionToken": "sessiontokenexample",
+                "expiration": 1705257600000
+            }
+        }"#;
+
+        let resp: RoleCredentialsResponse = serde_json::from_str(json).expect("valid JSON");
+        assert_eq!(resp.role_credentials.access_key_id, "ASIAEXAMPLE");
+        assert_eq!(resp.role_credentials.expiration, 1_705_257_600_000);
+        let ts = jiff::Timestamp::from_millisecond(resp.role_credentials.expiration)
+            .expect("valid timestamp");
+        assert_eq!(ts.as_millisecond(), 1_705_257_600_000);
+    }
 
     #[test]
     fn test_list_accounts_response_deserialization() {

--- a/crates/vouch-cli/src/main.rs
+++ b/crates/vouch-cli/src/main.rs
@@ -623,7 +623,19 @@ async fn run() -> Result<()> {
             .await
         }
         Commands::Credential { command } => match command {
-            CredentialCommands::Aws { role } => commands::credential::aws::run(server, &role).await,
+            CredentialCommands::Aws {
+                role,
+                account,
+                sso_session,
+            } => {
+                commands::credential::aws::run(
+                    server,
+                    &role,
+                    account.as_deref(),
+                    sso_session.as_deref(),
+                )
+                .await
+            }
             CredentialCommands::Ssh { key, force } => {
                 commands::credential::ssh::run(server, key.as_deref(), force).await
             }
@@ -731,6 +743,7 @@ async fn run() -> Result<()> {
                 discover,
             } => {
                 commands::setup::aws::run(
+                    server,
                     profile.as_deref(),
                     role.as_deref(),
                     region.as_deref(),

--- a/crates/vouch-server/src/handlers/credentials.rs
+++ b/crates/vouch-server/src/handlers/credentials.rs
@@ -8,7 +8,7 @@ use crate::services::integrations::aws::{AwsError, issue_aws_token, issue_sso_jw
 use crate::services::integrations::github::{GitHubInstallationId, minimal_git_permissions};
 use axum::extract::OriginalUri;
 use axum::http::Method;
-use axum::{Json, extract::Query, extract::State, http::HeaderMap, http::StatusCode};
+use axum::{Json, extract::State, http::HeaderMap, http::StatusCode};
 use axum_extra::extract::cookie::CookieJar;
 use jiff::Timestamp;
 use serde::Serialize;
@@ -312,17 +312,6 @@ pub(crate) struct SshRevocationCheckResponse {
 // AWS Token Endpoint
 // ============================================================================
 
-/// Maximum accepted length for the Identity Center audience parameter.
-const MAX_AUDIENCE_LEN: usize = 2048;
-
-/// Query parameters for the AWS Identity Center token endpoint.
-#[derive(serde::Deserialize)]
-pub(crate) struct AwsSsoTokenQuery {
-    /// The customer-managed application's configured Aud claim — the audience
-    /// of the issued RS256 token (REQUIRED).
-    audience: String,
-}
-
 /// Shared preamble for the AWS credential endpoints: authenticate the request,
 /// require a hardware-verified session, confirm the user is active, and resolve
 /// the user's email.
@@ -456,30 +445,22 @@ pub(crate) async fn get_aws_token(
 /// Get an RS256 OIDC ID token for AWS IAM Identity Center trusted identity
 /// propagation.
 ///
-/// GET /v1/credentials/aws/sso/token?audience=<aud>
+/// GET /v1/credentials/aws/sso/token
 ///
 /// The token is the subject (`assertion`) for `sso-oidc:CreateTokenWithIAM`
 /// (`jwt-bearer` grant). This is a distinct endpoint from the ES256
 /// `AssumeRoleWithWebIdentity` token because AWS's trusted-token-issuer contract
-/// requires RS256. `audience` is the customer-managed application's Aud claim.
-/// The same hardware-verification gate and AWS session tags apply.
+/// requires RS256. The token's `aud` is the Vouch issuer (server base URL); the
+/// customer-managed application's Aud claim must be set to that same URL. The
+/// same hardware-verification gate and AWS session tags apply.
 pub(crate) async fn get_aws_sso_token(
     method: Method,
     uri: OriginalUri,
     headers: HeaderMap,
     jar: CookieJar,
-    Query(query): Query<AwsSsoTokenQuery>,
     State(state): State<Arc<AppState>>,
     client_cert: OptionalClientCert,
 ) -> Result<Json<AwsTokenResponse>, ServiceError> {
-    if query.audience.is_empty() || query.audience.len() > MAX_AUDIENCE_LEN {
-        return Err(ServiceError::api(
-            StatusCode::BAD_REQUEST,
-            "invalid_audience",
-            "audience must be between 1 and 2048 characters",
-        ));
-    }
-
     let (token, user_email) =
         authorize_aws_token_request(&state, &headers, &jar, &method, uri.path(), &client_cert)
             .await?;
@@ -499,7 +480,6 @@ pub(crate) async fn get_aws_sso_token(
         config.session_hours,
         rsa_key,
         &user_email,
-        &query.audience,
         token.hardware_aaguid.clone(),
         token.org_domain.clone(),
         token.dpop_source.as_deref(),
@@ -1175,7 +1155,7 @@ mod tests {
 
         let (status, body) = http_get(
             &app,
-            "/v1/credentials/aws/sso/token?audience=vouch-identity-center",
+            "/v1/credentials/aws/sso/token",
             &[("Authorization", &format!("Bearer {token}"))],
         )
         .await;
@@ -1191,27 +1171,6 @@ mod tests {
             .expect("base64url header");
         let header: serde_json::Value = serde_json::from_slice(&header_bytes).expect("header JSON");
         assert_eq!(header["alg"], "RS256");
-    }
-
-    /// The Identity Center endpoint requires the `audience` query parameter.
-    #[tokio::test]
-    async fn test_aws_sso_token_requires_audience() {
-        let state = test_app_state_with_rsa_key().await;
-        let config = state.config();
-        let app = crate::infra::router::build_app(state.clone(), &config).expect("build app");
-
-        let user = create_test_user(&state.store, "sso-noaud@example.com").await;
-        let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
-
-        let (status, _body) = http_get(
-            &app,
-            "/v1/credentials/aws/sso/token",
-            &[("Authorization", &format!("Bearer {token}"))],
-        )
-        .await;
-
-        assert_eq!(status, StatusCode::BAD_REQUEST);
     }
 
     /// Regression for #451: a non-hardware-verified bootstrap session

--- a/crates/vouch-server/src/handlers/credentials.rs
+++ b/crates/vouch-server/src/handlers/credentials.rs
@@ -427,9 +427,7 @@ pub(crate) async fn get_aws_token(
         config.session_hours,
         &state.oidc_key,
         &user_email,
-        token.hardware_aaguid.clone(),
-        token.org_domain.clone(),
-        token.dpop_source.as_deref(),
+        &token,
     )
     .await
     .map_err(map_aws_error)?;
@@ -480,9 +478,7 @@ pub(crate) async fn get_aws_sso_token(
         config.session_hours,
         rsa_key,
         &user_email,
-        token.hardware_aaguid.clone(),
-        token.org_domain.clone(),
-        token.dpop_source.as_deref(),
+        &token,
     )
     .await
     .map_err(map_aws_error)?;

--- a/crates/vouch-server/src/handlers/credentials.rs
+++ b/crates/vouch-server/src/handlers/credentials.rs
@@ -4,11 +4,11 @@
 use crate::AppState;
 use crate::db::{self, GitHubCredentialAuditData};
 use crate::services::error::ServiceError;
-use crate::services::integrations::aws::{AwsError, issue_aws_token};
+use crate::services::integrations::aws::{AwsError, issue_aws_token, issue_sso_jwt};
 use crate::services::integrations::github::{GitHubInstallationId, minimal_git_permissions};
 use axum::extract::OriginalUri;
 use axum::http::Method;
-use axum::{Json, extract::State, http::HeaderMap, http::StatusCode};
+use axum::{Json, extract::Query, extract::State, http::HeaderMap, http::StatusCode};
 use axum_extra::extract::cookie::CookieJar;
 use jiff::Timestamp;
 use serde::Serialize;
@@ -19,7 +19,9 @@ use vouch_common::{
 };
 
 use super::extractors::{ClientInfo, OptionalClientCert};
-use super::session::{extract_resource_token, extract_resource_token_with_email};
+use super::session::{
+    ValidatedResourceToken, extract_resource_token, extract_resource_token_with_email,
+};
 use crate::redact_email;
 
 /// Issue an SSH certificate for the authenticated user.
@@ -310,42 +312,45 @@ pub(crate) struct SshRevocationCheckResponse {
 // AWS Token Endpoint
 // ============================================================================
 
-/// Get an OIDC ID token for AWS STS AssumeRoleWithWebIdentity.
+/// Maximum accepted length for the Identity Center audience parameter.
+const MAX_AUDIENCE_LEN: usize = 2048;
+
+/// Query parameters for the AWS Identity Center token endpoint.
+#[derive(serde::Deserialize)]
+pub(crate) struct AwsSsoTokenQuery {
+    /// The customer-managed application's configured Aud claim — the audience
+    /// of the issued RS256 token (REQUIRED).
+    audience: String,
+}
+
+/// Shared preamble for the AWS credential endpoints: authenticate the request,
+/// require a hardware-verified session, confirm the user is active, and resolve
+/// the user's email.
 ///
-/// GET /v1/credentials/aws/token
-///
-/// Returns an OIDC ID token that can be used with AWS STS to assume a role.
-/// The AWS IAM role must be configured to trust the Vouch OIDC provider.
-///
-/// When the DPoP proof includes a `source` custom claim (e.g., "claude-code"),
-/// the issued token includes AI-specific session tags (`vouch:AccessType=AI`,
-/// `vouch:Agent=<agent>`) for CloudTrail differentiation and IAM condition keys.
-pub(crate) async fn get_aws_token(
-    method: Method,
-    uri: OriginalUri,
-    headers: HeaderMap,
-    jar: CookieJar,
-    State(state): State<Arc<AppState>>,
-    client_cert: OptionalClientCert,
-) -> Result<Json<AwsTokenResponse>, ServiceError> {
-    // Single auth + user lookup (avoids duplicate get_user_by_id)
+/// AWS federation mints an OIDC token whose claims hardcode
+/// `hardware_verified: true`, so the *current session* must itself be
+/// hardware-verified — otherwise a non-verified bootstrap session could be
+/// laundered into a verified assertion (#451). The gate is on the access-token
+/// `hardware_verified` claim, not `authenticator_id` (a re-enrollment bootstrap
+/// session can have an `authenticator_id` while `hardware_verified` is false).
+async fn authorize_aws_token_request(
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    jar: &CookieJar,
+    method: &Method,
+    path: &str,
+    client_cert: &OptionalClientCert,
+) -> Result<(ValidatedResourceToken, String), ServiceError> {
     let token = extract_resource_token(
-        &state,
-        &headers,
-        &jar,
+        state,
+        headers,
+        jar,
         method.as_str(),
-        uri.path(),
+        path,
         client_cert.0.as_ref(),
     )
     .await?;
 
-    // AWS federation mints an OIDC ID token whose claims hardcode
-    // `hardware_verified: true`, so the *current session* must itself
-    // be hardware-verified — otherwise we'd be laundering a non-verified
-    // bootstrap session into a verified assertion (#451). Gate on the
-    // access-token `hardware_verified` claim, not on `authenticator_id`:
-    // a re-enrollment bootstrap session can legitimately have an
-    // `authenticator_id` set while `hardware_verified` is false.
     if !token.hardware_verified {
         return Err(ServiceError::api(
             StatusCode::FORBIDDEN,
@@ -379,20 +384,12 @@ pub(crate) async fn get_aws_token(
     }
 
     let user_email = token.email.clone().unwrap_or_else(|| user.email.clone());
+    Ok((token, user_email))
+}
 
-    // Issue AWS token using the session-time snapshot of aaguid and org domain.
-    let config = state.config();
-    let result = issue_aws_token(
-        &config.base_url,
-        config.session_hours,
-        &state.oidc_key,
-        &user_email,
-        token.hardware_aaguid.clone(),
-        token.org_domain.clone(),
-        token.dpop_source.as_deref(),
-    )
-    .await
-    .map_err(|e| match e {
+/// Map an [`AwsError`] to a `ServiceError`.
+fn map_aws_error(e: AwsError) -> ServiceError {
+    match e {
         AwsError::ClaimsBuild(ref err) => {
             tracing::error!("AWS token claims build error: {err}");
             ServiceError::api(
@@ -409,9 +406,108 @@ pub(crate) async fn get_aws_token(
                 "Failed to sign token",
             )
         }
-    })?;
+    }
+}
+
+/// Get an OIDC ID token for AWS STS AssumeRoleWithWebIdentity.
+///
+/// GET /v1/credentials/aws/token
+///
+/// Returns an **ES256** OIDC ID token that can be used with AWS STS to assume a
+/// role. The AWS IAM role must be configured to trust the Vouch OIDC provider.
+///
+/// When the DPoP proof includes a `source` custom claim (e.g., "claude-code"),
+/// the issued token includes AI-specific session tags (`vouch:AccessType=AI`,
+/// `vouch:Agent=<agent>`) for CloudTrail differentiation and IAM condition keys.
+pub(crate) async fn get_aws_token(
+    method: Method,
+    uri: OriginalUri,
+    headers: HeaderMap,
+    jar: CookieJar,
+    State(state): State<Arc<AppState>>,
+    client_cert: OptionalClientCert,
+) -> Result<Json<AwsTokenResponse>, ServiceError> {
+    let (token, user_email) =
+        authorize_aws_token_request(&state, &headers, &jar, &method, uri.path(), &client_cert)
+            .await?;
+
+    // Issue AWS token using the session-time snapshot of aaguid and org domain.
+    let config = state.config();
+    let result = issue_aws_token(
+        &config.base_url,
+        config.session_hours,
+        &state.oidc_key,
+        &user_email,
+        token.hardware_aaguid.clone(),
+        token.org_domain.clone(),
+        token.dpop_source.as_deref(),
+    )
+    .await
+    .map_err(map_aws_error)?;
 
     crate::infra::metrics::record_credential_issuance("aws");
+
+    Ok(Json(AwsTokenResponse {
+        id_token: result.id_token,
+        expires_in: result.expires_in,
+    }))
+}
+
+/// Get an RS256 OIDC ID token for AWS IAM Identity Center trusted identity
+/// propagation.
+///
+/// GET /v1/credentials/aws/sso/token?audience=<aud>
+///
+/// The token is the subject (`assertion`) for `sso-oidc:CreateTokenWithIAM`
+/// (`jwt-bearer` grant). This is a distinct endpoint from the ES256
+/// `AssumeRoleWithWebIdentity` token because AWS's trusted-token-issuer contract
+/// requires RS256. `audience` is the customer-managed application's Aud claim.
+/// The same hardware-verification gate and AWS session tags apply.
+pub(crate) async fn get_aws_sso_token(
+    method: Method,
+    uri: OriginalUri,
+    headers: HeaderMap,
+    jar: CookieJar,
+    Query(query): Query<AwsSsoTokenQuery>,
+    State(state): State<Arc<AppState>>,
+    client_cert: OptionalClientCert,
+) -> Result<Json<AwsTokenResponse>, ServiceError> {
+    if query.audience.is_empty() || query.audience.len() > MAX_AUDIENCE_LEN {
+        return Err(ServiceError::api(
+            StatusCode::BAD_REQUEST,
+            "invalid_audience",
+            "audience must be between 1 and 2048 characters",
+        ));
+    }
+
+    let (token, user_email) =
+        authorize_aws_token_request(&state, &headers, &jar, &method, uri.path(), &client_cert)
+            .await?;
+
+    let rsa_key = state.oidc_rsa_key.as_ref().ok_or_else(|| {
+        tracing::error!("Identity Center token requested but no OIDC RSA key configured");
+        ServiceError::api(
+            StatusCode::NOT_IMPLEMENTED,
+            "rsa_key_unavailable",
+            "RS256 signing key is not configured on this server",
+        )
+    })?;
+
+    let config = state.config();
+    let result = issue_sso_jwt(
+        &config.base_url,
+        config.session_hours,
+        rsa_key,
+        &user_email,
+        &query.audience,
+        token.hardware_aaguid.clone(),
+        token.org_domain.clone(),
+        token.dpop_source.as_deref(),
+    )
+    .await
+    .map_err(map_aws_error)?;
+
+    crate::infra::metrics::record_credential_issuance("aws_sso");
 
     Ok(Json(AwsTokenResponse {
         id_token: result.id_token,
@@ -1061,6 +1157,61 @@ mod tests {
         let resp: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
         assert!(resp["id_token"].is_string());
         assert!(resp["expires_in"].is_number());
+    }
+
+    /// The dedicated Identity Center endpoint issues an RS256 token (AWS trusted
+    /// token issuer contract) for a hardware-verified session.
+    #[tokio::test]
+    async fn test_aws_sso_token_returns_rs256_for_valid_session() {
+        use base64::Engine;
+
+        let state = test_app_state_with_rsa_key().await;
+        let config = state.config();
+        let app = crate::infra::router::build_app(state.clone(), &config).expect("build app");
+
+        let user = create_test_user(&state.store, "sso@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+
+        let (status, body) = http_get(
+            &app,
+            "/v1/credentials/aws/sso/token?audience=vouch-identity-center",
+            &[("Authorization", &format!("Bearer {token}"))],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        let resp: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+        let id_token = resp["id_token"].as_str().expect("id_token string");
+
+        // The header `alg` must be RS256 (vs ES256 for the web-identity endpoint).
+        let header_b64 = id_token.split('.').next().expect("jwt header");
+        let header_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(header_b64)
+            .expect("base64url header");
+        let header: serde_json::Value = serde_json::from_slice(&header_bytes).expect("header JSON");
+        assert_eq!(header["alg"], "RS256");
+    }
+
+    /// The Identity Center endpoint requires the `audience` query parameter.
+    #[tokio::test]
+    async fn test_aws_sso_token_requires_audience() {
+        let state = test_app_state_with_rsa_key().await;
+        let config = state.config();
+        let app = crate::infra::router::build_app(state.clone(), &config).expect("build app");
+
+        let user = create_test_user(&state.store, "sso-noaud@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+
+        let (status, _body) = http_get(
+            &app,
+            "/v1/credentials/aws/sso/token",
+            &[("Authorization", &format!("Bearer {token}"))],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
     }
 
     /// Regression for #451: a non-hardware-verified bootstrap session

--- a/crates/vouch-server/src/infra/router.rs
+++ b/crates/vouch-server/src/infra/router.rs
@@ -285,6 +285,10 @@ fn build_credential_routes(
             get(handlers::credentials::get_aws_token),
         )
         .route(
+            "/v1/credentials/aws/sso/token",
+            get(handlers::credentials::get_aws_sso_token),
+        )
+        .route(
             "/v1/credentials/github/token",
             post(handlers::credentials::get_github_token),
         )

--- a/crates/vouch-server/src/services/integrations/aws.rs
+++ b/crates/vouch-server/src/services/integrations/aws.rs
@@ -167,25 +167,24 @@ pub(crate) async fn issue_aws_token(
 /// matches the Vouch OIDC discovery document and its public key is published in
 /// the JWKS, so Identity Center can verify the signature.
 ///
+/// The `aud` claim is set to the issuer (server base URL), matching the STS
+/// token ([`issue_aws_token`]); the customer-managed application's Aud claim
+/// must be configured to that same URL. This path therefore differs from
+/// [`issue_aws_token`] only by signing algorithm.
+///
 /// # Arguments
-/// * `base_url` - Server base URL (issuer; must match the registered TTI)
+/// * `base_url` - Server base URL (issuer and `aud`; must match the registered TTI)
 /// * `session_hours` - Session duration in hours
 /// * `oidc_rsa_key` - OIDC RSA (RS256) signing key
 /// * `user_email` - Authenticated user's email (maps to the Identity Store user)
-/// * `audience` - The customer-managed application's configured Aud claim
 /// * `hardware_aaguid` - AAGUID snapshot from the session record
 /// * `hd` - Organization domain snapshot from the session record
 /// * `source` - AI coding agent identifier (for CloudTrail attribution tags)
-#[expect(
-    clippy::too_many_arguments,
-    reason = "Identity Center token issuance mirrors issue_aws_token plus an audience override"
-)]
 pub(crate) async fn issue_sso_jwt(
     base_url: &str,
     session_hours: u64,
     oidc_rsa_key: &OidcRsaSigningKey,
     user_email: &str,
-    audience: &str,
     hardware_aaguid: Option<String>,
     hd: Option<String>,
     source: Option<&str>,
@@ -196,7 +195,8 @@ pub(crate) async fn issue_sso_jwt(
     // ABAC/CloudTrail attribution.
     let aws_tags = build_aws_session_tags(user_email, hd.as_deref(), source);
 
-    let id_claims = OidcIdTokenClaimsBuilder::for_audience(base_url, user_email, audience)
+    // aud = issuer (server base URL), same as the STS token.
+    let id_claims = OidcIdTokenClaimsBuilder::for_aws(base_url, user_email)
         .hardware_aaguid(hardware_aaguid)
         .hd(hd)
         .aws_tags(aws_tags)
@@ -259,8 +259,6 @@ mod tests {
     const SESSION_HOURS: u64 = 8;
     const USER_EMAIL: &str = "user@example.com";
     const TEST_AAGUID: &str = "ee882879-721c-4913-9775-3dfcce97072a";
-    const IC_AUDIENCE: &str = "vouch-identity-center";
-
     /// The Identity Center JWT must be signed with RS256 (AWS TTI requirement),
     /// unlike the ES256 `AssumeRoleWithWebIdentity` token.
     #[tokio::test]
@@ -272,7 +270,6 @@ mod tests {
             SESSION_HOURS,
             &rsa_key,
             USER_EMAIL,
-            IC_AUDIENCE,
             Some(TEST_AAGUID.to_string()),
             None,
             None,
@@ -284,7 +281,7 @@ mod tests {
         assert_eq!(header["alg"], "RS256", "Identity Center JWT must use RS256");
     }
 
-    /// The JWT carries `iss` = issuer, `aud` = the configured Aud claim, `sub` =
+    /// The JWT carries `iss` = issuer, `aud` = issuer (server base URL), `sub` =
     /// the user email, and the same AWS session tags as the web-identity path.
     #[tokio::test]
     async fn test_sso_jwt_claims_and_tags() {
@@ -295,7 +292,6 @@ mod tests {
             SESSION_HOURS,
             &rsa_key,
             USER_EMAIL,
-            IC_AUDIENCE,
             None,
             Some("example.com".to_string()),
             Some("claude-code"),
@@ -305,7 +301,7 @@ mod tests {
 
         let claims = decode_jwt_payload(&result.id_token);
         assert_eq!(claims["iss"], BASE_URL, "iss must match the issuer URL");
-        assert_eq!(claims["aud"], IC_AUDIENCE, "aud must be the Aud claim");
+        assert_eq!(claims["aud"], BASE_URL, "aud must be the issuer URL");
         assert_eq!(claims["sub"], USER_EMAIL, "sub must be the user email");
 
         let principal_tags = &claims["https://aws.amazon.com/tags"]["principal_tags"];

--- a/crates/vouch-server/src/services/integrations/aws.rs
+++ b/crates/vouch-server/src/services/integrations/aws.rs
@@ -30,6 +30,7 @@
 //! }
 //! ```
 
+use crate::handlers::session::ValidatedResourceToken;
 use crate::redact_email;
 use crate::services::oidc::{
     AwsSessionTags, OidcIdTokenClaimsBuilder, OidcRsaSigningKey, OidcSigningKey,
@@ -110,29 +111,31 @@ fn build_aws_session_tags(
 /// * `base_url` - Server base URL (issuer)
 /// * `session_hours` - Session duration in hours
 /// * `oidc_key` - OIDC signing key
-/// * `user_email` - The authenticated user's email
-/// * `hardware_aaguid` - AAGUID snapshot from the session record
-/// * `hd` - Organization domain snapshot from the session record
-/// * `source` - AI coding agent identifier (e.g., "claude-code", "cursor")
+/// * `user_email` - The authenticated user's email (resolved with a DB fallback,
+///   so it is passed explicitly rather than read from the token)
+/// * `token` - The validated resource token; supplies the session-snapshot
+///   `hardware_aaguid`, `org_domain` (`hd`), and `dpop_source` federation claims
 pub(crate) async fn issue_aws_token(
     base_url: &str,
     session_hours: u64,
     oidc_key: &OidcSigningKey,
     user_email: &str,
-    hardware_aaguid: Option<String>,
-    hd: Option<String>,
-    source: Option<&str>,
+    token: &ValidatedResourceToken,
 ) -> AwsResult<AwsTokenResult> {
     // Token validity matches session duration
     let expires_in = session_hours.saturating_mul(3600);
 
-    let aws_tags = build_aws_session_tags(user_email, hd.as_deref(), source);
+    let aws_tags = build_aws_session_tags(
+        user_email,
+        token.org_domain.as_deref(),
+        token.dpop_source.as_deref(),
+    );
 
     // Build OIDC claims
     // For AWS, the audience is the issuer URL (AWS matches against the OIDC provider)
     let id_claims = OidcIdTokenClaimsBuilder::for_aws(base_url, user_email)
-        .hardware_aaguid(hardware_aaguid)
-        .hd(hd)
+        .hardware_aaguid(token.hardware_aaguid.clone())
+        .hd(token.org_domain.clone())
         .aws_tags(aws_tags)
         .valid_for_seconds(expires_in)
         .build()
@@ -176,29 +179,32 @@ pub(crate) async fn issue_aws_token(
 /// * `base_url` - Server base URL (issuer and `aud`; must match the registered TTI)
 /// * `session_hours` - Session duration in hours
 /// * `oidc_rsa_key` - OIDC RSA (RS256) signing key
-/// * `user_email` - Authenticated user's email (maps to the Identity Store user)
-/// * `hardware_aaguid` - AAGUID snapshot from the session record
-/// * `hd` - Organization domain snapshot from the session record
-/// * `source` - AI coding agent identifier (for CloudTrail attribution tags)
+/// * `user_email` - Authenticated user's email (maps to the Identity Store user;
+///   resolved with a DB fallback, so it is passed explicitly rather than read
+///   from the token)
+/// * `token` - The validated resource token; supplies the session-snapshot
+///   `hardware_aaguid`, `org_domain` (`hd`), and `dpop_source` federation claims
 pub(crate) async fn issue_sso_jwt(
     base_url: &str,
     session_hours: u64,
     oidc_rsa_key: &OidcRsaSigningKey,
     user_email: &str,
-    hardware_aaguid: Option<String>,
-    hd: Option<String>,
-    source: Option<&str>,
+    token: &ValidatedResourceToken,
 ) -> AwsResult<AwsTokenResult> {
     let expires_in = session_hours.saturating_mul(3600);
 
     // Reuse the same AWS session tags as the web-identity path for consistent
     // ABAC/CloudTrail attribution.
-    let aws_tags = build_aws_session_tags(user_email, hd.as_deref(), source);
+    let aws_tags = build_aws_session_tags(
+        user_email,
+        token.org_domain.as_deref(),
+        token.dpop_source.as_deref(),
+    );
 
     // aud = issuer (server base URL), same as the STS token.
     let id_claims = OidcIdTokenClaimsBuilder::for_aws(base_url, user_email)
-        .hardware_aaguid(hardware_aaguid)
-        .hd(hd)
+        .hardware_aaguid(token.hardware_aaguid.clone())
+        .hd(token.org_domain.clone())
         .aws_tags(aws_tags)
         .valid_for_seconds(expires_in)
         .build()
@@ -259,6 +265,31 @@ mod tests {
     const SESSION_HOURS: u64 = 8;
     const USER_EMAIL: &str = "user@example.com";
     const TEST_AAGUID: &str = "ee882879-721c-4913-9775-3dfcce97072a";
+
+    /// Build a `ValidatedResourceToken` carrying only the federation-snapshot
+    /// fields the `issue_*` functions read (`hardware_aaguid`, `org_domain`,
+    /// `dpop_source`). The remaining fields are placeholders; a hardware-verified
+    /// session is assumed since these functions run only after that gate.
+    fn test_token(
+        hardware_aaguid: Option<String>,
+        org_domain: Option<String>,
+        dpop_source: Option<String>,
+    ) -> super::ValidatedResourceToken {
+        super::ValidatedResourceToken {
+            sub: "user-id".to_string(),
+            email: None,
+            client_id: "test-client".to_string(),
+            scope: None,
+            authenticator_id: None,
+            hardware_verified: true,
+            auth_time: None,
+            token_hash: String::new(),
+            dpop_source,
+            hardware_aaguid,
+            org_domain,
+        }
+    }
+
     /// The Identity Center JWT must be signed with RS256 (AWS TTI requirement),
     /// unlike the ES256 `AssumeRoleWithWebIdentity` token.
     #[tokio::test]
@@ -270,9 +301,7 @@ mod tests {
             SESSION_HOURS,
             &rsa_key,
             USER_EMAIL,
-            Some(TEST_AAGUID.to_string()),
-            None,
-            None,
+            &test_token(Some(TEST_AAGUID.to_string()), None, None),
         )
         .await
         .expect("issue_sso_jwt should succeed");
@@ -292,9 +321,11 @@ mod tests {
             SESSION_HOURS,
             &rsa_key,
             USER_EMAIL,
-            None,
-            Some("example.com".to_string()),
-            Some("claude-code"),
+            &test_token(
+                None,
+                Some("example.com".to_string()),
+                Some("claude-code".to_string()),
+            ),
         )
         .await
         .expect("issue_sso_jwt should succeed");
@@ -330,9 +361,7 @@ mod tests {
             SESSION_HOURS,
             &key,
             USER_EMAIL,
-            Some(TEST_AAGUID.to_string()),
-            None,
-            None, // no source
+            &test_token(Some(TEST_AAGUID.to_string()), None, None),
         )
         .await
         .expect("issue_aws_token should succeed");
@@ -367,9 +396,11 @@ mod tests {
             SESSION_HOURS,
             &key,
             USER_EMAIL,
-            Some(TEST_AAGUID.to_string()),
-            Some("example.com".to_string()),
-            None,
+            &test_token(
+                Some(TEST_AAGUID.to_string()),
+                Some("example.com".to_string()),
+                None,
+            ),
         )
         .await
         .expect("issue_aws_token should succeed");
@@ -401,9 +432,11 @@ mod tests {
             SESSION_HOURS,
             &key,
             USER_EMAIL,
-            Some(TEST_AAGUID.to_string()),
-            None,
-            Some("claude-code"),
+            &test_token(
+                Some(TEST_AAGUID.to_string()),
+                None,
+                Some("claude-code".to_string()),
+            ),
         )
         .await
         .expect("issue_aws_token should succeed");
@@ -440,9 +473,11 @@ mod tests {
             SESSION_HOURS,
             &key,
             USER_EMAIL,
-            Some(TEST_AAGUID.to_string()),
-            Some("example.com".to_string()), // hd present, but no source
-            None,
+            &test_token(
+                Some(TEST_AAGUID.to_string()),
+                Some("example.com".to_string()),
+                None,
+            ),
         )
         .await
         .expect("issue_aws_token should succeed");
@@ -472,9 +507,11 @@ mod tests {
             SESSION_HOURS,
             &key,
             USER_EMAIL,
-            Some(TEST_AAGUID.to_string()),
-            Some("example.com".to_string()),
-            Some("cursor"),
+            &test_token(
+                Some(TEST_AAGUID.to_string()),
+                Some("example.com".to_string()),
+                Some("cursor".to_string()),
+            ),
         )
         .await
         .expect("issue_aws_token should succeed");
@@ -527,9 +564,7 @@ mod tests {
             4, // 4 hours
             &key,
             USER_EMAIL,
-            Some(TEST_AAGUID.to_string()),
-            None,
-            None,
+            &test_token(Some(TEST_AAGUID.to_string()), None, None),
         )
         .await
         .expect("issue_aws_token should succeed");
@@ -551,9 +586,7 @@ mod tests {
             SESSION_HOURS,
             &key,
             USER_EMAIL,
-            Some(TEST_AAGUID.to_string()),
-            None,
-            None,
+            &test_token(Some(TEST_AAGUID.to_string()), None, None),
         )
         .await
         .expect("issue_aws_token should succeed");

--- a/crates/vouch-server/src/services/integrations/aws.rs
+++ b/crates/vouch-server/src/services/integrations/aws.rs
@@ -31,7 +31,9 @@
 //! ```
 
 use crate::redact_email;
-use crate::services::oidc::{AwsSessionTags, OidcIdTokenClaimsBuilder, OidcSigningKey};
+use crate::services::oidc::{
+    AwsSessionTags, OidcIdTokenClaimsBuilder, OidcRsaSigningKey, OidcSigningKey,
+};
 
 /// Error types for AWS integration operations.
 #[derive(Debug, thiserror::Error)]
@@ -55,6 +57,43 @@ pub(crate) struct AwsTokenResult {
     pub id_token: String,
     /// Token validity in seconds.
     pub expires_in: u64,
+}
+
+/// Build the AWS session tags embedded in the `https://aws.amazon.com/tags`
+/// claim for ABAC and CloudTrail attribution.
+///
+/// `vouch:Email` is always present (and transitive). `vouch:Domain` is added
+/// when the org domain (`hd`) is known. When an AI coding agent is detected
+/// (`source`, set by the CLI via env-var sniffing and carried tamperproof in
+/// the DPoP proof), `vouch:AccessType=ai` and `vouch:Agent=<source>` are added.
+/// All tags are transitive so they propagate through role chains.
+fn build_aws_session_tags(
+    user_email: &str,
+    hd: Option<&str>,
+    source: Option<&str>,
+) -> AwsSessionTags {
+    let mut principal_tags = std::collections::HashMap::new();
+    let mut transitive_tag_keys = Vec::new();
+
+    principal_tags.insert("vouch:Email".to_string(), vec![user_email.to_string()]);
+    transitive_tag_keys.push("vouch:Email".to_string());
+
+    if let Some(domain) = hd {
+        principal_tags.insert("vouch:Domain".to_string(), vec![domain.to_string()]);
+        transitive_tag_keys.push("vouch:Domain".to_string());
+    }
+
+    if let Some(agent) = source {
+        principal_tags.insert("vouch:AccessType".to_string(), vec!["ai".to_string()]);
+        transitive_tag_keys.push("vouch:AccessType".to_string());
+        principal_tags.insert("vouch:Agent".to_string(), vec![agent.to_string()]);
+        transitive_tag_keys.push("vouch:Agent".to_string());
+    }
+
+    AwsSessionTags {
+        principal_tags,
+        transitive_tag_keys,
+    }
 }
 
 /// Issue an OIDC ID token for AWS STS.
@@ -87,36 +126,7 @@ pub(crate) async fn issue_aws_token(
     // Token validity matches session duration
     let expires_in = session_hours.saturating_mul(3600);
 
-    // Build AWS session tags for ABAC and CloudTrail attribution.
-    // Tags are embedded in the JWT so AWS extracts them during
-    // AssumeRoleWithWebIdentity and logs them as principalTags in CloudTrail.
-    let mut principal_tags = std::collections::HashMap::new();
-    let mut transitive_tag_keys = Vec::new();
-
-    principal_tags.insert("vouch:Email".to_string(), vec![user_email.to_string()]);
-    transitive_tag_keys.push("vouch:Email".to_string());
-
-    if let Some(ref domain) = hd {
-        principal_tags.insert("vouch:Domain".to_string(), vec![domain.clone()]);
-        transitive_tag_keys.push("vouch:Domain".to_string());
-    }
-
-    // Add AI-specific tags when a coding agent is detected.
-    // The `source` claim is set by the CLI via env-var sniffing (CLAUDECODE,
-    // CURSOR_AGENT, etc.) and carried tamperproof in the DPoP proof JWT.
-    // These tags enable IAM condition keys (aws:PrincipalTag/vouch:access-type)
-    // and CloudTrail filtering for agent-initiated API calls.
-    if let Some(agent) = source {
-        principal_tags.insert("vouch:AccessType".to_string(), vec!["ai".to_string()]);
-        transitive_tag_keys.push("vouch:AccessType".to_string());
-        principal_tags.insert("vouch:Agent".to_string(), vec![agent.to_string()]);
-        transitive_tag_keys.push("vouch:Agent".to_string());
-    }
-
-    let aws_tags = AwsSessionTags {
-        principal_tags,
-        transitive_tag_keys,
-    };
+    let aws_tags = build_aws_session_tags(user_email, hd.as_deref(), source);
 
     // Build OIDC claims
     // For AWS, the audience is the issuer URL (AWS matches against the OIDC provider)
@@ -142,6 +152,76 @@ pub(crate) async fn issue_aws_token(
     })
 }
 
+/// Issue an **RS256**-signed OIDC ID token for AWS IAM Identity Center trusted
+/// identity propagation.
+///
+/// This token is the subject (`assertion`) for the IAM Identity Center
+/// `sso-oidc:CreateTokenWithIAM` call (`jwt-bearer` grant), which exchanges it
+/// for an Identity Center token. That token then drives the SSO Portal
+/// (`ListAccounts`/`ListAccountRoles`/`GetRoleCredentials`) to reach every
+/// account+permission-set the user is assigned to — without role chaining.
+///
+/// AWS's trusted-token-issuer contract **requires RS256** (the
+/// `AssumeRoleWithWebIdentity` path uses ES256 via [`issue_aws_token`]; this
+/// path is distinct and signs with [`OidcRsaSigningKey`]). The token's `iss`
+/// matches the Vouch OIDC discovery document and its public key is published in
+/// the JWKS, so Identity Center can verify the signature.
+///
+/// # Arguments
+/// * `base_url` - Server base URL (issuer; must match the registered TTI)
+/// * `session_hours` - Session duration in hours
+/// * `oidc_rsa_key` - OIDC RSA (RS256) signing key
+/// * `user_email` - Authenticated user's email (maps to the Identity Store user)
+/// * `audience` - The customer-managed application's configured Aud claim
+/// * `hardware_aaguid` - AAGUID snapshot from the session record
+/// * `hd` - Organization domain snapshot from the session record
+/// * `source` - AI coding agent identifier (for CloudTrail attribution tags)
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Identity Center token issuance mirrors issue_aws_token plus an audience override"
+)]
+pub(crate) async fn issue_sso_jwt(
+    base_url: &str,
+    session_hours: u64,
+    oidc_rsa_key: &OidcRsaSigningKey,
+    user_email: &str,
+    audience: &str,
+    hardware_aaguid: Option<String>,
+    hd: Option<String>,
+    source: Option<&str>,
+) -> AwsResult<AwsTokenResult> {
+    let expires_in = session_hours.saturating_mul(3600);
+
+    // Reuse the same AWS session tags as the web-identity path for consistent
+    // ABAC/CloudTrail attribution.
+    let aws_tags = build_aws_session_tags(user_email, hd.as_deref(), source);
+
+    let id_claims = OidcIdTokenClaimsBuilder::for_audience(base_url, user_email, audience)
+        .hardware_aaguid(hardware_aaguid)
+        .hd(hd)
+        .aws_tags(aws_tags)
+        .valid_for_seconds(expires_in)
+        .build()
+        .map_err(|e| AwsError::ClaimsBuild(e.to_string()))?;
+
+    // Sign with RS256 — required by the AWS IAM Identity Center trusted token
+    // issuer contract.
+    let id_token = oidc_rsa_key
+        .sign_jwt(&id_claims)
+        .await
+        .map_err(|e| AwsError::TokenSign(e.to_string()))?;
+
+    tracing::info!(
+        "Issued AWS Identity Center JWT (RS256) for {}",
+        redact_email(user_email)
+    );
+
+    Ok(AwsTokenResult {
+        id_token,
+        expires_in,
+    })
+}
+
 #[cfg(test)]
 #[expect(
     clippy::expect_used,
@@ -150,7 +230,7 @@ pub(crate) async fn issue_aws_token(
 )]
 mod tests {
     use super::*;
-    use crate::services::oidc::OidcSigningKey;
+    use crate::services::oidc::{OidcRsaSigningKey, OidcSigningKey};
     use base64::Engine;
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 
@@ -165,10 +245,83 @@ mod tests {
         serde_json::from_slice(&payload_bytes).expect("Failed to parse JWT payload as JSON")
     }
 
+    /// Decode a JWT header (first part) into a `serde_json::Value`.
+    fn decode_jwt_header(token: &str) -> serde_json::Value {
+        let parts: Vec<&str> = token.split('.').collect();
+        assert_eq!(parts.len(), 3, "JWT must have exactly 3 parts");
+        let header_bytes = URL_SAFE_NO_PAD
+            .decode(parts[0])
+            .expect("Failed to base64url-decode JWT header");
+        serde_json::from_slice(&header_bytes).expect("Failed to parse JWT header as JSON")
+    }
+
     const BASE_URL: &str = "https://vouch.example.com";
     const SESSION_HOURS: u64 = 8;
     const USER_EMAIL: &str = "user@example.com";
     const TEST_AAGUID: &str = "ee882879-721c-4913-9775-3dfcce97072a";
+    const IC_AUDIENCE: &str = "vouch-identity-center";
+
+    /// The Identity Center JWT must be signed with RS256 (AWS TTI requirement),
+    /// unlike the ES256 `AssumeRoleWithWebIdentity` token.
+    #[tokio::test]
+    async fn test_sso_jwt_is_rs256_signed() {
+        let rsa_key = OidcRsaSigningKey::generate().expect("Failed to generate RSA key");
+
+        let result = issue_sso_jwt(
+            BASE_URL,
+            SESSION_HOURS,
+            &rsa_key,
+            USER_EMAIL,
+            IC_AUDIENCE,
+            Some(TEST_AAGUID.to_string()),
+            None,
+            None,
+        )
+        .await
+        .expect("issue_sso_jwt should succeed");
+
+        let header = decode_jwt_header(&result.id_token);
+        assert_eq!(header["alg"], "RS256", "Identity Center JWT must use RS256");
+    }
+
+    /// The JWT carries `iss` = issuer, `aud` = the configured Aud claim, `sub` =
+    /// the user email, and the same AWS session tags as the web-identity path.
+    #[tokio::test]
+    async fn test_sso_jwt_claims_and_tags() {
+        let rsa_key = OidcRsaSigningKey::generate().expect("Failed to generate RSA key");
+
+        let result = issue_sso_jwt(
+            BASE_URL,
+            SESSION_HOURS,
+            &rsa_key,
+            USER_EMAIL,
+            IC_AUDIENCE,
+            None,
+            Some("example.com".to_string()),
+            Some("claude-code"),
+        )
+        .await
+        .expect("issue_sso_jwt should succeed");
+
+        let claims = decode_jwt_payload(&result.id_token);
+        assert_eq!(claims["iss"], BASE_URL, "iss must match the issuer URL");
+        assert_eq!(claims["aud"], IC_AUDIENCE, "aud must be the Aud claim");
+        assert_eq!(claims["sub"], USER_EMAIL, "sub must be the user email");
+
+        let principal_tags = &claims["https://aws.amazon.com/tags"]["principal_tags"];
+        assert_eq!(
+            principal_tags["vouch:Email"],
+            serde_json::json!([USER_EMAIL])
+        );
+        assert_eq!(
+            principal_tags["vouch:Domain"],
+            serde_json::json!(["example.com"])
+        );
+        assert_eq!(
+            principal_tags["vouch:Agent"],
+            serde_json::json!(["claude-code"])
+        );
+    }
 
     /// Default tags present: `vouch:Email` is always included; `vouch:AccessType`
     /// and `vouch:Agent` must NOT be present when `source` is `None`.

--- a/crates/vouch-tests/tests/sig_policy.rs
+++ b/crates/vouch-tests/tests/sig_policy.rs
@@ -41,6 +41,7 @@ const V1_ROUTES: &[(&str, &str, bool)] = &[
     ("POST", "/v1/keys/register/complete", true),
     ("POST", "/v1/credentials/ssh", true),
     ("GET", "/v1/credentials/aws/token", true),
+    ("GET", "/v1/credentials/aws/sso/token", true),
     ("POST", "/v1/credentials/github/token", true),
     ("GET", "/v1/auth/status", false),
     ("GET", "/v1/credentials/ssh/ca", false),


### PR DESCRIPTION
## Summary

Adds AWS IAM Identity Center (IdC) support to Vouch and unifies all three AWS access patterns behind the **existing** `vouch credential aws` and `vouch setup aws` commands — no new commands. The mechanism is chosen by the target form and per-`[sso-session]` config, so moving from a single account to many (or from plain STS to Identity Center) only ever *adds config* — commands and existing profiles never change.

The three patterns:
1. **Single account** — STS `AssumeRoleWithWebIdentity(role_arn)`.
2. **Role chain** — `AssumeRoleWithWebIdentity(management_role)` → `AssumeRole(target)`.
3. **IdC + trusted token issuer** — Vouch RS256 token → `sso-oidc:CreateTokenWithIAM` (jwt-bearer) → SSO Portal `GetRoleCredentials`.

## `vouch credential aws` (non-interactive `credential_process` helper)

- `--role <arn>` → STS web identity; chains through the management role when configured (patterns 1 & 2, unchanged).
- `--account <id> --role <permission-set>` → IdC portal `GetRoleCredentials` (pattern 3). The Identity Center bearer token comes from the trusted-token-issuer exchange when the session is configured for it, otherwise from the cached `vouch aws login` device token.

## `vouch setup aws` (writes `~/.aws/config` profiles)

- `--role <arn>` → single STS profile (unchanged).
- `--discover` → auto-selects **IdC portal discovery** (writes `--account/--role` process lines) vs **STS role-chaining**, by session config.
- no `--role`/`--discover` → interactive single-account IdC setup (pick account + permission-set) when configured.

## Server

New `GET /v1/credentials/aws/sso/token` issues an **RS256** OIDC token (via the always-initialized `OidcRsaSigningKey`) — the `assertion` for `CreateTokenWithIAM`, whose trusted-token-issuer contract requires RS256. It's a **dedicated** endpoint, distinct from the ES256 `/v1/credentials/aws/token` (`AssumeRoleWithWebIdentity`), which is unchanged. Both share the hardware-verified gate and the AWS session-tag injection.

The token's `aud` is the **Vouch issuer (server base URL)** — the same value the ES256 STS token already uses. There is no configurable audience: the IdC admin simply sets the customer-managed application's Aud claim to the Vouch server URL.

## Config (per `[sso-session]`, progressive enhancement)

- `management_role` (+ `member_role_*`) → chaining / STS discovery.
- `identity_center_application_arn` → the IdC route (the `clientId` for `CreateTokenWithIAM`).

## AWS-side setup (one-time, by an IdC admin)

Requires an **organization** instance of Identity Center: register Vouch as a trusted token issuer, add a customer-managed OAuth 2.0 app (set its Aud claim = the **Vouch server URL**), enable the `sso:account:access` scope, and grant the management role `sso-oauth:CreateTokenWithIAM` (named in the app's resource policy).

## Testing

- Server: `make lint` clean; unit suite green, incl. a test asserting the endpoint issues **RS256**, plus the RFC 9421 signature-policy table.
- CLI: `make lint` clean; unit suite green; `get_role_credentials` / `create_token_with_iam` unit tests; command tree verified via `--help`.
- **Not yet validated against a live Identity Center org** — the exact `CreateTokenWithIAM` wire shape (field casing, optional `scope`) and acceptance of `aud = <Vouch server URL>` are coded to AWS's documented contract but need a smoke test against a real org instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds new AWS credential issuance paths (IdC portal and CreateTokenWithIAM) and server RS256 federation tokens; misconfiguration or the un-downscopable IdC path could grant broader access than the STS/agent-restricted flow, though agents are blocked on `--account`.
> 
> **Overview**
> Unifies **STS web-identity** and **IAM Identity Center permission-set** access behind the existing `vouch credential aws` and `vouch setup aws` flows, driven by flags and per-`[sso-session]` config (`identity_center_application_arn`).
> 
> **`vouch credential aws`** now branches on `--account`: without it, behavior stays **STS `AssumeRoleWithWebIdentity`** (optional management-role chaining). With `--account <id> --role <permission-set>` (and optional `--sso-session`), it uses the **SSO portal `GetRoleCredentials`**, obtaining an IdC bearer token either via **Vouch RS256 → `CreateTokenWithIAM`** when IdC is configured, or the cached **`vouch aws login`** device token otherwise. IdC results are **cached** like the STS path. **Coding agents are rejected** on the IdC path because portal creds cannot be downscoped with `ReadOnlyAccess` (#398).
> 
> **`vouch setup aws`** gains a **`server`** argument for discovery/setup, **IdC-aware `--discover`** (portal profiles with `--account/--role` process lines vs STS ARNs), **interactive single-account IdC setup** when no `--role`/`--discover`, and **quoted** `credential_process` command lines.
> 
> **Server:** new **`GET /v1/credentials/aws/sso/token`** issues an **RS256** assertion for Identity Center (shared hardware-verified gate and session-tag logic with the ES256 STS endpoint, refactored into `authorize_aws_token_request`). AWS token issuance now takes a **`ValidatedResourceToken`** instead of loose claim fields.
> 
> **CLI AWS integration:** adds **`identity_center::create_token_with_iam`**, **`sso_portal::get_role_credentials`**, and **SigV4 JSON POST** signing for `sso-oauth`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1168ea1d4e8fe02e0a8c6565d8e386e23a417b49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->