### PR TITLE
fix(i18n): route remaining user-facing strings through Fluent

### DIFF
--- a/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
+++ b/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
@@ -107,6 +107,8 @@ httpsig-err-key-unavailable =
     Hardware-backed signing key unavailable for { $path }: this request must be
     signed (RFC 9421). Run { -cmd } enroll (or unlock your keychain) and try again
 
+httpsig-warn-create-failed = Warning: HTTP signature creation failed ({ $error }).
+
 ## FIDO2 / CTAP2 user-facing errors
 
 fido2-err-credential-excluded = This { -yubikey } is already registered for this service.
@@ -1446,3 +1448,40 @@ setup-ca-err-fetch-token = failed to get CodeArtifact token
 setup-kc-err-read = failed to read kubeconfig: { $path }
 setup-kc-err-parse = failed to parse kubeconfig: { $path }
 setup-kc-err-serialize = failed to serialize kubeconfig
+
+## Helper binary installation (utils.rs)
+utils-created-directory = Created directory: { $path }
+utils-created-symlink = Created symlink: { $link } -> { $target }
+utils-created-file = Created: { $path }
+utils-path-note = Note: { $path } is not in your PATH.
+utils-path-profile-hint = Add it to your shell profile:
+utils-path-windows-hint = Add it to your system PATH environment variable.
+
+## Integration status lines (vouch status)
+integration-docker-helper-not-installed = credential helper not installed
+integration-docker-no-registries = no registries configured
+
+## Top-level error reporting (main.rs, exit_code.rs)
+cli-error-prefix = Error: { $error }
+err-permission-denied = permission denied — { $detail }
+err-step-up-required = step-up authentication required — run '{ -cmd } login' to re-authenticate with your YubiKey
+err-rate-limited = rate limited by server — wait a moment and retry
+
+## Server URL validation errors (server_url.rs)
+server-url-err-empty = server URL is empty
+server-url-err-invalid = invalid server URL: { $detail }
+server-url-err-insecure-http =
+    Server URL uses plain HTTP ({ $url }).
+    Credentials would be sent in plaintext.
+
+    Use an https:// URL, or set --allow-insecure / VOUCH_ALLOW_INSECURE=1 for development.
+
+## FAPI client-key errors (fapi/error.rs)
+fapi-err-key-generation = failed to generate ES256 keypair: { $error }
+fapi-err-key-load = failed to load key from disk: { $error }
+fapi-err-key-save = failed to save key to disk: { $error }
+fapi-err-invalid-key-format = invalid key format: { $error }
+fapi-err-jwt-signing = failed to sign JWT: { $error }
+fapi-err-serialization = serialization error: { $error }
+fapi-err-thumbprint = failed to compute JWK thumbprint: { $error }
+fapi-err-keychain = keychain access error: { $error }

--- a/crates/vouch-cli/src/client.rs
+++ b/crates/vouch-cli/src/client.rs
@@ -231,7 +231,7 @@ impl<H: HttpClient> VouchClient<H> {
             Ok(s) => s,
             Err(e) => {
                 tracing::warn!("HTTP signature signer creation failed: {e}");
-                eprintln!("Warning: HTTP signature creation failed ({e}).");
+                crate::tr_eprintln!("httpsig-warn-create-failed", error = e.to_string());
                 return Vec::new();
             }
         };
@@ -255,7 +255,7 @@ impl<H: HttpClient> VouchClient<H> {
             Ok(r) => r,
             Err(e) => {
                 tracing::warn!("HTTP signature request build failed: {e}");
-                eprintln!("Warning: HTTP signature creation failed ({e}).");
+                crate::tr_eprintln!("httpsig-warn-create-failed", error = e.to_string());
                 return Vec::new();
             }
         };
@@ -269,7 +269,7 @@ impl<H: HttpClient> VouchClient<H> {
             )
         {
             tracing::warn!("Content-Digest computation failed: {e}");
-            eprintln!("Warning: HTTP signature creation failed ({e}).");
+            crate::tr_eprintln!("httpsig-warn-create-failed", error = e.to_string());
             return Vec::new();
         }
 
