### PR TITLE
refactor(server): extract ServiceError::oauth_description helper (#663)

### DIFF
--- a/crates/vouch-server/src/error.rs
+++ b/crates/vouch-server/src/error.rs
@@ -251,6 +251,16 @@ impl ServiceError {
         }
     }
 
+    /// Returns the OAuth-facing description if this is an `OAuth` variant,
+    /// otherwise falls back to the error's `Display` output.
+    #[must_use]
+    pub(crate) fn oauth_description(&self) -> String {
+        match self {
+            Self::OAuth { description, .. } => description.clone(),
+            other => other.to_string(),
+        }
+    }
+
     /// Create a structured API error with a specific status code, error code,
     /// and message.
     ///
@@ -454,6 +464,19 @@ mod tests {
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert_eq!(json.error, "invalid_grant");
         assert_eq!(json.error_description, Some("Token expired".to_string()));
+    }
+
+    #[test]
+    fn test_oauth_description_returns_description_for_oauth_variant() {
+        let err = ServiceError::oauth(OAuthErrorCode::InvalidRequest, "boom");
+        assert_eq!(err.oauth_description(), "boom");
+    }
+
+    #[test]
+    fn test_oauth_description_falls_back_to_display_for_other_variant() {
+        let err = ServiceError::Internal("x".to_string());
+        assert_eq!(err.oauth_description(), "internal error: x");
+        assert_eq!(err.oauth_description(), err.to_string());
     }
 
     #[test]

