### PR TITLE
docs: remove change-history narration from code comments

### DIFF
--- a/crates/vouch-cli/src/commands/setup/ssh.rs
+++ b/crates/vouch-cli/src/commands/setup/ssh.rs
@@ -135,12 +135,11 @@ fn configure_ssh_config(hosts: Option<&str>) -> Result<()> {
     let key_path = default_key_path()?;
     let cert_path = PathBuf::from(format!("{}-cert.pub", key_path.display()));
     // The SSH agent socket is Unix-only: vouch-agent exposes a Unix domain socket
-    // for SSH agent forwarding, which has no equivalent on other platforms. We
-    // resolve it lazily, only on the paths that actually need it, and propagate
-    // the error rather than falling back to a stale literal (the legacy
-    // ~/.vouch/ssh-agent.sock no longer exists after the XDG migration). Resolving
-    // eagerly would make an already-configured host fail just because the socket
-    // can't be resolved. On non-Unix no IdentityAgent directive is emitted at all.
+    // for SSH agent forwarding, which has no equivalent on other platforms. Resolve
+    // it lazily, only on the paths that actually need it, and propagate the error
+    // rather than writing a fallback literal — resolving eagerly would make an
+    // already-configured host fail just because the socket can't be resolved.
+    // On non-Unix no IdentityAgent directive is emitted at all.
     #[cfg(unix)]
     let resolve_agent_socket = || -> Result<String> {
         vouch_agent::ssh_agent_socket_path()
@@ -160,15 +159,12 @@ fn configure_ssh_config(hosts: Option<&str>) -> Result<()> {
         String::new()
     };
 
-    // Normalize a stale IdentityAgent left over from the legacy ~/.vouch layout.
-    // Older versions wrote the agent socket under ~/.vouch/ssh-agent.sock; the
-    // socket now lives in the XDG runtime directory. Only an actual
-    // `IdentityAgent ...~/.vouch/ssh-agent.sock` line is rewritten (not a stray
-    // mention in a comment), and we fall through to the normal setup path
-    // afterwards rather than returning early — so a first run that also needs
-    // the IdentityFile/CertificateFile block still gets it.
-    // The SSH agent is Unix-only; on other platforms there is no IdentityAgent
-    // to rewrite and no agent socket to advertise.
+    // Rewrite a stale `IdentityAgent ...~/.vouch/ssh-agent.sock` line (the
+    // pre-XDG socket location) to the current XDG runtime path. Only an actual
+    // directive is rewritten (not a stray mention in a comment), and we fall
+    // through to the normal setup path afterwards rather than returning early —
+    // so a first run that also needs the IdentityFile/CertificateFile block
+    // still gets it. Unix-only; elsewhere there is no IdentityAgent to rewrite.
     #[cfg(unix)]
     let existing = {
         let has_stale_identity_agent = existing.lines().any(is_stale_identity_agent_line);

--- a/crates/vouch-cli/src/posture/macos.rs
+++ b/crates/vouch-cli/src/posture/macos.rs
@@ -60,9 +60,9 @@ fn detect_filevault(posture: &mut DevicePosture) {
 
 /// Detect screen lock configuration.
 ///
-/// Uses `sysadminctl -screenLock status` which works on all modern macOS
-/// versions. The legacy `com.apple.screensaver askForPassword` defaults
-/// key no longer exists on macOS 15+.
+/// Uses `sysadminctl -screenLock status`, which works on all modern macOS
+/// versions (the `com.apple.screensaver askForPassword` defaults key is
+/// absent on macOS 15+, so it is not consulted).
 ///
 /// Note: `sysadminctl` writes to stderr (via NSLog), not stdout.
 ///

--- a/crates/vouch-common/src/posture.rs
+++ b/crates/vouch-common/src/posture.rs
@@ -616,8 +616,8 @@ mod tests {
 
     #[test]
     fn test_wire_format_unchanged() {
-        // Verify the JSON format is backward-compatible with the old
-        // String-based fields.
+        // Lock the JSON wire format: the enum-based fields must serialize to
+        // the exact strings consumers parse.
         let posture = DevicePosture {
             detail_type: PostureTypeTag,
             posture_version: 1,

--- a/crates/vouch-tests/tests/i18n_brand_terms.rs
+++ b/crates/vouch-tests/tests/i18n_brand_terms.rs
@@ -108,9 +108,9 @@ fn collect_term_refs(line: &str, out: &mut std::collections::HashSet<String>) {
 /// reference resolves to a term **defined in the same catalog**. Fluent
 /// has no cross-file term import, so a message that references a term
 /// missing from its own catalog renders the placeable unresolved (e.g.
-/// "vouch: failed to get {-github} token: ..." instead of "GitHub").
-/// Caught in PR #492 review — the CLI added a message using `{ -github }`
-/// while `-github` was only defined in the server catalog.
+/// "vouch: failed to get {-github} token: ..." instead of "GitHub", as when
+/// a CLI message uses `{ -github }` while `-github` is defined only in
+/// the server catalog; see PR #492).
 #[test]
 fn every_term_reference_has_a_definition() {
     let catalogs = [

--- a/crates/vouch-tests/tests/integration.rs
+++ b/crates/vouch-tests/tests/integration.rs
@@ -1049,8 +1049,8 @@ mod oidc {
             Some("userinfo@example.com"),
             "Email should be present when email scope is granted"
         );
-        // hardware_verified is no longer included in standard OIDC userinfo
-        // responses (Task 9: only non-requested custom claims are excluded)
+        // Custom claims such as hardware_verified are excluded from standard
+        // OIDC userinfo responses unless explicitly requested.
         assert!(
             userinfo.get("hardware_verified").is_none(),
             "hardware_verified should not be in standard userinfo response"

--- a/crates/vouch-tests/tests/sig_policy.rs
+++ b/crates/vouch-tests/tests/sig_policy.rs
@@ -498,7 +498,7 @@ fn test_router_v1_literals_all_in_route_table() {
 
 /// Assert that `~/.vouch/ssh-agent.sock` does not appear in any CLI source file.
 ///
-/// The legacy path was used before the XDG migration.  Finding it again would
+/// This pre-XDG-migration path must never reappear — finding it would
 /// indicate a regression.
 #[test]
 fn test_no_legacy_ssh_agent_socket_in_cli() {


### PR DESCRIPTION
## Summary

Comment/doc audit of every crate except `vouch-server` (`vouch-cli`, `vouch-agent`, `vouch-common`, `vouch-httpsig`, `vouch-i18n`, `vouch-tests`, `fuzz/`), targeting comments that narrate change history instead of stating current behavior. The sweep found the codebase already very clean — only seven comments qualified, all fixed here (wording-only, no code changes):

- `vouch-cli/src/commands/setup/ssh.rs` — two blocks tightened: dropped the "legacy socket no longer exists after the XDG migration" narration while keeping the load-bearing rationale (lazy Unix-only socket resolution; stale `IdentityAgent` rewrite rules and fall-through behavior).
- `vouch-cli/src/posture/macos.rs` — restated the `sysadminctl` choice non-historically (the `askForPassword` defaults key is absent on macOS 15+).
- `vouch-common/src/posture.rs` — wire-format test comment now states the invariant (lock the JSON strings consumers parse) instead of referencing "the old String-based fields".
- `vouch-tests/tests/integration.rs` — removed internal task narration; states the userinfo custom-claim rule directly.
- `vouch-tests/tests/i18n_brand_terms.rs` — replaced review-process narration with a concrete example (PR #492 reference kept).
- `vouch-tests/tests/sig_policy.rs` — regression-guard doc reduced to the invariant.

Deliberately untouched: all RFC/spec/vendor-doc citations (dense in `vouch-httpsig` and `vouch-cli/src/fapi/`), documentation of live legacy-compat code paths (XDG migration in `paths.rs`, legacy config deserialization), long-but-load-bearing design rationale (e.g. `vouch-i18n` macro-duplication notes citing rust-lang/rust#52234), and short issue-number regression tags.

## Verification

- `git diff -U0 | grep -E '^-.*\b(RFC|https?://)'` — empty: no citation or URL was removed.
- Review-label sweep (`rg -n '\b([A-Z]{1,4}[0-9]{1,2}|GAP[0-9]+)\b'`) on changed files: only genuine technical terms remain (T2, EC2, SEC1).
- `make fmt` — no further changes; `make lint` — clean (`-D warnings`).
- `make test` — all green, plus targeted runs of the touched `sig_policy` and `i18n_brand_terms` test binaries (13 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9N9XtdoSrLhdbkWjY5jzN

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9N9XtdoSrLhdbkWjY5jzN)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only comment edits; no executable code, APIs, or test logic changed.
> 
> **Overview**
> **Comment-only cleanup** across CLI, common, and test crates (no runtime or test assertion changes).
> 
> Comments now describe **current behavior and invariants** instead of narrating migrations, tasks, or review history. Updates include: **`configure_ssh_config`** in `ssh.rs` (lazy Unix `IdentityAgent` resolution and stale `~/.vouch/ssh-agent.sock` rewrite rules, without XDG migration backstory); **macOS screen-lock** detection in `macos.rs` (why `sysadminctl` is used on macOS 15+); **`test_wire_format_unchanged`** in `posture.rs` (locked JSON strings consumers parse); integration and i18n test notes on **userinfo custom claims** and **Fluent term definitions**; and the **`sig_policy`** guard that the legacy SSH agent socket path must not return to CLI sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e11b58c8478734804e856af433ede1c3f6a1772d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->