@@ -301,7 +301,7 @@ impl<H: HttpClient> VouchClient<H> {
 
         if let Err(e) = sig_builder.sign_request(&mut req, &signer) {
             tracing::warn!("HTTP message signing failed: {e}");
-            eprintln!("Warning: HTTP signature creation failed ({e}).");
+            crate::tr_eprintln!("httpsig-warn-create-failed", error = e.to_string());
             return Vec::new();
         }
 

--- a/crates/vouch-cli/src/exit_code.rs
+++ b/crates/vouch-cli/src/exit_code.rs
@@ -40,10 +40,9 @@ pub(crate) const RATE_LIMITED: u8 = 8;
 /// use crate::exit_code::CliError;
 /// Err(CliError::NotAuthenticated { reason: "...".into() })?
 /// ```
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 pub(crate) enum CliError {
     /// User is not authenticated — session missing or expired.
-    #[error("{reason}")]
     NotAuthenticated {
         /// Context-specific message explaining why authentication failed.
         reason: String,
@@ -54,42 +53,68 @@ pub(crate) enum CliError {
         dead_code,
         reason = "variant for future error categorisation; lint fires inconsistently across compilation targets"
     )]
-    #[error("{0}")]
     HardwareNotFound(String),
 
     /// Network or server connectivity failure.
-    #[error("{0}")]
     NetworkError(String),
 
     /// Server denied the request (403).
-    #[error("permission denied — {0}")]
     PermissionDenied(String),
 
     /// Configuration is missing or invalid.
-    #[error("{0}")]
     ConfigError(String),
 
     /// RFC 9470: Step-up authentication required.
     ///
     /// Server returned `insufficient_user_authentication` in `WWW-Authenticate`.
     /// The CLI should re-authenticate and retry the request.
-    #[error(
-        "step-up authentication required — run 'vouch login' to re-authenticate with your YubiKey"
-    )]
     StepUpRequired {
         /// Requested ACR values from the challenge.
+        #[allow(
+            dead_code,
+            reason = "carried for future step-up handling; Display omits it"
+        )]
         acr_values: Option<String>,
         /// Maximum authentication age in seconds.
+        #[allow(
+            dead_code,
+            reason = "carried for future step-up handling; Display omits it"
+        )]
         max_age: Option<u64>,
     },
 
     /// Server returned 429 Too Many Requests.
-    #[error("rate limited by server — wait a moment and retry")]
     RateLimited {
         /// Seconds to wait before retrying (from `Retry-After` header).
+        #[allow(
+            dead_code,
+            reason = "carried for future retry backoff; Display omits it"
+        )]
         retry_after: Option<u64>,
     },
 }
+
+impl std::fmt::Display for CliError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotAuthenticated { reason } => f.write_str(reason),
+            Self::HardwareNotFound(msg) | Self::NetworkError(msg) | Self::ConfigError(msg) => {
+                f.write_str(msg)
+            }
+            Self::PermissionDenied(detail) => {
+                write!(
+                    f,
+                    "{}",
+                    crate::tr_args!("err-permission-denied", detail = detail.as_str())
+                )
+            }
+            Self::StepUpRequired { .. } => write!(f, "{}", crate::tr!("err-step-up-required")),
+            Self::RateLimited { .. } => write!(f, "{}", crate::tr!("err-rate-limited")),
+        }
+    }
+}
+
+impl std::error::Error for CliError {}
 
 /// Classify an `anyhow::Error` into an appropriate exit code.
 ///
@@ -347,6 +372,26 @@ mod tests {
         }
         .into();
         assert_eq!(code_value(classify(&err)), RATE_LIMITED);
+    }
+
+    #[test]
+    fn translated_error_display_resolves_from_catalog() {
+        assert_eq!(
+            CliError::PermissionDenied("no access".to_string()).to_string(),
+            "permission denied — no access"
+        );
+        assert_eq!(
+            CliError::StepUpRequired {
+                acr_values: None,
+                max_age: None,
+            }
+            .to_string(),
+            "step-up authentication required — run 'vouch login' to re-authenticate with your YubiKey"
+        );
+        assert_eq!(
+            CliError::RateLimited { retry_after: None }.to_string(),
+            "rate limited by server — wait a moment and retry"
+        );
     }
 
     #[test]

