### PR TITLE
fix(db): merge repo deltas in modify closure, add OCC test seam

### DIFF
--- a/crates/vouch-server/src/db/github.rs
+++ b/crates/vouch-server/src/db/github.rs
@@ -222,43 +222,36 @@ pub async fn update_github_installation_repos(
 /// Update repositories for a GitHub installation by
 /// adding/removing repos (used by webhook handler).
 ///
-/// # Concurrency note
-///
-/// The read-compute-write sequence here is NOT atomic end-to-end. The initial
-/// read (`get_github_installation_by_installation_id`) and the delta merge
-/// (`for repo in added …`) happen outside the `modify` closure inside
-/// `update_github_installation_repos`, so two concurrent delta webhooks for the
-/// same installation can each read stale repo lists and silently lose the other's
-/// additions/removals. Given that GitHub delivers webhook events sequentially
-/// per installation (low real-world contention), this is deferred rather than
-/// fixed here. If contention becomes a concern the merge logic must move inside
-/// a single `store.modify` closure so it re-reads and re-merges on each OCC retry.
+/// The delta merge runs inside the `store.modify` closure, so every
+/// optimistic-concurrency retry re-reads the current repo list and re-applies
+/// the delta to fresh state: two concurrent delta webhooks for the same
+/// installation both land. The merge is idempotent (adds are deduplicated,
+/// removals filter by name, the result is sorted). If the installation is
+/// deleted between index-resolve and modify, returns `Ok(false)`.
 pub async fn update_github_installation_repos_delta(
     store: &DocumentStore,
     installation_id: i64,
     added: &[String],
     removed: &[String],
 ) -> Result<bool> {
-    let installation = get_github_installation_by_installation_id(store, installation_id).await?;
-
-    let Some(installation) = installation else {
+    let Some(doc_id) = resolve_installation_doc_id(store, installation_id).await? else {
         return Ok(false);
     };
-
-    let mut repos: Vec<String> = installation.repositories.unwrap_or_default();
-
-    // Apply delta
-    for repo in added {
-        if !repos.contains(repo) {
-            repos.push(repo.clone());
-        }
-    }
-    repos.retain(|r| !removed.contains(r));
-
-    // Sort for consistency
-    repos.sort();
-
-    update_github_installation_repos(store, installation_id, &repos).await
+    // Owned copies for the `Fn` closure (may run once per OCC retry).
+    let added_owned = added.to_vec();
+    let removed_owned = removed.to_vec();
+    store
+        .modify::<GitHubInstallationDoc, _>(&doc_id, |data| {
+            let repos = data.repositories.get_or_insert_default();
+            for repo in &added_owned {
+                if !repos.contains(repo) {
+                    repos.push(repo.clone());
+                }
+            }
+            repos.retain(|r| !removed_owned.contains(r));
+            repos.sort();
+        })
+        .await
 }
 
 // ============================================================================

--- a/crates/vouch-server/src/db/organizations/domains.rs
+++ b/crates/vouch-server/src/db/organizations/domains.rs
@@ -1519,6 +1519,80 @@ mod tests {
         );
     }
 
+    /// A domain that flips to Verified between cleanup's read and its
+    /// compare-and-update must not be removed — and must not be *reported* as
+    /// removed: the per-attempt removal list is rewritten on every OCC retry
+    /// so only the committed attempt's removals reach the audit trail. Uses
+    /// the modify test seam to force the flip inside the OCC window.
+    #[tokio::test]
+    async fn cleanup_reports_only_committed_attempt_removals() {
+        use crate::db::documents::organization::OrganizationDoc;
+        use std::sync::Arc;
+
+        let store = fresh_store().await;
+        let org = create_organization(&store, "acme.com", None, None)
+            .await
+            .unwrap();
+
+        // Insert a stale Pending entry eligible for removal.
+        let stale_added = jiff::Timestamp::now()
+            .checked_sub(jiff::Span::new().hours(30 * 24))
+            .unwrap();
+        let mut doc = store
+            .get::<OrganizationDoc>(&org.id)
+            .await
+            .unwrap()
+            .unwrap();
+        doc.data.additional_domains.push(AdditionalDomain {
+            domain: "flips-late.example.com".to_string(),
+            verification_token: "tok".to_string(),
+            added_at: stale_added,
+            added_by_user_id: "u1".to_string(),
+            added_by_email: "u1@example.com".to_string(),
+            consecutive_failures: 0,
+            state: AdditionalDomainState::Pending,
+        });
+        store.update(&org.id, &doc.data).await.unwrap();
+
+        // Hook: verify the domain inside the OCC window, forcing a retry
+        // whose fresh read sees a Verified entry that must be kept.
+        let writer = store.clone();
+        let hook_org_id = org.id.clone();
+        let mut hooked = store.clone();
+        hooked.set_modify_test_hook(Arc::new(move |_doc_id: &str, attempt: u32| {
+            let writer = writer.clone();
+            let hook_org_id = hook_org_id.clone();
+            Box::pin(async move {
+                if attempt != 0 {
+                    return;
+                }
+                mark_additional_domain_verified(&writer, &hook_org_id, "flips-late.example.com")
+                    .await
+                    .unwrap();
+            })
+        }));
+
+        let removed = cleanup_stale_additional_domains(
+            &hooked,
+            jiff::Timestamp::now(),
+            jiff::Span::new().hours(7 * 24),
+            jiff::Span::new().hours(14 * 24),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            removed.is_empty(),
+            "a domain verified mid-cleanup must not be reported as removed: {removed:?}"
+        );
+        let list = list_additional_domains(&store, &org.id).await.unwrap();
+        assert_eq!(list.len(), 1, "the verified domain must survive cleanup");
+        assert!(
+            matches!(list[0].state, AdditionalDomainState::Verified { .. }),
+            "the entry must still be verified"
+        );
+    }
+
     /// Regression for issue #380. `cleanup_stale_additional_domains` computes
     /// its removal candidate set from a [`list_all_paginated`] snapshot, but
     /// the actual delete happens later inside [`DocumentStore::modify`]. If

--- a/crates/vouch-server/src/db/store.rs
+++ b/crates/vouch-server/src/db/store.rs
@@ -294,13 +294,41 @@ fn index_value_condition_aliased(
 pub struct DocumentStore {
     pool: Pool,
     crypto: Arc<dyn DocumentCrypto>,
+    /// See [`ModifyTestHook`]. Compiled out of non-test builds.
+    #[cfg(test)]
+    modify_test_hook: Option<ModifyTestHook>,
 }
+
+/// Boxed future returned by a [`ModifyTestHook`].
+#[cfg(test)]
+pub(crate) type ModifyHookFuture =
+    std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>>;
+
+/// Test-only hook invoked inside [`DocumentStore::modify`] between the
+/// internal read and the compare-and-update, receiving `(doc_id, attempt)`.
+///
+/// Lets tests deterministically interleave a concurrent write into the OCC
+/// window (forcing a version-conflict retry) without relying on
+/// task-scheduling races.
+#[cfg(test)]
+pub(crate) type ModifyTestHook = Arc<dyn Fn(&str, u32) -> ModifyHookFuture + Send + Sync>;
 
 impl DocumentStore {
     /// Create a new document store.
     #[must_use]
     pub fn new(pool: Pool, crypto: Arc<dyn DocumentCrypto>) -> Self {
-        Self { pool, crypto }
+        Self {
+            pool,
+            crypto,
+            #[cfg(test)]
+            modify_test_hook: None,
+        }
+    }
+
+    /// Install a hook that runs inside `modify` between the read and the CAS.
+    #[cfg(test)]
+    pub(crate) fn set_modify_test_hook(&mut self, hook: ModifyTestHook) {
+        self.modify_test_hook = Some(hook);
     }
 
     /// Access the underlying pool (for migrations and raw queries).
@@ -716,6 +744,10 @@ impl DocumentStore {
             let Some(doc) = self.get::<T>(id).await? else {
                 return Ok(false);
             };
+            #[cfg(test)]
+            if let Some(hook) = &self.modify_test_hook {
+                hook(id, attempt).await;
+            }
             let version = doc.version;
             let mut data = doc.data;
             modifier(&mut data);

--- a/crates/vouch-server/src/db/store.rs
+++ b/crates/vouch-server/src/db/store.rs
@@ -2219,6 +2219,83 @@ mod tests {
         assert_eq!(fetched.data.value, 15);
     }
 
+    /// A conflicting write on every attempt must exhaust the retry budget and
+    /// surface the version-conflict error rather than spinning or reporting
+    /// success. Uses the modify test seam to conflict deterministically.
+    #[tokio::test]
+    async fn modify_version_conflict_on_every_attempt_exhausts_retries() {
+        let mut store = test_store().await;
+        let doc = TestDoc {
+            name: "conflict-me".to_string(),
+            value: 1,
+        };
+        let inserted = store.insert(&doc).await.unwrap();
+        let doc_id = inserted.id.clone();
+
+        let writer = store.clone();
+        store.set_modify_test_hook(Arc::new(move |id: &str, _attempt: u32| {
+            let writer = writer.clone();
+            let id = id.to_string();
+            Box::pin(async move {
+                // Conflict on every attempt: any write bumps the version, so
+                // the in-flight compare_and_update always loses.
+                let current = writer.get::<TestDoc>(&id).await.unwrap().unwrap();
+                writer.update(&id, &current.data).await.unwrap();
+            })
+        }));
+
+        let err = store
+            .modify::<TestDoc, _>(&doc_id, |d| {
+                d.value += 1;
+            })
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("version conflict after retries"),
+            "exhausted retries must surface the version-conflict error, got: {err}"
+        );
+    }
+
+    /// A document deleted between `modify`'s read and its compare-and-update
+    /// is gone on the retry's re-read: `modify` must return `Ok(false)` rather
+    /// than erroring or resurrecting the document. The existing
+    /// deleted-between-resolve-and-modify coverage only deletes before the
+    /// first read; this exercises deletion mid-loop.
+    #[tokio::test]
+    async fn modify_doc_deleted_mid_loop_returns_false() {
+        let mut store = test_store().await;
+        let doc = TestDoc {
+            name: "delete-me".to_string(),
+            value: 1,
+        };
+        let inserted = store.insert(&doc).await.unwrap();
+        let doc_id = inserted.id.clone();
+
+        let writer = store.clone();
+        store.set_modify_test_hook(Arc::new(move |id: &str, attempt: u32| {
+            let writer = writer.clone();
+            let id = id.to_string();
+            Box::pin(async move {
+                if attempt != 0 {
+                    return;
+                }
+                writer.delete(&id).await.unwrap();
+            })
+        }));
+
+        let found = store
+            .modify::<TestDoc, _>(&doc_id, |d| {
+                d.value += 1;
+            })
+            .await
+            .unwrap();
+        assert!(!found, "doc deleted mid-loop must yield Ok(false)");
+        assert!(
+            store.get::<TestDoc>(&doc_id).await.unwrap().is_none(),
+            "the deletion must not be undone by the failed modify"
+        );
+    }
+
     // ========================================================================
     // index_value_condition tests
     // ========================================================================

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -4085,6 +4085,46 @@ async fn test_github_installation_concurrent_suspend_unsuspend_no_lost_update() 
     );
 }
 
+/// Two concurrent delta updates with disjoint adds must both land: the merge
+/// runs inside the `modify` closure, so an OCC retry re-reads fresh state and
+/// re-applies the delta instead of losing the other webhook's update.
+#[tokio::test]
+async fn test_update_github_installation_repos_delta_concurrent_deltas_both_land() {
+    let (store, _audit) = test_db().await;
+    create_test_github_installation(&store, 20_002, "org-concurrent-delta").await;
+    let seeded = update_github_installation_repos(&store, 20_002, &["seed".to_string()])
+        .await
+        .expect("seed repos");
+    assert!(seeded, "seeding must find the installation");
+
+    let store_a = store.clone();
+    let store_b = store.clone();
+    let add_a = vec!["alpha".to_string()];
+    let add_b = vec!["bravo".to_string()];
+    let (a, b) = tokio::join!(
+        update_github_installation_repos_delta(&store_a, 20_002, &add_a, &[]),
+        update_github_installation_repos_delta(&store_b, 20_002, &add_b, &[]),
+    );
+    assert!(
+        a.expect("delta a must not error"),
+        "delta a must find the installation"
+    );
+    assert!(
+        b.expect("delta b must not error"),
+        "delta b must find the installation"
+    );
+
+    let after = get_github_installation_by_installation_id(&store, 20_002)
+        .await
+        .expect("lookup after concurrent deltas")
+        .expect("installation must still exist");
+    assert_eq!(
+        after.repositories.as_deref(),
+        Some(&["alpha".to_string(), "bravo".to_string(), "seed".to_string()][..]),
+        "both concurrent deltas must land (no lost update)"
+    );
+}
+
 /// If an installation is deleted between the index-resolve and the `modify` call
 /// (race with an uninstall webhook), `modify` returns `Ok(false)` rather than
 /// updating a stale document.

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -4450,6 +4450,207 @@ async fn test_update_custom_policy_not_found_returns_none() {
     assert!(result.is_none(), "absent policy id must return None");
 }
 
+// ---- OCC applied-flag reset (uses the `modify` test seam) ----
+
+/// Regression: a concurrent org-ownership change landing between `modify`'s
+/// internal read and its compare-and-update must be reported as not-applied.
+/// Without the applied-flag reset at the top of each attempt, the stale
+/// `applied = true` from the failed first attempt leaks a false success.
+#[tokio::test]
+async fn test_update_scim_user_concurrent_org_change_reports_not_applied() {
+    use crate::db::documents::user::UserDoc;
+
+    let (store, _audit) = test_db().await;
+    let user = create_scim_user(
+        &store,
+        Some(TEST_ORG_ID),
+        "occ-race@example.com",
+        Some("Before"),
+        None,
+        true,
+    )
+    .await
+    .expect("create_scim_user");
+
+    // Hookless clone for the concurrent write: the hook must not re-enter
+    // itself when it writes through the store.
+    let writer = store.clone();
+    let mut hooked = store.clone();
+    hooked.set_modify_test_hook(Arc::new(move |doc_id: &str, attempt: u32| {
+        let writer = writer.clone();
+        let doc_id = doc_id.to_string();
+        Box::pin(async move {
+            if attempt != 0 {
+                return;
+            }
+            // Concurrent writer: move the user to another org after modify's
+            // read (stale version captured) but before its CAS, so the first
+            // attempt loses the version race and the loop retries.
+            let doc = writer
+                .get::<UserDoc>(&doc_id)
+                .await
+                .expect("hook get")
+                .expect("hook doc must exist");
+            let mut data = doc.data;
+            data.org_id = Some("other-org".to_string());
+            writer.update(&doc_id, &data).await.expect("hook update");
+        })
+    }));
+
+    let applied = update_scim_user(&hooked, &user.id, TEST_ORG_ID, Some("Hacked"), None, false)
+        .await
+        .expect("update_scim_user must not error");
+    assert!(
+        !applied,
+        "org changed mid-flight: update must report not-applied"
+    );
+
+    let after = store
+        .get::<UserDoc>(&user.id)
+        .await
+        .expect("get after")
+        .expect("must exist");
+    assert_eq!(
+        after.data.org_id.as_deref(),
+        Some("other-org"),
+        "the concurrent org change must not be clobbered"
+    );
+    assert_eq!(
+        after.data.name.as_deref(),
+        Some("Before"),
+        "the cross-org name mutation must not land"
+    );
+    assert!(after.data.active, "active must be unchanged");
+}
+
+/// Regression: same race as
+/// [`test_update_scim_user_concurrent_org_change_reports_not_applied`],
+/// for `update_scim_group`.
+#[tokio::test]
+async fn test_update_scim_group_concurrent_org_change_reports_not_applied() {
+    use crate::db::documents::scim::ScimGroupDoc;
+
+    let (store, _audit) = test_db().await;
+    let group = create_scim_group(&store, TEST_ORG_ID, "GroupBefore", None)
+        .await
+        .expect("create_scim_group");
+
+    let writer = store.clone();
+    let mut hooked = store.clone();
+    hooked.set_modify_test_hook(Arc::new(move |doc_id: &str, attempt: u32| {
+        let writer = writer.clone();
+        let doc_id = doc_id.to_string();
+        Box::pin(async move {
+            if attempt != 0 {
+                return;
+            }
+            let doc = writer
+                .get::<ScimGroupDoc>(&doc_id)
+                .await
+                .expect("hook get")
+                .expect("hook doc must exist");
+            let mut data = doc.data;
+            data.org_id = "other-org".to_string();
+            writer.update(&doc_id, &data).await.expect("hook update");
+        })
+    }));
+
+    let applied = update_scim_group(&hooked, &group.id, TEST_ORG_ID, Some("Hacked"), None)
+        .await
+        .expect("update_scim_group must not error");
+    assert!(
+        !applied,
+        "org changed mid-flight: update must report not-applied"
+    );
+
+    let after = store
+        .get::<ScimGroupDoc>(&group.id)
+        .await
+        .expect("get after")
+        .expect("must exist");
+    assert_eq!(
+        after.data.org_id, "other-org",
+        "the concurrent org change must not be clobbered"
+    );
+    assert_eq!(
+        after.data.display_name, "GroupBefore",
+        "the cross-org name mutation must not land"
+    );
+}
+
+/// Regression: same race as
+/// [`test_update_scim_user_concurrent_org_change_reports_not_applied`],
+/// for `update_custom_policy` (which reports not-applied as `None`).
+#[tokio::test]
+async fn test_update_custom_policy_concurrent_org_change_returns_none() {
+    use crate::db::documents::posture_policy::CustomPosturePolicyDoc;
+
+    let (store, _audit) = test_db().await;
+    let policy = create_custom_policy(
+        &store,
+        CreateCustomPolicyParams {
+            name: "PolicyBefore",
+            description: None,
+            cel_expression: "true",
+            org_id: "org-occ-race",
+        },
+    )
+    .await
+    .expect("create_custom_policy");
+
+    let writer = store.clone();
+    let mut hooked = store.clone();
+    hooked.set_modify_test_hook(Arc::new(move |doc_id: &str, attempt: u32| {
+        let writer = writer.clone();
+        let doc_id = doc_id.to_string();
+        Box::pin(async move {
+            if attempt != 0 {
+                return;
+            }
+            let doc = writer
+                .get::<CustomPosturePolicyDoc>(&doc_id)
+                .await
+                .expect("hook get")
+                .expect("hook doc must exist");
+            let mut data = doc.data;
+            data.org_id = "other-org".to_string();
+            writer.update(&doc_id, &data).await.expect("hook update");
+        })
+    }));
+
+    let result = update_custom_policy(
+        &hooked,
+        &policy.id,
+        "org-occ-race",
+        UpdateCustomPolicyParams {
+            name: Some("Hacked"),
+            description: FieldUpdate::Keep,
+            cel_expression: None,
+            active: None,
+        },
+    )
+    .await
+    .expect("update_custom_policy must not error");
+    assert!(
+        result.is_none(),
+        "org changed mid-flight: update must return None"
+    );
+
+    let after = store
+        .get::<CustomPosturePolicyDoc>(&policy.id)
+        .await
+        .expect("get after")
+        .expect("must exist");
+    assert_eq!(
+        after.data.org_id, "other-org",
+        "the concurrent org change must not be clobbered"
+    );
+    assert_eq!(
+        after.data.name, "PolicyBefore",
+        "the cross-org name mutation must not land"
+    );
+}
+
 /// `suspend_github_installation` with an `installation_id` that was never
 /// created returns `Ok(false)`.
 #[tokio::test]

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -4125,6 +4125,52 @@ async fn test_update_github_installation_repos_delta_concurrent_deltas_both_land
     );
 }
 
