### PR TITLE
fix: kubeconfig YAML coercion, subdomain release retry, setup aws flag conflict

### DIFF
--- a/crates/vouch-cli/src/commands/setup/kubeconfig.rs
+++ b/crates/vouch-cli/src/commands/setup/kubeconfig.rs
@@ -124,10 +124,22 @@ pub(crate) fn load_kubeconfig(path: &std::path::Path) -> Result<Kubeconfig> {
     let content = std::fs::read_to_string(path).with_context(|| {
         vouch_cli::tr_args!("setup-kc-err-read", path = path.display().to_string())
     })?;
-    let config: Kubeconfig = serde_saphyr::from_str(&content).with_context(|| {
+    let config: Kubeconfig = parse_kubeconfig(&content).with_context(|| {
         vouch_cli::tr_args!("setup-kc-err-parse", path = path.display().to_string())
     })?;
     Ok(config)
+}
+
+/// Parse kubeconfig YAML with YAML 1.2 boolean rules.
+///
+/// Only `true`/`false` are booleans; YAML 1.1 spellings (`no`, `yes`, `on`,
+/// `off`, ...) stay strings. Fields we don't model land in `#[serde(flatten)]`
+/// `serde_json::Value` catch-alls and are written back verbatim by
+/// [`save_kubeconfig`], so without strict booleans another user's unquoted
+/// `token: no` would round-trip as `token: false` and break their kubectl auth.
+fn parse_kubeconfig(content: &str) -> Result<Kubeconfig, serde_saphyr::Error> {
+    let options = serde_saphyr::options! { strict_booleans: true };
+    serde_saphyr::from_str_with_options(content, options)
 }
 
 /// Save kubeconfig to file.
@@ -333,5 +345,55 @@ users:
         assert_eq!(other2["token"], "super-secret-token");
         assert_eq!(other2["client-certificate-data"], "LS0tLS1DRVJU");
         assert_eq!(other2["username"], "admin");
+    }
+
+    /// Unquoted auth values that are YAML 1.1 reserved words (`no`, `yes`,
+    /// `on`, `off`) in *other* users' entries must stay strings across a
+    /// load -> save -> load round-trip. With default YAML 1.1 typing,
+    /// `token: no` parses as `Bool(false)` and `save_kubeconfig` would
+    /// persist `token: false`, breaking that user's kubectl auth (#670).
+    #[test]
+    fn test_yaml11_boolean_like_tokens_survive_roundtrip() {
+        let yaml = r#"
+apiVersion: v1
+kind: Config
+clusters: []
+contexts: []
+users:
+- name: legacy-user
+  user:
+    token: no
+    username: yes
+    password: on
+    client-key-data: off
+"#;
+
+        let config: Kubeconfig = parse_kubeconfig(yaml).expect("should parse");
+        let other = &config.users[0].user.other;
+        for (field, want) in [
+            ("token", "no"),
+            ("username", "yes"),
+            ("password", "on"),
+            ("client-key-data", "off"),
+        ] {
+            let value = other.get(field).expect(field);
+            assert!(value.is_string(), "{field}: got {value:?}, want a string");
+            assert_eq!(value, want, "{field}");
+        }
+
+        // Serialize and re-parse: the serializer quotes ambiguous scalars, so
+        // the values survive another strict parse unchanged.
+        let serialized = serde_saphyr::to_string(&config).expect("should serialize");
+        let reparsed: Kubeconfig = parse_kubeconfig(&serialized).expect("should re-parse");
+        let other2 = &reparsed.users[0].user.other;
+        assert_eq!(other2["token"], "no");
+        assert_eq!(other2["username"], "yes");
+        assert_eq!(other2["password"], "on");
+        assert_eq!(other2["client-key-data"], "off");
+
+        // Real booleans are still booleans under YAML 1.2 rules.
+        let bool_yaml = "users:\n- name: u\n  user:\n    some-flag: true\n";
+        let parsed: Kubeconfig = parse_kubeconfig(bool_yaml).expect("should parse");
+        assert_eq!(parsed.users[0].user.other["some-flag"], true);
     }
 }

--- a/crates/vouch-cli/src/commands/setup/mod.rs
+++ b/crates/vouch-cli/src/commands/setup/mod.rs
@@ -64,8 +64,9 @@ pub(crate) enum SetupCommands {
         region: Option<String>,
         /// Enumerate accounts and permission-sets via Identity Center and write
         /// one profile per assignment. Requires IdC config from this run or
-        /// previously stored with `vouch setup aws`.
-        #[arg(long, help = tr!("arg-setup-aws-discover-help"))]
+        /// previously stored with `vouch setup aws`. Discovery never uses a
+        /// target role, so combining with --role is rejected at parse time.
+        #[arg(long, conflicts_with = "role", help = tr!("arg-setup-aws-discover-help"))]
         discover: bool,
     },
     /// Configure SSH to use Vouch certificates.