--- a/crates/vouch-server/src/handlers/oidc/authorize.rs
+++ b/crates/vouch-server/src/handlers/oidc/authorize.rs
@@ -240,12 +240,13 @@ async fn run_security_pipeline(
 ) -> Result<(), Response> {
     // PKCE: required for public clients and Native/SPA types (RFC 9700).
     if let Err(e) = require_pkce_for_client(validated, &resolved.client) {
-        let description = match &e {
-            crate::error::ServiceError::OAuth { description, .. } => description.clone(),
-            _ => e.to_string(),
-        };
         return Err(resolved
-            .error_redirect(state, "invalid_request", &description, validated.state())
+            .error_redirect(
+                state,
+                "invalid_request",
+                &e.oauth_description(),
+                validated.state(),
+            )
             .await);
     }
 
@@ -256,12 +257,13 @@ async fn run_security_pipeline(
             false,
         )
     {
-        let description = match &e {
-            crate::error::ServiceError::OAuth { description, .. } => description.clone(),
-            _ => e.to_string(),
-        };
         return Err(resolved
-            .error_redirect(state, "invalid_request", &description, validated.state())
+            .error_redirect(
+                state,
+                "invalid_request",
+                &e.oauth_description(),
+                validated.state(),
+            )
             .await);
     }
 
@@ -613,13 +615,9 @@ async fn handle_jar_request(
     {
         Ok(params) => params,
         Err(e) => {
-            let description = match &e {
-                crate::error::ServiceError::OAuth { description, .. } => description.clone(),
-                _ => e.to_string(),
-            };
             return AuthorizeDeniedTemplate {
                 client_name: oauth_client.name,
-                error_message: format!("Invalid Request Object: {description}"),
+                error_message: format!("Invalid Request Object: {}", e.oauth_description()),
             }
             .into_response();
         }
@@ -921,13 +919,9 @@ async fn fetch_and_resolve_request_uri(
     if let Err(e) =
         crate::services::oidc::fapi::validate_fapi_authorization_request(&oauth_client, false)
     {
-        let description = match &e {
-            crate::error::ServiceError::OAuth { description, .. } => description.clone(),
-            _ => e.to_string(),
-        };
         return Err(AuthorizeDeniedTemplate {
             client_name: oauth_client.name,
-            error_message: format!("Invalid request: {description}"),
+            error_message: format!("Invalid request: {}", e.oauth_description()),
         }
         .into_response());
     }
@@ -948,21 +942,18 @@ async fn fetch_and_resolve_request_uri(
     // Loopback request_uri destinations are permitted only in local development
     // (no TLS configured); private/link-local targets stay blocked.
     let allow_loopback = !state.config().tls_configured();
-    let fetched_jwt =
-        match fetch_request_object(request_uri, allow_loopback, &state.http_client).await {
-            Ok(jwt) => jwt,
-            Err(e) => {
-                let description = match &e {
-                    crate::error::ServiceError::OAuth { description, .. } => description.clone(),
-                    _ => e.to_string(),
-                };
-                return Err(AuthorizeDeniedTemplate {
-                    client_name: oauth_client.name,
-                    error_message: format!("Failed to fetch Request Object: {description}"),
-                }
-                .into_response());
+    let fetched_jwt = match fetch_request_object(request_uri, allow_loopback, &state.http_client)
+        .await
+    {
+        Ok(jwt) => jwt,
+        Err(e) => {
+            return Err(AuthorizeDeniedTemplate {
+                client_name: oauth_client.name,
+                error_message: format!("Failed to fetch Request Object: {}", e.oauth_description()),
             }
-        };
+            .into_response());
+        }
+    };
 
     // Step 5: validate the JWT.
     let query_hints = QueryParamHints {

--- a/crates/vouch-server/src/handlers/oidc/par.rs
+++ b/crates/vouch-server/src/handlers/oidc/par.rs
@@ -165,14 +165,10 @@ pub(crate) async fn par(
     if let Some(ref request_jwt) = params.request
         && let Err(e) = validate_request_object_header(request_jwt)
     {
-        let description = match &e {
-            crate::error::ServiceError::OAuth { description, .. } => description.clone(),
-            _ => e.to_string(),
-        };
         return par_error_response(
             StatusCode::BAD_REQUEST,
             "invalid_request_object",
-            &description,
+            &e.oauth_description(),
         );
     }
 
@@ -243,11 +239,11 @@ pub(crate) async fn par(
         &authenticated_client.client,
         authenticated_client.client.token_endpoint_auth_method,
     ) {
-        let desc = match &e {
-            ServiceError::OAuth { description, .. } => description.clone(),
-            _ => e.to_string(),
-        };
-        return par_error_response(StatusCode::UNAUTHORIZED, "invalid_client", &desc);
+        return par_error_response(
+            StatusCode::UNAUTHORIZED,
+            "invalid_client",
+            &e.oauth_description(),
+        );
     }
 
     // RFC 9101: Enforce require_signed_request_object for this client.
@@ -407,11 +403,11 @@ pub(crate) async fn par(
 
     // RFC 9700: PKCE required for public clients and Native/SPA types.
     if let Err(e) = require_pkce_for_client(&validated, &authenticated_client.client) {
-        let description = match &e {
-            ServiceError::OAuth { description, .. } => description.clone(),
-            _ => e.to_string(),
-        };
-        return par_error_response(StatusCode::BAD_REQUEST, "invalid_request", &description);
+        return par_error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            &e.oauth_description(),
+        );
     }
 
     // Validate redirect_uri against registered URIs

--- a/crates/vouch-server/src/services/oidc/jar.rs
+++ b/crates/vouch-server/src/services/oidc/jar.rs
@@ -349,10 +349,7 @@ pub async fn validate_request_object(
     {
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidRequestObject,
-            match &e {
-                ServiceError::OAuth { description, .. } => description.clone(),
-                _ => e.to_string(),
-            },
+            e.oauth_description(),
         ));
     }
 


### PR DESCRIPTION
## What

Nine OIDC handler/service call sites copy-pasted the same `match` that extracts an OAuth-facing description from a `ServiceError`:

```rust
let description = match &e {
    ServiceError::OAuth { description, .. } => description.clone(),
    _ => e.to_string(),
};
```

This adds a single `ServiceError::oauth_description(&self) -> String` method (in `error.rs`, next to `oauth()`) and replaces all nine sites with a call to it, referencing the result in place so the now-single-use `description`/`desc` locals go away.

The method reproduces the existing logic exactly — `OAuth` variant returns `description.clone()`, every other variant falls back to `Display` — so there is no behavior change.

## Sites converted

- `services/oidc/jar.rs`
- `handlers/oidc/par.rs` (×3)
- `handlers/oidc/authorize.rs` (×5)

## Left unchanged

Three adjacent patterns the issue does not list as copies, because they differ semantically:

- The `(code, description)` tuple pattern (different return shape, some with a different fallback code).
- Two move-semantics sites with a custom fallback string.
- The `services/auth.rs` test with its diagnostic fallback.

## Tests

- Added two unit tests covering both branches of `oauth_description()`.
- `make fmt`, `make lint` (clippy `-D warnings`), `cargo test -p vouch-server --lib error::` (17 passed), and `cargo test -p vouch-server --lib oidc` (1135 passed) all green.

Closes #663.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication in OIDC error messaging only; logic is unchanged and covered by new unit tests.
> 
> **Overview**
> Introduces **`ServiceError::oauth_description()`** so OIDC code can get a client-facing error string in one place: OAuth variants return the stored `description`, everything else uses **`Display`**.
> 
> Replaces nine copy-pasted `match` blocks in **`authorize`**, **`par`**, and **`jar`** with calls to that helper. OAuth redirect, denied-page, and PAR JSON error text should be unchanged.
> 
> Adds two unit tests on **`oauth_description`** for both branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cea0059dddf069348bdc8e612d63a3727bad99a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->