--- a/crates/vouch-cli/src/fapi/error.rs
+++ b/crates/vouch-cli/src/fapi/error.rs
@@ -1,42 +1,77 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Error types for FAPI 2.0 client operations.
 
-use thiserror::Error;
-
 /// Errors that can occur during FAPI 2.0 client operations.
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum FapiError {
     /// Failed to generate an ES256 keypair.
-    #[error("failed to generate ES256 keypair: {0}")]
     KeyGeneration(String),
 
     /// Failed to load a key from disk.
-    #[error("failed to load key from disk: {0}")]
     KeyLoad(String),
 
     /// Failed to save a key to disk.
-    #[error("failed to save key to disk: {0}")]
     KeySave(String),
 
     /// Key file has an invalid format.
-    #[error("invalid key format: {0}")]
     InvalidKeyFormat(String),
 
     /// Failed to sign a JWT.
-    #[error("failed to sign JWT: {0}")]
     JwtSigning(String),
 
     /// JSON serialization or deserialization failure.
-    #[error("serialization error: {0}")]
-    Serialization(#[from] serde_json::Error),
+    Serialization(serde_json::Error),
 
     /// Failed to compute a JWK thumbprint per RFC 7638.
-    #[error("failed to compute JWK thumbprint: {0}")]
     ThumbprintComputation(String),
 
     /// Failed to access the OS keychain.
-    #[error("keychain access error: {0}")]
     KeychainAccess(String),
+}
+
+impl std::fmt::Display for FapiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let msg = match self {
+            Self::KeyGeneration(e) => {
+                crate::tr_args!("fapi-err-key-generation", error = e.as_str())
+            }
+            Self::KeyLoad(e) => crate::tr_args!("fapi-err-key-load", error = e.as_str()),
+            Self::KeySave(e) => crate::tr_args!("fapi-err-key-save", error = e.as_str()),
+            Self::InvalidKeyFormat(e) => {
+                crate::tr_args!("fapi-err-invalid-key-format", error = e.as_str())
+            }
+            Self::JwtSigning(e) => crate::tr_args!("fapi-err-jwt-signing", error = e.as_str()),
+            Self::Serialization(e) => {
+                crate::tr_args!("fapi-err-serialization", error = e.to_string())
+            }
+            Self::ThumbprintComputation(e) => {
+                crate::tr_args!("fapi-err-thumbprint", error = e.as_str())
+            }
+            Self::KeychainAccess(e) => crate::tr_args!("fapi-err-keychain", error = e.as_str()),
+        };
+        f.write_str(&msg)
+    }
+}
+
+impl std::error::Error for FapiError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Serialization(e) => Some(e),
+            Self::KeyGeneration(_)
+            | Self::KeyLoad(_)
+            | Self::KeySave(_)
+            | Self::InvalidKeyFormat(_)
+            | Self::JwtSigning(_)
+            | Self::ThumbprintComputation(_)
+            | Self::KeychainAccess(_) => None,
+        }
+    }
+}
+
+impl From<serde_json::Error> for FapiError {
+    fn from(e: serde_json::Error) -> Self {
+        Self::Serialization(e)
+    }
 }
 
 #[cfg(test)]

