### PR TITLE
refactor(server): consolidate AWS token issuance on RS256

### DIFF
--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -621,9 +621,9 @@ pub(crate) fn resolve_identity_center<'a>(
 /// credentials cannot be downscoped — so caller credentials are always full
 /// (no `ReadOnlyAccess` policy, no DPoP source tag).
 ///
-/// 1. Assume the management role via `AssumeRoleWithWebIdentity` (full creds).
-/// 2. Fetch an RS256 JWT from `GET /v1/credentials/aws/sso/token`.
-/// 3. Exchange it for an IdC access token via `CreateTokenWithIAM`.
+/// 1. Fetch the RS256 AWS token and assume the management role via
+///    `AssumeRoleWithWebIdentity` (full creds).
+/// 2. Exchange the same token for an IdC access token via `CreateTokenWithIAM`.
 pub(crate) async fn obtain_identity_center_token(
     http_client: &reqwest::Client,
     server: &str,
@@ -668,20 +668,13 @@ pub(crate) async fn obtain_identity_center_token(
     .await
     .context("failed to assume management role for IdC exchange")?;
 
-    // Step 2: fetch the RS256 JWT (the TTI assertion). Reuse `client` — the
-    // first `get_authenticated` call doesn't consume it, so there's no need
-    // for a second VouchClient::new (which would waste an IPC + keychain round-trip).
-    let rs256_token: OidcTokenResponse = client
-        .get_authenticated("/v1/credentials/aws/sso/token")
-        .await
-        .context("failed to get RS256 IdC token from Vouch server")?;
-
-    // Step 3: exchange for IdC access token.
+    // Step 2: exchange the same RS256 token (the TTI assertion) for an IdC
+    // access token.
     crate::integrations::aws::identity_center::create_token_with_iam(
         http_client,
         &idc.region,
         &idc.application_arn,
-        rs256_token.id_token.expose_secret(),
+        id_token,
         &caller_creds,
     )
     .await

--- a/crates/vouch-cli/src/integrations/aws/identity_center.rs
+++ b/crates/vouch-cli/src/integrations/aws/identity_center.rs
@@ -37,9 +37,9 @@ struct CreateTokenResponse {
 /// `sso-oidc:CreateTokenWithIAM` (`jwt-bearer` grant).
 ///
 /// `application_arn` is the customer-managed application's ARN (the `clientId`).
-/// `assertion_jwt` is the RS256 token from
-/// `GET /v1/credentials/aws/sso/token`. `caller_creds` are the
-/// SigV4 caller credentials (the management role, assumed via web identity,
+/// `assertion_jwt` is the RS256 token from `GET /v1/credentials/aws/token` —
+/// the same token used for the management-role `AssumeRoleWithWebIdentity`.
+/// `caller_creds` are the SigV4 caller credentials (the management role,
 /// which must hold `sso-oauth:CreateTokenWithIAM`).
 pub(crate) async fn create_token_with_iam(
     http_client: &reqwest::Client,

--- a/crates/vouch-server/src/handlers/credentials.rs
+++ b/crates/vouch-server/src/handlers/credentials.rs
@@ -4,7 +4,7 @@
 use crate::AppState;
 use crate::db::{self, GitHubCredentialAuditData};
 use crate::error::ServiceError;
-use crate::services::integrations::aws::{AwsError, issue_aws_token, issue_sso_jwt};
+use crate::services::integrations::aws::{AwsError, issue_aws_token};
 use crate::services::integrations::github::{GitHubInstallationId, minimal_git_permissions};
 use crate::services::oidc;
 use axum::extract::OriginalUri;
@@ -449,12 +449,16 @@ fn map_aws_error(e: AwsError) -> ServiceError {
     }
 }
 
-/// Get an OIDC ID token for AWS STS AssumeRoleWithWebIdentity.
+/// Get an OIDC ID token for AWS.
 ///
 /// GET /v1/credentials/aws/token
 ///
-/// Returns an **ES256** OIDC ID token that can be used with AWS STS to assume a
-/// role. The AWS IAM role must be configured to trust the Vouch OIDC provider.
+/// Returns an **RS256** OIDC ID token that serves both AWS consumers: STS
+/// `AssumeRoleWithWebIdentity` (the IAM role must trust the Vouch OIDC
+/// provider) and IAM Identity Center `sso-oidc:CreateTokenWithIAM`, where it
+/// is the `jwt-bearer` assertion (the trusted-token-issuer contract requires
+/// RS256; the customer-managed application's Aud claim must be the Vouch
+/// issuer URL).
 ///
 /// When the DPoP proof includes a `source` custom claim (e.g., "claude-code"),
 /// the issued token includes AI-specific session tags (`vouch:AccessType=AI`,
@@ -472,59 +476,9 @@ pub(crate) async fn get_aws_token(
             .await?;
 
     // Issue AWS token using the session-time snapshot of aaguid and org domain.
-    // Sign with the org's own ES256 key when it has a claimed subdomain, so the
-    // token verifies against the org-host JWKS; otherwise the common key.
-    let config = state.config();
-    let org_keys = oidc::resolve_org_keys(&state, ctx.org.as_ref())
-        .await
-        .map_err(map_signing_key_error)?;
-    let es_key = org_keys
-        .as_deref()
-        .map_or(&state.oidc_key, |k| &k.signers.es256);
-    let result = issue_aws_token(
-        &ctx.issuer,
-        config.session_hours,
-        es_key,
-        &ctx.user_email,
-        &ctx.token,
-    )
-    .await
-    .map_err(map_aws_error)?;
-
-    crate::infra::metrics::record_credential_issuance("aws");
-
-    Ok(Json(AwsTokenResponse {
-        id_token: result.id_token,
-        expires_in: result.expires_in,
-    }))
-}
-
-/// Get an RS256 OIDC ID token for AWS IAM Identity Center trusted identity
-/// propagation.
-///
-/// GET /v1/credentials/aws/sso/token
-///
-/// The token is the subject (`assertion`) for `sso-oidc:CreateTokenWithIAM`
-/// (`jwt-bearer` grant). This is a distinct endpoint from the ES256
-/// `AssumeRoleWithWebIdentity` token because AWS's trusted-token-issuer contract
-/// requires RS256. The token's `aud` is the Vouch issuer (server base URL); the
-/// customer-managed application's Aud claim must be set to that same URL. The
-/// same hardware-verification gate and AWS session tags apply.
-pub(crate) async fn get_aws_sso_token(
-    method: Method,
-    uri: OriginalUri,
-    headers: HeaderMap,
-    jar: CookieJar,
-    State(state): State<Arc<AppState>>,
-    client_cert: OptionalClientCert,
-) -> Result<Json<AwsTokenResponse>, ServiceError> {
-    let ctx =
-        authorize_aws_token_request(&state, &headers, &jar, &method, uri.path(), &client_cert)
-            .await?;
-
     // Sign with the org's own RS256 key when it has a claimed subdomain, so the
     // token verifies against the org-host JWKS; otherwise the common RSA key
-    // (which may be absent — Identity Center then isn't available).
+    // (always initialized at startup; the error branch is defensive).
     let org_keys = oidc::resolve_org_keys(&state, ctx.org.as_ref())
         .await
         .map_err(map_signing_key_error)?;
@@ -533,7 +487,7 @@ pub(crate) async fn get_aws_sso_token(
         .map(|k| &k.signers.rs256)
         .or(state.oidc_rsa_key.as_ref())
         .ok_or_else(|| {
-            tracing::error!("Identity Center token requested but no OIDC RSA key configured");
+            tracing::error!("AWS token requested but no OIDC RSA key configured");
             ServiceError::api(
                 StatusCode::NOT_IMPLEMENTED,
                 "rsa_key_unavailable",
@@ -542,7 +496,7 @@ pub(crate) async fn get_aws_sso_token(
         })?;
 
     let config = state.config();
-    let result = issue_sso_jwt(
+    let result = issue_aws_token(
         &ctx.issuer,
         config.session_hours,
         rsa_key,
@@ -552,7 +506,7 @@ pub(crate) async fn get_aws_sso_token(
     .await
     .map_err(map_aws_error)?;
 
-    crate::infra::metrics::record_credential_issuance("aws_sso");
+    crate::infra::metrics::record_credential_issuance("aws");
 
     Ok(Json(AwsTokenResponse {
         id_token: result.id_token,
@@ -1185,7 +1139,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_aws_token_returns_token_for_valid_session() {
-        let (app, state) = test_app().await;
+        use base64::Engine;
+
+        let state = test_app_state_with_rsa_key().await;
+        let config = state.config();
+        let app = crate::infra::router::build_app(state.clone(), &config).expect("build app");
 
         let user = create_test_user(&state.store, "user@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
@@ -1200,42 +1158,40 @@ mod tests {
 
         assert_eq!(status, StatusCode::OK);
         let resp: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
-        assert!(resp["id_token"].is_string());
         assert!(resp["expires_in"].is_number());
-    }
-
-    /// The dedicated Identity Center endpoint issues an RS256 token (AWS trusted
-    /// token issuer contract) for a hardware-verified session.
-    #[tokio::test]
-    async fn test_aws_sso_token_returns_rs256_for_valid_session() {
-        use base64::Engine;
-
-        let state = test_app_state_with_rsa_key().await;
-        let config = state.config();
-        let app = crate::infra::router::build_app(state.clone(), &config).expect("build app");
-
-        let user = create_test_user(&state.store, "sso@example.com").await;
-        let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
-
-        let (status, body) = http_get(
-            &app,
-            "/v1/credentials/aws/sso/token",
-            &[("Authorization", &format!("Bearer {token}"))],
-        )
-        .await;
-
-        assert_eq!(status, StatusCode::OK);
-        let resp: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
         let id_token = resp["id_token"].as_str().expect("id_token string");
 
-        // The header `alg` must be RS256 (vs ES256 for the web-identity endpoint).
+        // RS256, so the one token serves both AssumeRoleWithWebIdentity and
+        // the Identity Center CreateTokenWithIAM assertion.
         let header_b64 = id_token.split('.').next().expect("jwt header");
         let header_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
             .decode(header_b64)
             .expect("base64url header");
         let header: serde_json::Value = serde_json::from_slice(&header_bytes).expect("header JSON");
         assert_eq!(header["alg"], "RS256");
+    }
+
+    /// Without an RSA key in AppState the handler fails closed with 501.
+    /// Startup always initializes the key, so this exercises the defensive
+    /// branch rather than a reachable production state.
+    #[tokio::test]
+    async fn test_aws_token_without_rsa_key_returns_501() {
+        let (app, state) = test_app().await;
+
+        let user = create_test_user(&state.store, "norsa@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+
+        let (status, body) = http_get(
+            &app,
+            "/v1/credentials/aws/token",
+            &[("Authorization", &format!("Bearer {token}"))],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::NOT_IMPLEMENTED);
+        let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+        assert_eq!(error["code"], "rsa_key_unavailable");
     }
 
     /// Regression for #451: a non-hardware-verified bootstrap session
@@ -1294,7 +1250,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_aws_token_returns_token_for_org_user() {
-        let (app, state) = test_app().await;
+        let state = test_app_state_with_rsa_key().await;
+        let config = state.config();
+        let app = crate::infra::router::build_app(state.clone(), &config).expect("build app");
 
         let org = create_test_org(&state.store, "example.com").await;
         let user =

--- a/crates/vouch-server/src/infra/router.rs
+++ b/crates/vouch-server/src/infra/router.rs
@@ -293,10 +293,6 @@ fn build_credential_routes(
             get(handlers::credentials::get_aws_token),
         )
         .route(
-            "/v1/credentials/aws/sso/token",
-            get(handlers::credentials::get_aws_sso_token),
-        )
-        .route(
             "/v1/credentials/github/token",
             post(handlers::credentials::get_github_token),
         )

--- a/crates/vouch-server/src/infra/startup.rs
+++ b/crates/vouch-server/src/infra/startup.rs
@@ -447,6 +447,15 @@ async fn build_app_state(
         })
         .await
         .map_err(|e| anyhow::anyhow!("RSA key generation task panicked: {e}"))??;
+
+        if config.oidc_rsa_signing_key.is_none() {
+            tracing::warn!(
+                "Using ephemeral OIDC RSA signing key -- AWS credential tokens \
+                 (and RS256 ID tokens) will fail verification after a restart \
+                 and across multiple instances. Set VOUCH_OIDC_RSA_SIGNING_KEY \
+                 or VOUCH_OIDC_RSA_SIGNING_KMS_KEY_ID to persist."
+            );
+        }
         tracing::info!("OIDC RSA signing key initialized: {}", key.key_id());
         Some(key)
     };

--- a/crates/vouch-server/src/services/integrations/aws.rs
+++ b/crates/vouch-server/src/services/integrations/aws.rs
@@ -63,7 +63,7 @@
 //! }
 //! ```
 
-use crate::crypto::keys::{OidcRsaSigningKey, OidcSigningKey};
+use crate::crypto::keys::OidcRsaSigningKey;
 use crate::redact_email;
 use crate::services::auth::ValidatedResourceToken;
 use crate::services::oidc::{AwsSessionTags, OidcIdTokenClaimsBuilder};
@@ -129,10 +129,15 @@ fn build_aws_session_tags(
     }
 }
 
-/// Issue an OIDC ID token for AWS STS.
+/// Issue an OIDC ID token for AWS.
 ///
-/// The token can be used with `AssumeRoleWithWebIdentity` to get temporary
-/// AWS credentials. The token includes:
+/// The token serves two AWS consumers: STS `AssumeRoleWithWebIdentity` (for
+/// temporary credentials) and IAM Identity Center `sso-oidc:CreateTokenWithIAM`
+/// (as the `jwt-bearer` assertion for trusted identity propagation). It is
+/// signed with **RS256** because the Identity Center trusted-token-issuer
+/// contract rejects ES256, while STS accepts both. The token's `iss` matches
+/// the Vouch OIDC discovery document and its public key is published in the
+/// JWKS, so both consumers can verify the signature. The token includes:
 /// - `sub`: User email
 /// - `aud`: Vouch issuer URL (AWS matches against the OIDC provider)
 /// - `iss`: Vouch issuer URL
@@ -143,7 +148,7 @@ fn build_aws_session_tags(
 /// * `issuer` - Issuer URL (`iss` and `aud`): the org's claimed issuer
 ///   subdomain when one exists, otherwise the server base URL
 /// * `session_hours` - Session duration in hours
-/// * `oidc_key` - OIDC signing key
+/// * `oidc_rsa_key` - OIDC RSA (RS256) signing key
 /// * `user_email` - The authenticated user's email (resolved with a DB fallback,
 ///   so it is passed explicitly rather than read from the token)
 /// * `token` - The validated resource token; supplies the session-snapshot
@@ -151,7 +156,7 @@ fn build_aws_session_tags(
 pub(crate) async fn issue_aws_token(
     issuer: &str,
     session_hours: u64,
-    oidc_key: &OidcSigningKey,
+    oidc_rsa_key: &OidcRsaSigningKey,
     user_email: &str,
     token: &ValidatedResourceToken,
 ) -> AwsResult<AwsTokenResult> {
@@ -174,88 +179,14 @@ pub(crate) async fn issue_aws_token(
         .build()
         .map_err(|e| AwsError::ClaimsBuild(e.to_string()))?;
 
-    // Sign the token with ES256
-    let id_token = oidc_key
-        .sign_jwt(&id_claims)
-        .await
-        .map_err(|e| AwsError::TokenSign(e.to_string()))?;
-
-    tracing::info!("Issued AWS OIDC token for {}", redact_email(user_email));
-
-    Ok(AwsTokenResult {
-        id_token,
-        expires_in,
-    })
-}
-
-/// Issue an **RS256**-signed OIDC ID token for AWS IAM Identity Center trusted
-/// identity propagation.
-///
-/// This token is the subject (`assertion`) for the IAM Identity Center
-/// `sso-oidc:CreateTokenWithIAM` call (`jwt-bearer` grant), which exchanges it
-/// for an Identity Center token. That token then drives the SSO Portal
-/// (`ListAccounts`/`ListAccountRoles`/`GetRoleCredentials`) to reach every
-/// account+permission-set the user is assigned to — without role chaining.
-///
-/// AWS's trusted-token-issuer contract **requires RS256** (the
-/// `AssumeRoleWithWebIdentity` path uses ES256 via [`issue_aws_token`]; this
-/// path is distinct and signs with [`OidcRsaSigningKey`]). The token's `iss`
-/// matches the Vouch OIDC discovery document and its public key is published in
-/// the JWKS, so Identity Center can verify the signature.
-///
-/// The `aud` claim is set to the issuer, matching the STS token
-/// ([`issue_aws_token`]); the customer-managed application's Aud claim
-/// must be configured to that same URL. This path therefore differs from
-/// [`issue_aws_token`] only by signing algorithm.
-///
-/// # Arguments
-/// * `issuer` - Issuer URL (`iss` and `aud`; must match the registered TTI):
-///   the org's claimed issuer subdomain when one exists, otherwise the
-///   server base URL
-/// * `session_hours` - Session duration in hours
-/// * `oidc_rsa_key` - OIDC RSA (RS256) signing key
-/// * `user_email` - Authenticated user's email (maps to the Identity Store user;
-///   resolved with a DB fallback, so it is passed explicitly rather than read
-///   from the token)
-/// * `token` - The validated resource token; supplies the session-snapshot
-///   `hardware_aaguid`, `org_domain` (`hd`), and `dpop_source` federation claims
-pub(crate) async fn issue_sso_jwt(
-    issuer: &str,
-    session_hours: u64,
-    oidc_rsa_key: &OidcRsaSigningKey,
-    user_email: &str,
-    token: &ValidatedResourceToken,
-) -> AwsResult<AwsTokenResult> {
-    let expires_in = session_hours.saturating_mul(3600);
-
-    // Reuse the same AWS session tags as the web-identity path for consistent
-    // ABAC/CloudTrail attribution.
-    let aws_tags = build_aws_session_tags(
-        user_email,
-        token.org_domain.as_deref(),
-        token.dpop_source.as_deref(),
-    );
-
-    // aud = issuer, same as the STS token.
-    let id_claims = OidcIdTokenClaimsBuilder::for_aws(issuer, user_email)
-        .hardware_aaguid(token.hardware_aaguid.clone())
-        .hd(token.org_domain.clone())
-        .aws_tags(aws_tags)
-        .valid_for_seconds(expires_in)
-        .build()
-        .map_err(|e| AwsError::ClaimsBuild(e.to_string()))?;
-
     // Sign with RS256 — required by the AWS IAM Identity Center trusted token
-    // issuer contract.
+    // issuer contract; STS accepts it for AssumeRoleWithWebIdentity as well.
     let id_token = oidc_rsa_key
         .sign_jwt(&id_claims)
         .await
         .map_err(|e| AwsError::TokenSign(e.to_string()))?;
 
-    tracing::info!(
-        "Issued AWS Identity Center JWT (RS256) for {}",
-        redact_email(user_email)
-    );
+    tracing::info!("Issued AWS OIDC token for {}", redact_email(user_email));
 
     Ok(AwsTokenResult {
         id_token,
@@ -271,9 +202,16 @@ pub(crate) async fn issue_sso_jwt(
 )]
 mod tests {
     use super::*;
-    use crate::crypto::keys::{OidcRsaSigningKey, OidcSigningKey};
+    use crate::crypto::keys::OidcRsaSigningKey;
     use base64::Engine;
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+    /// Shared RSA-3072 signing key — generated once because RSA key
+    /// generation is slow enough to dominate per-test runtime.
+    fn test_rsa_key() -> &'static OidcRsaSigningKey {
+        static KEY: std::sync::OnceLock<OidcRsaSigningKey> = std::sync::OnceLock::new();
+        KEY.get_or_init(|| OidcRsaSigningKey::generate().expect("Failed to generate RSA key"))
+    }
 
     /// Decode a JWT payload (middle part) into a `serde_json::Value` without
     /// signature verification. Used only in tests to inspect claims.
@@ -325,76 +263,38 @@ mod tests {
         }
     }
 
-    /// The Identity Center JWT must be signed with RS256 (AWS TTI requirement),
-    /// unlike the ES256 `AssumeRoleWithWebIdentity` token.
+    /// The AWS token must be signed with RS256: the IAM Identity Center
+    /// trusted-token-issuer contract rejects ES256, and STS accepts RS256
+    /// for `AssumeRoleWithWebIdentity`.
     #[tokio::test]
-    async fn test_sso_jwt_is_rs256_signed() {
-        let rsa_key = OidcRsaSigningKey::generate().expect("Failed to generate RSA key");
-
-        let result = issue_sso_jwt(
+    async fn test_aws_token_is_rs256_signed() {
+        let result = issue_aws_token(
             BASE_URL,
             SESSION_HOURS,
-            &rsa_key,
+            test_rsa_key(),
             USER_EMAIL,
             &test_token(Some(TEST_AAGUID.to_string()), None, None),
         )
         .await
-        .expect("issue_sso_jwt should succeed");
+        .expect("issue_aws_token should succeed");
 
         let header = decode_jwt_header(&result.id_token);
-        assert_eq!(header["alg"], "RS256", "Identity Center JWT must use RS256");
-    }
-
-    /// The JWT carries `iss` = issuer, `aud` = issuer (server base URL), `sub` =
-    /// the user email, and the same AWS session tags as the web-identity path.
-    #[tokio::test]
-    async fn test_sso_jwt_claims_and_tags() {
-        let rsa_key = OidcRsaSigningKey::generate().expect("Failed to generate RSA key");
-
-        let result = issue_sso_jwt(
-            BASE_URL,
-            SESSION_HOURS,
-            &rsa_key,
-            USER_EMAIL,
-            &test_token(
-                None,
-                Some("example.com".to_string()),
-                Some("claude-code".to_string()),
-            ),
-        )
-        .await
-        .expect("issue_sso_jwt should succeed");
+        assert_eq!(header["alg"], "RS256", "AWS token must use RS256");
 
         let claims = decode_jwt_payload(&result.id_token);
         assert_eq!(claims["iss"], BASE_URL, "iss must match the issuer URL");
         assert_eq!(claims["aud"], BASE_URL, "aud must be the issuer URL");
         assert_eq!(claims["sub"], USER_EMAIL, "sub must be the user email");
-
-        let principal_tags = &claims["https://aws.amazon.com/tags"]["principal_tags"];
-        assert_eq!(
-            principal_tags["vouch:Email"],
-            serde_json::json!([USER_EMAIL])
-        );
-        assert_eq!(
-            principal_tags["vouch:Domain"],
-            serde_json::json!(["example.com"])
-        );
-        assert_eq!(
-            principal_tags["vouch:Agent"],
-            serde_json::json!(["claude-code"])
-        );
     }
 
     /// Default tags present: `vouch:Email` is always included; `vouch:AccessType`
     /// and `vouch:Agent` must NOT be present when `source` is `None`.
     #[tokio::test]
     async fn test_default_tags_present_without_source() {
-        let key = OidcSigningKey::generate().expect("Failed to generate OIDC key");
-
         let result = issue_aws_token(
             BASE_URL,
             SESSION_HOURS,
-            &key,
+            test_rsa_key(),
             USER_EMAIL,
             &test_token(Some(TEST_AAGUID.to_string()), None, None),
         )
@@ -424,12 +324,10 @@ mod tests {
     /// Domain tag: when `hd` is `Some`, `vouch:Domain` must be included.
     #[tokio::test]
     async fn test_domain_tag_included_when_hd_present() {
-        let key = OidcSigningKey::generate().expect("Failed to generate OIDC key");
-
         let result = issue_aws_token(
             BASE_URL,
             SESSION_HOURS,
-            &key,
+            test_rsa_key(),
             USER_EMAIL,
             &test_token(
                 Some(TEST_AAGUID.to_string()),
@@ -460,12 +358,10 @@ mod tests {
     /// and `vouch:Agent=<source>` must appear in `principal_tags`.
     #[tokio::test]
     async fn test_agent_tags_added_when_source_present() {
-        let key = OidcSigningKey::generate().expect("Failed to generate OIDC key");
-
         let result = issue_aws_token(
             BASE_URL,
             SESSION_HOURS,
-            &key,
+            test_rsa_key(),
             USER_EMAIL,
             &test_token(
                 Some(TEST_AAGUID.to_string()),
@@ -501,12 +397,10 @@ mod tests {
     /// `vouch:AccessType` nor `vouch:Agent` may appear.
     #[tokio::test]
     async fn test_agent_tags_absent_without_source() {
-        let key = OidcSigningKey::generate().expect("Failed to generate OIDC key");
-
         let result = issue_aws_token(
             BASE_URL,
             SESSION_HOURS,
-            &key,
+            test_rsa_key(),
             USER_EMAIL,
             &test_token(
                 Some(TEST_AAGUID.to_string()),
@@ -535,12 +429,10 @@ mod tests {
     /// present in `principal_tags`.
     #[tokio::test]
     async fn test_all_tags_are_transitive() {
-        let key = OidcSigningKey::generate().expect("Failed to generate OIDC key");
-
         let result = issue_aws_token(
             BASE_URL,
             SESSION_HOURS,
-            &key,
+            test_rsa_key(),
             USER_EMAIL,
             &test_token(
                 Some(TEST_AAGUID.to_string()),
@@ -592,13 +484,12 @@ mod tests {
     /// A per-org issuer subdomain flows through to both `iss` and `aud`.
     #[tokio::test]
     async fn test_org_issuer_sets_iss_and_aud() {
-        let key = OidcSigningKey::generate().expect("Failed to generate OIDC key");
         let org_issuer = "https://acme.us.vouch.sh";
 
         let result = issue_aws_token(
             org_issuer,
             SESSION_HOURS,
-            &key,
+            test_rsa_key(),
             USER_EMAIL,
             &test_token(Some(TEST_AAGUID.to_string()), None, None),
         )
@@ -613,12 +504,10 @@ mod tests {
     /// `expires_in` matches `session_hours * 3600`.
     #[tokio::test]
     async fn test_expires_in_matches_session_hours() {
-        let key = OidcSigningKey::generate().expect("Failed to generate OIDC key");
-
         let result = issue_aws_token(
             BASE_URL,
             4, // 4 hours
-            &key,
+            test_rsa_key(),
             USER_EMAIL,
             &test_token(Some(TEST_AAGUID.to_string()), None, None),
         )
@@ -635,12 +524,10 @@ mod tests {
     /// AAGUID claim is present in the issued token when supplied.
     #[tokio::test]
     async fn test_hardware_aaguid_claim_is_emitted() {
-        let key = OidcSigningKey::generate().expect("Failed to generate OIDC key");
-
         let result = issue_aws_token(
             BASE_URL,
             SESSION_HOURS,
-            &key,
+            test_rsa_key(),
             USER_EMAIL,
             &test_token(Some(TEST_AAGUID.to_string()), None, None),
         )

--- a/crates/vouch-tests/tests/org_subdomains.rs
+++ b/crates/vouch-tests/tests/org_subdomains.rs
@@ -553,7 +553,7 @@ async fn subdomain_ui_rejects_conflicts_and_ineligible_labels() {
 
 #[tokio::test]
 async fn aws_token_uses_org_issuer_when_claimed() {
-    let harness = TestHarness::new().await;
+    let harness = TestHarness::from_state(test_app_state_with_rsa_key().await);
     let org = harness.create_org("acme.com").await.unwrap();
     db::claim_subdomain(&harness.state.store, &org.id, "acme-com")
         .await
@@ -582,7 +582,7 @@ async fn aws_token_uses_org_issuer_when_claimed() {
 
 #[tokio::test]
 async fn aws_token_uses_base_url_without_claim() {
-    let harness = TestHarness::new().await;
+    let harness = TestHarness::from_state(test_app_state_with_rsa_key().await);
     let org = harness.create_org("acme.com").await.unwrap();
     let (_user, _auth_id, token) = harness
         .create_authenticated_org_member("user@acme.com", &org.id)
@@ -604,35 +604,6 @@ async fn aws_token_uses_base_url_without_claim() {
 
     assert_eq!(claims["iss"], "https://test.example.com");
     assert_eq!(claims["aud"], "https://test.example.com");
-}
-
-#[tokio::test]
-async fn aws_sso_token_uses_org_issuer_when_claimed() {
-    let harness = TestHarness::from_state(test_app_state_with_rsa_key().await);
-    let org = harness.create_org("acme.com").await.unwrap();
-    db::claim_subdomain(&harness.state.store, &org.id, "acme-com")
-        .await
-        .unwrap();
-    let (_user, _auth_id, token) = harness
-        .create_authenticated_org_member("user@acme.com", &org.id)
-        .await
-        .unwrap();
-
-    let resp = harness
-        .get_authenticated("/v1/credentials/aws/sso/token", &token)
-        .await
-        .unwrap();
-    assert_eq!(
-        resp.status,
-        200,
-        "body: {}",
-        resp.text().unwrap_or_default()
-    );
-    let body: serde_json::Value = resp.json().unwrap();
-    let claims = decode_jwt_payload(body["id_token"].as_str().unwrap());
-
-    assert_eq!(claims["iss"], "https://acme-com.test.example.com");
-    assert_eq!(claims["aud"], "https://acme-com.test.example.com");
 }
 
 // ============================================================================

--- a/crates/vouch-tests/tests/sig_policy.rs
+++ b/crates/vouch-tests/tests/sig_policy.rs
@@ -41,7 +41,6 @@ const V1_ROUTES: &[(&str, &str, bool)] = &[
     ("POST", "/v1/keys/register/complete", true),
     ("POST", "/v1/credentials/ssh", true),
     ("GET", "/v1/credentials/aws/token", true),
-    ("GET", "/v1/credentials/aws/sso/token", true),
     ("POST", "/v1/credentials/github/token", true),
     ("GET", "/v1/auth/status", false),
     ("GET", "/v1/credentials/ssh/ca", false),
@@ -173,7 +172,7 @@ async fn test_accept_signature_is_sfv_dictionary_on_unsigned() {
     let accept_sig_val = accept_sig
         .expect("accept-signature header must be present on unsigned request to protected route");
 
-    // Must parse as a Dictionary — not a bare inner list (critic C1).
+    // Must parse as a Dictionary — not a bare inner list.
     let dict = parse_dictionary(&accept_sig_val).unwrap_or_else(|e| {
         panic!("Accept-Signature is not a valid SFV Dictionary: {e}\nvalue: {accept_sig_val}")
     });

--- a/docs/src/operations/key-management.md
+++ b/docs/src/operations/key-management.md
@@ -101,7 +101,7 @@ When rotating the OIDC signing key:
 
 ## OIDC RSA Signing Key (RS256)
 
-Used to sign ID tokens with RS256 algorithm per [OIDC Core Section 3.1.3.7](https://openid.net/specs/openid-connect-core-1_0.html#IDToken) and AWS IAM Identity Center trusted-token-issuer tokens. RS256 is the default `id_token_signed_response_alg` in the OIDC specification and must be supported for conformance. Clients can select RS256 via OAuth 2.0 Dynamic Client Registration (`id_token_signed_response_alg` field). AWS's trusted-token-issuer contract also requires RS256 — the Identity Center endpoint (`/v1/credentials/aws/sso/token`) issues RS256-signed tokens for `sso-oidc:CreateTokenWithIAM`, distinct from the ES256 `AssumeRoleWithWebIdentity` token (`/v1/credentials/aws/token`).
+Used to sign ID tokens with RS256 algorithm per [OIDC Core Section 3.1.3.7](https://openid.net/specs/openid-connect-core-1_0.html#IDToken) and all AWS credential tokens. RS256 is the default `id_token_signed_response_alg` in the OIDC specification and must be supported for conformance. Clients can select RS256 via OAuth 2.0 Dynamic Client Registration (`id_token_signed_response_alg` field). The AWS token endpoint (`/v1/credentials/aws/token`) issues one RS256-signed token that serves both STS `AssumeRoleWithWebIdentity` and, as the `sso-oidc:CreateTokenWithIAM` assertion, the IAM Identity Center trusted-token-issuer contract (which rejects ES256).
 
 Access tokens are always signed with ES256 (the OIDC Signing Key above).
 
@@ -123,7 +123,7 @@ VOUCH_OIDC_RSA_SIGNING_KEY="$(base64 -i oidc_rsa_key.pem | tr -d '\n')"
 VOUCH_OIDC_RSA_SIGNING_KMS_KEY_ID=mrk-rsa1234abcd5678
 ```
 
-If neither is set, an ephemeral RSA-3072 key is generated on startup. This means RS256 ID tokens cannot be verified after a server restart unless the same key is provided. A warning is logged when an ephemeral key is generated.
+If neither is set, an ephemeral RSA-3072 key is generated on startup. This means RS256 ID tokens and AWS credential tokens cannot be verified after a server restart, and verification fails across multiple instances (each generates its own key). Any deployment using the AWS integration needs a durable key. A warning is logged when an ephemeral key is generated.
 
 When using KMS, the key must be:
 - Key spec: `RSA_3072`

--- a/docs/src/reference/environment-variables.md
+++ b/docs/src/reference/environment-variables.md
@@ -74,7 +74,7 @@ The previous flat single-IdP variables — `VOUCH_OIDC_ISSUER`, `VOUCH_OIDC_CLIE
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `VOUCH_OIDC_SIGNING_KEY` | No | _(auto-generate)_ | OIDC signing key content (base64-encoded PEM format, P-256 ECDSA). Used for signing access tokens and ID tokens with ES256 algorithm. If not set, an ephemeral key is generated on each server restart (not recommended for production). |
-| `VOUCH_OIDC_RSA_SIGNING_KEY` | No | _(auto-generate)_ | OIDC RSA signing key content (base64-encoded PEM format, RSA-3072). Used for signing ID tokens with RS256 algorithm per OIDC Core Section 3.1.3.7 and AWS IAM Identity Center trusted-token-issuer tokens (`/v1/credentials/aws/sso/token`). Minimum 3072-bit key enforced. If not set, an ephemeral key is generated on each server restart. |
+| `VOUCH_OIDC_RSA_SIGNING_KEY` | No | _(auto-generate)_ | OIDC RSA signing key content (base64-encoded PEM format, RSA-3072). Used for signing ID tokens with RS256 algorithm per OIDC Core Section 3.1.3.7 and all AWS credential tokens (`/v1/credentials/aws/token`, serving both STS `AssumeRoleWithWebIdentity` and IAM Identity Center `CreateTokenWithIAM`). Minimum 3072-bit key enforced. If not set, an ephemeral key is generated on each server restart — AWS token verification then breaks after restarts and across multiple instances, so any deployment using the AWS integration must set this (or the KMS variant). |
 
 ## AWS KMS
 


### PR DESCRIPTION
Closes #647. Extracted from #623, which now retains only the deferred identity-context decision.

## What this does

Signs the AWS credential token (`/v1/credentials/aws/token`) with the RSA key so one RS256
token serves both STS `AssumeRoleWithWebIdentity` and the IAM Identity Center
`CreateTokenWithIAM` assertion, and removes the now-redundant `/v1/credentials/aws/sso/token`
endpoint. The two tokens were already claim-identical (same builder, `iss`, `aud`, tags, TTL);
only the signing key differed.

- `services/integrations/aws.rs` — `issue_aws_token` takes `&OidcRsaSigningKey`; `issue_sso_jwt` deleted.
- `handlers/credentials.rs` — `get_aws_token` resolves the per-org RS256 key, falling back to the
  global RSA key (always initialized at startup; a defensive 501 branch remains and is now tested);
  `get_aws_sso_token` deleted.
- `infra/router.rs` — `/v1/credentials/aws/sso/token` route removed.
- `infra/startup.rs` — startup warning when the RSA key is boot-ephemeral (an ephemeral key on the
  AWS hot path breaks token verification after restarts and across instances).
- `commands/credential/aws.rs` — `obtain_identity_center_token` drops its second token fetch and
  reuses the one token for the management hop and the `CreateTokenWithIAM` assertion.
- Docs: `VOUCH_OIDC_RSA_SIGNING_KEY` reference and key-management page now state the durable-key
  requirement applies to every AWS deployment.

## Testing

- Live-tested 2026-07-07 against us.vouch.sh: an RS256/RSA-3072 token (claim-identical, fetched
  from the old endpoint) was accepted by `AssumeRoleWithWebIdentity` on the direct path — this was
  the one untested assumption, since Vouch had only ever sent ES256 to STS.
- `make lint` (zero warnings), `make test`, `make test-integration` all pass. Module tests now
  assert RS256 on `issue_aws_token`; handler and org-subdomain tests repointed; the sig-policy
  route table row removed.
- Before merge: live re-confirmation on this build — direct role, management chain, Identity
  Center path end-to-end, and the startup warning without `VOUCH_OIDC_RSA_SIGNING_KEY`.

## Version skew

- Old CLI + new server: `/v1/credentials/aws/sso/token` returns 404 — only the Identity Center
  path is lost; the STS path is unaffected (the token is opaque to the CLI).
- New CLI + old server: the single token is ES256, so `CreateTokenWithIAM` rejects it — the
  Identity Center path needs the server upgraded first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes AWS federation signing (ES256→RS256) and removes a public credential endpoint, affecting STS/IdC trust and CLI/server version skew on the Identity Center path.
> 
> **Overview**
> **One RS256 JWT from `GET /v1/credentials/aws/token` now covers both STS `AssumeRoleWithWebIdentity` and IAM Identity Center `CreateTokenWithIAM`.** The separate ES256 STS path and `GET /v1/credentials/aws/sso/token` are removed; `issue_sso_jwt` is folded into `issue_aws_token` with `OidcRsaSigningKey`.
> 
> The CLI **Identity Center flow** fetches a single token and reuses it for the management-role web-identity assume and the TTI assertion (no second server round-trip).
> 
> **Ops/docs:** startup warns when the OIDC RSA key is ephemeral, stressing that AWS verification breaks across restarts and instances; env/key-management docs say AWS deployments need a durable `VOUCH_OIDC_RSA_SIGNING_KEY` (or KMS). Tests and the sig-policy route table drop the SSO token route; handler tests assert RS256 and a defensive `501` when RSA is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 659c88808ebf6006c16889f61e4d31402828e951. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->