### PR TITLE
docs: clarify FIPS 140-3 validation status of the AMI kernel crypto module

### DIFF
--- a/docs/src/reference/ami-stig.md
+++ b/docs/src/reference/ami-stig.md
@@ -44,7 +44,7 @@ Status legend:
 |-----------|--------|------------------|
 | Remote access / SSH daemon hardening | **N/A by design / Exceeded** | `openssh-server` is not installed, `sshd` is masked, and any host keys are removed — there is no remote shell to harden (`appliance.kiwi`, `config.sh`) |
 | Interactive account policy (PAM, `pwquality`, `faillock`, session timeout, login banners) | **N/A by design** | No interactive user accounts exist and the root account is locked (`passwd -l root`); configuration is delivered only via AWS Parameter Store |
-| FIPS-validated cryptography | **Met** | Kernel `fips=1` plus OS crypto-policy set to FIPS (`appliance.kiwi`, `config.sh`); the server binary additionally embeds the aws-lc-rs FIPS module |
+| FIPS-validated cryptography | **Met (see note)** | Kernel `fips=1` plus OS crypto-policy set to FIPS (`appliance.kiwi`, `config.sh`); the server binary additionally embeds the FIPS 140-3 validated aws-lc-rs FIPS module. The kernel 6.18 crypto module itself is still in CMVP validation — see [Kernel crypto module validation status](#kernel-crypto-module-validation-status) |
 | Boot loader integrity / boot loader password | **Exceeded** | UEFI Secure Boot with a signed Unified Kernel Image, no GRUB present, and TPM PCR measurements (PCR4/7/12) published as AMI tags for attestation |
 | File-integrity monitoring (e.g. AIDE) | **Exceeded** | dm-verity provides cryptographic, kernel-enforced integrity of the entire root filesystem with `panic-on-corruption` |
 | Filesystem mount options (`nosuid`/`nodev`/`noexec`) | **Met (partial)** | `/boot/efi` is mounted `ro,nosuid,nodev,noexec` (`fstab.script`); the root filesystem is read-only via dm-verity |
@@ -71,3 +71,28 @@ enablement in `config.sh`, rules under `etc/audit/rules.d/`, and log forwarding
 in the CloudWatch agent configuration). This is not enabled by default to keep
 the image minimal and avoid a writable audit-log path on an otherwise userless
 appliance.
