### PR TITLE
fix(server): enforce access-token audience at resource endpoints (#688)

### DIFF
--- a/crates/vouch-server/src/crypto/jwt.rs
+++ b/crates/vouch-server/src/crypto/jwt.rs
@@ -380,6 +380,12 @@ impl<'a> TokenValidationContext<'a> {
 ///
 /// For access tokens, audience validation is contextual — callers MUST
 /// validate `aud` against their expected audience (RFC 8725 Section 3.9).
+/// For Vouch's own resource endpoints this is enforced by
+/// `handlers::session::extract_resource_token`, which rejects
+/// resource-narrowed tokens (`aud != client_id`) whose audience does not
+/// cover the deployment and request path. Authorization-server consumers
+/// (userinfo, introspection, revocation, token exchange) are deliberately
+/// audience-agnostic per their RFCs.
 ///
 /// This is the verification mechanism only; the access-token claims schema
 /// `C` is owned by the caller (`services::auth::AccessTokenClaims` for the

--- a/crates/vouch-server/src/handlers/oidc/tests/aud_enforcement.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/aud_enforcement.rs
@@ -1,0 +1,435 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! Access-token audience enforcement at resource endpoints
+//! (RFC 8707 / RFC 8725 §3.9 / RFC 9068).
+//!
+//! A token narrowed to an explicit resource (`aud != client_id`) is only
+//! accepted at endpoints its audience covers; tokens with the default
+//! audience (`aud == client_id`) remain deployment-wide. Authorization-server
+//! endpoints (userinfo, introspection, revocation, token exchange) stay
+//! audience-agnostic per their RFCs.
+
+use super::helpers::*;
+
+/// Narrowed token accepted at exactly the resource its audience names,
+/// including sub-paths at segment boundaries.
+#[tokio::test]
+async fn test_narrowed_token_accepted_at_named_resource() {
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "aud-named@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let base_url = state.config().base_url.clone();
+    let audience = format!("{base_url}/v1/keys");
+    let token = create_test_session_with_audience(
+        &state,
+        &user.id,
+        &user.email,
+        &auth_id,
+        &base_url,
+        &audience,
+    )
+    .await;
+
+    let (status, body) = http_get(
+        &app,
+        "/v1/keys",
+        &[("Authorization", &format!("Bearer {token}"))],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "Token narrowed to /v1/keys must be accepted at /v1/keys: {body}"
+    );
+}
+
+/// The issue's exact complaint: a token audience-scoped to resource A must
+/// be rejected at resource B with a spec-conformant 401.
+#[tokio::test]
+async fn test_narrowed_token_rejected_at_other_resource() {
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "aud-cross@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let base_url = state.config().base_url.clone();
+    let audience = format!("{base_url}/api/v1/applications");
+    let token = create_test_session_with_audience(
+        &state,
+        &user.id,
+        &user.email,
+        &auth_id,
+        &base_url,
+        &audience,
+    )
+    .await;
+
+    // Accepted at the named resource…
+    let (status, body) = http_get(
+        &app,
+        "/api/v1/applications",
+        &[("Authorization", &format!("Bearer {token}"))],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "named resource must accept: {body}");
+
+    // …rejected everywhere else, with WWW-Authenticate carrying the
+    // RFC 9728 protected-resource-metadata pointer.
+    let response = http_get_full(
+        &app,
+        "/v1/keys",
+        &[("Authorization", &format!("Bearer {token}"))],
+    )
+    .await;
+    assert_eq!(
+        response.status,
+        StatusCode::UNAUTHORIZED,
+        "cross-resource replay must be rejected: {}",
+        response.body
+    );
+    assert!(
+        response.body.contains("invalid_token"),
+        "401 must use the invalid_token error code, got: {}",
+        response.body
+    );
+    let www_auth = response
+        .headers
+        .get("www-authenticate")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default();
+    assert!(
+        www_auth.contains("resource_metadata="),
+        "WWW-Authenticate must carry the RFC 9728 metadata pointer, got: {www_auth}"
+    );
+}
+
+/// A segment-boundary sibling (`/v1/keysextra`-style) is not covered; only
+/// true sub-paths of the audience are.
+#[tokio::test]
+async fn test_narrowed_token_covers_subpath_not_sibling() {
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "aud-subpath@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let base_url = state.config().base_url.clone();
+    let audience = format!("{base_url}/v1/keys");
+    let token = create_test_session_with_audience(
+        &state,
+        &user.id,
+        &user.email,
+        &auth_id,
+        &base_url,
+        &audience,
+    )
+    .await;
+    let auth = format!("Bearer {token}");
+
+    // Sub-path of the audience: covered (route exists and requires a body,
+    // so anything but 401 shows the audience gate passed).
+    let (status, _body) = http_post_json(
+        &app,
+        "/v1/keys/register/start",
+        "{}",
+        &[("Authorization", &auth)],
+    )
+    .await;
+    assert_ne!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "sub-path of audience must pass the audience gate"
+    );
+
+    // Sibling resource: not covered.
+    let (status, _body) = http_get(
+        &app,
+        "/v1/credentials/aws/token",
+        &[("Authorization", &auth)],
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "sibling resource must be rejected"
+    );
+}
+
+/// An audience naming the deployment root (the RFC 9728 `resource={base_url}`
+/// registration) covers every resource endpoint.
+#[tokio::test]
+async fn test_root_scoped_audience_accepted_everywhere() {
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "aud-root@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let base_url = state.config().base_url.clone();
+    // Trailing slash: differs from client_id byte-wise (so the enforcement
+    // path runs) but still names the deployment root.
+    let audience = format!("{base_url}/");
+    let token = create_test_session_with_audience(
+        &state,
+        &user.id,
+        &user.email,
+        &auth_id,
+        &base_url,
+        &audience,
+    )
+    .await;
+    let auth = format!("Bearer {token}");
+
+    let (status, body) = http_get(&app, "/v1/keys", &[("Authorization", &auth)]).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "root-scoped aud at /v1/keys: {body}"
+    );
+
+    let (status, body) = http_get(&app, "/api/v1/applications", &[("Authorization", &auth)]).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "root-scoped aud at /api/v1/applications: {body}"
+    );
+}
+
+/// Tokens narrowed to an external resource server are useless at vouch's
+/// own endpoints, regardless of the DB session being valid.
+#[tokio::test]
+async fn test_external_audience_rejected_at_resource_endpoints() {
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "aud-external@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let base_url = state.config().base_url.clone();
+    let token = create_test_session_with_audience(
+        &state,
+        &user.id,
+        &user.email,
+        &auth_id,
+        &base_url,
+        "https://api.example.com",
+    )
+    .await;
+    let auth = format!("Bearer {token}");
+
+    for path in [
+        "/v1/keys",
+        "/api/v1/applications",
+        "/v1/credentials/aws/token",
+    ] {
+        let (status, body) = http_get(&app, path, &[("Authorization", &auth)]).await;
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "externally narrowed token must be rejected at {path}: {body}"
+        );
+    }
+}
+
+/// Non-URI logical audiences (RFC 8693 `audience=kubernetes`-style) cannot
+/// name this resource server.
+#[tokio::test]
+async fn test_logical_audience_rejected_at_resource_endpoints() {
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "aud-logical@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let base_url = state.config().base_url.clone();
+    let token = create_test_session_with_audience(
+        &state,
+        &user.id,
+        &user.email,
+        &auth_id,
+        &base_url,
+        "kubernetes",
+    )
+    .await;
+
+    let (status, body) = http_get(
+        &app,
+        "/v1/keys",
+        &[("Authorization", &format!("Bearer {token}"))],
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "logical audience must be rejected at resource endpoints: {body}"
+    );
+}
+
+/// Authorization-server endpoints stay audience-agnostic: userinfo accepts
+/// tokens from any client (aud is not a resource there), and introspection
+/// answers about the AS's own tokens regardless of audience.
+#[tokio::test]
+async fn test_external_audience_exempt_at_userinfo_and_introspect() {
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "aud-exempt@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+    // Bind to the registered client so the RFC 7662 cross-client check passes.
+    let token = create_test_session_with_audience(
+        &state,
+        &user.id,
+        &user.email,
+        &auth_id,
+        &client.client_id,
+        "https://api.example.com",
+    )
+    .await;
+
+    let (status, body) = http_get(
+        &app,
+        "/oauth/userinfo",
+        &[("Authorization", &format!("Bearer {token}"))],
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "userinfo must remain audience-agnostic: {body}"
+    );
+
+    let (status, body) = http_post_form(
+        &app,
+        "/oauth/introspect",
+        &format!("token={token}"),
+        &[("Authorization", &client.basic_auth_header())],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let response: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(
+        response["active"], true,
+        "introspection must remain audience-agnostic: {body}"
+    );
+    assert_eq!(
+        response["aud"], "https://api.example.com",
+        "introspection should echo the narrowed audience"
+    );
+}
+
+/// Fast-path pin: tokens with the default audience (`aud == client_id`,
+/// i.e. never resource-narrowed) are deployment-wide, exactly as before.
+#[tokio::test]
+async fn test_default_audience_token_accepted_everywhere() {
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "aud-default@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let auth = format!("Bearer {token}");
+
+    let (status, body) = http_get(&app, "/v1/keys", &[("Authorization", &auth)]).await;
+    assert_eq!(status, StatusCode::OK, "default token at /v1/keys: {body}");
+
+    let (status, body) = http_get(&app, "/api/v1/applications", &[("Authorization", &auth)]).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "default token at /api/v1/applications: {body}"
+    );
+}
+
+/// A token narrowed via RFC 8693 token exchange (`resource` parameter) is
+/// enforced identically to one narrowed at the authorization endpoint.
+#[tokio::test]
+async fn test_exchange_narrowed_token_enforced() {
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "aud-exchange@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    // Shared JWKS so the transparently-signed `/v1/*` requests verify against
+    // this client's registration (the exchanged token carries its client_id).
+    let client = create_test_client(
+        &state.store,
+        &user.id,
+        TestClientSpec {
+            jwks: TestJwks::Shared,
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let (subject_token, _) = issue_oauth_access_token(&app, &state, &user, &auth_id, &client).await;
+
+    let base_url = state.config().base_url.clone();
+    let resource_uri = format!("{base_url}/v1/keys");
+    let (status, body) = http_post_form(
+        &app,
+        "/oauth/token",
+        &format!(
+            "grant_type=urn:ietf:params:oauth:grant-type:token-exchange\
+             &subject_token={subject_token}\
+             &subject_token_type=urn:ietf:params:oauth:token-type:access_token\
+             &resource={resource_uri}"
+        ),
+        &[("Authorization", &client.basic_auth_header())],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "exchange should succeed: {body}");
+    let response: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let exchanged = response["access_token"].as_str().expect("access_token");
+    let auth = format!("Bearer {exchanged}");
+
+    let (status, body) = http_get(&app, "/v1/keys", &[("Authorization", &auth)]).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "exchanged token must work at its named resource: {body}"
+    );
+
+    let (status, body) = http_get(&app, "/api/v1/applications", &[("Authorization", &auth)]).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "exchanged token must be rejected at other resources: {body}"
+    );
+}
+
+/// Cookie-only extraction paths (browser UI handlers pass an empty request
+/// path) accept only deployment-root audiences; narrowed tokens smuggled
+/// into the session cookie are rejected.
+#[tokio::test]
+async fn test_cookie_only_path_rejects_narrowed_token() {
+    use axum_extra::extract::CookieJar;
+    use axum_extra::extract::cookie::Cookie;
+
+    let (_app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "aud-cookie@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let base_url = state.config().base_url.clone();
+
+    let narrowed = create_test_session_with_audience(
+        &state,
+        &user.id,
+        &user.email,
+        &auth_id,
+        &base_url,
+        &format!("{base_url}/v1/keys"),
+    )
+    .await;
+    let jar = CookieJar::new().add(Cookie::new(vouch_common::SESSION_COOKIE_NAME, narrowed));
+    let result = crate::handlers::extract_session_from_cookie(&state, &jar).await;
+    assert!(
+        result.is_err(),
+        "narrowed token must be rejected on cookie-only paths"
+    );
+
+    let root_scoped = create_test_session_with_audience(
+        &state,
+        &user.id,
+        &user.email,
+        &auth_id,
+        &base_url,
+        &format!("{base_url}/"),
+    )
+    .await;
+    let jar = CookieJar::new().add(Cookie::new(vouch_common::SESSION_COOKIE_NAME, root_scoped));
+    let result = crate::handlers::extract_session_from_cookie(&state, &jar).await;
+    assert!(
+        result.is_ok(),
+        "deployment-root audience must be accepted on cookie-only paths: {result:?}"
+    );
+}

--- a/crates/vouch-server/src/handlers/oidc/tests/mod.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/mod.rs
@@ -12,6 +12,7 @@
 
 mod helpers;
 
+mod aud_enforcement;
 mod auth_flows;
 mod e2e;
 mod fapi2;

--- a/crates/vouch-server/src/handlers/session.rs
+++ b/crates/vouch-server/src/handlers/session.rs
@@ -59,12 +59,18 @@ impl AuthContext {
 /// 2. `Authorization: Bearer <token>` — standard Bearer token
 /// 3. `__Host-vouch_session` cookie — browser sessions
 ///
-/// Validates the token as ES256 `at+jwt` (RFC 9068), verifies session
-/// existence in DB, and validates DPoP proof if the token is sender-constrained.
+/// Validates the token as ES256 `at+jwt` (RFC 9068), enforces audience
+/// coverage for resource-narrowed tokens (RFC 8707 / RFC 8725 §3.9 — a
+/// token whose `aud` differs from its `client_id` is accepted only when
+/// the audience covers this deployment and request path; see
+/// [`crate::services::oidc::resource::audience_covers_resource`]), verifies
+/// session existence in DB, and validates DPoP proof if the token is
+/// sender-constrained.
 ///
 /// `method` and `uri` are the actual HTTP method and path of the request,
-/// used for DPoP proof validation. Pass empty strings for cookie-only paths
-/// where DPoP validation is skipped.
+/// used for DPoP proof validation and audience coverage. Pass empty strings
+/// for cookie-only paths where DPoP validation is skipped (an empty `uri`
+/// means only deployment-root audiences pass the coverage check).
 pub(crate) async fn extract_resource_token(
     state: &AppState,
     headers: &axum::http::HeaderMap,
@@ -91,6 +97,9 @@ pub(crate) async fn extract_resource_token(
         })?;
 
     let crate::services::auth::DecodedToken::AccessToken(access_claims) = decoded;
+
+    // 2b. Audience coverage for resource-narrowed tokens.
+    enforce_audience_coverage(&access_claims, &config.base_url, uri)?;
 
     // 3. Verify session exists in DB via token_hash
     let token_hash = hash_token(&token);
@@ -231,6 +240,7 @@ pub(crate) async fn extract_resource_token(
         sub: access_claims.sub,
         email: access_claims.email,
         client_id: access_claims.client_id,
+        aud: access_claims.aud,
         scope: access_claims.scope,
         authenticator_id: session.authenticator_id,
         hardware_verified: access_claims.hardware_verified,
@@ -240,6 +250,42 @@ pub(crate) async fn extract_resource_token(
         hardware_aaguid: session.hardware_aaguid,
         org_domain: session.org_domain,
     })
+}
+
+/// Reject a resource-narrowed access token whose audience does not cover
+/// the requested resource (RFC 8725 §3.9 / RFC 8707).
+///
+/// Tokens with the default audience (`aud == client_id`, i.e. never
+/// resource-narrowed) are deployment-wide and always pass. Narrowed tokens
+/// pass only when
+/// [`crate::services::oidc::resource::audience_covers_resource`] accepts
+/// the audience for this deployment and request path.
+fn enforce_audience_coverage(
+    access_claims: &crate::services::auth::AccessTokenClaims,
+    base_url: &str,
+    uri: &str,
+) -> Result<(), ServiceError> {
+    if access_claims.aud == access_claims.client_id
+        || crate::services::oidc::resource::audience_covers_resource(
+            &access_claims.aud,
+            base_url,
+            uri,
+        )
+    {
+        return Ok(());
+    }
+
+    tracing::warn!(
+        client_id = %access_claims.client_id,
+        aud = %access_claims.aud,
+        path = %uri,
+        "rejected access token: audience does not cover resource"
+    );
+    Err(ServiceError::api(
+        StatusCode::UNAUTHORIZED,
+        "invalid_token",
+        "Access token audience does not cover this resource",
+    ))
 }
 
 /// Extract resource token and also fetch the user email from DB.

--- a/crates/vouch-server/src/services/auth.rs
+++ b/crates/vouch-server/src/services/auth.rs
@@ -844,6 +844,11 @@ pub(crate) struct ValidatedResourceToken {
     pub email: Option<String>,
     /// OAuth client_id from the access token.
     pub client_id: String,
+    /// Audience (`aud` claim) from the access token. Equals `client_id`
+    /// for un-narrowed tokens; a resource URI for tokens narrowed via
+    /// RFC 8707 `resource` or RFC 8693 `audience`. Audience coverage has
+    /// already been enforced by `extract_resource_token`.
+    pub aud: String,
     /// Granted OAuth scope.
     pub scope: Option<crate::services::oidc::ScopeSet>,
     /// Authenticator ID from the server-side session record (not in JWT).

--- a/crates/vouch-server/src/services/integrations/aws.rs
+++ b/crates/vouch-server/src/services/integrations/aws.rs
@@ -252,6 +252,7 @@ mod tests {
             sub: "user-id".to_string(),
             email: None,
             client_id: "test-client".to_string(),
+            aud: "test-client".to_string(),
             scope: None,
             authenticator_id: None,
             hardware_verified: true,

--- a/crates/vouch-server/src/services/oidc/resource.rs
+++ b/crates/vouch-server/src/services/oidc/resource.rs
@@ -75,6 +75,83 @@ impl std::fmt::Display for ResourceUri {
     }
 }
 
+/// Strip at most one trailing `/` so `https://x/` and `https://x` compare equal.
+fn trim_trailing_slash(path: &str) -> &str {
+    path.strip_suffix('/').unwrap_or(path)
+}
+
+/// True when a resource-narrowed `aud` authorizes a request to `request_path`
+/// on the deployment identified by `base_url` (RFC 8707 / RFC 8725 §3.9).
+///
+/// A narrowed audience covers a request when all of the following hold:
+/// - `aud` is an absolute URI without query or fragment components;
+/// - its origin (scheme + host + port) equals the deployment's `base_url`
+///   origin — audiences naming external resource servers never authorize
+///   requests to this deployment;
+/// - its path covers the request path at a segment boundary: an audience
+///   equal to the deployment root covers every request, while
+///   `{base_url}/v1/keys` covers `/v1/keys` and `/v1/keys/register` but not
+///   `/v1/keysextra`.
+///
+/// `request_path` is the request path relative to `base_url` (as passed to
+/// `extract_resource_token`); an empty value is treated as `/`, so only a
+/// root-scoped audience covers cookie-only extraction paths.
+///
+/// Trailing slashes are insignificant on both the audience path and the
+/// request path. Comparison is on URL-normalized paths (no percent-decoding);
+/// audiences are matched as issued.
+pub(crate) fn audience_covers_resource(aud: &str, base_url: &str, request_path: &str) -> bool {
+    let Ok(aud_url) = url::Url::parse(aud) else {
+        // Non-URI audiences (e.g. a token-exchange logical audience like
+        // "kubernetes") cannot name this resource server.
+        return false;
+    };
+    let Ok(base) = url::Url::parse(base_url) else {
+        return false;
+    };
+
+    // Conservative: an audience with a query or fragment never matches.
+    if aud_url.query().is_some() || aud_url.fragment().is_some() {
+        return false;
+    }
+
+    // Scheme + host + port must match the deployment. `Url::origin` handles
+    // host case-insensitivity and default-port elision; opaque origins
+    // (non-special schemes such as `urn:`) never compare equal.
+    if aud_url.origin() != base.origin() {
+        return false;
+    }
+
+    let aud_path = trim_trailing_slash(aud_url.path());
+    let base_path = trim_trailing_slash(base.path());
+
+    // Audience names the deployment root (`resource={base_url}`): covers
+    // every path on this deployment.
+    if aud_path == base_path {
+        return true;
+    }
+
+    // Otherwise the audience must extend the base path at a segment boundary;
+    // the remainder is the resource path relative to base_url.
+    let rel = match aud_path.strip_prefix(base_path) {
+        Some(rel) if rel.starts_with('/') => rel,
+        _ => return false,
+    };
+
+    let request = if request_path.is_empty() {
+        "/"
+    } else {
+        request_path
+    };
+    let request = trim_trailing_slash(request);
+
+    // Exact resource, or a sub-path at a segment boundary.
+    request == rel
+        || request
+            .strip_prefix(rel)
+            .is_some_and(|rest| rest.starts_with('/'))
+}
+
 #[cfg(test)]
 #[expect(
     clippy::unwrap_used,
@@ -139,5 +216,173 @@ mod tests {
     fn test_display() {
         let uri = ResourceUri::parse("https://api.example.com").unwrap();
         assert_eq!(format!("{uri}"), "https://api.example.com/");
+    }
+
+    const BASE: &str = "https://vouch.example.com";
+
+    #[test]
+    fn test_covers_exact_path() {
+        assert!(audience_covers_resource(
+            "https://vouch.example.com/v1/keys",
+            BASE,
+            "/v1/keys"
+        ));
+    }
+
+    #[test]
+    fn test_covers_sub_path() {
+        assert!(audience_covers_resource(
+            "https://vouch.example.com/v1/keys",
+            BASE,
+            "/v1/keys/register/start"
+        ));
+    }
+
+    #[test]
+    fn test_rejects_sibling_path() {
+        assert!(!audience_covers_resource(
+            "https://vouch.example.com/v1/keys",
+            BASE,
+            "/v1/credentials/ssh"
+        ));
+    }
+
+    #[test]
+    fn test_rejects_segment_boundary_violation() {
+        // aud=…/v1/keys must not authorize /v1/keysextra
+        assert!(!audience_covers_resource(
+            "https://vouch.example.com/v1/keys",
+            BASE,
+            "/v1/keysextra"
+        ));
+    }
+
+    #[test]
+    fn test_root_audience_covers_everything() {
+        assert!(audience_covers_resource(BASE, BASE, "/v1/keys"));
+        assert!(audience_covers_resource(BASE, BASE, "/v1/credentials/ssh"));
+        assert!(audience_covers_resource(BASE, BASE, ""));
+        // With url's host-only normalization (`https://x` parses to path `/`)
+        assert!(audience_covers_resource(
+            "https://vouch.example.com/",
+            BASE,
+            "/v1/keys"
+        ));
+    }
+
+    #[test]
+    fn test_trailing_slash_insensitive() {
+        assert!(audience_covers_resource(
+            "https://vouch.example.com/v1/keys/",
+            BASE,
+            "/v1/keys"
+        ));
+        assert!(audience_covers_resource(
+            "https://vouch.example.com/v1/keys",
+            BASE,
+            "/v1/keys/"
+        ));
+        assert!(audience_covers_resource(
+            "https://vouch.example.com/v1/keys",
+            "https://vouch.example.com/",
+            "/v1/keys"
+        ));
+    }
+
+    #[test]
+    fn test_host_case_and_default_port_normalization() {
+        assert!(audience_covers_resource(
+            "HTTPS://Vouch.Example.COM:443/v1/keys",
+            BASE,
+            "/v1/keys"
+        ));
+    }
+
+    #[test]
+    fn test_rejects_external_origin() {
+        assert!(!audience_covers_resource(
+            "https://api.example.com",
+            BASE,
+            "/v1/keys"
+        ));
+        assert!(!audience_covers_resource(
+            "https://api.example.com/v1/keys",
+            BASE,
+            "/v1/keys"
+        ));
+        // Same host, different scheme or explicit non-default port
+        assert!(!audience_covers_resource(
+            "http://vouch.example.com",
+            BASE,
+            "/v1/keys"
+        ));
+        assert!(!audience_covers_resource(
+            "https://vouch.example.com:8443",
+            BASE,
+            "/v1/keys"
+        ));
+    }
+
+    #[test]
+    fn test_rejects_non_uri_audience() {
+        assert!(!audience_covers_resource("kubernetes", BASE, "/v1/keys"));
+        assert!(!audience_covers_resource("", BASE, "/v1/keys"));
+        assert!(!audience_covers_resource(
+            "urn:example:resource",
+            BASE,
+            "/v1/keys"
+        ));
+    }
+
+    #[test]
+    fn test_rejects_query_and_fragment() {
+        assert!(!audience_covers_resource(
+            "https://vouch.example.com/v1/keys?x=1",
+            BASE,
+            "/v1/keys"
+        ));
+        assert!(!audience_covers_resource(
+            "https://vouch.example.com/v1/keys#frag",
+            BASE,
+            "/v1/keys"
+        ));
+    }
+
+    #[test]
+    fn test_empty_request_path_only_covered_by_root() {
+        // Cookie-only extraction passes an empty request path.
+        assert!(audience_covers_resource(BASE, BASE, ""));
+        assert!(!audience_covers_resource(
+            "https://vouch.example.com/v1/keys",
+            BASE,
+            ""
+        ));
+    }
+
+    #[test]
+    fn test_base_url_with_path_prefix() {
+        let base = "https://vouch.example.com/vouch";
+        assert!(audience_covers_resource(
+            "https://vouch.example.com/vouch/v1/keys",
+            base,
+            "/v1/keys"
+        ));
+        assert!(audience_covers_resource(
+            "https://vouch.example.com/vouch",
+            base,
+            "/v1/keys"
+        ));
+        // aud path must extend the base path at a segment boundary
+        assert!(!audience_covers_resource(
+            "https://vouch.example.com/vouchextra/v1/keys",
+            base,
+            "/v1/keys"
+        ));
+        // aud outside the base path never matches
+        assert!(!audience_covers_resource(
+            "https://vouch.example.com/v1/keys",
+            base,
+            "/v1/keys"
+        ));
     }
 }

--- a/crates/vouch-server/src/test_utils.rs
+++ b/crates/vouch-server/src/test_utils.rs
@@ -861,6 +861,66 @@ pub async fn create_test_session(
     result.token.expose_secret().to_string()
 }
 
+/// Create a test session whose access token is narrowed to an explicit
+/// audience (RFC 8707 resource / RFC 8693 audience).
+///
+/// Mirrors [`create_test_session`] but passes `audience: Some(..)`, so the
+/// minted token has `aud != client_id` and exercises the audience-coverage
+/// enforcement in `extract_resource_token` without driving the full
+/// authorization-code flow. `client_id` is explicit so tests can bind the
+/// token to a registered OAuth client (e.g. for the introspection
+/// cross-client check); pass `&state.config().base_url` to mirror
+/// [`create_test_session`].
+pub async fn create_test_session_with_audience(
+    state: &AppState,
+    user_id: &str,
+    email: &str,
+    auth_id: &str,
+    client_id: &str,
+    audience: &str,
+) -> String {
+    use crate::services::auth::{
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, TokenIssuanceProof,
+        create_oauth_access_token,
+    };
+    use crate::services::oidc::ScopeSet;
+    use secrecy::ExposeSecret;
+
+    let (hardware_aaguid, org_domain) =
+        resolve_session_snapshot(state, user_id, Some(auth_id)).await;
+
+    let result = create_oauth_access_token(
+        state,
+        CreateOAuthTokenParams {
+            user_id,
+            email,
+            authenticator_id: Some(auth_id),
+            client_id,
+            scope: Some(ScopeSet::all()),
+            dpop_jkt: None,
+            mtls_cert_thumbprint: None,
+            act: None,
+            audience: Some(audience),
+            auth_time: Some(jiff::Timestamp::now().as_second()),
+            hardware_verification: crate::services::auth::HardwareVerification::Verified,
+            session_purpose: crate::db::SessionPurpose::OAuthAccessToken,
+            authorization_details: None,
+            hardware_aaguid: hardware_aaguid.as_deref(),
+            org_domain: org_domain.as_deref(),
+        },
+        TokenIssuanceProof {
+            grant: GrantProof::TestingOnly,
+            client_auth: ClientAuthProof::NoAuth(
+                crate::services::auth::NoClientAuth::internal_endpoint(),
+            ),
+        },
+    )
+    .await
+    .expect("Failed to create audience-narrowed test session");
+
+    result.token.expose_secret().to_string()
+}
+
 /// Create a test session backed by a non-hardware-verified access token.
 ///
 /// Mirrors the enrollment-bootstrap shape in `handlers/enroll.rs`: a real

--- a/docs/src/operations/sessions.md
+++ b/docs/src/operations/sessions.md
@@ -53,4 +53,36 @@ VOUCH_CLEANUP_INTERVAL=15
 - **Time-limited** — Sessions cannot be renewed; a new login is required after expiry
 - **DPoP-bound** — Access tokens are bound to the client's DPoP key; token theft without the key is useless
 - **Non-transferable** — Sessions are bound to the client that created them
+- **Audience-restricted** — Tokens narrowed to a specific resource are rejected at every other resource (see below)
 - **Audited** — Every session creation and usage is logged
+
+## Audience Enforcement (RFC 8707 Resource Indicators)
+
+Access tokens carry an `aud` (audience) claim per RFC 9068. By default the
+audience equals the requesting `client_id` and the token is valid at every
+Vouch resource endpoint — this covers all standard flows (`vouch login`,
+browser sessions, device flow, client credentials).
+
+A client may instead narrow a token to a specific resource, either with the
+RFC 8707 `resource` parameter at the authorization endpoint or with the
+`audience`/`resource` parameters at token exchange (RFC 8693). Vouch's
+resource endpoints (`/v1/credentials/*`, `/v1/keys`, `/api/v1/*`, RFC 7592
+client management) enforce that narrowing: a narrowed token is accepted only
+when its audience names this deployment (same scheme, host, and port as the
+configured base URL) and its path covers the request at a path-segment
+boundary. An audience of the deployment root (the base URL itself) covers
+every endpoint; `{base_url}/v1/keys` covers `/v1/keys` and everything below
+it, but nothing else. Requests failing the check receive `401 invalid_token`
+with the standard `WWW-Authenticate` challenge, and the rejection is logged
+with the client ID, audience, and request path.
+
+Per their RFCs, the authorization-server endpoints remain audience-agnostic:
+`/oauth/userinfo` accepts tokens from any client, `/oauth/introspect` and
+`/oauth/revoke` answer about any token the server issued, and token exchange
+accepts narrowed subject tokens (re-scoping them is its purpose).
+
+Clients registered without `resource_uris` may request any `resource` value
+at issuance. This is safe under enforcement: a token narrowed to an external
+resource server is *less* usable at Vouch, not more — it can only be spent at
+the external service it names. Registering `resource_uris` additionally
+restricts which values a client may request at all.


### PR DESCRIPTION
Closes #688.

## Problem

vouch-server mints RFC 9068 access tokens whose `aud` is caller-influenceable (RFC 8707 `resource` at `/oauth/authorize`+PAR; `audience`/`resource` at RFC 8693 token exchange) and advertises `resource_indicators_supported: true` — but no resource endpoint validated `aud`. A token audience-narrowed to resource A was accepted at resource B; security rested entirely on the DB session lookup.

## Approach: enforce when narrowed

One check in `extract_resource_token` (the single extractor guarding `/v1/credentials/*`, `/v1/keys*`, `/api/v1/*`, and RFC 7592 client management), immediately after JWT decode:

- **Default tokens** (`aud == client_id` — every FIDO2 login, browser session, device flow, client-credentials token) pass exactly as before. Zero behavior change for existing clients.
- **Narrowed tokens** (`aud != client_id`) are accepted only when the audience covers the resource: `aud` must be an absolute URI without query/fragment, match the deployment's `base_url` origin (scheme+host+port), and cover the request path at a segment boundary (`{base_url}` covers everything; `{base_url}/v1/keys` covers `/v1/keys` and `/v1/keys/register` but not `/v1/keysextra`). Otherwise: `401 invalid_token` with the standard `WWW-Authenticate` challenge + RFC 9728 `resource_metadata` pointer, and a `tracing::warn!` with client_id/aud/path.

The coverage predicate is a new pure helper `audience_covers_resource` in `services/oidc/resource.rs`; `ValidatedResourceToken` now surfaces `aud`.

## Deliberately unchanged (FAPI 2.0 / OpenID certification safety)

- **Issuance is byte-identical** — no change to `create_oauth_access_token`, RFC 8707 resource narrowing, token-exchange audience routing, `is_valid_resource_uri`, or discovery metadata. All rfc8707/rfc9068/rfc8693/rfc8414 pins hold verbatim.
- **Audience-agnostic AS endpoints stay exempt** per their RFCs: `/oauth/userinfo` (tokens from any client), `/oauth/introspect` + `/oauth/revoke` (RFC 7662/7009), token-exchange subject/actor tokens (re-scoping is the point of RFC 8693).
- **Client-assertion `aud` validation** (`jwt_bearer/validate.rs`, pinned by fapi2/rfc7523 tests) is a separate `aud` universe and untouched.
- The FAPI 2.0 conformance suite exercises only AS endpoints, none of which flow through `extract_resource_token`, and every conformance token is un-narrowed (fast path). Audience restriction at the resource server is FAPI 2.0 Attacker Model AC4 — this implements the profile rather than deviating from it. All existing suites (`fapi2`, `rfc7523`, `rfc8707`, `rfc9068`, `rfc8693`, `rfc9126`, `rfc9728`, `rfc8414`, `rfc9449`, `org_subdomains`) run unedited as the regression gate.

The `is_valid_resource_uri` fail-open at issuance (empty registration list accepts any `resource`) is intentionally left as-is: with endpoint-side enforcement, an attacker-chosen external `aud` now strictly *reduces* what the token can do at vouch, and tightening would break the legitimate AS-for-external-resource-server pattern (WIF, k8s). Documented in `docs/src/operations/sessions.md`.

## Tests

- 13 new unit tests for `audience_covers_resource` (origin matching, segment boundaries, trailing slashes, host-case/default-port normalization, non-URI/query/fragment audiences, base-url path prefixes).
- New `handlers/oidc/tests/aud_enforcement.rs` (10 tests): cross-resource replay rejected with RFC 9728 pointer, named-resource + sub-path acceptance, root-scoped audience accepted everywhere, external/logical audiences rejected, userinfo/introspection exemptions pinned, default-token fast path pinned, token-exchange-narrowed tokens enforced, cookie-only paths reject narrowed tokens.
- New `create_test_session_with_audience` test util.
- Gates: `make fmt`, `make lint` (zero warnings under the no-panic policy), `make test` (2511 vouch-server tests green), `make test-integration` (all green, incl. `org_subdomains`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2noishf4pB8Tph4b9vfTX

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2noishf4pB8Tph4b9vfTX)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Central auth gate change for all `/v1/*` and `/api/v1/*` traffic; default tokens are unchanged but narrowed-token and cookie-session edge cases could surprise integrators.
> 
> **Overview**
> **Resource endpoints** now reject access tokens whose `aud` was narrowed away from `client_id` unless that audience covers the deployment and the request path (RFC 8707 / RFC 8725 §3.9). The check runs in `extract_resource_token` right after JWT decode, before session lookup.
> 
> Tokens with **`aud == client_id`** still pass everywhere (unchanged). Narrowed tokens must match this host’s origin and path rules via new `audience_covers_resource` in `services/oidc/resource.rs` (segment boundaries, root audience, external/logical `aud` rejected). Failures return **`401 invalid_token`** with logging; `ValidatedResourceToken` now carries **`aud`**.
> 
> **Authorization-server routes** (userinfo, introspect, etc.) are unchanged and stay audience-agnostic. **Cookie-only** session extraction (empty path) accepts only deployment-root audiences. Docs in `sessions.md` describe the behavior; broad unit and OIDC integration tests cover coverage rules and exemptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a8edf09bf31439e8277a28ebf46ec7e2a6434c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->