### PR TITLE
feat(aws): pin OIDC tokens to the requested role via the STS roles claim

### DIFF
--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -693,8 +693,8 @@ pub(crate) async fn obtain_identity_center_token(
 
     // Deliberately unpinned (no `?role_arn=`): this one token is used both to
     // assume the management role AND as the jwt-bearer assertion for
-    // CreateTokenWithIAM, and the roles-claim semantics are undefined for the
-    // latter. Trust policies on IdC management roles must therefore not
+    // CreateTokenWithIAM, and AWS does not document how the latter treats the
+    // roles claim. Trust policies on IdC management roles must therefore not
     // require `sts:RoleAuthorizedByIdp`.
     let client = VouchClient::new(server).await?;
     let token_response: OidcTokenResponse = client

--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -289,15 +289,17 @@ pub(crate) async fn exchange_for_sts_credentials(req: StsRequest<'_>) -> Result<
     // credentials minted in the wrong context (issue #398).
     let policies = agent_session_policies(agent_source);
 
+    let (chain_role, pin_role) = select_chain_and_pin(role_arn, mgmt);
+
     let (http_client, id_token_secret, session) =
-        fetch_aws_oidc_token(server, agent_source).await?;
+        fetch_aws_oidc_token(server, agent_source, Some(pin_role)).await?;
     let id_token = id_token_secret.expose_secret();
 
     // Session tags travel inside the JWT (server-side `https://aws.amazon.com/tags`
     // claim); AWS extracts them during AssumeRoleWithWebIdentity and logs them as
     // principalTags, so they must NOT also be passed as STS API parameters.
 
-    if let Some(mgmt_role_arn) = mgmt.filter(|m| *m != role_arn) {
+    if let Some(mgmt_role_arn) = chain_role {
         // Chain through the management role, then assume the target role.
         let credentials = assume_role_via_management_chain(ChainInputs {
             http_client: &http_client,
@@ -342,11 +344,15 @@ pub(crate) async fn exchange_for_sts_credentials(req: StsRequest<'_>) -> Result<
 /// role-session name from its `sub` claim.
 ///
 /// When `agent_source` is set, the DPoP source claim is attached so the server
-/// embeds the AI-agent session tags. Returns the HTTP client used for the
-/// subsequent STS calls, the ID token, and the session name.
+/// embeds the AI-agent session tags. When `pin_role` is set, the server pins
+/// the token to that role via the `https://aws.amazon.com/roles` claim and
+/// STS rejects it for any other role — pass the exact ARN the subsequent
+/// `AssumeRoleWithWebIdentity` call will use. Returns the HTTP client used
+/// for the subsequent STS calls, the ID token, and the session name.
 async fn fetch_aws_oidc_token(
     server: &str,
     agent_source: Option<&str>,
+    pin_role: Option<&str>,
 ) -> Result<(reqwest::Client, SecretString, String)> {
     let mut client = VouchClient::new(server).await?;
 
@@ -357,8 +363,9 @@ async fn fetch_aws_oidc_token(
         client.set_dpop_source(source);
     }
 
+    let path = aws_token_path(pin_role)?;
     let token_response: OidcTokenResponse = client
-        .get_authenticated("/v1/credentials/aws/token")
+        .get_authenticated(&path)
         .await
         .context("failed to get OIDC token from Vouch server")?;
 
@@ -370,6 +377,39 @@ async fn fetch_aws_oidc_token(
         .context("server returned invalid OIDC token")?;
 
     Ok((http_client, token_response.id_token, session))
+}
+
+/// Decide role chaining and token pinning in one place, before the token is
+/// fetched.
+///
+/// Returns `(chain_role, pin_role)`: `chain_role` is the management role to
+/// hop through when it is configured and differs from the target, and
+/// `pin_role` is the exact role the `AssumeRoleWithWebIdentity` call will
+/// use — the management role when chaining, the target role otherwise. The
+/// OIDC token must be pinned to `pin_role`; the second SigV4 `AssumeRole`
+/// hop of a chain is not constrained by the roles claim.
+fn select_chain_and_pin<'a>(
+    role_arn: &'a str,
+    mgmt: Option<&'a str>,
+) -> (Option<&'a str>, &'a str) {
+    let chain_role = mgmt.filter(|m| *m != role_arn);
+    (chain_role, chain_role.unwrap_or(role_arn))
+}
+
+/// Build the AWS token endpoint path, appending `?role_arn=` when pinning.
+///
+/// The ARN is percent-encoded (it contains `:` and `/`); the HTTP message
+/// signature covers `@query`, so the pin is tamperproof in transit.
+fn aws_token_path(pin_role: Option<&str>) -> Result<String> {
+    const TOKEN_PATH: &str = "/v1/credentials/aws/token";
+    match pin_role {
+        Some(role) => {
+            let query = serde_urlencoded::to_string([("role_arn", role)])
+                .context("failed to encode role_arn query parameter")?;
+            Ok(format!("{TOKEN_PATH}?{query}"))
+        }
+        None => Ok(TOKEN_PATH.to_string()),
+    }
 }
 
 /// Borrowed inputs to the two-hop management-role chain.
@@ -651,6 +691,11 @@ pub(crate) async fn obtain_identity_center_token(
     let mgmt_arn = crate::integrations::aws::sts::parse_role_arn(management_role)?;
     let domain_suffix = mgmt_arn.partition.dns_suffix();
 
+    // Deliberately unpinned (no `?role_arn=`): this one token is used both to
+    // assume the management role AND as the jwt-bearer assertion for
+    // CreateTokenWithIAM, and the roles-claim semantics are undefined for the
+    // latter. Trust policies on IdC management roles must therefore not
+    // require `sts:RoleAuthorizedByIdp`.
     let client = VouchClient::new(server).await?;
     let token_response: OidcTokenResponse = client
         .get_authenticated("/v1/credentials/aws/token")
@@ -925,6 +970,49 @@ mod tests {
 
         // Must have exactly 5 fields — no extra fields allowed
         assert_eq!(json.as_object().unwrap().len(), 5);
+    }
+
+    /// Direct flow: no management role means no chaining and the pin is the
+    /// target role itself.
+    #[test]
+    fn test_select_chain_and_pin_direct() {
+        let target = "arn:aws:iam::111122223333:role/Target";
+        assert_eq!(select_chain_and_pin(target, None), (None, target));
+    }
+
+    /// Chained flow: the pin must be the management role — the role actually
+    /// passed to AssumeRoleWithWebIdentity.
+    #[test]
+    fn test_select_chain_and_pin_chained() {
+        let target = "arn:aws:iam::111122223333:role/Target";
+        let mgmt = "arn:aws:iam::444455556666:role/Management";
+        assert_eq!(select_chain_and_pin(target, Some(mgmt)), (Some(mgmt), mgmt));
+    }
+
+    /// Management role equal to the target collapses to the direct flow,
+    /// pinned to the target.
+    #[test]
+    fn test_select_chain_and_pin_mgmt_equals_target() {
+        let target = "arn:aws:iam::111122223333:role/Target";
+        assert_eq!(select_chain_and_pin(target, Some(target)), (None, target));
+    }
+
+    /// The role ARN is percent-encoded in the query string (`:` and `/`
+    /// are reserved characters).
+    #[test]
+    fn test_aws_token_path_encodes_role_arn() {
+        let path = aws_token_path(Some("arn:aws:iam::111122223333:role/Example")).unwrap();
+        assert_eq!(
+            path,
+            "/v1/credentials/aws/token?role_arn=arn%3Aaws%3Aiam%3A%3A111122223333%3Arole%2FExample"
+        );
+    }
+
+    /// No pin requested → bare path, identical to the pre-pinning request
+    /// shape (backwards compatible with older servers).
+    #[test]
+    fn test_aws_token_path_without_pin() {
+        assert_eq!(aws_token_path(None).unwrap(), "/v1/credentials/aws/token");
     }
 
     #[test]

--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -665,8 +665,8 @@ pub(crate) fn resolve_identity_center<'a>(
 /// credentials cannot be downscoped — so caller credentials are always full
 /// (no `ReadOnlyAccess` policy, no DPoP source tag).
 ///
-/// 1. Fetch the RS256 AWS token and assume the management role via
-///    `AssumeRoleWithWebIdentity` (full creds).
+/// 1. Fetch the RS256 AWS token pinned to the management role and assume
+///    that role via `AssumeRoleWithWebIdentity` (full creds).
 /// 2. Exchange the same token for an IdC access token via `CreateTokenWithIAM`.
 pub(crate) async fn obtain_identity_center_token(
     http_client: &reqwest::Client,
@@ -691,14 +691,17 @@ pub(crate) async fn obtain_identity_center_token(
     let mgmt_arn = crate::integrations::aws::sts::parse_role_arn(management_role)?;
     let domain_suffix = mgmt_arn.partition.dns_suffix();
 
-    // Deliberately unpinned (no `?role_arn=`): this one token is used both to
-    // assume the management role AND as the jwt-bearer assertion for
-    // CreateTokenWithIAM, and AWS does not document how the latter treats the
-    // roles claim. Trust policies on IdC management roles must therefore not
-    // require `sts:RoleAuthorizedByIdp`.
+    // Pinned to the management role — the role this token's
+    // AssumeRoleWithWebIdentity hop assumes, so IdC management roles can
+    // require `sts:RoleAuthorizedByIdp` like any other web-identity role.
+    // The same token is also the jwt-bearer assertion for CreateTokenWithIAM;
+    // AWS does not document how that operation treats the roles claim, but it
+    // already accepts this token carrying the other AWS-namespaced claims it
+    // does not consume (tags, source_identity) — observed behavior is that
+    // unrecognized claims are ignored.
     let client = VouchClient::new(server).await?;
     let token_response: OidcTokenResponse = client
-        .get_authenticated("/v1/credentials/aws/token")
+        .get_authenticated(&aws_token_path(Some(management_role))?)
         .await
         .context("failed to get OIDC token for management role")?;
     let id_token = token_response.id_token.expose_secret();

--- a/crates/vouch-server/src/handlers/credentials.rs
+++ b/crates/vouch-server/src/handlers/credentials.rs
@@ -7,12 +7,12 @@ use crate::error::ServiceError;
 use crate::services::integrations::aws::{AwsError, issue_aws_token};
 use crate::services::integrations::github::{GitHubInstallationId, minimal_git_permissions};
 use crate::services::oidc;
-use axum::extract::OriginalUri;
+use axum::extract::{OriginalUri, Query};
 use axum::http::Method;
 use axum::{Json, extract::State, http::HeaderMap, http::StatusCode};
 use axum_extra::extract::cookie::CookieJar;
 use jiff::Timestamp;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use vouch_common::{
     AwsTokenResponse, GitHubStatusResponse, GitHubTokenRequest, GitHubTokenResponse,
@@ -449,6 +449,40 @@ fn map_aws_error(e: AwsError) -> ServiceError {
     }
 }
 
+/// Query parameters for `GET /v1/credentials/aws/token`.
+#[derive(Debug, Deserialize)]
+pub(crate) struct AwsTokenParams {
+    /// IAM role ARN to pin the token to via the
+    /// `https://aws.amazon.com/roles` claim. Optional: absent means an
+    /// unpinned token (required for the Identity Center path and issued
+    /// to CLIs that predate pinning).
+    role_arn: Option<String>,
+}
+
+/// Maximum accepted length for the `role_arn` query parameter. IAM role
+/// ARNs max out well below this; the cap bounds what we parse and echo
+/// into logs and tokens.
+const MAX_ROLE_ARN_LEN: usize = 2048;
+
+/// Validate a requested pin as a plausible IAM role ARN.
+///
+/// Rejecting malformed ARNs here (400) beats minting a token AWS would
+/// later refuse with an opaque STS-side `InvalidIdentityToken` error. The
+/// CLI validates the ARN before calling, so only broken clients hit this.
+fn validate_pinned_role(role_arn: &str) -> Result<(), ServiceError> {
+    let is_role = role_arn.len() <= MAX_ROLE_ARN_LEN
+        && vouch_common::aws::Arn::parse(role_arn).is_ok_and(|arn| arn.is_iam_role());
+    if is_role {
+        Ok(())
+    } else {
+        Err(ServiceError::api(
+            StatusCode::BAD_REQUEST,
+            "invalid_role_arn",
+            "role_arn must be an IAM role ARN (arn:<partition>:iam::<account>:role/<name>)",
+        ))
+    }
+}
+
 /// Get an OIDC ID token for AWS.
 ///
 /// GET /v1/credentials/aws/token
@@ -460,6 +494,11 @@ fn map_aws_error(e: AwsError) -> ServiceError {
 /// RS256; the customer-managed application's Aud claim must be the Vouch
 /// issuer URL).
 ///
+/// When `?role_arn=` is present, the token is pinned to that role via the
+/// `https://aws.amazon.com/roles` claim — STS refuses to let it assume any
+/// other role. STS callers should always pin; the Identity Center path must
+/// not (see `services::integrations::aws` module docs).
+///
 /// When the DPoP proof includes a `source` custom claim (e.g., "claude-code"),
 /// the issued token includes AI-specific session tags (`vouch:AccessType=AI`,
 /// `vouch:Agent=<agent>`) for CloudTrail differentiation and IAM condition keys.
@@ -469,8 +508,14 @@ pub(crate) async fn get_aws_token(
     headers: HeaderMap,
     jar: CookieJar,
     State(state): State<Arc<AppState>>,
+    Query(params): Query<AwsTokenParams>,
     client_cert: OptionalClientCert,
 ) -> Result<Json<AwsTokenResponse>, ServiceError> {
+    let pinned_role = params.role_arn.as_deref();
+    if let Some(role_arn) = pinned_role {
+        validate_pinned_role(role_arn)?;
+    }
+
     let ctx =
         authorize_aws_token_request(&state, &headers, &jar, &method, uri.path(), &client_cert)
             .await?;
@@ -502,6 +547,7 @@ pub(crate) async fn get_aws_token(
         rsa_key,
         &ctx.user_email,
         &ctx.token,
+        pinned_role,
     )
     .await
     .map_err(map_aws_error)?;
@@ -1271,6 +1317,116 @@ mod tests {
         let resp: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
         assert!(resp["id_token"].is_string());
         assert!(resp["expires_in"].is_number());
+    }
+
+    /// Decode a JWT payload (middle part) without signature verification.
+    fn decode_jwt_payload(token: &str) -> serde_json::Value {
+        use base64::Engine;
+        let payload_b64 = token.split('.').nth(1).expect("jwt payload");
+        let payload_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(payload_b64)
+            .expect("base64url payload");
+        serde_json::from_slice(&payload_bytes).expect("payload JSON")
+    }
+
+    /// `?role_arn=` pins the token: the ARN must appear as a single-element
+    /// array in the `https://aws.amazon.com/roles` claim.
+    #[tokio::test]
+    async fn test_aws_token_pins_role_from_query() {
+        let state = test_app_state_with_rsa_key().await;
+        let config = state.config();
+        let app = crate::infra::router::build_app(state.clone(), &config).expect("build app");
+
+        let user = create_test_user(&state.store, "pinned@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+
+        let (status, body) = http_get(
+            &app,
+            "/v1/credentials/aws/token?role_arn=arn%3Aaws%3Aiam%3A%3A111122223333%3Arole%2FExample",
+            &[("Authorization", &format!("Bearer {token}"))],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        let resp: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+        let claims = decode_jwt_payload(resp["id_token"].as_str().expect("id_token string"));
+        assert_eq!(
+            claims["https://aws.amazon.com/roles"],
+            serde_json::json!(["arn:aws:iam::111122223333:role/Example"]),
+        );
+    }
+
+    /// Without `?role_arn=` the roles claim is absent — the pre-pinning
+    /// token shape older CLIs and the Identity Center path rely on.
+    #[tokio::test]
+    async fn test_aws_token_without_query_omits_roles_claim() {
+        let state = test_app_state_with_rsa_key().await;
+        let config = state.config();
+        let app = crate::infra::router::build_app(state.clone(), &config).expect("build app");
+
+        let user = create_test_user(&state.store, "unpinned@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+
+        let (status, body) = http_get(
+            &app,
+            "/v1/credentials/aws/token",
+            &[("Authorization", &format!("Bearer {token}"))],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        let resp: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+        let claims = decode_jwt_payload(resp["id_token"].as_str().expect("id_token string"));
+        assert!(
+            claims.get("https://aws.amazon.com/roles").is_none(),
+            "roles claim must be absent without a pin request"
+        );
+    }
+
+    /// A `role_arn` that does not parse as an ARN is rejected with 400
+    /// before any token is minted.
+    #[tokio::test]
+    async fn test_aws_token_rejects_malformed_role_arn() {
+        let (app, state) = test_app().await;
+
+        let user = create_test_user(&state.store, "badarn@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+
+        let (status, body) = http_get(
+            &app,
+            "/v1/credentials/aws/token?role_arn=not-an-arn",
+            &[("Authorization", &format!("Bearer {token}"))],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+        assert_eq!(error["code"], "invalid_role_arn");
+    }
+
+    /// A syntactically valid ARN that is not an IAM role (e.g. an IAM user)
+    /// is rejected — the claim only makes sense for roles.
+    #[tokio::test]
+    async fn test_aws_token_rejects_non_role_arn() {
+        let (app, state) = test_app().await;
+
+        let user = create_test_user(&state.store, "userarn@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+
+        let (status, body) = http_get(
+            &app,
+            "/v1/credentials/aws/token?role_arn=arn%3Aaws%3Aiam%3A%3A111122223333%3Auser%2FBob",
+            &[("Authorization", &format!("Bearer {token}"))],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+        assert_eq!(error["code"], "invalid_role_arn");
     }
 
     // ========================================================================

--- a/crates/vouch-server/src/handlers/credentials.rs
+++ b/crates/vouch-server/src/handlers/credentials.rs
@@ -454,8 +454,7 @@ fn map_aws_error(e: AwsError) -> ServiceError {
 pub(crate) struct AwsTokenParams {
     /// IAM role ARN to pin the token to via the
     /// `https://aws.amazon.com/roles` claim. Optional: absent means an
-    /// unpinned token (required for the Identity Center path and issued
-    /// to CLIs that predate pinning).
+    /// unpinned token (issued to CLIs that predate pinning).
     role_arn: Option<String>,
 }
 
@@ -497,8 +496,10 @@ fn validate_pinned_role(role_arn: &str) -> Result<(), ServiceError> {
 ///
 /// When `?role_arn=` is present, the token is pinned to that role via the
 /// `https://aws.amazon.com/roles` claim — STS refuses to let it assume any
-/// other role. STS callers should always pin; the Identity Center path must
-/// not (see `services::integrations::aws` module docs).
+/// other role. Every CLI path pins to the role its `AssumeRoleWithWebIdentity`
+/// call assumes, including the Identity Center management-role hop (see the
+/// `services::integrations::aws` module docs for the `CreateTokenWithIAM`
+/// note).
 ///
 /// When the DPoP proof includes a `source` custom claim (e.g., "claude-code"),
 /// the issued token includes AI-specific session tags (`vouch:AccessType=AI`,

--- a/crates/vouch-server/src/handlers/credentials.rs
+++ b/crates/vouch-server/src/handlers/credentials.rs
@@ -466,9 +466,10 @@ const MAX_ROLE_ARN_LEN: usize = 2048;
 
 /// Validate a requested pin as a plausible IAM role ARN.
 ///
-/// Rejecting malformed ARNs here (400) beats minting a token AWS would
-/// later refuse with an opaque STS-side `InvalidIdentityToken` error. The
-/// CLI validates the ARN before calling, so only broken clients hit this.
+/// Rejecting malformed ARNs here (400) beats minting a token that can
+/// never match its own roles claim and only fails later, opaquely, at the
+/// STS exchange. The CLI validates the ARN before calling, so only broken
+/// clients hit this.
 fn validate_pinned_role(role_arn: &str) -> Result<(), ServiceError> {
     let is_role = role_arn.len() <= MAX_ROLE_ARN_LEN
         && vouch_common::aws::Arn::parse(role_arn).is_ok_and(|arn| arn.is_iam_role());

--- a/crates/vouch-server/src/services/integrations/aws.rs
+++ b/crates/vouch-server/src/services/integrations/aws.rs
@@ -97,13 +97,16 @@
 //!   `sts:AssumeRole` (e.g. the second hop of a management-role chain) has
 //!   no OIDC token in the request, so a Bool-`true` condition there can
 //!   never match.
-//! - **Do not require it on a management role that is also used by the
-//!   Identity Center path** (`vouch credential aws --account/--permission-set`,
-//!   `vouch setup aws --discover`). That path deliberately requests an
-//!   unpinned token: the same token doubles as the `jwt-bearer` assertion
-//!   for `sso-oidc:CreateTokenWithIAM`, and AWS does not document how that
-//!   operation treats the roles claim, so Vouch omits it there. An unpinned
-//!   token fails the condition.
+//!
+//! The Identity Center path (`vouch credential aws --account/--permission-set`,
+//! `vouch setup aws --discover`) pins its token to the management role — the
+//! role its `AssumeRoleWithWebIdentity` hop assumes — so IdC management roles
+//! can require the condition key like any other web-identity role. The same
+//! token doubles as the `jwt-bearer` assertion for
+//! `sso-oidc:CreateTokenWithIAM`; AWS does not document how that operation
+//! treats the roles claim, but it already accepts this token carrying the
+//! other AWS-namespaced claims it does not consume (`tags`,
+//! `source_identity`) — observed behavior, not a documented contract.
 //!
 //! [AWS Service Authorization Reference for STS]: https://docs.aws.amazon.com/service-authorization/latest/reference/list_sts.html
 //! [awsteele.com, 2026-07-13]: https://awsteele.com/blog/2026/07/13/oidc-tokens-can-restrict-which-aws-roles-they-assume.html
@@ -200,8 +203,7 @@ fn build_aws_session_tags(
 ///   `hardware_aaguid`, `org_domain` (`hd`), and `dpop_source` federation claims
 /// * `pinned_role` - Role ARN to pin the token to via the
 ///   `https://aws.amazon.com/roles` claim; `None` omits the claim (STS then
-///   accepts the token for any role trusting this issuer). Must stay `None`
-///   for Identity Center consumers — see the module docs.
+///   accepts the token for any role trusting this issuer)
 pub(crate) async fn issue_aws_token(
     issuer: &str,
     session_hours: u64,
@@ -613,7 +615,7 @@ mod tests {
     }
 
     /// Without a requested pin the roles claim is absent, preserving the
-    /// pre-pinning token shape for older CLIs and the Identity Center path.
+    /// pre-pinning token shape for older CLIs.
     #[tokio::test]
     async fn test_roles_claim_absent_without_pin() {
         let result = issue_aws_token(

--- a/crates/vouch-server/src/services/integrations/aws.rs
+++ b/crates/vouch-server/src/services/integrations/aws.rs
@@ -62,6 +62,34 @@
 //!   }]
 //! }
 //! ```
+//!
+//! # Requiring role pinning
+//!
+//! The CLI requests tokens pinned to the role it is about to assume
+//! (`?role_arn=` on `/v1/credentials/aws/token`), which Vouch embeds as the
+//! `https://aws.amazon.com/roles` claim. STS then rejects
+//! `AssumeRoleWithWebIdentity` for any role not listed in the claim (exact
+//! ARN match, checked before the trust policy is evaluated), so a leaked
+//! token cannot be exchanged outside the role it was minted for.
+//!
+//! Trust policies can require the claim, rejecting unpinned tokens:
+//!
+//! ```json
+//! "Condition": {
+//!   "Bool": {"sts:RoleAuthorizedByIdp": "true"}
+//! }
+//! ```
+//!
+//! Two caveats before enforcing it:
+//!
+//! - **Older CLIs do not request pinning.** Their tokens carry no roles
+//!   claim and fail the condition; roll the CLI out first.
+//! - **Do not set it on a management role that is also used by the
+//!   Identity Center path** (`vouch credential aws --account/--permission-set`,
+//!   `vouch setup aws --discover`). That path deliberately requests an
+//!   unpinned token because the same token is also the `jwt-bearer`
+//!   assertion for `sso-oidc:CreateTokenWithIAM`, which does not define
+//!   semantics for the roles claim.
 
 use crate::crypto::keys::OidcRsaSigningKey;
 use crate::redact_email;
@@ -153,12 +181,17 @@ fn build_aws_session_tags(
 ///   so it is passed explicitly rather than read from the token)
 /// * `token` - The validated resource token; supplies the session-snapshot
 ///   `hardware_aaguid`, `org_domain` (`hd`), and `dpop_source` federation claims
+/// * `pinned_role` - Role ARN to pin the token to via the
+///   `https://aws.amazon.com/roles` claim; `None` omits the claim (STS then
+///   accepts the token for any role trusting this issuer). Must stay `None`
+///   for Identity Center consumers — see the module docs.
 pub(crate) async fn issue_aws_token(
     issuer: &str,
     session_hours: u64,
     oidc_rsa_key: &OidcRsaSigningKey,
     user_email: &str,
     token: &ValidatedResourceToken,
+    pinned_role: Option<&str>,
 ) -> AwsResult<AwsTokenResult> {
     // Token validity matches session duration
     let expires_in = session_hours.saturating_mul(3600);
@@ -175,6 +208,7 @@ pub(crate) async fn issue_aws_token(
         .hardware_aaguid(token.hardware_aaguid.clone())
         .hd(token.org_domain.clone())
         .aws_tags(aws_tags)
+        .aws_role(pinned_role)
         .valid_for_seconds(expires_in)
         .build()
         .map_err(|e| AwsError::ClaimsBuild(e.to_string()))?;
@@ -186,7 +220,14 @@ pub(crate) async fn issue_aws_token(
         .await
         .map_err(|e| AwsError::TokenSign(e.to_string()))?;
 
-    tracing::info!("Issued AWS OIDC token for {}", redact_email(user_email));
+    match pinned_role {
+        Some(role) => tracing::info!(
+            pinned_role_arn = %role,
+            "Issued AWS OIDC token for {} pinned to role",
+            redact_email(user_email)
+        ),
+        None => tracing::info!("Issued AWS OIDC token for {}", redact_email(user_email)),
+    }
 
     Ok(AwsTokenResult {
         id_token,
@@ -275,6 +316,7 @@ mod tests {
             test_rsa_key(),
             USER_EMAIL,
             &test_token(Some(TEST_AAGUID.to_string()), None, None),
+            None,
         )
         .await
         .expect("issue_aws_token should succeed");
@@ -298,6 +340,7 @@ mod tests {
             test_rsa_key(),
             USER_EMAIL,
             &test_token(Some(TEST_AAGUID.to_string()), None, None),
+            None,
         )
         .await
         .expect("issue_aws_token should succeed");
@@ -335,6 +378,7 @@ mod tests {
                 Some("example.com".to_string()),
                 None,
             ),
+            None,
         )
         .await
         .expect("issue_aws_token should succeed");
@@ -369,6 +413,7 @@ mod tests {
                 None,
                 Some("claude-code".to_string()),
             ),
+            None,
         )
         .await
         .expect("issue_aws_token should succeed");
@@ -408,6 +453,7 @@ mod tests {
                 Some("example.com".to_string()),
                 None,
             ),
+            None,
         )
         .await
         .expect("issue_aws_token should succeed");
@@ -440,6 +486,7 @@ mod tests {
                 Some("example.com".to_string()),
                 Some("cursor".to_string()),
             ),
+            None,
         )
         .await
         .expect("issue_aws_token should succeed");
@@ -493,6 +540,7 @@ mod tests {
             test_rsa_key(),
             USER_EMAIL,
             &test_token(Some(TEST_AAGUID.to_string()), None, None),
+            None,
         )
         .await
         .expect("issue_aws_token should succeed");
@@ -511,6 +559,7 @@ mod tests {
             test_rsa_key(),
             USER_EMAIL,
             &test_token(Some(TEST_AAGUID.to_string()), None, None),
+            None,
         )
         .await
         .expect("issue_aws_token should succeed");
@@ -519,6 +568,52 @@ mod tests {
             result.expires_in,
             4 * 3600,
             "expires_in must be session_hours * 3600"
+        );
+    }
+
+    /// A requested pin appears as a single-element array in the
+    /// `https://aws.amazon.com/roles` claim.
+    #[tokio::test]
+    async fn test_pinned_role_emitted_in_roles_claim() {
+        let role = "arn:aws:iam::123456789012:role/ExampleRole";
+        let result = issue_aws_token(
+            BASE_URL,
+            SESSION_HOURS,
+            test_rsa_key(),
+            USER_EMAIL,
+            &test_token(Some(TEST_AAGUID.to_string()), None, None),
+            Some(role),
+        )
+        .await
+        .expect("issue_aws_token should succeed");
+
+        let claims = decode_jwt_payload(&result.id_token);
+        assert_eq!(
+            claims["https://aws.amazon.com/roles"],
+            serde_json::json!([role]),
+            "roles claim must be a single-element array with the pinned ARN"
+        );
+    }
+
+    /// Without a requested pin the roles claim is absent, preserving the
+    /// pre-pinning token shape for older CLIs and the Identity Center path.
+    #[tokio::test]
+    async fn test_roles_claim_absent_without_pin() {
+        let result = issue_aws_token(
+            BASE_URL,
+            SESSION_HOURS,
+            test_rsa_key(),
+            USER_EMAIL,
+            &test_token(Some(TEST_AAGUID.to_string()), None, None),
+            None,
+        )
+        .await
+        .expect("issue_aws_token should succeed");
+
+        let claims = decode_jwt_payload(&result.id_token);
+        assert!(
+            claims.get("https://aws.amazon.com/roles").is_none(),
+            "roles claim must be absent when no pin is requested"
         );
     }
 
@@ -531,6 +626,7 @@ mod tests {
             test_rsa_key(),
             USER_EMAIL,
             &test_token(Some(TEST_AAGUID.to_string()), None, None),
+            None,
         )
         .await
         .expect("issue_aws_token should succeed");

--- a/crates/vouch-server/src/services/integrations/aws.rs
+++ b/crates/vouch-server/src/services/integrations/aws.rs
@@ -67,12 +67,14 @@
 //!
 //! The CLI requests tokens pinned to the role it is about to assume
 //! (`?role_arn=` on `/v1/credentials/aws/token`), which Vouch embeds as the
-//! `https://aws.amazon.com/roles` claim. STS then rejects
-//! `AssumeRoleWithWebIdentity` for any role not listed in the claim (exact
-//! ARN match, checked before the trust policy is evaluated), so a leaked
-//! token cannot be exchanged outside the role it was minted for.
+//! `https://aws.amazon.com/roles` claim, so a leaked token cannot be
+//! exchanged for a role it was not minted for.
 //!
-//! Trust policies can require the claim, rejecting unpinned tokens:
+//! The [AWS Service Authorization Reference for STS] defines the Bool
+//! condition key `sts:RoleAuthorizedByIdp` on `AssumeRoleWithWebIdentity`
+//! (and only that action): "Filters access based on whether the identity
+//! provider authorized the role via the roles claim in the OIDC token".
+//! A web-identity trust statement can use it to require a pinned token:
 //!
 //! ```json
 //! "Condition": {
@@ -80,16 +82,31 @@
 //! }
 //! ```
 //!
-//! Two caveats before enforcing it:
+//! The claim's matching behavior — exact role ARN, string or array value,
+//! no wildcards or bare role names, rejection with `InvalidIdentityToken`
+//! when the target role is absent — is not yet described in the
+//! `AssumeRoleWithWebIdentity` API reference; it is based on third-party
+//! testing ([awsteele.com, 2026-07-13]).
+//!
+//! Caveats before requiring the condition key:
 //!
 //! - **Older CLIs do not request pinning.** Their tokens carry no roles
 //!   claim and fail the condition; roll the CLI out first.
-//! - **Do not set it on a management role that is also used by the
+//! - **Only use it on web-identity trust statements.** The key is defined
+//!   for `AssumeRoleWithWebIdentity` only; a role assumed by SigV4
+//!   `sts:AssumeRole` (e.g. the second hop of a management-role chain) has
+//!   no OIDC token in the request, so a Bool-`true` condition there can
+//!   never match.
+//! - **Do not require it on a management role that is also used by the
 //!   Identity Center path** (`vouch credential aws --account/--permission-set`,
 //!   `vouch setup aws --discover`). That path deliberately requests an
-//!   unpinned token because the same token is also the `jwt-bearer`
-//!   assertion for `sso-oidc:CreateTokenWithIAM`, which does not define
-//!   semantics for the roles claim.
+//!   unpinned token: the same token doubles as the `jwt-bearer` assertion
+//!   for `sso-oidc:CreateTokenWithIAM`, and AWS does not document how that
+//!   operation treats the roles claim, so Vouch omits it there. An unpinned
+//!   token fails the condition.
+//!
+//! [AWS Service Authorization Reference for STS]: https://docs.aws.amazon.com/service-authorization/latest/reference/list_sts.html
+//! [awsteele.com, 2026-07-13]: https://awsteele.com/blog/2026/07/13/oidc-tokens-can-restrict-which-aws-roles-they-assume.html
 
 use crate::crypto::keys::OidcRsaSigningKey;
 use crate::redact_email;

--- a/crates/vouch-server/src/services/oidc/claims.rs
+++ b/crates/vouch-server/src/services/oidc/claims.rs
@@ -85,6 +85,26 @@ pub struct OidcIdTokenClaims {
         skip_serializing_if = "Option::is_none"
     )]
     pub aws_tags: Option<AwsSessionTags>,
+    /// AWS role ARNs this token is authorized to assume (role pinning).
+    ///
+    /// When present, AWS STS rejects `AssumeRoleWithWebIdentity` for any
+    /// role whose ARN is not an exact match of an entry in this claim —
+    /// enforcement happens at the STS layer, before the role's trust
+    /// policy is evaluated. Trust policies can additionally require the
+    /// claim with the `sts:RoleAuthorizedByIdp` condition key.
+    ///
+    /// Serialized as an array of ARN strings (STS accepts a bare string
+    /// too, but the array form is forward-compatible with pinning more
+    /// than one role). Exact-match only — no wildcards or role names.
+    ///
+    /// Only set for AWS STS tokens when the client requests pinning;
+    /// never set for Kubernetes/WIF tokens or the Identity Center path
+    /// (`CreateTokenWithIAM` does not define semantics for this claim).
+    #[serde(
+        rename = "https://aws.amazon.com/roles",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub aws_roles: Option<Vec<String>>,
 }
 
 /// AWS session tags claim structure (nested format).
@@ -117,6 +137,7 @@ pub struct OidcIdTokenClaimsBuilder {
     hd: Option<String>,
     source_identity: Option<String>,
     aws_tags: Option<AwsSessionTags>,
+    aws_roles: Option<Vec<String>>,
     valid_for_seconds: u64,
 }
 
@@ -133,6 +154,7 @@ impl OidcIdTokenClaimsBuilder {
             hd: None,
             source_identity: None,
             aws_tags: None,
+            aws_roles: None,
             valid_for_seconds: 28800, // 8 hours default
         }
     }
@@ -237,6 +259,18 @@ impl OidcIdTokenClaimsBuilder {
         self
     }
 
+    /// Pin the token to a single AWS role ARN (`https://aws.amazon.com/roles`).
+    ///
+    /// When set, AWS STS rejects `AssumeRoleWithWebIdentity` for any other
+    /// role, so a leaked token cannot be exchanged outside the intended role.
+    /// Takes an `Option` (mirroring [`hd`](Self::hd)) so callers can chain it
+    /// unconditionally; `None` leaves the claim absent.
+    #[must_use]
+    pub fn aws_role(mut self, role_arn: Option<&str>) -> Self {
+        self.aws_roles = role_arn.map(|arn| vec![arn.to_string()]);
+        self
+    }
+
     /// Set the token validity period in seconds.
     #[must_use]
     pub fn valid_for_seconds(mut self, seconds: u64) -> Self {
@@ -279,6 +313,7 @@ impl OidcIdTokenClaimsBuilder {
             hd: self.hd,
             source_identity: self.source_identity,
             aws_tags: self.aws_tags,
+            aws_roles: self.aws_roles,
         })
     }
 }
@@ -499,6 +534,36 @@ mod tests {
         assert!(
             json.get("https://aws.amazon.com/tags").is_none(),
             "aws tags claim should be absent when not set"
+        );
+    }
+
+    #[test]
+    fn test_aws_role_serialized_as_single_element_array() {
+        let claims =
+            OidcIdTokenClaimsBuilder::for_aws("https://vouch.example.com", "user@example.com")
+                .aws_role(Some("arn:aws:iam::123456789012:role/MyRole"))
+                .build()
+                .unwrap();
+
+        let json = serde_json::to_value(&claims).unwrap();
+        assert_eq!(
+            json["https://aws.amazon.com/roles"],
+            serde_json::json!(["arn:aws:iam::123456789012:role/MyRole"])
+        );
+    }
+
+    #[test]
+    fn test_aws_roles_omitted_when_none() {
+        let claims =
+            OidcIdTokenClaimsBuilder::for_aws("https://vouch.example.com", "user@example.com")
+                .aws_role(None)
+                .build()
+                .unwrap();
+
+        let json = serde_json::to_value(&claims).unwrap();
+        assert!(
+            json.get("https://aws.amazon.com/roles").is_none(),
+            "aws roles claim should be absent when no pin is requested"
         );
     }
 }

--- a/crates/vouch-server/src/services/oidc/claims.rs
+++ b/crates/vouch-server/src/services/oidc/claims.rs
@@ -87,19 +87,23 @@ pub struct OidcIdTokenClaims {
     pub aws_tags: Option<AwsSessionTags>,
     /// AWS role ARNs this token is authorized to assume (role pinning).
     ///
-    /// When present, AWS STS rejects `AssumeRoleWithWebIdentity` for any
-    /// role whose ARN is not an exact match of an entry in this claim —
-    /// enforcement happens at the STS layer, before the role's trust
-    /// policy is evaluated. Trust policies can additionally require the
-    /// claim with the `sts:RoleAuthorizedByIdp` condition key.
+    /// When present, AWS STS only allows `AssumeRoleWithWebIdentity` for
+    /// a role listed in this claim. Trust policies can require the claim
+    /// via the Bool condition key `sts:RoleAuthorizedByIdp`, defined in
+    /// the AWS Service Authorization Reference for STS as "Filters access
+    /// based on whether the identity provider authorized the role via the
+    /// roles claim in the OIDC token":
+    /// <https://docs.aws.amazon.com/service-authorization/latest/reference/list_sts.html>
     ///
-    /// Serialized as an array of ARN strings (STS accepts a bare string
-    /// too, but the array form is forward-compatible with pinning more
-    /// than one role). Exact-match only — no wildcards or role names.
+    /// Serialized as an array of full role ARNs. Matching is reported to
+    /// be by exact ARN — no wildcards or bare role names (third-party
+    /// testing; not yet in the `AssumeRoleWithWebIdentity` API reference):
+    /// <https://awsteele.com/blog/2026/07/13/oidc-tokens-can-restrict-which-aws-roles-they-assume.html>
     ///
     /// Only set for AWS STS tokens when the client requests pinning;
-    /// never set for Kubernetes/WIF tokens or the Identity Center path
-    /// (`CreateTokenWithIAM` does not define semantics for this claim).
+    /// never set for Kubernetes/WIF tokens or the Identity Center
+    /// assertion (AWS does not document how `CreateTokenWithIAM` treats
+    /// this claim, so Vouch omits it there).
     #[serde(
         rename = "https://aws.amazon.com/roles",
         skip_serializing_if = "Option::is_none"

--- a/crates/vouch-server/src/services/oidc/claims.rs
+++ b/crates/vouch-server/src/services/oidc/claims.rs
@@ -100,10 +100,12 @@ pub struct OidcIdTokenClaims {
     /// testing; not yet in the `AssumeRoleWithWebIdentity` API reference):
     /// <https://awsteele.com/blog/2026/07/13/oidc-tokens-can-restrict-which-aws-roles-they-assume.html>
     ///
-    /// Only set for AWS STS tokens when the client requests pinning;
-    /// never set for Kubernetes/WIF tokens or the Identity Center
-    /// assertion (AWS does not document how `CreateTokenWithIAM` treats
-    /// this claim, so Vouch omits it there).
+    /// Only set for AWS tokens when the client requests pinning; never
+    /// set for Kubernetes/WIF tokens. The Identity Center token is pinned
+    /// to the management role its `AssumeRoleWithWebIdentity` hop assumes;
+    /// `CreateTokenWithIAM` also receives it and, in observed behavior
+    /// (undocumented), ignores the claim as it does the other
+    /// AWS-namespaced claims it does not consume.
     #[serde(
         rename = "https://aws.amazon.com/roles",
         skip_serializing_if = "Option::is_none"

--- a/crates/vouch-tests/tests/org_subdomains.rs
+++ b/crates/vouch-tests/tests/org_subdomains.rs
@@ -606,6 +606,42 @@ async fn aws_token_uses_base_url_without_claim() {
     assert_eq!(claims["aud"], "https://test.example.com");
 }
 
+/// End-to-end through the merged router: `?role_arn=` (percent-encoded, as
+/// the CLI sends it) pins the token via the `https://aws.amazon.com/roles`
+/// claim, while the rest of the claim set is unchanged.
+#[tokio::test]
+async fn aws_token_pins_role_from_query_param() {
+    let harness = TestHarness::from_state(test_app_state_with_rsa_key().await);
+    let org = harness.create_org("acme.com").await.unwrap();
+    let (_user, _auth_id, token) = harness
+        .create_authenticated_org_member("user@acme.com", &org.id)
+        .await
+        .unwrap();
+
+    let resp = harness
+        .get_authenticated(
+            "/v1/credentials/aws/token?role_arn=arn%3Aaws%3Aiam%3A%3A111122223333%3Arole%2FExample",
+            &token,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status,
+        200,
+        "body: {}",
+        resp.text().unwrap_or_default()
+    );
+    let body: serde_json::Value = resp.json().unwrap();
+    let claims = decode_jwt_payload(body["id_token"].as_str().unwrap());
+
+    assert_eq!(
+        claims["https://aws.amazon.com/roles"],
+        serde_json::json!(["arn:aws:iam::111122223333:role/Example"])
+    );
+    assert_eq!(claims["iss"], "https://test.example.com");
+    assert_eq!(claims["sub"], "user@acme.com");
+}
+
 // ============================================================================
 // Per-org signing keys (require a store that encrypts at rest)
 // ============================================================================


### PR DESCRIPTION
## Summary

AWS STS supports a `https://aws.amazon.com/roles` claim in web-identity tokens that restricts which roles the token can assume, and a Bool condition key `sts:RoleAuthorizedByIdp` — defined on `AssumeRoleWithWebIdentity` in the [AWS Service Authorization Reference for STS](https://docs.aws.amazon.com/service-authorization/latest/reference/list_sts.html) as "Filters access based on whether the identity provider authorized the role via the roles claim in the OIDC token" — that trust policies can use to *require* the claim. Per [third-party testing](https://awsteele.com/blog/2026/07/13/oidc-tokens-can-restrict-which-aws-roles-they-assume.html) (the matching behavior is not yet in the `AssumeRoleWithWebIdentity` API reference), matching is by exact role ARN, string or array value, no wildcards, rejected with `InvalidIdentityToken` before trust-policy evaluation.

Today a Vouch AWS token is minted with no knowledge of the target role — the CLI picks the role locally and calls STS itself — so a leaked token works against **any** role that trusts the Vouch issuer. This PR closes that gap with client-requested pinning:

- **CLI** (`vouch credential aws` and everything that routes through it: eks, rds, codeartifact, docker, codecommit, exec, console, and the Identity Center flow) sends the exact role it is about to pass to `AssumeRoleWithWebIdentity` as `?role_arn=` — the target role in the direct flow, the **management** role when chaining or on the Identity Center path (the second SigV4 `AssumeRole` hop carries no OIDC token, so the claim cannot apply there).
- **Server** validates the pin as an IAM role ARN (`400 invalid_role_arn` otherwise), embeds it as a single-element `https://aws.amazon.com/roles` claim, and logs the pinned ARN on issuance.
- **Operator docs** (module doc in `services/integrations/aws.rs`) gain a "Requiring role pinning" section recommending `"Bool": {"sts:RoleAuthorizedByIdp": "true"}` on web-identity trust statements, with rollout caveats and citations to the sources above; statements not backed by first-party AWS docs are explicitly attributed.

## Compatibility

- No query parameter → no claim: older CLIs and older servers behave exactly as before, in both directions.
- The Identity Center path pins its token to the management role (the role its `AssumeRoleWithWebIdentity` hop assumes), so IdC management roles can require `sts:RoleAuthorizedByIdp` like any other web-identity role. The same token doubles as the `jwt-bearer` assertion for `sso-oidc:CreateTokenWithIAM`; AWS does not document how that operation treats the roles claim, but it already accepts this token carrying the other AWS-namespaced claims it does not consume (`tags`, `source_identity`) — observed behavior, not a documented contract. **This is the one part best confirmed against a live TTI-configured IdC instance** (run `vouch credential aws --account … --permission-set …` with the new CLI) before relying on required pinning there.
- The condition key is defined for `AssumeRoleWithWebIdentity` only — a Bool-`true` condition on a role assumed via SigV4 `sts:AssumeRole` (chain second hop) can never match; the docs say to use it on web-identity trust statements only.
- No new dependencies; the existing RFC 9421 signature already covers `@query`, and DPoP `htu` strips the query on both ends.

## Testing

- `make fmt` / `make lint` (clippy `-D warnings`) clean.
- `make test`: full workspace green (0 failures), including new unit tests for claim serialization (present as single-element array / absent without pin), `issue_aws_token` pinning, handler query validation (200 with claim, 200 without, 400 on malformed and non-role ARNs), and CLI pin-selection (direct / chained / mgmt==target) plus ARN percent-encoding.
- `cargo test -p vouch-tests --test org_subdomains`: 20/20, including a new end-to-end test through the merged router with the percent-encoded query string.

Live STS/IdC enforcement (an AWS role trusting a reachable Vouch issuer) is not exercisable locally.

## Sources

- [AWS Service Authorization Reference — STS](https://docs.aws.amazon.com/service-authorization/latest/reference/list_sts.html) (`sts:RoleAuthorizedByIdp`, Bool, `AssumeRoleWithWebIdentity` only)
- [AssumeRoleWithWebIdentity API Reference](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html) (does not yet describe the roles claim)
- [awsteele.com, 2026-07-13](https://awsteele.com/blog/2026/07/13/oidc-tokens-can-restrict-which-aws-roles-they-assume.html) (claim shape and matching behavior, third-party testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gMB2PiiZnBFCpgxXRfECW