### PR TITLE
build(deps): replace unmaintained serde_yaml with serde-saphyr (#595)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +81,17 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "annotate-snippets"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width 0.2.2",
+]
 
 [[package]]
 name = "anstyle"
@@ -117,6 +141,12 @@ checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "askama"
@@ -1980,6 +2010,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2415,6 +2463,16 @@ dependencies = [
  "smallvec",
  "spinning_top",
  "web-time",
+]
+
+[[package]]
+name = "granit-parser"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d03f81ad4732830d85cfd417a9f62cde6dadda4354d37d078a6084a19560aa2d"
+dependencies = [
+ "arraydeque",
+ "smallvec",
 ]
 
 [[package]]
@@ -3589,6 +3647,12 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -4927,6 +4991,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-saphyr"
+version = "0.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd22781911de0ca6debda95f073c8f18bec65d1a94f1fa9573f3102e514cea4"
+dependencies = [
+ "ahash",
+ "annotate-snippets",
+ "base64 0.22.1",
+ "encoding_rs_io",
+ "getrandom 0.3.4",
+ "granit-parser",
+ "nohash-hasher",
+ "num-traits",
+ "serde_core",
+ "smallvec",
+ "zmij",
+]
+
+[[package]]
 name = "serde_cbor_2"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4990,19 +5073,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -6148,12 +6218,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6288,9 +6352,9 @@ dependencies = [
  "rust-ini",
  "secrecy",
  "serde",
+ "serde-saphyr",
  "serde_json",
  "serde_urlencoded",
- "serde_yaml",
  "ssh-key",
  "sys-locale",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ secrecy = { version = "=0.10.3", default-features = false }
 serde = { version = "=1.0.228", default-features = false }
 serde_json = { version = "=1.0.150", default-features = false }
 serde_urlencoded = { version = "=0.7.1", default-features = false }
-serde_yaml = { version = "=0.9.34", default-features = false }
+serde-saphyr = { version = "=0.0.29", default-features = false }
 sqlx = { version = "=0.9.0", default-features = false }
 signature = { version = "=2.2.0", default-features = false }
 spki = { version = "=0.7.3", default-features = false }

--- a/crates/vouch-cli/Cargo.toml
+++ b/crates/vouch-cli/Cargo.toml
@@ -48,7 +48,7 @@ sys-locale = { workspace = true }
 serde = { workspace = true, features = ["std", "derive"] }
 serde_json = { workspace = true, features = ["std"] }
 serde_urlencoded = { workspace = true }
-serde_yaml = { workspace = true }
+serde-saphyr = { workspace = true, features = ["serialize", "deserialize"] }
 ssh-key = { workspace = true, features = ["std", "ed25519", "encryption", "rand_core", "getrandom"] }
 tempfile = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/vouch-cli/src/commands/setup/eks.rs
+++ b/crates/vouch-cli/src/commands/setup/eks.rs
@@ -181,7 +181,7 @@ pub(crate) async fn run(
                 env: None,
                 interactive_mode: Some("Never".to_string()),
             }),
-            other: serde_yaml::Value::Mapping(serde_yaml::Mapping::new()),
+            other: serde_json::Value::Object(serde_json::Map::new()),
         },
     });
 