--- a/crates/vouch-cli/src/integrations/docker.rs
+++ b/crates/vouch-cli/src/integrations/docker.rs
@@ -42,14 +42,14 @@ fn check_docker_status(status: &DockerSetupStatus) -> IntegrationState {
 
     if !status.symlink_exists {
         return IntegrationState::Partial {
-            message: "credential helper not installed".to_string(),
+            message: crate::tr!("integration-docker-helper-not-installed"),
             setup_hint: Some("vouch setup docker --configure".to_string()),
         };
     }
 
     if status.configured_registries.is_empty() {
         return IntegrationState::Partial {
-            message: "no registries configured".to_string(),
+            message: crate::tr!("integration-docker-no-registries"),
             setup_hint: Some("vouch setup docker --configure <registry>".to_string()),
         };
     }

--- a/crates/vouch-cli/src/main.rs
+++ b/crates/vouch-cli/src/main.rs
@@ -15,7 +15,7 @@ use tracing_subscriber::EnvFilter;
 // `vouch` binary (e.g. `fido2/unix.rs`, which is compiled into both the lib
 // and the bin) can reference them as `crate::tr!` regardless of compilation
 // context.
-use vouch_cli::{tr, tr_args, tr_eprintln, tr_println};
+pub(crate) use vouch_cli::{tr, tr_args, tr_eprintln, tr_println};
 
 mod client;
 mod commands;
@@ -462,7 +462,7 @@ async fn main() -> ExitCode {
     match run().await {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
-            eprintln!("Error: {err:#}");
+            vouch_cli::tr_eprintln!("cli-error-prefix", error = format!("{err:#}"));
             exit_code::classify(&err)
         }
     }

--- a/crates/vouch-cli/src/server_url.rs
+++ b/crates/vouch-cli/src/server_url.rs
@@ -77,24 +77,41 @@ impl AsRef<str> for ServerUrl {
 }
 
 /// Errors from [`ServerUrl::parse`].
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 pub(crate) enum ServerUrlError {
     /// The URL string was empty.
-    #[error("server URL is empty")]
     Empty,
 
     /// The URL could not be parsed.
-    #[error("invalid server URL: {0}")]
     Invalid(String),
 
     /// The URL uses HTTP for a non-loopback host.
-    #[error(
-        "Server URL uses plain HTTP ({0}).\n\
-         Credentials would be sent in plaintext.\n\n\
-         Use an https:// URL, or set --allow-insecure / VOUCH_ALLOW_INSECURE=1 for development."
-    )]
     InsecureHttp(String),
 }
+
+impl std::fmt::Display for ServerUrlError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Empty => write!(f, "{}", crate::tr!("server-url-err-empty")),
+            Self::Invalid(detail) => {
+                write!(
+                    f,
+                    "{}",
+                    crate::tr_args!("server-url-err-invalid", detail = detail.as_str())
+                )
+            }
+            Self::InsecureHttp(url) => {
+                write!(
+                    f,
+                    "{}",
+                    crate::tr_args!("server-url-err-insecure-http", url = url.as_str())
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ServerUrlError {}
 
 #[cfg(test)]
 #[expect(
@@ -136,6 +153,32 @@ mod tests {
             result.unwrap_err(),
             ServerUrlError::InsecureHttp(_)
         ));
+    }
+
+    #[test]
+    fn error_display_resolves_from_catalog() {
+        assert_eq!(ServerUrlError::Empty.to_string(), "server URL is empty");
+        assert_eq!(
+            ServerUrlError::Invalid("bad".to_string()).to_string(),
+            "invalid server URL: bad"
+        );
+        let msg = ServerUrlError::InsecureHttp("http://x".to_string()).to_string();
+        assert!(
+            msg.contains("Server URL uses plain HTTP (http://x)."),
+            "{msg}"
+        );
+        assert!(
+            msg.contains("Credentials would be sent in plaintext."),
+            "{msg}"
+        );
+        assert!(
+            msg.contains("--allow-insecure / VOUCH_ALLOW_INSECURE=1"),
+            "{msg}"
+        );
+        assert!(
+            msg.contains("plaintext.\n\nUse an https://"),
+            "blank line between paragraphs must survive Fluent round-trip: {msg:?}"
+        );
     }
 
     #[test]

