### PR TITLE
fix: nine bug fixes from the Detail reports (#740-#748)

### DIFF
--- a/crates/vouch-cli/src/commands/doctor.rs
+++ b/crates/vouch-cli/src/commands/doctor.rs
@@ -521,15 +521,10 @@ fn check_ssh_config() -> CheckResult {
 
 /// Check EKS configuration for Vouch integration.
 fn check_eks_config() -> CheckResult {
-    let home = match dirs::home_dir() {
-        Some(h) => h,
-        None => return CheckResult::fail("eks", tr!("doctor-eks-no-home")),
+    let kubeconfig_path = match crate::commands::setup::kubeconfig::default_kubeconfig_path() {
+        Ok(p) => p,
+        Err(_) => return CheckResult::fail("eks", tr!("doctor-eks-no-home")),
     };
-
-    let kubeconfig_path = std::env::var("KUBECONFIG")
-        .ok()
-        .and_then(|k| k.split(':').next().map(std::path::PathBuf::from))
-        .unwrap_or_else(|| home.join(".kube").join("config"));
 
     if !kubeconfig_path.exists() {
         return CheckResult::pass("eks", tr!("doctor-eks-no-kubeconfig"));

--- a/crates/vouch-cli/src/commands/setup/kubeconfig.rs
+++ b/crates/vouch-cli/src/commands/setup/kubeconfig.rs
@@ -3,6 +3,7 @@
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use std::ffi::OsStr;
 use std::path::PathBuf;
 
 use crate::utils::ensure_secure_dir;
@@ -102,13 +103,30 @@ pub(crate) struct EnvVar {
 // Kubeconfig Helpers
 // ============================================================================
 
-/// Get the default kubeconfig path (~/.kube/config).
+/// Pick the effective kubeconfig path from a `KUBECONFIG` value.
+///
+/// `KUBECONFIG` holds a platform-separated list of paths (`:` on Unix, `;` on
+/// Windows), so it must be split with [`std::env::split_paths`] rather than a
+/// hardcoded separator — on Windows `:` is the drive separator and splitting on
+/// it truncates `D:\kube\config` to `D`. Returns the first non-empty entry, or
+/// `None` when the value is empty or contains only empty entries.
+///
+/// Split out from [`default_kubeconfig_path`] so it can be tested without
+/// mutating process environment variables.
+fn first_kubeconfig_entry(kubeconfig: &OsStr) -> Option<PathBuf> {
+    std::env::split_paths(kubeconfig).find(|p| !p.as_os_str().is_empty())
+}
+
+/// Get the default kubeconfig path.
+///
+/// Honors `KUBECONFIG` (first non-empty entry), falling back to
+/// `~/.kube/config` when it is unset or holds no usable entry.
 pub(crate) fn default_kubeconfig_path() -> Result<PathBuf> {
-    if let Ok(kubeconfig) = std::env::var("KUBECONFIG")
-        && let Some(first_path) = kubeconfig.split(':').next()
-        && !first_path.is_empty()
+    if let Some(path) = std::env::var_os("KUBECONFIG")
+        .as_deref()
+        .and_then(first_kubeconfig_entry)
     {
-        return Ok(PathBuf::from(first_path));
+        return Ok(path);
     }
 
     let home = dirs::home_dir().with_context(|| vouch_cli::tr!("setup-err-no-home"))?;
@@ -205,6 +223,55 @@ pub(crate) fn existing_user_other(config: &Kubeconfig, name: &str) -> serde_json
 )]
 mod tests {
     use super::*;
+
+    /// Join path entries with the platform list separator so these tests assert
+    /// the same behavior on Unix (`:`) and Windows (`;`).
+    fn join(entries: &[&str]) -> std::ffi::OsString {
+        std::env::join_paths(entries.iter().map(std::ffi::OsStr::new)).expect("join_paths failed")
+    }
+
+    #[test]
+    fn kubeconfig_entry_returns_first_of_many() {
+        let value = join(&["/first/config", "/second/config"]);
+        assert_eq!(
+            first_kubeconfig_entry(&value),
+            Some(PathBuf::from("/first/config"))
+        );
+    }
+
+    #[test]
+    fn kubeconfig_entry_preserves_single_path() {
+        assert_eq!(
+            first_kubeconfig_entry(std::ffi::OsStr::new("/only/config")),
+            Some(PathBuf::from("/only/config"))
+        );
+    }
+
+    #[test]
+    fn kubeconfig_entry_skips_leading_empty_entry() {
+        let value = join(&["", "/second/config"]);
+        assert_eq!(
+            first_kubeconfig_entry(&value),
+            Some(PathBuf::from("/second/config"))
+        );
+    }
+
+    #[test]
+    fn kubeconfig_entry_is_none_when_unusable() {
+        // Empty, and all-empty entries, both fall through to ~/.kube/config.
+        assert_eq!(first_kubeconfig_entry(std::ffi::OsStr::new("")), None);
+        assert_eq!(first_kubeconfig_entry(&join(&["", ""])), None);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn kubeconfig_entry_keeps_windows_drive_letter() {
+        // The bug this guards: splitting on ':' truncates `D:\...` to `D`.
+        assert_eq!(
+            first_kubeconfig_entry(std::ffi::OsStr::new(r"D:\kube\config")),
+            Some(PathBuf::from(r"D:\kube\config"))
+        );
+    }
 
     #[test]
     fn test_kubeconfig_parsing() {

--- a/crates/vouch-cli/src/commands/setup/ssm.rs
+++ b/crates/vouch-cli/src/commands/setup/ssm.rs
@@ -110,39 +110,73 @@ fn ssm_block_host_pattern(content: &str) -> Option<&str> {
     None
 }
 
+/// Is this line the start of a top-level `ssh_config` stanza?
+///
+/// Stanza keywords sit in column 0; anything indented belongs to the stanza
+/// above it. Matched case-insensitively, and `Host=x` is accepted alongside
+/// `Host x`, because failing to recognize a stanza start is what makes
+/// [`strip_ssm_block`] delete a user's entries.
+fn is_stanza_start(line: &str) -> bool {
+    if line.starts_with([' ', '\t']) {
+        return false;
+    }
+    let keyword = line.split([' ', '\t', '=']).next().unwrap_or("");
+    keyword.eq_ignore_ascii_case("Host") || keyword.eq_ignore_ascii_case("Match")
+}
+
 /// Remove an existing SSM config block from the SSH config content.
 ///
-/// Finds the block starting with `SSM_MARKER` and removes everything up to
-/// the next blank line or end of file.
+/// The block runs from `SSM_MARKER` to the next blank line, the next top-level
+/// stanza, or end of file — whichever comes first. Terminating on a stanza
+/// matters because the block is not required to be followed by a blank line;
+/// keying only on `"\n\n"` ran to end of file and deleted every entry the user
+/// kept after it.
+///
+/// The block emits its own column-0 `Host` line, so the first stanza start
+/// after the marker is part of the block; only the second one ends it.
+///
+/// Lines are reassembled with their original terminators, so content outside
+/// the block round-trips byte for byte.
 fn strip_ssm_block(content: &str) -> String {
-    let Some(start) = content.find(SSM_MARKER) else {
-        return content.to_string();
-    };
+    let mut result = String::with_capacity(content.len());
+    let mut in_block = false;
+    let mut block_seen = false;
+    let mut own_stanza_seen = false;
 
-    // Walk backwards from the marker to consume the leading newline
-    let block_start =
-        if start > 0 && content.as_bytes().get(start.saturating_sub(1)) == Some(&b'\n') {
-            start.saturating_sub(1)
+    for line in content.split_inclusive('\n') {
+        if !in_block {
+            if !block_seen && line.contains(SSM_MARKER) {
+                // The block is written with a blank separator line before the
+                // marker; drop it so removal doesn't leave a widening gap.
+                if result.ends_with("\n\n") {
+                    result.pop();
+                }
+                in_block = true;
+                block_seen = true;
+            } else {
+                result.push_str(line);
+            }
+            continue;
+        }
+
+        let trimmed = line.trim_end_matches(['\n', '\r']);
+        let ends_block = if trimmed.is_empty() {
+            true
+        } else if is_stanza_start(trimmed) {
+            // First stanza after the marker is the block's own `Host` line.
+            let is_own = !own_stanza_seen;
+            own_stanza_seen = true;
+            !is_own
         } else {
-            start
+            false
         };
 
-    // Split safely at ASCII boundaries (SSM_MARKER and newlines are ASCII)
-    let (before, from_marker) = content.split_at(block_start);
+        if ends_block {
+            in_block = false;
+            result.push_str(line);
+        }
+    }
 
-    // Find the end of the block in the remaining content: look for a blank
-    // line or treat everything as the block.
-    let marker_offset = start.saturating_sub(block_start);
-    let after_marker = from_marker.get(marker_offset..).unwrap_or("");
-    let block_rest_len = after_marker.find("\n\n").map_or(from_marker.len(), |pos| {
-        marker_offset.saturating_add(pos).saturating_add(1)
-    });
-
-    let after = from_marker.get(block_rest_len..).unwrap_or("");
-
-    let mut result = String::with_capacity(content.len());
-    result.push_str(before);
-    result.push_str(after);
     result
 }
 
@@ -426,5 +460,58 @@ mod tests {
         let content = "Host *\n    ServerAliveInterval 60\n";
         let result = strip_ssm_block(content);
         assert_eq!(result, content);
+    }
+
+    /// The regression for #741: without a blank line after the SSM block, the
+    /// old `find("\n\n")` fell through to end of file and deleted the rest of
+    /// the user's config.
+    #[test]
+    fn test_strip_ssm_block_keeps_adjacent_host_without_blank_line() {
+        let content = format!(
+            "Host *\n    ServerAliveInterval 60\n\
+             \n{SSM_MARKER}\n# Added by: vouch setup ssm\n\
+             Host i-* mi-*\n    ProxyCommand sh -c \"aws ssm start-session\"\n\
+             Host other\n    Port 22\n"
+        );
+        let result = strip_ssm_block(&content);
+
+        // The following entry survives in full.
+        assert!(result.contains("Host other"), "result: {result:?}");
+        assert!(result.contains("Port 22"), "result: {result:?}");
+        assert!(result.contains("ServerAliveInterval"), "result: {result:?}");
+
+        // ...and the block is gone in full. The block emits its own column-0
+        // `Host` line, so a scan that stops at the first stanza start would
+        // leave the ProxyCommand line orphaned under `Host *`.
+        assert!(!result.contains(SSM_MARKER), "result: {result:?}");
+        assert!(!result.contains("Added by"), "result: {result:?}");
+        assert!(!result.contains("i-* mi-*"), "result: {result:?}");
+        assert!(!result.contains("ProxyCommand"), "result: {result:?}");
+    }
+
+    #[test]
+    fn test_strip_ssm_block_stops_at_match_stanza() {
+        let content = format!(
+            "{SSM_MARKER}\n# Added by: vouch setup ssm\n\
+             Host i-* mi-*\n    ProxyCommand sh -c \"aws ssm start-session\"\n\
+             Match host bastion\n    User admin\n"
+        );
+        let result = strip_ssm_block(&content);
+        assert!(!result.contains("ProxyCommand"), "result: {result:?}");
+        assert_eq!(result, "Match host bastion\n    User admin\n");
+    }
+
+    /// Content outside the block must survive byte for byte, including the
+    /// absence of a trailing newline.
+    #[test]
+    fn test_strip_ssm_block_preserves_surrounding_bytes() {
+        let content = format!(
+            "Host a\n    Port 1\n\
+             \n{SSM_MARKER}\n# Added by: vouch setup ssm\n\
+             Host i-*\n    ProxyCommand sh -c \"x\"\n\
+             \nHost b\n    Port 2"
+        );
+        let result = strip_ssm_block(&content);
+        assert_eq!(result, "Host a\n    Port 1\n\nHost b\n    Port 2");
     }
 }

--- a/crates/vouch-cli/src/integrations/eks.rs
+++ b/crates/vouch-cli/src/integrations/eks.rs
@@ -2,7 +2,6 @@
 //! Amazon EKS integration status checking.
 
 use serde::Deserialize;
-use std::path::PathBuf;
 
 use super::{ConfiguredDetails, IntegrationCheck, IntegrationState};
 
@@ -89,21 +88,9 @@ impl IntegrationCheck for EksIntegration {
     }
 }
 
-/// Get the default kubeconfig path.
-fn default_kubeconfig_path() -> Option<PathBuf> {
-    if let Ok(kubeconfig) = std::env::var("KUBECONFIG")
-        && let Some(first_path) = kubeconfig.split(':').next()
-        && !first_path.is_empty()
-    {
-        return Some(PathBuf::from(first_path));
-    }
-
-    dirs::home_dir().map(|h| h.join(".kube").join("config"))
-}
-
 /// Find all kubeconfig contexts using `vouch credential eks`.
 fn find_vouch_eks_contexts() -> Vec<String> {
-    let kubeconfig_path = match default_kubeconfig_path() {
+    let kubeconfig_path = match crate::commands::setup::kubeconfig::default_kubeconfig_path().ok() {
         Some(p) if p.exists() => p,
         _ => return Vec::new(),
     };

--- a/crates/vouch-server/i18n/en-US/vouch-server.ftl
+++ b/crates/vouch-server/i18n/en-US/vouch-server.ftl
@@ -259,7 +259,12 @@ login-cert-test-deny = Certification Test Deny
 
 ## Generic error page (error.html)
 error-page-title = { -product } - Error
+error-heading = Error
 error-back = Back
+
+## Enrollment failures (error.html, rendered from handlers/enroll.rs)
+enroll-error-device-auth-approve-failed = Failed to approve the sign-in request. Please run the command again.
+enroll-error-session-create-failed = Failed to start enrollment. Please run the command again.
 
 ## Enrollment success (success.html)
 success-page-title = { -product } - Success

--- a/crates/vouch-server/i18n/en-US/vouch-server.ftl
+++ b/crates/vouch-server/i18n/en-US/vouch-server.ftl
@@ -265,6 +265,25 @@ error-back = Back
 ## Enrollment failures (error.html, rendered from handlers/enroll.rs)
 enroll-error-device-auth-approve-failed = Failed to approve the sign-in request. Please run the command again.
 enroll-error-session-create-failed = Failed to start enrollment. Please run the command again.
+enroll-error-unknown-provider-title = Unknown Provider
+enroll-error-unknown-provider = Identity provider '{ $slug }' is not configured.
+enroll-error-not-configured-title = Not Configured
+enroll-error-idp-not-configured = Identity provider is not configured. Please contact your administrator.
+enroll-error-oidc-not-configured = OIDC not configured. If using SAML, responses should be sent to /saml/acs, not /oauth/callback.
+enroll-error-auth-start-failed = Failed to start authentication
+enroll-error-state-create-failed = Failed to create session state
+enroll-error-missing-code = Missing authorization code
+enroll-error-missing-state = Missing state parameter
+enroll-error-invalid-state = Invalid state parameter
+enroll-error-state-expired = Invalid or expired state
+enroll-error-state-verify-failed = Failed to verify state
+enroll-error-auth-complete-failed = Failed to complete authentication
+enroll-error-token-verify-failed = Failed to verify identity token
+enroll-error-domain-not-allowed-title = Domain Not Allowed
+enroll-error-domain-not-allowed = Only users from the following domains can enroll: { $domains }. Your email ({ $email }) is not from an allowed domain.
+enroll-error-user-create-failed = Failed to create user
+enroll-error-session-failed = Failed to create session
+enroll-error-enrollment-start-failed = Failed to start enrollment. Please try again.
 
 ## Enrollment success (success.html)
 success-page-title = { -product } - Success

--- a/crates/vouch-server/src/db/enrollment.rs
+++ b/crates/vouch-server/src/db/enrollment.rs
@@ -199,6 +199,17 @@ pub async fn enroll_user_with_org(
             // winner's user row and admin slot are now visible) and commits a
             // non-admin user. A non-claiming loser merely raced the
             // opportunistic `created_by_user_id` repair and proceeds.
+            // Only a member of this org may occupy its admin slot. An existing
+            // user keeps the `org_id` from their own row, so enrolling through
+            // a domain that resolves to some other org would otherwise write
+            // their id into that org's `created_by_user_id` — filling the slot
+            // with a non-member and leaving the org's first real enrollee
+            // permanently non-admin. A newly inserted user is always built with
+            // this same `org_id`, so the legitimate first-admin claim still
+            // passes.
+            let claimable_org =
+                claimable_org.filter(|org_doc| user.org_id.as_deref() == Some(org_doc.id.as_str()));
+
             if let Some(org_doc) = claimable_org {
                 let mut data = org_doc.data;
                 data.created_by_user_id = Some(user.id.clone());

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -118,12 +118,11 @@ pub use config::{AuthEventParams, AuthEventType, ClientInfo, spawn_audit_event};
 // Re-export SCIM types and functions
 pub use scim::{
     ScimFilterError, ScimGroupRecord, ScimScope, ScimScopeSet, ScimToken, ScimUserRecord,
-    add_scim_group_member, count_active_scim_tokens, create_scim_group, create_scim_token,
-    create_scim_user, delete_expired_scim_tokens, delete_scim_group, delete_scim_token,
-    get_scim_group, get_scim_group_members, get_scim_token_by_hash, get_scim_user,
-    insert_scim_audit, list_scim_groups, list_scim_tokens, list_scim_users,
-    remove_scim_group_member, replace_scim_group_members, update_scim_group,
-    update_scim_token_last_used, update_scim_user,
+    add_scim_group_member, create_scim_group, create_scim_token, create_scim_user,
+    delete_expired_scim_tokens, delete_scim_group, delete_scim_token, get_scim_group,
+    get_scim_group_members, get_scim_token_by_hash, get_scim_user, insert_scim_audit,
+    list_scim_groups, list_scim_tokens, list_scim_users, remove_scim_group_member,
+    replace_scim_group_members, update_scim_group, update_scim_token_last_used, update_scim_user,
 };
 
 // Re-export credential audit payload types (envelope + per-kind details)

--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -391,23 +391,27 @@ pub async fn update_oauth_client(
 /// Delete an OAuth client permanently.
 ///
 /// Cascade deletes secrets and the client within a single transaction
-/// so no orphaned secrets remain on partial failure.
+/// so no orphaned secrets remain on partial failure. Each delete is
+/// idempotent, so the transaction is safe to retry on a transient
+/// serialization failure.
 pub async fn delete_oauth_client(store: &DocumentStore, id: &str) -> Result<u64> {
-    let mut tx = store.begin().await?;
+    crate::with_dsql_retry!(async {
+        let mut tx = store.begin().await?;
 
-    // Delete secrets
-    tx.delete_by_index::<OAuthClientSecretDoc>("oauth_client_id", id)
-        .await?;
+        // Delete secrets
+        tx.delete_by_index::<OAuthClientSecretDoc>("oauth_client_id", id)
+            .await?;
 
-    // Delete the client's JWKS cache in the same transaction so it can never
-    // outlive the client
-    tx.delete(&super::jwks_cache::cache_id(id)).await?;
+        // Delete the client's JWKS cache in the same transaction so it can never
+        // outlive the client
+        tx.delete(&super::jwks_cache::cache_id(id)).await?;
 
-    // Delete the client
-    tx.delete(id).await?;
+        // Delete the client
+        tx.delete(id).await?;
 
-    tx.commit().await?;
-    Ok(1)
+        tx.commit().await?;
+        Ok(1)
+    })
 }
 
 /// Update last used timestamp for an OAuth client.

--- a/crates/vouch-server/src/db/scim.rs
+++ b/crates/vouch-server/src/db/scim.rs
@@ -4,9 +4,11 @@
 use super::audit::{AuditEventKind, AuditStore};
 use super::document_type::{Document, DocumentType};
 use super::documents::audit::ScimAuditData;
+use super::documents::organization::OrganizationDoc;
 use super::documents::scim::{ScimGroupDoc, ScimGroupMemberDoc, ScimTokenDoc};
 use super::documents::user::UserDoc;
 use super::store::DocumentStore;
+use crate::error::ServiceError;
 use anyhow::Result;
 use jiff::Timestamp;
 
@@ -174,27 +176,118 @@ pub async fn update_scim_token_last_used(store: &DocumentStore, token_id: &str) 
     store.update_last_used_at(token_id).await
 }
 
-/// Create a new SCIM token.
+/// Maximum SCIM tokens an organization may hold at once (supports rotation).
+pub(crate) const MAX_SCIM_TOKENS: usize = 2;
+
+/// Create an organization's SCIM token, enforcing [`MAX_SCIM_TOKENS`] atomically.
+///
+/// The cap cannot be enforced by counting in the handler and then inserting:
+/// two concurrent requests both observe `active < MAX_SCIM_TOKENS` and both
+/// insert, leaving the organization over the limit. DSQL has no row locks, so
+/// the organization document's version is the serialization point — every
+/// creator must win a `compare_and_update` against it. Concurrent creators
+/// therefore collide on one row, and the loser re-runs against fresh state.
+///
+/// # Errors
+///
+/// - `ServiceError::NotFound` — organization does not exist.
+/// - `ServiceError::Api(409 "token_limit_reached")` — cap reached (terminal).
+/// - `ServiceError::Api(409 "conflict")` — OCC retry budget exhausted; caller may retry.
 pub async fn create_scim_token(
     store: &DocumentStore,
+    org_id: &str,
     token_hash: &str,
     description: Option<&str>,
     expires_at: Option<Timestamp>,
-    org_id: Option<&str>,
-    scope: Option<&ScimScopeSet>,
-) -> Result<String> {
-    let default_scope = ScimScopeSet::default();
-    let scope_val = scope.unwrap_or(&default_scope).as_db_string();
+) -> Result<String, ServiceError> {
+    // Owned copies so the async block, which re-runs on retry, can borrow them.
+    let org_id = org_id.to_string();
+    let token_hash = token_hash.to_string();
+    let description = description.map(String::from);
 
-    let doc = ScimTokenDoc {
-        token_hash: token_hash.to_string(),
-        org_id: org_id.map(String::from),
-        description: description.map(String::from),
-        expires_at,
-        scope: scope_val,
-    };
-    let result = store.insert(&doc).await?;
-    Ok(result.id)
+    crate::with_dsql_retry!(async {
+        let mut tx = store.begin().await.map_err(|e| {
+            ServiceError::from_db_contention(e, "Failed to begin transaction for SCIM token create")
+        })?;
+
+        let org_doc = tx
+            .get::<OrganizationDoc>(&org_id)
+            .await
+            .map_err(|e| {
+                ServiceError::from_db_contention(
+                    e,
+                    "Failed to load organization for SCIM token create",
+                )
+            })?
+            .ok_or(ServiceError::NotFound("organization"))?;
+
+        // Count by filtering rather than SQL COUNT: expired tokens are retained
+        // until cleanup runs but cannot authenticate, so they must not consume a
+        // slot. Matches the expiry rule in `get_scim_token_by_hash`.
+        let now = Timestamp::now();
+        let active = tx
+            .find_all::<ScimTokenDoc>("org_id", &org_id)
+            .await
+            .map_err(|e| {
+                ServiceError::from_db_contention(e, "Failed to list SCIM tokens for cap check")
+            })?
+            .iter()
+            .filter(|doc| doc.data.expires_at.is_none_or(|exp| exp > now))
+            .count();
+
+        if active >= MAX_SCIM_TOKENS {
+            // Terminal business error — retrying cannot help.
+            return Err(ServiceError::api(
+                axum::http::StatusCode::CONFLICT,
+                "token_limit_reached",
+                "Maximum of 2 SCIM tokens per organization. Revoke one before creating another.",
+            ));
+        }
+
+        let doc = ScimTokenDoc {
+            token_hash: token_hash.clone(),
+            org_id: Some(org_id.clone()),
+            description: description.clone(),
+            expires_at,
+            scope: ScimScopeSet::default().as_db_string(),
+        };
+        let inserted = tx
+            .insert(&doc)
+            .await
+            .map_err(|e| ServiceError::from_db_contention(e, "Failed to insert SCIM token"))?;
+
+        // Version-bump the organization. This is what makes the cap atomic: a
+        // concurrent creator that committed after our read changed the version,
+        // so this returns Ok(false) and the whole block re-runs with its token
+        // visible in the count.
+        let won = tx
+            .compare_and_update::<OrganizationDoc>(&org_id, org_doc.version, &org_doc.data)
+            .await
+            .map_err(|e| {
+                ServiceError::from_db_contention(
+                    e,
+                    "Failed to version-bump org for SCIM token create",
+                )
+            })?;
+
+        if !won {
+            return Err(ServiceError::OccConflict);
+        }
+
+        tx.commit().await.map_err(|e| {
+            ServiceError::from_db_contention(e, "Failed to commit SCIM token create")
+        })?;
+
+        Ok(inserted.id)
+    })
+    .map_err(|e| match e {
+        ServiceError::OccConflict => ServiceError::api(
+            axum::http::StatusCode::CONFLICT,
+            "conflict",
+            "SCIM token creation conflicted with a concurrent operation. Please retry.",
+        ),
+        other => other,
+    })
 }
 
 /// Delete a SCIM token, scoped to the given organization.
@@ -231,20 +324,6 @@ pub async fn list_scim_tokens(
         store.list_all::<ScimTokenDoc>().await?
     };
     Ok(docs.into_iter().map(ScimToken::from).collect())
-}
-
-/// Count an organization's SCIM tokens that can still authenticate.
-///
-/// Expired tokens are excluded: authentication already treats them as
-/// non-existent ([`get_scim_token_by_hash`]), so they must not count
-/// toward the per-org creation limit either.
-pub async fn count_active_scim_tokens(store: &DocumentStore, org_id: &str) -> Result<usize> {
-    let docs = store.find_all::<ScimTokenDoc>("org_id", org_id).await?;
-    let now = Timestamp::now();
-    Ok(docs
-        .into_iter()
-        .filter(|doc| doc.data.expires_at.is_none_or(|exp| exp > now))
-        .count())
 }
 
 /// Delete expired SCIM tokens. Returns count deleted.

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -1729,16 +1729,9 @@ async fn test_scim_token_management() {
 
     // Create SCIM token with org
     let token_hash = "hashed_scim_token";
-    let token_id = create_scim_token(
-        &store,
-        token_hash,
-        Some("Admin token"),
-        None,
-        Some(org_id),
-        None,
-    )
-    .await
-    .expect("Failed to create SCIM token");
+    let token_id = create_scim_token(&store, org_id, token_hash, Some("Admin token"), None)
+        .await
+        .expect("Failed to create SCIM token");
 
     assert!(!token_id.is_empty());
 
@@ -1821,30 +1814,44 @@ async fn test_expired_scim_tokens_excluded_from_active_count() {
         ("expired-2", Some(past)),
         ("active-1", Some(future)),
     ] {
-        create_scim_token(&store, hash, None, expiry, Some(org_id), None)
+        create_scim_token(&store, org_id, hash, None, expiry)
             .await
             .expect("Failed to create SCIM token");
     }
 
-    // list returns everything; the active count excludes the expired pair
+    // list returns everything, expired rows included
     let all = list_scim_tokens(&store, Some(org_id))
         .await
         .expect("Failed to list tokens");
     assert_eq!(all.len(), 3);
 
-    let active = count_active_scim_tokens(&store, org_id)
-        .await
-        .expect("Failed to count active tokens");
-    assert_eq!(active, 1);
+    // An expired token cannot authenticate...
+    assert!(
+        get_scim_token_by_hash(&store, "expired-1")
+            .await
+            .expect("lookup expired token")
+            .is_none(),
+        "an expired token must not authenticate"
+    );
+    assert!(
+        get_scim_token_by_hash(&store, "active-1")
+            .await
+            .expect("lookup active token")
+            .is_some(),
+        "an unexpired token must authenticate"
+    );
 
-    // Tokens without an expiration are always active
-    create_scim_token(&store, "no-expiry", None, None, Some(org_id), None)
+    // ...so it must not consume a slot either. Only `active-1` counts against
+    // the cap of 2, leaving room for one more. A token with no expiration is
+    // always active, so the one after that is refused.
+    create_scim_token(&store, org_id, "no-expiry", None, None)
         .await
-        .expect("Failed to create SCIM token");
-    let active = count_active_scim_tokens(&store, org_id)
-        .await
-        .expect("Failed to count active tokens");
-    assert_eq!(active, 2);
+        .expect("a second active token must be allowed alongside 2 expired ones");
+
+    match create_scim_token(&store, org_id, "third-active", None, Some(future)).await {
+        Err(crate::error::ServiceError::Api { ref code, .. }) if code == "token_limit_reached" => {}
+        other => panic!("a third active token must hit the cap; got {other:?}"),
+    }
 
     // Cleanup purges only the expired tokens
     let deleted = delete_expired_scim_tokens(&store)
@@ -5492,6 +5499,62 @@ async fn test_concurrent_secret_add_never_exceeds_two() {
         .expect("list secrets");
     let active = secrets.iter().filter(|s| s.is_valid(&now)).count();
     assert_eq!(active, 2, "exactly 2 active secrets must exist");
+}
+
+/// Regression for #744: 4 concurrent SCIM token creates → exactly 2 `Ok`, rest
+/// `409 token_limit_reached`. Counting in the handler and inserting afterwards
+/// let every concurrent request pass the check; the count now happens inside the
+/// insert's transaction, with the organization document's version as the
+/// serialization point. Mirrors `test_concurrent_secret_add_never_exceeds_two`.
+///
+/// Scope note: this runs on SQLite, which serializes writers, so moving the
+/// count inside the transaction is by itself sufficient here — the test still
+/// passes if the `compare_and_update` version guard is removed. That guard
+/// exists for PostgreSQL and DSQL, where two transactions can read the same
+/// snapshot and neither conflicts on a predicate read. Proving it therefore
+/// requires a snapshot-isolated backend, not this test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_concurrent_scim_token_create_never_exceeds_two() {
+    use crate::db::create_scim_token;
+
+    let (store, _audit) = test_db().await;
+    let org = create_organization(&store, "scim-cap.example", Some("Cap Org"), None)
+        .await
+        .expect("create org");
+
+    let handles: Vec<_> = (0_u8..4)
+        .map(|i| {
+            let store = store.clone();
+            let org_id = org.id.clone();
+            tokio::spawn(async move {
+                create_scim_token(&store, &org_id, &format!("scim_hash_{i}"), None, None).await
+            })
+        })
+        .collect();
+
+    let mut ok_count: usize = 0;
+    let mut limit_count: usize = 0;
+    for h in handles {
+        match h.await.expect("task must not panic") {
+            Ok(_) => ok_count = ok_count.saturating_add(1),
+            Err(crate::error::ServiceError::Api { ref code, .. })
+                if code == "token_limit_reached" =>
+            {
+                limit_count = limit_count.saturating_add(1);
+            }
+            Err(e) => panic!("unexpected error: {e}"),
+        }
+    }
+
+    assert_eq!(ok_count, 2, "exactly 2 creates must succeed");
+    assert_eq!(limit_count, 2, "exactly 2 creates must be rejected");
+
+    // Verify at the DB level — the cap must hold in storage, not just in the
+    // return values. None of these carry an expiry, so every stored row counts.
+    let stored = list_scim_tokens(&store, Some(&org.id))
+        .await
+        .expect("list tokens");
+    assert_eq!(stored.len(), 2, "exactly 2 SCIM tokens must be stored");
 }
 
 /// Seed 2 active secrets, 4 concurrent revokes → at least 1 active always remains.

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -3992,6 +3992,67 @@ async fn test_enroll_promotes_admin_for_org_without_one() {
     );
 }
 
+// Regression for #742: a user who already belongs to one org must not claim
+// a different org's admin slot by enrolling through that org's domain. The
+// slot has to stay open for that org's own first enrollee.
+#[tokio::test]
+async fn test_enroll_cross_org_user_does_not_claim_admin_slot() {
+    use crate::db::documents::organization::OrganizationDoc;
+    use crate::db::enroll_user_with_org;
+
+    let (store, _audit) = test_db().await;
+    let domain_a = "org-a.example";
+    let domain_b = "org-b.example";
+
+    // Alice belongs to org A, and is its admin.
+    let alice = enroll_user_with_org(&store, "alice@org-a.example", None, Some(domain_a))
+        .await
+        .expect("alice enrollment");
+    let org_a = alice.org_id.clone().expect("org a id");
+    assert!(alice.is_org_admin, "alice is org A's first enrollee");
+
+    // Alice now enrolls through org B's domain. Her user row keeps org A, so
+    // she is not a member of B and must not take B's admin slot.
+    let alice_again = enroll_user_with_org(&store, "alice@org-a.example", None, Some(domain_b))
+        .await
+        .expect("alice cross-org enrollment");
+    assert_eq!(
+        alice_again.org_id,
+        Some(org_a),
+        "enrolling via another domain must not move an existing user's org"
+    );
+
+    let org_b_doc = store
+        .find_one::<OrganizationDoc>("domain", domain_b)
+        .await
+        .expect("find org b")
+        .expect("org b exists");
+    assert_eq!(
+        org_b_doc.data.created_by_user_id, None,
+        "a non-member must leave org B's admin slot unclaimed"
+    );
+
+    // ...and org B's own first enrollee still gets promoted.
+    let bob = enroll_user_with_org(&store, "bob@org-b.example", None, Some(domain_b))
+        .await
+        .expect("bob enrollment");
+    assert!(
+        bob.is_org_admin,
+        "org B's first genuine enrollee must still become admin"
+    );
+
+    let org_b_doc = store
+        .find_one::<OrganizationDoc>("domain", domain_b)
+        .await
+        .expect("find org b")
+        .expect("org b exists");
+    assert_eq!(
+        org_b_doc.data.created_by_user_id,
+        Some(bob.id),
+        "org B's admin slot must record its own first enrollee"
+    );
+}
+
 // A retrying CAS loser must re-derive its admin decision from fresh state:
 // with the winner's user row committed and the org's created_by_user_id
 // still unset (the state a loser observes when it re-runs after aborting

--- a/crates/vouch-server/src/handlers/admin/mod.rs
+++ b/crates/vouch-server/src/handlers/admin/mod.rs
@@ -34,9 +34,6 @@ use serde::Deserialize;
 
 use super::session::extract_org_admin;
 
-/// Maximum number of SCIM tokens per org (supports key rotation).
-pub(crate) const MAX_SCIM_TOKENS: usize = 2;
-
 /// Query parameters for paginated pages.
 #[derive(Debug, Deserialize)]
 pub(crate) struct PaginationParams {

--- a/crates/vouch-server/src/handlers/admin/scim_tokens.rs
+++ b/crates/vouch-server/src/handlers/admin/scim_tokens.rs
@@ -17,7 +17,7 @@ use secrecy::ExposeSecret;
 use serde::Deserialize;
 use std::sync::Arc;
 
-use super::{MAX_SCIM_TOKENS, compute_token_expiry, generate_scim_token};
+use super::{compute_token_expiry, generate_scim_token};
 use crate::filters;
 use crate::handlers::browser_login::validate_origin;
 use crate::handlers::session::{AuthContext, extract_org_admin, get_resource_auth_context};
@@ -105,29 +105,17 @@ pub(crate) async fn create_scim_token(
     let (user, org_id) =
         extract_org_admin(&state, &headers, &jar, method.as_str(), uri.path(), None).await?;
 
-    // Enforce 2-token limit (expired tokens cannot authenticate and do
-    // not count toward the limit)
-    let active = db::count_active_scim_tokens(&state.store, &org_id).await?;
-
-    if active >= MAX_SCIM_TOKENS {
-        return Err(ServiceError::api(
-            StatusCode::CONFLICT,
-            "token_limit_reached",
-            "Maximum of 2 SCIM tokens per organization. Revoke one before creating another.",
-        ));
-    }
-
     let generated = generate_scim_token()?;
     let expires_at = Some(compute_token_expiry(req.expires_in_days)?);
 
-    // Store the token
+    // The 2-token limit is enforced inside the transaction: counting here and
+    // inserting afterwards lets two concurrent requests both pass the check.
     let token_id = db::create_scim_token(
         &state.store,
+        &org_id,
         &generated.hash,
         req.description.as_deref(),
         expires_at,
-        Some(&org_id),
-        None, // Default scope: full access
     )
     .await?;
 
@@ -366,17 +354,6 @@ pub(crate) async fn admin_create_scim_token(
     let (admin, org_id) =
         extract_org_admin(&state, &headers, &jar, method.as_str(), uri.path(), None).await?;
 
-    // Enforce 2-token limit (expired tokens cannot authenticate and do
-    // not count toward the limit)
-    let active = db::count_active_scim_tokens(&state.store, &org_id).await?;
-
-    if active >= MAX_SCIM_TOKENS {
-        return Ok(redirect_error(
-            jar,
-            "Maximum of 2 SCIM tokens. Revoke one before creating another.",
-        ));
-    }
-
     let generated = generate_scim_token()?;
     let expires_at = Some(compute_token_expiry(form.expires_in_days)?);
 
@@ -387,16 +364,25 @@ pub(crate) async fn admin_create_scim_token(
         .filter(|s| !s.is_empty())
         .map(String::from);
 
-    // Store the token
-    let token_id = db::create_scim_token(
+    // The 2-token limit is enforced inside the transaction: counting here and
+    // inserting afterwards lets two concurrent requests both pass the check.
+    let token_id = match db::create_scim_token(
         &state.store,
+        &org_id,
         &generated.hash,
         description.as_deref(),
         expires_at,
-        Some(&org_id),
-        None,
     )
-    .await?;
+    .await
+    {
+        Ok(id) => id,
+        // Hitting the cap is ordinary form input, not a server fault — keep the
+        // flash-message redirect rather than rendering an API error page.
+        Err(ServiceError::Api { code, message, .. }) if code == "token_limit_reached" => {
+            return Ok(redirect_error(jar, &message));
+        }
+        Err(e) => return Err(e),
+    };
 
     let data = serde_json::json!({
         "action": "create_scim_token",

--- a/crates/vouch-server/src/handlers/applications/api.rs
+++ b/crates/vouch-server/src/handlers/applications/api.rs
@@ -2190,6 +2190,62 @@ mod tests {
         assert_eq!(json["code"], "invalid_redirect_uris", "body: {body}");
     }
 
+    // Regression for #743: a FAPI client authenticates with private_key_jwt and
+    // holds no client secret. Switching it to a standard profile set
+    // client_secret_basic without minting one, so every later token request
+    // failed with invalid_client. The update must be refused outright.
+    #[tokio::test]
+    async fn test_update_application_rejects_fapi_downgrade() {
+        let (app, state) = test_app().await;
+        let user = create_test_user(&state.store, "fapi-downgrade@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let auth = bearer(&token);
+
+        let client = create_test_client(
+            &state.store,
+            &user.id,
+            TestClientSpec {
+                fapi_profile: Some(crate::db::FapiProfile::Fapi2Security),
+                token_endpoint_auth_method: Some(crate::db::TokenEndpointAuthMethod::PrivateKeyJwt),
+                jwks: TestJwks::Shared,
+                dpop_bound_access_tokens: true,
+                with_secret: false,
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let (status, body) = http_request(
+            &app,
+            "PATCH",
+            &format!("/api/v1/applications/{}", client.app_id),
+            Some(r#"{"fapi_profile": "standard"}"#.to_string()),
+            &[
+                ("Content-Type", "application/json"),
+                ("Authorization", &auth),
+            ],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
+        let json: serde_json::Value = serde_json::from_str(&body).expect("valid json");
+        assert_eq!(json["code"], "fapi_downgrade_unsupported", "body: {body}");
+
+        // The rejection must leave the client untouched — in particular it must
+        // not be left on client_secret_basic with no secret.
+        let persisted = crate::db::get_oauth_client_by_id(&state.store, &client.app_id)
+            .await
+            .expect("db lookup")
+            .expect("client still exists");
+        assert!(persisted.is_fapi(), "client must remain FAPI");
+        assert_eq!(
+            persisted.token_endpoint_auth_method,
+            crate::db::TokenEndpointAuthMethod::PrivateKeyJwt,
+            "auth method must be unchanged"
+        );
+    }
+
     #[tokio::test]
     async fn test_update_application_should_reject_empty_name() {
         let (app, state) = test_app().await;

--- a/crates/vouch-server/src/handlers/applications/validate.rs
+++ b/crates/vouch-server/src/handlers/applications/validate.rs
@@ -30,6 +30,7 @@ pub(super) enum AppValidationError {
     InvalidResourceUri { uri: String, detail: String },
     FapiRequiresConfidentialClient,
     FapiMissingJwks,
+    FapiDowngradeUnsupported,
     JwksNotJson,
     JwksMissingKeys,
     InvalidJwksUri,
@@ -46,6 +47,7 @@ impl AppValidationError {
             Self::InvalidResourceUri { .. } => "invalid_resource_uri",
             Self::FapiRequiresConfidentialClient => "invalid_fapi_profile",
             Self::FapiMissingJwks => "missing_jwks",
+            Self::FapiDowngradeUnsupported => "fapi_downgrade_unsupported",
             Self::JwksNotJson | Self::JwksMissingKeys => "invalid_jwks",
             Self::InvalidJwksUri => "invalid_jwks_uri",
         }
@@ -78,6 +80,11 @@ impl AppValidationError {
             }
             Self::FapiMissingJwks => {
                 "FAPI 2.0 requires jwks or jwks_uri for private_key_jwt authentication".to_string()
+            }
+            Self::FapiDowngradeUnsupported => {
+                "A FAPI 2.0 application cannot be changed to a standard profile. \
+                 Create a new standard application instead."
+                    .to_string()
             }
             Self::JwksNotJson => "JWKS must be valid JSON".to_string(),
             Self::JwksMissingKeys => {
@@ -275,6 +282,14 @@ pub(super) fn validate_update_fapi(
     }
 
     if !validated.is_fapi {
+        // A FAPI client authenticates with private_key_jwt and therefore has
+        // no client secret. Moving it to a standard profile would switch it to
+        // client_secret_basic without minting one, so every subsequent token
+        // request would fail with invalid_client and the application would be
+        // unusable with no way back. Refuse the transition instead.
+        if validated.fapi_profile_provided && client.is_fapi() {
+            return Err(AppValidationError::FapiDowngradeUnsupported);
+        }
         return Ok(());
     }
 
@@ -393,8 +408,9 @@ pub(super) struct FapiUpdateFields<'a> {
 ///
 /// An absent `fapi_profile` preserves the client's current profile, auth
 /// method, JWKS, and DPoP binding. A provided FAPI profile enforces
-/// `private_key_jwt` + DPoP; a provided non-FAPI value transitions the
-/// client back to standard `client_secret_basic` with no JWKS.
+/// `private_key_jwt` + DPoP. A provided non-FAPI value clears the profile,
+/// JWKS, and DPoP binding of a client that was not already FAPI; downgrading
+/// a FAPI client is rejected upstream by [`validate_update_fapi`].
 pub(super) fn compute_fapi_update_fields<'a>(
     validated: &'a ValidatedUpdateApp<'_>,
     client: &'a OAuthClient,
@@ -410,11 +426,10 @@ pub(super) fn compute_fapi_update_fields<'a>(
         client.fapi_profile
     };
 
+    // A FAPI→standard transition never reaches here: `validate_update_fapi`
+    // rejects it, because the client has no secret to fall back to.
     let token_endpoint_auth_method = if is_fapi {
         TokenEndpointAuthMethod::PrivateKeyJwt
-    } else if validated.fapi_profile_provided && client.is_fapi() {
-        // Transitioning from FAPI to Standard
-        TokenEndpointAuthMethod::ClientSecretBasic
     } else {
         client.token_endpoint_auth_method
     };
@@ -681,21 +696,42 @@ mod tests {
         assert!(fields.dpop_bound_access_tokens);
     }
 
+    // Regression for #743: a FAPI client has no client secret, so switching it
+    // to client_secret_basic left it unable to authenticate at all. The
+    // transition is refused rather than silently producing a broken client.
     #[tokio::test]
-    async fn fapi_update_explicit_non_fapi_transitions_to_standard() {
+    async fn fapi_update_explicit_non_fapi_is_rejected() {
         let state = test_app_state().await;
         let client = fapi_test_client(&state, "fapi-disable@example.com").await;
 
         let validated = update_input(Some("standard"));
-        let fields = compute_fapi_update_fields(&validated, &client);
+        let err =
+            validate_update_fapi(&validated, &client).expect_err("FAPI downgrade must be rejected");
 
+        assert_eq!(err.code(), "fapi_downgrade_unsupported");
+    }
+
+    // The guard must not fire for a client that was never FAPI: explicitly
+    // setting `standard` on a standard client stays a no-op update.
+    #[tokio::test]
+    async fn non_fapi_client_may_be_set_to_standard() {
+        let state = test_app_state().await;
+        let user = create_test_user(&state.store, "std-restate@example.com").await;
+        let created = create_test_client(&state.store, &user.id, TestClientSpec::default()).await;
+        let client = crate::db::get_oauth_client_by_id(&state.store, &created.app_id)
+            .await
+            .expect("db lookup")
+            .expect("client exists");
+
+        let validated = update_input(Some("standard"));
+        validate_update_fapi(&validated, &client).expect("standard -> standard is allowed");
+
+        let fields = compute_fapi_update_fields(&validated, &client);
         assert_eq!(fields.fapi_profile, FapiProfile::None);
         assert_eq!(
-            fields.token_endpoint_auth_method,
-            TokenEndpointAuthMethod::ClientSecretBasic
+            fields.token_endpoint_auth_method, client.token_endpoint_auth_method,
+            "a non-FAPI client keeps its existing auth method"
         );
-        assert!(fields.jwks.is_none(), "JWKS dropped on FAPI exit");
-        assert!(fields.jwks_uri.is_none());
         assert!(!fields.dpop_bound_access_tokens);
     }
 

--- a/crates/vouch-server/src/handlers/applications/web.rs
+++ b/crates/vouch-server/src/handlers/applications/web.rs
@@ -420,10 +420,10 @@ pub(crate) async fn update_application_form(
         return validation_error_response(&e, format!("/applications/{}", app_id));
     }
 
-    // Merge FAPI-related fields against the existing client record. The
-    // form's security-profile radio group always submits fapi_profile, so
-    // an explicit non-FAPI value transitions the client back to standard
-    // auth — including resetting the DPoP binding, matching the JSON API.
+    // Merge FAPI-related fields against the existing client record. The form's
+    // security-profile radio group always submits fapi_profile; selecting
+    // Standard for a client that is already FAPI is rejected above, so what
+    // reaches here either enables FAPI or leaves a non-FAPI client standard.
     let fapi = compute_fapi_update_fields(&validated, &client);
 
     // Update the application
@@ -878,10 +878,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_web_update_form_fapi_exit_resets_dpop_binding() {
-        // Transitioning a FAPI client back to the standard profile via the
-        // web form must reset the DPoP binding and auth method, matching
-        // the JSON API's update semantics.
+    async fn test_web_update_form_rejects_fapi_exit() {
+        // Regression for #743: selecting Standard for a FAPI client used to
+        // move it to client_secret_basic without minting a secret, leaving it
+        // unable to authenticate. The web form must refuse the transition and
+        // leave the client untouched, matching the JSON API.
         let (app, state) = test_app().await;
         let user = create_test_user(&state.store, "web-update-fapi-exit@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
@@ -911,23 +912,31 @@ mod tests {
         )
         .await;
         assert!(
-            status.is_redirection(),
-            "FAPI exit must succeed with a redirect, got {status}: {body}"
+            !status.is_redirection(),
+            "FAPI exit must not be applied, got {status}: {body}"
+        );
+        assert!(
+            body.contains("cannot be changed to a standard profile"),
+            "the error page must explain the refusal: {body}"
         );
 
+        // Every FAPI-sensitive field must survive the rejected update.
         let record = crate::db::get_oauth_client_by_id(&state.store, &client.app_id)
             .await
             .expect("db query ok")
             .expect("client must still exist");
-        assert_eq!(record.fapi_profile, crate::db::FapiProfile::None);
+        assert_eq!(record.fapi_profile, crate::db::FapiProfile::Fapi2Security);
         assert_eq!(
             record.token_endpoint_auth_method,
-            crate::db::TokenEndpointAuthMethod::ClientSecretBasic
+            crate::db::TokenEndpointAuthMethod::PrivateKeyJwt
         );
         assert!(
-            !record.dpop_bound_access_tokens,
-            "leaving FAPI must clear the DPoP binding"
+            record.dpop_bound_access_tokens,
+            "a rejected update must not clear the DPoP binding"
         );
-        assert!(record.jwks.is_none(), "leaving FAPI must drop the JWKS");
+        assert!(
+            record.jwks.is_some(),
+            "a rejected update must not drop the JWKS"
+        );
     }
 }

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -5,6 +5,7 @@ use crate::AppState;
 use crate::db::ClientInfo;
 use crate::db::{self, AuthEventParams, AuthEventType};
 use crate::impl_template_response;
+use crate::infra::i18n::Tr;
 // This file's flows are heavily branched into error/redirect paths constructed
 // from helpers without easy access to the request-scoped `I18nContext`, so
 // every template here uses `PageContext::current()` (en-US). Upgrading any
@@ -787,18 +788,28 @@ pub(crate) async fn complete_enrollment_after_identity(
             )
             .await
             {
-                tracing::warn!("Failed to authorize device auth: {}", e);
-            } else {
-                let event = db::AuthEventParams {
-                    user_id: user.id.clone(),
-                    event_type: db::AuthEventType::DeviceAuthApproved,
-                    authenticator_id: Some(auth_id.clone()),
-                    success: true,
-                    client: client_info,
-                    ..Default::default()
-                };
-                db::spawn_audit_event(&state.audit, event, Some(identity.email.clone()));
+                // Surface the failure instead of redirecting to the keys page
+                // as though sign-in succeeded: the device auth was never
+                // approved, so the waiting CLI would poll until it timed out
+                // with nothing on screen to explain why.
+                tracing::error!("Failed to authorize device auth: {}", e);
+                return ErrorTemplate {
+                    title: Tr::new("error-heading").to_string(),
+                    message: Tr::new("enroll-error-device-auth-approve-failed").to_string(),
+                    back_url: None,
+                }
+                .into_response();
             }
+
+            let event = db::AuthEventParams {
+                user_id: user.id.clone(),
+                event_type: db::AuthEventType::DeviceAuthApproved,
+                authenticator_id: Some(auth_id.clone()),
+                success: true,
+                client: client_info,
+                ..Default::default()
+            };
+            db::spawn_audit_event(&state.audit, event, Some(identity.email.clone()));
         } else {
             // No key yet — store the device_auth_id in an enrollment session
             // so browser_register_complete can authorize it after WebAuthn registration.
@@ -812,7 +823,17 @@ pub(crate) async fn complete_enrollment_after_identity(
             )
             .await
             {
-                tracing::warn!("Failed to create enrollment session for CLI: {}", e);
+                // Without this row browser_register_complete cannot authorize
+                // the device auth after WebAuthn registration, so continuing
+                // would walk the user through enrolling a key that could never
+                // release the waiting CLI.
+                tracing::error!("Failed to create enrollment session for CLI: {}", e);
+                return ErrorTemplate {
+                    title: Tr::new("error-heading").to_string(),
+                    message: Tr::new("enroll-error-session-create-failed").to_string(),
+                    back_url: None,
+                }
+                .into_response();
             }
         }
     } else if authenticator_id.is_some() {
@@ -2237,6 +2258,64 @@ mod tests {
         assert!(
             logins.is_empty(),
             "a CLI approval is not additionally recorded as a website login"
+        );
+    }
+
+    // Regression for #746: if the device auth cannot be authorized — the row
+    // expired and was reclaimed, or the callback was submitted twice — the
+    // failure was logged and the flow continued to the keys page as though
+    // sign-in had worked, leaving the CLI to poll until timeout. The user must
+    // get an error page instead.
+    #[tokio::test]
+    async fn test_cli_device_auth_failure_renders_error_instead_of_redirect() {
+        let state = test_app_state().await;
+        let user = create_test_user(&state.store, "cli-stale-da@example.com").await;
+        create_test_authenticator(&state.store, &user.id).await;
+
+        // A device_auth_id with no row behind it: authorize_device_auth bails.
+        let (stored, claim) = seed_and_consume_oidc_state(
+            &state,
+            "cli-stale-da-state",
+            Some("reclaimed-device-auth"),
+        )
+        .await;
+
+        let identity = IdentityResult {
+            email: "cli-stale-da@example.com".to_string(),
+            domain: Some("example.com".to_string()),
+        };
+
+        let resp = complete_enrollment_after_identity(
+            &state,
+            &stored,
+            identity,
+            claim,
+            ClientInfo::default(),
+        )
+        .await;
+
+        assert_ne!(
+            resp.status(),
+            StatusCode::SEE_OTHER,
+            "a failed device authorization must not redirect as though sign-in succeeded"
+        );
+        assert!(
+            resp.headers().get(header::SET_COOKIE).is_none(),
+            "no session cookie may be issued when the device auth was not approved"
+        );
+
+        // The device auth stays unapproved rather than being silently skipped.
+        let approvals = state
+            .audit
+            .query_events(&crate::db::AuditEventFilter {
+                event_types: Some(vec!["device_auth_approved".to_string()]),
+                ..Default::default()
+            })
+            .await
+            .expect("query audit events");
+        assert!(
+            approvals.is_empty(),
+            "no approval event may be recorded when authorization failed"
         );
     }
 

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -6,11 +6,6 @@ use crate::db::ClientInfo;
 use crate::db::{self, AuthEventParams, AuthEventType};
 use crate::impl_template_response;
 use crate::infra::i18n::Tr;
-// This file's flows are heavily branched into error/redirect paths constructed
-// from helpers without easy access to the request-scoped `I18nContext`, so
-// every template here uses `PageContext::current()` (en-US). Upgrading any
-// individual handler to thread per-request locale is a localized change once
-// a second language ships.
 use askama::Template;
 use axum::{
     Form, Json,
@@ -330,8 +325,10 @@ pub(crate) async fn device_verify_submit(
             Some(idp) => idp,
             None => {
                 return ErrorTemplate {
-                    title: "Unknown Provider".to_string(),
-                    message: format!("Identity provider '{slug}' is not configured."),
+                    title: Tr::new("enroll-error-unknown-provider-title").to_string(),
+                    message: Tr::new("enroll-error-unknown-provider")
+                        .arg("slug", slug)
+                        .to_string(),
                     back_url: Some("/device".to_string()),
                 }
                 .into_response();
@@ -351,10 +348,8 @@ pub(crate) async fn device_verify_submit(
                 Some(idp) => idp,
                 None => {
                     return ErrorTemplate {
-                        title: "Not Configured".to_string(),
-                        message: "Identity provider is not configured. \
-                                  Please contact your administrator."
-                            .to_string(),
+                        title: Tr::new("enroll-error-not-configured-title").to_string(),
+                        message: Tr::new("enroll-error-idp-not-configured").to_string(),
                         back_url: Some("/".to_string()),
                     }
                     .into_response();
@@ -371,8 +366,8 @@ pub(crate) async fn device_verify_submit(
         Err(e) => {
             tracing::error!("Failed to initiate auth: {e:#}");
             return ErrorTemplate {
-                title: "Error".to_string(),
-                message: "Failed to start authentication".to_string(),
+                title: Tr::new("error-heading").to_string(),
+                message: Tr::new("enroll-error-auth-start-failed").to_string(),
                 back_url: None,
             }
             .into_response();
@@ -394,8 +389,8 @@ pub(crate) async fn device_verify_submit(
     {
         tracing::error!("Failed to create auth state: {}", e);
         return ErrorTemplate {
-            title: "Error".to_string(),
-            message: "Failed to create session state".to_string(),
+            title: Tr::new("error-heading").to_string(),
+            message: Tr::new("enroll-error-state-create-failed").to_string(),
             back_url: None,
         }
         .into_response();
@@ -445,8 +440,8 @@ pub(crate) async fn oidc_callback(
     // Get authorization code and state
     let Some(code) = params.code else {
         return ErrorTemplate {
-            title: "Error".to_string(),
-            message: "Missing authorization code".to_string(),
+            title: Tr::new("error-heading").to_string(),
+            message: Tr::new("enroll-error-missing-code").to_string(),
             back_url: None,
         }
         .into_response();
@@ -454,8 +449,8 @@ pub(crate) async fn oidc_callback(
 
     let Some(oidc_state) = params.state else {
         return ErrorTemplate {
-            title: "Error".to_string(),
-            message: "Missing state parameter".to_string(),
+            title: Tr::new("error-heading").to_string(),
+            message: Tr::new("enroll-error-missing-state").to_string(),
             back_url: None,
         }
         .into_response();
@@ -465,8 +460,8 @@ pub(crate) async fn oidc_callback(
     // OIDC state is base64url-encoded 32 random bytes (43 chars).
     if oidc_state.len() > 128 {
         return ErrorTemplate {
-            title: "Error".to_string(),
-            message: "Invalid state parameter".to_string(),
+            title: Tr::new("error-heading").to_string(),
+            message: Tr::new("enroll-error-invalid-state").to_string(),
             back_url: None,
         }
         .into_response();
@@ -482,8 +477,8 @@ pub(crate) async fn oidc_callback(
             Ok(pair) => pair,
             Err(db::ClaimError::AlreadyConsumed) => {
                 return ErrorTemplate {
-                    title: "Error".to_string(),
-                    message: "Invalid or expired state".to_string(),
+                    title: Tr::new("error-heading").to_string(),
+                    message: Tr::new("enroll-error-state-expired").to_string(),
                     back_url: None,
                 }
                 .into_response();
@@ -491,8 +486,8 @@ pub(crate) async fn oidc_callback(
             Err(e) => {
                 tracing::error!("Failed to consume OIDC state: {e:#}");
                 return ErrorTemplate {
-                    title: "Error".to_string(),
-                    message: "Failed to verify state".to_string(),
+                    title: Tr::new("error-heading").to_string(),
+                    message: Tr::new("enroll-error-state-verify-failed").to_string(),
                     back_url: None,
                 }
                 .into_response();
@@ -518,10 +513,8 @@ pub(crate) async fn oidc_callback(
     };
     let Some(oidc_provider) = oidc_provider else {
         return ErrorTemplate {
-            title: "Error".to_string(),
-            message: "OIDC not configured. If using SAML, responses should be \
-                      sent to /saml/acs, not /oauth/callback."
-                .to_string(),
+            title: Tr::new("error-heading").to_string(),
+            message: Tr::new("enroll-error-oidc-not-configured").to_string(),
             back_url: None,
         }
         .into_response();
@@ -557,8 +550,8 @@ pub(crate) async fn oidc_callback(
         Err(e) => {
             tracing::error!("Failed to exchange code: {}", e);
             return ErrorTemplate {
-                title: "Error".to_string(),
-                message: "Failed to complete authentication".to_string(),
+                title: Tr::new("error-heading").to_string(),
+                message: Tr::new("enroll-error-auth-complete-failed").to_string(),
                 back_url: None,
             }
             .into_response();
@@ -569,8 +562,8 @@ pub(crate) async fn oidc_callback(
         let error_text = token_response.text().await.unwrap_or_default();
         tracing::error!("Token exchange failed: {}", error_text);
         return ErrorTemplate {
-            title: "Error".to_string(),
-            message: "Failed to complete authentication".to_string(),
+            title: Tr::new("error-heading").to_string(),
+            message: Tr::new("enroll-error-auth-complete-failed").to_string(),
             back_url: None,
         }
         .into_response();
@@ -581,8 +574,8 @@ pub(crate) async fn oidc_callback(
         Err(e) => {
             tracing::error!("Failed to parse token response: {}", e);
             return ErrorTemplate {
-                title: "Error".to_string(),
-                message: "Failed to complete authentication".to_string(),
+                title: Tr::new("error-heading").to_string(),
+                message: Tr::new("enroll-error-auth-complete-failed").to_string(),
                 back_url: None,
             }
             .into_response();
@@ -604,8 +597,8 @@ pub(crate) async fn oidc_callback(
         Err(e) => {
             tracing::error!("ID token verification failed: {e:#}");
             return ErrorTemplate {
-                title: "Error".to_string(),
-                message: "Failed to verify identity token".to_string(),
+                title: Tr::new("error-heading").to_string(),
+                message: Tr::new("enroll-error-token-verify-failed").to_string(),
                 back_url: None,
             }
             .into_response();
@@ -646,12 +639,11 @@ pub(crate) async fn complete_enrollment_after_identity(
         if !domains.iter().any(|d| d.eq_ignore_ascii_case(email_domain)) {
             let allowed_list = domains.join(", ");
             return ErrorTemplate {
-                title: "Domain Not Allowed".to_string(),
-                message: format!(
-                    "Only users from the following domains can enroll: {}. Your email ({}) is not from an allowed domain.",
-                    allowed_list,
-                    identity.email
-                ),
+                title: Tr::new("enroll-error-domain-not-allowed-title").to_string(),
+                message: Tr::new("enroll-error-domain-not-allowed")
+                    .arg("domains", allowed_list.as_str())
+                    .arg("email", identity.email.as_str())
+                    .to_string(),
                 back_url: None,
             }
             .into_response();
@@ -673,8 +665,8 @@ pub(crate) async fn complete_enrollment_after_identity(
         Err(e) => {
             tracing::error!("Failed to enroll user: {}", e);
             return ErrorTemplate {
-                title: "Error".to_string(),
-                message: "Failed to create user".to_string(),
+                title: Tr::new("error-heading").to_string(),
+                message: Tr::new("enroll-error-user-create-failed").to_string(),
                 back_url: None,
             }
             .into_response();
@@ -690,8 +682,8 @@ pub(crate) async fn complete_enrollment_after_identity(
         Err(e) => {
             tracing::error!("Failed to calculate session expiration: {}", e);
             return ErrorTemplate {
-                title: "Error".to_string(),
-                message: "Failed to create session".to_string(),
+                title: Tr::new("error-heading").to_string(),
+                message: Tr::new("enroll-error-session-failed").to_string(),
                 back_url: None,
             }
             .into_response();
@@ -716,8 +708,8 @@ pub(crate) async fn complete_enrollment_after_identity(
             Err(e) => {
                 tracing::error!("Failed to snapshot org domain: {}", e);
                 return ErrorTemplate {
-                    title: "Error".to_string(),
-                    message: "Failed to create session".to_string(),
+                    title: Tr::new("error-heading").to_string(),
+                    message: Tr::new("enroll-error-session-failed").to_string(),
                     back_url: None,
                 }
                 .into_response();
@@ -763,8 +755,8 @@ pub(crate) async fn complete_enrollment_after_identity(
         Err(e) => {
             tracing::error!("Failed to create session: {}", e);
             return ErrorTemplate {
-                title: "Error".to_string(),
-                message: "Failed to create session".to_string(),
+                title: Tr::new("error-heading").to_string(),
+                message: Tr::new("enroll-error-session-failed").to_string(),
                 back_url: None,
             }
             .into_response();
@@ -1663,8 +1655,10 @@ pub(crate) async fn direct_enroll_start(
             Some(i) => Some(i),
             None => {
                 return ErrorTemplate {
-                    title: "Unknown Provider".to_string(),
-                    message: format!("Identity provider '{slug}' is not configured."),
+                    title: Tr::new("enroll-error-unknown-provider-title").to_string(),
+                    message: Tr::new("enroll-error-unknown-provider")
+                        .arg("slug", slug)
+                        .to_string(),
                     back_url: Some("/".to_string()),
                 }
                 .into_response();
@@ -1675,9 +1669,8 @@ pub(crate) async fn direct_enroll_start(
 
     let Some(idp) = chosen_idp else {
         return ErrorTemplate {
-            title: "Not Configured".to_string(),
-            message: "Identity provider is not configured. Please contact your administrator."
-                .to_string(),
+            title: Tr::new("enroll-error-not-configured-title").to_string(),
+            message: Tr::new("enroll-error-idp-not-configured").to_string(),
             back_url: Some("/".to_string()),
         }
         .into_response();
@@ -1693,8 +1686,8 @@ pub(crate) async fn direct_enroll_start(
                 provider_id
             );
             return ErrorTemplate {
-                title: "Error".to_string(),
-                message: "Failed to start enrollment. Please try again.".to_string(),
+                title: Tr::new("error-heading").to_string(),
+                message: Tr::new("enroll-error-enrollment-start-failed").to_string(),
                 back_url: Some("/".to_string()),
             }
             .into_response();
@@ -1720,8 +1713,8 @@ pub(crate) async fn direct_enroll_start(
     {
         tracing::error!("Failed to create auth state: {}", e);
         return ErrorTemplate {
-            title: "Error".to_string(),
-            message: "Failed to start enrollment. Please try again.".to_string(),
+            title: Tr::new("error-heading").to_string(),
+            message: Tr::new("enroll-error-enrollment-start-failed").to_string(),
             back_url: Some("/".to_string()),
         }
         .into_response();

--- a/crates/vouch-server/src/infra/httpsig.rs
+++ b/crates/vouch-server/src/infra/httpsig.rs
@@ -61,11 +61,12 @@ impl KeyResolver for OAuthClientKeyResolver {
 
             // Only clients registered with `jwks_uri` (no inline JWKS) need the
             // cached fetch — skip the extra DB round trip for the common inline case.
-            let cached;
+            let resolved;
             let jwks_value = if let Some(jwks) = client.jwks.as_ref() {
                 jwks
             } else {
-                cached = crate::db::get_jwks_cache(&self.state.store, &client.id)
+                let uri = client.jwks_uri.as_deref()?;
+                let cached = crate::db::get_jwks_cache(&self.state.store, &client.id)
                     .await
                     .map_err(|e| {
                         tracing::warn!(
@@ -73,8 +74,26 @@ impl KeyResolver for OAuthClientKeyResolver {
                         );
                     })
                     .ok()
-                    .flatten()?;
-                &cached.value
+                    .flatten();
+
+                // Honor the cache TTL rather than trusting whatever was stored:
+                // reading it verbatim let a key the client had already rotated
+                // out keep verifying signatures until the row happened to be
+                // replaced.
+                resolved = crate::infra::jwks::resolve_cached_jwks(
+                    &self.state.store,
+                    &client.id,
+                    uri,
+                    cached.as_ref(),
+                    !self.state.config().tls_configured(),
+                    &self.state.http_client,
+                )
+                .await
+                .map_err(|e| {
+                    tracing::warn!("JWKS resolution failed for HTTP signature verification: {e}");
+                })
+                .ok()?;
+                &resolved
             };
             let keys = jwks_value.get("keys")?.as_array()?;
 

--- a/crates/vouch-server/src/infra/jwks.rs
+++ b/crates/vouch-server/src/infra/jwks.rs
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! Remote JWKS fetching and cache freshness.
+//!
+//! Every consumer of a client's `jwks_uri` needs the same guarantees — HTTPS
+//! only, SSRF-guarded egress, a response size cap, and a cache that is checked
+//! for freshness rather than trusted indefinitely. This module owns that core so
+//! the RFC 7523 assertion path (`services::oidc::jwt_bearer::jwks`) and the RFC
+//! 9421 signature path (`infra::httpsig`) cannot drift apart on it.
+//!
+//! Callers differ in *policy* — how stale is too stale, and what to do when a
+//! fetch fails — so that stays with them. [`fetch_and_cache`] is the primitive;
+//! [`resolve_cached_jwks`] adds the TTL plus stale-while-revalidate policy that
+//! both request-verification paths want.
+
+use crate::db;
+use crate::db::documents::jwks_cache::{JWKS_STALE_MAX_AGE_SECONDS, JwksCacheDoc};
+use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
+
+/// Maximum JWKS response size (256KB).
+const MAX_JWKS_RESPONSE_SIZE: usize = 256 * 1024;
+
+/// JWKS URI cache TTL in seconds (1 hour).
+pub(crate) const JWKS_CACHE_TTL_SECONDS: i64 = 3600;
+
+/// Fetch a JWKS document from a remote URI.
+///
+/// Enforces HTTPS-only and a response size cap.
+async fn fetch_jwks(
+    uri: &str,
+    allow_loopback: bool,
+    http_client: &reqwest::Client,
+) -> ServiceResult<String> {
+    // HTTPS-only
+    if !uri.starts_with("https://") {
+        return Err(ServiceError::oauth(
+            OAuthErrorCode::InvalidClient,
+            "JWKS URI must use HTTPS",
+        ));
+    }
+
+    // SSRF egress guard: a client-registered `jwks_uri` is fetched here while
+    // verifying a `private_key_jwt` assertion or an RFC 9421 signature, and
+    // dynamic client registration is unauthenticated — refuse to dial
+    // private/link-local targets. Loopback is permitted only in local
+    // development (`allow_loopback`).
+    crate::infra::ssrf::assert_public_destination(
+        uri,
+        allow_loopback,
+        OAuthErrorCode::InvalidClient,
+    )
+    .await?;
+
+    let response = http_client.get(uri).send().await.map_err(|e| {
+        tracing::warn!("Failed to fetch JWKS from {uri}: {e}");
+        ServiceError::oauth(
+            OAuthErrorCode::InvalidClient,
+            "Failed to fetch JWKS from URI",
+        )
+    })?;
+
+    if !response.status().is_success() {
+        return Err(ServiceError::oauth(
+            OAuthErrorCode::InvalidClient,
+            "JWKS URI request failed",
+        ));
+    }
+
+    // Check content length before reading body
+    if let Some(len) = response.content_length()
+        && len > MAX_JWKS_RESPONSE_SIZE as u64
+    {
+        return Err(ServiceError::oauth(
+            OAuthErrorCode::InvalidClient,
+            "JWKS response exceeds maximum size (256KB)",
+        ));
+    }
+
+    let body = response.bytes().await.map_err(|e| {
+        ServiceError::oauth(
+            OAuthErrorCode::InvalidClient,
+            format!("Failed to read JWKS response: {e}"),
+        )
+    })?;
+
+    if body.len() > MAX_JWKS_RESPONSE_SIZE {
+        return Err(ServiceError::oauth(
+            OAuthErrorCode::InvalidClient,
+            "JWKS response exceeds maximum size (256KB)",
+        ));
+    }
+
+    String::from_utf8(body.to_vec()).map_err(|_| {
+        ServiceError::oauth(
+            OAuthErrorCode::InvalidClient,
+            "JWKS response is not valid UTF-8",
+        )
+    })
+}
+
+/// Fetch a JWKS from `uri` and write it to the cache under `parent_id`.
+///
+/// A cache-write failure is logged and swallowed: the freshly fetched keys are
+/// still correct, and failing the request would turn a caching problem into an
+/// authentication outage.
+///
+/// This is the unconditional fetch. Callers that want to consult a cache first
+/// use [`resolve_cached_jwks`], or apply their own freshness rule.
+pub(crate) async fn fetch_and_cache(
+    store: &db::store::DocumentStore,
+    parent_id: &str,
+    uri: &str,
+    allow_loopback: bool,
+    http_client: &reqwest::Client,
+) -> ServiceResult<serde_json::Value> {
+    let jwks_json = fetch_jwks(uri, allow_loopback, http_client).await?;
+    let jwks_value: serde_json::Value = serde_json::from_str(&jwks_json).map_err(|e| {
+        tracing::debug!("Failed to parse JWKS as JSON value: {e}");
+        ServiceError::oauth(OAuthErrorCode::InvalidClient, "Invalid JWKS format")
+    })?;
+
+    if let Err(e) = db::upsert_jwks_cache(store, parent_id, &jwks_value).await {
+        tracing::warn!("Failed to update JWKS cache for {parent_id}: {e}");
+    }
+
+    Ok(jwks_value)
+}
+
+/// Resolve a client's JWKS, refetching when the cache is past its TTL.
+///
+/// Returns the cached document while it is younger than
+/// [`JWKS_CACHE_TTL_SECONDS`]; otherwise refetches. If the refetch fails, falls
+/// back to the stale cache while it is within [`JWKS_STALE_MAX_AGE_SECONDS`] so
+/// a brief outage at the client's JWKS host does not break verification —
+/// beyond that the error is surfaced, because a key rotated out long ago must
+/// stop verifying.
+pub(crate) async fn resolve_cached_jwks(
+    store: &db::store::DocumentStore,
+    parent_id: &str,
+    uri: &str,
+    cached: Option<&JwksCacheDoc>,
+    allow_loopback: bool,
+    http_client: &reqwest::Client,
+) -> ServiceResult<serde_json::Value> {
+    if let Some(cache) = cached
+        && cache.is_fresh(JWKS_CACHE_TTL_SECONDS)
+    {
+        return Ok(cache.value.clone());
+    }
+
+    match fetch_and_cache(store, parent_id, uri, allow_loopback, http_client).await {
+        Ok(value) => Ok(value),
+        Err(e) => {
+            // Stale-while-revalidate, capped so a rotated-out key cannot verify
+            // indefinitely just because the client's host is unreachable.
+            if let Some(cache) = cached {
+                if cache.is_within_stale_window(JWKS_STALE_MAX_AGE_SECONDS) {
+                    tracing::warn!("JWKS fetch failed, using stale cache: {e}");
+                    return Ok(cache.value.clone());
+                }
+                tracing::warn!(
+                    "JWKS fetch failed and stale cache too old ({}s)",
+                    cache.age_seconds()
+                );
+            }
+            Err(e)
+        }
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
+mod tests {
+    use super::*;
+
+    /// Assert the error is an `invalid_client` OAuth error rejecting non-HTTPS.
+    fn assert_rejected_as_non_https(err: &ServiceError) {
+        assert!(
+            matches!(err, ServiceError::OAuth { code, .. } if *code == OAuthErrorCode::InvalidClient)
+        );
+        assert!(
+            matches!(err, ServiceError::OAuth { description, .. } if description == "JWKS URI must use HTTPS")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fetch_jwks_rejects_http_url() {
+        let client = reqwest::Client::new();
+        let err = fetch_jwks("http://example.com/jwks", false, &client)
+            .await
+            .expect_err("http:// must be rejected");
+        assert_rejected_as_non_https(&err);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_jwks_rejects_ftp_url() {
+        let client = reqwest::Client::new();
+        let err = fetch_jwks("ftp://example.com/jwks", false, &client)
+            .await
+            .expect_err("ftp:// must be rejected");
+        assert_rejected_as_non_https(&err);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_jwks_rejects_empty_uri() {
+        let client = reqwest::Client::new();
+        let err = fetch_jwks("", false, &client)
+            .await
+            .expect_err("empty URI must be rejected");
+        assert_rejected_as_non_https(&err);
+    }
+
+    /// A cache doc aged `age_seconds` in the past, holding one key id.
+    fn cache_doc(age_seconds: i64, kid: &str) -> JwksCacheDoc {
+        JwksCacheDoc {
+            value: serde_json::json!({ "keys": [{ "kty": "EC", "kid": kid }] }),
+            cached_at: jiff::Timestamp::now()
+                .checked_sub(jiff::SignedDuration::from_secs(age_seconds))
+                .expect("cache age must be representable"),
+        }
+    }
+
+    /// A URI the SSRF guard always refuses, standing in for an unreachable
+    /// JWKS host without touching the network.
+    const UNREACHABLE_URI: &str = "https://127.0.0.1:1/jwks.json";
+
+    #[tokio::test]
+    async fn resolve_returns_fresh_cache_without_fetching() {
+        let state = crate::test_utils::test_app_state().await;
+        let cached = cache_doc(60, "fresh-key");
+
+        // The URI would fail if dialed, so a success proves no fetch happened.
+        let value = resolve_cached_jwks(
+            &state.store,
+            "client-fresh",
+            UNREACHABLE_URI,
+            Some(&cached),
+            false,
+            &state.http_client,
+        )
+        .await
+        .expect("a fresh cache must be served without a fetch");
+
+        assert_eq!(value, cached.value);
+    }
+
+    /// Regression for #748: past the TTL, a key the client has rotated out must
+    /// stop verifying. The RFC 9421 resolver previously read the cache verbatim,
+    /// so a stale key stayed valid until the row happened to be replaced.
+    #[tokio::test]
+    async fn resolve_rejects_cache_older_than_the_stale_window() {
+        let state = crate::test_utils::test_app_state().await;
+        let cached = cache_doc(JWKS_STALE_MAX_AGE_SECONDS + 3600, "rotated-out-key");
+
+        let result = resolve_cached_jwks(
+            &state.store,
+            "client-ancient",
+            UNREACHABLE_URI,
+            Some(&cached),
+            false,
+            &state.http_client,
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "a cache past the stale window must not be served: {result:?}"
+        );
+    }
+
+    /// Between the TTL and the stale-window cap, an unreachable JWKS host must
+    /// not break verification outright.
+    #[tokio::test]
+    async fn resolve_serves_stale_cache_within_the_window() {
+        let state = crate::test_utils::test_app_state().await;
+        let cached = cache_doc(JWKS_CACHE_TTL_SECONDS + 60, "recently-stale-key");
+
+        let value = resolve_cached_jwks(
+            &state.store,
+            "client-stale",
+            UNREACHABLE_URI,
+            Some(&cached),
+            false,
+            &state.http_client,
+        )
+        .await
+        .expect("a cache within the stale window must survive a failed fetch");
+
+        assert_eq!(value, cached.value);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_jwks_rejects_loopback_when_not_allowed() {
+        let client = reqwest::Client::new();
+        let err = fetch_jwks("https://127.0.0.1/jwks.json", false, &client)
+            .await
+            .expect_err("loopback must be rejected without allow_loopback");
+        // The SSRF guard, not the HTTPS check, must be what rejects this.
+        assert!(
+            !matches!(&err, ServiceError::OAuth { description, .. } if description == "JWKS URI must use HTTPS"),
+            "expected SSRF rejection, got: {err}"
+        );
+    }
+}

--- a/crates/vouch-server/src/infra/mod.rs
+++ b/crates/vouch-server/src/infra/mod.rs
@@ -11,6 +11,7 @@ pub mod dns;
 pub mod generate_document_key;
 pub mod httpsig;
 pub mod i18n;
+pub(crate) mod jwks;
 pub mod kms_arn;
 pub mod metrics;
 pub(crate) mod mtls_listener;

--- a/crates/vouch-server/src/services/integrations/github/app.rs
+++ b/crates/vouch-server/src/services/integrations/github/app.rs
@@ -12,7 +12,7 @@ use anyhow::{Context, Result, bail};
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
 use jsonwebtoken::{Algorithm, EncodingKey, Header};
-use secrecy::SecretString;
+use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use zeroize::Zeroizing;
@@ -378,6 +378,70 @@ impl GitHubApp {
         })
     }
 
+    /// List every repository an installation can access.
+    ///
+    /// Authenticates with an installation access token, which is what the
+    /// `/installation/repositories` endpoint requires. The token endpoint's own
+    /// `repositories` field is not a substitute: it only echoes back a scope the
+    /// request asked for, so an unscoped mint reports nothing even for an
+    /// installation limited to selected repositories.
+    ///
+    /// Returns bare repository names (no owner prefix), matching what
+    /// `db::update_github_installation_repos` stores.
+    pub async fn list_installation_repositories(
+        &self,
+        installation_id: GitHubInstallationId,
+    ) -> Result<Vec<String>> {
+        let token = self
+            .get_installation_token(installation_id, None, None)
+            .await?;
+
+        let mut all_repos = Vec::new();
+        let mut page: u32 = 1;
+
+        loop {
+            let response = self
+                .http_client
+                .get(format!(
+                    "https://api.github.com/installation/repositories?per_page=100&page={page}"
+                ))
+                .header(
+                    "Authorization",
+                    format!("Bearer {}", token.token.expose_secret()),
+                )
+                .header("Accept", "application/vnd.github+json")
+                .header("X-GitHub-Api-Version", "2022-11-28")
+                .send()
+                .await
+                .context("Failed to request installation repositories from GitHub")?;
+
+            if !response.status().is_success() {
+                let status = response.status();
+                let body = response.text().await.unwrap_or_default();
+                bail!(
+                    "GitHub API error ({}): {}",
+                    status,
+                    body.chars().take(200).collect::<String>()
+                );
+            }
+
+            let body: InstallationRepositoriesResponse = response
+                .json()
+                .await
+                .context("Failed to parse installation repositories response")?;
+
+            let count = body.repositories.len();
+            all_repos.extend(body.repositories.into_iter().map(|r| r.name));
+
+            if count < 100 {
+                break;
+            }
+            page = page.saturating_add(1);
+        }
+
+        Ok(all_repos)
+    }
+
     /// Get the App ID.
     #[must_use]
     pub fn app_id(&self) -> GitHubAppId {
@@ -406,6 +470,13 @@ pub(crate) fn minimal_git_permissions() -> HashMap<String, String> {
 // ============================================================================
 // User OAuth Token APIs
 // ============================================================================
+
+/// Response from GET /installation/repositories (paginated).
+#[derive(Debug, Deserialize)]
+struct InstallationRepositoriesResponse {
+    /// List of repositories the installation can access.
+    repositories: Vec<GitHubRepository>,
+}
 
 /// Response from GET /user/installations (paginated).
 #[derive(Debug, Deserialize)]
@@ -864,5 +935,37 @@ eyYRskrWOAtu0DuWJARLn74r5B4ze8s4DvUdPe781neRB1hMbXte6g==
             "iat→exp span must respect GitHub's 10-minute cap (got {})",
             exp - iat
         );
+    }
+
+    // Regression for #745: the repository list is read from
+    // GET /installation/repositories, whose entries carry a bare `name`
+    // alongside `full_name`. The stored list is bare names, so picking the
+    // wrong field would silently store "owner/repo" everywhere.
+    #[test]
+    fn installation_repositories_response_maps_to_bare_names() {
+        let body = serde_json::json!({
+            "total_count": 2,
+            "repositories": [
+                { "id": 1, "name": "api", "full_name": "acme/api" },
+                { "id": 2, "name": "web", "full_name": "acme/web" },
+            ]
+        });
+
+        let parsed: InstallationRepositoriesResponse =
+            serde_json::from_value(body).expect("parse installation repositories response");
+        let names: Vec<String> = parsed.repositories.into_iter().map(|r| r.name).collect();
+
+        assert_eq!(names, vec!["api".to_string(), "web".to_string()]);
+    }
+
+    // An installation scoped to all repositories reports an empty page here;
+    // the caller stores that as "no explicit selection" rather than an empty
+    // allow-list.
+    #[test]
+    fn installation_repositories_response_accepts_empty_page() {
+        let body = serde_json::json!({ "total_count": 0, "repositories": [] });
+        let parsed: InstallationRepositoriesResponse =
+            serde_json::from_value(body).expect("parse empty page");
+        assert!(parsed.repositories.is_empty());
     }
 }

--- a/crates/vouch-server/src/services/integrations/github/installations.rs
+++ b/crates/vouch-server/src/services/integrations/github/installations.rs
@@ -60,6 +60,77 @@ pub(crate) struct UnlinkedInstallation {
 // ============================================================================
 
 impl GitHubService<'_> {
+    /// Fetch and store the installation's repository list.
+    ///
+    /// The `installation.created` webhook carries this list, but it races the
+    /// OAuth callback that creates the installation row: when the webhook wins,
+    /// `update_github_installation_repos` finds no row, returns `Ok(false)`, and
+    /// the list is lost — later webhooks only carry deltas, so nothing restores
+    /// it. Fetching here makes the stored list independent of which arrives
+    /// first.
+    ///
+    /// Only meaningful for `repository_selection == "selected"`; an all-repos
+    /// installation is represented by a stored `None`.
+    ///
+    /// Failures are logged, not propagated: the installation itself is already
+    /// connected, and a later `installation_repositories` webhook can still fill
+    /// the list in.
+    async fn store_installation_repositories(
+        &self,
+        app: &crate::services::integrations::github::GitHubApp,
+        installation_id: u64,
+        repository_selection: &str,
+    ) {
+        if repository_selection != "selected" {
+            return;
+        }
+
+        // Network call, deliberately outside any DB retry closure.
+        let repos = match app
+            .list_installation_repositories(GitHubInstallationId(installation_id))
+            .await
+        {
+            Ok(repos) => repos,
+            Err(e) => {
+                tracing::warn!(
+                    installation_id,
+                    error = %e,
+                    "Failed to list installation repositories; repo list left unset"
+                );
+                return;
+            }
+        };
+
+        match db::update_github_installation_repos(
+            self.store,
+            installation_id.cast_signed(),
+            &repos,
+        )
+        .await
+        {
+            Ok(true) => {
+                tracing::info!(
+                    installation_id,
+                    count = repos.len(),
+                    "Stored selected repositories for installation"
+                );
+            }
+            Ok(false) => {
+                tracing::warn!(
+                    installation_id,
+                    "Installation row missing when storing repositories"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    installation_id,
+                    error = %e,
+                    "Failed to store installation repositories"
+                );
+            }
+        }
+    }
+
     /// Connect a new GitHub App installation to an organization.
     ///
     /// This is called after the user installs the GitHub App and is redirected
@@ -91,6 +162,13 @@ impl GitHubService<'_> {
         )
         .await
         .map_err(GitHubError::Database)?;
+
+        self.store_installation_repositories(
+            app,
+            params.installation_id,
+            &details.repository_selection,
+        )
+        .await;
 
         tracing::info!(
             "GitHub installation connected: {} -> org {}",
@@ -182,6 +260,13 @@ impl GitHubService<'_> {
         )
         .await
         .map_err(GitHubError::Database)?;
+
+        self.store_installation_repositories(
+            app,
+            params.installation_id,
+            &details.repository_selection,
+        )
+        .await;
 
         tracing::info!(
             "GitHub installation reconnected: {} -> org {} by user {}",

--- a/crates/vouch-server/src/services/integrations/github/webhooks.rs
+++ b/crates/vouch-server/src/services/integrations/github/webhooks.rs
@@ -213,18 +213,27 @@ impl GitHubService<'_> {
                         installation.account.login,
                         repo_names.len()
                     );
-                    if let Err(e) = db::update_github_installation_repos(
+                    match db::update_github_installation_repos(
                         self.store,
                         installation_id,
                         &repo_names,
                     )
                     .await
                     {
-                        tracing::error!(
+                        Ok(true) => {}
+                        // The OAuth callback has not created the row yet. It
+                        // fetches the repository list itself once it does, so
+                        // nothing is lost — but the race is worth seeing.
+                        Ok(false) => tracing::warn!(
+                            "Installation {} not yet stored; repo list from webhook \
+                             dropped, callback will fetch it",
+                            installation_id
+                        ),
+                        Err(e) => tracing::error!(
                             "Failed to update repos for installation {}: {}",
                             installation_id,
                             e
-                        );
+                        ),
                     }
                 }
             }

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/jwks.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/jwks.rs
@@ -5,16 +5,10 @@
 //! with database-backed caching for multi-instance deployments.
 
 use super::validate::JwtAssertionHeader;
-use crate::db::documents::jwks_cache::{JWKS_STALE_MAX_AGE_SECONDS, JwksCacheDoc};
-use crate::db::{self, store::DocumentStore};
+use crate::db::documents::jwks_cache::JwksCacheDoc;
+use crate::db::store::DocumentStore;
 use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
 use serde::Deserialize;
-
-/// Maximum JWKS response size (256KB).
-const MAX_JWKS_RESPONSE_SIZE: usize = 256 * 1024;
-
-/// JWKS URI cache TTL in seconds (1 hour).
-const JWKS_CACHE_TTL_SECONDS: i64 = 3600;
 
 /// A JSON Web Key Set (RFC 7517 Section 5).
 #[derive(Debug, Deserialize)]
@@ -95,6 +89,9 @@ pub async fn resolve_client_jwks(
 }
 
 /// Fetch JWKS from a URI with caching.
+///
+/// Fetching, cache freshness, and stale-while-revalidate live in
+/// [`crate::infra::jwks`] so the RFC 9421 signature path applies the same rules.
 async fn resolve_jwks_uri(
     store: &DocumentStore,
     parent_id: &str,
@@ -103,125 +100,16 @@ async fn resolve_jwks_uri(
     allow_loopback: bool,
     http_client: &reqwest::Client,
 ) -> ServiceResult<JwkSet> {
-    // Check cache freshness
-    if let Some(cache) = cached
-        && cache.is_fresh(JWKS_CACHE_TTL_SECONDS)
-    {
-        return parse_jwks_value(&cache.value);
-    }
-
-    // Cache is stale or missing — attempt fetch
-    match fetch_and_parse_jwks(uri, allow_loopback, http_client).await {
-        Ok((jwks_value, jwks_set)) => {
-            if let Err(e) = db::upsert_jwks_cache(store, parent_id, &jwks_value).await {
-                tracing::warn!("Failed to update JWKS cache for {parent_id}: {e}");
-            }
-            Ok(jwks_set)
-        }
-        Err(e) => {
-            // Stale-while-revalidate: use stale cache on fetch failure (with max age cap)
-            if let Some(cache) = cached {
-                if cache.is_within_stale_window(JWKS_STALE_MAX_AGE_SECONDS) {
-                    tracing::warn!("JWKS fetch failed, using stale cache: {e}");
-                    return parse_jwks_value(&cache.value);
-                }
-                tracing::warn!(
-                    "JWKS fetch failed and stale cache too old ({}s)",
-                    cache.age_seconds()
-                );
-            }
-            Err(e)
-        }
-    }
-}
-
-/// Fetch JWKS from a remote URI.
-///
-/// Enforces HTTPS-only and response size cap.
-async fn fetch_jwks(
-    uri: &str,
-    allow_loopback: bool,
-    http_client: &reqwest::Client,
-) -> ServiceResult<String> {
-    // HTTPS-only
-    if !uri.starts_with("https://") {
-        return Err(ServiceError::oauth(
-            OAuthErrorCode::InvalidClient,
-            "JWKS URI must use HTTPS",
-        ));
-    }
-
-    // SSRF egress guard: a client-registered `jwks_uri` is fetched here while
-    // verifying a `private_key_jwt` assertion, and dynamic client registration
-    // is unauthenticated — refuse to dial private/link-local targets. Loopback
-    // is permitted only in local development (`allow_loopback`).
-    crate::infra::ssrf::assert_public_destination(
+    let value = crate::infra::jwks::resolve_cached_jwks(
+        store,
+        parent_id,
         uri,
+        cached,
         allow_loopback,
-        OAuthErrorCode::InvalidClient,
+        http_client,
     )
     .await?;
-
-    let response = http_client.get(uri).send().await.map_err(|e| {
-        tracing::warn!("Failed to fetch JWKS from {uri}: {e}");
-        ServiceError::oauth(
-            OAuthErrorCode::InvalidClient,
-            "Failed to fetch JWKS from URI",
-        )
-    })?;
-
-    if !response.status().is_success() {
-        return Err(ServiceError::oauth(
-            OAuthErrorCode::InvalidClient,
-            "JWKS URI request failed",
-        ));
-    }
-
-    // Check content length before reading body
-    if let Some(len) = response.content_length()
-        && len > MAX_JWKS_RESPONSE_SIZE as u64
-    {
-        return Err(ServiceError::oauth(
-            OAuthErrorCode::InvalidClient,
-            "JWKS response exceeds maximum size (256KB)",
-        ));
-    }
-
-    let body = response.bytes().await.map_err(|e| {
-        ServiceError::oauth(
-            OAuthErrorCode::InvalidClient,
-            format!("Failed to read JWKS response: {e}"),
-        )
-    })?;
-
-    if body.len() > MAX_JWKS_RESPONSE_SIZE {
-        return Err(ServiceError::oauth(
-            OAuthErrorCode::InvalidClient,
-            "JWKS response exceeds maximum size (256KB)",
-        ));
-    }
-
-    String::from_utf8(body.to_vec()).map_err(|_| {
-        ServiceError::oauth(
-            OAuthErrorCode::InvalidClient,
-            "JWKS response is not valid UTF-8",
-        )
-    })
-}
-
-/// Fetch JWKS from a URI and parse into both a `Value` (for caching) and a `JwkSet`.
-async fn fetch_and_parse_jwks(
-    uri: &str,
-    allow_loopback: bool,
-    http_client: &reqwest::Client,
-) -> ServiceResult<(serde_json::Value, JwkSet)> {
-    let jwks_json = fetch_jwks(uri, allow_loopback, http_client).await?;
-    let jwks_value: serde_json::Value = serde_json::from_str(&jwks_json).map_err(|e| {
-        tracing::debug!("Failed to parse JWKS as JSON value: {e}");
-        ServiceError::oauth(OAuthErrorCode::InvalidClient, "Invalid JWKS format")
-    })?;
-    let jwks_set = parse_jwks_value(&jwks_value)?;
-    Ok((jwks_value, jwks_set))
+    parse_jwks_value(&value)
 }
 
 /// Parse a JWKS JSON string.
@@ -346,13 +234,20 @@ pub async fn find_matching_key_with_refresh_client(
     }
 
     tracing::debug!("Key not found in JWKS cache for client {client_id}; force-refreshing");
-    match fetch_and_parse_jwks(uri, allow_loopback, http_client).await {
-        Ok((jwks_value, fresh_jwks)) => {
-            if let Err(e) = db::upsert_jwks_cache(store, client_id, &jwks_value).await {
-                tracing::warn!("Failed to update JWKS cache for client {client_id}: {e}");
+    // Deliberately the unconditional fetch, not `resolve_cached_jwks`: this path
+    // has already decided the cache is not to be trusted (the kid is missing
+    // from it), so the TTL and the stale fallback must both be bypassed. The
+    // 10-second rate limit above is what bounds the fetch rate here.
+    match crate::infra::jwks::fetch_and_cache(store, client_id, uri, allow_loopback, http_client)
+        .await
+    {
+        Ok(jwks_value) => match parse_jwks_value(&jwks_value) {
+            Ok(fresh_jwks) => find_matching_key(&fresh_jwks, header),
+            Err(e) => {
+                tracing::warn!("Force-refreshed JWKS for client {client_id} did not parse: {e}");
+                find_matching_key(jwks, header)
             }
-            find_matching_key(&fresh_jwks, header)
-        }
+        },
         Err(e) => {
             tracing::warn!("JWKS force-refresh failed for client {client_id}: {e}");
             find_matching_key(jwks, header)
@@ -902,49 +797,6 @@ mod tests {
         let key = ec_jwk_entry(None, None, None);
         let result = build_decoding_key_from_jwk(&key, "ES384");
         assert!(result.is_err());
-    }
-
-    // =======================================================================
-    // fetch_jwks HTTPS enforcement test
-    // =======================================================================
-
-    #[tokio::test]
-    async fn test_fetch_jwks_rejects_http_url() {
-        let client = reqwest::Client::new();
-        let result = fetch_jwks("http://example.com/jwks", false, &client).await;
-        let err = result.unwrap_err();
-        assert!(
-            matches!(&err, ServiceError::OAuth { code, .. } if *code == OAuthErrorCode::InvalidClient)
-        );
-        assert!(
-            matches!(&err, ServiceError::OAuth { description, .. } if description == "JWKS URI must use HTTPS")
-        );
-    }
-
-    #[tokio::test]
-    async fn test_fetch_jwks_rejects_ftp_url() {
-        let client = reqwest::Client::new();
-        let result = fetch_jwks("ftp://example.com/jwks", false, &client).await;
-        let err = result.unwrap_err();
-        assert!(
-            matches!(&err, ServiceError::OAuth { code, .. } if *code == OAuthErrorCode::InvalidClient)
-        );
-        assert!(
-            matches!(&err, ServiceError::OAuth { description, .. } if description == "JWKS URI must use HTTPS")
-        );
-    }
-
-    #[tokio::test]
-    async fn test_fetch_jwks_rejects_empty_uri() {
-        let client = reqwest::Client::new();
-        let result = fetch_jwks("", false, &client).await;
-        let err = result.unwrap_err();
-        assert!(
-            matches!(&err, ServiceError::OAuth { code, .. } if *code == OAuthErrorCode::InvalidClient)
-        );
-        assert!(
-            matches!(&err, ServiceError::OAuth { description, .. } if description == "JWKS URI must use HTTPS")
-        );
     }
 
     // ====================================================================

--- a/crates/vouch-server/src/test_utils.rs
+++ b/crates/vouch-server/src/test_utils.rs
@@ -1339,6 +1339,10 @@ pub struct TestClientSpec {
     pub token_endpoint_auth_method: Option<crate::db::TokenEndpointAuthMethod>,
     /// JWKS to register with the client. Default: `TestJwks::None`.
     pub jwks: TestJwks,
+    /// Remote JWKS URI to register. Default: `None`. Required for clients whose
+    /// keys are resolved through the JWKS cache, which is only ever populated
+    /// by fetching this URI.
+    pub jwks_uri: Option<String>,
     /// Require DPoP-bound access tokens. Default: `false`.
     pub dpop_bound_access_tokens: bool,
     /// Allowed grant types override. Default: `None`.
@@ -1377,6 +1381,7 @@ impl Default for TestClientSpec {
             resource_uris: vec![],
             token_endpoint_auth_method: Option::None,
             jwks: TestJwks::None,
+            jwks_uri: Option::None,
             dpop_bound_access_tokens: false,
             grant_types: Option::None,
             fapi_profile: Option::None,
@@ -1446,7 +1451,7 @@ pub async fn create_test_client(
             resource_uris: &spec.resource_uris,
             token_endpoint_auth_method: spec.token_endpoint_auth_method,
             jwks: jwks_value.as_ref(),
-            jwks_uri: Option::None,
+            jwks_uri: spec.jwks_uri.as_deref(),
             fapi_profile: spec.fapi_profile,
             dpop_bound_access_tokens: if spec.dpop_bound_access_tokens {
                 Some(true)

--- a/crates/vouch-server/src/test_utils.rs
+++ b/crates/vouch-server/src/test_utils.rs
@@ -1259,17 +1259,34 @@ pub async fn create_test_scim_token(
     // Hash for storage
     let token_hash = hex::encode(digest::digest(&SHA256, token.as_bytes()));
 
+    // Token creation enforces the per-org cap against the organization row, so
+    // the org must exist. Tests pass opaque ids like "test-org" rather than
+    // building an org first, so seed one on demand.
+    if store
+        .get::<crate::db::documents::organization::OrganizationDoc>(org_id)
+        .await
+        .expect("look up test org")
+        .is_none()
+    {
+        store
+            .insert_with_id(
+                org_id,
+                &crate::db::documents::organization::OrganizationDoc {
+                    domain: format!("{org_id}.example"),
+                    name: Some(org_id.to_string()),
+                    created_by_user_id: None,
+                    additional_domains: Vec::new(),
+                    subdomain: None,
+                },
+            )
+            .await
+            .expect("seed test org");
+    }
+
     // Store in database with org_id so authenticate_scim accepts it
-    crate::db::create_scim_token(
-        store,
-        &token_hash,
-        Some(description),
-        None,
-        Some(org_id),
-        None,
-    )
-    .await
-    .expect("Failed to create SCIM token");
+    crate::db::create_scim_token(store, org_id, &token_hash, Some(description), None)
+        .await
+        .expect("Failed to create SCIM token");
 
     token
 }

--- a/crates/vouch-server/tests/arch_boundaries.rs
+++ b/crates/vouch-server/tests/arch_boundaries.rs
@@ -76,6 +76,12 @@ const EXCEPTIONS: &[Exception] = &[
         reason: "RFC 9421 key resolver reads OAuth client JWKS from storage",
     },
     Exception {
+        file: "infra/jwks.rs",
+        target: "db",
+        reason: "owns the JWKS cache freshness rule, so it reads and writes \
+                 the cache rows it decides are stale",
+    },
+    Exception {
         file: "infra/org_host.rs",
         target: "db",
         reason: "pure domain-label validation fn, no I/O",

--- a/crates/vouch-tests/tests/integration.rs
+++ b/crates/vouch-tests/tests/integration.rs
@@ -2738,7 +2738,9 @@ mod httpsig {
     #[tokio::test]
     async fn test_httpsig_jwks_cache_fallback_verifies() {
         // A client registered without inline JWKS (the jwks_uri flow) resolves
-        // its signing key from the JWKS cache row instead.
+        // its signing key from the JWKS cache row instead. The cache row is only
+        // ever populated by fetching jwks_uri, so the client must carry one —
+        // a cache row with no URI behind it can never be revalidated.
         use vouch_server::test_utils::{TestClientSpec, TestJwks, create_test_client};
 
         let harness = TestHarness::new().await;
@@ -2764,6 +2766,7 @@ mod httpsig {
                     vouch_server::db::TokenEndpointAuthMethod::PrivateKeyJwt,
                 ),
                 jwks: TestJwks::None,
+                jwks_uri: Some("https://client.example/jwks.json".to_string()),
                 dpop_bound_access_tokens: true,
                 id_token_signed_response_alg: vouch_server::db::JwsAlgorithm::Es256,
                 with_secret: false,


### PR DESCRIPTION
Fixes the nine bugs reported in #740–#748, one commit each, plus a follow-on
i18n commit for the file #746 touches.

Fixes #740
Fixes #741
Fixes #742
Fixes #743
Fixes #744
Fixes #745
Fixes #746
Fixes #747
Fixes #748

## CLI

- **#740** — `KUBECONFIG` was split on `':'`, truncating Windows paths at the
  drive letter (`D:\kube\config` → `D`). Uses `std::env::split_paths`. The same
  defect existed in three places; they are consolidated onto the one
  `default_kubeconfig_path()`. The copy in `doctor.rs` also lacked the
  empty-entry guard, so a leading `:` produced an empty path instead of falling
  back to `~/.kube/config`.
- **#741** — `strip_ssm_block` ended the SSM block at the next blank line and
  ran to end of file when there was none, so `vouch setup ssm --force` deleted
  every SSH config entry after the block, and emptied the file entirely when the
  block came first. It now ends at the next top-level `Host`/`Match` stanza.

## Server

- **#742** — enrollment wrote `created_by_user_id` on any organization with an
  empty admin slot, without checking the enrollee belonged to it. The enrollee
  gained no privileges, but the slot was filled, so the organization's first real
  enrollee was permanently denied promotion.
- **#743** — updating a FAPI 2.0 application to the standard profile set
  `client_secret_basic` without minting a secret, leaving it unable to
  authenticate with no way back. The transition is now rejected; operators create
  a standard client instead. **This blocks an operation that previously
  succeeded.**
- **#744** — both SCIM token handlers counted an organization's active tokens and
  then inserted in a separate transaction, so concurrent requests could exceed the
  two-token cap. The count moves inside the insert's transaction, with the
  organization document's version as the serialization point.
- **#745** — the `installation.created` webhook races the OAuth callback that
  creates the installation row; when the webhook won, the selected-repository list
  was dropped and never restored, since later webhooks carry only deltas. The
  callback now fetches the list itself via `GET /installation/repositories`.
- **#746** — device enrollment logged `authorize_device_auth` and
  `create_enrollment_session` failures at `warn!` and continued to the keys page,
  so the browser showed success while the CLI polled to timeout. Both now render
  the error page.
- **#747** — `delete_oauth_client` ran a multi-step transaction with no retry
  wrapper. Wrapped in `with_dsql_retry!`, matching `delete_scim_group`.
- **#748** — the RFC 9421 key resolver read the JWKS cache row with no TTL check,
  so a key a client had rotated out kept verifying signatures. Fetching, cache
  freshness, and stale-while-revalidate move into `infra/jwks.rs`, shared with the
  RFC 7523 assertion path so the two cannot drift.

## i18n

Every `ErrorTemplate` in the enrollment handlers passed hardcoded English into
`error.html`, which translates its own chrome but renders caller-supplied text
verbatim. All 24 now resolve through Fluent.

## Other behavior changes

Beyond the reported symptoms:

- #748 — resolving through the JWKS cache now requires the `jwks_uri` the row was
  fetched from. A row with no URI behind it can never be revalidated, which is the
  same stale-key exposure.
- #744 — `create_scim_token` takes a required `org_id` (every caller already
  passed one) and drops its unused `scope` parameter. `count_active_scim_tokens`
  is removed with its last caller.

## Test coverage notes

- #744's concurrency test passes on SQLite even with the `compare_and_update`
  version guard removed, because SQLite serializes writers. The guard is there for
  PostgreSQL and DSQL, where two transactions read the same snapshot. This is
  documented in the test. The same applies to the existing
  `test_concurrent_secret_add_never_exceeds_two`.
- #745 has no end-to-end coverage — that needs a real GitHub App install. The
  response parsing is unit-tested.
- #746 covers the `authorize_device_auth` failure path, which is reachable via a
  missing or non-pending row. The `create_enrollment_session` path would need
  fault injection the harness does not have.

Two tests that asserted the old behavior were rewritten:
`fapi_update_explicit_non_fapi_transitions_to_standard` and
`test_web_update_form_fapi_exit_resets_dpop_binding` (#743), plus
`test_httpsig_jwks_cache_fallback_verifies` (#748), which seeded a cache row with
no `jwks_uri` — a state production cannot produce.

## Verification

`make fmt`, `make lint`, `make test` (4211 passed), `make test-integration`
(357 passed), and `prek run` are all clean. `make audit` was not run; no
dependency changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