+/// Deterministic companion to the concurrent-delta test above (whose
+/// `tokio::join!` contention depends on scheduling): the modify test seam
+/// applies a second delta inside the OCC window, guaranteeing the retry path
+/// runs and asserting the retried merge re-reads the fresh repo list.
+#[tokio::test]
+async fn test_update_github_installation_repos_delta_occ_retry_merges_fresh_state() {
+    let (store, _audit) = test_db().await;
+    create_test_github_installation(&store, 20_004, "org-delta-seam").await;
+    let seeded = update_github_installation_repos(&store, 20_004, &["seed".to_string()])
+        .await
+        .expect("seed repos");
+    assert!(seeded, "seeding must find the installation");
+
+    let writer = store.clone();
+    let mut hooked = store.clone();
+    hooked.set_modify_test_hook(Arc::new(move |_doc_id: &str, attempt: u32| {
+        let writer = writer.clone();
+        Box::pin(async move {
+            if attempt != 0 {
+                return;
+            }
+            let bravo = vec!["bravo".to_string()];
+            let found = update_github_installation_repos_delta(&writer, 20_004, &bravo, &[])
+                .await
+                .expect("hook delta must not error");
+            assert!(found, "hook delta must find the installation");
+        })
+    }));
+
+    let alpha = vec!["alpha".to_string()];
+    let found = update_github_installation_repos_delta(&hooked, 20_004, &alpha, &[])
+        .await
+        .expect("delta must not error");
+    assert!(found, "delta must find the installation");
+
+    let after = get_github_installation_by_installation_id(&store, 20_004)
+        .await
+        .expect("lookup after deltas")
+        .expect("installation must still exist");
+    assert_eq!(
+        after.repositories.as_deref(),
+        Some(&["alpha".to_string(), "bravo".to_string(), "seed".to_string()][..]),
+        "the delta applied inside the OCC window must survive the retried merge"
+    );
+}
+
 /// If an installation is deleted between the index-resolve and the `modify` call
 /// (race with an uninstall webhook), `modify` returns `Ok(false)` rather than
 /// updating a stale document.
