### PR TITLE
build: harden Claude Code session setup hooks

### DIFF
--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -69,7 +69,11 @@ if [ -d /root/.ccr ]; then
   # --all-features cycle) and has little value in a container that starts cold,
   # while the session's disk allowance is fixed.
   cargo_config="$HOME/.cargo/config.toml"
-  if ! grep -qs 'incremental' "$cargo_config"; then
+  if grep -qsE '^[[:space:]]*incremental[[:space:]]*=' "$cargo_config"; then
+    # Flip any existing setting in place; appending a second [build] table
+    # would be invalid TOML.
+    sed -i -E 's/^([[:space:]]*incremental[[:space:]]*=[[:space:]]*).*/\1false/' "$cargo_config"
+  else
     mkdir -p "$HOME/.cargo"
     printf '\n[build]\nincremental = false\n' >>"$cargo_config"
   fi
@@ -100,6 +104,12 @@ exec ssh-keygen "$@"
 EOF
     chmod 755 "$shim"
     git config --global gpg.ssh.program "$shim"
+    # The provisioned value may live in repo-local .git/config, which overrides
+    # the global write above; if the effective value still isn't the shim, set
+    # it in the local scope too (.git/config is never committed).
+    if [ "$(git config --get gpg.ssh.program 2>/dev/null)" != "$shim" ]; then
+      git config --local gpg.ssh.program "$shim"
+    fi
   fi
 fi
 

--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Claude Code SessionStart hook: prepare a fresh container to build and gate this repo.
+#
+# Every step is idempotent and skips silently when already satisfied or when the
+# network policy blocks a download. The hook must never fail the session, so it
+# always exits 0. Linux-only; a no-op elsewhere.
+
+[ "$(uname)" = "Linux" ] || exit 0
+
+# System packages: aws-lc-rs (FIPS) and hidapi builds (see AGENTS.md), plus the
+# shell linters the prek hooks invoke. dpkg -s fails if ANY package is missing.
+pkgs=(libudev-dev libssl-dev pkg-config cmake clang golang-go shellcheck shfmt)
+if ! dpkg -s "${pkgs[@]}" >/dev/null 2>&1; then
+  # Not &&-chained: a single broken third-party repo makes `update` exit nonzero,
+  # but installs from the already-cached indexes still succeed.
+  sudo apt-get update -qq >/dev/null 2>&1 || true
+  sudo apt-get install -y -qq "${pkgs[@]}" >/dev/null 2>&1
+fi
+
+# Rust toolchain manager. rust-toolchain.toml pins the actual toolchain, which
+# rustup fetches on first cargo invocation.
+if ! command -v rustup >/dev/null 2>&1 && [ ! -x "$HOME/.cargo/bin/rustup" ]; then
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |
+    sh -s -- -y --default-toolchain none >/dev/null 2>&1
+fi
+
+# TailwindCSS CLI, required by `make css-build` (and thus build/run-server).
+# Prefer the standalone binary (repo policy); fall back to the npm registry,
+# which stays reachable when github.com egress is restricted to session repos.
+if ! command -v tailwindcss >/dev/null 2>&1; then
+  case "$(uname -m)" in
+  x86_64) tw_arch=x64 ;;
+  aarch64 | arm64) tw_arch=arm64 ;;
+  *) tw_arch="" ;;
+  esac
+  if [ -n "$tw_arch" ]; then
+    tw_tmp=$(mktemp)
+    if curl -fsSL --max-time 120 -o "$tw_tmp" \
+      "https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-${tw_arch}" \
+      >/dev/null 2>&1; then
+      sudo install -m 755 "$tw_tmp" /usr/local/bin/tailwindcss >/dev/null 2>&1
+    fi
+    rm -f "$tw_tmp"
+  fi
+  if ! command -v tailwindcss >/dev/null 2>&1 && command -v npm >/dev/null 2>&1; then
+    npm install -g --silent @tailwindcss/cli >/dev/null 2>&1
+    # Unlike the standalone binary, the npm CLI resolves `@import "tailwindcss"`
+    # by walking node_modules up from the input CSS file, so the package must
+    # also be installed. Put it in the checkout's parent directory: that is on
+    # the resolution path but keeps the repo working tree clean (--no-save
+    # writes no package.json there either).
+    (cd "$(dirname "$PWD")" && npm install --no-save --silent tailwindcss >/dev/null 2>&1)
+  fi
+fi
+
+# prek, required by the pre-PR gate (see .claude/rules/branching.md). PyPI ships
+# prebuilt binaries and stays reachable when github.com egress is restricted.
+if ! command -v prek >/dev/null 2>&1 && [ ! -x "$HOME/.local/bin/prek" ]; then
+  pip3 install --user --quiet prek >/dev/null 2>&1
+fi
+if [ -x "$HOME/.local/bin/prek" ] && ! command -v prek >/dev/null 2>&1; then
+  sudo ln -sf "$HOME/.local/bin/prek" /usr/local/bin/prek >/dev/null 2>&1
+fi
+
+# Claude remote-execution containers only (detected by the agent-proxy config
+# directory). These tweaks must not touch local developer machines.
+if [ -d /root/.ccr ]; then
+  # Incremental compilation roughly doubles target/ (~30 GB vs ~14 GB for a full
+  # --all-features cycle) and has little value in a container that starts cold,
+  # while the session's disk allowance is fixed.
+  cargo_config="$HOME/.cargo/config.toml"
+  if ! grep -qs 'incremental' "$cargo_config"; then
+    mkdir -p "$HOME/.cargo"
+    printf '\n[build]\nincremental = false\n' >>"$cargo_config"
+  fi
+
+  # git uses one program (gpg.ssh.program) for both signing and verification, but
+  # the provisioned signer implements only "-Y sign", so locally every signed
+  # commit reports as unverifiable (%G? = N/E) and the stop hook flags good
+  # commits. Route verification subcommands to the real ssh-keygen instead; the
+  # allowed-signers file is already provisioned.
+  # Read config unscoped: the signer program is global but the allowed-signers
+  # file is provisioned in the repo-local .git/config (cwd is the project root
+  # when SessionStart hooks run).
+  shim=/usr/local/bin/git-ssh-sign-shim
+  sign_prog=$(git config --get gpg.ssh.program 2>/dev/null)
+  signers=$(git config --get gpg.ssh.allowedSignersFile 2>/dev/null)
+  if [ "$(git config --get gpg.format 2>/dev/null)" = "ssh" ] &&
+    { [ "$sign_prog" = "/tmp/code-sign" ] || [ "$sign_prog" = "$shim" ]; } &&
+    [ -f "$signers" ] && [ -e /tmp/code-sign ] &&
+    command -v ssh-keygen >/dev/null 2>&1; then
+    cat >"$shim" <<'EOF'
+#!/bin/sh
+# Route git SSH signing to the provisioned signer and everything else
+# (-Y verify, -Y find-principals, ...) to the real ssh-keygen.
+if [ "$1" = "-Y" ] && [ "$2" = "sign" ]; then
+  exec /tmp/code-sign "$@"
+fi
+exec ssh-keygen "$@"
+EOF
+    chmod 755 "$shim"
+    git config --global gpg.ssh.program "$shim"
+  fi
+fi
+
+exit 0

