### PR TITLE
refactor(oidc): make OAuthGrantType the single source for grant types

### DIFF
--- a/crates/vouch-server/src/handlers/oidc/tests/oidc_discovery.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/oidc_discovery.rs
@@ -125,10 +125,11 @@ async fn test_oidc_discovery_grant_types_match_token_parser() {
         .map(|v| v.as_str().expect("grant type should be string").to_string())
         .collect();
 
-    let parser_supported = crate::handlers::oidc::token::OAuthGrantType::supported_wire_values()
-        .into_iter()
-        .map(String::from)
-        .collect::<BTreeSet<_>>();
+    let parser_supported =
+        crate::services::oidc::grant_type::OAuthGrantType::supported_wire_values()
+            .into_iter()
+            .map(String::from)
+            .collect::<BTreeSet<_>>();
 
     assert_eq!(
         discovered, parser_supported,
@@ -136,7 +137,7 @@ async fn test_oidc_discovery_grant_types_match_token_parser() {
     );
 
     for grant in &discovered {
-        let parsed = grant.parse::<crate::handlers::oidc::token::OAuthGrantType>();
+        let parsed = grant.parse::<crate::services::oidc::grant_type::OAuthGrantType>();
         assert!(
             parsed.is_ok(),
             "discovery advertises unsupported grant type in parser: {grant}"

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -13,6 +13,7 @@ use crate::services::oidc::{
     ScopeSet,
     client_credentials::exchange_client_credentials,
     exchange::{TokenExchangeParams, exchange_token},
+    grant_type::{OAuthGrantType, ParseOAuthGrantTypeError},
     jwt_bearer::client_auth::{PendingJti, authenticate_client_jwt},
     token::{AuthCodeExchangeParams, exchange_authorization_code, validate_dpop_if_present},
 };
@@ -26,84 +27,6 @@ use axum::{
 use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-
-/// OAuth grant types supported by this server.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum OAuthGrantType {
-    /// Standard OAuth 2.0 authorization code grant.
-    AuthorizationCode,
-    /// Client credentials grant (RFC 6749 Section 4.4).
-    ClientCredentials,
-    /// Device authorization grant (RFC 8628).
-    DeviceCode,
-    /// Token exchange grant (RFC 8693).
-    TokenExchange,
-    /// FIDO2 assertion grant (custom extension per RFC 6749 Section 4.5).
-    Fido2Assertion,
-}
-
-/// Parse error for OAuth `grant_type` values.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct ParseOAuthGrantTypeError {
-    value: String,
-}
-
-impl ParseOAuthGrantTypeError {
-    #[must_use]
-    pub(super) fn new(value: &str) -> Self {
-        Self {
-            value: value.to_string(),
-        }
-    }
-}
-
-impl std::fmt::Display for ParseOAuthGrantTypeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "unsupported grant_type: {}", self.value)
-    }
-}
-
-impl std::error::Error for ParseOAuthGrantTypeError {}
-
-impl OAuthGrantType {
-    const SUPPORTED: [Self; 5] = [
-        Self::AuthorizationCode,
-        Self::ClientCredentials,
-        Self::DeviceCode,
-        Self::TokenExchange,
-        Self::Fido2Assertion,
-    ];
-
-    /// Wire-format `grant_type` value.
-    #[must_use]
-    pub(super) const fn as_str(self) -> &'static str {
-        match self {
-            Self::AuthorizationCode => "authorization_code",
-            Self::ClientCredentials => "client_credentials",
-            Self::DeviceCode => "urn:ietf:params:oauth:grant-type:device_code",
-            Self::TokenExchange => "urn:ietf:params:oauth:grant-type:token-exchange",
-            Self::Fido2Assertion => "urn:ietf:params:oauth:grant-type:fido2-assertion",
-        }
-    }
-
-    /// All supported `grant_type` wire values.
-    #[must_use]
-    pub(super) fn supported_wire_values() -> Vec<&'static str> {
-        Self::SUPPORTED.iter().copied().map(Self::as_str).collect()
-    }
-}
-
-impl std::str::FromStr for OAuthGrantType {
-    type Err = ParseOAuthGrantTypeError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Self::SUPPORTED
-            .iter()
-            .copied()
-            .find(|grant_type| grant_type.as_str() == s)
-            .ok_or_else(|| ParseOAuthGrantTypeError::new(s))
-    }
-}
 
 /// Token response (RFC 6749 Section 5.1).
 #[derive(Serialize)]