--- a/crates/vouch-cli/src/utils.rs
+++ b/crates/vouch-cli/src/utils.rs
@@ -76,7 +76,10 @@ pub(crate) fn create_symlink_with_fallback(
     {
         fs::create_dir_all(parent)
             .with_context(|| format!("failed to create directory {}", parent.display()))?;
-        println!("Created directory: {}", parent.display());
+        crate::tr_println!(
+            "utils-created-directory",
+            path = parent.display().to_string()
+        );
     }
 
     #[cfg(unix)]
@@ -107,10 +110,10 @@ pub(crate) fn create_symlink_with_fallback(
         std::os::unix::fs::symlink(vouch_path, symlink_path)
             .with_context(|| format!("failed to create symlink at {}", symlink_path.display()))?;
 
-        println!(
-            "Created symlink: {} -> {}",
-            symlink_path.display(),
-            vouch_path.display()
+        crate::tr_println!(
+            "utils-created-symlink",
+            link = symlink_path.display().to_string(),
+            target = vouch_path.display().to_string()
         );
 
         // Check if the symlink directory is in PATH
@@ -119,8 +122,8 @@ pub(crate) fn create_symlink_with_fallback(
             && !std::env::split_paths(&path_var).any(|p| p == parent)
         {
             println!();
-            println!("Note: {} is not in your PATH.", parent.display());
-            println!("Add it to your shell profile:");
+            crate::tr_println!("utils-path-note", path = parent.display().to_string());
+            crate::tr_println!("utils-path-profile-hint");
             println!("  export PATH=\"$PATH:{}\"", parent.display());
         }
     }
@@ -137,15 +140,15 @@ pub(crate) fn create_symlink_with_fallback(
         vouch_common::fs::atomic_write(&bat_path, windows_batch_content.as_bytes())
             .with_context(|| format!("failed to create {}", bat_path.display()))?;
 
-        println!("Created: {}", bat_path.display());
+        crate::tr_println!("utils-created-file", path = bat_path.display().to_string());
 
         if let Some(parent) = bat_path.parent() {
             if let Ok(path_var) = std::env::var("PATH")
                 && !std::env::split_paths(&path_var).any(|p| p == parent)
             {
                 println!();
-                println!("Note: {} is not in your PATH.", parent.display());
-                println!("Add it to your system PATH environment variable.");
+                crate::tr_println!("utils-path-note", path = parent.display().to_string());
+                crate::tr_println!("utils-path-windows-hint");
             }
         }
     }

--- a/crates/vouch-server/i18n/en-US/vouch-server.ftl
+++ b/crates/vouch-server/i18n/en-US/vouch-server.ftl
@@ -756,3 +756,9 @@ logout-confirm-cancel = Cancel
 logout-done-title = { -product } - Signed Out
 logout-done-heading = You have been signed out.
 logout-done-body = Your session has ended. Close this tab or return to the application.
+
+## Redirect interstitials (form_post_response.html, saml_post_form.html)
+redirect-title = Redirecting...
+redirect-continue = Continue
+redirect-form-post-noscript = Submitting authorization response. If you are not redirected, click the button below.
+redirect-saml-noscript = Redirecting to identity provider. If you are not redirected, click the button below.

--- a/crates/vouch-server/templates/form_post_response.html
+++ b/crates/vouch-server/templates/form_post_response.html
@@ -1,16 +1,16 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ self.lang() }}" dir="{{ self.dir() }}">
 <head>
   <meta charset="utf-8">
-  <title>Redirecting...</title>
+  <title>{{ self.tr("redirect-title") }}</title>
 </head>
 <body onload="document.forms[0].submit()">
-  <noscript><p>Submitting authorization response. If you are not redirected, click the button below.</p></noscript>
+  <noscript><p>{{ self.tr("redirect-form-post-noscript") }}</p></noscript>
   <form method="post" action="{{ redirect_uri|e }}">
     {% for (name, value) in params %}
     <input type="hidden" name="{{ name|e }}" value="{{ value|e }}">
     {% endfor %}
-    <noscript><button type="submit">Continue</button></noscript>
+    <noscript><button type="submit">{{ self.tr("redirect-continue") }}</button></noscript>
   </form>
 </body>
 </html>

--- a/crates/vouch-server/templates/saml_post_form.html
+++ b/crates/vouch-server/templates/saml_post_form.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ self.lang() }}" dir="{{ self.dir() }}">
 <head>
   <meta charset="utf-8">
-  <title>Redirecting...</title>
+  <title>{{ self.tr("redirect-title") }}</title>
 </head>
 <body>