@@ -238,4 +239,52 @@ pub(crate) enum SetupCommands {
         #[arg(long, help = tr!("arg-setup-codeartifact-profile-help"))]
         profile: Option<String>,
     },
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(subcommand)]
+        cmd: SetupCommands,
+    }
+
+    /// `--discover` ignores any target role (`run` returns into discovery
+    /// before `--role` is read), so the combination must be rejected at
+    /// parse time instead of silently dropping the flag (#672).
+    #[test]
+    fn setup_aws_rejects_role_with_discover() {
+        let err = TestCli::try_parse_from([
+            "vouch",
+            "aws",
+            "--role",
+            "arn:aws:iam::123456789012:role/dev",
+            "--discover",
+        ])
+        .err()
+        .expect("--role with --discover must fail to parse");
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    /// `--discover` alone (IdC config already stored) must keep parsing.
+    #[test]
+    fn setup_aws_allows_discover_alone() {
+        let cli = TestCli::try_parse_from(["vouch", "aws", "--discover"])
+            .expect("--discover alone must parse");
+        assert!(matches!(
+            cli.cmd,
+            SetupCommands::Aws {
+                discover: true,
+                role: None,
+                ..
+            }
+        ));
+    }
 }

--- a/crates/vouch-server/src/db/organizations/domains.rs
+++ b/crates/vouch-server/src/db/organizations/domains.rs
@@ -72,6 +72,21 @@ impl crate::db::pool::RetryableError for OrgCasError {
     }
 }
 
+/// Slot CAS conflicts from the subdomain auto-release hook must stay
+/// retryable through the org-doc retry loop; everything else is terminal
+/// (unwrapping `Other` keeps any retryable DB error code visible to
+/// `is_retryable_db_error`).
+impl From<super::issuer::SubdomainClaimError> for OrgCasError {
+    fn from(e: super::issuer::SubdomainClaimError) -> Self {
+        use super::issuer::SubdomainClaimError;
+        match e {
+            SubdomainClaimError::OccConflict => Self::OccConflict,
+            SubdomainClaimError::Other(inner) => Self::Other(inner),
+            other => Self::Other(anyhow::Error::new(other)),
+        }
+    }
+}
+
 /// Errors returned by [`add_additional_domain`].
 ///
 /// Business-rejection variants are terminal (not retried); `OccConflict` and
@@ -1806,6 +1821,21 @@ mod tests {
 
         assert!(OrgCasError::OccConflict.is_retryable());
         assert!(!OrgCasError::Other(anyhow::anyhow!("domain is already attached")).is_retryable());
+    }
+
+    /// A slot CAS loss inside the subdomain auto-release hook must convert to
+    /// the retryable `OccConflict` so `with_dsql_retry!` re-runs the org-doc
+    /// transaction; other claim errors stay terminal (#671).
+    #[test]
+    fn subdomain_claim_error_maps_to_org_cas_retryability() {
+        use crate::db::organizations::issuer::SubdomainClaimError;
+        use crate::db::pool::RetryableError;
+
+        assert!(OrgCasError::from(SubdomainClaimError::OccConflict).is_retryable());
+        assert!(
+            !OrgCasError::from(SubdomainClaimError::Other(anyhow::anyhow!("boom"))).is_retryable()
+        );
+        assert!(!OrgCasError::from(SubdomainClaimError::NotEligible).is_retryable());
     }
 
     /// All business-rejection variants of `AddDomainError` are terminal; only

--- a/crates/vouch-server/src/db/organizations/issuer.rs
+++ b/crates/vouch-server/src/db/organizations/issuer.rs
@@ -19,7 +19,7 @@ use crate::db::documents::organization::{
     OrgSigningKeyDoc, OrganizationDoc, SigningKeyState, SubdomainClaimDoc,
 };
 use crate::db::store::{DocumentStore, StoreTransaction};
-use anyhow::{Result, bail};
+use anyhow::Result;
 use jiff::Timestamp;
 
 // ============================================================================