@@ -1364,59 +1287,4 @@ fn token_error_response(error: &str, description: &str) -> Response {
         }),
     )
         .into_response()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::OAuthGrantType;
-
-    #[test]
-    fn test_oauth_grant_type_from_str_authorization_code() {
-        let result: Result<OAuthGrantType, _> = "authorization_code".parse();
-        assert_eq!(result, Ok(OAuthGrantType::AuthorizationCode));
-    }
-
-    #[test]
-    fn test_oauth_grant_type_from_str_device_code() {
-        let result: Result<OAuthGrantType, _> =
-            "urn:ietf:params:oauth:grant-type:device_code".parse();
-        assert_eq!(result, Ok(OAuthGrantType::DeviceCode));
-    }
-
-    #[test]
-    fn test_oauth_grant_type_from_str_token_exchange() {
-        let result: Result<OAuthGrantType, _> =
-            "urn:ietf:params:oauth:grant-type:token-exchange".parse();
-        assert_eq!(result, Ok(OAuthGrantType::TokenExchange));
-    }
-
-    #[test]
-    fn test_oauth_grant_type_from_str_fido2_assertion() {
-        let result: Result<OAuthGrantType, _> =
-            "urn:ietf:params:oauth:grant-type:fido2-assertion".parse();
-        assert_eq!(result, Ok(OAuthGrantType::Fido2Assertion));
-    }
-
-    #[test]
-    fn test_oauth_grant_type_from_str_client_credentials() {
-        let result: Result<OAuthGrantType, _> = "client_credentials".parse();
-        assert_eq!(result, Ok(OAuthGrantType::ClientCredentials));
-    }
-
-    #[test]
-    fn test_oauth_grant_type_from_str_rejects_unknown() {
-        let result: Result<OAuthGrantType, _> = "password".parse();
-        assert!(result.is_err());
-
-        let result2: Result<OAuthGrantType, _> = "".parse();
-        assert!(result2.is_err());
-
-        let result3: Result<OAuthGrantType, _> = "jwt-bearer".parse();
-        assert!(result3.is_err());
-
-        // Lock-in: §2.1 grant URN must be rejected (RFC 7523 §2.1 removed).
-        let bearer: Result<OAuthGrantType, _> =
-            "urn:ietf:params:oauth:grant-type:jwt-bearer".parse();
-        assert!(bearer.is_err());
-    }
 }

--- a/crates/vouch-server/src/services/oidc/discovery.rs
+++ b/crates/vouch-server/src/services/oidc/discovery.rs
@@ -11,6 +11,7 @@ use crate::db::{JwsAlgorithm, TokenEndpointAuthMethod};
 use crate::services::ServiceError;
 use crate::services::auth::ACR_AAL3;
 use crate::services::oidc::OAuthScope;
+use crate::services::oidc::grant_type::OAuthGrantType;
 use serde::Serialize;
 use std::sync::Arc;
 
@@ -216,13 +217,10 @@ pub fn build_discovery_document(state: &Arc<AppState>) -> OidcDiscoveryDocument 
             "jwt".to_string(),
             "query.jwt".to_string(),
         ],
