### PR TITLE
refactor(server): dedupe SAML element lookup and consolidate CSPRNG helpers

### DIFF
--- a/crates/vouch-server/src/db/dpop.rs
+++ b/crates/vouch-server/src/db/dpop.rs
@@ -6,7 +6,6 @@ use super::document_type::DocumentType;
 use super::documents::dpop::{DpopJtiDoc, DpopNonceDoc};
 use super::store::DocumentStore;
 use anyhow::{Context, Result};
-use aws_lc_rs::rand as aws_rand;
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use jiff::{Timestamp, ToSpan};
@@ -39,20 +38,13 @@ fn deterministic_dpop_nonce_id(nonce: &str) -> String {
     hex::encode(ctx.finish().as_ref())
 }
 
-/// Generate a random URL-safe string.
-fn generate_random_string(len: usize) -> Result<String> {
-    let mut bytes = vec![0u8; len];
-    aws_rand::fill(&mut bytes).map_err(|_| anyhow::anyhow!("RNG failure"))?;
-    Ok(URL_SAFE_NO_PAD.encode(&bytes))
-}
-
 /// Generate and store a DPoP nonce. Returns the nonce string.
 ///
 /// Stores the nonce under a deterministic document ID derived from the
 /// nonce itself, so [`validate_and_consume_dpop_nonce`] can perform an
 /// atomic primary-key DELETE without a find-then-delete TOCTOU window.
 pub async fn generate_dpop_nonce(store: &DocumentStore, validity_seconds: i64) -> Result<String> {
-    let nonce = generate_random_string(32)?;
+    let nonce = URL_SAFE_NO_PAD.encode(crate::crypto::generate_random_bytes(32)?);
     let now = Timestamp::now();
     let expires_at = now
         .checked_add(validity_seconds.seconds())

--- a/crates/vouch-server/src/db/organizations/domains.rs
+++ b/crates/vouch-server/src/db/organizations/domains.rs
@@ -15,7 +15,6 @@ use crate::db::documents::organization::{
 };
 use crate::db::store::DocumentStore;
 use anyhow::Result;
-use aws_lc_rs::rand as aws_rand;
 use jiff::Timestamp;
 
 /// Maximum additional (non-primary) email domains per organization.
@@ -39,9 +38,7 @@ pub struct AddedDomain {
 
 /// Generate a fresh verification token suitable for use in a DNS TXT record.
 fn generate_verification_token() -> Result<String> {
-    let mut bytes = [0u8; 32];
-    aws_rand::fill(&mut bytes).map_err(|_| anyhow::anyhow!("RNG failure"))?;
-    Ok(hex::encode(bytes))
+    Ok(hex::encode(crate::crypto::generate_random_bytes(32)?))
 }
 
 /// Internal OCC-retry error for organization document CAS mutations.

--- a/crates/vouch-server/src/db/par.rs
+++ b/crates/vouch-server/src/db/par.rs
@@ -116,10 +116,7 @@ pub struct CreateParParams<'a> {
 ///
 /// Returns an error if the CSPRNG fails.
 fn generate_request_uri() -> Result<String> {
-    let mut buf = [0u8; 32];
-    aws_lc_rs::rand::fill(&mut buf)
-        .map_err(|_| anyhow::anyhow!("Failed to generate random bytes for request_uri"))?;
-    let encoded = URL_SAFE_NO_PAD.encode(buf);
+    let encoded = URL_SAFE_NO_PAD.encode(crate::crypto::generate_random_bytes(32)?);
     Ok(format!("urn:ietf:params:oauth:request_uri:{encoded}"))
 }
 

--- a/crates/vouch-server/src/handlers/admin/mod.rs
+++ b/crates/vouch-server/src/handlers/admin/mod.rs
@@ -24,7 +24,6 @@ use crate::AppState;
 use crate::db;
 use crate::error::ServiceError;
 use aws_lc_rs::digest::{self, SHA256};
-use aws_lc_rs::rand as aws_rand;
 use axum::http::StatusCode;
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -50,8 +49,7 @@ pub(crate) struct GeneratedScimToken {
 
 /// Generate a random SCIM token and its hash for storage.
 pub(crate) fn generate_scim_token() -> Result<GeneratedScimToken, ServiceError> {
-    let mut token_bytes = [0u8; 32];
-    aws_rand::fill(&mut token_bytes).map_err(|_| {
+    let token_bytes = crate::crypto::generate_random_bytes(32).map_err(|_| {
         ServiceError::api(
             StatusCode::INTERNAL_SERVER_ERROR,
             "rng_error",

--- a/crates/vouch-server/src/services/idp/saml/authn_request.rs
+++ b/crates/vouch-server/src/services/idp/saml/authn_request.rs
@@ -129,8 +129,8 @@ pub(crate) fn build_authn_request(
 /// The `_` prefix ensures the ID is a valid XML NCName. SAML IDs may not
 /// start with a digit.
 fn generate_request_id() -> Result<String, AuthnRequestError> {
-    let mut bytes = [0u8; 16];
-    aws_lc_rs::rand::fill(&mut bytes).map_err(|e| AuthnRequestError::RandomId(e.to_string()))?;
+    let bytes = crate::crypto::generate_random_bytes(16)
+        .map_err(|e| AuthnRequestError::RandomId(e.to_string()))?;
     let hex: String = bytes.iter().fold(String::with_capacity(32), |mut s, b| {
         use std::fmt::Write as _;
         // Writing to a String never fails; ignore the formal Result.

--- a/crates/vouch-server/src/services/idp/saml/metadata.rs
+++ b/crates/vouch-server/src/services/idp/saml/metadata.rs
@@ -93,9 +93,13 @@ pub(crate) fn parse_idp_metadata(xml: &str) -> Result<IdpMetadata, MetadataError
     let doc =
         roxmltree::Document::parse(xml).map_err(|e| MetadataError::XmlParse(e.to_string()))?;
 
-    // Find EntityDescriptor -- handle both direct root and EntitiesDescriptor wrapper.
-    let entity_descriptor =
-        find_entity_descriptor(&doc).ok_or(MetadataError::MissingEntityDescriptor)?;
+    // Find EntityDescriptor -- descendants() handles both a direct root and the
+    // EntitiesDescriptor wrapper some federations use (ADFS, Shibboleth).
+    let entity_descriptor = doc
+        .root()
+        .descendants()
+        .find(|n| n.has_tag_name((NS_MD, "EntityDescriptor")))
+        .ok_or(MetadataError::MissingEntityDescriptor)?;
 
     // Extract entityID attribute.
     let entity_id = entity_descriptor
@@ -173,7 +177,8 @@ pub(crate) fn parse_idp_metadata(xml: &str) -> Result<IdpMetadata, MetadataError
         return Err(MetadataError::NoSsoEndpoint);
     }
 
-    // Warn if no signing certificates found (F1 fix).
+    // Metadata without signing certificates is accepted but unusable for
+    // response verification, so surface it rather than failing the parse.
     if signing_certificates.is_empty() {
         tracing::warn!(
             entity_id,
@@ -188,18 +193,6 @@ pub(crate) fn parse_idp_metadata(xml: &str) -> Result<IdpMetadata, MetadataError
         sso_redirect_url,
         signing_certificates,
     })
-}
-
-/// Find the first `EntityDescriptor` element in the document.
-///
-/// Handles both direct root `EntityDescriptor` and the `EntitiesDescriptor`
-/// wrapper used by some federation metadata (ADFS, Shibboleth federations).
-fn find_entity_descriptor<'a, 'input>(
-    doc: &'a roxmltree::Document<'input>,
-) -> Option<roxmltree::Node<'a, 'input>> {
-    doc.root()
-        .descendants()
-        .find(|n| n.has_tag_name((NS_MD, "EntityDescriptor")))
 }
 
 /// Generate SP metadata XML for the `/saml/metadata` endpoint.
@@ -608,7 +601,7 @@ mod tests {
         );
     }
 
-    /// F1: Empty signing_certificates should trigger a tracing::warn but not fail.
+    /// Empty signing_certificates should trigger a tracing::warn but not fail.
     #[test]
     fn empty_signing_certificates_is_accepted_with_warning() {
         // No KeyDescriptor elements -- metadata is valid but no certs.

--- a/crates/vouch-server/src/services/idp/saml/response.rs
+++ b/crates/vouch-server/src/services/idp/saml/response.rs
@@ -167,13 +167,16 @@ pub(crate) fn validate_saml_response(
     let signed_id =
         super::signature::verify_xml_signature(&doc, &provider.idp_metadata.signing_certificates)?;
 
-    // After verification, re-resolve signed element by ID (XSW mitigation)
-    let signed_element = find_element_by_id(&doc, &signed_id.0).ok_or_else(|| {
-        ResponseError::Other(format!(
-            "signed element '{}' not found after verification",
-            signed_id.0
-        ))
-    })?;
+    // After verification, re-resolve signed element by ID (XSW mitigation).
+    // Deliberately the same lookup verify_xml_signature used, so the element we
+    // consume is provably the element that was verified.
+    let signed_element =
+        super::signature::find_element_by_id(&doc, &signed_id.0).ok_or_else(|| {
+            ResponseError::Other(format!(
+                "signed element '{}' not found after verification",
+                signed_id.0
+            ))
+        })?;
 
     // Step 4: Require Destination matches ACS URL
     // SAML Bindings Section 3.5.5.2: Destination is REQUIRED for POST binding.
@@ -594,19 +597,6 @@ fn find_saml_attribute(assertion: roxmltree::Node<'_, '_>, attr_name: &str) -> O
         }
     }
     None
-}
-
-/// Find an element whose `ID` attribute matches the given value.
-fn find_element_by_id<'a, 'input>(
-    doc: &'a roxmltree::Document<'input>,
-    id: &str,
-) -> Option<roxmltree::Node<'a, 'input>> {
-    doc.root().descendants().find(|n| {
-        n.is_element()
-            && (n.attribute("ID") == Some(id)
-                || n.attribute("Id") == Some(id)
-                || n.attribute("id") == Some(id))
-    })
 }
 
 /// Parse a SAML timestamp string (ISO 8601 / RFC 3339) into a `jiff::Timestamp`.

--- a/crates/vouch-server/src/services/idp/saml/signature.rs
+++ b/crates/vouch-server/src/services/idp/saml/signature.rs
@@ -377,8 +377,11 @@ fn c14n_excluding_signature(
     // recurse into children (skipping sig_node), then close.
     //
     // The cleanest approach: serialize the signed_element to XML without the
-    // Signature subtree, then parse that and canonicalize it.
-    let xml_without_sig = serialize_without_signature(signed_element, sig_node);
+    // Signature subtree, then parse that and canonicalize it. The serialization
+    // copies namespace declarations down from ancestors so the fragment stands
+    // alone as a well-formed document.
+    let mut xml_without_sig = String::with_capacity(4096);
+    serialize_node_excl(&mut xml_without_sig, signed_element, sig_node.id());
 
     let doc = match roxmltree::Document::parse(&xml_without_sig) {
         Ok(d) => d,
@@ -394,20 +397,6 @@ fn c14n_excluding_signature(
     } else {
         String::new()
     }
-}
-
-/// Serialize an element subtree to XML string, excluding the given signature node.
-///
-/// Produces a well-formed XML fragment with all necessary namespace declarations
-/// copied from ancestors to make it a standalone document.
-fn serialize_without_signature(
-    element: roxmltree::Node<'_, '_>,
-    sig_node: roxmltree::Node<'_, '_>,
-) -> String {
-    let sig_id = sig_node.id();
-    let mut out = String::with_capacity(4096);
-    serialize_node_excl(&mut out, element, sig_id);
-    out
 }
 
 /// Recursively serialize a node, skipping the node with the given ID.

--- a/crates/vouch-server/src/services/idp/saml/signature.rs
+++ b/crates/vouch-server/src/services/idp/saml/signature.rs
@@ -312,7 +312,13 @@ fn find_child_element<'a, 'input>(
 /// Find an element whose `ID` attribute (case-sensitive) matches the given value.
 ///
 /// Searches by common SAML ID attribute names: `ID`, `Id`, `id`.
-fn find_element_by_id<'a, 'input>(
+///
+/// This is the XML Signature Wrapping mitigation's identity function, so both
+/// halves of it must resolve identically: `verify_xml_signature` uses it to find
+/// the `Reference URI` target before verifying, and `response.rs` uses it again
+/// afterwards to re-resolve the element it consumes. Two copies that drift would
+/// silently turn that second lookup into a different element.
+pub(super) fn find_element_by_id<'a, 'input>(
     doc: &'a roxmltree::Document<'input>,
     id: &str,
 ) -> Option<roxmltree::Node<'a, 'input>> {

--- a/crates/vouch-server/src/services/integrations/github/app.rs
+++ b/crates/vouch-server/src/services/integrations/github/app.rs
@@ -49,19 +49,15 @@ impl RsaPrivateKeyDer {
     pub(crate) fn from_pem(pem_or_base64: &str) -> Result<Self> {
         let pem =
             crate::crypto::pem::decode_base64_pem(pem_or_base64).context("Invalid key format")?;
-        Self::parse_pem(&pem)
-    }
 
-    /// Parse a PEM-formatted PKCS#1 key.
-    fn parse_pem(content: &str) -> Result<Self> {
-        if !content.contains("RSA PRIVATE KEY") {
+        if !pem.contains("RSA PRIVATE KEY") {
             anyhow::bail!(
                 "Invalid key format: expected PKCS#1 PEM ('BEGIN RSA PRIVATE KEY'), \
                  not PKCS#8. GitHub App keys should be in PKCS#1 format."
             );
         }
 
-        let der_bytes = Self::pem_to_der(content)?;
+        let der_bytes = Self::pem_to_der(&pem)?;
         tracing::debug!("Parsed PKCS#1 RSA key: {} DER bytes", der_bytes.len());
         Ok(Self(Zeroizing::new(der_bytes)))
     }


### PR DESCRIPTION
Follow-up work from an audit of private single-caller functions in `vouch-server`.

## Dedupe `find_element_by_id`

`saml/signature.rs` and `saml/response.rs` held byte-identical copies of this
lookup. Both are halves of the XML Signature Wrapping mitigation:
`verify_xml_signature` resolves the `Reference URI` target before verifying, and
`validate_saml_response` re-resolves the same element afterwards so the element
it consumes is provably the one that was verified. If the copies drift, that
second lookup stops being an identity check.

The `signature.rs` copy is kept — its two unit tests already cover it — and made
`pub(super)`.

## Inline three single-caller helpers

`serialize_without_signature`, `find_entity_descriptor` and `parse_pem` each had
one caller, no test naming them, and no step worth a name. Two were a single
expression; the third folded into a 6-line caller.

These are the only three of 27 similarly-shaped helpers that were safe to
inline. The rest stay: some name an invariant such as a document-ID domain
separator, some are covered by tests that drive the HTTP handler rather than
calling them by name, and some sit at call sites where inlining is not
expressible — match guards, `Option::map` closures, let-chain bindings, and `?`
inside a `tokio::spawn` body that returns `()`.

## Consolidate CSPRNG calls

Five sites hand-rolled the `aws_lc_rs::rand::fill` idiom that
`crypto::generate_random_bytes` already provides and unit-tests: DPoP nonces,
PAR request URIs, domain verification tokens, SCIM tokens and SAML request IDs.

Three copies are left alone deliberately. `ssh_ca.rs` and `cleanup.rs` need a
fixed-size array for `u64::from_*_bytes`, which the `Vec`-returning helper would
turn into a fallible conversion for no benefit. `applications::generate_client_secret`
is infallible by signature, so converting it would cascade a `Result` to four
callers.

## Verification

- `make lint` — clean
- `make test` — pass, no failures
- `make test-integration` — pass, no failures
- `prek run` on the changed files — pass
- Each of the three commits builds independently (`cargo check -p vouch-server --all-features`)

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication and RNG centralization in SAML and token paths; PR states no behavior change and tests were run.
> 
> **Overview**
> Refactors `vouch-server` to remove duplicated helpers and route token/nonce generation through shared crypto, with **no intended behavior change**.
> 
> **SAML:** Duplicated `find_element_by_id` in `signature.rs` and `response.rs` is collapsed to a single `pub(super)` implementation in `signature.rs`, which `validate_saml_response` calls after verification so XSW re-resolution cannot drift from the pre-verify lookup. IdP metadata parsing inlines `find_entity_descriptor`; enveloped-signature canonicalization inlines `serialize_without_signature`.
> 
> **CSPRNG:** DPoP nonces, PAR `request_uri`s, org domain verification tokens, SCIM tokens, and SAML AuthnRequest IDs now use `crate::crypto::generate_random_bytes` instead of local `aws_lc_rs::rand::fill` wrappers.
> 
> **GitHub App:** `RsaPrivateKey::from_pem` folds PKCS#1 parsing into the caller instead of a separate `parse_pem` helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d6e1389a51dc63de1ab62fcb82432d3af3d6cf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->