### PR TITLE
fix(cli): AWS credential/setup follow-ups (#602, #605, #606, #607)

### DIFF
--- a/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
+++ b/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
@@ -616,8 +616,9 @@ aws-err-via-ambiguous =
     Run '{ -cmd } status' to see configured organizations.
 
 aws-err-no-org-covers-account =
-    No configured AWS organization covers account { $account }.
-    Run '{ -cmd } setup aws' to add its management role.
+    No configured organization's management account matches account { $account }.
+    Specify --via <management-role-arn> to chain through a configured organization,
+    or run '{ -cmd } setup aws' if none covers this account.
 
 aws-err-idc-not-configured =
     No AWS organizations configured. Run '{ -cmd } setup aws --management-role <arn>

--- a/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
+++ b/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
@@ -615,6 +615,10 @@ aws-err-via-ambiguous =
     Multiple AWS organizations are configured; specify --via <management-role-arn> to select one.
     Run '{ -cmd } status' to see configured organizations.
 
+aws-err-no-org-covers-account =
+    No configured AWS organization covers account { $account }.
+    Run '{ -cmd } setup aws' to add its management role.
+
 aws-err-idc-not-configured =
     No AWS organizations configured. Run '{ -cmd } setup aws --management-role <arn>
     --identity-center-application <arn> --region <region>' first.

--- a/crates/vouch-cli/src/commands/aws/console.rs
+++ b/crates/vouch-cli/src/commands/aws/console.rs
@@ -152,13 +152,23 @@ async fn get_sts_console_creds(server: &str, args: ConsoleArgs) -> Result<Consol
         }
     };
 
+    // Validate/resolve --via the same way `vouch credential aws` does, so an
+    // unconfigured management role fails fast with a Vouch error instead of an
+    // opaque AWS AccessDenied at the STS call.
+    let vouch_config = crate::config::Config::load()?;
+    let management_role = crate::commands::credential::aws::resolve_management_role_for(
+        &vouch_config,
+        &role_arn,
+        args.via.as_deref(),
+    )?;
+
     let agent_source = crate::commands::credential::aws::detect_agent_source();
     let result = crate::commands::credential::aws::exchange_for_sts_credentials(
         crate::commands::credential::aws::StsRequest {
             server,
             role_arn: &role_arn,
             region: &region,
-            management_role: args.via.as_deref(),
+            management_role: management_role.as_deref(),
             agent_source: agent_source.as_deref(),
         },
     )