-        grant_types_supported: vec![
-            "authorization_code".to_string(),
-            "client_credentials".to_string(),
-            "urn:ietf:params:oauth:grant-type:device_code".to_string(),
-            "urn:ietf:params:oauth:grant-type:token-exchange".to_string(),
-            "urn:ietf:params:oauth:grant-type:fido2-assertion".to_string(),
-        ],
+        grant_types_supported: OAuthGrantType::supported_wire_values()
+            .into_iter()
+            .map(String::from)
+            .collect(),
         subject_types_supported: vec!["public".to_string()],
         id_token_signing_alg_values_supported: if state.oidc_rsa_key.is_some() {
             vec![JwsAlgorithm::Rs256, JwsAlgorithm::Es256]

--- a/crates/vouch-server/src/services/oidc/grant_type.rs
+++ b/crates/vouch-server/src/services/oidc/grant_type.rs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! OAuth 2.0 `grant_type` wire values — single source of truth.
+//!
+//! [`OAuthGrantType`] enumerates every grant the token endpoint dispatches.
+//! The token handler (parsing and dispatch) and the discovery document
+//! (`grant_types_supported`) both derive from it, so the advertised set can
+//! never drift from the accepted set.
+
+/// OAuth grant types supported by this server's token endpoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OAuthGrantType {
+    /// Standard OAuth 2.0 authorization code grant.
+    AuthorizationCode,
+    /// Client credentials grant (RFC 6749 Section 4.4).
+    ClientCredentials,
+    /// Device authorization grant (RFC 8628).
+    DeviceCode,
+    /// Token exchange grant (RFC 8693).
+    TokenExchange,
+    /// FIDO2 assertion grant (custom extension per RFC 6749 Section 4.5).
+    Fido2Assertion,
+}
+
+/// Parse error for OAuth `grant_type` values.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ParseOAuthGrantTypeError {
+    value: String,
+}
+
+impl ParseOAuthGrantTypeError {
+    #[must_use]
+    pub(crate) fn new(value: &str) -> Self {
+        Self {
+            value: value.to_string(),
+        }
+    }
+}
+
+impl std::fmt::Display for ParseOAuthGrantTypeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "unsupported grant_type: {}", self.value)
+    }
+}
+
+impl std::error::Error for ParseOAuthGrantTypeError {}
+
+impl OAuthGrantType {
+    const SUPPORTED: [Self; 5] = [
+        Self::AuthorizationCode,
+        Self::ClientCredentials,
+        Self::DeviceCode,
+        Self::TokenExchange,
+        Self::Fido2Assertion,
+    ];
+
+    /// Wire-format `grant_type` value.
+    #[must_use]
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::AuthorizationCode => "authorization_code",
+            Self::ClientCredentials => "client_credentials",
+            Self::DeviceCode => "urn:ietf:params:oauth:grant-type:device_code",
+            Self::TokenExchange => "urn:ietf:params:oauth:grant-type:token-exchange",
+            Self::Fido2Assertion => "urn:ietf:params:oauth:grant-type:fido2-assertion",
+        }
+    }
+
+    /// All supported `grant_type` wire values.
+    #[must_use]
+    pub(crate) fn supported_wire_values() -> Vec<&'static str> {
+        Self::SUPPORTED.iter().copied().map(Self::as_str).collect()
+    }
+}
+
+impl std::str::FromStr for OAuthGrantType {
+    type Err = ParseOAuthGrantTypeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::SUPPORTED
+            .iter()
+            .copied()
+            .find(|grant_type| grant_type.as_str() == s)
+            .ok_or_else(|| ParseOAuthGrantTypeError::new(s))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OAuthGrantType;
+
+    #[test]
+    fn test_oauth_grant_type_from_str_authorization_code() {
+        let result: Result<OAuthGrantType, _> = "authorization_code".parse();
+        assert_eq!(result, Ok(OAuthGrantType::AuthorizationCode));
+    }
+
+    #[test]
+    fn test_oauth_grant_type_from_str_device_code() {
+        let result: Result<OAuthGrantType, _> =
+            "urn:ietf:params:oauth:grant-type:device_code".parse();
+        assert_eq!(result, Ok(OAuthGrantType::DeviceCode));
+    }
+
+    #[test]
+    fn test_oauth_grant_type_from_str_token_exchange() {
+        let result: Result<OAuthGrantType, _> =
+            "urn:ietf:params:oauth:grant-type:token-exchange".parse();
+        assert_eq!(result, Ok(OAuthGrantType::TokenExchange));
+    }
+
+    #[test]
+    fn test_oauth_grant_type_from_str_fido2_assertion() {
+        let result: Result<OAuthGrantType, _> =
+            "urn:ietf:params:oauth:grant-type:fido2-assertion".parse();
+        assert_eq!(result, Ok(OAuthGrantType::Fido2Assertion));
+    }
+
+    #[test]
+    fn test_oauth_grant_type_from_str_client_credentials() {
+        let result: Result<OAuthGrantType, _> = "client_credentials".parse();
+        assert_eq!(result, Ok(OAuthGrantType::ClientCredentials));
+    }
+
+    #[test]
+    fn test_oauth_grant_type_from_str_rejects_unknown() {
+        let result: Result<OAuthGrantType, _> = "password".parse();
+        assert!(result.is_err());
+
+        let result2: Result<OAuthGrantType, _> = "".parse();
+        assert!(result2.is_err());
+
+        let result3: Result<OAuthGrantType, _> = "jwt-bearer".parse();
+        assert!(result3.is_err());
+
+        // Lock-in: §2.1 grant URN must be rejected (RFC 7523 §2.1 removed).
+        let bearer: Result<OAuthGrantType, _> =
+            "urn:ietf:params:oauth:grant-type:jwt-bearer".parse();
+        assert!(bearer.is_err());
+    }
+}

