### PR TITLE
fix(cli): run CLI on a thread with an 8 MiB stack

### DIFF
--- a/crates/vouch-cli/src/main.rs
+++ b/crates/vouch-cli/src/main.rs
@@ -457,8 +457,27 @@ use commands::credential::CredentialCommands;
 use commands::keys::KeysCommands;
 use commands::setup::SetupCommands;
 
+/// Stack reserve for the thread that runs the CLI. Building the clap command
+/// tree in an unoptimized build needs more than the 1 MiB Windows reserves
+/// for the process main thread (Unix reserves 8 MiB), so all work runs on a
+/// spawned thread with an explicit 8 MiB stack.
+const MAIN_THREAD_STACK_SIZE: usize = 8 * 1024 * 1024;
+
+fn main() -> ExitCode {
+    match std::thread::Builder::new()
+        .name("vouch-main".to_string())
+        .stack_size(MAIN_THREAD_STACK_SIZE)
+        .spawn(tokio_main)
+    {
+        Ok(handle) => handle.join().unwrap_or(ExitCode::FAILURE),
+        // Could not spawn a thread: fall back to the main thread, which has
+        // enough stack everywhere except Windows debug builds.
+        Err(_) => tokio_main(),
+    }
+}
+
 #[tokio::main]
-async fn main() -> ExitCode {
+async fn tokio_main() -> ExitCode {
     match run().await {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {


### PR DESCRIPTION
## Summary

Fixes the `Unit Tests (windows)` failure on #668.

The new `bare_invocation_prints_help_with_platform_exit_code` test crashed with exit code `-1073741571` (`0xC00000FD`, STATUS_STACK_OVERFLOW) when it spawned the debug `vouch.exe`. The cause is not the new help path specifically: building the clap command tree in an unoptimized build needs more stack than the 1 MiB Windows reserves for the process main thread (Unix reserves 8 MiB). Existing unit tests never hit it because libtest runs tests on 8 MiB worker threads — this test was the first thing to execute the debug binary's main thread on Windows.

Reproduced on Linux by clamping the main-thread stack to 1 MiB (`ulimit -s 1024`): **any** debug invocation crashes, including `vouch --help`, so `Cli::parse()` and the completions path have the same exposure.

The fix spawns the tokio entry point on a thread with an explicit 8 MiB stack (the same pattern rustc and cargo use), covering every code path that builds the command tree. If the spawn itself fails, it falls back to running on the main thread — identical to today's behavior.

## Testing

- Reproduced pre-fix on Linux: `ulimit -s 1024; ./target/debug/vouch` → crash. Post-fix: exits 2 with help, and `--help` exits 0, under the same 1 MiB limit.
- `cargo test -p vouch-cli`: 749 passed, 0 failed (includes the previously failing `bare_invocation` integration test).
- `cargo clippy -p vouch-cli --all-targets --all-features -- -D warnings`: clean. `make fmt`: no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FGYKK6ubucvzuZcY2qD8E9

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGYKK6ubucvzuZcY2qD8E9)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bootstrap-only threading change with spawn-failure fallback; no auth, credentials, or business-logic changes.
> 
> **Overview**
> Fixes **stack overflow** on Windows debug builds (and any 1 MiB main-thread limit) when the CLI builds the large **clap** command tree.
> 
> **`main`** now spawns **`tokio_main`** on a named thread with an explicit **8 MiB** stack (matching typical Unix main-thread reserve), joins it for the process exit code, and **falls back** to running **`tokio_main`** on the real main thread if spawn fails. The previous **`#[tokio::main] async fn main`** entry is renamed to **`tokio_main`**; behavior of **`run()`** and all commands is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7739cefc50708601547c2851db1904c07779ca06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->