@@ -4839,6 +4885,169 @@ async fn test_update_authenticator_counter_high_concurrency_no_lost_update() {
     assert_eq!(
         auth.counter, target,
         "counter must equal the max value applied in the concurrent burst"
+    );
+}
+
+/// Deterministic companion to the #545 burst test above (whose contention
+/// depends on scheduling): a higher counter written inside the OCC window via
+/// the modify test seam must win over the in-flight lower value — the retry
+/// re-reads the fresh counter and `max()` keeps it. A blind write would
+/// regress the counter to 50.
+#[tokio::test]
+async fn test_update_authenticator_counter_concurrent_higher_value_wins() {
+    use crate::db::documents::authenticator::AuthenticatorDoc;
+
+    let (store, _audit) = test_db().await;
+    let (user_id, _) = upsert_user(&store, "counter-seam@example.com", None)
+        .await
+        .expect("upsert user");
+    let auth_id = create_authenticator(
+        &store,
+        &CreateAuthenticatorParams {
+            user_id: &user_id,
+            user_email: "counter-seam@example.com",
+            name: "Counter Seam Key",
+            credential_id: b"cred-counter-seam",
+            public_key: &[0u8; 32],
+            aaguid: None,
+            user_handle: None,
+            attestation_verified: false,
+        },
+    )
+    .await
+    .expect("create authenticator");
+
+    let writer = store.clone();
+    let mut hooked = store.clone();
+    hooked.set_modify_test_hook(Arc::new(move |doc_id: &str, attempt: u32| {
+        let writer = writer.clone();
+        let doc_id = doc_id.to_string();
+        Box::pin(async move {
+            if attempt != 0 {
+                return;
+            }
+            let doc = writer
+                .get::<AuthenticatorDoc>(&doc_id)
+                .await
+                .expect("hook get")
+                .expect("hook doc must exist");
+            let mut data = doc.data;
+            data.counter = 100;
+            writer.update(&doc_id, &data).await.expect("hook update");
+        })
+    }));
+
+    update_authenticator_counter(&hooked, &auth_id, 50)
+        .await
+        .expect("counter update must not error");
+
+    let auth = get_authenticator_by_id(&store, &auth_id)
+        .await
+        .expect("get authenticator")
+        .expect("authenticator must exist");
+    assert_eq!(
+        auth.counter, 100,
+        "the concurrent higher counter must survive the retried max()"
+    );
+}
+
+/// The concurrent suspend/unsuspend test cannot distinguish OCC from a blind
+/// write (its own comment says so — both bump the version). This
+/// deterministic variant proves the re-read: a sibling-field write
+/// (repositories) landing inside the OCC window must survive the suspend
+/// that retries over it.
+#[tokio::test]
+async fn test_suspend_github_installation_preserves_concurrent_sibling_write() {
+    use crate::db::documents::github::GitHubInstallationDoc;
+
+    let (store, _audit) = test_db().await;
+    let doc_id = create_test_github_installation(&store, 20_005, "org-sibling-preserve").await;
+
+    let writer = store.clone();
+    let mut hooked = store.clone();
+    hooked.set_modify_test_hook(Arc::new(move |_doc_id: &str, attempt: u32| {
+        let writer = writer.clone();
+        Box::pin(async move {
+            if attempt != 0 {
+                return;
+            }
+            let found =
+                update_github_installation_repos(&writer, 20_005, &["hook/repo".to_string()])
+                    .await
+                    .expect("hook repos update must not error");
+            assert!(found, "hook must find the installation");
+        })
+    }));
+
+    let found = suspend_github_installation(&hooked, 20_005)
+        .await
+        .expect("suspend must not error");
+    assert!(found, "suspend must find the installation");
+
+    let after = store
+        .get::<GitHubInstallationDoc>(&doc_id)
+        .await
+        .expect("get after")
+        .expect("must exist");
+    assert!(after.data.suspended_at.is_some(), "suspend must land");
+    assert_eq!(
+        after.data.repositories.as_deref(),
+        Some(&["hook/repo".to_string()][..]),
+        "the concurrent repositories write must not be clobbered by the suspend"
+    );
+}
+
+/// Deterministic companion to the #537 sequential test above: an admin
+/// demotion landing inside the OCC window (not merely before the call) must
+/// survive `update_user_github_identity`'s retry — the doc comment on that
+/// function promises exactly this.
+#[tokio::test]
+async fn test_update_user_github_identity_preserves_concurrent_admin_change() {
+    let (store, _audit) = test_db().await;
+    let (user_id, _) = upsert_user_with_org(
+        &store,
+        "seam-race@example.com",
+        Some("Seam Race User"),
+        Some("org-seam-race"),
+        true, // starts as admin
+    )
+    .await
+    .expect("upsert admin user");
+
+    let writer = store.clone();
+    let demote_user_id = user_id.clone();
+    let mut hooked = store.clone();
+    hooked.set_modify_test_hook(Arc::new(move |_doc_id: &str, attempt: u32| {
+        let writer = writer.clone();
+        let demote_user_id = demote_user_id.clone();
+        Box::pin(async move {
+            if attempt != 0 {
+                return;
+            }
+            let found = update_user_admin_status(&writer, &demote_user_id, false)
+                .await
+                .expect("hook demotion must not error");
+            assert!(found, "hook must find the user");
+        })
+    }));
+
+    update_user_github_identity(&hooked, &user_id, 42, "gh-user", None)
+        .await
+        .expect("github identity update must not error");
+
+    let user = get_user_by_id(&store, &user_id)
+        .await
+        .expect("get user")
+        .expect("user must exist");
+    assert!(
+        !user.is_org_admin,
+        "the demotion inside the OCC window must survive the identity update"
+    );
+    assert_eq!(user.github_id, Some(42), "github_id must be set");
+    assert_eq!(
+        user.github_login.as_deref(),
+        Some("gh-user"),
+        "github_login must be set"
     );
 }
 