-  <noscript><p>Redirecting to identity provider. If you are not redirected, click the button below.</p></noscript>
+  <noscript><p>{{ self.tr("redirect-saml-noscript") }}</p></noscript>
   <form method="post" action="{{ action_url }}">
     <input type="hidden" name="SAMLRequest" value="{{ saml_request }}">
     <input type="hidden" name="RelayState" value="{{ relay_state }}">
-    <noscript><button type="submit">Continue</button></noscript>
+    <noscript><button type="submit">{{ self.tr("redirect-continue") }}</button></noscript>
   </form>
   <script src="/static/js/saml-autosubmit.js" defer></script>
 </body>


### PR DESCRIPTION
## Summary

Implements #643 — the remaining user-facing strings found by the i18n audit now resolve from the Fluent catalogs, so adding a locale is purely catalog content. en-US output is byte-identical.

**Server** (4 new catalog entries):
- `form_post_response.html` and `saml_post_form.html` translate their title, `<noscript>` fallback text, and Continue button, and gain `lang`/`dir` attributes matching `base.html`. The server completeness test (`every_template_key_is_defined`, incl. its dead-entry check) covers the new entries.

**CLI** (~20 new catalog entries):
- `utils.rs` helper-install messages and PATH hints, the four RFC 9421 signing warnings in `client.rs`, the docker integration status lines, and the top-level `Error:` prefix in `main.rs` now use the `tr` macro family. The bin-root macro import is `pub(crate)` so modules compiled into both the lib and the bin (e.g. `utils.rs`) can use `crate::tr_println!`.
- `CliError`, `ServerUrlError`, and `FapiError` move from `thiserror` `#[error]` texts to manual `Display` impls resolving from the catalog. `source()` chaining and `From<serde_json::Error>` are preserved. Exit-code classification is unaffected: the typed downcast in `classify()` runs before the English message-pattern fallback (that fallback still depends on English text from other crates' errors — pre-existing, out of scope).
- Shell commands printed for copy-paste (`export PATH=...`, `vouch setup docker --configure`) stay literal by design.

**New tests**: display round-trip assertions for `ServerUrlError` (including proof that the multiline insecure-HTTP message keeps its paragraph break through Fluent) and the three translated `CliError` variants. The existing 8 `FapiError` display tests pass unchanged against the catalog.

Out of scope, per the issue: OS/brand names on install/landing pages (exempt), clap's built-in error strings, log lines.

Closes #643.

## Test plan

- `make fmt`, `make lint` clean (zero warnings)
- `make test` exit 0 (server i18n completeness tests: 24 passed; CLI: 617 lib + 119 bin tests)
- `make test-integration` exit 0
- Grep-verified the old hardcoded strings are gone from templates and CLI sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String and localization plumbing only; exit-code behavior stays type-driven and en-US output is intended to be unchanged.
> 
> **Overview**
> Completes the i18n audit by moving **remaining hardcoded user-facing text** into Fluent catalogs so new locales are catalog-only work.
> 
> **Server:** OAuth/SAML redirect interstitials (`form_post_response.html`, `saml_post_form.html`) now use `self.tr()` for title, noscript fallback, and Continue, and pick up **`lang`/`dir`** like other pages.
> 
> **CLI:** Adds ~20 **en-US** keys and switches prints/warnings to `tr!` / `tr_println!` / `tr_eprintln!` in helper install (`utils.rs`), HTTP signing warnings (`client.rs`), Docker status lines, and the top-level **`Error:`** prefix in `main.rs`. **`pub(crate)`** re-exports i18n macros from the binary root so code shared between lib and bin can use `crate::tr_*`.
> 
> **Errors:** `CliError`, `ServerUrlError`, and `FapiError` drop `thiserror` `#[error]` strings in favor of **`Display`** that resolves from the catalog; `FapiError` keeps `source()` / `From<serde_json::Error>`. Exit-code **`classify()`** still keys off typed `CliError` variants, not message text.
> 
> **Tests:** Assert catalog-backed display for translated `CliError` variants and `ServerUrlError` (including multiline insecure-HTTP paragraph breaks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d76e56a9c0a24a4ba3d5cb1e039ed997db16ebc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->