### PR TITLE
build: upgrade toolchain to Rust 1.97.0 (#657)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ permissions: {}
 
 env:
   CARGO_TERM_COLOR: always
+  # Deny rustc warnings on plain `cargo build`/`cargo test` (new in cargo 1.97)
+  # without invalidating the build cache, unlike RUSTFLAGS="-D warnings".
+  CARGO_BUILD_WARNINGS: deny
 
 jobs:
   fmt:

--- a/.kiro/steering/build-and-test.md
+++ b/.kiro/steering/build-and-test.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Rust 1.96+ (pinned in `rust-toolchain.toml`)
+- Rust 1.97+ (pinned in `rust-toolchain.toml`)
 - TailwindCSS v4 standalone CLI (not npm) for CSS compilation
 - Docker for container builds
 - System packages (Linux): `libssl-dev`, `libudev-dev`, `cmake`, `golang-go`, `clang`, `pkg-config`

--- a/.kiro/steering/project-overview.md
+++ b/.kiro/steering/project-overview.md
@@ -52,7 +52,7 @@ The data model is document-oriented by design:
 
 ## Toolchain
 
-- Rust 1.96.1, edition 2024 (pinned in `rust-toolchain.toml`)
+- Rust 1.97.0, edition 2024 (pinned in `rust-toolchain.toml`)
 - Max line width: 100 chars (`.rustfmt.toml`)
 - Release profile: `lto = true`, `codegen-units = 1`, `opt-level = "z"`, `panic = "abort"`, `strip = true`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ make bake-all              # musl binaries via Docker Bake (also bake-cli, bake-
 
 **Running the server locally:** at least one upstream IdP must be configured via `VOUCH_IDPS` / `VOUCH_IDP_<SLUG>_*` (the server refuses to start without one), plus `VOUCH_RP_ID`, `VOUCH_JWT_SECRET`, and `VOUCH_DATABASE_URL`. See `AGENTS.md` for a minimum viable command and `docs/src/reference/environment-variables.md` for the full reference.
 
-**Toolchain:** Rust 1.96.1, edition 2024 (pinned in `rust-toolchain.toml`). Max line width 100 chars (`.rustfmt.toml`). Release profile uses `lto = true`, `codegen-units = 1`, `opt-level = "z"`, `panic = "abort"`, `strip = true`.
+**Toolchain:** Rust 1.97.0, edition 2024 (pinned in `rust-toolchain.toml`). Max line width 100 chars (`.rustfmt.toml`). Release profile uses `lto = true`, `codegen-units = 1`, `opt-level = "z"`, `panic = "abort"`, `strip = true`.
 
 ## Code Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Be respectful and constructive. We're building security software — thoughtful 
 
 ### Prerequisites
 
-- **Rust** 1.96+ (install via [rustup](https://rustup.rs/), pinned in `rust-toolchain.toml`)
+- **Rust** 1.97+ (install via [rustup](https://rustup.rs/), pinned in `rust-toolchain.toml`)
 - **YubiKey 5 series** for testing FIDO2 flows (use a dedicated test key, not your primary)
 - **Docker** for building and running the server image
 - **TailwindCSS CLI** for CSS compilation (`make css-build`)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["crates/*"]
 version = "2026.7.2"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
-rust-version = "1.96.1"
+rust-version = "1.97.0"
 repository = "https://github.com/vouch-sh/vouch"
 publish = false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN cd crates/vouch-server \
     && /app/tailwindcss -i styles/input.css -o static/css/output.css --minify
 
 # cargo-chef base stage - shared between planner and builder
-FROM rust:1.96.1-alpine AS chef
+FROM rust:1.97.0-alpine AS chef
 RUN cargo install cargo-chef --locked
 WORKDIR /app
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -8,7 +8,7 @@
 # are recompiled when source changes — dependencies are cached as long as
 # Cargo.toml/Cargo.lock stay the same.
 
-FROM rust:1.96.1-alpine AS base
+FROM rust:1.97.0-alpine AS base
 RUN apk add --no-cache musl-dev pkgconfig cmake make go clang linux-headers \
     openssl-dev openssl-libs-static perl eudev-dev
 ENV AWS_LC_FIPS_SYS_CC=clang

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/vouch-sh/vouch/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/vouch-sh/vouch/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache--2.0%20OR%20MIT-blue)](LICENSE-APACHE)
-[![Rust](https://img.shields.io/badge/rust-1.96%2B-orange)](https://www.rust-lang.org)
+[![Rust](https://img.shields.io/badge/rust-1.97%2B-orange)](https://www.rust-lang.org)
 
 **Prove you're here.**
 
@@ -104,7 +104,7 @@ sudo apt install vouch
 # See https://packages.vouch.sh for repository setup
 sudo dnf install vouch
 
-# From source (requires Rust 1.96+)
+# From source (requires Rust 1.97+)
 cargo install --git https://github.com/vouch-sh/vouch vouch-cli
 ```
 

--- a/crates/vouch-cli/src/commands/setup/ssh.rs
+++ b/crates/vouch-cli/src/commands/setup/ssh.rs
@@ -115,6 +115,10 @@ pub(crate) async fn run(server: &str, hosts: Option<&str>) -> Result<()> {
 ///
 /// Deliberately narrow: a stray mention of the path in a comment or unrelated
 /// directive does not match, so it cannot trigger a spurious rewrite.
+///
+/// All production callers are behind `#[cfg(unix)]`; compiled for tests on
+/// every platform so the string logic stays covered.
+#[cfg(any(unix, test))]
 fn is_stale_identity_agent_line(line: &str) -> bool {
     let trimmed = line.trim_start();
     trimmed.starts_with("IdentityAgent") && trimmed.contains(".vouch/ssh-agent.sock")

--- a/crates/vouch-server/src/handlers/oidc/logout.rs
+++ b/crates/vouch-server/src/handlers/oidc/logout.rs
@@ -175,16 +175,15 @@ fn verify_id_token_hint(state: &AppState, hint: &str) -> Option<IdTokenHintClaim
 
     let claims = if let Ok(token_data) = es256_result {
         token_data.claims
-    } else if let Some(rsa_key) = state.oidc_rsa_key.as_ref() {
+    } else {
         // Fall back to RS256 if an RSA key is configured.
+        let rsa_key = state.oidc_rsa_key.as_ref()?;
         let rs256_validation = hint_validation(jsonwebtoken::Algorithm::RS256);
         match jsonwebtoken::decode::<IdTokenClaims>(hint, rsa_key.decoding_key(), &rs256_validation)
         {
             Ok(token_data) => token_data.claims,
             Err(_) => return None,
         }
-    } else {
-        return None;
     };
 
     // Manually verify iss — must match this server's base_url.

--- a/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
@@ -552,7 +552,7 @@ async fn test_fapi2_authorize_rejects_without_par() {
             || body.contains("invalid_request")
             || body.contains("PAR"),
         "FAPI client without PAR must not succeed, got {status}: first 200 chars: {}",
-        &body.chars().take(200).collect::<String>()
+        body.chars().take(200).collect::<String>()
     );
 }
 

--- a/crates/vouch-server/src/services/oidc/client_credentials.rs
+++ b/crates/vouch-server/src/services/oidc/client_credentials.rs
@@ -67,7 +67,7 @@ pub(crate) async fn exchange_client_credentials(
     });
 
     // Flatten empty scope to None
-    let scope = scope.and_then(|s| if s.is_empty() { None } else { Some(s) });
+    let scope = scope.filter(|s| !s.is_empty());
 
     // Issue access token with client_id as the subject (RFC 9068 Section 2.2)
     let session_result = create_oauth_access_token(

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.96.1"
+channel = "1.97.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Closes #657.

The ready condition is met: `rust:1.97.0-alpine` was published to Docker Hub on 2026-07-09 (amd64 and arm64 images present).

## Changes

- **Toolchain pin**: `rust-toolchain.toml` channel and workspace `rust-version` bumped to `1.97.0`.
- **Docker base images**: `Dockerfile` and `Dockerfile.build` now use `rust:1.97.0-alpine`.
- **Docs**: version references updated in `README.md`, `CONTRIBUTING.md`, `CLAUDE.md`, and `.kiro/steering/`.
- **New 1.97 clippy lints** — three findings fixed so `make lint` stays clean under the zero-warnings policy:
  - `question_mark` in `handlers/oidc/logout.rs` (RS256 fallback now uses `?` on `oidc_rsa_key.as_ref()`)
  - `manual_filter` in `services/oidc/client_credentials.rs` (`Option::filter` instead of `and_then`)
  - `useless_borrows_in_formatting` in `handlers/oidc/tests/fapi2.rs`
- **CI hardening (optional step 4 from the issue)**: `CARGO_BUILD_WARNINGS: deny` added to `ci.yml` env — denies rustc warnings on plain `cargo build`/`cargo test` without invalidating the build cache. Verified locally that cargo's future-incompat notice for `proc-macro-error2` (a cargo-level note, not a rustc warning) does not trip it.
- **`linker_messages`**: no linker noise surfaced on Linux (`make lint` clean), so no `[lints.rust]` configuration was added. If the macOS CI job surfaces duplicate-library warnings, that's the third-party case the issue anticipated and can be scoped there.

## Not done (and why)

- **Optional step 5** — `u8::bit_width()` in `crypto/keys.rs`: the method is **still unstable in 1.97.0** (feature `uint_bit_width`, tracking issue rust-lang/rust#142326), verified against the installed 1.97.0 toolchain. The existing `leading_zeros`-based computation stays.

## Verification

- `make fmt` — no reformatting under 1.97 rustfmt
- `make lint` — clean (exit 0) after the three lint fixes
- `make test` — all unit tests pass (2511 + 627 + 237 + … passed, 0 failed)
- `make test-integration` — all integration tests pass (0 failed)
- `CARGO_BUILD_WARNINGS=deny cargo test --locked --all-features --no-run` — exit 0
- `make docker-build` / `make bake-all` — not runnable in this environment (no Docker daemon); the CI build job runs `docker/bake-action` against the new base image and will verify this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PKpJSQn5gqsSniuVjbGD5B

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKpJSQn5gqsSniuVjbGD5B)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Toolchain and lint/doc/CI changes only; logout RS256 path is a style refactor with the same early-return behavior when no RSA key is configured.
> 
> **Overview**
> Bumps the workspace to **Rust 1.97.0** (`rust-toolchain.toml`, workspace `rust-version`, `Dockerfile` / `Dockerfile.build` Alpine bases, and doc badges/prereqs).
> 
> CI sets **`CARGO_BUILD_WARNINGS: deny`** so plain `cargo build` / `cargo test` fail on rustc warnings without the cache-busting effect of `RUSTFLAGS="-D warnings"`.
> 
> Three **Clippy** cleanups for the new toolchain: RP-initiated logout **`id_token_hint`** RS256 fallback uses `?` on `oidc_rsa_key`; client-credentials scope flattening uses **`Option::filter`**; FAPI test assertion drops a useless borrow in `format!`. **`is_stale_identity_agent_line`** in SSH setup is gated with **`#[cfg(any(unix, test))]`** so the helper stays testable off Unix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db57f486a86d73ea99e699524579d1f465ac9a94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->