### PR DESCRIPTION
Closes #561 (items 2 and 3; item 1 is declined on the issue).

## What this does

**GitHub repo delta merge is now atomic.** `update_github_installation_repos_delta` previously read the installation and merged the added/removed repo lists outside the `store.modify` closure, so two concurrent `installation_repositories` webhooks for the same installation could each read a stale list and lose the other's changes. The merge (dedup adds, filter removals, sort) now runs inside the closure, so every optimistic-concurrency retry re-reads fresh state and re-applies the delta. Covered by a `tokio::join!` concurrent-delta test and a deterministic seam-based twin that guarantees the retry path executes.

**`DocumentStore::modify` gains a `cfg(test)`-only hook** invoked between the internal read and the compare-and-update, receiving `(doc_id, attempt)`. Tests use it to interleave a concurrent write into the OCC window deterministically instead of relying on task scheduling. It is compiled out of non-test builds.

**Three regression tests for the applied-flag reset** fixed in #560: a concurrent org-ownership change landing mid-modify must be reported as not-applied by `update_scim_user`, `update_scim_group`, and `update_custom_policy`. Each test was verified to fail when the reset at the top of the closure is removed.

**Seven further seam-based tests** pin OCC paths that were untriggerable or only probabilistically covered before:

- `modify`'s retry-exhaustion error and mid-loop-deletion (`Ok(false)`) paths
- deterministic twins of the scheduling-dependent counter (#545) and identity-vs-demotion (#537) concurrency tests
- sibling-field preservation under `suspend_github_installation`, distinguishing OCC from a blind write (a gap the existing concurrent test's own comment acknowledges)
- domain cleanup reporting only the committed attempt's removals when an entry flips to Verified inside the OCC window

## Testing

- `make fmt`, `make lint` (clippy `--all-targets --all-features -D warnings`) clean
- `make test`: all targets passing (2474 vouch-server lib tests)
- `make test-integration`: all passing
- Mutation checks: the applied-flag tests fail without the #560 reset; the seam delta test fails against the racy merge-outside-closure shape; the cleanup test fails against an accumulating removal report. All restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes webhook-driven GitHub installation repo persistence (data correctness under concurrency); production surface is narrow but affects integration state if merge logic regresses.
> 
> **Overview**
> **GitHub installation repo deltas are merged atomically under optimistic concurrency.** `update_github_installation_repos_delta` no longer reads and merges the repo list outside `store.modify`; deduped adds, removals, and sorting run inside the closure so each retry re-reads current state and concurrent `installation_repositories` webhooks cannot drop each other’s changes.
> 
> **`DocumentStore::modify` gains a `cfg(test)` hook** between read and compare-and-update (`doc_id`, attempt) so tests can force version conflicts and interleaved writes without scheduler races. The hook is stripped from non-test builds.
> 
> **Broad regression coverage** exercises OCC behavior: concurrent GitHub repo deltas, domain cleanup not auditing removals when a pending domain flips to verified mid-modify, SCIM/policy “not applied” when org ownership changes in the OCC window, authenticator counter `max()`, suspend vs sibling field writes, and `modify` retry exhaustion / mid-loop deletion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1b1c17c6a1fb7b0e64f5dfa2b50849f48778bdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->