### PR TITLE
refactor(oidc): extract testable units from token-path functions

### DIFF
--- a/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
@@ -6,11 +6,12 @@
 
 use super::jwks::{find_matching_key_with_refresh_client, resolve_client_jwks};
 use super::validate::{
-    decode_claims_unverified, map_algorithm, parse_assertion_header, validate_jwt_assertion,
+    JwtAssertionClaims, JwtAssertionHeader, decode_claims_unverified, map_algorithm,
+    parse_assertion_header, validate_jwt_assertion,
 };
 use crate::AppState;
 use crate::db::claim::ClaimError;
-use crate::db::{self, JwtAssertionJtiClaim, TokenEndpointAuthMethod};
+use crate::db::{self, JwtAssertionJtiClaim, OAuthClient, TokenEndpointAuthMethod};
 use crate::services::oidc::token::{AuthenticatedClient, ClientAuthError};
 use jiff::{Timestamp, ToSpan};
 use std::sync::Arc;
@@ -127,10 +128,6 @@ impl PendingJti {
 ///   passed. Thread it forward to construct
 ///   [`crate::services::auth::ClientAuthProof::PrivateKeyJwt`] regardless of
 ///   whether the assertion carried a `jti`.
-#[expect(
-    clippy::too_many_lines,
-    reason = "single-pass RFC 7523 client assertion validation"
-)]
 pub async fn authenticate_client_jwt(
     state: &Arc<AppState>,
     client_assertion: &str,
@@ -148,30 +145,8 @@ pub async fn authenticate_client_jwt(
         ClientAuthError::InvalidCredentials
     })?;
 
-    // RFC 7523 Section 3: For client authentication, iss and sub MUST be the client_id
+    verify_assertion_subject(&unverified_claims, client_id_hint)?;
     let assertion_client_id = &unverified_claims.iss;
-
-    // If client_id was provided in the request body, it must match
-    if let Some(hint) = client_id_hint
-        && hint != assertion_client_id
-    {
-        tracing::warn!(
-            "client_id mismatch: body='{}' vs assertion iss='{}'",
-            hint,
-            assertion_client_id
-        );
-        return Err(ClientAuthError::InvalidCredentials);
-    }
-
-    // iss must equal sub for client authentication
-    if unverified_claims.iss != unverified_claims.sub {
-        tracing::warn!(
-            "JWT assertion iss ({}) != sub ({})",
-            unverified_claims.iss,
-            unverified_claims.sub
-        );
-        return Err(ClientAuthError::InvalidCredentials);
-    }
 
     // 3. Look up client
     let client = db::get_oauth_client_by_client_id(&state.store, assertion_client_id)
@@ -193,57 +168,8 @@ pub async fn authenticate_client_jwt(
         return Err(ClientAuthError::InvalidCredentials);
     }
 
-    // 5. Resolve client's JWKS (inline or from URI).
-    // Load cache once; pass to both resolver calls (pre-refresh timestamp matches prior behavior).
-    let jwks_cache = crate::db::get_jwks_cache(&state.store, &client.id)
-        .await
-        .map_err(|e| {
-            tracing::debug!(
-                "JWKS cache lookup failed for client {}: {e}",
-                client.client_id
-            );
-            ClientAuthError::InvalidCredentials
-        })?;
-
-    // Loopback JWKS destinations are permitted only in local development
-    // (no TLS configured), matching the WebAuthn `allow_localhost_origin`
-    // relaxation; private/link-local targets stay blocked.
-    let allow_loopback = !state.config().tls_configured();
-
-    let jwks = resolve_client_jwks(
-        &state.store,
-        &client.id,
-        client.jwks.as_ref(),
-        client.jwks_uri.as_deref(),
-        jwks_cache.as_ref(),
-        allow_loopback,
-        &state.http_client,
-    )
-    .await
-    .map_err(|e| {
-        tracing::debug!(
-            "JWKS resolution failed for client {}: {e}",
-            client.client_id
-        );
-        ClientAuthError::InvalidCredentials
-    })?;
-
-    // 6. Find matching key, with force-refresh on kid-miss for jwks_uri clients
-    let decoding_key = find_matching_key_with_refresh_client(
-        &state.store,
-        &client.id,
-        client.jwks_uri.as_deref(),
-        jwks_cache.as_ref(),
-        allow_loopback,
-        &state.http_client,
-        &jwks,
-        &header,
-    )
-    .await
-    .map_err(|e| {
-        tracing::debug!("No matching key found for client {}: {e}", client.client_id);
-        ClientAuthError::InvalidCredentials
-    })?;
+    // 5+6. Resolve the client's JWKS and select the verification key
+    let decoding_key = resolve_client_decoding_key(state, &client, &header).await?;
 
     // 7. Validate JWT assertion (signature + claims)
     let algorithm = map_algorithm(&header.alg).map_err(|_| ClientAuthError::InvalidCredentials)?;