--- a/crates/vouch-server/src/services/oidc/mod.rs
+++ b/crates/vouch-server/src/services/oidc/mod.rs
@@ -36,6 +36,7 @@
 //! - [`protected_resource`] - Protected Resource Metadata (RFC 9728)
 //! - [`authorization`] - Authorization code issuance and validation
 //! - [`token`] - Token endpoint logic (auth code, device code grants)
+//! - [`grant_type`] - OAuth `grant_type` wire values (single source of truth)
 //! - [`client_credentials`] - Client credentials grant (RFC 6749 Section 4.4)
 //! - [`exchange`] - Token exchange (RFC 8693)
 //! - [`jwt_bearer`] - JWT client authentication and bearer grants (RFC 7523)
@@ -59,6 +60,7 @@ pub mod dpop;
 pub mod exchange;
 pub mod fapi;
 pub mod fido2_grant;
+pub(crate) mod grant_type;
 pub mod introspection;
 pub mod jar;
 pub mod jarm;

--- a/crates/vouch-server/src/services/oidc/registration.rs
+++ b/crates/vouch-server/src/services/oidc/registration.rs
@@ -2111,6 +2111,19 @@ mod tests {
         );
     }
 
+    /// Every grant the token endpoint dispatches must also be registrable.
+    /// `ALLOWED_GRANT_TYPES` is a deliberate superset (it adds `refresh_token`),
+    /// so this guards one direction: no dispatchable grant is unregistrable.
+    #[test]
+    fn every_dispatched_grant_is_registrable() {
+        for grant in crate::services::oidc::grant_type::OAuthGrantType::supported_wire_values() {
+            assert!(
+                ALLOWED_GRANT_TYPES.contains(&grant),
+                "token-endpoint grant {grant} must also be an allowed registration grant"
+            );
+        }
+    }
+
     #[test]
     fn test_allowed_response_types_includes_code() {
         assert!(


### PR DESCRIPTION
Makes `OAuthGrantType` the single source of truth for the server's OAuth
`grant_type` wire values, resolving the duplication tracked in #621.

## Changes

- Move `OAuthGrantType` and `ParseOAuthGrantTypeError` from
  `handlers/oidc/token.rs` to a new `services/oidc/grant_type.rs` with
  `pub(crate)` visibility, so both the token handler and the discovery
  service reference one definition. The grant-type parse tests move with it.
- Derive the discovery document's `grant_types_supported` from
  `OAuthGrantType::supported_wire_values()` instead of a hand-written list.
- Keep `ALLOWED_GRANT_TYPES` in `registration.rs` as a superset — it adds
  `refresh_token`, which is accepted at registration but never issued. A new
  test, `every_dispatched_grant_is_registrable`, asserts every dispatched
  grant is also registrable.
- Update the discovery parity test to the new type path.

## Behavior

Wire output is unchanged: discovery advertises the same five grant types,
now sourced from the enum. The advertised set can no longer drift from the
token endpoint's dispatch set.

## Testing

- `make fmt`, `make lint`, `make test` clean
- Relocated `grant_type` tests, the discovery parity test, and the new
  registration parity test pass

Closes #621

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor with no intended wire or dispatch behavior change; parity tests guard discovery vs token parsing and registration vs dispatched grants.
> 
> **Overview**
> **Refactors OAuth grant-type definitions** so discovery metadata and the token endpoint cannot advertise or accept different `grant_type` values.
> 
> `OAuthGrantType` and `ParseOAuthGrantTypeError` move out of `handlers/oidc/token.rs` into new **`services/oidc/grant_type.rs`** (`pub(crate)`), with the existing `FromStr` / `supported_wire_values()` tests relocated there. The token handler imports the shared types; behavior and wire strings are unchanged.
> 
> **Discovery** now sets `grant_types_supported` from `OAuthGrantType::supported_wire_values()` instead of a duplicated literal list. The discovery parity test points at the new module path.
> 
> **Registration** keeps `ALLOWED_GRANT_TYPES` as a superset (still includes `refresh_token` for registration only). A new test **`every_dispatched_grant_is_registrable`** asserts every token-endpoint grant is allowed at dynamic registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ffb81332fef8e745232bdc2c9f664e3ad15521d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->