### PR TITLE
fix(server): align application create/update behavior across API and web

### DIFF
--- a/crates/vouch-server/src/handlers/applications/api.rs
+++ b/crates/vouch-server/src/handlers/applications/api.rs
@@ -204,14 +204,26 @@ pub(crate) async fn create_application_api(
         let secret = generate_client_secret();
         let secret_hash = hash_token(&secret);
 
-        db::create_oauth_client_secret(
+        if let Err(e) = db::create_oauth_client_secret(
             &state.store,
             &client.id,
             &secret_hash,
             Some("Initial secret"),
             None,
         )
-        .await?;
+        .await
+        {
+            tracing::error!("Failed to create client secret: {e}");
+            // Remove the just-created client so a failed registration does
+            // not leave a secretless confidential client behind (matches
+            // the web form path).
+            if let Err(cleanup_err) = db::delete_oauth_client(&state.store, &client.id).await {
+                tracing::warn!(
+                    "Failed to clean up OAuth client after secret creation failure: {cleanup_err}"
+                );
+            }
+            return Err(e);
+        }
 
         Some(secret)
     } else {

--- a/crates/vouch-server/src/handlers/applications/web.rs
+++ b/crates/vouch-server/src/handlers/applications/web.rs
@@ -5,7 +5,7 @@
 //! self-service application management portal.
 
 use crate::AppState;
-use crate::db::{self, AccessScope, FapiProfile, TokenEndpointAuthMethod, UpdateOAuthClientParams};
+use crate::db::{self, AccessScope, UpdateOAuthClientParams};
 use axum::{
     Form,
     extract::{Path, State},
@@ -22,7 +22,8 @@ use super::types::{
 };
 use super::validate::{
     AppValidationError, CreateAppContext, CreateAppInput, UpdateAppInput, build_create_params,
-    validate_create_application, validate_update_fapi, validate_update_format,
+    compute_fapi_update_fields, validate_create_application, validate_update_fapi,
+    validate_update_format,
 };
 use super::{
     extract_auth_from_cookie, generate_client_secret, parse_redirect_uris, parse_resource_uris,
@@ -418,48 +419,12 @@ pub(crate) async fn update_application_form(
     if let Err(e) = validate_update_fapi(&validated, &client) {
         return validation_error_response(&e, format!("/applications/{}", app_id));
     }
-    let is_fapi = validated.is_fapi;
-    let jwks_value = validated.jwks;
-    let jwks_uri_trimmed = validated.jwks_uri;
 
-    // Compute FAPI-related values: merge form values with existing client values
-    let fapi_profile = if is_fapi {
-        FapiProfile::Fapi2Security
-    } else {
-        FapiProfile::None
-    };
-
-    let token_endpoint_auth_method = if is_fapi {
-        TokenEndpointAuthMethod::PrivateKeyJwt
-    } else if !is_fapi && client.is_fapi() {
-        // Transitioning from FAPI to Standard: reset to default
-        TokenEndpointAuthMethod::ClientSecretBasic
-    } else {
-        client.token_endpoint_auth_method
-    };
-
-    // Resolve final JWKS values: use form values if provided, otherwise keep existing
-    let effective_jwks = if jwks_value.is_some() {
-        jwks_value.as_ref()
-    } else if is_fapi {
-        client.jwks.as_ref()
-    } else {
-        None
-    };
-
-    let effective_jwks_uri = if jwks_uri_trimmed.is_some() {
-        jwks_uri_trimmed
-    } else if is_fapi {
-        client.jwks_uri.as_deref()
-    } else {
-        None
-    };
-
-    let dpop_bound = if is_fapi {
-        true
-    } else {
-        client.dpop_bound_access_tokens
-    };
+    // Merge FAPI-related fields against the existing client record. The
+    // form's security-profile radio group always submits fapi_profile, so
+    // an explicit non-FAPI value transitions the client back to standard
+    // auth — including resetting the DPoP binding, matching the JSON API.
+    let fapi = compute_fapi_update_fields(&validated, &client);
 
     // Update the application
     if let Err(e) = db::update_oauth_client(
@@ -472,11 +437,11 @@ pub(crate) async fn update_application_form(
             access_scope,
             org_id,
             resource_uris: &resource_uris,
-            token_endpoint_auth_method,
-            jwks: effective_jwks,
-            jwks_uri: effective_jwks_uri,
-            fapi_profile,
-            dpop_bound_access_tokens: dpop_bound,
+            token_endpoint_auth_method: fapi.token_endpoint_auth_method,
+            jwks: fapi.jwks,
+            jwks_uri: fapi.jwks_uri,
+            fapi_profile: fapi.fapi_profile,
+            dpop_bound_access_tokens: fapi.dpop_bound_access_tokens,
             post_logout_redirect_uris: validated.post_logout_redirect_uris.map(<[String]>::to_vec),
         },
     )
@@ -910,5 +875,59 @@ mod tests {
             vec!["https://example.com/callback".to_string()],
             "Empty redirect_uris must not overwrite existing uris in the database"
         );
+    }
+
+    #[tokio::test]
+    async fn test_web_update_form_fapi_exit_resets_dpop_binding() {
+        // Transitioning a FAPI client back to the standard profile via the
+        // web form must reset the DPoP binding and auth method, matching
+        // the JSON API's update semantics.
+        let (app, state) = test_app().await;
+        let user = create_test_user(&state.store, "web-update-fapi-exit@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let client = create_test_client(
+            &state.store,
+            &user.id,
+            TestClientSpec {
+                token_endpoint_auth_method: Some(crate::db::TokenEndpointAuthMethod::PrivateKeyJwt),
+                jwks: TestJwks::Shared,
+                dpop_bound_access_tokens: true,
+                fapi_profile: Some(crate::db::FapiProfile::Fapi2Security),
+                with_secret: false,
+                ..Default::default()
+            },
+        )
+        .await;
+
+        // The security-profile radio group always submits; "" selects Standard.
+        let form_body =
+            "name=Test%20App&redirect_uris=https%3A%2F%2Fexample.com%2Fcallback&fapi_profile=";
+        let (status, body) = http_post_form(
+            &app,
+            &format!("/applications/{}", client.app_id),
+            form_body,
+            &[("Cookie", &format!("__Host-vouch_session={session_token}"))],
+        )
+        .await;
+        assert!(
+            status.is_redirection(),
+            "FAPI exit must succeed with a redirect, got {status}: {body}"
+        );
+
+        let record = crate::db::get_oauth_client_by_id(&state.store, &client.app_id)
+            .await
+            .expect("db query ok")
+            .expect("client must still exist");
+        assert_eq!(record.fapi_profile, crate::db::FapiProfile::None);
+        assert_eq!(
+            record.token_endpoint_auth_method,
+            crate::db::TokenEndpointAuthMethod::ClientSecretBasic
+        );
+        assert!(
+            !record.dpop_bound_access_tokens,
+            "leaving FAPI must clear the DPoP binding"
+        );
+        assert!(record.jwks.is_none(), "leaving FAPI must drop the JWKS");
     }
 }


### PR DESCRIPTION
## Summary

Fixes two behavior divergences between the JSON API and web form application paths, found while consolidating them in #733 (this PR is stacked on that branch; GitHub will retarget to main when #733 merges):

- **Orphaned client on secret failure (API create):** when the initial client-secret insert failed, the API path propagated the error but left the just-created client row behind — a confidential client with no secret. It now deletes the client before returning the error, matching the web path's existing compensating cleanup.
- **DPoP binding survives FAPI exit (web update):** transitioning a client off the FAPI profile via the web form reset the profile and auth method but kept `dpop_bound_access_tokens` — leaving a standard client with a stale DPoP requirement. The web update now uses the shared `compute_fapi_update_fields` merge from #733, resetting the binding like the API. Side effect: an absent `fapi_profile` field (not producible by the real form — the security-profile radio group always submits) now preserves the existing profile instead of clearing it, matching the API's PATCH semantics.

## Tests

- New: `test_web_update_form_fapi_exit_resets_dpop_binding` — FAPI client updated to Standard via the form; asserts profile, auth method, DPoP flag, and JWKS are all reset in the DB.
- `cargo test -p vouch-server --all-features handlers::applications::` — 67 passed.
- The secret-failure cleanup path has no test — it requires DB fault injection to trigger; the change mirrors the already-shipped web-path cleanup verbatim.
- `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth client registration and FAPI/DPoP client settings; incorrect merge could break token or auth behavior for existing apps, but changes are narrow parity fixes with a new regression test.
> 
> **Overview**
> Aligns OAuth application **create** and **update** behavior between the JSON API and the web portal.
> 
> **API create:** If storing the initial client secret fails after the client row is created, the handler now **deletes the new client** before returning the error, avoiding orphaned confidential clients with no secret (same compensating cleanup the web form already had).
> 
> **Web update:** Replaces duplicated FAPI field merging with shared **`compute_fapi_update_fields`**. Switching from FAPI to Standard via the form now clears **DPoP binding**, resets **token endpoint auth** to `client_secret_basic`, and drops **JWKS**—matching the API PATCH path.
> 
> Adds **`test_web_update_form_fapi_exit_resets_dpop_binding`** to lock in the web FAPI-exit semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c9f8a602f6cc873eef87b08027cca8f3580ce0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->