@@ -332,6 +258,101 @@ pub async fn authenticate_client_jwt(
         pending_jti,
         JwtAuthSucceeded { _private: () },
     ))
+}
+
+/// RFC 7523 Section 3: For client authentication, `iss` and `sub` MUST both
+/// be the client_id, and a `client_id` provided in the request body must
+/// match the assertion's issuer.
+///
+/// # Errors
+/// Returns `InvalidCredentials` on any mismatch.
+fn verify_assertion_subject(
+    claims: &JwtAssertionClaims,
+    client_id_hint: Option<&str>,
+) -> Result<(), ClientAuthError> {
+    // If client_id was provided in the request body, it must match
+    if let Some(hint) = client_id_hint
+        && hint != claims.iss
+    {
+        tracing::warn!(
+            "client_id mismatch: body='{}' vs assertion iss='{}'",
+            hint,
+            claims.iss
+        );
+        return Err(ClientAuthError::InvalidCredentials);
+    }
+
+    // iss must equal sub for client authentication
+    if claims.iss != claims.sub {
+        tracing::warn!("JWT assertion iss ({}) != sub ({})", claims.iss, claims.sub);
+        return Err(ClientAuthError::InvalidCredentials);
+    }
+
+    Ok(())
+}
+
+/// Resolve the client's JWKS (inline or from `jwks_uri`) and select the
+/// verification key for the assertion header, force-refreshing the JWKS
+/// cache on a kid-miss for `jwks_uri` clients.
+///
+/// # Errors
+/// Returns `InvalidCredentials` when the JWKS cannot be resolved or no key
+/// matches the header.
+async fn resolve_client_decoding_key(
+    state: &Arc<AppState>,
+    client: &OAuthClient,
+    header: &JwtAssertionHeader,
+) -> Result<jsonwebtoken::DecodingKey, ClientAuthError> {
+    // Load cache once; pass to both resolver calls (pre-refresh timestamp matches prior behavior).
+    let jwks_cache = crate::db::get_jwks_cache(&state.store, &client.id)
+        .await
+        .map_err(|e| {
+            tracing::debug!(
+                "JWKS cache lookup failed for client {}: {e}",
+                client.client_id
+            );
+            ClientAuthError::InvalidCredentials
+        })?;
+
+    // Loopback JWKS destinations are permitted only in local development
+    // (no TLS configured), matching the WebAuthn `allow_localhost_origin`
+    // relaxation; private/link-local targets stay blocked.
+    let allow_loopback = !state.config().tls_configured();
+
+    let jwks = resolve_client_jwks(
+        &state.store,
+        &client.id,
+        client.jwks.as_ref(),
+        client.jwks_uri.as_deref(),
+        jwks_cache.as_ref(),
+        allow_loopback,
+        &state.http_client,
+    )
+    .await
+    .map_err(|e| {
+        tracing::debug!(
+            "JWKS resolution failed for client {}: {e}",
+            client.client_id
+        );
+        ClientAuthError::InvalidCredentials
+    })?;
+
+    // Find matching key, with force-refresh on kid-miss for jwks_uri clients
+    find_matching_key_with_refresh_client(
+        &state.store,
+        &client.id,
+        client.jwks_uri.as_deref(),
+        jwks_cache.as_ref(),
+        allow_loopback,
+        &state.http_client,
+        &jwks,
+        header,
+    )
+    .await
+    .map_err(|e| {
+        tracing::debug!("No matching key found for client {}: {e}", client.client_id);
+        ClientAuthError::InvalidCredentials
+    })
 }
 
 #[cfg(test)]