--- a/crates/vouch-cli/src/commands/setup/kubeconfig.rs
+++ b/crates/vouch-cli/src/commands/setup/kubeconfig.rs
@@ -28,7 +28,7 @@ pub(crate) struct Kubeconfig {
     #[serde(default)]
     pub users: Vec<KubeconfigUser>,
     #[serde(default)]
-    pub preferences: serde_yaml::Value,
+    pub preferences: serde_json::Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -73,7 +73,7 @@ pub(crate) struct KubeconfigUserData {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exec: Option<ExecConfig>,
     #[serde(flatten)]
-    pub other: serde_yaml::Value,
+    pub other: serde_json::Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -124,7 +124,7 @@ pub(crate) fn load_kubeconfig(path: &std::path::Path) -> Result<Kubeconfig> {
     let content = std::fs::read_to_string(path).with_context(|| {
         vouch_cli::tr_args!("setup-kc-err-read", path = path.display().to_string())
     })?;
-    let config: Kubeconfig = serde_yaml::from_str(&content).with_context(|| {
+    let config: Kubeconfig = serde_saphyr::from_str(&content).with_context(|| {
         vouch_cli::tr_args!("setup-kc-err-parse", path = path.display().to_string())
     })?;
     Ok(config)
@@ -136,8 +136,8 @@ pub(crate) fn save_kubeconfig(path: &std::path::Path, config: &Kubeconfig) -> Re
         ensure_secure_dir(parent)?;
     }
 
-    let content =
-        serde_yaml::to_string(config).with_context(|| vouch_cli::tr!("setup-kc-err-serialize"))?;
+    let content = serde_saphyr::to_string(config)
+        .with_context(|| vouch_cli::tr!("setup-kc-err-serialize"))?;
     write_secure_file(path, &content)?;
     Ok(())
 }
@@ -182,7 +182,7 @@ users:
       interactiveMode: Never
 "#;
 
-        let config: Kubeconfig = serde_yaml::from_str(yaml).expect("should parse");
+        let config: Kubeconfig = serde_saphyr::from_str(yaml).expect("should parse");
 
         assert_eq!(config.clusters.len(), 1);
         assert_eq!(config.clusters[0].name, "my-cluster");
@@ -214,7 +214,7 @@ contexts: []
 users: []
 "#;
 
-        let config: Kubeconfig = serde_yaml::from_str(yaml).expect("should parse");
+        let config: Kubeconfig = serde_saphyr::from_str(yaml).expect("should parse");
 
         assert!(config.clusters.is_empty());
         assert!(config.contexts.is_empty());
@@ -238,7 +238,7 @@ users: []
             interactive_mode: Some("Never".to_string()),
         };
 
-        let yaml = serde_yaml::to_string(&exec).expect("should serialize");
+        let yaml = serde_saphyr::to_string(&exec).expect("should serialize");
         assert!(yaml.contains("apiVersion: client.authentication.k8s.io/v1"));
         assert!(yaml.contains("command: vouch"));
         assert!(yaml.contains("interactiveMode: Never"));
@@ -257,7 +257,7 @@ users: []
             },
         };
 
-        let yaml = serde_yaml::to_string(&context).expect("should serialize");
+        let yaml = serde_saphyr::to_string(&context).expect("should serialize");
         assert!(yaml.contains("name: my-cluster-vouch"));
         assert!(yaml.contains("cluster: my-cluster"));
         assert!(yaml.contains("user: vouch-k8s-my-cluster"));
@@ -274,7 +274,7 @@ users: []
             },
         };
 
-        let yaml = serde_yaml::to_string(&cluster).expect("should serialize");
+        let yaml = serde_saphyr::to_string(&cluster).expect("should serialize");
         assert!(yaml.contains("certificate-authority-data:"));
         assert!(yaml.contains("LS0tLS1CRUdJTi..."));
     }
@@ -289,8 +289,49 @@ users: []
             },
         };
 
-        let yaml = serde_yaml::to_string(&cluster).expect("should serialize");
+        let yaml = serde_saphyr::to_string(&cluster).expect("should serialize");
         assert!(yaml.contains("name: dev"));
         assert!(!yaml.contains("certificate-authority-data"));
+    }
+
+    /// The `#[serde(flatten)] other` field must preserve arbitrary user auth
+    /// fields (token, client-certificate-data, etc.) losslessly across a
+    /// load -> save -> load round-trip. This is the behaviour serde_yaml's
+    /// untyped `Value` catch-all provided and that the serde-saphyr +
+    /// serde_json::Value migration must keep (#595).
+    #[test]
+    fn test_kubeconfig_flatten_preserves_arbitrary_user_fields() {
+        let yaml = r#"
+apiVersion: v1
+kind: Config
+clusters: []
+contexts: []
+users:
+- name: legacy-user
+  user:
+    token: super-secret-token
+    client-certificate-data: LS0tLS1DRVJU
+    username: admin
+"#;
+
+        let config: Kubeconfig = serde_saphyr::from_str(yaml).expect("should parse");
+        let other = &config.users[0].user.other;
+        assert_eq!(other["token"], "super-secret-token");
+        assert_eq!(other["client-certificate-data"], "LS0tLS1DRVJU");
+        assert_eq!(other["username"], "admin");
+
+        // Round-trip: serialize, then re-parse, and confirm the fields survive.
+        let serialized = serde_saphyr::to_string(&config).expect("should serialize");
+        assert!(serialized.contains("super-secret-token"), "{serialized}");
+        assert!(
+            serialized.contains("client-certificate-data"),
+            "{serialized}"
+        );
+
+        let reparsed: Kubeconfig = serde_saphyr::from_str(&serialized).expect("should re-parse");
+        let other2 = &reparsed.users[0].user.other;
+        assert_eq!(other2["token"], "super-secret-token");
+        assert_eq!(other2["client-certificate-data"], "LS0tLS1DRVJU");
+        assert_eq!(other2["username"], "admin");
     }
 }

