### PR TITLE
feat(cli): add interactive setup aws wizard

### DIFF
--- a/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
+++ b/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
@@ -216,7 +216,7 @@ cmd-keys-long-about = Without a subcommand, opens an interactive menu.
 cmd-exec-about = Run a command with { -product }-provided credentials in the environment
 cmd-credential-about = Obtain credentials for various services
 cmd-setup-about = Configure integrations
-cmd-aws-about = AWS Identity Center commands for multi-account management
+cmd-aws-about = AWS Management Console access
 cmd-completions-about = Generate shell completions
 cmd-doctor-about = Check your { -product } environment for common issues
 cmd-posture-about = Show device posture signals (what the CLI detects about this machine)
@@ -762,7 +762,7 @@ cmd-setup-codeartifact-about = Configure a package manager for AWS CodeArtifact
 
 # setup/aws arg help
 arg-setup-aws-profile-help = AWS profile name to configure. Defaults to "vouch" if not specified.
-arg-setup-aws-role-help = Target AWS IAM role ARN. Required for single-account setup.
+arg-setup-aws-role-help = Target AWS IAM role ARN for single-account setup. Omit all flags to launch the interactive wizard.
 arg-setup-aws-management-role-help =
     Management role ARN — the OIDC-trusted anchor for multi-account and Identity Center
     access. Stored in { -product } config as an organization entry.
@@ -893,6 +893,27 @@ install-path-hint-nix =
 
 setup-aws-err-role-required = Either --role or --discover is required
 setup-aws-err-region-required = --region is required when --identity-center-application is specified
