### PR TITLE
ci: run tests with --all-features to match make test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           echo "AWS_LC_FIPS_SYS_CC=${{ matrix.fips-cc }}" >> "$GITHUB_ENV"
           echo "AWS_LC_FIPS_SYS_CXX=${{ matrix.fips-cxx }}" >> "$GITHUB_ENV"
       - name: Run tests
-        run: cargo test --locked ${{ matrix.cargo-args }} # zizmor: ignore[template-injection] — static matrix value
+        run: cargo test --locked --all-features ${{ matrix.cargo-args }} # zizmor: ignore[template-injection] — static matrix value
 
   build:
     name: Build (${{ matrix.name }})


### PR DESCRIPTION
## Summary

CI's test step ran `cargo test --locked` without `--all-features`, while `make test` deliberately uses `--all-features` so feature-gated tests run. As a result, tests behind crate features — the `vouch-httpsig` `axum` middleware tests and the `test-utils` helpers in cli/agent/server — never ran in CI.

This adds `--all-features` to the test invocation on all three platforms. The features it enables are pure-Rust and cross-platform (`axum`, `tower`, `ed25519-dalek/rand_core`); FIPS is unaffected because `aws-lc-rs`'s `fips` feature is already enabled unconditionally as a dependency feature in vouch-server and vouch-cli.

Verified locally: `cargo test --all-features` passes across the workspace; `actionlint` and `zizmor` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that broadens test coverage; no application or security logic is modified.
> 
> **Overview**
> Aligns the CI **Unit Tests** job with local `make test` by adding `--all-features` to `cargo test --locked` on all matrix platforms (Linux, macOS, Windows).
> 
> Previously, feature-gated tests (e.g. `vouch-httpsig` Axum middleware and `test-utils` in cli/agent/server) did not run in CI even though Clippy in the same workflow already used `--all-features`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b2fa90d0238641795153192596176d57c9b8240. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->