@@ -569,5 +590,115 @@ mod tests {
             matches!(result, Ok(Some(_))),
             "commit on retry must succeed when the first PendingJti was not committed: {result:?}"
         );
+    }
+
+    fn make_claims(iss: &str, sub: &str) -> JwtAssertionClaims {
+        JwtAssertionClaims {
+            iss: iss.to_string(),
+            sub: sub.to_string(),
+            aud: super::super::validate::JwtAudience::Single(
+                "https://test.example.com".to_string(),
+            ),
+            exp: i64::MAX,
+            iat: None,
+            nbf: None,
+            jti: None,
+        }
+    }
+
+    #[test]
+    fn test_verify_assertion_subject_accepts_matching_iss_sub_and_hint() {
+        let claims = make_claims("client-1", "client-1");
+        assert!(verify_assertion_subject(&claims, Some("client-1")).is_ok());
+        assert!(verify_assertion_subject(&claims, None).is_ok());
+    }
+
+    #[test]
+    fn test_verify_assertion_subject_rejects_hint_mismatch() {
+        let claims = make_claims("client-1", "client-1");
+        let result = verify_assertion_subject(&claims, Some("client-2"));
+        assert!(matches!(result, Err(ClientAuthError::InvalidCredentials)));
+    }
+
+    #[test]
+    fn test_verify_assertion_subject_rejects_iss_sub_mismatch() {
+        let claims = make_claims("client-1", "client-2");
+        let result = verify_assertion_subject(&claims, None);
+        assert!(matches!(result, Err(ClientAuthError::InvalidCredentials)));
+    }
+
+    /// Create a client whose inline JWKS is the shared test signing key and
+    /// return it with the key's `kid` (read back from the stored JWKS).
+    async fn make_client_with_jwks(state: &Arc<crate::AppState>) -> (OAuthClient, String) {
+        use crate::test_utils::{TestClientSpec, TestJwks, create_test_client, create_test_user};
+
+        let user = create_test_user(&state.store, "jwks-resolve@example.com").await;
+        let created = create_test_client(
+            &state.store,
+            &user.id,
+            TestClientSpec {
+                token_endpoint_auth_method: Some(TokenEndpointAuthMethod::PrivateKeyJwt),
+                jwks: TestJwks::Shared,
+                with_secret: false,
+                ..Default::default()
+            },
+        )
+        .await;
+        let client = db::get_oauth_client_by_id(&state.store, &created.app_id)
+            .await
+            .expect("db lookup")
+            .expect("client exists");
+        let kid = client
+            .jwks
+            .as_ref()
+            .and_then(|j| j.get("keys"))
+            .and_then(|k| k.get(0))
+            .and_then(|k| k.get("kid"))
+            .and_then(|k| k.as_str())
+            .expect("shared test JWKS has a kid")
+            .to_string();
+        (client, kid)
+    }
+
+    #[tokio::test]
+    async fn test_resolve_client_decoding_key_matches_kid() {
+        let state = make_state().await;
+        let (client, kid) = make_client_with_jwks(&state).await;
+
+        let header = JwtAssertionHeader {
+            alg: "ES256".to_string(),
+            kid: Some(kid),
+        };
+        let result = resolve_client_decoding_key(&state, &client, &header).await;
+        assert!(result.is_ok(), "matching kid must resolve a key");
+    }
+
+    #[tokio::test]
+    async fn test_resolve_client_decoding_key_falls_back_without_kid() {
+        let state = make_state().await;
+        let (client, _kid) = make_client_with_jwks(&state).await;
+
+        // No kid: single EC key in the JWKS matches the ES256 algorithm.
+        let header = JwtAssertionHeader {
+            alg: "ES256".to_string(),
+            kid: None,
+        };
+        let result = resolve_client_decoding_key(&state, &client, &header).await;
+        assert!(result.is_ok(), "single-key JWKS must match by key type");
+    }
+
+    #[tokio::test]
+    async fn test_resolve_client_decoding_key_rejects_unknown_kid() {
+        let state = make_state().await;
+        let (client, _kid) = make_client_with_jwks(&state).await;
+
+        // Inline-JWKS client (no jwks_uri): a kid miss cannot force-refresh
+        // and must fail closed.
+        let header = JwtAssertionHeader {
+            alg: "ES256".to_string(),
+            kid: Some("no-such-key".to_string()),
+        };
+        let result = resolve_client_decoding_key(&state, &client, &header).await;
+        assert!(matches!(result, Err(ClientAuthError::InvalidCredentials)));
     }
 }