+
+## Kernel crypto module validation status
+
+The image runs AL2023 kernel 6.18, where the FIPS 140-3 kernel cryptography is
+packaged as a standalone modularized kernel module that loads and initializes
+automatically at boot. Enablement is unchanged by this packaging: `fips=1` on
+the kernel command line plus the FIPS crypto-policy (both baked into the image)
+remain the mechanism, and the AMI build pipeline boot-verifies
+`fips mode: enabled` on the serial console.
+
+Validation status of the layers differs:
+
+- **Userspace (server binary):** the embedded aws-lc-rs FIPS module is
+  FIPS 140-3 validated.
+- **Kernel:** the AL2023 kernel 6.18 modularized crypto module is under CMVP
+  review (Implementation Under Test), with validation expected to complete in
+  2027 per AWS. Because the module is decoupled from the kernel image, later
+  kernel updates will no longer invalidate the certificate once it is granted.
+
+For deployments that contractually require a *completed* CMVP certificate for
+kernel cryptography today, AL2023 kernel 6.1 carries the currently validated
+kernel crypto module (certificate #5369) and is supported by AWS for the
+lifetime of AL2023. Repinning the image is a one-line change to the
+`ami-minimal-kernel6.18` collection in `appliance.kiwi`, followed by a re-run
+of the AMI boot-verification workflow.

--- a/docs/src/reference/compliance.md
+++ b/docs/src/reference/compliance.md
@@ -25,7 +25,7 @@ This page maps Vouch features to common compliance frameworks. Vouch's hardware-
 | AC-11 | Device Lock | Sessions expire after configurable duration (default 8 hours); re-authentication required |
 | AC-12 | Session Termination | Explicit logout (`vouch logout`) and automatic session expiration |
 | SC-12 | Cryptographic Key Establishment and Management | Ed25519 SSH CA key; ES256 OIDC signing key; support for HSM and split-custody key storage |
-| SC-13 | Cryptographic Protection | FIDO2/CTAP2 with hardware-backed cryptography; TLS for transport; JWT signing for tokens; FIPS 140-3 validated cryptography (aws-lc-rs FIPS module embedded in server binaries on Linux; OS FIPS mode enabled in the attestable AMI) |
+| SC-13 | Cryptographic Protection | FIDO2/CTAP2 with hardware-backed cryptography; TLS for transport; JWT signing for tokens; FIPS 140-3 cryptography (validated aws-lc-rs FIPS module embedded in server binaries on Linux; OS FIPS mode enabled in the attestable AMI — the kernel 6.18 modularized crypto module's CMVP validation is in process, expected 2027) |
 | SC-23 | Session Authenticity | DPoP (RFC 9449) sender-constrained tokens; FAPI 2.0 client authentication |
 
 ## SOC 2
@@ -56,7 +56,7 @@ This page maps Vouch features to common compliance frameworks. Vouch's hardware-
 | Access Control (AC) | AC-12 | Sessions auto-expire; explicit logout available |
 | Audit and Accountability (AU) | AU-2, AU-3 | All authentication and credential issuance events logged with identity, timestamp, and method |
 | Audit and Accountability (AU) | AU-8 | Time-bound certificates; NTP/GPS time sync supported for air-gapped deployments |
-| System and Communications Protection (SC) | SC-12, SC-13 | Hardware-backed cryptography; Ed25519 CA; ES256 OIDC signing; TLS transport encryption; FIPS 140-3: aws-lc-rs FIPS module in server binaries, OS crypto-policy FIPS + kernel `fips=1` in the attestable AMI |
+| System and Communications Protection (SC) | SC-12, SC-13 | Hardware-backed cryptography; Ed25519 CA; ES256 OIDC signing; TLS transport encryption; FIPS 140-3: validated aws-lc-rs FIPS module in server binaries; OS crypto-policy FIPS + kernel `fips=1` in the attestable AMI (kernel crypto module validation in process) |
 | System and Communications Protection (SC) | SC-23 | FAPI 2.0 with DPoP sender-constrained tokens; private_key_jwt client authentication |
 | Configuration Management (CM) | CM-2 | Server configured via environment variables with S3 centralized config support |
 | Contingency Planning (CP) | CP-9 | Database backup/restore procedures; CA key recovery with split custody |


### PR DESCRIPTION
## Summary

Review of our FIPS enablement against AWS's announcement of [modularized kernel cryptography in Amazon Linux](https://aws.amazon.com/blogs/compute/introducing-modularized-kernel-cryptography-in-amazon-linux/).

**Outcome: no enablement changes needed; docs wording corrected.**

- On AL2023 kernel 6.18 (which our attestable AMI pins via `ami-minimal-kernel6.18`), the FIPS kernel crypto now ships as a standalone modularized module that loads automatically at boot. Our mechanism — `fips=1` on the signed UKI cmdline plus `update-crypto-policies --set FIPS` at image build — is unchanged, and `ami-test.yml` already boot-verifies `fips mode: enabled` on the serial console.
- However, the 6.18 module is only **Implementation Under Test** with CMVP (validation expected 2027, per the AL2023 FAQ). Only kernel 6.1 carries a validated kernel crypto module today (certificate #5369). Our docs claimed "FIPS-validated cryptography — Met" without that distinction.

## Changes

- `docs/src/reference/ami-stig.md`: FIPS row now reads **Met (see note)** and distinguishes the validated aws-lc-rs userspace module from the in-process kernel module; new "Kernel crypto module validation status" section documents the modularized module, the validation timeline, and the kernel 6.1 repin option for deployments requiring a completed certificate today.
- `docs/src/reference/compliance.md`: SC-13 (NIST) and SC-12/SC-13 (FedRAMP) rows qualified the same way.

No packaging, code, or CI changes.

## Verification

- `make docs-build` — mdBook builds cleanly; the new intra-page anchor resolves in the generated HTML.
- Internal-label sweep (`rg -n '\b([A-Z]{1,4}[0-9]{1,2}|GAP[0-9]+)\b'`) over changed files — only pre-existing control IDs (SC-13, IA-2, …), no new label tokens.
- `prek` hook environments could not be installed in this sandbox (PyPI fetch timeout); trailing-whitespace and EOF-newline checks were run manually on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLq4mK2SiEMytNjFK3cgoT

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLq4mK2SiEMytNjFK3cgoT)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only wording changes; no runtime, packaging, or CI behavior is modified.
> 
> **Overview**
> **Documentation-only** update after reviewing AL2023’s modularized kernel FIPS crypto: **no AMI enablement or packaging changes** — `fips=1` and FIPS crypto-policy remain the mechanism.
> 
> In **`ami-stig.md`**, the FIPS STIG row is now **Met (see note)** and calls out that **aws-lc-rs userspace** is FIPS 140-3 validated while the **kernel 6.18** crypto module is still **CMVP Implementation Under Test** (validation expected 2027). A new **Kernel crypto module validation status** section explains modularized kernel crypto, the validation split, and how to **repin to kernel 6.1** (`ami-minimal-kernel6.18` in `appliance.kiwi`) for deployments that need a **completed** kernel CMVP certificate today (#5369).
> 
> In **`compliance.md`**, **SC-13** (NIST) and **SC-12/SC-13** (FedRAMP) wording is aligned so FIPS claims distinguish validated userspace from in-process kernel validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68fe317d8dadcd91675fcde7e257166d5cd90c11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->