--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -542,9 +542,10 @@ pub(crate) fn resolve_management_role_for(
                     .and_then(|o| chain_if_different_role(o, target_role_arn)));
             }
             0 => {
-                // No configured org's management account covers this target.
-                // "specify --via" would be misleading — the account simply has
-                // no organization set up for it.
+                // No org's management account matches the target account. The
+                // target may be a member account reachable by chaining through a
+                // configured org (--via), or an account no org covers (setup aws) —
+                // config doesn't record member accounts, so the message offers both.
                 return Err(crate::exit_code::CliError::ConfigError(tr_args!(
                     "aws-err-no-org-covers-account",
                     account = acct.to_string()
@@ -1231,17 +1232,22 @@ mod tests {
 
     #[test]
     fn resolve_multi_org_no_match_returns_no_coverage_error() {
-        // Two orgs; target account matches neither management account. This is
-        // "no org covers the account", not --via ambiguity: the message names
-        // the uncovered account rather than telling the user to specify --via.
+        // Two orgs; target account matches neither management account. The target
+        // may be a member account reachable via --via, so the message names the
+        // account and recommends --via (with setup aws as the fallback).
         let mgmt1 = "arn:aws:iam::111:role/Mgmt1";
         let mgmt2 = "arn:aws:iam::222:role/Mgmt2";
         let target = "arn:aws:iam::333:role/Target";
         let cfg = make_config(&[mgmt1, mgmt2]);
         let err = resolve_management_role_for(&cfg, target, None).unwrap_err();
+        let msg = err.to_string();
         assert!(
-            err.to_string().contains("333"),
-            "no-coverage error should name the uncovered account 333: {err}"
+            msg.contains("333"),
+            "no-coverage error should name the target account 333: {msg}"
+        );
+        assert!(
+            msg.contains("--via"),
+            "no-coverage error should recommend --via for member-account targets: {msg}"
         );
     }
 

--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -253,7 +253,7 @@ where
 /// claim for CloudTrail attribution.
 pub(crate) async fn exchange_for_sts_credentials(req: StsRequest<'_>) -> Result<StsExchangeResult> {
     use crate::integrations::aws::sts::{
-        WebIdentityRequest, assume_role, assume_role_with_web_identity, parse_role_arn,
+        WebIdentityRequest, assume_role_with_web_identity, parse_role_arn,
     };
 
     let StsRequest {
@@ -289,64 +289,26 @@ pub(crate) async fn exchange_for_sts_credentials(req: StsRequest<'_>) -> Result<
     // credentials minted in the wrong context (issue #398).
     let policies = agent_session_policies(agent_source);
 
-    let mut client = VouchClient::new(server).await?;
+    let (http_client, id_token_secret, session) =
+        fetch_aws_oidc_token(server, agent_source).await?;
+    let id_token = id_token_secret.expose_secret();
 
-    // Set DPoP source claim for agent attribution (tamperproof via DPoP signature).
-    // Server extracts this to add AI-specific session tags to the JWT.
-    if let Some(source) = agent_source {
-        tracing::info!("AI agent detected ({source}), applying ReadOnlyAccess session policy");
-        client.set_dpop_source(source);
-    }
-
-    let token_response: OidcTokenResponse = client
-        .get_authenticated("/v1/credentials/aws/token")
-        .await
-        .context("failed to get OIDC token from Vouch server")?;
-
-    let id_token = token_response.id_token.expose_secret();
-
-    // Session tags are now embedded in the JWT via the
-    // https://aws.amazon.com/tags claim (server-side). AWS extracts them
-    // during AssumeRoleWithWebIdentity and logs them as principalTags in
-    // CloudTrail. Tags must NOT also be passed as STS API parameters —
-    // AWS rejects requests that include both.
-
-    let http_client =
-        vouch_common::http::credential_client(&format!("vouch-cli/{}", env!("CARGO_PKG_VERSION")))
-            .context("failed to create HTTP client")?;
-
-    let session = extract_sub_from_jwt(id_token).context("server returned invalid OIDC token")?;
+    // Session tags travel inside the JWT (server-side `https://aws.amazon.com/tags`
+    // claim); AWS extracts them during AssumeRoleWithWebIdentity and logs them as
+    // principalTags, so they must NOT also be passed as STS API parameters.
 
     if let Some(mgmt_role_arn) = mgmt.filter(|m| *m != role_arn) {
-        // Chain: AssumeRoleWithWebIdentity into management role, then AssumeRole into target.
-        // Management hop gets an inline STS-only policy; final hop gets ReadOnlyAccess.
-        let mgmt_arn = parse_role_arn(mgmt_role_arn)?;
-        let mgmt_domain_suffix = mgmt_arn.partition.dns_suffix();
-
-        let mgmt_credentials = assume_role_with_web_identity(WebIdentityRequest {
+        // Chain through the management role, then assume the target role.
+        let credentials = assume_role_via_management_chain(ChainInputs {
             http_client: &http_client,
-            role_arn: mgmt_role_arn,
-            role_session_name: &session,
-            web_identity_token: id_token,
-            region,
-            domain_suffix: mgmt_domain_suffix,
-            session_policy_names: &[],
-            session_policy: policies.mgmt_hop_policy.as_ref(),
-        })
-        .await
-        .context("failed to assume management role")?;
-
-        let credentials = assume_role(
-            &http_client,
+            id_token,
+            session: &session,
             role_arn,
-            &session,
+            mgmt_role_arn,
             region,
-            &mgmt_credentials,
-            policies.session_policy_names,
-            None,
-        )
-        .await
-        .context("failed to assume target role via chaining")?;
+            policies: &policies,
+        })
+        .await?;
 
         return Ok(StsExchangeResult {
             http_client,
@@ -374,6 +336,90 @@ pub(crate) async fn exchange_for_sts_credentials(req: StsRequest<'_>) -> Result<
         credentials,
         domain_suffix,
     })
+}
+
+/// Fetch a fresh OIDC ID token from the Vouch server and derive the STS
+/// role-session name from its `sub` claim.
+///
+/// When `agent_source` is set, the DPoP source claim is attached so the server
+/// embeds the AI-agent session tags. Returns the HTTP client used for the
+/// subsequent STS calls, the ID token, and the session name.
+async fn fetch_aws_oidc_token(
+    server: &str,
+    agent_source: Option<&str>,
+) -> Result<(reqwest::Client, SecretString, String)> {
+    let mut client = VouchClient::new(server).await?;
+
+    // Set DPoP source claim for agent attribution (tamperproof via DPoP signature).
+    // Server extracts this to add AI-specific session tags to the JWT.
+    if let Some(source) = agent_source {
+        tracing::info!("AI agent detected ({source}), applying ReadOnlyAccess session policy");
+        client.set_dpop_source(source);
+    }
+
+    let token_response: OidcTokenResponse = client
+        .get_authenticated("/v1/credentials/aws/token")
+        .await
+        .context("failed to get OIDC token from Vouch server")?;
+
+    let http_client =
+        vouch_common::http::credential_client(&format!("vouch-cli/{}", env!("CARGO_PKG_VERSION")))
+            .context("failed to create HTTP client")?;
+
+    let session = extract_sub_from_jwt(token_response.id_token.expose_secret())
+        .context("server returned invalid OIDC token")?;
+
+    Ok((http_client, token_response.id_token, session))
+}
+
+/// Borrowed inputs to the two-hop management-role chain.
+struct ChainInputs<'a> {
+    http_client: &'a reqwest::Client,
+    id_token: &'a str,
+    session: &'a str,
+    role_arn: &'a str,
+    mgmt_role_arn: &'a str,
+    region: &'a str,
+    policies: &'a AgentSessionPolicies,
+}
+
+/// Assume the target role by chaining through a management role:
+/// `AssumeRoleWithWebIdentity` into the management role (with an inline
+/// STS-only policy when agent-restricted), then `AssumeRole` into the target.
+async fn assume_role_via_management_chain(
+    input: ChainInputs<'_>,
+) -> Result<crate::integrations::aws::sts::StsCredentials> {
+    use crate::integrations::aws::sts::{
+        WebIdentityRequest, assume_role, assume_role_with_web_identity, parse_role_arn,
+    };
+
+    let mgmt_arn = parse_role_arn(input.mgmt_role_arn)?;
+    let mgmt_domain_suffix = mgmt_arn.partition.dns_suffix();
+
+    let mgmt_credentials = assume_role_with_web_identity(WebIdentityRequest {
+        http_client: input.http_client,
+        role_arn: input.mgmt_role_arn,
+        role_session_name: input.session,
+        web_identity_token: input.id_token,
+        region: input.region,
+        domain_suffix: mgmt_domain_suffix,
+        session_policy_names: &[],
+        session_policy: input.policies.mgmt_hop_policy.as_ref(),
+    })
+    .await
+    .context("failed to assume management role")?;
+
+    assume_role(
+        input.http_client,
+        input.role_arn,
+        input.session,
+        input.region,
+        &mgmt_credentials,
+        input.policies.session_policy_names,
+        None,
+    )
+    .await
+    .context("failed to assume target role via chaining")
 }
 
 /// Session policies applied to STS calls, restricted when an AI coding
@@ -440,11 +486,12 @@ fn extract_account_from_arn(arn: &str) -> Option<&str> {
 /// - `via` supplied → match the org whose `management_role` equals the given full ARN
 ///   exactly; error if no match.
 /// - Multiple orgs, no `via` → disambiguate by account ID: if the target role's
-///   account matches exactly one org's management-role account, use that org;
-///   otherwise return an error requiring `--via`.
+///   account matches exactly one org's management-role account, use that org.
+///   Zero matches → `aws-err-no-org-covers-account`; multiple matches →
+///   `aws-err-via-ambiguous`.
 ///
-/// Returns `Err` if `via` matches no org, or if multiple orgs are configured and
-/// the target account is ambiguous.
+/// Returns `Err` if `via` matches no org, if no configured org covers the target
+/// account, or if multiple orgs match the target account (true ambiguity).
 pub(crate) fn resolve_management_role_for(
     vouch_config: &crate::config::Config,
     target_role_arn: &str,
@@ -488,10 +535,27 @@ pub(crate) fn resolve_management_role_for(
             .iter()
             .filter(|o| extract_account_from_arn(&o.management_role) == Some(acct))
             .collect();
-        if matches.len() == 1 {
-            return Ok(matches
-                .first()
-                .and_then(|o| chain_if_different_role(o, target_role_arn)));
+        match matches.len() {
+            1 => {
+                return Ok(matches
+                    .first()
+                    .and_then(|o| chain_if_different_role(o, target_role_arn)));
+            }
+            0 => {
+                // No configured org's management account covers this target.
+                // "specify --via" would be misleading — the account simply has
+                // no organization set up for it.
+                return Err(crate::exit_code::CliError::ConfigError(tr_args!(
+                    "aws-err-no-org-covers-account",
+                    account = acct.to_string()
+                ))
+                .into());
+            }
+            _ => {
+                return Err(
+                    crate::exit_code::CliError::ConfigError(tr!("aws-err-via-ambiguous")).into(),
+                );
+            }
         }
     }
     Err(crate::exit_code::CliError::ConfigError(tr!("aws-err-via-ambiguous")).into())
@@ -1166,25 +1230,34 @@ mod tests {
     }
 
     #[test]
-    fn resolve_multi_org_no_match_returns_ambiguous_error() {
-        // Two orgs; target account doesn't match either management account.
+    fn resolve_multi_org_no_match_returns_no_coverage_error() {
+        // Two orgs; target account matches neither management account. This is
+        // "no org covers the account", not --via ambiguity: the message names
+        // the uncovered account rather than telling the user to specify --via.
         let mgmt1 = "arn:aws:iam::111:role/Mgmt1";
         let mgmt2 = "arn:aws:iam::222:role/Mgmt2";
         let target = "arn:aws:iam::333:role/Target";
         let cfg = make_config(&[mgmt1, mgmt2]);
-        let result = resolve_management_role_for(&cfg, target, None);
-        assert!(result.is_err());
+        let err = resolve_management_role_for(&cfg, target, None).unwrap_err();
+        assert!(
+            err.to_string().contains("333"),
+            "no-coverage error should name the uncovered account 333: {err}"
+        );
     }
 
     #[test]
     fn resolve_multi_org_both_match_returns_ambiguous_error() {
-        // Two orgs in the SAME account; target in that account → ambiguous.
+        // Two orgs in the SAME account; target in that account → true ambiguity,
+        // so the error tells the user to disambiguate with --via.
         let mgmt1 = "arn:aws:iam::111:role/Mgmt1";
         let mgmt2 = "arn:aws:iam::111:role/Mgmt2";
         let target = "arn:aws:iam::111:role/Target";
         let cfg = make_config(&[mgmt1, mgmt2]);
-        let result = resolve_management_role_for(&cfg, target, None);
-        assert!(result.is_err());
+        let err = resolve_management_role_for(&cfg, target, None).unwrap_err();
+        assert!(
+            err.to_string().contains("--via"),
+            "true ambiguity should tell the user to specify --via: {err}"
+        );
     }
 
     // --- resolve_identity_center -----------------------------------------------

--- a/crates/vouch-cli/src/commands/setup/aws.rs
+++ b/crates/vouch-cli/src/commands/setup/aws.rs
@@ -62,6 +62,18 @@ fn load_or_create_aws_config() -> Result<AwsConfig> {
     Ok(AwsConfig::load_from(config_path.clone()).unwrap_or_else(|_| AwsConfig::empty(config_path)))
 }
 
+/// Arguments for `setup aws`, one field per CLI flag. Grouped into a borrow
+/// struct to stay within the positional-parameter limit.
+pub(crate) struct SetupAwsArgs<'a> {
+    pub profile: Option<&'a str>,
+    pub role_arn: Option<&'a str>,
+    pub management_role: Option<&'a str>,
+    pub identity_center_application: Option<&'a str>,
+    pub region: Option<&'a str>,
+    pub discover: bool,
+    pub server: &'a str,
+}
+
 /// Run the AWS setup command.
 ///
 /// Dispatches based on the combination of flags:
@@ -71,19 +83,16 @@ fn load_or_create_aws_config() -> Result<AwsConfig> {
 /// - `--management-role` + `--identity-center-application` + `--region` + `--discover`:
 ///   IdC discovery (org + IdC stored, profiles written per account/permission-set).
 /// - `--discover` alone: IdC discovery using an already-stored org.
-#[allow(
-    clippy::too_many_arguments,
-    reason = "setup aws takes one arg per distinct CLI flag; no reasonable grouping exists"
-)]
-pub(crate) async fn run(
-    profile: Option<&str>,
-    role_arn: Option<&str>,
-    management_role: Option<&str>,
-    identity_center_application: Option<&str>,
-    region: Option<&str>,
-    discover: bool,
-    server: &str,
-) -> Result<()> {
+pub(crate) async fn run(args: SetupAwsArgs<'_>) -> Result<()> {
+    let SetupAwsArgs {
+        profile,
+        role_arn,
+        management_role,
+        identity_center_application,
+        region,
+        discover,
+        server,
+    } = args;
     // No flags supplied → launch the interactive first-run wizard.
     if profile.is_none()
         && role_arn.is_none()

--- a/crates/vouch-cli/src/commands/setup/codecommit.rs
+++ b/crates/vouch-cli/src/commands/setup/codecommit.rs
@@ -71,8 +71,10 @@ pub(crate) async fn run(
     // Get vouch binary path for the credential helper command and symlink
     let vouch_path = resolve_install_path();
 
-    // Build the native credential helper command
-    let helper_command = format!("{} credential codecommit", vouch_path.display());
+    // Build the native credential helper command. Git runs credential helpers
+    // through a shell, so the path must be quoted or it breaks when the vouch
+    // binary lives under a path containing spaces (matches setup/github.rs).
+    let helper_command = format!("\"{}\" credential codecommit", vouch_path.display());
 
     // Determine the credential pattern(s)
     let patterns: Vec<String> = if let Some(r) = region {
@@ -262,4 +264,26 @@ fn detect_conflicting_helpers() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    /// Git runs credential helpers through a shell, so a vouch binary path
+    /// containing spaces must stay quoted as a single token. This guards
+    /// against re-dropping the quotes (the bug regressed once via the #597
+    /// revert). Mirrors the `helper_command` format built in `run`.
+    #[test]
+    fn helper_command_quotes_path_with_spaces() {
+        let vouch_path = std::path::Path::new("/Users/John Smith/.cargo/bin/vouch");
+        let helper_command = format!("\"{}\" credential codecommit", vouch_path.display());
+
+        assert_eq!(
+            helper_command,
+            "\"/Users/John Smith/.cargo/bin/vouch\" credential codecommit"
+        );
+        assert!(
+            helper_command.starts_with('"'),
+            "helper command must quote the binary path: {helper_command}"
+        );
+    }
 }

--- a/crates/vouch-cli/src/main.rs
+++ b/crates/vouch-cli/src/main.rs
@@ -748,15 +748,15 @@ async fn run() -> Result<()> {
                 region,
                 discover,
             } => {
-                commands::setup::aws::run(
-                    profile.as_deref(),
-                    role.as_deref(),
-                    management_role.as_deref(),
-                    identity_center_application.as_deref(),
-                    region.as_deref(),
+                commands::setup::aws::run(commands::setup::aws::SetupAwsArgs {
+                    profile: profile.as_deref(),
+                    role_arn: role.as_deref(),
+                    management_role: management_role.as_deref(),
+                    identity_center_application: identity_center_application.as_deref(),
+                    region: region.as_deref(),
                     discover,
                     server,
-                )
+                })
                 .await
             }
             SetupCommands::Ssh { hosts } => {


### PR DESCRIPTION
## Summary

Follow-ups to #601 (AWS credential/setup redesign around org anchors).

- **#602** — quote the vouch binary path in the CodeCommit credential helper so paths containing spaces work. Git runs credential helpers through a shell, so the path must be quoted; `setup/aws.rs` already quotes, this brings `codecommit.rs` in line with `github.rs`. Adds a regression test (the bug regressed once via the #597 revert).
- **#606** — `aws console --via` is now resolved through `resolve_management_role_for` before the STS exchange, matching `credential aws`. An unconfigured `--via` fails with a Vouch error instead of an opaque AWS AccessDenied.
- **#607** — split the multi-org resolution error: zero orgs covering the target account returns a new `aws-err-no-org-covers-account` (naming the account), distinct from the true multi-match `aws-err-via-ambiguous`.
- **#605** — extract `fetch_aws_oidc_token` and `assume_role_via_management_chain` from `exchange_for_sts_credentials` (124 → 86 lines); `setup aws run()` takes a `SetupAwsArgs` borrow struct and drops the `too_many_arguments` allow.

## Verification

- `make lint` clean
- `cargo test -p vouch-cli` — 729 pass, including new codecommit-quoting and org-coverage-error tests

Closes #602
Closes #605
Closes #606
Closes #607

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CLI setup, clearer config errors, and internal STS refactors with tests; credential behavior is aligned rather than broadened.
> 
> **Overview**
> **CodeCommit setup** now wraps the vouch binary path in quotes in the git credential helper command (same pattern as GitHub setup), so installs under paths with spaces work when git runs the helper through a shell. A regression test locks in the format.
> 
> **`aws console`** resolves `--via` with `resolve_management_role_for` before STS, matching `credential aws`, so bad or ambiguous management roles surface as Vouch config errors instead of AWS `AccessDenied`.
> 
> **Multi-org management-role resolution** distinguishes **no org whose management account matches the target** (`aws-err-no-org-covers-account`, names the account and suggests `--via` or `setup aws`) from **true ambiguity** when multiple orgs match (`aws-err-via-ambiguous`). Tests were updated accordingly.
> 
> **Refactor:** `exchange_for_sts_credentials` pulls OIDC fetch and management-role chaining into `fetch_aws_oidc_token` and `assume_role_via_management_chain`; `vouch setup aws` takes a `SetupAwsArgs` struct instead of a long parameter list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9acd7b806c88d902a990c7cf55415eb69e234a6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->