--- a/.claude/rules/branching.md
+++ b/.claude/rules/branching.md
@@ -26,7 +26,7 @@ Branch names mirror the Conventional Commit type of the work (see `commits-and-i
 Run the project gates from the workspace root (all are `make` targets):
 
 ```bash
-make fmt        # cargo +nightly fmt — ALWAYS run before pushing; never a follow-up commit
+make fmt        # cargo fmt --all — ALWAYS run before pushing; never a follow-up commit
 make lint       # cargo clippy --all-targets --all-features -- -D warnings (zero warnings)
 make test       # unit tests (--all-features; covers feature-gated middleware/tests)
 prek run        # git hooks (formatting, lint, secrets)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,11 +8,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"$(uname)\" = \"Linux\" ] && (dpkg -s libudev-dev > /dev/null 2>&1 || sudo apt-get update && sudo apt-get install -y libudev-dev cmake golang-go clang) > /dev/null 2>&1; true"
-          },
-          {
-            "type": "command",
-            "command": "[ \"$(uname)\" = \"Linux\" ] && { which rustup > /dev/null 2>&1 || (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none && . \"$HOME/.cargo/env\"); } > /dev/null 2>&1; true"
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-setup.sh",
+            "timeout": 300
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 See `CLAUDE.md` for full project overview, architecture, code conventions, and commands.
 
-## Cursor Cloud specific instructions
+## Cloud environment instructions (Cursor Cloud, Claude Code remote)
 
 ### System dependencies
 
@@ -15,9 +15,15 @@ export AWS_LC_FIPS_SYS_CXX=clang++
 
 These are already configured in `~/.bashrc` on the Cloud VM.
 
+On Claude Code sessions, `.claude/hooks/session-setup.sh` runs at session start and installs the system packages, rustup, the TailwindCSS CLI, and `prek` when missing (each step skips silently if the network policy blocks its download).
+
 ### TailwindCSS
 
-The server UI requires the **standalone** TailwindCSS v4 CLI binary (not npm). It is installed at `/usr/local/bin/tailwindcss`. Run `make css-build` before starting the server or building the project.
+The server UI requires the **standalone** TailwindCSS v4 CLI binary (not npm). It is installed at `/usr/local/bin/tailwindcss`. Run `make css-build` before starting the server or building the project. (On Claude Code remote containers, where GitHub release downloads may be blocked, the session hook falls back to installing the same CLI from the npm registry — this does not add a node toolchain to the project.)
+
+### Disk space (Claude Code remote containers)
+
+Writable disk is a fixed per-session allowance, and a full `--all-features` build of this workspace is large. The session hook disables incremental compilation in these containers (`~/.cargo/config.toml`), which roughly halves `target/` (~14 GB vs ~30 GB per full build cycle). On "no space left on device", delete `target/` subdirectories you no longer need — deletes still succeed while writes fail.
 
 ### Running the server locally
 


### PR DESCRIPTION
Replaces the inline SessionStart commands in `.claude/settings.json` with a checked-in `.claude/hooks/session-setup.sh` (covered by the repo's shellcheck/shfmt prek hooks), and fixes five concrete problems observed in live Claude Code remote sessions:

## Fixes

1. **Operator-precedence bug in the apt hook.** `(dpkg -s libudev-dev … || sudo apt-get update && sudo apt-get install …)` parses as `(A || B) && C`, so the install ran on *every* session start even when packages were present. The script now uses a proper guard, and no longer `&&`-chains install onto `apt-get update` — a single broken third-party repo makes `update` exit nonzero while installs from cached indexes still succeed.
2. **Missing packages.** Adds `libssl-dev` and `pkg-config` (required per AGENTS.md but never installed by the old hook) plus `shellcheck` and `shfmt` (invoked by the prek hooks).
3. **TailwindCSS CLI and prek installation.** `make css-build` (and thus `make build` / `make run-server`) and the `prek run` pre-PR gate were unusable in Claude web containers. The script prefers the standalone Tailwind binary from GitHub releases; where the network policy restricts `github.com` egress to session repos, it falls back to the npm registry (installing the `tailwindcss` package in the checkout's *parent* directory so `@import "tailwindcss"` resolves without touching the repo tree). prek installs from PyPI, which ships prebuilt binaries.
4. **Remote-container-only tweaks**, guarded by the `/root/.ccr` marker so local developer machines are untouched:
   - Disables incremental compilation via `~/.cargo/config.toml` — a full `--all-features` build cycle is ~14 GB instead of ~30 GB against the container's fixed disk allowance.
   - Installs a `gpg.ssh.program` shim that routes `-Y sign` to the provisioned signer and verification subcommands to real `ssh-keygen`, so locally signed commits verify (`%G? = G`) instead of reporting as unverifiable and triggering false "Unverified commits" stop-hook warnings.
5. **Doc fixes.** AGENTS.md now covers Claude Code remote containers (setup hook behavior, disk-allowance note); `.claude/rules/branching.md` no longer claims `make fmt` uses `cargo +nightly fmt` (the Makefile runs plain `cargo fmt --all`).

## Verification

- `bash -n`, `shellcheck`, and `shfmt -i 2 -d` clean on the new script; `jq` parses the edited settings.json
- Script run twice in a live container: second run is a ~30 ms no-op (idempotent), always exits 0
- `make css-build` succeeds via the npm-registry fallback; `prek run` passes all hooks (trailing-whitespace → shfmt) on the changed files
- `~/.cargo/config.toml` gains the `[build] incremental = false` block exactly once; a subsequent `cargo build` creates no `target/debug/incremental` entries
- The commit on this PR was signed through the new shim and verifies locally as `%G? = G`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZqAuaVUEtCmpC2sJL8VwS

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZqAuaVUEtCmpC2sJL8VwS)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Claude/agent hook scripts and documentation; no application runtime or security-sensitive product code paths.
> 
> **Overview**
> **SessionStart** setup moves from two inline shell one-liners in `.claude/settings.json` into checked-in `.claude/hooks/session-setup.sh` (300s timeout), so the same logic can be linted with **shellcheck**/**shfmt** via prek.
> 
> The script fixes **apt** guarding (install only when packages are missing; `update` failures no longer block install) and expands Linux deps (**libssl-dev**, **pkg-config**, **shellcheck**, **shfmt**). It idempotently installs **rustup**, **tailwindcss** (GitHub binary with npm fallback + parent-dir `tailwindcss` for `@import`), and **prek** (PyPI + optional `/usr/local/bin` symlink).
> 
> When `/root/.ccr` is present (Claude remote only), it sets **Cargo** `incremental = false` in `~/.cargo/config.toml` and installs a **git SSH signing shim** so `-Y sign` uses `/tmp/code-sign` while verify uses real **ssh-keygen**.
> 
> Docs: **AGENTS.md** covers the hook, Tailwind fallback, and disk usage; **branching.md** documents `make fmt` as `cargo fmt --all` (not nightly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f49c2d2bfb5127da7bafda1d4c45396e14d1bef7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->