### PR TITLE
refactor(cli): centralize git config access in one module

### DIFF
--- a/crates/vouch-cli/src/commands/setup/codecommit.rs
+++ b/crates/vouch-cli/src/commands/setup/codecommit.rs
@@ -13,7 +13,6 @@
 //! OIDC token → STS AssumeRoleWithWebIdentity → SigV4 signing for CodeCommit.
 
 use anyhow::{Context, Result};
-use std::process::Command;
 
 use crate::config::Config;
 use crate::install_path::resolve_install_path;
@@ -95,7 +94,7 @@ pub(crate) async fn run(
 
     if configure {
         // Check for conflicting credential helpers
-        detect_conflicting_helpers()?;
+        detect_conflicting_helpers();
 
         // 1. Create git-remote-codecommit symlink for codecommit:// URLs
         create_remote_helper_symlink(&vouch_path, &symlink_path)?;
@@ -105,12 +104,9 @@ pub(crate) async fn run(
             let config_key = format!("credential.{pattern}.helper");
             let use_http_path_key = format!("credential.{pattern}.useHttpPath");
 
-            let status = Command::new("git")
-                .args(["config", "--global", &config_key, &helper_command])
-                .status()
-                .with_context(|| tr!("setup-codecommit-err-run-config"))?;
-
-            if !status.success() {
+            if !crate::git_config::set_global(&config_key, &helper_command)
+                .with_context(|| tr!("setup-codecommit-err-run-config"))?
+            {
                 return Err(crate::exit_code::CliError::ConfigError(tr_args!(
                     "setup-codecommit-err-helper-pattern",
                     pattern = pattern,
@@ -119,12 +115,9 @@ pub(crate) async fn run(
             }
 
             // useHttpPath is critical — git must pass the full path (region + repo)
-            let status = Command::new("git")
-                .args(["config", "--global", &use_http_path_key, "true"])
-                .status()
-                .with_context(|| tr!("setup-codecommit-err-run-config"))?;
-
-            if !status.success() {
+            if !crate::git_config::set_global(&use_http_path_key, "true")
+                .with_context(|| tr!("setup-codecommit-err-run-config"))?
+            {
                 return Err(crate::exit_code::CliError::ConfigError(tr_args!(
                     "setup-codecommit-err-http-path",
                     pattern = pattern,
@@ -235,35 +228,20 @@ fn create_remote_helper_symlink(
 }
 
 /// Detect credential helpers that may conflict with Vouch.
-fn detect_conflicting_helpers() -> Result<()> {
-    use vouch_cli::{tr, tr_println};
+fn detect_conflicting_helpers() {
+    use vouch_cli::tr_println;
 
-    let output = Command::new("git")
-        .args([
-            "config",
-            "--global",
-            "--get-regexp",
-            r"credential.*codecommit.*helper",
-        ])
-        .output()
-        .with_context(|| tr!("setup-codecommit-err-run-config"))?;
-
-    if output.status.success() {
-        let existing = String::from_utf8_lossy(&output.stdout);
-        for line in existing.lines() {
-            // Skip entries that already use vouch
-            if line.contains("vouch credential codecommit") {
-                continue;
-            }
-            if line.contains("aws codecommit credential-helper")
-                || line.contains("git-remote-codecommit")
-            {
-                tr_println!("setup-codecommit-warn-existing-block", line = line);
-            }
+    for line in crate::git_config::get_regexp_global(r"credential.*codecommit.*helper") {
+        // Skip entries that already use vouch
+        if line.contains("vouch credential codecommit") {
+            continue;
+        }
+        if line.contains("aws codecommit credential-helper")
+            || line.contains("git-remote-codecommit")
+        {
+            tr_println!("setup-codecommit-warn-existing-block", line = line);
         }
     }
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/vouch-cli/src/commands/setup/codecommit.rs
+++ b/crates/vouch-cli/src/commands/setup/codecommit.rs
@@ -232,8 +232,11 @@ fn detect_conflicting_helpers() {
     use vouch_cli::tr_println;
 
     for line in crate::git_config::get_regexp_global(r"credential.*codecommit.*helper") {
-        // Skip entries that already use vouch
-        if line.contains("vouch credential codecommit") {
+        // Skip entries that already use vouch. Match the bare binary name, not
+        // "vouch credential codecommit": git returns the value with the path's
+        // closing quote attached (`"…/vouch" credential codecommit`) and the
+        // binary is `vouch.exe` on Windows, so neither substring is adjacent.
+        if line.contains("vouch") {
             continue;
         }
         if line.contains("aws codecommit credential-helper")

--- a/crates/vouch-cli/src/commands/setup/github.rs
+++ b/crates/vouch-cli/src/commands/setup/github.rs
@@ -4,7 +4,6 @@
 //! Configures Git to use Vouch for GitHub credentials.
 
 use anyhow::{Context, Result};
-use std::process::Command;
 use vouch_cli::{tr, tr_println};
 use vouch_common::GitHubStatusResponse;
 
@@ -80,7 +79,7 @@ pub(crate) async fn run(host: &str, configure: bool) -> Result<()> {
 
     if configure {
         // Check for existing helpers that might conflict
-        if let Some(existing) = detect_existing_helper(host)? {
+        if let Some(existing) = detect_existing_helper(host) {
             tr_println!(
                 "setup-github-existing-warning-block",
                 existing = existing.as_str()
@@ -89,12 +88,9 @@ pub(crate) async fn run(host: &str, configure: bool) -> Result<()> {
         }
 
         // Configure git
-        let status = Command::new("git")
-            .args(["config", "--global", &config_key, &helper_command])
-            .status()
-            .with_context(|| tr!("setup-github-err-run-config"))?;
-
-        if !status.success() {
+        if !crate::git_config::set_global(&config_key, &helper_command)
+            .with_context(|| tr!("setup-github-err-run-config"))?
+        {
             return Err(
                 crate::exit_code::CliError::ConfigError(tr!("setup-github-err-helper")).into(),
             );
@@ -148,20 +144,10 @@ fn print_status(status: &GitHubStatusResponse) {
 }
 
 /// Detect existing credential helpers for the given host.
-fn detect_existing_helper(host: &str) -> Result<Option<String>> {
+///
+/// Returns a non-vouch helper if one is already configured, so the caller can
+/// warn before overwriting it.
+fn detect_existing_helper(host: &str) -> Option<String> {
     let config_key = format!("credential.https://{}.helper", host);
-
-    let output = Command::new("git")
-        .args(["config", "--global", "--get", &config_key])
-        .output()
-        .context("failed to run git config")?;
-
-    if output.status.success() {
-        let helper = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if !helper.is_empty() && !helper.contains("vouch") {
-            return Ok(Some(helper));
-        }
-    }
-
-    Ok(None)
+    crate::git_config::get_global(&config_key).filter(|helper| !helper.contains("vouch"))
 }

--- a/crates/vouch-cli/src/git_config.rs
+++ b/crates/vouch-cli/src/git_config.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! Global git config access via the `git config --global` subprocess.
+//!
+//! vouch never parses git config in Rust — it only writes credential-helper
+//! keys or reads a handful back to detect conflicts. `git config --global` is
+//! authoritative: it honors `GIT_CONFIG_GLOBAL`, selects correctly between
+//! `~/.gitconfig` and `~/.config/git/config`, and handles includes/locking.
+//! This module is the single audited place vouch shells out to `git config`.
+
+use anyhow::Result;
+use std::process::{Command, Output};
+
+/// Run `git config --global <args...>` and capture its output.
+fn run(args: &[&str]) -> std::io::Result<Output> {
+    Command::new("git")
+        .args(["config", "--global"])
+        .args(args)
+        .output()
+}
+
+/// Set a key in the user's global git config.
+///
+/// Returns `Ok(true)` on success, `Ok(false)` when git ran but exited non-zero,
+/// and `Err` only when git could not be spawned. Callers attach their own
+/// translated context and map a `false` result to the appropriate `CliError`.
+pub(crate) fn set_global(key: &str, value: &str) -> Result<bool> {
+    Ok(run(&[key, value])?.status.success())
+}
+
+/// Read a single value from the global git config (`--get`).
+///
+/// Returns `None` when the key is unset, empty, or git is unavailable — all of
+/// which the callers treat identically as "not configured".
+pub(crate) fn get_global(key: &str) -> Option<String> {
+    let out = run(&["--get", key]).ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let value = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!value.is_empty()).then_some(value)
+}
+
+/// Read matching `key value` lines from the global git config (`--get-regexp`).
+///
+/// Returns an empty `Vec` when nothing matches or git is unavailable. Kept
+/// alongside [`set_global`]/[`get_global`] so every `git config` invocation
+/// flows through this module, even though it has a single caller today.
+pub(crate) fn get_regexp_global(pattern: &str) -> Vec<String> {
+    let Some(out) = run(&["--get-regexp", pattern])
+        .ok()
+        .filter(|o| o.status.success())
+    else {
+        return Vec::new();
+    };
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .map(str::to_string)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A synthetic key/pattern that cannot exist in any real global config, so
+    /// these reads are deterministic and mutate nothing.
+    const ABSENT_KEY: &str = "credential.https://vouch-selftest.invalid.helper";
+    const ABSENT_PATTERN: &str = r"credential\.vouch-selftest\.invalid\.helper";
+
+    /// An unset key returns `None` (not `Some("")`) and a non-matching pattern
+    /// returns an empty `Vec` — the module's "not configured" contract.
+    ///
+    /// The write round-trip cannot be unit-tested in-process: redirecting
+    /// `--global` needs `GIT_CONFIG_GLOBAL` in the process environment, and
+    /// `std::env::set_var` requires an `unsafe` block that the workspace denies.
+    /// It is covered by the live verification steps for `vouch setup github`.
+    #[test]
+    fn absent_key_and_pattern_return_nothing() {
+        // Skip cleanly if git is unavailable (e.g. minimal CI images).
+        if Command::new("git").arg("--version").output().is_err() {
+            return;
+        }
+
+        assert!(get_global(ABSENT_KEY).is_none());
+        assert!(get_regexp_global(ABSENT_PATTERN).is_empty());
+    }
+}

--- a/crates/vouch-cli/src/integrations/github.rs
+++ b/crates/vouch-cli/src/integrations/github.rs
@@ -151,17 +151,10 @@ fn check_git_credential_helper() -> (bool, Option<String>) {
     // Check common GitHub hosts
     for host in &["github.com", "ghe.com"] {
         let config_key = format!("credential.https://{}.helper", host);
-        let output = std::process::Command::new("git")
-            .args(["config", "--global", "--get", &config_key])
-            .output();
-
-        if let Ok(output) = output
-            && output.status.success()
+        if let Some(helper) = crate::git_config::get_global(&config_key)
+            && helper.contains("vouch")
         {
-            let helper = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if helper.contains("vouch") {
-                return (true, Some((*host).to_string()));
-            }
+            return (true, Some((*host).to_string()));
         }
     }
 

--- a/crates/vouch-cli/src/main.rs
+++ b/crates/vouch-cli/src/main.rs
@@ -27,6 +27,7 @@ mod exit_code;
     reason = "items pub for lib.rs re-exports used by vouch-tests"
 )]
 mod fido2;
+mod git_config;
 mod install_path;
 mod integrations;
 mod server_url;


### PR DESCRIPTION
## What

Moves the inline `git config --global` subprocess calls out of `setup/github.rs`, `setup/codecommit.rs`, and `integrations/github.rs` into a new `crates/vouch-cli/src/git_config.rs` module. The module exposes `set_global`, `get_global` (returns `Option`, collapsing unset/empty/git-unavailable to `None`), and `get_regexp_global` (returns `Vec<String>`), all over a private `run(args)`. This is the single place vouch shells out to `git config`.

Net −42 lines in the refactored files; no new dependency.

## Why not gix-config

This started as the question "should vouch-cli use `gix-config` for modifying `.gitconfig`?" The answer is no:

- git is already a hard runtime requirement for these flows — the credential helper (`credential.*.helper`) and remote helper (`git-remote-codecommit`) are invoked by git itself.
- `git config --global` writes authoritatively: it honors `GIT_CONFIG_GLOBAL`, selects correctly between `~/.gitconfig` and `~/.config/git/config`, and handles includes/locking.
- vouch never parses whole git config in Rust, so gix-config's core value has no consumer.
- The pre-1.0 gitoxide `gix-*` subtree conflicts with the add-deps-sparingly / min-binary-size policy.

The real finding underneath the question was that the subprocess logic was duplicated inline; this PR consolidates it while keeping the subprocess approach.

## Behavior note

Writes now go through `.output()` instead of `.status()`, so git's own stderr is suppressed on a failed write. Callers still surface the translated `CliError::ConfigError`.

## Testing

- `cargo clippy -p vouch-cli --all-targets --all-features` and whole-workspace `make lint`: clean.
- `cargo test -p vouch-cli`: 638 passed, including a new `absent_key_and_pattern_return_nothing` test and the preserved `helper_command_quotes_path_with_spaces` test.
- Live-verified the git mechanism against a throwaway `GIT_CONFIG_GLOBAL` file: absent key → `None`, set → success, the space-in-path quoted value round-trips intact, and `--get-regexp` returns only the helper line.

The write round-trip is not unit-tested in-process: redirecting `--global` needs `GIT_CONFIG_GLOBAL` in the process environment, and `std::env::set_var` requires an `unsafe` block the workspace denies at the lint level. It is covered by the live verification above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor of git config I/O with minor behavior shifts (suppressed git stderr on write failure, softer handling when git is missing on reads); no change to credential signing or server auth.
> 
> **Overview**
> Introduces **`git_config`** as the only place the CLI shells out to `git config --global`, with **`set_global`**, **`get_global`**, and **`get_regexp_global`** replacing duplicated `Command::new("git")` calls in **`setup/github`**, **`setup/codecommit`**, and **`integrations/github`**.
> 
> Setup flows now use the shared helpers for writing credential helpers and reading existing values; conflict detection is simplified (**`Option`** / void returns) and treats missing git or failed reads like “not configured” instead of surfacing subprocess errors. **CodeCommit** conflict scanning now skips any helper line containing **`vouch`** (not the full **`vouch credential codecommit`** string), so quoted paths and **`vouch.exe`** on Windows are recognized correctly.
> 
> Failed config writes still map to **`CliError::ConfigError`**, but writes go through **`.output()`** so git’s stderr is no longer printed on failure. A small unit test documents the “absent key” read contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84019894cd8486631a4c67ef96e28b8b1f41ea55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->