### PR TITLE
refactor(server): clean up enrollment CAS handling

### DIFF
--- a/crates/vouch-server/src/db/enrollment.rs
+++ b/crates/vouch-server/src/db/enrollment.rs
@@ -118,128 +118,117 @@ pub async fn enroll_user_with_org(
         None => None,
     };
 
-    // Map a DB error from any tx operation into either an OccConflict (if it
-    // signals writer contention) or a generic 500. OccConflict is retried by
-    // with_dsql_retry!; the Internal path propagates.
-    let map_db_err = |e: anyhow::Error, msg: &'static str| -> ServiceError {
-        tracing::error!("{msg}: {e}");
-        if crate::db::pool::is_retryable_db_error(&e) {
-            ServiceError::OccConflict
-        } else {
-            ServiceError::Internal(msg.to_string())
-        }
-    };
+    let result =
+        crate::with_dsql_retry!(async {
+            let mut tx = store.begin().await.map_err(|e| {
+                ServiceError::from_db_contention(e, "Failed to begin enrollment transaction")
+            })?;
 
-    let result = crate::with_dsql_retry!(async {
-        let mut tx = store
-            .begin()
-            .await
-            .map_err(|e| map_db_err(e, "Failed to begin enrollment transaction"))?;
+            // One in-transaction snapshot of the org row: the admin-count
+            // predicate, the CAS guard (id + version), and the CAS payload all
+            // derive from it.
+            let org = match &org_id {
+                Some(oid) => tx.get::<OrganizationDoc>(oid).await.map_err(|e| {
+                    ServiceError::from_db_contention(e, "Failed to load organization")
+                })?,
+                None => None,
+            };
+            // Carried forward only while the admin slot is open; encodes
+            // "admin slot open ⇒ org exists" in the type.
+            let claimable_org = org.filter(|o| o.data.created_by_user_id.is_none());
 
-        // One in-transaction snapshot of the org row: the admin-count
-        // predicate, the CAS guard (id + version), and the CAS payload all
-        // derive from it.
-        let org = match &org_id {
-            Some(oid) => tx
-                .get::<OrganizationDoc>(oid)
-                .await
-                .map_err(|e| map_db_err(e, "Failed to load organization"))?,
-            None => None,
-        };
-        // Carried forward only while the admin slot is open; encodes
-        // "admin slot open ⇒ org exists" in the type.
-        let claimable_org = org.filter(|o| o.data.created_by_user_id.is_none());
+            let is_org_admin = match &claimable_org {
+                Some(org_doc) => {
+                    let count = tx
+                        .count::<UserDoc>("org_id", &org_doc.id)
+                        .await
+                        .map_err(|e| {
+                            ServiceError::from_db_contention(e, "Failed to count org users")
+                        })?;
+                    count == 0
+                }
+                None => false,
+            };
 
-        let is_org_admin = match &claimable_org {
-            Some(org_doc) => {
-                let count = tx
-                    .count::<UserDoc>("org_id", &org_doc.id)
+            // Get or create user
+            let existing_user = tx.find_one::<UserDoc>("email", email).await.map_err(|e| {
+                ServiceError::from_db_contention(e, "Failed to look up user by email")
+            })?;
+
+            let user = match existing_user {
+                Some(doc) => EnrolledUser {
+                    id: doc.id,
+                    email: doc.data.email,
+                    name: doc.data.name,
+                    org_id: doc.data.org_id,
+                    is_org_admin: doc.data.is_org_admin,
+                },
+                None => {
+                    let doc = UserDoc {
+                        email: email.to_string(),
+                        name: name.map(String::from),
+                        org_id: org_id.clone(),
+                        is_org_admin,
+                        active: true,
+                        external_id: None,
+                        github_id: None,
+                        github_login: None,
+                        github_refresh_token: None,
+                    };
+                    let result = tx.insert(&doc).await.map_err(|e| {
+                        ServiceError::from_db_contention(e, "Failed to insert user")
+                    })?;
+                    EnrolledUser {
+                        id: result.id,
+                        email: result.data.email,
+                        name: result.data.name,
+                        org_id: result.data.org_id,
+                        is_org_admin: result.data.is_org_admin,
+                    }
+                }
+            };
+
+            // Claim (or repair) the org admin slot. Winning this CAS is a
+            // REQUIREMENT for committing a user row that claims
+            // `is_org_admin = true`: the count above is a predicate read that
+            // concurrent transactions do not conflict on (write skew under READ
+            // COMMITTED), so two first-enrollees can both compute
+            // `is_org_admin = true` — the org-row version is the one write both
+            // must collide on. A claiming loser aborts so `with_dsql_retry!`
+            // re-runs the transaction; the retry re-reads fresh state (the
+            // winner's user row and admin slot are now visible) and commits a
+            // non-admin user. A non-claiming loser merely raced the
+            // opportunistic `created_by_user_id` repair and proceeds.
+            if let Some(org_doc) = claimable_org {
+                let mut data = org_doc.data;
+                data.created_by_user_id = Some(user.id.clone());
+                let won = tx
+                    .compare_and_update(&org_doc.id, org_doc.version, &data)
                     .await
-                    .map_err(|e| map_db_err(e, "Failed to count org users"))?;
-                count == 0
-            }
-            None => false,
-        };
-
-        // Get or create user
-        let existing_user = tx
-            .find_one::<UserDoc>("email", email)
-            .await
-            .map_err(|e| map_db_err(e, "Failed to look up user by email"))?;
-
-        let user = match existing_user {
-            Some(doc) => EnrolledUser {
-                id: doc.id,
-                email: doc.data.email,
-                name: doc.data.name,
-                org_id: doc.data.org_id,
-                is_org_admin: doc.data.is_org_admin,
-            },
-            None => {
-                let doc = UserDoc {
-                    email: email.to_string(),
-                    name: name.map(String::from),
-                    org_id: org_id.clone(),
-                    is_org_admin,
-                    active: true,
-                    external_id: None,
-                    github_id: None,
-                    github_login: None,
-                    github_refresh_token: None,
-                };
-                let result = tx
-                    .insert(&doc)
-                    .await
-                    .map_err(|e| map_db_err(e, "Failed to insert user"))?;
-                EnrolledUser {
-                    id: result.id,
-                    email: result.data.email,
-                    name: result.data.name,
-                    org_id: result.data.org_id,
-                    is_org_admin: result.data.is_org_admin,
+                    .map_err(|e| {
+                        ServiceError::from_db_contention(e, "Failed to update organization admin")
+                    })?;
+                if !won && is_org_admin {
+                    tracing::debug!(
+                        org_id = %org_doc.id,
+                        "Lost race to claim org admin during enrollment — retrying as non-admin"
+                    );
+                    return Err(ServiceError::OccConflict);
+                }
+                if !won {
+                    tracing::debug!(
+                        org_id = %org_doc.id,
+                        "Lost race to repair org admin during enrollment — another enrollee won"
+                    );
                 }
             }
-        };
 
-        // Claim (or repair) the org admin slot. Winning this CAS is a
-        // REQUIREMENT for committing a user row that claims
-        // `is_org_admin = true`: the count above is a predicate read that
-        // concurrent transactions do not conflict on (write skew under READ
-        // COMMITTED), so two first-enrollees can both compute
-        // `is_org_admin = true` — the org-row version is the one write both
-        // must collide on. A claiming loser aborts so `with_dsql_retry!`
-        // re-runs the transaction; the retry re-reads fresh state (the
-        // winner's user row and admin slot are now visible) and commits a
-        // non-admin user. A non-claiming loser merely raced the
-        // opportunistic `created_by_user_id` repair and proceeds.
-        if let Some(org_doc) = claimable_org {
-            let mut data = org_doc.data;
-            data.created_by_user_id = Some(user.id.clone());
-            let won = tx
-                .compare_and_update(&org_doc.id, org_doc.version, &data)
-                .await
-                .map_err(|e| map_db_err(e, "Failed to update organization admin"))?;
-            if !won && is_org_admin {
-                tracing::debug!(
-                    org_id = %org_doc.id,
-                    "Lost race to claim org admin during enrollment — retrying as non-admin"
-                );
-                return Err(ServiceError::OccConflict);
-            }
-            if !won {
-                tracing::debug!(
-                    org_id = %org_doc.id,
-                    "Lost race to repair org admin during enrollment — another enrollee won"
-                );
-            }
-        }
+            tx.commit().await.map_err(|e| {
+                ServiceError::from_db_contention(e, "Failed to commit enrollment transaction")
+            })?;
 
-        tx.commit()
-            .await
-            .map_err(|e| map_db_err(e, "Failed to commit enrollment transaction"))?;
-
-        Ok::<_, ServiceError>(user)
-    })?;
+            Ok::<_, ServiceError>(user)
+        })?;
 
     Ok(result)
 }

--- a/crates/vouch-server/src/db/enrollment.rs
+++ b/crates/vouch-server/src/db/enrollment.rs
@@ -50,80 +50,83 @@ pub struct EnrolledUser {
     pub is_org_admin: bool,
 }
 
+/// Get or create the organization row for `domain`, returning its ID.
+///
+/// Runs OUTSIDE the user-creation transaction so the unique-violation
+/// recovery path doesn't abort it. The deterministic ID makes concurrent
+/// enrollees for the same domain race on the documents primary key, and
+/// exactly one INSERT wins.
+///
+/// Lookup falls back from the deterministic ID to the domain index: rows
+/// with random-UUID IDs (created before deterministic IDs) are only
+/// findable by domain, and skipping the fallback would insert a duplicate
+/// org.
+///
+/// If user creation later fails, the organization row may persist with
+/// `created_by_user_id = None`. That is benign: the next enrollee for the
+/// domain reuses the row and the enrollment transaction claims the admin
+/// slot via `compare_and_update`.
+async fn get_or_create_org(store: &DocumentStore, domain: &str) -> Result<String> {
+    let id = deterministic_org_id(domain);
+    let existing = match store.get::<OrganizationDoc>(&id).await? {
+        Some(org) => Some(org),
+        None => store.find_one::<OrganizationDoc>("domain", domain).await?,
+    };
+    if let Some(org) = existing {
+        return Ok(org.id);
+    }
+
+    let doc = OrganizationDoc {
+        domain: domain.to_string(),
+        name: None,
+        created_by_user_id: None,
+        additional_domains: Vec::new(),
+        subdomain: None,
+    };
+    match store.insert_with_id(&id, &doc).await {
+        Ok(result) => Ok(result.id),
+        Err(e) if super::pool::is_unique_violation(&e) => {
+            // Concurrent enrollee inserted first — re-fetch.
+            let org = match store.get::<OrganizationDoc>(&id).await? {
+                Some(o) => o,
+                None => store
+                    .find_one::<OrganizationDoc>("domain", domain)
+                    .await?
+                    .context("organization vanished after unique violation")?,
+            };
+            Ok(org.id)
+        }
+        Err(e) => Err(e),
+    }
+}
+
 /// Enroll a user with their organization.
 ///
 /// This function:
-/// 1. Gets or creates the organization for the user's domain
-/// 2. Determines if the user should be an org admin (first user)
-/// 3. Creates or gets the user with the org association
-/// 4. Updates the org's `created_by_user_id` if first user
+/// 1. Gets or creates the organization for the user's domain, outside the
+///    user-creation transaction (see [`get_or_create_org`])
+/// 2. Inside a single retried transaction: reads one snapshot of the
+///    organization row, derives the admin decision from it (first user of
+///    an org whose admin slot is open), creates or gets the user, and
+///    claims the admin slot via `compare_and_update` against that
+///    snapshot's version
 ///
-/// Steps 2-4 run inside a single transaction. Step 1 runs outside the
-/// transaction so that a primary-key collision from a concurrent
-/// enrollment for the same domain can be recovered from without
-/// aborting the user-creation transaction (see the inline comment for
-/// the atomicity tradeoff).
+/// Deriving everything from one in-transaction snapshot means every
+/// interleaving with a concurrent enrollee is caught by the single
+/// version guard: a lost CAS while claiming admin aborts with
+/// [`ServiceError::OccConflict`] and `with_dsql_retry!` re-runs the
+/// transaction against fresh state. If the organization row was deleted
+/// after step 1, the snapshot is `None` and the user is enrolled without
+/// any admin claim.
 pub async fn enroll_user_with_org(
     store: &DocumentStore,
     email: &str,
     name: Option<&str>,
     domain: Option<&str>,
 ) -> Result<EnrollmentResult> {
-    // Step 1: Get or create organization (if domain provided).
-    //
-    // Runs OUTSIDE the user-creation transaction so the unique-violation
-    // recovery path doesn't abort it. The deterministic ID makes concurrent
-    // enrollees for the same domain race on the documents primary key, and
-    // exactly one INSERT wins.
-    //
-    // Lookup falls back from deterministic ID to the domain index: rows with
-    // random-UUID IDs (created before deterministic IDs) are only findable by
-    // domain, and skipping the fallback would insert a duplicate org.
-    //
-    // If user creation later fails, the organization row may persist with
-    // `created_by_user_id = None`. That is benign: the next enrollee for the
-    // domain reuses the row and Step 4 sets them as admin via
-    // `compare_and_update`.
-    let (org_id, org_needs_admin) = if let Some(domain) = domain {
-        let id = deterministic_org_id(domain);
-        let existing = match store.get::<OrganizationDoc>(&id).await? {
-            Some(org) => Some(org),
-            None => store.find_one::<OrganizationDoc>("domain", domain).await?,
-        };
-
-        match existing {
-            Some(org) => {
-                let needs_admin = org.data.created_by_user_id.is_none();
-                (Some(org.id), needs_admin)
-            }
-            None => {
-                let doc = OrganizationDoc {
-                    domain: domain.to_string(),
-                    name: None,
-                    created_by_user_id: None,
-                    additional_domains: Vec::new(),
-                    subdomain: None,
-                };
-                match store.insert_with_id(&id, &doc).await {
-                    Ok(result) => (Some(result.id), true),
-                    Err(e) if super::pool::is_unique_violation(&e) => {
-                        // Concurrent enrollee inserted first — re-fetch.
-                        let org = match store.get::<OrganizationDoc>(&id).await? {
-                            Some(o) => o,
-                            None => store
-                                .find_one::<OrganizationDoc>("domain", domain)
-                                .await?
-                                .context("organization vanished after unique violation")?,
-                        };
-                        let needs_admin = org.data.created_by_user_id.is_none();
-                        (Some(org.id), needs_admin)
-                    }
-                    Err(e) => return Err(e),
-                }
-            }
-        }
-    } else {
-        (None, false)
+    let org_id = match domain {
+        Some(domain) => Some(get_or_create_org(store, domain).await?),
+        None => None,
     };
 
     // Map a DB error from any tx operation into either an OccConflict (if it
@@ -144,22 +147,32 @@ pub async fn enroll_user_with_org(
             .await
             .map_err(|e| map_db_err(e, "Failed to begin enrollment transaction"))?;
 
-        // Step 2: Determine admin status
-        let is_org_admin = if org_needs_admin {
-            if let Some(ref oid) = org_id {
+        // One in-transaction snapshot of the org row: the admin-count
+        // predicate, the CAS guard (id + version), and the CAS payload all
+        // derive from it.
+        let org = match &org_id {
+            Some(oid) => tx
+                .get::<OrganizationDoc>(oid)
+                .await
+                .map_err(|e| map_db_err(e, "Failed to load organization"))?,
+            None => None,
+        };
+        // Carried forward only while the admin slot is open; encodes
+        // "admin slot open ⇒ org exists" in the type.
+        let claimable_org = org.filter(|o| o.data.created_by_user_id.is_none());
+
+        let is_org_admin = match &claimable_org {
+            Some(org_doc) => {
                 let count = tx
-                    .count::<UserDoc>("org_id", oid)
+                    .count::<UserDoc>("org_id", &org_doc.id)
                     .await
                     .map_err(|e| map_db_err(e, "Failed to count org users"))?;
                 count == 0
-            } else {
-                false
             }
-        } else {
-            false
+            None => false,
         };
 
-        // Step 3: Get or create user
+        // Get or create user
         let existing_user = tx
             .find_one::<UserDoc>("email", email)
             .await
@@ -199,28 +212,36 @@ pub async fn enroll_user_with_org(
             }
         };
 
-        // Step 4: Ensure org has an admin. Uses compare_and_update so that
-        // only one concurrent enrollee wins the admin slot. On re-run after a
-        // crash, this also repairs a missing created_by_user_id.
-        if let Some(ref oid) = org_id
-            && let Some(org_doc) = tx
-                .get::<OrganizationDoc>(oid)
+        // Claim (or repair) the org admin slot. Winning this CAS is a
+        // REQUIREMENT for committing a user row that claims
+        // `is_org_admin = true`: the count above is a predicate read that
+        // concurrent transactions do not conflict on (write skew under READ
+        // COMMITTED), so two first-enrollees can both compute
+        // `is_org_admin = true` — the org-row version is the one write both
+        // must collide on. A claiming loser aborts so `with_dsql_retry!`
+        // re-runs the transaction; the retry re-reads fresh state (the
+        // winner's user row and admin slot are now visible) and commits a
+        // non-admin user. A non-claiming loser merely raced the
+        // opportunistic `created_by_user_id` repair and proceeds.
+        if let Some(org_doc) = claimable_org {
+            let mut data = org_doc.data;
+            data.created_by_user_id = Some(user.id.clone());
+            let won = tx
+                .compare_and_update(&org_doc.id, org_doc.version, &data)
                 .await
-                .map_err(|e| map_db_err(e, "Failed to load organization"))?
-        {
-            if org_doc.data.created_by_user_id.is_none() {
-                let mut data = org_doc.data;
-                data.created_by_user_id = Some(user.id.clone());
-                let won = tx
-                    .compare_and_update(oid, org_doc.version, &data)
-                    .await
-                    .map_err(|e| map_db_err(e, "Failed to update organization admin"))?;
-                admin_cas_outcome(won, is_org_admin, oid)?;
-            } else if is_org_admin {
-                // Another enrollee committed the admin slot between Step 2's
-                // count and this read (READ COMMITTED lets each statement see
-                // newer commits). A stale admin claim must abort and retry.
-                admin_cas_outcome(false, true, oid)?;
+                .map_err(|e| map_db_err(e, "Failed to update organization admin"))?;
+            if !won && is_org_admin {
+                tracing::debug!(
+                    org_id = %org_doc.id,
+                    "Lost race to claim org admin during enrollment — retrying as non-admin"
+                );
+                return Err(ServiceError::OccConflict);
+            }
+            if !won {
+                tracing::debug!(
+                    org_id = %org_doc.id,
+                    "Lost race to repair org admin during enrollment — another enrollee won"
+                );
             }
         }
 
@@ -238,71 +259,9 @@ pub async fn enroll_user_with_org(
     Ok(result)
 }
 
-/// Decide the outcome of the Step-4 admin CAS on the organization row.
-///
-/// Winning the CAS is a REQUIREMENT for committing a user row that claims
-/// `is_org_admin = true`: the count-based admin decision in Step 2 is a
-/// predicate read that concurrent transactions do not conflict on (write
-/// skew under READ COMMITTED), so two first-enrollees can both compute
-/// `is_org_admin = true`. The org-row CAS is the one write both must
-/// collide on. A claiming loser aborts with `OccConflict` so
-/// `with_dsql_retry!` re-runs the transaction; the retry re-counts (the
-/// winner's user row is now visible), derives `is_org_admin = false`, and
-/// commits a non-admin user.
-///
-/// A non-claiming loser (this enrollee never computed admin status) merely
-/// raced the opportunistic `created_by_user_id` repair and proceeds.
-fn admin_cas_outcome(won: bool, claimed_admin: bool, org_id: &str) -> Result<(), ServiceError> {
-    if won || !claimed_admin {
-        if !won {
-            tracing::debug!(
-                org_id = %org_id,
-                "Lost race to repair org admin during enrollment — another enrollee won"
-            );
-        }
-        return Ok(());
-    }
-    tracing::debug!(
-        org_id = %org_id,
-        "Lost race to claim org admin during enrollment — retrying as non-admin"
-    );
-    Err(ServiceError::OccConflict)
-}
-
 #[cfg(test)]
-#[expect(
-    clippy::expect_used,
-    reason = "test code: panic on assertion failure is acceptable"
-)]
 mod tests {
-    use super::{admin_cas_outcome, deterministic_org_id};
-
-    /// Winning the CAS always commits, whether or not admin was claimed.
-    #[test]
-    fn admin_cas_outcome_winner_commits() {
-        assert!(admin_cas_outcome(true, true, "org-1").is_ok());
-        assert!(admin_cas_outcome(true, false, "org-1").is_ok());
-    }
-
-    /// A loser that claimed admin must abort with the one retryable error
-    /// so `with_dsql_retry!` re-runs the transaction and re-derives the
-    /// admin decision from fresh state.
-    #[test]
-    fn admin_cas_outcome_claiming_loser_is_retryable_conflict() {
-        use crate::db::pool::RetryableError;
-        use crate::error::ServiceError;
-
-        let err = admin_cas_outcome(false, true, "org-1").expect_err("must abort");
-        assert!(matches!(err, ServiceError::OccConflict));
-        assert!(err.is_retryable(), "OccConflict must be retryable");
-    }
-
-    /// A loser that never claimed admin only raced the opportunistic
-    /// `created_by_user_id` repair; committing is harmless.
-    #[test]
-    fn admin_cas_outcome_non_claiming_loser_commits() {
-        assert!(admin_cas_outcome(false, false, "org-1").is_ok());
-    }
+    use super::deterministic_org_id;
 
     #[test]
     fn deterministic_org_id_collides_on_equal_domains() {

--- a/crates/vouch-server/src/db/enrollment.rs
+++ b/crates/vouch-server/src/db/enrollment.rs
@@ -29,17 +29,6 @@ fn deterministic_org_id(domain: &str) -> String {
     hex::encode(ctx.finish().as_ref())
 }
 
-/// Result of enrolling a user with their organization.
-#[derive(Debug)]
-pub struct EnrollmentResult {
-    /// The user record (created or existing).
-    pub user: EnrolledUser,
-    /// The organization ID if the user belongs to one.
-    pub org_id: Option<String>,
-    /// Whether this user is the organization admin.
-    pub is_org_admin: bool,
-}
-
 /// User record from enrollment.
 #[derive(Debug)]
 pub struct EnrolledUser {
@@ -123,7 +112,7 @@ pub async fn enroll_user_with_org(
     email: &str,
     name: Option<&str>,
     domain: Option<&str>,
-) -> Result<EnrollmentResult> {
+) -> Result<EnrolledUser> {
     let org_id = match domain {
         Some(domain) => Some(get_or_create_org(store, domain).await?),
         None => None,
@@ -249,11 +238,7 @@ pub async fn enroll_user_with_org(
             .await
             .map_err(|e| map_db_err(e, "Failed to commit enrollment transaction"))?;
 
-        Ok::<_, ServiceError>(EnrollmentResult {
-            user,
-            org_id: org_id.clone(),
-            is_org_admin,
-        })
+        Ok::<_, ServiceError>(user)
     })?;
 
     Ok(result)

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -215,7 +215,7 @@ pub use authorization_codes::{
 };
 
 // Re-export enrollment types and functions
-pub use enrollment::{EnrolledUser, EnrollmentResult, enroll_user_with_org};
+pub use enrollment::{EnrolledUser, enroll_user_with_org};
 
 // Re-export posture policy types and functions
 pub use posture_policies::{

--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -510,22 +510,9 @@ pub async fn create_oauth_client_secret(
     let secret_hash = secret_hash.to_string();
     let description = description.map(String::from);
 
-    // Map a DB error from any tx operation into either an OccConflict (if it
-    // signals writer contention — Postgres serialization failure, Aurora DSQL
-    // OC000/OC001, SQLite BUSY/LOCKED) or a generic 500.
-    // OccConflict is retried by with_dsql_retry!; the 500 path propagates.
-    let map_db_err = |e: anyhow::Error, msg: &'static str| -> ServiceError {
-        tracing::error!("{msg}: {e}");
-        if crate::db::pool::is_retryable_db_error(&e) {
-            ServiceError::OccConflict
-        } else {
-            ServiceError::Internal(msg.to_string())
-        }
-    };
-
     crate::with_dsql_retry!(async {
         let mut tx = store.begin().await.map_err(|e| {
-            map_db_err(
+            ServiceError::from_db_contention(
                 e,
                 "Failed to begin transaction for create_oauth_client_secret",
             )
@@ -537,7 +524,12 @@ pub async fn create_oauth_client_secret(
         let client_doc = tx
             .get::<OAuthClientDoc>(&oauth_client_id)
             .await
-            .map_err(|e| map_db_err(e, "Failed to load OAuthClientDoc for secret create"))?
+            .map_err(|e| {
+                ServiceError::from_db_contention(
+                    e,
+                    "Failed to load OAuthClientDoc for secret create",
+                )
+            })?
             .ok_or(ServiceError::NotFound("OAuth client"))?;
 
         // Count currently-active secrets by filtering (not SQL COUNT) because
@@ -546,7 +538,9 @@ pub async fn create_oauth_client_secret(
         let all_secrets = tx
             .find_all::<OAuthClientSecretDoc>("oauth_client_id", &oauth_client_id)
             .await
-            .map_err(|e| map_db_err(e, "Failed to list secrets for secret create"))?;
+            .map_err(|e| {
+                ServiceError::from_db_contention(e, "Failed to list secrets for secret create")
+            })?;
 
         // Filter directly on the doc fields to avoid a needless From conversion.
         // Mirrors the `is_valid` predicate: not revoked, not expired.
@@ -585,7 +579,7 @@ pub async fn create_oauth_client_secret(
         let inserted = tx
             .insert(&new_secret_doc)
             .await
-            .map_err(|e| map_db_err(e, "Failed to insert secret"))?;
+            .map_err(|e| ServiceError::from_db_contention(e, "Failed to insert secret"))?;
 
         // Version-bump the client doc.  This is the OCC serialization point:
         // any concurrent secret-set mutation on this client will have bumped the
@@ -597,7 +591,12 @@ pub async fn create_oauth_client_secret(
                 &client_doc.data,
             )
             .await
-            .map_err(|e| map_db_err(e, "Failed to version-bump client for secret create"))?;
+            .map_err(|e| {
+                ServiceError::from_db_contention(
+                    e,
+                    "Failed to version-bump client for secret create",
+                )
+            })?;
 
         if !ok {
             // OCC conflict — another writer beat us to the client row.  Signal
@@ -605,9 +604,9 @@ pub async fn create_oauth_client_secret(
             return Err(ServiceError::OccConflict);
         }
 
-        tx.commit()
-            .await
-            .map_err(|e| map_db_err(e, "Failed to commit create_oauth_client_secret"))?;
+        tx.commit().await.map_err(|e| {
+            ServiceError::from_db_contention(e, "Failed to commit create_oauth_client_secret")
+        })?;
 
         Ok(OAuthClientSecret::from(inserted))
     })
@@ -710,22 +709,9 @@ pub async fn revoke_oauth_client_secret(
     let secret_id = secret_id.to_string();
     let oauth_client_id = oauth_client_id.to_string();
 
-    // Map a DB error from any tx operation into either an OccConflict (if it
-    // signals writer contention — Postgres serialization failure, Aurora DSQL
-    // OC000/OC001, SQLite BUSY/LOCKED) or a generic 500.
-    // OccConflict is retried by with_dsql_retry!; the 500 path propagates.
-    let map_db_err = |e: anyhow::Error, msg: &'static str| -> ServiceError {
-        tracing::error!("{msg}: {e}");
-        if crate::db::pool::is_retryable_db_error(&e) {
-            ServiceError::OccConflict
-        } else {
-            ServiceError::Internal(msg.to_string())
-        }
-    };
-
     crate::with_dsql_retry!(async {
         let mut tx = store.begin().await.map_err(|e| {
-            map_db_err(
+            ServiceError::from_db_contention(
                 e,
                 "Failed to begin transaction for revoke_oauth_client_secret",
             )
@@ -735,7 +721,7 @@ pub async fn revoke_oauth_client_secret(
         let secret_doc = tx
             .get::<OAuthClientSecretDoc>(&secret_id)
             .await
-            .map_err(|e| map_db_err(e, "Failed to load secret for revoke"))?
+            .map_err(|e| ServiceError::from_db_contention(e, "Failed to load secret for revoke"))?
             .ok_or(ServiceError::NotFound("Secret"))?;
 
         if secret_doc.data.oauth_client_id != oauth_client_id {
@@ -752,7 +738,9 @@ pub async fn revoke_oauth_client_secret(
         let client_doc = tx
             .get::<OAuthClientDoc>(&oauth_client_id)
             .await
-            .map_err(|e| map_db_err(e, "Failed to load OAuthClientDoc for revoke"))?
+            .map_err(|e| {
+                ServiceError::from_db_contention(e, "Failed to load OAuthClientDoc for revoke")
+            })?
             .ok_or(ServiceError::NotFound("OAuth client"))?;
 
         // Count active secrets (filter, not SQL COUNT — soft-deleted rows are retained).
@@ -760,7 +748,9 @@ pub async fn revoke_oauth_client_secret(
         let all_secrets = tx
             .find_all::<OAuthClientSecretDoc>("oauth_client_id", &oauth_client_id)
             .await
-            .map_err(|e| map_db_err(e, "Failed to list secrets for revoke"))?;
+            .map_err(|e| {
+                ServiceError::from_db_contention(e, "Failed to list secrets for revoke")
+            })?;
 
         // Count the *other* active secrets — exclude the target row itself, so a
         // revoke that leaves a valid secret behind is allowed even when the target
@@ -797,7 +787,7 @@ pub async fn revoke_oauth_client_secret(
         updated_data.revoked_at = Some(now);
         tx.update(&secret_id, &updated_data)
             .await
-            .map_err(|e| map_db_err(e, "Failed to soft-delete secret"))?;
+            .map_err(|e| ServiceError::from_db_contention(e, "Failed to soft-delete secret"))?;
 
         // Version-bump the client doc.  This is the OCC serialization point.
         let ok = tx
@@ -807,15 +797,17 @@ pub async fn revoke_oauth_client_secret(
                 &client_doc.data,
             )
             .await
-            .map_err(|e| map_db_err(e, "Failed to version-bump client for revoke"))?;
+            .map_err(|e| {
+                ServiceError::from_db_contention(e, "Failed to version-bump client for revoke")
+            })?;
 
         if !ok {
             return Err(ServiceError::OccConflict);
         }
 
-        tx.commit()
-            .await
-            .map_err(|e| map_db_err(e, "Failed to commit revoke_oauth_client_secret"))
+        tx.commit().await.map_err(|e| {
+            ServiceError::from_db_contention(e, "Failed to commit revoke_oauth_client_secret")
+        })
     })
     // `with_dsql_retry!` exhausts OccConflict after MAX_DSQL_RETRIES attempts.
     // Surface as 409 "conflict" (not 500) — mirrors the delete_key precedent.

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -3972,6 +3972,16 @@ async fn test_enroll_promotes_admin_for_org_without_one() {
         user.is_org_admin,
         "an org with no admin must promote the next enrollee"
     );
+
+    // The promotion must be persisted on the user doc, not just reported in
+    // the return value — authorization reads `UserDoc.is_org_admin`.
+    let persisted = store
+        .find_one::<crate::db::documents::user::UserDoc>("email", "rescuer@orphaned-org.example")
+        .await
+        .expect("find enrolled user")
+        .expect("enrolled user exists");
+    assert!(persisted.data.is_org_admin);
+
     let org_count = store
         .count::<OrganizationDoc>("domain", domain)
         .await

--- a/crates/vouch-server/src/error.rs
+++ b/crates/vouch-server/src/error.rs
@@ -479,6 +479,24 @@ mod tests {
         assert_eq!(err.oauth_description(), err.to_string());
     }
 
+    /// `OccConflict` is the only retryable `ServiceError`. Every
+    /// `with_dsql_retry!` loop over `ServiceError` depends on this
+    /// contract — if it regresses, transactional writes silently stop
+    /// retrying transient OCC conflicts.
+    #[test]
+    fn occ_conflict_is_the_only_retryable_service_error() {
+        use crate::db::pool::RetryableError;
+
+        assert!(ServiceError::OccConflict.is_retryable());
+        assert!(!ServiceError::Internal("boom".to_string()).is_retryable());
+        assert!(!ServiceError::Conflict("duplicate".to_string()).is_retryable());
+        // Business-logic 409s must propagate immediately, never retry.
+        assert!(
+            !ServiceError::api(StatusCode::CONFLICT, "max_secrets_reached", "cap hit")
+                .is_retryable()
+        );
+    }
+
     #[test]
     fn test_service_error_api_factory() {
         let err = ServiceError::api(

--- a/crates/vouch-server/src/error.rs
+++ b/crates/vouch-server/src/error.rs
@@ -276,6 +276,21 @@ impl ServiceError {
         }
     }
 
+    /// Classify a database error from a transactional operation.
+    ///
+    /// Writer contention (Postgres serialization failure, Aurora DSQL
+    /// OC000/OC001, SQLite BUSY/LOCKED) becomes [`Self::OccConflict`] so the
+    /// enclosing `with_dsql_retry!` re-runs the transaction; anything else
+    /// becomes [`Self::Internal`] and propagates as a 500.
+    pub(crate) fn from_db_contention(err: anyhow::Error, msg: &'static str) -> Self {
+        tracing::error!("{msg}: {err}");
+        if crate::db::pool::is_retryable_db_error(&err) {
+            Self::OccConflict
+        } else {
+            Self::Internal(msg.to_string())
+        }
+    }
+
     /// Convert to an OAuth error response.
     pub fn into_oauth_response(self) -> (StatusCode, Json<OAuthErrorResponse>) {
         match self {

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -660,7 +660,7 @@ pub(crate) async fn complete_enrollment_after_identity(
     // Enroll user with organization in a single atomic transaction.
     // This ensures that if org creation succeeds but user creation fails,
     // the entire operation is rolled back to prevent orphaned state.
-    let enrollment = match db::enroll_user_with_org(
+    let user = match db::enroll_user_with_org(
         &state.store,
         &identity.email,
         None,
@@ -668,7 +668,7 @@ pub(crate) async fn complete_enrollment_after_identity(
     )
     .await
     {
-        Ok(e) => e,
+        Ok(user) => user,
         Err(e) => {
             tracing::error!("Failed to enroll user: {}", e);
             return ErrorTemplate {
@@ -679,8 +679,6 @@ pub(crate) async fn complete_enrollment_after_identity(
             .into_response();
         }
     };
-
-    let user = enrollment.user;
 
     // Create session for this user (using session cookie instead of enrollment cookie)
     let now = Timestamp::now();

--- a/crates/vouch-server/src/services/keys.rs
+++ b/crates/vouch-server/src/services/keys.rs
@@ -220,24 +220,11 @@ pub(crate) async fn delete_key(
         ));
     }
 
-    // Map a DB error from any tx operation into either an OccConflict (if it
-    // signals contention with a concurrent writer — Postgres serialization
-    // failure, Aurora DSQL OC000/OC001, SQLite BUSY/LOCKED) or a generic 500.
-    // OccConflict is retried by with_dsql_retry!; the 500 path propagates.
-    let map_db_err = |e: anyhow::Error, msg: &'static str| -> ServiceError {
-        tracing::error!("{msg}: {e}");
-        if crate::db::pool::is_retryable_db_error(&e) {
-            ServiceError::OccConflict
-        } else {
-            ServiceError::Internal(msg.to_string())
-        }
-    };
-
     let result = crate::with_dsql_retry!(async {
         let mut tx = store
             .begin()
             .await
-            .map_err(|e| map_db_err(e, "Failed to start transaction"))?;
+            .map_err(|e| ServiceError::from_db_contention(e, "Failed to start transaction"))?;
 
         // Load the User doc with its version. The version is bumped at the end of
         // the transaction so that two concurrent deletes against the same user
@@ -247,14 +234,14 @@ pub(crate) async fn delete_key(
         let user_doc = tx
             .get::<UserDoc>(user_id)
             .await
-            .map_err(|e| map_db_err(e, "Failed to load user"))?
+            .map_err(|e| ServiceError::from_db_contention(e, "Failed to load user"))?
             .ok_or(ServiceError::NotFound("User"))?;
 
         // Load the authenticator and verify ownership within the transaction.
         let auth_doc = tx
             .get::<AuthenticatorDoc>(key_id)
             .await
-            .map_err(|e| map_db_err(e, "Failed to retrieve key"))?
+            .map_err(|e| ServiceError::from_db_contention(e, "Failed to retrieve key"))?
             .ok_or(ServiceError::NotFound("Key"))?;
 
         if auth_doc.data.user_id != user_id {
@@ -273,7 +260,7 @@ pub(crate) async fn delete_key(
         let count_before = tx
             .count::<AuthenticatorDoc>("user_id", user_id)
             .await
-            .map_err(|e| map_db_err(e, "Failed to check key count"))?;
+            .map_err(|e| ServiceError::from_db_contention(e, "Failed to check key count"))?;
         if count_before <= 1 {
             return Err(ServiceError::api(
                 axum::http::StatusCode::BAD_REQUEST,
@@ -287,12 +274,12 @@ pub(crate) async fn delete_key(
         let sessions_revoked = tx
             .count::<SessionDoc>("authenticator_id", key_id)
             .await
-            .map_err(|e| map_db_err(e, "Failed to count sessions"))?;
+            .map_err(|e| ServiceError::from_db_contention(e, "Failed to count sessions"))?;
 
         // Cascade-delete the authenticator (device_auth refs, sessions, doc).
         db::delete_authenticator_in_tx(&mut tx, key_id)
             .await
-            .map_err(|e| map_db_err(e, "Failed to delete key"))?;
+            .map_err(|e| ServiceError::from_db_contention(e, "Failed to delete key"))?;
 
         // Post-delete invariant. Under PostgreSQL READ COMMITTED both concurrent
         // transactions would still see count_after == 1 (each observes the other's
@@ -301,7 +288,7 @@ pub(crate) async fn delete_key(
         let count_after = tx
             .count::<AuthenticatorDoc>("user_id", user_id)
             .await
-            .map_err(|e| map_db_err(e, "Failed to verify key count"))?;
+            .map_err(|e| ServiceError::from_db_contention(e, "Failed to verify key count"))?;
         if count_after < 1 {
             return Err(ServiceError::api(
                 axum::http::StatusCode::BAD_REQUEST,
@@ -314,7 +301,7 @@ pub(crate) async fn delete_key(
         let ok = tx
             .compare_and_update::<UserDoc>(user_id, user_doc.version, &user_doc.data)
             .await
-            .map_err(|e| map_db_err(e, "Failed to version-bump user doc"))?;
+            .map_err(|e| ServiceError::from_db_contention(e, "Failed to version-bump user doc"))?;
         if !ok {
             // OCC conflict — another writer beat us to the User doc.  Signal
             // with_dsql_retry! to re-run the entire block.
@@ -323,7 +310,7 @@ pub(crate) async fn delete_key(
 
         tx.commit()
             .await
-            .map_err(|e| map_db_err(e, "Failed to commit key deletion"))?;
+            .map_err(|e| ServiceError::from_db_contention(e, "Failed to commit key deletion"))?;
 
         let sessions = u64::try_from(sessions_revoked).unwrap_or_default();
         tracing::info!("Deleted key {key_id} for user {user_id}, revoked {sessions} sessions");


### PR DESCRIPTION
## Summary

`enroll_user_with_org` derived its admin decision from two different snapshots: a pre-transaction org read (`org_needs_admin`) and an in-transaction user count. Reconciling them required a patch-up branch that fed a fabricated lost-CAS outcome into the `admin_cas_outcome(won, claimed_admin, org_id)` boolean-pair helper when no CAS had run.

- **One in-transaction snapshot.** The admin-count predicate, the CAS guard (id + version), and the CAS payload all derive from a single in-transaction read of the organization row (`claimable_org = org.filter(|o| o.data.created_by_user_id.is_none())`), so every interleaving with a concurrent enrollee is caught by the one version guard. `admin_cas_outcome` is deleted; a lost CAS while claiming admin is the inline `return Err(ServiceError::OccConflict)` idiom used by the other cross-row invariants (oauth secret cap/floor, subdomain claims). Step 1 is extracted as `get_or_create_org` and no longer threads the admin flag out of a stale snapshot.
- **Return `EnrolledUser` directly.** The sole caller consumed only the `user` field of `EnrollmentResult`, and the wrapper's top-level `is_org_admin` could diverge from the persisted `UserDoc.is_org_admin` for an existing user; authorization always reads the persisted flag. The promote test now also asserts the persisted flag.
- **Dedupe `map_db_err`.** The closure classifying transactional DB errors as `OccConflict` (writer contention) or `Internal` was copy-pasted in `enrollment.rs`, `oauth.rs` (create and revoke secret), and `services/keys.rs`; it is now `ServiceError::from_db_contention` in `error.rs`, next to the `OccConflict` contract it implements.

One behavior divergence: an org row deleted between get-or-create and the transaction can no longer yield a committed user with `is_org_admin = true` pointing at a dead org — the in-transaction snapshot is `None`, so no admin claim is made.

The deleted `admin_cas_outcome` unit tests carried the only assertion that `ServiceError::OccConflict.is_retryable()`; a replacement test in `error.rs` now pins that contract.

## Test plan

- `cargo test -p vouch-server --all-features` — 2544 passed, 0 failed, including the three DB-backed `test_enroll_*` tests (`#389` regression among them) which pass unchanged
- `tests/arch_boundaries.rs` passes (`error.rs` is a crate-root module and already referenced `db::pool`)
- `make lint` (clippy `--all-targets --all-features -D warnings`) — zero warnings
- `make test` — full workspace, zero failures
- Grep-verified the sweep: no `map_db_err` remains in `crates/vouch-server/src`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches enrollment admin claiming and concurrent-enrollee semantics (authorization-critical), with a deliberate edge-case change when an org row is deleted mid-flow; transactional retry behavior is centralized but should behave equivalently.
> 
> **Overview**
> Refactors OIDC **enrollment** so org admin decisions use a **single in-transaction org snapshot** (`claimable_org`) instead of mixing a pre-tx `org_needs_admin` flag with a second in-tx read. Org get/create moves to **`get_or_create_org`**; **`admin_cas_outcome`** is removed in favor of inline `OccConflict` when a claiming enrollee loses the org-row CAS.
> 
> **`enroll_user_with_org`** now returns **`EnrolledUser`** directly (drops **`EnrollmentResult`**); the enroll handler uses that value. Orphaned-org promotion test also asserts persisted **`UserDoc.is_org_admin`**.
> 
> Repeated transactional **`map_db_err`** closures in enrollment, OAuth secret create/revoke, and key deletion are replaced by **`ServiceError::from_db_contention`**, with a new unit test that **`OccConflict`** is the only retryable **`ServiceError`**.
> 
> **Behavior note:** if the org row disappears between get-or-create and the enrollment transaction, enrollment no longer commits a user with **`is_org_admin = true`** for a missing org.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 815e0ac76477d039ab9086c0472113159b020350. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->