+
+# Interactive first-run wizard (bare `vouch setup aws`).
+setup-aws-wizard-intro = Let's set up AWS access with { -product }.
+setup-aws-wizard-mode-prompt = How do you access AWS?
+setup-aws-wizard-mode-single = Single account — one IAM role
+setup-aws-wizard-mode-chain = Multiple accounts — a management role that assumes into member roles
+setup-aws-wizard-mode-idc = Identity Center (SSO) — permission sets
+setup-aws-wizard-cancelled = Setup cancelled. No changes were made.
+setup-aws-wizard-role-prompt = Role ARN to assume:
+setup-aws-wizard-mgmt-role-prompt = Management role ARN (the role that trusts { -product }'s OIDC provider):
+setup-aws-wizard-target-role-prompt = Target role ARN:
+setup-aws-wizard-region-prompt = Region (optional, press Enter to skip):
+setup-aws-wizard-idc-region-prompt = Identity Center region (e.g. us-east-1):
+setup-aws-wizard-idc-app-prompt = Identity Center application ARN:
+setup-aws-wizard-idc-aud-reminder = Reminder: set this application's audience (aud) claim to your { -product } issuer: { $issuer }
+setup-aws-wizard-add-target = Add a target role now?
+setup-aws-wizard-add-another = Add another target role?
+setup-aws-wizard-discover = Discover accounts and permission sets now?
+setup-aws-wizard-invalid-role-arn = That doesn't look like an IAM role ARN (expected arn:PARTITION:iam::ACCOUNT:role/NAME). Try again.
+setup-aws-wizard-invalid-idc-arn = That doesn't look like an Identity Center application ARN (expected arn:PARTITION:sso::ACCOUNT:application/...). Try again.
+setup-aws-wizard-err-input = Input error: { $reason }
 setup-aws-profile-already-exists =
     Profile [{ $profile }] already exists in ~/.aws/config.
     To update it, edit ~/.aws/config directly.

--- a/crates/vouch-cli/src/commands/setup/aws.rs
+++ b/crates/vouch-cli/src/commands/setup/aws.rs
@@ -11,7 +11,8 @@
 //!   --region <region> [--discover]` — stores org + IdC, optionally enumerates.
 
 use anyhow::{Context, Result};
-use vouch_cli::{tr, tr_println};
+use inquire::{Confirm, InquireError, Select, Text};
+use vouch_cli::{tr, tr_args, tr_println};
 
 use crate::config::{AwsIdentityCenter, AwsOrganization};
 use crate::install_path::resolve_install_path;
@@ -83,6 +84,17 @@ pub(crate) async fn run(
     discover: bool,
     server: &str,
 ) -> Result<()> {
+    // No flags supplied → launch the interactive first-run wizard.
+    if profile.is_none()
+        && role_arn.is_none()
+        && management_role.is_none()
+        && identity_center_application.is_none()
+        && region.is_none()
+        && !discover
+    {
+        return run_wizard(server).await;
+    }
+
     // Store the org in vouch config if a management role was provided.
     if let Some(mgmt) = management_role {
         store_org(mgmt, identity_center_application, region)?;
@@ -109,6 +121,218 @@ pub(crate) async fn run(
     };
 
     write_sts_profile(profile, role, management_role.unwrap_or(role), region)
+}
+
+/// Interactive first-run wizard, launched when `setup aws` is run with no flags.
+///
+/// Establishes one organization per run, reusing the same helpers as the
+/// flag-based paths (`store_org` / `write_sts_profile` / `run_discover`).
+async fn run_wizard(server: &str) -> Result<()> {
+    tr_println!("setup-aws-wizard-intro");
+
+    let single = tr!("setup-aws-wizard-mode-single");
+    let chain = tr!("setup-aws-wizard-mode-chain");
+    let idc = tr!("setup-aws-wizard-mode-idc");
+    let options = vec![single.clone(), chain.clone(), idc.clone()];
+
+    let choice = match Select::new(&tr!("setup-aws-wizard-mode-prompt"), options).prompt() {
+        Ok(c) => c,
+        Err(InquireError::OperationCanceled | InquireError::OperationInterrupted) => {
+            tr_println!("setup-aws-wizard-cancelled");
+            return Ok(());
+        }
+        Err(e) => return Err(wizard_input_error(&e)),
+    };
+
+    if choice == single {
+        wizard_single_account()
+    } else if choice == chain {
+        wizard_management_chain()
+    } else {
+        wizard_identity_center(server).await
+    }
+}
+
+/// Single account: prompt for a role ARN and write one profile.
+fn wizard_single_account() -> Result<()> {
+    let Some(role) = prompt_role_arn(&tr!("setup-aws-wizard-role-prompt"), None)? else {
+        tr_println!("setup-aws-wizard-cancelled");
+        return Ok(());
+    };
+    let region = prompt_optional(&tr!("setup-aws-wizard-region-prompt"))?;
+    write_sts_profile(None, &role, &role, region.as_deref())
+}
+
+/// Management-role chain: store the org, then optionally add target-role profiles.
+fn wizard_management_chain() -> Result<()> {
+    let orgs = configured_orgs();
+    let mgmt_default = orgs.first().map(|o| o.management_role.as_str());
+    let Some(mgmt) = prompt_role_arn(&tr!("setup-aws-wizard-mgmt-role-prompt"), mgmt_default)?
+    else {
+        tr_println!("setup-aws-wizard-cancelled");
+        return Ok(());
+    };
+    store_org(&mgmt, None, None)?;
+
+    if prompt_confirm(&tr!("setup-aws-wizard-add-target"), true)? {
+        loop {
+            let Some(role) = prompt_role_arn(&tr!("setup-aws-wizard-target-role-prompt"), None)?
+            else {
+                break;
+            };
+            let region = prompt_optional(&tr!("setup-aws-wizard-region-prompt"))?;
+            write_sts_profile(None, &role, &mgmt, region.as_deref())?;
+            if !prompt_confirm(&tr!("setup-aws-wizard-add-another"), false)? {
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Identity Center: store the org + IdC anchor, show the audience reminder for
+/// the current issuer, and optionally run discovery.
+async fn wizard_identity_center(server: &str) -> Result<()> {
+    let orgs = configured_orgs();
+    let mgmt_default = orgs.first().map(|o| o.management_role.as_str());
+    let Some(mgmt) = prompt_role_arn(&tr!("setup-aws-wizard-mgmt-role-prompt"), mgmt_default)?
+    else {
+        tr_println!("setup-aws-wizard-cancelled");
+        return Ok(());
+    };
+
+    // The customer's Identity Center application must set its audience claim to
+    // this Vouch issuer, or CreateTokenWithIAM rejects the assertion.
+    tr_println!("setup-aws-wizard-idc-aud-reminder", issuer = server);
+
+    // If the org for this management role already has Identity Center configured,
+    // offer its application ARN and region as defaults.
+    let existing_idc = orgs
+        .iter()
+        .find(|o| o.management_role == mgmt)
+        .and_then(|o| o.identity_center.as_ref());
+
+    let Some(app) = prompt_idc_application(
+        &tr!("setup-aws-wizard-idc-app-prompt"),
+        existing_idc.map(|i| i.application_arn.as_str()),
+    )?
+    else {
+        tr_println!("setup-aws-wizard-cancelled");
+        return Ok(());
+    };
+
+    // Region is required for Identity Center; prompt until provided or cancelled.
+    let region_default = existing_idc.map(|i| i.region.as_str());
+    let region_prompt = tr!("setup-aws-wizard-idc-region-prompt");
+    let region = loop {
+        let text = match region_default {
+            Some(d) => Text::new(&region_prompt).with_default(d),
+            None => Text::new(&region_prompt),
+        };
+        match text.prompt() {
+            Ok(input) if !input.trim().is_empty() => break input.trim().to_string(),
+            Ok(_) => continue,
+            Err(InquireError::OperationCanceled | InquireError::OperationInterrupted) => {
+                tr_println!("setup-aws-wizard-cancelled");
+                return Ok(());
+            }
+            Err(e) => return Err(wizard_input_error(&e)),
+        }
+    };
+
+    store_org(&mgmt, Some(app.as_str()), Some(region.as_str()))?;
+
+    if prompt_confirm(&tr!("setup-aws-wizard-discover"), true)? {
+        run_discover(None, Some(app.as_str()), server).await?;
+    }
+    Ok(())
+}
+
+/// Prompt for a required IAM role ARN, re-prompting until it parses or the user
+/// cancels. Returns `Ok(None)` on cancel (Esc / Ctrl-C).
+fn prompt_role_arn(prompt: &str, default: Option<&str>) -> Result<Option<String>> {
+    loop {
+        let text = match default {
+            Some(d) => Text::new(prompt).with_default(d),
+            None => Text::new(prompt),
+        };
+        match text.prompt() {
+            Ok(input) => {
+                let trimmed = input.trim();
+                if crate::integrations::aws::sts::parse_role_arn(trimmed).is_ok() {
+                    return Ok(Some(trimmed.to_string()));
+                }
+                tr_println!("setup-aws-wizard-invalid-role-arn");
+            }
+            Err(InquireError::OperationCanceled | InquireError::OperationInterrupted) => {
+                return Ok(None);
+            }
+            Err(e) => return Err(wizard_input_error(&e)),
+        }
+    }
+}
+
+/// Prompt for a required Identity Center application ARN (service `sso`),
+/// re-prompting until valid or cancelled.
+fn prompt_idc_application(prompt: &str, default: Option<&str>) -> Result<Option<String>> {
+    loop {
+        let text = match default {
+            Some(d) => Text::new(prompt).with_default(d),
+            None => Text::new(prompt),
+        };
+        match text.prompt() {
+            Ok(input) => {
+                let trimmed = input.trim();
+                let is_sso =
+                    vouch_common::aws::Arn::parse(trimmed).is_ok_and(|a| a.service == "sso");
+                if is_sso {
+                    return Ok(Some(trimmed.to_string()));
+                }
+                tr_println!("setup-aws-wizard-invalid-idc-arn");
+            }
+            Err(InquireError::OperationCanceled | InquireError::OperationInterrupted) => {
+                return Ok(None);
+            }
+            Err(e) => return Err(wizard_input_error(&e)),
+        }
+    }
+}
+
+/// Prompt for an optional value; empty input or cancel → `None`.
+fn prompt_optional(prompt: &str) -> Result<Option<String>> {
+    match Text::new(prompt).prompt() {
+        Ok(input) if input.trim().is_empty() => Ok(None),
+        Ok(input) => Ok(Some(input.trim().to_string())),
+        Err(InquireError::OperationCanceled | InquireError::OperationInterrupted) => Ok(None),
+        Err(e) => Err(wizard_input_error(&e)),
+    }
+}
+
+/// Yes/no confirmation with a default; cancel is treated as "no".
+fn prompt_confirm(prompt: &str, default: bool) -> Result<bool> {
+    match Confirm::new(prompt).with_default(default).prompt() {
+        Ok(b) => Ok(b),
+        Err(InquireError::OperationCanceled | InquireError::OperationInterrupted) => Ok(false),
+        Err(e) => Err(wizard_input_error(&e)),
+    }
+}
+
+/// Map an unexpected inquire error into a user-facing error.
+fn wizard_input_error(e: &InquireError) -> anyhow::Error {
+    anyhow::anyhow!(tr_args!(
+        "setup-aws-wizard-err-input",
+        reason = e.to_string()
+    ))
+}
+
+/// The organizations currently in vouch config, used to pre-fill wizard defaults.
+/// Returns an empty list on any load error (the wizard still works, just without
+/// pre-filled values).
+fn configured_orgs() -> Vec<AwsOrganization> {
+    crate::config::Config::load()
+        .ok()
+        .and_then(|c| c.aws().map(|a| a.organizations.clone()))
+        .unwrap_or_default()
 }
 
 /// Append or update the org entry in vouch config.

--- a/crates/vouch-cli/src/commands/setup/mod.rs
+++ b/crates/vouch-cli/src/commands/setup/mod.rs
@@ -23,6 +23,8 @@ pub(crate) mod ssm;
 pub(crate) enum SetupCommands {
     /// Configure AWS CLI/SDK to use Vouch credentials.
     ///
+    /// Run with no flags for a guided, interactive setup — or use flags directly:
+    ///
     /// Three patterns:
     ///
     ///   Single account: `--role <full-arn>`. Writes a profile; no org stored.
@@ -42,12 +44,8 @@ pub(crate) enum SetupCommands {
         /// AWS profile name for the generated profile.
         #[arg(long, help = tr!("arg-setup-aws-profile-help"))]
         profile: Option<String>,
-        /// Target role ARN. Required for single-account setup; optional with --discover.
-        #[arg(
-            long,
-            required_unless_present_any = ["management_role", "discover"],
-            help = tr!("arg-setup-aws-role-help"),
-        )]
+        /// Target role ARN. Omit all flags to launch the interactive wizard.
+        #[arg(long, help = tr!("arg-setup-aws-role-help"))]
         role: Option<String>,
         /// Management role ARN — the OIDC-trusted anchor for multi-account and
         /// Identity Center access. Stored in vouch config as an organization entry.

--- a/crates/vouch-cli/src/main.rs
+++ b/crates/vouch-cli/src/main.rs
@@ -396,7 +396,7 @@ enum Commands {
         #[command(subcommand)]
         command: SetupCommands,
     },
-    /// AWS Identity Center commands for multi-account management.
+    /// AWS Management Console access.
     #[command(about = tr!("cmd-aws-about"))]
     Aws {
         #[command(subcommand)]


### PR DESCRIPTION
Follows #601. Running `vouch setup aws` with no flags now launches an
interactive wizard instead of erroring on a required --role.

- Mode picker: single account / management-role chain / Identity Center,
  reusing the existing store_org / write_sts_profile / run_discover helpers
- Pre-fills the management-role ARN (and, for Identity Center, the
  application ARN + region) from an existing org as [defaults] — Enter accepts
- Identity Center step reminds you to set the app's audience claim to the
  current issuer (from the logged-in server)
- --role is now optional; flag-based paths unchanged
- Fixes the stale `vouch aws` help text → "AWS Management Console access"

## Verification
- make fmt / make lint clean; cargo test -p vouch-cli: 610 pass
- Interactive flow tested manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)