--- a/crates/vouch-server/src/services/oidc/token.rs
+++ b/crates/vouch-server/src/services/oidc/token.rs
@@ -253,10 +253,6 @@ pub struct IdTokenClaims {
 ///
 /// # Errors
 /// Returns `ServiceError` for invalid requests.
-#[expect(
-    clippy::too_many_lines,
-    reason = "linear authorization-code exchange sequence"
-)]
 pub(crate) async fn exchange_authorization_code(
     state: &Arc<AppState>,
     params: AuthCodeExchangeParams<'_>,
@@ -273,63 +269,10 @@ pub(crate) async fn exchange_authorization_code(
     let code_hash = hash_token(params.code);
     let auth_code_claim = enforce_single_use_code(state, &code_hash, &auth_code).await?;
 
-    // Reject deactivated users before issuing tokens
-    let user = db::get_user_by_id(&state.store, &auth_code.user_id)
-        .await
-        .map_err(|e| ServiceError::Internal(e.to_string()))?
-        .ok_or(ServiceError::oauth(
-            OAuthErrorCode::InvalidGrant,
-            "User not found",
-        ))?;
-    if !user.active {
-        return Err(ServiceError::oauth(
-            OAuthErrorCode::InvalidGrant,
-            "User account is deactivated",
-        ));
-    }
+    let user = load_and_validate_grant_subject(state, &auth_code).await?;
 
-    // Reject tokens for revoked/deleted authenticators (GH#272)
-    let _authenticator = db::get_authenticator_by_id(&state.store, &auth_code.authenticator_id)
-        .await
-        .map_err(|e| ServiceError::Internal(e.to_string()))?
-        .ok_or(ServiceError::oauth(
-            OAuthErrorCode::InvalidGrant,
-            "Authenticator not found",
-        ))?;
-
-    // RFC 6749 Section 4.1.3: Verify the handler-authenticated client
-    // matches the authorization code's recorded client_id, and that PKCE
-    // (RFC 7636) is present when required for this client type. Client
-    // authentication itself (RFC 6749 §2.3 / RFC 7523 §2.2 / RFC 8705)
-    // ran at the handler before this function was called; here we only
-    // check consistency with the auth code.
     let authenticated_client = params.authenticated_client;
-    if let Some(client) = authenticated_client
-        && client.client.client_id != auth_code.client_id
-    {
-        tracing::warn!(
-            "Client ID mismatch: token request from {} but code was issued to {}",
-            client.client.client_id,
-            auth_code.client_id
-        );
-        return Err(ServiceError::oauth(
-            OAuthErrorCode::InvalidGrant,
-            "Client ID mismatch",
-        ));
-    }
-    if let Some(client) = authenticated_client {
-        let pkce_required = client.is_public || client.client.application_type.requires_pkce();
-        if pkce_required && auth_code.code_challenge.is_none() {
-            tracing::warn!(
-                "Client {} requires PKCE but no code_challenge was present",
-                client.client.client_id
-            );
-            return Err(ServiceError::oauth(
-                OAuthErrorCode::InvalidRequest,
-                "PKCE required for this client type",
-            ));
-        }
-    }
+    verify_client_matches_code(authenticated_client, &auth_code)?;
 
     // Validate redirect_uri, PKCE, DPoP binding, and ACR
     validate_code_bindings(
@@ -458,6 +401,86 @@ pub(crate) async fn exchange_authorization_code(
         scope: auth_code.scope,
         authorization_details: grants.authorization_details,
     })
+}
+
+/// Load the authorization code's subject and reject grants whose user is
+/// deactivated or whose authenticator has been revoked or deleted (GH#272).
+///
+/// # Errors
+/// Returns `invalid_grant` when the user or authenticator no longer
+/// qualifies for token issuance.
+async fn load_and_validate_grant_subject(
+    state: &Arc<AppState>,
+    auth_code: &AuthorizationCode,
+) -> ServiceResult<db::User> {
+    // Reject deactivated users before issuing tokens
+    let user = db::get_user_by_id(&state.store, &auth_code.user_id)
+        .await
+        .map_err(|e| ServiceError::Internal(e.to_string()))?
+        .ok_or(ServiceError::oauth(
+            OAuthErrorCode::InvalidGrant,
+            "User not found",
+        ))?;
+    if !user.active {
+        return Err(ServiceError::oauth(
+            OAuthErrorCode::InvalidGrant,
+            "User account is deactivated",
+        ));
+    }
+
+    // Reject tokens for revoked/deleted authenticators (GH#272)
+    db::get_authenticator_by_id(&state.store, &auth_code.authenticator_id)
+        .await
+        .map_err(|e| ServiceError::Internal(e.to_string()))?
+        .ok_or(ServiceError::oauth(
+            OAuthErrorCode::InvalidGrant,
+            "Authenticator not found",
+        ))?;
+
+    Ok(user)
+}
+
+/// RFC 6749 Section 4.1.3: Verify the handler-authenticated client matches
+/// the authorization code's recorded client_id, and that PKCE (RFC 7636) is
+/// present when required for this client type. Client authentication itself
+/// (RFC 6749 §2.3 / RFC 7523 §2.2 / RFC 8705) ran at the handler before
+/// `exchange_authorization_code` was called; this only checks consistency
+/// with the auth code.
+///
+/// # Errors
+/// Returns `invalid_grant` on client mismatch and `invalid_request` when a
+/// required PKCE challenge is absent.
+fn verify_client_matches_code(
+    authenticated_client: Option<&AuthenticatedClient>,
+    auth_code: &AuthorizationCode,
+) -> ServiceResult<()> {
+    if let Some(client) = authenticated_client
+        && client.client.client_id != auth_code.client_id
+    {
+        tracing::warn!(
+            "Client ID mismatch: token request from {} but code was issued to {}",
+            client.client.client_id,
+            auth_code.client_id
+        );
+        return Err(ServiceError::oauth(
+            OAuthErrorCode::InvalidGrant,
+            "Client ID mismatch",
+        ));
+    }
+    if let Some(client) = authenticated_client {
+        let pkce_required = client.is_public || client.client.application_type.requires_pkce();
+        if pkce_required && auth_code.code_challenge.is_none() {
+            tracing::warn!(
+                "Client {} requires PKCE but no code_challenge was present",
+                client.client.client_id
+            );
+            return Err(ServiceError::oauth(
+                OAuthErrorCode::InvalidRequest,
+                "PKCE required for this client type",
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Result of resolving authorization details and resource audience.
@@ -1727,5 +1750,135 @@ mod tests {
             matches!(result, Err(ClientAuthError::MtlsVerificationFailed(_))),
             "non-matching x5c must return MtlsVerificationFailed: {result:?}"
         );
+    }
+
+    // =========================================================================
+    // verify_client_matches_code
+    // =========================================================================
+
+    #[test]
+    fn test_verify_client_matches_code_no_client_ok() {
+        let auth_code = make_auth_code("");
+        assert!(verify_client_matches_code(None, &auth_code).is_ok());
+    }
+
+    #[test]
+    fn test_verify_client_matches_code_matching_confidential_client_ok() {
+        let client = AuthenticatedClient {
+            client: make_mtls_client(TokenEndpointAuthMethod::ClientSecretBasic, None),
+            is_public: false,
+        };
+        let auth_code = AuthorizationCode {
+            client_id: client.client.client_id.clone(),
+            ..make_auth_code("")
+        };
+        // Service client, not public: PKCE is not required.
+        assert!(verify_client_matches_code(Some(&client), &auth_code).is_ok());
+    }
+
+    #[test]
+    fn test_verify_client_matches_code_rejects_client_id_mismatch() {
+        let client = AuthenticatedClient {
+            client: make_mtls_client(TokenEndpointAuthMethod::ClientSecretBasic, None),
+            is_public: false,
+        };
+        // make_auth_code uses client_id "test", which differs from the client's.
+        let auth_code = make_auth_code("");
+        let result = verify_client_matches_code(Some(&client), &auth_code);
+        assert_oauth_error(result, OAuthErrorCode::InvalidGrant);
+    }
+
+    #[test]
+    fn test_verify_client_matches_code_public_client_requires_pkce() {
+        let client = AuthenticatedClient {
+            client: make_mtls_client(TokenEndpointAuthMethod::ClientSecretBasic, None),
+            is_public: true,
+        };
+        let auth_code = AuthorizationCode {
+            client_id: client.client.client_id.clone(),
+            ..make_auth_code("")
+        };
+        let result = verify_client_matches_code(Some(&client), &auth_code);
+        assert_oauth_error(result, OAuthErrorCode::InvalidRequest);
+    }
+
+    #[test]
+    fn test_verify_client_matches_code_public_client_with_pkce_ok() {
+        let client = AuthenticatedClient {
+            client: make_mtls_client(TokenEndpointAuthMethod::ClientSecretBasic, None),
+            is_public: true,
+        };
+        let auth_code = AuthorizationCode {
+            client_id: client.client.client_id.clone(),
+            code_challenge: Some("a-code-challenge".to_string()),
+            code_challenge_method: Some(CodeChallengeMethod::S256),
+            ..make_auth_code("")
+        };
+        assert!(verify_client_matches_code(Some(&client), &auth_code).is_ok());
+    }
+
+    // =========================================================================
+    // load_and_validate_grant_subject
+    // =========================================================================
+
+    use crate::test_utils::{create_test_authenticator, create_test_user, test_app_state};
+
+    #[tokio::test]
+    async fn test_grant_subject_active_user_ok() {
+        let state = test_app_state().await;
+        let user = create_test_user(&state.store, "grant-ok@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+
+        let auth_code = AuthorizationCode {
+            user_id: user.id.clone(),
+            authenticator_id: auth_id,
+            ..make_auth_code("")
+        };
+        let result = load_and_validate_grant_subject(&state, &auth_code).await;
+        let loaded = result.expect("active user with authenticator must pass");
+        assert_eq!(loaded.id, user.id);
+    }
+
+    #[tokio::test]
+    async fn test_grant_subject_rejects_unknown_user() {
+        let state = test_app_state().await;
+        let auth_code = AuthorizationCode {
+            user_id: "no-such-user".to_string(),
+            ..make_auth_code("")
+        };
+        let result = load_and_validate_grant_subject(&state, &auth_code).await;
+        assert_oauth_error(result, OAuthErrorCode::InvalidGrant);
+    }
+
+    #[tokio::test]
+    async fn test_grant_subject_rejects_deactivated_user() {
+        let state = test_app_state().await;
+        let user = create_test_user(&state.store, "grant-inactive@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        db::update_user_active_status(&state.store, &user.id, false)
+            .await
+            .expect("deactivate user");
+
+        let auth_code = AuthorizationCode {
+            user_id: user.id.clone(),
+            authenticator_id: auth_id,
+            ..make_auth_code("")
+        };
+        let result = load_and_validate_grant_subject(&state, &auth_code).await;
+        assert_oauth_error(result, OAuthErrorCode::InvalidGrant);
+    }
+
+    #[tokio::test]
+    async fn test_grant_subject_rejects_missing_authenticator() {
+        let state = test_app_state().await;
+        let user = create_test_user(&state.store, "grant-no-auth@example.com").await;
+
+        let auth_code = AuthorizationCode {
+            user_id: user.id.clone(),
+            authenticator_id: "revoked-and-deleted".to_string(),
+            ..make_auth_code("")
+        };
+        let result = load_and_validate_grant_subject(&state, &auth_code).await;
+        assert_oauth_error(result, OAuthErrorCode::InvalidGrant);
     }
 }


### PR DESCRIPTION
## Summary

Removes two `clippy::too_many_lines` escapes from the OIDC token path by extracting independently testable units (refs #662). Issue #662's core complaint was that these rules could only be exercised end-to-end over HTTP.

**`authenticate_client_jwt`** (services/oidc/jwt_bearer/client_auth.rs):
- `resolve_client_decoding_key` — JWKS cache load, inline/URI resolution, and key selection with kid-miss force-refresh, as one named step.
- `verify_assertion_subject` — the RFC 7523 §3 `iss`/`sub`/`client_id` consistency rules as a pure function.

**`exchange_authorization_code`** (services/oidc/token.rs) — joins the existing `validate_code_bindings` / `resolve_authorization_details` helper idiom in that file:
- `load_and_validate_grant_subject` — deactivated-user and revoked/deleted-authenticator rejection.
- `verify_client_matches_code` — client-matches-code and PKCE-required consistency (pure).

Behavior-preserving: logic, log lines, error mapping, and check ordering are unchanged.

## Tests

15 new unit tests: kid match/miss/no-kid-fallback key resolution, iss/sub/hint mismatch permutations, public-client PKCE enforcement, and grant-subject rejections. Mutation-checked: inverting one branch in each file made exactly the new tests fail.

- `cargo test -p vouch-server --all-features services::oidc::` — 499 passed
- rfc7523 (27), rfc6749 (36), fapi2 (21) e2e suites — all passing
- `cargo clippy --all-targets --all-features` — clean with both annotations removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with preserved logic and new unit tests; touches token issuance validation but does not alter OAuth semantics.
> 
> **Overview**
> Refactors the OIDC **private_key_jwt** and **authorization-code exchange** paths by pulling logic into named helpers so rules can be covered with unit tests instead of only HTTP e2e (refs #662). **No behavior change**—check order, logging, and error mapping stay the same; two `clippy::too_many_lines` suppressions are removed.
> 
> In **`authenticate_client_jwt`**, RFC 7523 §3 **`iss`/`sub`/body `client_id`** checks move to pure **`verify_assertion_subject`**, and JWKS cache load, inline/`jwks_uri` resolution, and kid-miss refresh move to **`resolve_client_decoding_key`**.
> 
> In **`exchange_authorization_code`**, deactivated users and missing/revoked authenticators are handled in **`load_and_validate_grant_subject`**, and auth-code **client_id** consistency plus **PKCE-required** checks move to pure **`verify_client_matches_code`**, matching the existing `validate_code_bindings` / `resolve_authorization_details` pattern.
> 
> Adds **15 unit tests** for these helpers (JWKS kid match/miss/fallback, iss/sub/hint permutations, public-client PKCE, grant-subject rejections).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4b78d1b17b10600e1dee1815e3776133d5323ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->