### PR TITLE
fix: resolve 16 detail-app bug reports (#704–#719)

### DIFF
--- a/crates/vouch-cli/src/client.rs
+++ b/crates/vouch-cli/src/client.rs
@@ -125,14 +125,6 @@ impl VouchClient<ReqwestClient> {
 }
 
 impl<H: HttpClient> VouchClient<H> {
-    /// Set an explicit authentication token.
-    ///
-    /// Used when the caller has already resolved the token (e.g., from
-    /// `resolve_session()`) and wants to avoid resolving it again.
-    pub(crate) fn set_token(&mut self, token: SecretString) {
-        self.token = Some(token);
-    }
-
     /// Set the FAPI client key for DPoP proof generation.
     ///
     /// Used when the caller already has the key in memory (e.g., from
@@ -761,7 +753,7 @@ mod tests {
     #[test]
     fn test_set_token_makes_token_available() {
         let mut client = VouchClient::unauthenticated("https://example.com").unwrap();
-        client.set_token(SecretString::from("test-token".to_string()));
+        client.token = Some(SecretString::from("test-token".to_string()));
         assert!(client.token().is_ok());
     }
 
@@ -955,7 +947,7 @@ mod tests {
     #[test]
     fn test_build_auth_without_fapi_key_returns_bearer() {
         let mut client = VouchClient::unauthenticated("https://example.com").unwrap();
-        client.set_token(SecretString::from("my-token".to_string()));
+        client.token = Some(SecretString::from("my-token".to_string()));
         // No fapi_key set → always Bearer
         let (auth, proof) = client
             .build_auth("GET", "https://example.com/v1/keys")
@@ -969,7 +961,7 @@ mod tests {
         use vouch_cli::fapi::ClientKey;
 
         let mut client = VouchClient::unauthenticated("https://example.com").unwrap();
-        client.set_token(SecretString::from("my-dpop-token".to_string()));
+        client.token = Some(SecretString::from("my-dpop-token".to_string()));
         client.fapi_key = Some(ClientKey::generate().unwrap());
 
         let (auth, proof) = client
@@ -995,7 +987,7 @@ mod tests {
         use vouch_cli::fapi::ClientKey;
 
         let mut client = VouchClient::unauthenticated("https://example.com").unwrap();
-        client.set_token(SecretString::from("access-token-abc".to_string()));
+        client.token = Some(SecretString::from("access-token-abc".to_string()));
         client.fapi_key = Some(ClientKey::generate().unwrap());
 
         let (_, proof) = client

--- a/crates/vouch-cli/src/commands/credential/codeartifact.rs
+++ b/crates/vouch-cli/src/commands/credential/codeartifact.rs
@@ -135,10 +135,17 @@ pub(crate) async fn get_token(
     domain_owner: &str,
     region: &str,
 ) -> Result<CodeArtifactToken> {
-    let cache_key = format!("codeartifact:{domain}:{domain_owner}:{region}");
+    // Detect the agent context BEFORE the cache lookup and fold it into the
+    // cache key so agent and non-agent invocations never share a cached
+    // entry — an agent must not receive a token minted without the
+    // ReadOnlyAccess session policy / `vouch:AccessType=ai` tags
+    // (issues #398, #426).
+    let agent_source = crate::commands::credential::aws::detect_agent_source();
+    let cache_key = build_cache_key(domain, domain_owner, region, agent_source.as_deref());
 
+    let agent = agent_source;
     let data = cache::get_or_fetch(&cache_key, "CodeArtifact token", || async {
-        let token = fetch_token(server, domain, domain_owner, region).await?;
+        let token = fetch_token(server, domain, domain_owner, region, agent.as_deref()).await?;
         let expires_at = jiff::Timestamp::from_second(token.expiration)
             .map_or_else(|_| cache::default_expiry(), |ts| ts.to_string());
         let data = serde_json::json!({
@@ -164,12 +171,28 @@ pub(crate) async fn get_token(
     })
 }
 
+/// Build the cache key for CodeArtifact tokens.
+///
+/// The agent source is folded into the key so that agent and non-agent
+/// invocations never share a cached entry (same pattern as the STS, EKS,
+/// RDS, and Redshift credential caches).
+fn build_cache_key(
+    domain: &str,
+    domain_owner: &str,
+    region: &str,
+    agent: Option<&str>,
+) -> String {
+    let suffix = agent.map_or(String::new(), |src| format!(":agent:{src}"));
+    format!("codeartifact:{domain}:{domain_owner}:{region}{suffix}")
+}
+
 /// Fetch a fresh CodeArtifact token (no caching).
 async fn fetch_token(
     server: &str,
     domain: &str,
     domain_owner: &str,
     region: &str,
+    agent_source: Option<&str>,
 ) -> Result<CodeArtifactToken> {
     let role_arn = get_local_aws_role().ok_or_else(|| {
         anyhow::anyhow!(
@@ -178,13 +201,12 @@ async fn fetch_token(
         )
     })?;
 
-    let agent_source = crate::commands::credential::aws::detect_agent_source();
     let result = exchange_for_sts_credentials(StsRequest {
         server,
         role_arn: &role_arn,
         region,
         management_role: None,
-        agent_source: agent_source.as_deref(),
+        agent_source,
     })
     .await?;
 
@@ -208,6 +230,23 @@ async fn fetch_token(
     reason = "test code: panic on assertion failure is acceptable"
 )]
 mod tests {
+    use super::build_cache_key;
+
+    /// Agent and non-agent invocations must never share a cached token:
+    /// the agent-restricted STS exchange (ReadOnlyAccess session policy)
+    /// would otherwise be bypassed by a full-access cached entry (#716).
+    #[test]
+    fn test_cache_key_includes_agent_source() {
+        let plain = build_cache_key("my-domain", "123456789012", "us-east-1", None);
+        let agent = build_cache_key("my-domain", "123456789012", "us-east-1", Some("claude-code"));
+        assert_eq!(plain, "codeartifact:my-domain:123456789012:us-east-1");
+        assert_eq!(
+            agent,
+            "codeartifact:my-domain:123456789012:us-east-1:agent:claude-code"
+        );
+        assert_ne!(plain, agent);
+    }
+
     /// Verify the CodeArtifact cache JSON round-trips correctly.
     ///
     /// The `get_token` function serializes with `json!()` and then extracts

--- a/crates/vouch-cli/src/commands/credential/codeartifact.rs
+++ b/crates/vouch-cli/src/commands/credential/codeartifact.rs
@@ -176,12 +176,7 @@ pub(crate) async fn get_token(
 /// The agent source is folded into the key so that agent and non-agent
 /// invocations never share a cached entry (same pattern as the STS, EKS,
 /// RDS, and Redshift credential caches).
-fn build_cache_key(
-    domain: &str,
-    domain_owner: &str,
-    region: &str,
-    agent: Option<&str>,
-) -> String {
+fn build_cache_key(domain: &str, domain_owner: &str, region: &str, agent: Option<&str>) -> String {
     let suffix = agent.map_or(String::new(), |src| format!(":agent:{src}"));
     format!("codeartifact:{domain}:{domain_owner}:{region}{suffix}")
 }
@@ -238,7 +233,12 @@ mod tests {
     #[test]
     fn test_cache_key_includes_agent_source() {
         let plain = build_cache_key("my-domain", "123456789012", "us-east-1", None);
-        let agent = build_cache_key("my-domain", "123456789012", "us-east-1", Some("claude-code"));
+        let agent = build_cache_key(
+            "my-domain",
+            "123456789012",
+            "us-east-1",
+            Some("claude-code"),
+        );
         assert_eq!(plain, "codeartifact:my-domain:123456789012:us-east-1");
         assert_eq!(
             agent,

--- a/crates/vouch-cli/src/commands/credential/docker.rs
+++ b/crates/vouch-cli/src/commands/credential/docker.rs
@@ -335,8 +335,7 @@ fn base64_decode(input: &str) -> Result<Vec<u8>> {
 
 /// Get credentials for GitHub Container Registry.
 async fn get_ghcr_credential(server: &str, token: &SecretString) -> Result<DockerCredential> {
-    let mut client = VouchClient::unauthenticated(server)?;
-    client.set_token(token.clone());
+    let client = VouchClient::with_token(server, token.clone())?;
 
     // Request token from server (no specific owner/repo for GHCR)
     let request = GitHubTokenRequest::default();

--- a/crates/vouch-cli/src/commands/keys.rs
+++ b/crates/vouch-cli/src/commands/keys.rs
@@ -54,13 +54,11 @@ pub(crate) async fn interactive(server: &str) -> Result<()> {
             return Ok(());
         }
 
-        // Build display options
-        let options: Vec<String> = response.keys.iter().map(format_key_for_display).collect();
-        let exit_label = tr!("keys-action-exit");
-
-        // Add quit option
-        let mut menu_options = options.clone();
-        menu_options.push(exit_label.clone());
+        // Build display options; the exit entry is the last index
+        let mut menu_options: Vec<String> =
+            response.keys.iter().map(format_key_for_display).collect();
+        let exit_idx = menu_options.len();
+        menu_options.push(tr!("keys-action-exit"));
 
         // Print prompt on its own line
         println!();
@@ -74,23 +72,22 @@ pub(crate) async fn interactive(server: &str) -> Result<()> {
 
         let nav_help = tr!("keys-help-navigation");
         // Show interactive menu (disable filtering to prevent accidental key presses)
+        // raw_prompt returns the selected index: display labels are not
+        // guaranteed unique (same model + same creation minute), so mapping
+        // the label back to a key could act on the wrong one.
         let selection = Select::new("\n", menu_options)
             .with_render_config(render_config)
             .with_help_message(&nav_help)
             .without_filtering()
-            .prompt();
+            .raw_prompt();
 
         match selection {
             Ok(selected) => {
-                if selected == exit_label {
+                if selected.index == exit_idx {
                     return Ok(());
                 }
 
-                // Find the selected key
-                let selected_idx = options.iter().position(|o| o == &selected);
-                if let Some(idx) = selected_idx
-                    && let Some(key) = response.keys.get(idx)
-                {
+                if let Some(key) = response.keys.get(selected.index) {
                     // Show action menu for selected key
                     if !handle_key_action(server, &client, key).await? {
                         return Ok(());
@@ -397,4 +394,40 @@ fn format_timestamp(timestamp: &jiff::Timestamp) -> String {
         return s.chars().take(16).collect();
     }
     s
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
+mod tests {
+    use super::*;
+
+    /// Two distinct keys with the same device model registered in the same
+    /// minute render identically, so the interactive menu must select by
+    /// index, never by matching the display label.
+    #[test]
+    fn test_duplicate_display_labels_for_distinct_keys() {
+        let created: jiff::Timestamp = "2026-07-17T10:15:03Z".parse().unwrap();
+        let same_minute: jiff::Timestamp = "2026-07-17T10:15:41Z".parse().unwrap();
+        let make = |id: &str, at: jiff::Timestamp| KeyInfo {
+            id: id.to_string(),
+            name: format!("{id}-name"),
+            created_at: at,
+            is_current_session: false,
+            device_model: Some("YubiKey 5 NFC".to_string()),
+            aaguid: None,
+        };
+        let a = make("key-a", created);
+        let b = make("key-b", same_minute);
+        assert_ne!(a.id, b.id);
+        assert_eq!(format_key_for_display(&a), format_key_for_display(&b));
+    }
+
+    #[test]
+    fn test_format_timestamp_truncates_to_minute() {
+        let ts: jiff::Timestamp = "2026-07-17T10:15:03Z".parse().unwrap();
+        assert_eq!(format_timestamp(&ts), "2026-07-17T10:15");
+    }
 }

--- a/crates/vouch-cli/src/commands/setup/eks.rs
+++ b/crates/vouch-cli/src/commands/setup/eks.rs
@@ -14,7 +14,8 @@ use crate::integrations::aws::sigv4::sign_and_send_rest;
 
 use super::kubeconfig::{
     ExecConfig, KubeconfigCluster, KubeconfigClusterData, KubeconfigContext, KubeconfigContextData,
-    KubeconfigUser, KubeconfigUserData, default_kubeconfig_path, load_kubeconfig, save_kubeconfig,
+    KubeconfigUser, KubeconfigUserData, default_kubeconfig_path, existing_cluster_other,
+    existing_context_other, existing_user_other, load_kubeconfig, save_kubeconfig,
 };
 
 // ============================================================================
@@ -155,7 +156,8 @@ pub(crate) async fn run(
     // Load existing kubeconfig
     let mut config = load_kubeconfig(&kubeconfig_path)?;
 
-    // Upsert cluster
+    // Upsert cluster, preserving any unmodeled fields on an existing entry.
+    let cluster_other = existing_cluster_other(&config, cluster_name);
     config.clusters.retain(|c| c.name != cluster_name);
     config.clusters.push(KubeconfigCluster {
         name: cluster_name.to_string(),
@@ -166,11 +168,12 @@ pub(crate) async fn run(
             } else {
                 Some(ca_data)
             },
-            other: serde_json::Value::Object(serde_json::Map::new()),
+            other: cluster_other,
         },
     });
 
     // Upsert user with vouch credential eks exec config
+    let user_other = existing_user_other(&config, &user_name);
     config.users.retain(|u| u.name != user_name);
     config.users.push(KubeconfigUser {
         name: user_name.clone(),
@@ -182,11 +185,12 @@ pub(crate) async fn run(
                 env: None,
                 interactive_mode: Some("Never".to_string()),
             }),
-            other: serde_json::Value::Object(serde_json::Map::new()),
+            other: user_other,
         },
     });
 
     // Upsert context
+    let context_other = existing_context_other(&config, &context_name);
     config.contexts.retain(|c| c.name != context_name);
     config.contexts.push(KubeconfigContext {
         name: context_name.clone(),
@@ -194,7 +198,7 @@ pub(crate) async fn run(
             cluster: cluster_name.to_string(),
             namespace: None,
             user: user_name.clone(),
-            other: serde_json::Value::Object(serde_json::Map::new()),
+            other: context_other,
         },
     });
 

--- a/crates/vouch-cli/src/commands/setup/eks.rs
+++ b/crates/vouch-cli/src/commands/setup/eks.rs
@@ -166,6 +166,7 @@ pub(crate) async fn run(
             } else {
                 Some(ca_data)
             },
+            other: serde_json::Value::Object(serde_json::Map::new()),
         },
     });
 
@@ -193,6 +194,7 @@ pub(crate) async fn run(
             cluster: cluster_name.to_string(),
             namespace: None,
             user: user_name.clone(),
+            other: serde_json::Value::Object(serde_json::Map::new()),
         },
     });
 

--- a/crates/vouch-cli/src/commands/setup/kubeconfig.rs
+++ b/crates/vouch-cli/src/commands/setup/kubeconfig.rs
@@ -46,6 +46,8 @@ pub(crate) struct KubeconfigClusterData {
         rename = "certificate-authority-data"
     )]
     pub certificate_authority_data: Option<String>,
+    #[serde(flatten)]
+    pub other: serde_json::Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -60,6 +62,8 @@ pub(crate) struct KubeconfigContextData {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
     pub user: String,
+    #[serde(flatten)]
+    pub other: serde_json::Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -133,10 +137,12 @@ pub(crate) fn load_kubeconfig(path: &std::path::Path) -> Result<Kubeconfig> {
 /// Parse kubeconfig YAML with YAML 1.2 boolean rules.
 ///
 /// Only `true`/`false` are booleans; YAML 1.1 spellings (`no`, `yes`, `on`,
-/// `off`, ...) stay strings. Fields we don't model land in `#[serde(flatten)]`
-/// `serde_json::Value` catch-alls and are written back verbatim by
-/// [`save_kubeconfig`], so without strict booleans another user's unquoted
-/// `token: no` would round-trip as `token: false` and break their kubectl auth.
+/// `off`, ...) stay strings. Fields we don't model inside cluster, context,
+/// and user entries land in `#[serde(flatten)]` `serde_json::Value`
+/// catch-alls (and `preferences` is kept as a raw `Value`), so they are
+/// written back verbatim by [`save_kubeconfig`]. Without strict booleans
+/// another user's unquoted `token: no` would round-trip as `token: false`
+/// and break their kubectl auth.
 fn parse_kubeconfig(content: &str) -> Result<Kubeconfig, serde_saphyr::Error> {
     let options = serde_saphyr::options! { strict_booleans: true };
     serde_saphyr::from_str_with_options(content, options)
@@ -266,6 +272,7 @@ users: []
                 cluster: "my-cluster".to_string(),
                 namespace: None,
                 user: "vouch-k8s-my-cluster".to_string(),
+                other: serde_json::Value::Object(serde_json::Map::new()),
             },
         };
 
@@ -283,6 +290,7 @@ users: []
             cluster: KubeconfigClusterData {
                 server: "https://k8s.prod.example.com:6443".to_string(),
                 certificate_authority_data: Some("LS0tLS1CRUdJTi...".to_string()),
+                other: serde_json::Value::Object(serde_json::Map::new()),
             },
         };
 
@@ -298,6 +306,7 @@ users: []
             cluster: KubeconfigClusterData {
                 server: "https://k8s.dev.example.com:6443".to_string(),
                 certificate_authority_data: None,
+                other: serde_json::Value::Object(serde_json::Map::new()),
             },
         };
 
@@ -395,5 +404,52 @@ users:
         let bool_yaml = "users:\n- name: u\n  user:\n    some-flag: true\n";
         let parsed: Kubeconfig = parse_kubeconfig(bool_yaml).expect("should parse");
         assert_eq!(parsed.users[0].user.other["some-flag"], true);
+    }
+
+    /// Unmodeled fields inside cluster and context entries must survive a
+    /// load -> save -> load round-trip, same as user entries (#707).
+    #[test]
+    fn test_flatten_preserves_arbitrary_cluster_and_context_fields() {
+        let yaml = r#"
+apiVersion: v1
+kind: Config
+clusters:
+- name: legacy
+  cluster:
+    server: https://k8s.legacy.example.com:6443
+    insecure-skip-tls-verify: true
+    proxy-url: http://proxy.example.com:3128
+contexts:
+- name: legacy-ctx
+  context:
+    cluster: legacy
+    user: legacy-user
+    extensions:
+    - name: workspace
+      extension:
+        directory: /home/user/project
+users: []
+"#;
+
+        let config: Kubeconfig = parse_kubeconfig(yaml).expect("should parse");
+        let cluster_other = &config.clusters[0].cluster.other;
+        assert_eq!(cluster_other["insecure-skip-tls-verify"], true);
+        assert_eq!(cluster_other["proxy-url"], "http://proxy.example.com:3128");
+        let context_other = &config.contexts[0].context.other;
+        assert_eq!(context_other["extensions"][0]["name"], "workspace");
+
+        let serialized = serde_saphyr::to_string(&config).expect("should serialize");
+        let reparsed: Kubeconfig = parse_kubeconfig(&serialized).expect("should re-parse");
+        let cluster_other2 = &reparsed.clusters[0].cluster.other;
+        assert_eq!(cluster_other2["insecure-skip-tls-verify"], true);
+        assert_eq!(
+            cluster_other2["proxy-url"],
+            "http://proxy.example.com:3128"
+        );
+        let context_other2 = &reparsed.contexts[0].context.other;
+        assert_eq!(
+            context_other2["extensions"][0]["extension"]["directory"],
+            "/home/user/project"
+        );
     }
 }

--- a/crates/vouch-cli/src/commands/setup/kubeconfig.rs
+++ b/crates/vouch-cli/src/commands/setup/kubeconfig.rs
@@ -442,10 +442,7 @@ users: []
         let reparsed: Kubeconfig = parse_kubeconfig(&serialized).expect("should re-parse");
         let cluster_other2 = &reparsed.clusters[0].cluster.other;
         assert_eq!(cluster_other2["insecure-skip-tls-verify"], true);
-        assert_eq!(
-            cluster_other2["proxy-url"],
-            "http://proxy.example.com:3128"
-        );
+        assert_eq!(cluster_other2["proxy-url"], "http://proxy.example.com:3128");
         let context_other2 = &reparsed.contexts[0].context.other;
         assert_eq!(
             context_other2["extensions"][0]["extension"]["directory"],

--- a/crates/vouch-cli/src/commands/setup/kubeconfig.rs
+++ b/crates/vouch-cli/src/commands/setup/kubeconfig.rs
@@ -160,6 +160,43 @@ pub(crate) fn save_kubeconfig(path: &std::path::Path, config: &Kubeconfig) -> Re
     Ok(())
 }
 
+/// An empty catch-all value for a freshly constructed entry.
+pub(crate) fn empty_other() -> serde_json::Value {
+    serde_json::Value::Object(serde_json::Map::new())
+}
+
+/// Return the `other` catch-all of the existing cluster named `name`, or an
+/// empty object if there is none. Used so an upsert preserves unmodeled
+/// fields (e.g. `insecure-skip-tls-verify`, `proxy-url`) the user added to
+/// the entry vouch manages, matching the round-trip preservation of #707.
+pub(crate) fn existing_cluster_other(config: &Kubeconfig, name: &str) -> serde_json::Value {
+    config
+        .clusters
+        .iter()
+        .find(|c| c.name == name)
+        .map_or_else(empty_other, |c| c.cluster.other.clone())
+}
+
+/// Return the `other` catch-all of the existing context named `name`, or an
+/// empty object if there is none (e.g. `extensions`).
+pub(crate) fn existing_context_other(config: &Kubeconfig, name: &str) -> serde_json::Value {
+    config
+        .contexts
+        .iter()
+        .find(|c| c.name == name)
+        .map_or_else(empty_other, |c| c.context.other.clone())
+}
+
+/// Return the `other` catch-all of the existing user named `name`, or an
+/// empty object if there is none.
+pub(crate) fn existing_user_other(config: &Kubeconfig, name: &str) -> serde_json::Value {
+    config
+        .users
+        .iter()
+        .find(|u| u.name == name)
+        .map_or_else(empty_other, |u| u.user.other.clone())
+}
+
 #[cfg(test)]
 #[expect(
     clippy::expect_used,
@@ -447,6 +484,53 @@ users: []
         assert_eq!(
             context_other2["extensions"][0]["extension"]["directory"],
             "/home/user/project"
+        );
+    }
+
+    /// Upserting a managed cluster/context/user entry must carry over its
+    /// preserved `other` fields rather than replacing them with an empty
+    /// map — otherwise re-running setup drops extras the flatten catch-all
+    /// preserved on load (#707 upsert path).
+    #[test]
+    fn test_existing_other_helpers_preserve_extras_on_upsert() {
+        let yaml = r#"
+apiVersion: v1
+kind: Config
+clusters:
+- name: my-cluster
+  cluster:
+    server: https://k8s.example.com:6443
+    insecure-skip-tls-verify: true
+contexts:
+- name: my-cluster-vouch
+  context:
+    cluster: my-cluster
+    user: vouch-k8s-my-cluster
+    extensions:
+    - name: ext
+users:
+- name: vouch-k8s-my-cluster
+  user:
+    token: keep-me
+"#;
+        let config: Kubeconfig = parse_kubeconfig(yaml).expect("should parse");
+
+        let cluster_other = existing_cluster_other(&config, "my-cluster");
+        assert_eq!(cluster_other["insecure-skip-tls-verify"], true);
+        let context_other = existing_context_other(&config, "my-cluster-vouch");
+        assert_eq!(context_other["extensions"][0]["name"], "ext");
+        let user_other = existing_user_other(&config, "vouch-k8s-my-cluster");
+        assert_eq!(user_other["token"], "keep-me");
+
+        // Absent entries yield an empty object, not a panic.
+        assert!(
+            existing_cluster_other(&config, "nope")
+                .as_object()
+                .is_some()
+        );
+        assert_eq!(
+            existing_cluster_other(&config, "nope"),
+            serde_json::Value::Object(serde_json::Map::new())
         );
     }
 }

--- a/crates/vouch-cli/src/commands/setup/kubernetes.rs
+++ b/crates/vouch-cli/src/commands/setup/kubernetes.rs
@@ -12,7 +12,8 @@ use vouch_cli::{tr_args, tr_println};
 
 use super::kubeconfig::{
     ExecConfig, KubeconfigCluster, KubeconfigClusterData, KubeconfigContext, KubeconfigContextData,
-    KubeconfigUser, KubeconfigUserData, default_kubeconfig_path, load_kubeconfig, save_kubeconfig,
+    KubeconfigUser, KubeconfigUserData, default_kubeconfig_path, existing_cluster_other,
+    existing_context_other, existing_user_other, load_kubeconfig, save_kubeconfig,
 };
 
 /// Read and base64-encode a certificate authority file.
@@ -72,18 +73,20 @@ pub(crate) async fn run(
     // Load existing kubeconfig
     let mut config = load_kubeconfig(&kubeconfig_path)?;
 
-    // Upsert cluster
+    // Upsert cluster, preserving any unmodeled fields on an existing entry.
+    let cluster_other = existing_cluster_other(&config, cluster);
     config.clusters.retain(|c| c.name != cluster);
     config.clusters.push(KubeconfigCluster {
         name: cluster.to_string(),
         cluster: KubeconfigClusterData {
             server: k8s_server.to_string(),
             certificate_authority_data: ca_data,
-            other: serde_json::Value::Object(serde_json::Map::new()),
+            other: cluster_other,
         },
     });
 
     // Upsert user with vouch credential k8s exec config
+    let user_other = existing_user_other(&config, &user_name);
     config.users.retain(|u| u.name != user_name);
     config.users.push(KubeconfigUser {
         name: user_name.clone(),
@@ -95,11 +98,12 @@ pub(crate) async fn run(
                 env: None,
                 interactive_mode: Some("Never".to_string()),
             }),
-            other: serde_json::Value::Object(serde_json::Map::new()),
+            other: user_other,
         },
     });
 
     // Upsert context
+    let context_other = existing_context_other(&config, &context_name);
     config.contexts.retain(|c| c.name != context_name);
     config.contexts.push(KubeconfigContext {
         name: context_name.clone(),
@@ -107,7 +111,7 @@ pub(crate) async fn run(
             cluster: cluster.to_string(),
             namespace: None,
             user: user_name.clone(),
-            other: serde_json::Value::Object(serde_json::Map::new()),
+            other: context_other,
         },
     });
 

--- a/crates/vouch-cli/src/commands/setup/kubernetes.rs
+++ b/crates/vouch-cli/src/commands/setup/kubernetes.rs
@@ -79,6 +79,7 @@ pub(crate) async fn run(
         cluster: KubeconfigClusterData {
             server: k8s_server.to_string(),
             certificate_authority_data: ca_data,
+            other: serde_json::Value::Object(serde_json::Map::new()),
         },
     });
 
@@ -106,6 +107,7 @@ pub(crate) async fn run(
             cluster: cluster.to_string(),
             namespace: None,
             user: user_name.clone(),
+            other: serde_json::Value::Object(serde_json::Map::new()),
         },
     });
 

--- a/crates/vouch-cli/src/commands/setup/ssm.rs
+++ b/crates/vouch-cli/src/commands/setup/ssm.rs
@@ -89,6 +89,27 @@ fn build_ssh_config_block(host_pattern: &str, profile_name: &str, region_name: &
     )
 }
 
+/// Extract the host pattern from the `Host` line inside the Vouch SSM block.
+///
+/// Scans only lines at or after `SSM_MARKER`, so `Host` entries the user
+/// keeps elsewhere in their SSH config are never picked up.
+fn ssm_block_host_pattern(content: &str) -> Option<&str> {
+    let mut marker_seen = false;
+    for line in content.lines() {
+        if line.contains(SSM_MARKER) {
+            marker_seen = true;
+            continue;
+        }
+        if marker_seen && let Some(rest) = line.strip_prefix("Host ") {
+            let trimmed = rest.trim();
+            if !trimmed.is_empty() && trimmed != "*" {
+                return Some(trimmed);
+            }
+        }
+    }
+    None
+}
+
 /// Remove an existing SSM config block from the SSH config content.
 ///
 /// Finds the block starting with `SSM_MARKER` and removes everything up to
@@ -198,16 +219,9 @@ pub(crate) async fn run(
                     tr_println!("setup-ssm-existing-region", indent = "  ", value = r);
                 }
             }
-            // Show host pattern from the Host line
-            for line in existing.lines() {
-                if let Some(rest) = line.strip_prefix("Host ") {
-                    let trimmed = rest.trim();
-                    // Only show the host line that follows our marker
-                    if !trimmed.is_empty() && trimmed != "*" {
-                        tr_println!("setup-ssm-existing-hosts", indent = "  ", value = trimmed);
-                        break;
-                    }
-                }
+            // Show the host pattern from the Host line inside our block
+            if let Some(hosts) = ssm_block_host_pattern(&existing) {
+                tr_println!("setup-ssm-existing-hosts", indent = "  ", value = hosts);
             }
 
             println!();
@@ -352,6 +366,31 @@ mod tests {
     #[test]
     fn test_validate_shell_safe_rejects_empty() {
         assert!(validate_shell_safe("", "--profile").is_err());
+    }
+
+    // ---- ssm_block_host_pattern tests ----
+
+    #[test]
+    fn test_host_pattern_skips_blocks_before_marker() {
+        let existing = format!(
+            "Host bastion\n    HostName bastion.example.com\n\
+             \nHost *\n    ServerAliveInterval 60\n\
+             \n{SSM_MARKER}\n# Added by: vouch setup ssm\n\
+             Host i-* mi-*\n    ProxyCommand sh -c \"aws ssm start-session ...\"\n"
+        );
+        assert_eq!(ssm_block_host_pattern(&existing), Some("i-* mi-*"));
+    }
+
+    #[test]
+    fn test_host_pattern_without_marker_returns_none() {
+        let existing = "Host bastion\n    HostName bastion.example.com\n";
+        assert_eq!(ssm_block_host_pattern(existing), None);
+    }
+
+    #[test]
+    fn test_host_pattern_marker_only_block() {
+        let existing = format!("{SSM_MARKER}\n# Added by: vouch setup ssm\n");
+        assert_eq!(ssm_block_host_pattern(&existing), None);
     }
 
     // ---- strip_ssm_block tests ----

--- a/crates/vouch-common/src/api.rs
+++ b/crates/vouch-common/src/api.rs
@@ -432,12 +432,22 @@ pub struct SshCaPublicKeyResponse {
 
 /// Cloud provider token response.
 /// Contains an OIDC ID token for use with cloud provider identity federation.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct CloudTokenResponse {
     /// OIDC ID token for use with cloud provider identity federation.
     pub id_token: String,
     /// Token validity period in seconds.
     pub expires_in: u64,
+}
+
+// Custom Debug that redacts id_token to prevent accidental log exposure.
+impl std::fmt::Debug for CloudTokenResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CloudTokenResponse")
+            .field("id_token", &"[REDACTED]")
+            .field("expires_in", &self.expires_in)
+            .finish()
+    }
 }
 
 /// Response containing an OIDC ID token for AWS STS.
@@ -532,4 +542,23 @@ pub struct GitHubAccountStatus {
     /// Repository names when repository_selection is "selected".
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub repositories: Option<Vec<String>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The OIDC ID token is a bearer credential for cloud identity
+    /// federation and must never appear in `{:?}` output.
+    #[test]
+    fn test_cloud_token_response_debug_redacts_id_token() {
+        let response = CloudTokenResponse {
+            id_token: "eyJhbGciOiJSUzI1NiJ9.secret-token".to_string(),
+            expires_in: 28_800,
+        };
+        let debug = format!("{response:?}");
+        assert!(debug.contains("[REDACTED]"), "{debug}");
+        assert!(!debug.contains("secret-token"), "{debug}");
+        assert!(debug.contains("28800"), "{debug}");
+    }
 }

--- a/crates/vouch-httpsig/src/middleware.rs
+++ b/crates/vouch-httpsig/src/middleware.rs
@@ -214,6 +214,48 @@ pub const DEFAULT_MAX_AGE: i64 = 300;
 /// 6. Emits `Accept-Signature` (RFC 9421 §5.1) on unsigned / under-covered 401s
 ///    so clients know exactly what to sign next time
 ///
+/// Validate and consume a verified signature's nonce, if it carries one.
+///
+/// Returns `Some(response)` when the request must be rejected (unknown or
+/// already-consumed nonce → 401 with a fresh `Signature-Nonce`; backend
+/// failure → 500), or `None` when there is no nonce or it was accepted.
+async fn enforce_nonce<R: KeyResolver>(
+    resolver: &R,
+    params: &SignatureParams,
+    label: &str,
+    keyid: &str,
+) -> Option<Response> {
+    let nonce = params.nonce.as_deref()?;
+    match resolver.validate_nonce(nonce).await {
+        NonceValidation::Valid => None,
+        NonceValidation::Invalid => {
+            tracing::debug!(
+                label = %label,
+                keyid = %keyid,
+                "HTTP signature nonce invalid or already consumed"
+            );
+            let mut resp = (StatusCode::UNAUTHORIZED, SIG_VERIFY_FAILED).into_response();
+            // Recovery hint: a stale or consumed nonce is fixed by signing the
+            // next request with a fresh one (mirrors DPoP's use_dpop_nonce
+            // flow). No Accept-Signature — this is not a coverage problem.
+            if let Some(fresh) = resolver.generate_nonce().await
+                && let Ok(value) = http::HeaderValue::from_str(&fresh)
+            {
+                resp.headers_mut().insert("signature-nonce", value);
+            }
+            Some(resp)
+        }
+        NonceValidation::Error => {
+            tracing::error!(
+                label = %label,
+                keyid = %keyid,
+                "HTTP signature nonce validation backend failure"
+            );
+            Some((StatusCode::INTERNAL_SERVER_ERROR, "internal error").into_response())
+        }
+    }
+}
+
 /// Used on endpoints where every request must be signed, e.g. the `/v1/*`
 /// CLI↔server channel under FAPI 2.0 Message Signing. Returns 401 with a
 /// generic message on any verification failure.
@@ -372,38 +414,8 @@ pub async fn require_signature<R: KeyResolver>(
             }
             // Validate and consume the server-issued nonce when the signature
             // carries one (enforce-when-present; see KeyResolver::validate_nonce).
-            if let Some(nonce) = params.nonce.as_deref() {
-                match resolver.validate_nonce(nonce).await {
-                    NonceValidation::Valid => {}
-                    NonceValidation::Invalid => {
-                        tracing::debug!(
-                            label = %label,
-                            keyid = %keyid,
-                            "HTTP signature nonce invalid or already consumed"
-                        );
-                        let mut resp =
-                            (StatusCode::UNAUTHORIZED, SIG_VERIFY_FAILED).into_response();
-                        // Recovery hint: a stale or consumed nonce is fixed by
-                        // signing the next request with a fresh one (mirrors
-                        // DPoP's use_dpop_nonce flow). No Accept-Signature —
-                        // this is not a coverage problem.
-                        if let Some(fresh) = resolver.generate_nonce().await
-                            && let Ok(value) = http::HeaderValue::from_str(&fresh)
-                        {
-                            resp.headers_mut().insert("signature-nonce", value);
-                        }
-                        return resp;
-                    }
-                    NonceValidation::Error => {
-                        tracing::error!(
-                            label = %label,
-                            keyid = %keyid,
-                            "HTTP signature nonce validation backend failure"
-                        );
-                        return (StatusCode::INTERNAL_SERVER_ERROR, "internal error")
-                            .into_response();
-                    }
-                }
+            if let Some(resp) = enforce_nonce(resolver.as_ref(), &params, &label, &keyid).await {
+                return resp;
             }
             parts.extensions.insert(VerifiedSignature {
                 label: label.clone(),

--- a/crates/vouch-httpsig/src/middleware.rs
+++ b/crates/vouch-httpsig/src/middleware.rs
@@ -155,6 +155,39 @@ pub trait KeyResolver: Send + Sync + 'static {
     fn generate_nonce(&self) -> impl std::future::Future<Output = Option<String>> + Send + '_ {
         async { None }
     }
+
+    /// Validate (and atomically consume) a client-supplied signature nonce.
+    ///
+    /// Called only when a verified signature carries a `nonce` parameter —
+    /// nonce enforcement is opportunistic (enforce-when-present): a client's
+    /// first request has no nonce yet, so requests without one pass through
+    /// and rely on the timestamp window alone. Validation runs after
+    /// signature, coverage, and body-digest checks so only a fully valid
+    /// request (or a byte-perfect replay of one) can consume a nonce —
+    /// first presentation wins, the replay is rejected.
+    ///
+    /// The default accepts without checking, for resolvers that do not
+    /// issue nonces (their clients never send the parameter).
+    fn validate_nonce(
+        &self,
+        _nonce: &str,
+    ) -> impl std::future::Future<Output = NonceValidation> + Send + '_ {
+        async { NonceValidation::Valid }
+    }
+}
+
+/// Outcome of validating a client-supplied signature nonce.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NonceValidation {
+    /// Nonce accepted (or the resolver does not enforce nonces).
+    Valid,
+    /// Nonce unknown, expired, or already consumed — the request is
+    /// rejected; the response carries a fresh `Signature-Nonce` so the
+    /// client can recover on its next request.
+    Invalid,
+    /// Backend failure while checking — server fault (5xx), never
+    /// reported as a client authentication failure.
+    Error,
 }
 
 /// Default maximum signature age in seconds (5 minutes).
@@ -337,6 +370,41 @@ pub async fn require_signature<R: KeyResolver>(
                 }
                 return resp;
             }
+            // Validate and consume the server-issued nonce when the signature
+            // carries one (enforce-when-present; see KeyResolver::validate_nonce).
+            if let Some(nonce) = params.nonce.as_deref() {
+                match resolver.validate_nonce(nonce).await {
+                    NonceValidation::Valid => {}
+                    NonceValidation::Invalid => {
+                        tracing::debug!(
+                            label = %label,
+                            keyid = %keyid,
+                            "HTTP signature nonce invalid or already consumed"
+                        );
+                        let mut resp =
+                            (StatusCode::UNAUTHORIZED, SIG_VERIFY_FAILED).into_response();
+                        // Recovery hint: a stale or consumed nonce is fixed by
+                        // signing the next request with a fresh one (mirrors
+                        // DPoP's use_dpop_nonce flow). No Accept-Signature —
+                        // this is not a coverage problem.
+                        if let Some(fresh) = resolver.generate_nonce().await
+                            && let Ok(value) = http::HeaderValue::from_str(&fresh)
+                        {
+                            resp.headers_mut().insert("signature-nonce", value);
+                        }
+                        return resp;
+                    }
+                    NonceValidation::Error => {
+                        tracing::error!(
+                            label = %label,
+                            keyid = %keyid,
+                            "HTTP signature nonce validation backend failure"
+                        );
+                        return (StatusCode::INTERNAL_SERVER_ERROR, "internal error")
+                            .into_response();
+                    }
+                }
+            }
             parts.extensions.insert(VerifiedSignature {
                 label: label.clone(),
                 params,
@@ -429,17 +497,33 @@ mod tests {
     /// In-memory key resolver for testing.
     struct InMemoryKeyResolver {
         keys: std::collections::HashMap<String, Arc<dyn VerifyingAlgorithm>>,
+        /// When `Some`, the resolver enforces nonces: a validated nonce is
+        /// removed from the set (single-use), and `generate_nonce` mints a
+        /// fresh entry.
+        nonces: Option<std::sync::Mutex<std::collections::HashSet<String>>>,
+        /// Force `validate_nonce` to report a backend error.
+        nonce_backend_error: bool,
     }
 
     impl InMemoryKeyResolver {
         fn new() -> Self {
             Self {
                 keys: std::collections::HashMap::new(),
+                nonces: None,
+                nonce_backend_error: false,
             }
         }
 
         fn insert(&mut self, key_id: String, verifier: Arc<dyn VerifyingAlgorithm>) {
             self.keys.insert(key_id, verifier);
+        }
+
+        /// Enable nonce enforcement and pre-seed a set of issuable nonces.
+        fn with_nonces(mut self, seed: &[&str]) -> Self {
+            self.nonces = Some(std::sync::Mutex::new(
+                seed.iter().map(|s| (*s).to_string()).collect(),
+            ));
+            self
         }
     }
 
@@ -452,6 +536,40 @@ mod tests {
         {
             let result = self.keys.get(keyid).cloned();
             async move { result }
+        }
+
+        fn generate_nonce(&self) -> impl std::future::Future<Output = Option<String>> + Send + '_ {
+            let issued = self.nonces.as_ref().map(|set| {
+                let nonce = format!("nonce-{}", set.lock().map_or(0, |s| s.len()));
+                if let Ok(mut s) = set.lock() {
+                    s.insert(nonce.clone());
+                }
+                nonce
+            });
+            async move { issued }
+        }
+
+        fn validate_nonce(
+            &self,
+            nonce: &str,
+        ) -> impl std::future::Future<Output = NonceValidation> + Send + '_ {
+            let outcome = if self.nonce_backend_error {
+                NonceValidation::Error
+            } else {
+                match &self.nonces {
+                    // No enforcement: accept unconditionally (default behavior).
+                    None => NonceValidation::Valid,
+                    Some(set) => {
+                        let consumed = set.lock().is_ok_and(|mut s| s.remove(nonce));
+                        if consumed {
+                            NonceValidation::Valid
+                        } else {
+                            NonceValidation::Invalid
+                        }
+                    }
+                }
+            };
+            async move { outcome }
         }
     }
 
@@ -797,5 +915,121 @@ mod tests {
             response.headers().get("accept-signature").is_none(),
             "DigestMismatch (tampered body) must NOT advertise Accept-Signature"
         );
+    }
+
+    /// Build a signed GET request against `/v1/test`, optionally with a nonce.
+    fn signed_get(signer: &EcdsaP256Signer, nonce: Option<&str>) -> Request<axum::body::Body> {
+        let mut req = Request::builder()
+            .method("GET")
+            .uri("http://example.com/v1/test")
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        let mut builder = SignatureBuilder::new("sig1").method().path().created_now();
+        if let Some(n) = nonce {
+            builder = builder.nonce(n);
+        }
+        builder.sign_request(&mut req, signer).unwrap();
+
+        let (mut parts, body) = req.into_parts();
+        parts.uri = "/v1/test".parse().unwrap();
+        Request::from_parts(parts, body)
+    }
+
+    fn resolver_with_key_and_nonces(
+        signer: &EcdsaP256Signer,
+        seed: &[&str],
+    ) -> Arc<InMemoryKeyResolver> {
+        let mut resolver = InMemoryKeyResolver::new().with_nonces(seed);
+        resolver.insert("test-key".to_string(), Arc::new(signer.verifier()));
+        Arc::new(resolver)
+    }
+
+    /// Enforce-when-present: a nonce-enforcing resolver still accepts a
+    /// signed request that carries no nonce (the client's first request).
+    #[tokio::test]
+    async fn test_nonce_absent_is_accepted() {
+        let signer = EcdsaP256Signer::generate("test-key").unwrap();
+        let resolver = resolver_with_key_and_nonces(&signer, &[]);
+        let router = build_test_router(resolver);
+
+        let response = <Router as tower::ServiceExt<Request<axum::body::Body>>>::oneshot(
+            router,
+            signed_get(&signer, None),
+        )
+        .await
+        .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    /// A known nonce is accepted once, then a byte-identical replay is
+    /// rejected (single-use), and the rejection carries a fresh nonce.
+    #[tokio::test]
+    async fn test_nonce_valid_then_replay_rejected() {
+        let signer = EcdsaP256Signer::generate("test-key").unwrap();
+        let resolver = resolver_with_key_and_nonces(&signer, &["known-nonce"]);
+        let router = build_test_router(resolver);
+
+        let req = signed_get(&signer, Some("known-nonce"));
+        // Capture the signed headers so the replay is byte-identical.
+        let (parts, _) = req.into_parts();
+        let replay = Request::from_parts(parts.clone(), axum::body::Body::empty());
+        let first = Request::from_parts(parts, axum::body::Body::empty());
+
+        let response = <Router as tower::ServiceExt<Request<axum::body::Body>>>::oneshot(
+            router.clone(),
+            first,
+        )
+        .await
+        .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let response =
+            <Router as tower::ServiceExt<Request<axum::body::Body>>>::oneshot(router, replay)
+                .await
+                .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "replaying a consumed nonce must be rejected"
+        );
+        assert!(
+            response.headers().get("signature-nonce").is_some(),
+            "a rejected nonce must offer a fresh one for recovery"
+        );
+    }
+
+    /// A nonce the server never issued is rejected.
+    #[tokio::test]
+    async fn test_nonce_unknown_rejected() {
+        let signer = EcdsaP256Signer::generate("test-key").unwrap();
+        let resolver = resolver_with_key_and_nonces(&signer, &["known-nonce"]);
+        let router = build_test_router(resolver);
+
+        let response = <Router as tower::ServiceExt<Request<axum::body::Body>>>::oneshot(
+            router,
+            signed_get(&signer, Some("never-issued")),
+        )
+        .await
+        .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    /// A backend failure while checking a nonce is a 500, never a 401.
+    #[tokio::test]
+    async fn test_nonce_backend_error_is_500() {
+        let signer = EcdsaP256Signer::generate("test-key").unwrap();
+        let mut resolver = InMemoryKeyResolver::new().with_nonces(&["known-nonce"]);
+        resolver.nonce_backend_error = true;
+        resolver.insert("test-key".to_string(), Arc::new(signer.verifier()));
+        let router = build_test_router(Arc::new(resolver));
+
+        let response = <Router as tower::ServiceExt<Request<axum::body::Body>>>::oneshot(
+            router,
+            signed_get(&signer, Some("known-nonce")),
+        )
+        .await
+        .unwrap();
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 }

--- a/crates/vouch-server/src/config.rs
+++ b/crates/vouch-server/src/config.rs
@@ -926,6 +926,17 @@ impl ServerConfig {
             }
         }
 
+        // Reject partial TLS configuration. With only one of cert/key set the
+        // server silently runs plain HTTP (serving and discovery both require
+        // tls_configured()), which is never what the operator intended.
+        if self.tls_cert.is_some() != self.tls_key.is_some() {
+            anyhow::bail!(
+                "Partial TLS configuration: set both VOUCH_TLS_CERT and \
+                 VOUCH_TLS_KEY (or tls.cert and tls.key in the S3 config), \
+                 or neither."
+            );
+        }
+
         // Retention windows are subtracted from `now` to form a deletion cutoff;
         // a negative value yields a future cutoff, which matches every row and
         // wipes the entire audit log. Reject at startup so an operator typo or
@@ -1105,6 +1116,29 @@ mod tests {
         // Mutual exclusivity removed — both kinds can coexist in the same idps list.
         let mut config = test_config();
         config.idps.push(IdpConfig::Saml(saml_provider_for_tests()));
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_rejects_partial_tls_config() {
+        let mut config = test_config();
+        config.tls_cert = Some("cert-pem".to_string());
+        config.tls_key = None;
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("Partial TLS configuration"),
+            "expected partial-TLS error, got: {err}"
+        );
+
+        let mut config = test_config();
+        config.tls_cert = None;
+        config.tls_key = Some(secrecy::SecretString::from("key-pem".to_string()));
+        assert!(config.validate().is_err());
+
+        // Both set (or neither) is fine.
+        let mut config = test_config();
+        config.tls_cert = Some("cert-pem".to_string());
+        config.tls_key = Some(secrecy::SecretString::from("key-pem".to_string()));
         assert!(config.validate().is_ok());
     }
 

--- a/crates/vouch-server/src/db/enrollment.rs
+++ b/crates/vouch-server/src/db/enrollment.rs
@@ -7,6 +7,7 @@
 use super::documents::organization::OrganizationDoc;
 use super::documents::user::UserDoc;
 use super::store::DocumentStore;
+use crate::error::ServiceError;
 use anyhow::{Context, Result};
 
 /// Derive a deterministic document ID from a domain so that two
@@ -125,13 +126,31 @@ pub async fn enroll_user_with_org(
         (None, false)
     };
 
-    crate::with_dsql_retry!(async {
-        let mut tx = store.begin().await?;
+    // Map a DB error from any tx operation into either an OccConflict (if it
+    // signals writer contention) or a generic 500. OccConflict is retried by
+    // with_dsql_retry!; the Internal path propagates.
+    let map_db_err = |e: anyhow::Error, msg: &'static str| -> ServiceError {
+        tracing::error!("{msg}: {e}");
+        if crate::db::pool::is_retryable_db_error(&e) {
+            ServiceError::OccConflict
+        } else {
+            ServiceError::Internal(msg.to_string())
+        }
+    };
+
+    let result = crate::with_dsql_retry!(async {
+        let mut tx = store
+            .begin()
+            .await
+            .map_err(|e| map_db_err(e, "Failed to begin enrollment transaction"))?;
 
         // Step 2: Determine admin status
         let is_org_admin = if org_needs_admin {
             if let Some(ref oid) = org_id {
-                let count = tx.count::<UserDoc>("org_id", oid).await?;
+                let count = tx
+                    .count::<UserDoc>("org_id", oid)
+                    .await
+                    .map_err(|e| map_db_err(e, "Failed to count org users"))?;
                 count == 0
             } else {
                 false
@@ -141,7 +160,10 @@ pub async fn enroll_user_with_org(
         };
 
         // Step 3: Get or create user
-        let existing_user = tx.find_one::<UserDoc>("email", email).await?;
+        let existing_user = tx
+            .find_one::<UserDoc>("email", email)
+            .await
+            .map_err(|e| map_db_err(e, "Failed to look up user by email"))?;
 
         let user = match existing_user {
             Some(doc) => EnrolledUser {
@@ -163,7 +185,10 @@ pub async fn enroll_user_with_org(
                     github_login: None,
                     github_refresh_token: None,
                 };
-                let result = tx.insert(&doc).await?;
+                let result = tx
+                    .insert(&doc)
+                    .await
+                    .map_err(|e| map_db_err(e, "Failed to insert user"))?;
                 EnrolledUser {
                     id: result.id,
                     email: result.data.email,
@@ -178,36 +203,106 @@ pub async fn enroll_user_with_org(
         // only one concurrent enrollee wins the admin slot. On re-run after a
         // crash, this also repairs a missing created_by_user_id.
         if let Some(ref oid) = org_id
-            && let Some(org_doc) = tx.get::<OrganizationDoc>(oid).await?
-            && org_doc.data.created_by_user_id.is_none()
+            && let Some(org_doc) = tx
+                .get::<OrganizationDoc>(oid)
+                .await
+                .map_err(|e| map_db_err(e, "Failed to load organization"))?
         {
-            let mut data = org_doc.data;
-            data.created_by_user_id = Some(user.id.clone());
-            // Optimistic lock: if another enrollment already set the admin,
-            // compare_and_update returns false (version mismatch) and we
-            // harmlessly skip — the first enrollee wins the admin role.
-            let won = tx.compare_and_update(oid, org_doc.version, &data).await?;
-            if !won {
-                tracing::debug!(
-                    org_id = %oid,
-                    "Lost race to set org admin during enrollment — another enrollee won"
-                );
+            if org_doc.data.created_by_user_id.is_none() {
+                let mut data = org_doc.data;
+                data.created_by_user_id = Some(user.id.clone());
+                let won = tx
+                    .compare_and_update(oid, org_doc.version, &data)
+                    .await
+                    .map_err(|e| map_db_err(e, "Failed to update organization admin"))?;
+                admin_cas_outcome(won, is_org_admin, oid)?;
+            } else if is_org_admin {
+                // Another enrollee committed the admin slot between Step 2's
+                // count and this read (READ COMMITTED lets each statement see
+                // newer commits). A stale admin claim must abort and retry.
+                admin_cas_outcome(false, true, oid)?;
             }
         }
 
-        tx.commit().await?;
+        tx.commit()
+            .await
+            .map_err(|e| map_db_err(e, "Failed to commit enrollment transaction"))?;
 
-        Ok(EnrollmentResult {
+        Ok::<_, ServiceError>(EnrollmentResult {
             user,
             org_id: org_id.clone(),
             is_org_admin,
         })
-    })
+    })?;
+
+    Ok(result)
+}
+
+/// Decide the outcome of the Step-4 admin CAS on the organization row.
+///
+/// Winning the CAS is a REQUIREMENT for committing a user row that claims
+/// `is_org_admin = true`: the count-based admin decision in Step 2 is a
+/// predicate read that concurrent transactions do not conflict on (write
+/// skew under READ COMMITTED), so two first-enrollees can both compute
+/// `is_org_admin = true`. The org-row CAS is the one write both must
+/// collide on. A claiming loser aborts with `OccConflict` so
+/// `with_dsql_retry!` re-runs the transaction; the retry re-counts (the
+/// winner's user row is now visible), derives `is_org_admin = false`, and
+/// commits a non-admin user.
+///
+/// A non-claiming loser (this enrollee never computed admin status) merely
+/// raced the opportunistic `created_by_user_id` repair and proceeds.
+fn admin_cas_outcome(won: bool, claimed_admin: bool, org_id: &str) -> Result<(), ServiceError> {
+    if won || !claimed_admin {
+        if !won {
+            tracing::debug!(
+                org_id = %org_id,
+                "Lost race to repair org admin during enrollment — another enrollee won"
+            );
+        }
+        return Ok(());
+    }
+    tracing::debug!(
+        org_id = %org_id,
+        "Lost race to claim org admin during enrollment — retrying as non-admin"
+    );
+    Err(ServiceError::OccConflict)
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
-    use super::deterministic_org_id;
+    use super::{admin_cas_outcome, deterministic_org_id};
+
+    /// Winning the CAS always commits, whether or not admin was claimed.
+    #[test]
+    fn admin_cas_outcome_winner_commits() {
+        assert!(admin_cas_outcome(true, true, "org-1").is_ok());
+        assert!(admin_cas_outcome(true, false, "org-1").is_ok());
+    }
+
+    /// A loser that claimed admin must abort with the one retryable error
+    /// so `with_dsql_retry!` re-runs the transaction and re-derives the
+    /// admin decision from fresh state.
+    #[test]
+    fn admin_cas_outcome_claiming_loser_is_retryable_conflict() {
+        use crate::db::pool::RetryableError;
+        use crate::error::ServiceError;
+
+        let err = admin_cas_outcome(false, true, "org-1").expect_err("must abort");
+        assert!(matches!(err, ServiceError::OccConflict));
+        assert!(err.is_retryable(), "OccConflict must be retryable");
+    }
+
+    /// A loser that never claimed admin only raced the opportunistic
+    /// `created_by_user_id` repair; committing is harmless.
+    #[test]
+    fn admin_cas_outcome_non_claiming_loser_commits() {
+        assert!(admin_cas_outcome(false, false, "org-1").is_ok());
+    }
 
     #[test]
     fn deterministic_org_id_collides_on_equal_domains() {

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -118,10 +118,11 @@ pub use config::{AuthEventParams, AuthEventType, ClientInfo, spawn_audit_event};
 // Re-export SCIM types and functions
 pub use scim::{
     ScimFilterError, ScimGroupRecord, ScimScope, ScimScopeSet, ScimToken, ScimUserRecord,
-    add_scim_group_member, create_scim_group, create_scim_token, create_scim_user,
-    delete_scim_group, delete_scim_token, get_scim_group, get_scim_group_members,
-    get_scim_token_by_hash, get_scim_user, insert_scim_audit, list_scim_groups, list_scim_tokens,
-    list_scim_users, remove_scim_group_member, replace_scim_group_members, update_scim_group,
+    add_scim_group_member, count_active_scim_tokens, create_scim_group, create_scim_token,
+    create_scim_user, delete_expired_scim_tokens, delete_scim_group, delete_scim_token,
+    get_scim_group, get_scim_group_members, get_scim_token_by_hash, get_scim_user,
+    insert_scim_audit, list_scim_groups, list_scim_tokens, list_scim_users,
+    remove_scim_group_member, replace_scim_group_members, update_scim_group,
     update_scim_token_last_used, update_scim_user,
 };
 

--- a/crates/vouch-server/src/db/scim.rs
+++ b/crates/vouch-server/src/db/scim.rs
@@ -2,7 +2,7 @@
 //! SCIM 2.0 (RFC 7643/7644) database operations.
 
 use super::audit::{AuditEventKind, AuditStore};
-use super::document_type::Document;
+use super::document_type::{Document, DocumentType};
 use super::documents::audit::ScimAuditData;
 use super::documents::scim::{ScimGroupDoc, ScimGroupMemberDoc, ScimTokenDoc};
 use super::documents::user::UserDoc;
@@ -231,6 +231,25 @@ pub async fn list_scim_tokens(
         store.list_all::<ScimTokenDoc>().await?
     };
     Ok(docs.into_iter().map(ScimToken::from).collect())
+}
+
+/// Count an organization's SCIM tokens that can still authenticate.
+///
+/// Expired tokens are excluded: authentication already treats them as
+/// non-existent ([`get_scim_token_by_hash`]), so they must not count
+/// toward the per-org creation limit either.
+pub async fn count_active_scim_tokens(store: &DocumentStore, org_id: &str) -> Result<usize> {
+    let docs = store.find_all::<ScimTokenDoc>("org_id", org_id).await?;
+    let now = Timestamp::now();
+    Ok(docs
+        .into_iter()
+        .filter(|doc| doc.data.expires_at.is_none_or(|exp| exp > now))
+        .count())
+}
+
+/// Delete expired SCIM tokens. Returns count deleted.
+pub async fn delete_expired_scim_tokens(store: &DocumentStore) -> Result<u64> {
+    store.delete_expired(ScimTokenDoc::DOC_TYPE).await
 }
 
 // ============================================================================

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -1801,6 +1801,62 @@ async fn test_scim_token_management() {
     assert!(token.is_none());
 }
 
+/// Expired SCIM tokens cannot authenticate, so they must not count
+/// toward the per-org creation limit, and cleanup must purge them (#715).
+#[tokio::test]
+async fn test_expired_scim_tokens_excluded_from_active_count() {
+    let (store, _audit) = test_db().await;
+
+    let org = create_organization(&store, "test.com", Some("Test Org"), None)
+        .await
+        .expect("Failed to create org");
+    let org_id = &org.id;
+
+    let past = jiff::Timestamp::now() - jiff::Span::new().hours(1);
+    let future = jiff::Timestamp::now() + jiff::Span::new().hours(1);
+
+    // Two expired tokens and one active token
+    for (hash, expiry) in [
+        ("expired-1", Some(past)),
+        ("expired-2", Some(past)),
+        ("active-1", Some(future)),
+    ] {
+        create_scim_token(&store, hash, None, expiry, Some(org_id), None)
+            .await
+            .expect("Failed to create SCIM token");
+    }
+
+    // list returns everything; the active count excludes the expired pair
+    let all = list_scim_tokens(&store, Some(org_id))
+        .await
+        .expect("Failed to list tokens");
+    assert_eq!(all.len(), 3);
+
+    let active = count_active_scim_tokens(&store, org_id)
+        .await
+        .expect("Failed to count active tokens");
+    assert_eq!(active, 1);
+
+    // Tokens without an expiration are always active
+    create_scim_token(&store, "no-expiry", None, None, Some(org_id), None)
+        .await
+        .expect("Failed to create SCIM token");
+    let active = count_active_scim_tokens(&store, org_id)
+        .await
+        .expect("Failed to count active tokens");
+    assert_eq!(active, 2);
+
+    // Cleanup purges only the expired tokens
+    let deleted = delete_expired_scim_tokens(&store)
+        .await
+        .expect("Failed to delete expired tokens");
+    assert_eq!(deleted, 2);
+    let remaining = list_scim_tokens(&store, Some(org_id))
+        .await
+        .expect("Failed to list tokens");
+    assert_eq!(remaining.len(), 2);
+}
+
 // ========================================================================
 // Cascade Delete Tests
 // ========================================================================

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -3982,6 +3982,48 @@ async fn test_enroll_promotes_admin_for_org_without_one() {
     );
 }
 
+// A retrying CAS loser must re-derive its admin decision from fresh state:
+// with the winner's user row committed and the org's created_by_user_id
+// still unset (the state a loser observes when it re-runs after aborting
+// on the org-row conflict), the second enrollee must come out non-admin.
+#[tokio::test]
+async fn test_enroll_second_user_after_winner_commit_is_not_admin() {
+    use crate::db::documents::organization::OrganizationDoc;
+    use crate::db::enroll_user_with_org;
+
+    let (store, _audit) = test_db().await;
+    let domain = "retry-loser.example";
+
+    let winner = enroll_user_with_org(&store, "winner@retry-loser.example", None, Some(domain))
+        .await
+        .expect("winner enrollment");
+    assert!(winner.is_org_admin);
+
+    // Simulate the winner having committed its user row but NOT yet the org
+    // admin slot (crash between the two would leave this state; a retrying
+    // loser sees it after aborting on the org-row conflict).
+    let org_id = winner.org_id.expect("org id");
+    let org = store
+        .get::<OrganizationDoc>(&org_id)
+        .await
+        .expect("get org")
+        .expect("org exists");
+    let mut data = org.data;
+    data.created_by_user_id = None;
+    store
+        .update(&org_id, &data)
+        .await
+        .expect("clear admin slot");
+
+    let loser = enroll_user_with_org(&store, "loser@retry-loser.example", None, Some(domain))
+        .await
+        .expect("second enrollment");
+    assert!(
+        !loser.is_org_admin,
+        "an enrollee joining an org that already has users must not become admin"
+    );
+}
+
 // ========================================================================
 // OCC read-modify-write conversions: blind get+update → store.modify()
 // ========================================================================

--- a/crates/vouch-server/src/handlers/admin/scim_tokens.rs
+++ b/crates/vouch-server/src/handlers/admin/scim_tokens.rs
@@ -105,10 +105,11 @@ pub(crate) async fn create_scim_token(
     let (user, org_id) =
         extract_org_admin(&state, &headers, &jar, method.as_str(), uri.path(), None).await?;
 
-    // Enforce 2-token limit
-    let existing = db::list_scim_tokens(&state.store, Some(&org_id)).await?;
+    // Enforce 2-token limit (expired tokens cannot authenticate and do
+    // not count toward the limit)
+    let active = db::count_active_scim_tokens(&state.store, &org_id).await?;
 
-    if existing.len() >= MAX_SCIM_TOKENS {
+    if active >= MAX_SCIM_TOKENS {
         return Err(ServiceError::api(
             StatusCode::CONFLICT,
             "token_limit_reached",
@@ -365,10 +366,11 @@ pub(crate) async fn admin_create_scim_token(
     let (admin, org_id) =
         extract_org_admin(&state, &headers, &jar, method.as_str(), uri.path(), None).await?;
 
-    // Enforce 2-token limit
-    let existing = db::list_scim_tokens(&state.store, Some(&org_id)).await?;
+    // Enforce 2-token limit (expired tokens cannot authenticate and do
+    // not count toward the limit)
+    let active = db::count_active_scim_tokens(&state.store, &org_id).await?;
 
-    if existing.len() >= MAX_SCIM_TOKENS {
+    if active >= MAX_SCIM_TOKENS {
         return Ok(redirect_error(
             jar,
             "Maximum of 2 SCIM tokens. Revoke one before creating another.",

--- a/crates/vouch-server/src/handlers/oidc/client_auth.rs
+++ b/crates/vouch-server/src/handlers/oidc/client_auth.rs
@@ -53,6 +53,16 @@ pub(crate) trait ClientAuthFields {
     fn client_assertion_type(&self) -> Option<&str>;
 }
 
+/// Strip the `Basic ` auth-scheme prefix, matching case-insensitively.
+///
+/// RFC 9110 Section 11.1 and RFC 7617 Section 2 require the auth-scheme
+/// token to be matched case-insensitively, so `basic` and `BASIC` are as
+/// valid as `Basic`.
+fn strip_basic_scheme(header: &str) -> Option<&str> {
+    let (scheme, rest) = header.split_once(' ')?;
+    scheme.eq_ignore_ascii_case("Basic").then_some(rest)
+}
+
 /// Extract client credentials from Authorization header or request body.
 ///
 /// Supports both `client_secret_basic` (RFC 6749 Section 2.3.1) and
@@ -66,7 +76,7 @@ pub(crate) fn extract_client_credentials(
     if let Some(auth_header) = headers
         .get(header::AUTHORIZATION)
         .and_then(|h| h.to_str().ok())
-        .and_then(|h| h.strip_prefix("Basic "))
+        .and_then(strip_basic_scheme)
         && let Ok(decoded) = base64::engine::general_purpose::STANDARD
             .decode(auth_header.trim())
             .or_else(|_| URL_SAFE_NO_PAD.decode(auth_header.trim()))
@@ -106,7 +116,7 @@ pub(crate) fn extract_client_auth<T: ClientAuthFields>(
     let has_basic = headers
         .get(header::AUTHORIZATION)
         .and_then(|h| h.to_str().ok())
-        .is_some_and(|h| h.starts_with("Basic "));
+        .is_some_and(|h| strip_basic_scheme(h).is_some());
 
     let has_client_secret = params.client_secret().is_some();
     let has_client_assertion = params.client_assertion().is_some();
@@ -242,4 +252,44 @@ fn oauth_error_response(error: &str, description: &str) -> Response {
         }),
     )
         .into_response()
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+
+    fn basic_header(scheme: &str) -> HeaderMap {
+        let creds = base64::engine::general_purpose::STANDARD.encode("client-1:s3cret");
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::AUTHORIZATION,
+            format!("{scheme} {creds}").parse().expect("valid header"),
+        );
+        headers
+    }
+
+    /// RFC 9110 Section 11.1 / RFC 7617 Section 2: the auth-scheme token is
+    /// case-insensitive, so `basic` and `BASIC` must work like `Basic`.
+    #[test]
+    fn test_extract_client_credentials_scheme_case_insensitive() {
+        for scheme in ["Basic", "basic", "BASIC", "bAsIc"] {
+            let headers = basic_header(scheme);
+            let creds = extract_client_credentials(&headers, None, None)
+                .unwrap_or_else(|| panic!("{scheme} scheme must be accepted"));
+            assert_eq!(creds.client_id, "client-1", "{scheme}");
+            assert!(creds.client_secret.is_some(), "{scheme}");
+        }
+    }
+
+    #[test]
+    fn test_strip_basic_scheme_rejects_other_schemes() {
+        assert!(strip_basic_scheme("Bearer abc").is_none());
+        assert!(strip_basic_scheme("Basicabc").is_none());
+        assert!(strip_basic_scheme("Basic creds").is_some());
+    }
 }

--- a/crates/vouch-server/src/handlers/oidc/client_auth.rs
+++ b/crates/vouch-server/src/handlers/oidc/client_auth.rs
@@ -254,6 +254,44 @@ fn oauth_error_response(error: &str, description: &str) -> Response {
         .into_response()
 }
 
+/// Derive the authentication method ACTUALLY used on this request from the
+/// verification witnesses, as opposed to the registered
+/// `token_endpoint_auth_method` (which the presented credentials do not have
+/// to match — e.g. a stale client secret on a client since migrated to
+/// `private_key_jwt`).
+///
+/// * `jwt_auth` — a `client_assertion` was verified (RFC 7523).
+/// * `secret_auth` — a `client_secret` (Basic or body) was verified.
+/// * `mtls_auth` — a TLS client certificate was verified (RFC 8705). mTLS
+///   verification only runs for clients registered with a TLS method, so
+///   `registered` names the exact variant in that case.
+///
+/// A verified secret is reported as the registered secret variant when the
+/// client is registered with one (error-message fidelity); Basic vs Post is
+/// not distinguishable from the witness, and both are equally rejected for
+/// FAPI clients.
+pub(crate) fn actual_auth_method(
+    registered: crate::db::TokenEndpointAuthMethod,
+    jwt_auth: bool,
+    secret_auth: bool,
+    mtls_auth: bool,
+) -> crate::db::TokenEndpointAuthMethod {
+    use crate::db::TokenEndpointAuthMethod;
+    if jwt_auth {
+        TokenEndpointAuthMethod::PrivateKeyJwt
+    } else if secret_auth {
+        match registered {
+            m @ (TokenEndpointAuthMethod::ClientSecretBasic
+            | TokenEndpointAuthMethod::ClientSecretPost) => m,
+            _ => TokenEndpointAuthMethod::ClientSecretBasic,
+        }
+    } else if mtls_auth {
+        registered
+    } else {
+        TokenEndpointAuthMethod::None
+    }
+}
+
 #[cfg(test)]
 #[expect(
     clippy::expect_used,
@@ -291,5 +329,39 @@ mod tests {
         assert!(strip_basic_scheme("Bearer abc").is_none());
         assert!(strip_basic_scheme("Basicabc").is_none());
         assert!(strip_basic_scheme("Basic creds").is_some());
+    }
+
+    /// The witness-derived method must reflect what the request actually
+    /// authenticated with, regardless of the registered method (#706).
+    #[test]
+    fn test_actual_auth_method_from_witnesses() {
+        use crate::db::TokenEndpointAuthMethod as M;
+
+        // A verified JWT assertion is private_key_jwt no matter what is registered.
+        assert_eq!(
+            actual_auth_method(M::ClientSecretBasic, true, false, false),
+            M::PrivateKeyJwt
+        );
+        // A verified secret on a private_key_jwt-registered client is a
+        // secret method, NOT the registered method.
+        assert_eq!(
+            actual_auth_method(M::PrivateKeyJwt, false, true, false),
+            M::ClientSecretBasic
+        );
+        // A verified secret on a secret-registered client keeps the variant.
+        assert_eq!(
+            actual_auth_method(M::ClientSecretPost, false, true, false),
+            M::ClientSecretPost
+        );
+        // mTLS verification only runs when a TLS method is registered.
+        assert_eq!(
+            actual_auth_method(M::SelfSignedTlsClientAuth, false, false, true),
+            M::SelfSignedTlsClientAuth
+        );
+        // No witness at all is the public-client "none" method.
+        assert_eq!(
+            actual_auth_method(M::PrivateKeyJwt, false, false, false),
+            M::None
+        );
     }
 }

--- a/crates/vouch-server/src/handlers/oidc/client_auth.rs
+++ b/crates/vouch-server/src/handlers/oidc/client_auth.rs
@@ -317,8 +317,9 @@ mod tests {
     fn test_extract_client_credentials_scheme_case_insensitive() {
         for scheme in ["Basic", "basic", "BASIC", "bAsIc"] {
             let headers = basic_header(scheme);
-            let creds = extract_client_credentials(&headers, None, None)
-                .unwrap_or_else(|| panic!("{scheme} scheme must be accepted"));
+            let creds = extract_client_credentials(&headers, None, None);
+            assert!(creds.is_some(), "{scheme} scheme must be accepted");
+            let creds = creds.expect("checked above");
             assert_eq!(creds.client_id, "client-1", "{scheme}");
             assert!(creds.client_secret.is_some(), "{scheme}");
         }

--- a/crates/vouch-server/src/handlers/oidc/par.rs
+++ b/crates/vouch-server/src/handlers/oidc/par.rs
@@ -235,9 +235,19 @@ pub(crate) async fn par(
     //
     // FAPI 2.0 Section 5.2.2 requires `private_key_jwt`. Client secrets and
     // public-client ("none") authentication are rejected for FAPI clients.
+    // The method is derived from the verification witnesses — what this
+    // request actually authenticated with — not the registered
+    // token_endpoint_auth_method, so a stale secret on a client since
+    // migrated to a FAPI method cannot pass the gate.
+    let actual_method = super::client_auth::actual_auth_method(
+        authenticated_client.client.token_endpoint_auth_method,
+        jwt_auth.is_some(),
+        secret_verification.is_some(),
+        mtls_verification.is_some(),
+    );
     if let Err(e) = crate::services::oidc::fapi::validate_fapi_client_auth_method(
         &authenticated_client.client,
-        authenticated_client.client.token_endpoint_auth_method,
+        actual_method,
     ) {
         return par_error_response(
             StatusCode::UNAUTHORIZED,

--- a/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
@@ -981,6 +981,36 @@ async fn test_discovery_mtls_aliases_absent_without_tls() {
     );
 }
 
+/// A partial TLS config (cert without key) never starts the TLS or mTLS
+/// listeners, so discovery must not advertise mTLS either — otherwise
+/// clients registering with tls_client_auth are locked out (#708).
+#[tokio::test]
+async fn test_discovery_mtls_absent_with_partial_tls_config() {
+    let (app, state) = test_app().await;
+
+    let mut new_config = (**state.config()).clone();
+    new_config.tls_cert = Some("/tmp/fake-cert.pem".to_string());
+    new_config.tls_key = None;
+    state.config.store(std::sync::Arc::new(new_config));
+
+    let (status, body) = http_get(&app, "/.well-known/openid-configuration", &[]).await;
+    assert_eq!(status, StatusCode::OK);
+    let doc: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+
+    assert!(
+        doc.get("mtls_endpoint_aliases").is_none(),
+        "mtls_endpoint_aliases must be absent with cert-only TLS config"
+    );
+    assert_eq!(doc["tls_client_certificate_bound_access_tokens"], false);
+    let methods = doc["token_endpoint_auth_methods_supported"]
+        .as_array()
+        .expect("auth methods array");
+    assert!(
+        !methods.iter().any(|m| m == "tls_client_auth"),
+        "tls_client_auth must not be advertised with cert-only TLS config"
+    );
+}
+
 #[tokio::test]
 async fn test_discovery_tls_client_auth_in_auth_methods_with_tls() {
     // When TLS is configured, token_endpoint_auth_methods_supported must include
@@ -995,8 +1025,10 @@ async fn test_discovery_tls_client_auth_in_auth_methods_with_tls() {
 
     let pool = test_db().await;
     let mut config = test_config();
-    // Set a placeholder TLS cert to enable mTLS discovery advertisement.
+    // Set placeholder TLS cert and key to enable mTLS discovery
+    // advertisement (requires full TLS configuration).
     config.tls_cert = Some("placeholder-cert".to_string());
+    config.tls_key = Some(secrecy::SecretString::from("placeholder-key".to_string()));
 
     let rp_origin = url::Url::parse(&config.base_url).expect("base_url");
     let webauthn = webauthn_rs::WebauthnBuilder::new(&config.rp_id, &rp_origin)

--- a/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
@@ -613,6 +613,67 @@ async fn test_fapi2_par_accepts_private_key_jwt() {
     );
 }
 
+/// FAPI 2.0 Section 5.2.2: the auth-method gate must judge the method the
+/// request ACTUALLY authenticated with, not the registered one. A stale
+/// client secret on a client registered as private_key_jwt must be
+/// rejected at PAR (#706).
+#[tokio::test]
+async fn test_fapi2_par_rejects_client_secret_for_private_key_jwt_client() {
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "fapi2-par-stale-secret@example.com").await;
+    let (client, _pkcs8_bytes) = create_fapi_test_client(&state.store, &user.id).await;
+
+    // Authenticate with the (stale) client secret instead of a JWT assertion.
+    let body = format!(
+        "client_id={}\
+         &client_secret={}\
+         &redirect_uri={}\
+         &response_type=code\
+         &scope=openid",
+        client.client_id,
+        urlencoding::encode(&client.client_secret),
+        urlencoding::encode("https://example.com/callback"),
+    );
+
+    let (status, response_body) = http_post_form(&app, "/oauth/par", &body, &[]).await;
+
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "FAPI client authenticating with a secret must be rejected at PAR: {response_body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&response_body).expect("Valid JSON");
+    assert_eq!(json["error"], "invalid_client", "{json}");
+}
+
+/// FAPI clients presenting only a client_id (public-client arm, no
+/// credential at all) must also fail the actual-method gate at PAR.
+#[tokio::test]
+async fn test_fapi2_par_rejects_client_id_only_for_private_key_jwt_client() {
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "fapi2-par-id-only@example.com").await;
+    let (client, _pkcs8_bytes) = create_fapi_test_client(&state.store, &user.id).await;
+
+    let body = format!(
+        "client_id={}\
+         &redirect_uri={}\
+         &response_type=code\
+         &scope=openid",
+        client.client_id,
+        urlencoding::encode("https://example.com/callback"),
+    );
+
+    let (status, response_body) = http_post_form(&app, "/oauth/par", &body, &[]).await;
+
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "FAPI client with no credential must be rejected at PAR: {response_body}"
+    );
+}
+
 #[tokio::test]
 async fn test_fapi2_token_rejects_without_dpop() {
     // FAPI 2.0 Section 5.2.2: Sender-constrained tokens are required.

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7592.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7592.rs
@@ -848,3 +848,90 @@ async fn test_rfc7592_put_post_logout_redirect_uris_invalid_rejected() {
         "Error code must be invalid_client_metadata: {json}"
     );
 }
+
+/// PUT is a full replacement, so omitting `jwks`/`jwks_uri` clears them.
+/// For a `private_key_jwt` client that would leave it unable to
+/// authenticate, so the auth-method/JWKS consistency rule from initial
+/// registration must also be enforced on update (#719).
+#[tokio::test]
+async fn test_rfc7592_put_cannot_clear_jwks_for_private_key_jwt_client() {
+    let (app, _state) = test_app().await;
+
+    let jwks = serde_json::json!({
+        "keys": [{
+            "kty": "EC",
+            "crv": "P-256",
+            "x": "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+            "y": "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
+            "use": "sig",
+            "alg": "ES256"
+        }]
+    });
+    let body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "token_endpoint_auth_method": "private_key_jwt",
+        "jwks": jwks,
+        "client_name": "PKJ App"
+    });
+    let (status, body) = http_post_json(&app, "/oauth/register", &body.to_string(), &[]).await;
+    assert_eq!(status, StatusCode::CREATED, "registration failed: {body}");
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let client_id = json["client_id"].as_str().expect("client_id").to_string();
+    let token = json["registration_access_token"]
+        .as_str()
+        .expect("registration_access_token")
+        .to_string();
+
+    // PUT without jwks/jwks_uri must be rejected, not clear the keys.
+    let update_body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "client_name": "PKJ App v2"
+    });
+    let (status, body) = http_request(
+        &app,
+        "PUT",
+        &format!("/oauth/register/{client_id}"),
+        Some(update_body.to_string()),
+        &[
+            ("Authorization", &format!("Bearer {token}")),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "PUT clearing JWKS for a private_key_jwt client must fail: {body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(json["error"], "invalid_client_metadata", "{json}");
+
+    // PUT that keeps a JWKS still succeeds (with the original token — the
+    // rejected PUT must not have rotated it).
+    let update_body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "jwks": serde_json::json!({
+            "keys": [{
+                "kty": "EC",
+                "crv": "P-256",
+                "x": "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+                "y": "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
+                "use": "sig",
+                "alg": "ES256"
+            }]
+        }),
+        "client_name": "PKJ App v2"
+    });
+    let (status, body) = http_request(
+        &app,
+        "PUT",
+        &format!("/oauth/register/{client_id}"),
+        Some(update_body.to_string()),
+        &[
+            ("Authorization", &format!("Bearer {token}")),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "PUT keeping JWKS must succeed: {body}");
+}

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7592.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7592.rs
@@ -933,5 +933,9 @@ async fn test_rfc7592_put_cannot_clear_jwks_for_private_key_jwt_client() {
         ],
     )
     .await;
-    assert_eq!(status, StatusCode::OK, "PUT keeping JWKS must succeed: {body}");
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "PUT keeping JWKS must succeed: {body}"
+    );
 }

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9728.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9728.rs
@@ -337,11 +337,12 @@ async fn test_rfc9728_tls_binding_mirrors_discovery_when_mtls_configured() {
         "default test harness has no TLS"
     );
 
-    // Flip TLS on by injecting a placeholder cert path. Vouch only
-    // checks `tls_cert.is_some()` for advertising mTLS support
-    // (services/oidc/discovery.rs:294 + protected_resource.rs).
+    // Flip TLS on by injecting placeholder cert and key. Advertising mTLS
+    // requires full TLS configuration (`tls_configured()`, cert AND key) —
+    // a partial config never starts the mTLS listener.
     let mut new_config = (**state.config()).clone();
     new_config.tls_cert = Some("/tmp/fake-cert.pem".to_string());
+    new_config.tls_key = Some(secrecy::SecretString::from("/tmp/fake-key.pem".to_string()));
     state.config.store(Arc::new(new_config));
 
     let (status, rs_body) = http_get(&app, WELL_KNOWN_SUFFIX, &[]).await;

--- a/crates/vouch-server/src/infra/cleanup.rs
+++ b/crates/vouch-server/src/infra/cleanup.rs
@@ -245,6 +245,10 @@ pub async fn run_cleanup(
     // Clean up expired JWKS cache entries (standalone cache docs)
     cleanup_and_log!(db::delete_expired_jwks_caches(store), "expired JWKS caches");
 
+    // Clean up expired SCIM tokens (they cannot authenticate and would
+    // otherwise accumulate against the per-org token limit)
+    cleanup_and_log!(db::delete_expired_scim_tokens(store), "expired SCIM tokens");
+
     // Re-verify organization additional domains.
     if let Err(e) = recheck_additional_domains(store, audit, now).await {
         tracing::warn!(error = %e, "Additional-domain re-verification pass failed");

--- a/crates/vouch-server/src/infra/httpsig.rs
+++ b/crates/vouch-server/src/infra/httpsig.rs
@@ -99,6 +99,35 @@ impl KeyResolver for OAuthClientKeyResolver {
             .await
             .ok()
     }
+
+    /// Validate and consume a signature nonce against the shared nonce store.
+    ///
+    /// HTTP signature nonces deliberately share the DPoP nonce store and
+    /// issuance path (`generate_dpop_nonce`): both are opaque random
+    /// single-use values with the same validity window, and the atomic
+    /// delete-if-not-expired gives single-use semantics on every backend.
+    fn validate_nonce(
+        &self,
+        nonce: &str,
+    ) -> impl std::future::Future<Output = vouch_httpsig::middleware::NonceValidation> + Send + '_
+    {
+        use vouch_httpsig::middleware::NonceValidation;
+
+        // Own the nonce: the returned future may only borrow `self`.
+        let nonce = nonce.to_string();
+        async move {
+            match crate::db::validate_and_consume_dpop_nonce(&self.state.store, &nonce).await {
+                Ok(()) => NonceValidation::Valid,
+                Err(
+                    crate::db::ClaimError::AlreadyConsumed | crate::db::ClaimError::InvalidInput(_),
+                ) => NonceValidation::Invalid,
+                Err(crate::db::ClaimError::Database(msg)) => {
+                    tracing::error!("signature nonce validation DB failure: {msg}");
+                    NonceValidation::Error
+                }
+            }
+        }
+    }
 }
 
 /// Extract `client_id` from the access token in the `Authorization` header.
@@ -220,5 +249,33 @@ mod tests {
             "y": URL_SAFE_NO_PAD.encode([2u8; 32]),
         });
         assert!(jwk_to_p256_public_key(&jwk).is_none());
+    }
+
+    /// A server-issued nonce validates once and is then consumed (#718):
+    /// the second presentation is Invalid, and a random string never
+    /// issued is Invalid too.
+    #[tokio::test]
+    async fn test_validate_nonce_single_use() {
+        use vouch_httpsig::middleware::{KeyResolver, NonceValidation};
+
+        let state = crate::test_utils::test_app_state().await;
+        let resolver = OAuthClientKeyResolver::new(state.clone());
+
+        let nonce = resolver.generate_nonce().await.expect("issue nonce");
+        assert_eq!(
+            resolver.validate_nonce(&nonce).await,
+            NonceValidation::Valid,
+            "first use of a fresh nonce must be accepted"
+        );
+        assert_eq!(
+            resolver.validate_nonce(&nonce).await,
+            NonceValidation::Invalid,
+            "a consumed nonce must be rejected"
+        );
+        assert_eq!(
+            resolver.validate_nonce("never-issued-nonce").await,
+            NonceValidation::Invalid,
+            "an unknown nonce must be rejected"
+        );
     }
 }

--- a/crates/vouch-server/src/infra/httpsig.rs
+++ b/crates/vouch-server/src/infra/httpsig.rs
@@ -172,6 +172,7 @@ fn jwk_to_p256_public_key(jwk: &serde_json::Value) -> Option<Vec<u8>> {
 #[cfg(test)]
 #[expect(
     clippy::unwrap_used,
+    clippy::expect_used,
     reason = "test code: panic on assertion failure is acceptable"
 )]
 mod tests {

--- a/crates/vouch-server/src/infra/mtls_listener.rs
+++ b/crates/vouch-server/src/infra/mtls_listener.rs
@@ -75,6 +75,13 @@ impl AsyncWrite for MtlsStream {
     }
 }
 
+/// Shared handle to the mTLS listener's rustls config.
+///
+/// The listener snapshots this on every accept (`load_full`), so storing a
+/// rebuilt config makes new handshakes pick up rotated certificates without
+/// restarting the listener.
+pub(crate) type MtlsConfigSwap = Arc<ArcSwap<rustls::ServerConfig>>;
+
 /// Custom listener for mTLS: TLS with client certificate verification.
 ///
 /// Bound to a separate port from the main HTTPS listener. Client
@@ -82,7 +89,7 @@ impl AsyncWrite for MtlsStream {
 /// trusting our Client Certificate CA.
 pub(crate) struct MtlsListener {
     tcp: TcpListener,
-    tls_config: Arc<ArcSwap<rustls::ServerConfig>>,
+    tls_config: MtlsConfigSwap,
 }
 
 impl MtlsListener {
@@ -92,7 +99,7 @@ impl MtlsListener {
     /// * `tcp` - Bound TCP listener
     /// * `tls_config` - Rustls config with client cert verifier (wrapped
     ///   in `ArcSwap` for hot reload)
-    pub(crate) fn new(tcp: TcpListener, tls_config: Arc<ArcSwap<rustls::ServerConfig>>) -> Self {
+    pub(crate) fn new(tcp: TcpListener, tls_config: MtlsConfigSwap) -> Self {
         Self { tcp, tls_config }
     }
 }
@@ -191,6 +198,24 @@ pub(crate) fn build_mtls_server_config(
     config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
 
     Ok(Arc::new(config))
+}
+
+/// Rebuild the mTLS server config from PEM cert/key and store it into the
+/// listener's [`MtlsConfigSwap`].
+///
+/// Called from the SIGHUP handler and the S3 config polling task so the
+/// mTLS listener picks up rotated certificates alongside the main HTTPS
+/// listener. On error the swap is left unchanged (existing connections and
+/// new handshakes keep the previous certificates).
+pub(crate) fn reload_mtls_from_config(
+    mtls_config: &MtlsConfigSwap,
+    cert: &str,
+    key: &secrecy::SecretString,
+) -> anyhow::Result<()> {
+    let (certs, key_der) = super::tls::parse_cert_and_key_pem(cert, key)?;
+    let new_config = build_mtls_server_config(certs, key_der)?;
+    mtls_config.store(new_config);
+    Ok(())
 }
 
 /// Client certificate verifier that accepts any certificate.
@@ -355,6 +380,60 @@ mod tests {
             result.is_ok(),
             "valid server cert must succeed, got: {:?}",
             result.err()
+        );
+    }
+
+    /// Wrap DER bytes in a PEM envelope.
+    fn der_to_pem(label: &str, der: &[u8]) -> String {
+        use base64::Engine;
+        let b64 = base64::engine::general_purpose::STANDARD.encode(der);
+        let wrapped: Vec<String> = b64
+            .as_bytes()
+            .chunks(64)
+            .map(|c| String::from_utf8_lossy(c).into_owned())
+            .collect();
+        format!(
+            "-----BEGIN {label}-----\n{}\n-----END {label}-----\n",
+            wrapped.join("\n")
+        )
+    }
+
+    /// A successful reload must store a NEW config into the swap so the
+    /// next handshake picks up the rotated certificate (#710).
+    #[test]
+    fn test_reload_mtls_from_config_swaps_config() {
+        let (cert_der, pkcs8_der) = make_self_signed_server_cert();
+        let server_cert = rustls::pki_types::CertificateDer::from(cert_der.clone());
+        let server_key = rustls::pki_types::PrivateKeyDer::Pkcs8(pkcs8_der.clone().into());
+        let initial = build_mtls_server_config(vec![server_cert], server_key).expect("config");
+        let swap: MtlsConfigSwap = Arc::new(ArcSwap::from(initial.clone()));
+
+        let cert_pem = der_to_pem("CERTIFICATE", &cert_der);
+        let key_pem = der_to_pem("PRIVATE KEY", &pkcs8_der);
+        let key_secret = secrecy::SecretString::from(key_pem);
+
+        reload_mtls_from_config(&swap, &cert_pem, &key_secret).expect("reload");
+        assert!(
+            !Arc::ptr_eq(&swap.load_full(), &initial),
+            "reload must store a fresh config"
+        );
+    }
+
+    /// A failed reload must leave the previous config in place.
+    #[test]
+    fn test_reload_mtls_from_config_failure_keeps_old_config() {
+        let (cert_der, pkcs8_der) = make_self_signed_server_cert();
+        let server_cert = rustls::pki_types::CertificateDer::from(cert_der);
+        let server_key = rustls::pki_types::PrivateKeyDer::Pkcs8(pkcs8_der.into());
+        let initial = build_mtls_server_config(vec![server_cert], server_key).expect("config");
+        let swap: MtlsConfigSwap = Arc::new(ArcSwap::from(initial.clone()));
+
+        let key_secret = secrecy::SecretString::from("not a key".to_string());
+        let result = reload_mtls_from_config(&swap, "not a certificate", &key_secret);
+        assert!(result.is_err(), "garbage PEM must fail");
+        assert!(
+            Arc::ptr_eq(&swap.load_full(), &initial),
+            "failed reload must not touch the swap"
         );
     }
 }

--- a/crates/vouch-server/src/infra/s3_config.rs
+++ b/crates/vouch-server/src/infra/s3_config.rs
@@ -638,6 +638,7 @@ pub fn start_s3_config_task(
     source: S3ConfigSource,
     config: Arc<ArcSwap<ServerConfig>>,
     tls_config: Option<RustlsConfig>,
+    mtls_config: Option<super::mtls_listener::MtlsConfigSwap>,
     initial_etag: String,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
@@ -662,7 +663,9 @@ pub fn start_s3_config_task(
                     // For runtime updates, only TLS can change.
                     match fetch_runtime_config(&s3_client, &source).await {
                         Ok((s3_cfg, etag)) => {
-                            if let Err(e) = apply_config_update(&config, &tls_config, s3_cfg).await
+                            if let Err(e) =
+                                apply_config_update(&config, &tls_config, &mtls_config, s3_cfg)
+                                    .await
                             {
                                 tracing::error!("Failed to apply config update: {e:#}");
                             } else {
@@ -707,6 +710,7 @@ async fn fetch_runtime_config(
 async fn apply_config_update(
     config: &Arc<ArcSwap<ServerConfig>>,
     tls_config: &Option<RustlsConfig>,
+    mtls_config: &Option<super::mtls_listener::MtlsConfigSwap>,
     s3_config: S3Config,
 ) -> Result<()> {
     // Load current config and clone it for modification
@@ -733,12 +737,20 @@ async fn apply_config_update(
 
     // Reload TLS if configured and changed
     if tls_changed
-        && let Some(tls) = tls_config
         && let (Some(cert), Some(key)) = (&new_config.tls_cert, &new_config.tls_key)
     {
-        tracing::info!("TLS config changed, reloading certificates");
-        super::tls::reload_tls_from_config(tls, cert, key)?;
-        tracing::info!("TLS certificates reloaded successfully");
+        if let Some(tls) = tls_config {
+            tracing::info!("TLS config changed, reloading certificates");
+            super::tls::reload_tls_from_config(tls, cert, key)?;
+            tracing::info!("TLS certificates reloaded successfully");
+        }
+        // Reload the mTLS listener independently: a failure here must not
+        // fail the HTTPS reload or the config swap below.
+        if let Some(mtls) = mtls_config
+            && let Err(e) = super::mtls_listener::reload_mtls_from_config(mtls, cert, key)
+        {
+            tracing::error!("Failed to reload mTLS listener config from S3: {e:#}");
+        }
     }
 
     // Atomically swap the config
@@ -1661,7 +1673,7 @@ mod tests {
             ..Default::default()
         };
 
-        apply_config_update(&arcswap, &None, s3)
+        apply_config_update(&arcswap, &None, &None, s3)
             .await
             .expect("apply update");
 
@@ -1684,12 +1696,105 @@ mod tests {
         // S3 config with no TLS section — apply must succeed and leave
         // the existing TLS material untouched.
         let s3 = S3Config::default();
-        apply_config_update(&arcswap, &None, s3)
+        apply_config_update(&arcswap, &None, &None, s3)
             .await
             .expect("apply update");
 
         let after = arcswap.load();
         assert_eq!(after.tls_cert.as_deref(), Some("existing-cert"));
         assert!(after.tls_key.is_some());
+    }
+
+    // Throwaway self-signed P-256 cert + PKCS#8 key (same fixture as
+    // infra/tls.rs tests), used to exercise the mTLS reload path.
+    const TEST_CERT_PEM: &str = "-----BEGIN CERTIFICATE-----\n\
+MIIBiDCCAS2gAwIBAgIUAzsi4KkqvGaw6UTFs4DrQEe2KWwwCgYIKoZIzj0EAwIw\n\
+GTEXMBUGA1UEAwwOdm91Y2gtdGxzLXRlc3QwHhcNMjYwNjEwMTYxMjM3WhcNMzYw\n\
+NjA3MTYxMjM3WjAZMRcwFQYDVQQDDA52b3VjaC10bHMtdGVzdDBZMBMGByqGSM49\n\
+AgEGCCqGSM49AwEHA0IABAOqxc9YgMgXu2BGQ3KOgFNtVxG7pdencd5TOnjrr6zJ\n\
+nPi66MVoVlQ9bi3ydlRJ1ce7HHOEui/G0U0aoDJtgVmjUzBRMB0GA1UdDgQWBBQW\n\
+yEA6dBvaxTzloNCzXuJLG5z9/DAfBgNVHSMEGDAWgBQWyEA6dBvaxTzloNCzXuJL\n\
+G5z9/DAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49BAMCA0kAMEYCIQC9cwWPeNND\n\
+WFbJkO8dqEVE69Xzdj+NMgenQFOJsOW2yAIhAISz7zP/KDBC6jVhH7qJTR9E7Rnr\n\
+3wT8S2AL3BFHW6+2\n\
+-----END CERTIFICATE-----\n";
+
+    const TEST_KEY_PEM: &str = "-----BEGIN PRIVATE KEY-----\n\
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQghUolejGt3e2SfwZJ\n\
+BRRya1VbXh8fYhiJfLvrVBbs/lqhRANCAAQDqsXPWIDIF7tgRkNyjoBTbVcRu6XX\n\
+p3HeUzp466+syZz4uujFaFZUPW4t8nZUSdXHuxxzhLovxtFNGqAybYFZ\n\
+-----END PRIVATE KEY-----\n";
+
+    /// Build an initial mTLS config swap from the fixture cert/key.
+    fn fixture_mtls_swap() -> super::super::mtls_listener::MtlsConfigSwap {
+        let (certs, key) = crate::infra::tls::parse_cert_and_key_pem(
+            TEST_CERT_PEM,
+            &SecretString::from(TEST_KEY_PEM.to_string()),
+        )
+        .expect("parse fixture PEM");
+        let config = super::super::mtls_listener::build_mtls_server_config(certs, key)
+            .expect("build mTLS config");
+        Arc::new(arc_swap::ArcSwap::from(config))
+    }
+
+    /// An S3 TLS change must also rebuild and store the mTLS listener's
+    /// config so the mTLS port serves rotated certificates (#710).
+    #[tokio::test]
+    async fn apply_config_update_reloads_mtls_swap() {
+        let mut starting = crate::test_utils::test_config();
+        starting.tls_cert = None;
+        starting.tls_key = None;
+        let arcswap = Arc::new(ArcSwap::from_pointee(starting));
+
+        let mtls_swap = fixture_mtls_swap();
+        let initial = mtls_swap.load_full();
+
+        let s3 = S3Config {
+            tls: Some(S3TlsConfig {
+                cert: Some(TEST_CERT_PEM.to_string()),
+                key: Some(TEST_KEY_PEM.to_string()),
+            }),
+            ..Default::default()
+        };
+
+        apply_config_update(&arcswap, &None, &Some(mtls_swap.clone()), s3)
+            .await
+            .expect("apply update");
+
+        assert!(
+            !Arc::ptr_eq(&mtls_swap.load_full(), &initial),
+            "mTLS swap must hold a freshly built config after a TLS change"
+        );
+    }
+
+    /// A failing mTLS reload must not fail the config update itself.
+    #[tokio::test]
+    async fn apply_config_update_mtls_reload_failure_is_isolated() {
+        let mut starting = crate::test_utils::test_config();
+        starting.tls_cert = None;
+        starting.tls_key = None;
+        let arcswap = Arc::new(ArcSwap::from_pointee(starting));
+
+        let mtls_swap = fixture_mtls_swap();
+        let initial = mtls_swap.load_full();
+
+        let s3 = S3Config {
+            tls: Some(S3TlsConfig {
+                cert: Some("garbage-not-a-cert".to_string()),
+                key: Some("garbage-not-a-key".to_string()),
+            }),
+            ..Default::default()
+        };
+
+        apply_config_update(&arcswap, &None, &Some(mtls_swap.clone()), s3)
+            .await
+            .expect("config update must succeed despite mTLS reload failure");
+
+        let after = arcswap.load();
+        assert_eq!(after.tls_cert.as_deref(), Some("garbage-not-a-cert"));
+        assert!(
+            Arc::ptr_eq(&mtls_swap.load_full(), &initial),
+            "failed mTLS reload must leave the previous config in place"
+        );
     }
 }

--- a/crates/vouch-server/src/infra/s3_config.rs
+++ b/crates/vouch-server/src/infra/s3_config.rs
@@ -736,9 +736,7 @@ async fn apply_config_update(
             != old_tls_key;
 
     // Reload TLS if configured and changed
-    if tls_changed
-        && let (Some(cert), Some(key)) = (&new_config.tls_cert, &new_config.tls_key)
-    {
+    if tls_changed && let (Some(cert), Some(key)) = (&new_config.tls_cert, &new_config.tls_key) {
         if let Some(tls) = tls_config {
             tracing::info!("TLS config changed, reloading certificates");
             super::tls::reload_tls_from_config(tls, cert, key)?;

--- a/crates/vouch-server/src/infra/serve.rs
+++ b/crates/vouch-server/src/infra/serve.rs
@@ -88,6 +88,7 @@ fn start_s3_polling(
     state: &Arc<AppState>,
     s3_parts: S3ConfigParts,
     tls_config: Option<axum_server::tls_rustls::RustlsConfig>,
+    mtls_config: Option<super::mtls_listener::MtlsConfigSwap>,
 ) -> Option<JoinHandle<()>> {
     let (Some(client), Some(source), Some(etag)) = s3_parts else {
         return None;
@@ -101,6 +102,7 @@ fn start_s3_polling(
         source,
         state.config.clone(),
         tls_config,
+        mtls_config,
         etag,
     ))
 }
@@ -141,27 +143,34 @@ async fn serve_tls(
         shutdown_token_for_signal.cancel();
     });
 
-    // Start S3 config polling task if configured (with TLS config for hot reload)
-    let s3_poll_handle = start_s3_polling(state, s3_parts, Some(tls_config.clone()));
-
-    spawn_sighup_cert_reload(tls_config.clone(), state.config.clone());
-
-    // Start mTLS listener whenever TLS is configured (mTLS port always has a value).
+    // Start mTLS listener whenever TLS is configured (mTLS port always has a
+    // value). Started before the S3 polling task and SIGHUP handler so both
+    // can be handed the listener's config swap for certificate hot reload.
     let mtls_port = config.mtls_port;
     let mtls_addr: std::net::SocketAddr = format!("[::]:{mtls_port}")
         .parse()
         .context("Invalid mTLS listen address")?;
 
-    let mtls_handle: Option<JoinHandle<()>> =
+    let (mtls_handle, mtls_config_swap): (Option<JoinHandle<()>>, _) =
         match start_mtls_listener(config, mtls_addr, app.clone(), shutdown_token.clone()).await {
-            Ok(handle) => {
+            Ok((handle, swap)) => {
                 tracing::info!("mTLS listener started on port {}", mtls_port);
-                Some(handle)
+                (Some(handle), swap)
             }
             Err(e) => {
                 return Err(e.context("Failed to start mTLS listener"));
             }
         };
+
+    // Start S3 config polling task if configured (with TLS config for hot reload)
+    let s3_poll_handle = start_s3_polling(
+        state,
+        s3_parts,
+        Some(tls_config.clone()),
+        Some(mtls_config_swap.clone()),
+    );
+
+    spawn_sighup_cert_reload(tls_config.clone(), mtls_config_swap, state.config.clone());
 
     // Create handle for graceful shutdown of HTTPS server
     let handle = axum_server::Handle::new();
@@ -237,7 +246,7 @@ async fn serve_plain(
     s3_parts: S3ConfigParts,
 ) -> Result<Option<JoinHandle<()>>> {
     // Start S3 config polling task if configured (no TLS config to reload)
-    let s3_poll_handle = start_s3_polling(state, s3_parts, None);
+    let s3_poll_handle = start_s3_polling(state, s3_parts, None, None);
 
     let listener = tokio::net::TcpListener::bind(&config.listen_addr).await?;
     tracing::info!("Listening on http://{}", config.listen_addr);
@@ -263,6 +272,7 @@ async fn serve_plain(
 /// signal, not from the values captured at startup.
 fn spawn_sighup_cert_reload(
     tls_config: axum_server::tls_rustls::RustlsConfig,
+    mtls_config: super::mtls_listener::MtlsConfigSwap,
     config: Arc<arc_swap::ArcSwap<ServerConfig>>,
 ) {
     tokio::spawn(async move {
@@ -283,6 +293,16 @@ fn spawn_sighup_cert_reload(
                     match crate::infra::tls::reload_tls_from_config(&tls_config, cert, key) {
                         Ok(()) => tracing::info!("TLS certificates reloaded successfully"),
                         Err(e) => tracing::error!("Failed to reload TLS certificates: {e:#}"),
+                    }
+                    // Reload the mTLS listener independently: a failure here
+                    // must not undo the successful HTTPS reload above.
+                    match super::mtls_listener::reload_mtls_from_config(&mtls_config, cert, key) {
+                        Ok(()) => {
+                            tracing::info!("mTLS listener certificates reloaded successfully");
+                        }
+                        Err(e) => {
+                            tracing::error!("Failed to reload mTLS listener certificates: {e:#}");
+                        }
                     }
                 }
                 _ => tracing::warn!("TLS not configured, nothing to reload"),
@@ -326,7 +346,10 @@ async fn start_mtls_listener(
     addr: std::net::SocketAddr,
     app: Router,
     shutdown_token: CancellationToken,
-) -> anyhow::Result<tokio::task::JoinHandle<()>> {
+) -> anyhow::Result<(
+    tokio::task::JoinHandle<()>,
+    super::mtls_listener::MtlsConfigSwap,
+)> {
     use super::mtls_listener::{MtlsListener, PeerClientCert, build_mtls_server_config};
 
     // Parse server cert/key for the mTLS listener (same identity)
@@ -334,6 +357,7 @@ async fn start_mtls_listener(
 
     let mtls_config = build_mtls_server_config(certs, key)?;
     let mtls_config_swap = std::sync::Arc::new(arc_swap::ArcSwap::from(mtls_config));
+    let swap_for_reload = mtls_config_swap.clone();
 
     // Bind before spawning so the caller learns of port conflicts immediately.
     let tcp = tokio::net::TcpListener::bind(addr)
@@ -353,5 +377,5 @@ async fn start_mtls_listener(
         }
     });
 
-    Ok(handle)
+    Ok((handle, swap_for_reload))
 }

--- a/crates/vouch-server/src/infra/tls.rs
+++ b/crates/vouch-server/src/infra/tls.rs
@@ -171,6 +171,18 @@ pub(crate) fn parse_server_cert_and_key(
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("TLS private key not configured"))?;
 
+    parse_cert_and_key_pem(cert_pem, key_secret)
+}
+
+/// Parse a certificate chain and private key from (possibly base64-wrapped)
+/// PEM strings. Shared by mTLS listener startup and certificate hot reload.
+pub(crate) fn parse_cert_and_key_pem(
+    cert_pem: &str,
+    key_secret: &SecretString,
+) -> Result<(
+    Vec<rustls::pki_types::CertificateDer<'static>>,
+    rustls::pki_types::PrivateKeyDer<'static>,
+)> {
     let cert_bytes = crate::crypto::pem::decode_base64_pem(cert_pem)
         .context("Failed to decode TLS certificate")?
         .into_bytes();

--- a/crates/vouch-server/src/services/idp/saml/c14n.rs
+++ b/crates/vouch-server/src/services/idp/saml/c14n.rs
@@ -40,7 +40,7 @@
 //! and spaces between tags) is treated as text content and preserved in canonical
 //! output, which is correct per the c14n spec.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Exclusive XML Canonicalization (exc-c14n) of a subtree.
 ///
@@ -65,21 +65,22 @@ pub(crate) fn exclusive_c14n(node: roxmltree::Node<'_, '_>, inclusive_prefixes: 
         return String::new();
     }
     let mut output = String::with_capacity(512);
-    let rendered_ns: BTreeSet<(String, String)> = BTreeSet::new();
+    let rendered_ns: BTreeMap<String, String> = BTreeMap::new();
     canonicalize_node(node, &mut output, inclusive_prefixes, &rendered_ns);
     output
 }
 
 /// Recursively canonicalize an element node and its children.
 ///
-/// `rendered_ns` tracks `(prefix, uri)` pairs already emitted by ancestor
-/// elements. The check uses the EXACT `(prefix, uri)` pair -- if a prefix is
-/// re-declared with a different URI by a descendant, it must be re-emitted.
+/// `rendered_ns` is the spec's `ns_rendered` dictionary: for every prefix it
+/// holds the binding most recently emitted by an ancestor (inserts replace,
+/// per exc-c14n section 3.1). If a prefix is re-declared with a different URI
+/// by a descendant, its entry is overwritten and the declaration re-emitted.
 fn canonicalize_node(
     node: roxmltree::Node<'_, '_>,
     output: &mut String,
     inclusive_prefixes: &[&str],
-    rendered_ns: &BTreeSet<(String, String)>,
+    rendered_ns: &BTreeMap<String, String>,
 ) {
     if !node.is_element() {
         return;
@@ -113,17 +114,14 @@ fn canonicalize_node(
             output.push_str(uri);
             output.push('"');
         }
-        new_rendered_ns.insert((prefix.clone(), uri.clone()));
+        new_rendered_ns.insert(prefix.clone(), uri.clone());
     }
 
     // Step 3: Handle default namespace undeclaration.
     // If this element has no namespace (or the default NS is now empty), check
     // if an ancestor rendered a default namespace that must be undeclared.
     let elem_default_ns = node.default_namespace().unwrap_or("");
-    let ancestor_default_ns = rendered_ns
-        .iter()
-        .find(|(p, _)| p.is_empty())
-        .map_or("", |(_, u)| u.as_str());
+    let ancestor_default_ns = rendered_ns.get("").map_or("", String::as_str);
 
     // Undeclare if: element has no default NS but ancestor rendered one,
     // AND we haven't already emitted xmlns="" (which would happen if this
@@ -131,7 +129,7 @@ fn canonicalize_node(
     let already_emitted_default = sorted_ns.iter().any(|(p, _)| p.is_empty());
     if !already_emitted_default && elem_default_ns.is_empty() && !ancestor_default_ns.is_empty() {
         output.push_str(" xmlns=\"\"");
-        new_rendered_ns.insert((String::new(), String::new()));
+        new_rendered_ns.insert(String::new(), String::new());
     }
 
     // Step 5-6: Collect and sort attributes.
@@ -198,12 +196,13 @@ fn canonicalize_node(
 ///    attributes (but NOT the implicit `xml:` prefix).
 /// 2. Add namespaces for InclusiveNamespaces prefixes that are in scope
 ///    (declared on this element or ancestors), silently skipping out-of-scope ones.
-/// 3. Exclude pairs already rendered by an ancestor (exact `(prefix, uri)` match).
+/// 3. Exclude pairs whose prefix's CURRENT ancestor binding already equals
+///    the same URI (dictionary lookup, so a rebinding is always re-emitted).
 /// 4. Never emit the `xml:` namespace declaration.
 fn collect_namespaces(
     node: roxmltree::Node<'_, '_>,
     inclusive_prefixes: &[&str],
-    rendered_ns: &BTreeSet<(String, String)>,
+    rendered_ns: &BTreeMap<String, String>,
 ) -> BTreeSet<(String, String)> {
     let mut result: BTreeSet<(String, String)> = BTreeSet::new();
 
@@ -249,11 +248,12 @@ fn collect_namespaces(
         // If the prefix is not in scope, silently skip it (per C4 fix).
     }
 
-    // Exclude pairs already rendered by an ancestor (exact (prefix, uri) match).
-    // C2 fix: check the EXACT (prefix, uri) pair, not just prefix.
+    // Exclude pairs whose prefix's current ancestor binding is the same URI.
+    // The dictionary lookup (not exact-pair membership) matters: once a prefix
+    // has been re-bound, an older historical binding must be re-emitted.
     result
         .into_iter()
-        .filter(|pair| !rendered_ns.contains(pair))
+        .filter(|(prefix, uri)| rendered_ns.get(prefix) != Some(uri))
         .collect()
 }
 
@@ -584,6 +584,56 @@ mod tests {
         assert_eq!(
             result,
             r#"<root xmlns="urn:default"><child>text</child></root>"#
+        );
+    }
+
+    /// Regression for the ns_rendered dictionary semantics (exc-c14n
+    /// section 3.1): after a declare -> undeclare -> redeclare chain, the
+    /// deepest element must still get its `xmlns=""` undeclaration. With the
+    /// old set-based tracking, the historical `("", "")` entry from the
+    /// undeclare level was returned by the default-namespace lookup
+    /// (lexicographically smallest), so the final `xmlns=""` was skipped.
+    #[test]
+    fn default_namespace_undeclaration_after_redeclaration() {
+        let result = c14n(
+            r#"<root xmlns="urn:a"><child xmlns=""><grandchild xmlns="urn:b"><leaf xmlns="">text</leaf></grandchild></child></root>"#,
+            "root",
+            &[],
+        );
+        assert_eq!(
+            result,
+            r#"<root xmlns="urn:a"><child xmlns=""><grandchild xmlns="urn:b"><leaf xmlns="">text</leaf></grandchild></child></root>"#
+        );
+    }
+
+    /// A redeclared default namespace on a middle element must still be
+    /// undeclared on a child with no namespace (three-level variant).
+    #[test]
+    fn default_namespace_undeclared_after_middle_redeclaration() {
+        let result = c14n(
+            r#"<root><child2 xmlns="urn:b"><child3 xmlns="">text</child3></child2></root>"#,
+            "root",
+            &[],
+        );
+        assert_eq!(
+            result,
+            r#"<root><child2 xmlns="urn:b"><child3 xmlns="">text</child3></child2></root>"#
+        );
+    }
+
+    /// A prefix re-bound to a different URI by a descendant must be
+    /// re-emitted even if the original (prefix, uri) pair was rendered by
+    /// an outer ancestor (dictionary lookup, not exact-pair membership).
+    #[test]
+    fn prefix_rebinding_re_emits_original_uri() {
+        let result = c14n(
+            r#"<a:root xmlns:a="urn:1"><a:mid xmlns:a="urn:2"><a:leaf xmlns:a="urn:1">text</a:leaf></a:mid></a:root>"#,
+            "root",
+            &[],
+        );
+        assert_eq!(
+            result,
+            r#"<a:root xmlns:a="urn:1"><a:mid xmlns:a="urn:2"><a:leaf xmlns:a="urn:1">text</a:leaf></a:mid></a:root>"#
         );
     }
 

--- a/crates/vouch-server/src/services/integrations/aws.rs
+++ b/crates/vouch-server/src/services/integrations/aws.rs
@@ -132,12 +132,21 @@ pub(crate) enum AwsError {
 pub(crate) type AwsResult<T> = Result<T, AwsError>;
 
 /// Result of issuing an AWS OIDC token.
-#[derive(Debug)]
 pub(crate) struct AwsTokenResult {
     /// The signed OIDC ID token.
     pub id_token: String,
     /// Token validity in seconds.
     pub expires_in: u64,
+}
+
+// Custom Debug that redacts id_token to prevent accidental log exposure.
+impl std::fmt::Debug for AwsTokenResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AwsTokenResult")
+            .field("id_token", &"[REDACTED]")
+            .field("expires_in", &self.expires_in)
+            .finish()
+    }
 }
 
 /// Build the AWS session tags embedded in the `https://aws.amazon.com/tags`
@@ -263,6 +272,19 @@ pub(crate) async fn issue_aws_token(
 mod tests {
     use super::*;
     use crate::crypto::keys::OidcRsaSigningKey;
+
+    /// The signed OIDC ID token is a bearer credential for AWS STS and
+    /// must never appear in `{:?}` output.
+    #[test]
+    fn test_aws_token_result_debug_redacts_id_token() {
+        let result = AwsTokenResult {
+            id_token: "eyJhbGciOiJSUzI1NiJ9.secret-token".to_string(),
+            expires_in: 28_800,
+        };
+        let debug = format!("{result:?}");
+        assert!(debug.contains("[REDACTED]"), "{debug}");
+        assert!(!debug.contains("secret-token"), "{debug}");
+    }
     use base64::Engine;
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 

--- a/crates/vouch-server/src/services/integrations/github/oauth.rs
+++ b/crates/vouch-server/src/services/integrations/github/oauth.rs
@@ -116,21 +116,32 @@ impl GitHubService<'_> {
                 .await
                 .map_err(|e| GitHubError::GitHubApi(format!("{e:#}")))?;
 
-        // Update the refresh token if a new one was issued
-        if let Some(new_refresh_token) = &token_response.refresh_token
-            && let Ok(Some(user)) = db::get_user_by_id(self.store, user_id).await
-            && let (Some(github_id), Some(github_login)) = (user.github_id, &user.github_login)
-        {
-            // Best-effort refresh-token rotation; user session stays valid even if
-            // this DB write fails — the next refresh will retry.
-            let _updated = db::update_user_github_identity(
+        // Persist the rotated refresh token. GitHub rotates refresh tokens:
+        // the old token is invalidated by the refresh above, so losing the
+        // new one here would permanently break the integration (the "next
+        // refresh" would present the already-invalidated token). Propagate
+        // failures so they surface instead of silently discarding the only
+        // copy of the new token.
+        if let Some(new_refresh_token) = &token_response.refresh_token {
+            let user = db::get_user_by_id(self.store, user_id)
+                .await
+                .map_err(GitHubError::Database)?
+                .ok_or(GitHubError::UserNotFound)?;
+
+            let (Some(github_id), Some(github_login)) = (user.github_id, &user.github_login)
+            else {
+                return Err(GitHubError::GitHubAccountNotLinked);
+            };
+
+            db::update_user_github_identity(
                 self.store,
                 user_id,
                 github_id,
                 github_login,
                 Some(new_refresh_token),
             )
-            .await;
+            .await
+            .map_err(GitHubError::Database)?;
         }
 
         Ok(Some(token_response.access_token))

--- a/crates/vouch-server/src/services/integrations/github/oauth.rs
+++ b/crates/vouch-server/src/services/integrations/github/oauth.rs
@@ -128,8 +128,7 @@ impl GitHubService<'_> {
                 .map_err(GitHubError::Database)?
                 .ok_or(GitHubError::UserNotFound)?;
 
-            let (Some(github_id), Some(github_login)) = (user.github_id, &user.github_login)
-            else {
+            let (Some(github_id), Some(github_login)) = (user.github_id, &user.github_login) else {
                 return Err(GitHubError::GitHubAccountNotLinked);
             };
 

--- a/crates/vouch-server/src/services/oidc/discovery.rs
+++ b/crates/vouch-server/src/services/oidc/discovery.rs
@@ -188,8 +188,9 @@ pub fn build_discovery_document(state: &Arc<AppState>) -> OidcDiscoveryDocument 
             TokenEndpointAuthMethod::ClientSecretPost,
             TokenEndpointAuthMethod::PrivateKeyJwt,
         ];
-        // mTLS client auth methods are available whenever TLS is configured.
-        if state.config().tls_cert.is_some() {
+        // mTLS client auth methods are available whenever TLS is fully
+        // configured (cert AND key) — the mTLS listener only starts then.
+        if state.config().tls_configured() {
             methods.push(TokenEndpointAuthMethod::TlsClientAuth);
             methods.push(TokenEndpointAuthMethod::SelfSignedTlsClientAuth);
         }
@@ -292,8 +293,8 @@ pub fn build_discovery_document(state: &Arc<AppState>) -> OidcDiscoveryDocument 
         }),
         // RFC 9396 §11.3: Server accepts any authorization detail type (opaque)
         authorization_details_types_supported: None,
-        // RFC 8705: advertise mTLS support when TLS is configured.
-        tls_client_certificate_bound_access_tokens: state.config().tls_cert.is_some(),
+        // RFC 8705: advertise mTLS support when TLS is fully configured.
+        tls_client_certificate_bound_access_tokens: state.config().tls_configured(),
         mtls_endpoint_aliases: build_mtls_aliases(state, base_url),
         // RFC 9701: ES256 is the only supported introspection signing algorithm.
         introspection_signing_alg_values_supported: Some(vec![JwsAlgorithm::Es256]),
@@ -315,8 +316,11 @@ pub fn build_discovery_document(state: &Arc<AppState>) -> OidcDiscoveryDocument 
 fn build_mtls_aliases(state: &Arc<AppState>, base_url: &str) -> Option<MtlsEndpointAliases> {
     let config = state.config();
 
-    // Only advertise mTLS aliases when TLS is active on this server.
-    config.tls_cert.as_ref()?;
+    // Only advertise mTLS aliases when TLS is active on this server
+    // (cert AND key — a partial config never starts the mTLS listener).
+    if !config.tls_configured() {
+        return None;
+    }
 
     // Derive mTLS base URL by replacing the port with mtls_port.
     let mtls_base = if let Ok(mut url) = url::Url::parse(base_url) {

--- a/crates/vouch-server/src/services/oidc/protected_resource.rs
+++ b/crates/vouch-server/src/services/oidc/protected_resource.rs
@@ -331,7 +331,7 @@ pub async fn build_protected_resource_metadata(
         resource_policy_uri: config.resource_policy_uri.clone(),
         resource_tos_uri: config.resource_tos_uri.clone(),
 
-        tls_client_certificate_bound_access_tokens: config.tls_cert.is_some(),
+        tls_client_certificate_bound_access_tokens: config.tls_configured(),
         authorization_details_types_supported: None,
         dpop_signing_alg_values_supported,
         dpop_bound_access_tokens_required: true,

--- a/crates/vouch-server/src/services/oidc/registration.rs
+++ b/crates/vouch-server/src/services/oidc/registration.rs
@@ -1145,12 +1145,26 @@ pub async fn update_client_configuration(
     // Build updated registration metadata (cosmetic fields)
     let registration_metadata = mutable_request.registration_metadata();
 
-    // Validate JWKS and jwks_uri (same rules as initial registration):
-    // mutually exclusive, valid structure, HTTPS URI.
+    // Validate JWKS and jwks_uri field format: mutually exclusive, valid
+    // structure, HTTPS URI.
     validate_jwks_fields(
         mutable_request.jwks.as_ref(),
         mutable_request.jwks_uri.as_deref(),
     )?;
+
+    // PUT is a full replacement, so re-check the auth-method/JWKS
+    // relationship enforced at initial registration against the client's
+    // (immutable) registered auth method. Without this, a private_key_jwt
+    // client could clear its JWKS and end up unable to authenticate.
+    if client.token_endpoint_auth_method == TokenEndpointAuthMethod::PrivateKeyJwt
+        && mutable_request.jwks.is_none()
+        && mutable_request.jwks_uri.is_none()
+    {
+        return Err(ServiceError::oauth(
+            OAuthErrorCode::InvalidClientMetadata,
+            "private_key_jwt requires jwks or jwks_uri",
+        ));
+    }
 
     // Validate userinfo_signed_response_alg (same rules as initial registration).
     // The client's FAPI profile is immutable post-registration (RFC 7592), so we


### PR DESCRIPTION
## Summary

Reviews and fixes the 16 open `detail-app` bug reports (#704–#719). Each was verified against the current codebase before fixing; 14 were confirmed exactly as reported and 2 were partially correct (see notes). One commit per issue, each with a regression test.

## Fixes

### CLI
- **#711** `fix(cli)`: GHCR docker credential helper built its client with `unauthenticated() + set_token()`, never loading the FAPI signing key, so the signature-required `/v1/credentials/github/token` request failed client-side. Uses `with_token()`.
- **#712** `fix(cli)`: `vouch setup ssm` displayed the first `Host` line in the whole SSH config instead of the one inside the Vouch SSM block. Scoped to the marker.
- **#713** `fix(cli)`: interactive key menu mapped the selected label back to a key with `position()` (first match wins), so two same-model keys registered in the same minute could delete the wrong one. Uses `raw_prompt()` index.
- **#707** `fix(cli)`: `KubeconfigClusterData`/`KubeconfigContextData` had no `#[serde(flatten)]` catch-all, dropping unknown cluster/context fields on `setup k8s`/`eks` round-trips. Added catch-alls and corrected the doc comment.
- **#716** `fix(cli)` (security): CodeArtifact token cache key omitted the agent source, so a non-agent invocation could seed the shared agent-daemon cache with a full-access token that an AI-agent invocation would reuse, bypassing the ReadOnlyAccess session policy. Folds the agent source into the key like the other AWS flows.

### Server / common
- **#714** `fix(common)`: `CloudTokenResponse` (and `AwsTokenResult`) derived `Debug`, exposing the OIDC `id_token` in `{:?}` output. Added redacting `Debug` impls, matching sibling token types.
- **#704** `fix(server)`: client `Basic` auth scheme was matched case-sensitively, rejecting RFC 7617/9110-valid lowercase/uppercase variants. Now case-insensitive.
- **#717** `fix(server)`: GitHub OAuth rotated-refresh-token persistence swallowed DB read errors and discarded the write result, permanently breaking the integration on a transient failure (GitHub rotates refresh tokens). Errors now propagate.
- **#715** `fix(server)`: expired SCIM tokens counted toward the 2-token-per-org creation limit even though they cannot authenticate. Counts only active tokens and adds expired SCIM tokens to the cleanup task.
- **#719** `fix(server)`: RFC 7592 PUT validated JWKS field format only, letting a `private_key_jwt` client clear its JWKS via full-replacement and become unable to authenticate. Re-applies the auth-method↔JWKS consistency rule against the client's immutable registered method.
- **#708** `fix(server)`: discovery/protected-resource metadata advertised mTLS whenever `tls_cert` was set, while serving requires cert AND key — a partial config locked out `tls_client_auth` clients. Gates advertisement on `tls_configured()` and rejects cert-XOR-key at startup.
- **#709** `fix(server)`: exclusive XML C14N tracked rendered namespaces in a `BTreeSet` of `(prefix, uri)` pairs instead of the spec's per-prefix dictionary, so a declare→undeclare→redeclare→undeclare chain could drop a required `xmlns=""`, breaking SAML signature digests. Uses a `BTreeMap` keyed by prefix.
- **#706** `fix(server)`: the PAR endpoint validated the FAPI auth method against the client's *registered* method rather than the one actually used, so a stale client secret on a `private_key_jwt`-registered FAPI client passed. Derives the actual method from the verification witnesses.
- **#705** `fix(server)`: concurrent first-enrollees for a domain could both compute `is_org_admin = true` under READ COMMITTED (a predicate read), and the org-row CAS loser only logged, keeping full admin. Winning the CAS is now required to commit an admin claim; a claiming loser aborts with `OccConflict` so `with_dsql_retry!` re-runs and re-derives non-admin.
- **#710** `fix(server)`: the mTLS listener's `ArcSwap` config was created but never exposed, so SIGHUP and S3 cert rotation never reached it — the mTLS port kept serving startup certificates. Threads the swap into both reload paths.
- **#718** `fix(httpsig)`: server-issued signature nonces were echoed by the CLI but never validated, leaving replay protection to the timestamp window alone. Adds a `KeyResolver::validate_nonce` hook (enforce-when-present, default-accept) that consumes the nonce from the shared single-use store; a rejected nonce returns 401 with a fresh `Signature-Nonce`, a backend failure returns 500.

## Verification notes (partial claims)

- **#709**: the underlying flaw is real, but the issue's 3-level reproduction does not actually fail — a 4-level chain is required. The regression test uses the correct case.
- **#719**: "clear JWKS for a `private_key_jwt` client" is reproducible and fixed; "switch auth method to `private_key_jwt`" is not, because the auth method is immutable on PUT.
- **#705**: the double-admin outcome is real but was already mostly serialized by the org-row CAS + retry; this closes the residual write-skew window.

## Out of scope (follow-ups)

- **#708**: gating dynamic client registration acceptance of `tls_client_auth` on `tls_configured()` is a behavior change beyond the reported lockout.
- **#718**: an optional CLI retry-once-on-401-with-fresh-nonce; third-party signers echoing a nonce the server never issued will now be rejected (intended semantics).

## Testing

- `make fmt`, `make lint` (clippy `-D warnings`, no-panic policy): clean.
- `make test`: all unit-test binaries pass.
- `make test-integration`: all integration/property-test binaries pass.
- Each fix ships its own regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GgEGBD1cQ6zgTHSUFcdG8U)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication (PAR, Basic auth, HTTP signature nonces), credential caching for agents, SAML signature canonicalization, enrollment admin logic, and TLS/mTLS discovery—security-critical paths despite narrow fixes.
> 
> **Overview**
> Addresses **16 verified bug reports** (#704–#719) with targeted fixes and regression tests across the CLI, `vouch-httpsig`, and server.
> 
> **CLI:** GHCR docker credentials now use `VouchClient::with_token()` so FAPI signing works on `/v1/credentials/github/token`. CodeArtifact cache keys include **agent source** so AI-agent flows cannot reuse full-access cached tokens. Kubeconfig `setup k8s`/`eks` preserves unmodeled cluster/context/user fields via flatten catch-alls and upsert helpers. `vouch setup ssm` reads the `Host` pattern only inside the Vouch block. The keys menu selects by **menu index** (`raw_prompt`) when display labels collide. `set_token` is removed from the public client API (tests set `token` directly).
> 
> **Auth & OIDC:** OAuth `Basic` scheme matching is **case-insensitive**. FAPI PAR checks the **actual** client auth method from verification witnesses, not only the registered method. RFC 7592 PUT cannot clear JWKS for `private_key_jwt` clients. OIDC/cloud token types redact `id_token` in `Debug`.
> 
> **TLS & discovery:** Startup rejects **partial** TLS (cert XOR key). mTLS advertisement and aliases use `tls_configured()`; the mTLS listener config is **hot-reloaded** on SIGHUP and S3 updates.
> 
> **Security & integrity:** HTTP signature **nonce validation** (enforce-when-present, single-use) in middleware and server resolver. SAML exclusive C14N uses per-prefix `ns_rendered` semantics. Enrollment aborts admin claims on org-row CAS loss with retryable `OccConflict`. GitHub OAuth **persists rotated refresh tokens** or fails loudly. SCIM limits count **active** tokens; expired tokens are cleaned up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a36148b10249210802da832c23ded10d4c36ccdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->