@@ -430,12 +430,17 @@ pub(super) fn subdomain_to_release(data: &OrganizationDoc) -> Option<String> {
 /// Cancelling rotation on auto-release is safe: auto-release already signals
 /// disruption (discovery 404s), so dropping a Previous key's still-valid tokens
 /// is acceptable.
+///
+/// # Errors
+/// Returns [`SubdomainClaimError::OccConflict`] when the claim slot loses its
+/// CAS race — callers run inside `with_dsql_retry!`, which re-runs the whole
+/// transaction from a fresh read. Other failures are terminal.
 pub(super) async fn release_ineligible_subdomain(
     tx: &mut StoreTransaction<'_>,
     org_id: &str,
     data: &mut OrganizationDoc,
     label: &str,
-) -> Result<()> {
+) -> Result<(), SubdomainClaimError> {
     data.subdomain = None;
 
     let claim_id = deterministic_subdomain_claim_id(label);
@@ -449,7 +454,7 @@ pub(super) async fn release_ineligible_subdomain(
                 .compare_and_update(&claim_id, slot.version, &released)
                 .await?
             {
-                bail!("subdomain claim was modified concurrently; please retry");
+                return Err(SubdomainClaimError::OccConflict);
             }
         }
         other => {


### PR DESCRIPTION
Fixes the three Detail bug reports #670, #671, #672 — all verified as real bugs before fixing.

## `fix(cli)`: parse kubeconfig with strict YAML 1.2 booleans (#670)

`load_kubeconfig` used default `serde_saphyr::from_str`, which applies YAML 1.1 implicit typing: an unquoted `token: no` in *another* user's kubeconfig entry parsed as `Bool(false)`, and `save_kubeconfig` (which rewrites the whole file) persisted `token: false`, breaking kubectl auth for contexts vouch never touched. Parsing now uses `serde_saphyr::options! { strict_booleans: true }`, so only `true`/`false` are booleans. The serde-saphyr serializer already quotes YAML 1.1 boolean spellings in value position, so the load → save round-trip is lossless. Added a regression round-trip test covering `no`/`yes`/`on`/`off` tokens (the failing test from the issue) plus a check that real booleans still parse as booleans. The read-only kubeconfig parse in `integrations/eks.rs` never writes back, so it is intentionally unchanged.

Fixes #670

## `fix(server)`: retry subdomain auto-release on slot CAS conflict (#671)

`release_ineligible_subdomain` turned a claim-slot `compare_and_update` failure into a plain `anyhow::Error` via `bail!`, which reached the `with_dsql_retry!` callers (`remove_additional_domain`, `record_recheck_result`) as non-retryable `OrgCasError::Other` and permanently failed the remove/unverify operation with a spurious "please retry" message. It now returns `SubdomainClaimError::OccConflict` — matching the sibling `release_subdomain` path — and a `From<SubdomainClaimError> for OrgCasError` conversion maps it to the retryable `OrgCasError::OccConflict` (unwrapping `Other` so DB error codes stay visible to `is_retryable_db_error`). Added a unit test asserting the retryability mapping.

Fixes #671

## `fix(cli)`: reject `--role` with `--discover` in `setup aws` (#672)

`setup aws` returns into discovery before `--role` is ever read, so the flag was silently ignored when combined with `--discover`. Restored the `conflicts_with = "role"` guard (dropped in #601) so the combination fails at parse time with a clear conflict error, matching how the credential subcommands handle mutually exclusive flags. Added parse tests for both the rejected combination and `--discover` alone (which must keep working for discovery from a stored org).

Fixes #672

## Verification

- `make fmt` / `make lint` (clippy `-D warnings`, no-panic policy) — clean
- `make test` — 4,155 passed, 0 failed
- `make test-integration` — 348 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZqAuaVUEtCmpC2sJL8VwS

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZqAuaVUEtCmpC2sJL8VwS)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Kubeconfig and org-domain/subdomain paths affect real auth and OIDC issuer state; changes are narrow with regression tests but touch credential persistence and transactional retry behavior.
> 
> **Overview**
> Three targeted bug fixes across CLI and server.
> 
> **Kubeconfig (#670):** `load_kubeconfig` now parses through `parse_kubeconfig` with `strict_booleans: true`, so YAML 1.1 words like `no`/`yes` in other users' auth fields stay strings instead of becoming `false`/`true` on save. A round-trip regression test covers `no`/`yes`/`on`/`off` plus real `true` booleans.
> 
> **Subdomain auto-release (#671):** When the claim-slot CAS fails in `release_ineligible_subdomain`, the code returns `SubdomainClaimError::OccConflict` (aligned with `release_subdomain`) instead of a non-retryable `anyhow` error. `From<SubdomainClaimError> for OrgCasError` maps that to retryable `OrgCasError::OccConflict` so domain remove/recheck transactions can retry.
> 
> **`vouch setup aws` (#672):** `--discover` again declares `conflicts_with = "role"` so `--role` plus `--discover` fails at parse time instead of silently ignoring `--role`. Parse tests cover both the conflict and discover-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1694fef7e13750a9c1a61c2c30c59c5fb21edb7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->