--- a/crates/vouch-cli/src/commands/setup/kubernetes.rs
+++ b/crates/vouch-cli/src/commands/setup/kubernetes.rs
@@ -94,7 +94,7 @@ pub(crate) async fn run(
                 env: None,
                 interactive_mode: Some("Never".to_string()),
             }),
-            other: serde_yaml::Value::Mapping(serde_yaml::Mapping::new()),
+            other: serde_json::Value::Object(serde_json::Map::new()),
         },
     });
 

--- a/crates/vouch-cli/src/integrations/eks.rs
+++ b/crates/vouch-cli/src/integrations/eks.rs
@@ -113,7 +113,7 @@ fn find_vouch_eks_contexts() -> Vec<String> {
         Err(_) => return Vec::new(),
     };
 
-    let config: Kubeconfig = match serde_yaml::from_str(&content) {
+    let config: Kubeconfig = match serde_saphyr::from_str(&content) {
         Ok(c) => c,
         Err(_) => return Vec::new(),
     };
@@ -267,7 +267,7 @@ users:
     token: some-token
 "#;
 
-        let config: Kubeconfig = serde_yaml::from_str(yaml).expect("should parse");
+        let config: Kubeconfig = serde_saphyr::from_str(yaml).expect("should parse");
 
         assert_eq!(config.contexts.len(), 2);
         assert_eq!(config.users.len(), 2);
@@ -291,7 +291,7 @@ contexts: []
 users: []
 "#;
 
-        let config: Kubeconfig = serde_yaml::from_str(yaml).expect("should parse");
+        let config: Kubeconfig = serde_saphyr::from_str(yaml).expect("should parse");
 
         assert!(config.contexts.is_empty());
         assert!(config.users.is_empty());
@@ -304,7 +304,7 @@ apiVersion: v1
 kind: Config
 "#;
 
-        let config: Kubeconfig = serde_yaml::from_str(yaml).expect("should parse");
+        let config: Kubeconfig = serde_saphyr::from_str(yaml).expect("should parse");
 
         assert!(config.contexts.is_empty());
         assert!(config.users.is_empty());


### PR DESCRIPTION
## Summary

`serde_yaml` is deprecated and flagged unmaintained (RustSec). This migrates the kubeconfig read/write path — its only use, in vouch-cli — to `serde-saphyr`, a pure-Rust YAML (de)serializer with no `unsafe`, no C dependency, panic-free parsing, and configurable DoS budgets.

- Workspace dependency swapped to `serde-saphyr =0.0.29` (`default-features = false`); `serialize`/`deserialize` features enabled in `vouch-cli`.
- `serde_saphyr::{from_str, to_string}` replace the `serde_yaml` calls.
- The two untyped `serde_yaml::Value` catch-alls (`Kubeconfig.preferences`, `KubeconfigUserData.other`) move to `serde_json::Value` (already a dependency). The `#[serde(flatten)] other` field still preserves arbitrary user auth fields; a new round-trip test proves `token` / `client-certificate-data` / `username` survive a load → save → load cycle.
- serde-saphyr's parser is `granit-parser` (pure Rust); no libyaml binding is pulled in.

## Verification

- `cargo test -p vouch-cli` — 729 pass, including the new flatten round-trip test
- `make lint` clean
- `make audit` (cargo-deny) — advisories / licenses / sources ok; the serde_yaml unmaintained advisory is resolved

Note: automated tests confirm round-trip fidelity through serde-saphyr. A manual `kubectl config view` check against a real `~/.kube/config` (native kubectl still reads the saved file) is worth running before merge, as it needs a machine with kubectl.

Closes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how real `~/.kube/config` files are parsed and rewritten; mistakes could drop or corrupt non-exec user entries, though the new round-trip test targets that behavior.
> 
> **Overview**
> Replaces deprecated **`serde_yaml`** with **`serde-saphyr`** for all vouch-cli kubeconfig YAML read/write (setup EKS/K8s, shared `kubeconfig` helpers, EKS integration status).
> 
> Kubeconfig load/save and tests now use `serde_saphyr::{from_str, to_string}`. Untyped catch-all fields (`preferences`, `#[serde(flatten)] other` on user entries) switch from `serde_yaml::Value` to **`serde_json::Value`**; new vouch exec users get an empty JSON object for `other`. A **round-trip test** asserts legacy user fields (`token`, `client-certificate-data`, `username`) survive parse → serialize → re-parse.
> 
> **`Cargo.lock`** drops `serde_yaml` / `unsafe-libyaml` and pulls in `serde-saphyr` and its parser stack (`granit-parser`, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 522cbdd4c3be68c6c28a44e3aee6f1c962ee1436. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->