### PR TITLE
perf(server): skip JWKS cache lookup when client JWKS is inline

### DIFF
--- a/crates/vouch-server/src/infra/httpsig.rs
+++ b/crates/vouch-server/src/infra/httpsig.rs
@@ -59,17 +59,23 @@ impl KeyResolver for OAuthClientKeyResolver {
                 .ok()
                 .flatten()?;
 
-            let jwks_cache = crate::db::get_jwks_cache(&self.state.store, &client.id)
-                .await
-                .map_err(|e| {
-                    tracing::warn!("JWKS cache lookup failed for HTTP signature verification: {e}");
-                })
-                .ok()
-                .flatten();
-            let jwks_value = client
-                .jwks
-                .as_ref()
-                .or_else(|| jwks_cache.as_ref().map(|c| &c.value))?;
+            // Only clients registered with `jwks_uri` (no inline JWKS) need the
+            // cached fetch — skip the extra DB round trip for the common inline case.
+            let cached;
+            let jwks_value = if let Some(jwks) = client.jwks.as_ref() {
+                jwks
+            } else {
+                cached = crate::db::get_jwks_cache(&self.state.store, &client.id)
+                    .await
+                    .map_err(|e| {
+                        tracing::warn!(
+                            "JWKS cache lookup failed for HTTP signature verification: {e}"
+                        );
+                    })
+                    .ok()
+                    .flatten()?;
+                &cached.value
+            };
             let keys = jwks_value.get("keys")?.as_array()?;
 
             for jwk in keys {

--- a/crates/vouch-tests/tests/integration.rs
+++ b/crates/vouch-tests/tests/integration.rs
@@ -2736,6 +2736,87 @@ mod httpsig {
     }
 
     #[tokio::test]
+    async fn test_httpsig_jwks_cache_fallback_verifies() {
+        // A client registered without inline JWKS (the jwks_uri flow) resolves
+        // its signing key from the JWKS cache row instead.
+        use vouch_server::test_utils::{TestClientSpec, TestJwks, create_test_client};
+
+        let harness = TestHarness::new().await;
+        let key = ClientKey::generate().unwrap();
+
+        let user = harness
+            .create_user("httpsig-cache@example.com")
+            .await
+            .unwrap();
+        let auth_id = harness.create_authenticator(&user.id).await.unwrap();
+
+        let public_jwk = key.public_jwk().unwrap();
+        let jwks = serde_json::json!({ "keys": [public_jwk] });
+
+        let client = create_test_client(
+            &harness.state.store,
+            &user.id,
+            TestClientSpec {
+                name: "Test FAPI Client".to_string(),
+                application_type: vouch_server::db::OAuthClientType::Native,
+                redirect_uris: vec![],
+                token_endpoint_auth_method: Some(
+                    vouch_server::db::TokenEndpointAuthMethod::PrivateKeyJwt,
+                ),
+                jwks: TestJwks::None,
+                dpop_bound_access_tokens: true,
+                id_token_signed_response_alg: vouch_server::db::JwsAlgorithm::Es256,
+                with_secret: false,
+                ..Default::default()
+            },
+        )
+        .await;
+
+        vouch_server::db::upsert_jwks_cache(&harness.state.store, &client.app_id, &jwks)
+            .await
+            .unwrap();
+
+        let token = harness
+            .create_session_for_client(
+                &user.id,
+                "httpsig-cache@example.com",
+                &auth_id,
+                &client.client_id,
+            )
+            .await
+            .unwrap();
+
+        let url = harness.url("/v1/keys");
+        let auth_header = format!("Bearer {token}");
+        let sig_headers = sign_get_request(&url, &auth_header, &key);
+
+        let extra_refs: Vec<(&str, &str)> = sig_headers
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+
+        let response = harness
+            .http_client
+            .request(
+                "GET",
+                &url,
+                None,
+                None,
+                Some(&auth_header),
+                Some(&extra_refs),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status,
+            200,
+            "signature resolved via JWKS cache should verify: {}",
+            response.text().unwrap_or_default()
+        );
+    }
+
+    #[tokio::test]
     async fn test_httpsig_unsigned_request_rejected_on_v1_keys() {
         // A signature-required /v1/* endpoint rejects an unsigned request.
         let harness = TestHarness::new().await;


### PR DESCRIPTION
## Summary

A performance review of `crates/vouch-server/src/` found one confirmed instance of wasted work on a hot path: `OAuthClientKeyResolver::resolve` (`infra/httpsig.rs`) awaited `db::get_jwks_cache()` on every signed `/v1/*` request, but the result is only used when the OAuth client has no inline JWKS. Since inline JWKS (RFC 7591 dynamic registration) is the common case for CLI/agent traffic, nearly every signed API request paid an extra DB round trip whose result was discarded.

## Changes

- `crates/vouch-server/src/infra/httpsig.rs` — branch on `client.jwks` first; the JWKS-cache query now runs only in the fallback arm for `jwks_uri`-registered clients. Behavior in both branches is unchanged.
- `crates/vouch-tests/tests/integration.rs` — new `test_httpsig_jwks_cache_fallback_verifies`: registers a client with no inline JWKS, seeds the cache via `upsert_jwks_cache`, and asserts a signed `/v1/keys` request verifies through the cache path. The inline branch was already covered by the existing httpsig tests.

## Testing

- `make lint` — clean
- `make test` — all suites pass
- `make test-integration` — 75/75 in `integration.rs`, zero failures
- `prek run` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is unchanged for both inline and cache-backed JWKS; the change only avoids an unnecessary DB read on the common path.
> 
> **Overview**
> **HTTP signature verification** on signed `/v1/*` requests no longer hits the JWKS cache on every resolve when the OAuth client already stores inline JWKS. `OAuthClientKeyResolver` in `infra/httpsig.rs` now uses `client.jwks` directly and only calls `get_jwks_cache` when inline JWKS is absent (`jwks_uri`-style clients).
> 
> A new integration test, `test_httpsig_jwks_cache_fallback_verifies`, registers a client without inline JWKS, seeds the cache with `upsert_jwks_cache`, and asserts a signed `GET /v1/keys` still verifies via the cache path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6580ffaa3d377ce1f6aa4d55f2465cd04025f93d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->