### PR TITLE
docs: recommend NLB TCP passthrough over ALB

### DIFF
--- a/docs/src/admin/organizations.md
+++ b/docs/src/admin/organizations.md
@@ -21,13 +21,7 @@ cannot be managed through SCIM.
 
 ## The first enrollee becomes the administrator
 
-The first user to enroll from a domain is made that organization's administrator automatically, as
-part of the same transaction that creates their account. If several people enroll simultaneously,
-they race on a compare-and-swap against the organization record — exactly one wins and becomes
-administrator; the others enroll as ordinary members.
-
-There is no bootstrap token, no `VOUCH_ADMIN_EMAILS` setting, and no way to designate the first
-administrator ahead of time.
+The first user to enroll from a domain is made that organization's administrator automatically.
 
 > **Plan the first enrollment.** Whoever enrolls first from your domain holds the only
 > administrator account, and every subsequent administrator is promoted by an existing one. Enroll

--- a/docs/src/configuration/reverse-proxy.md
+++ b/docs/src/configuration/reverse-proxy.md
@@ -1,8 +1,8 @@
 # Behind a Reverse Proxy
 
-Most deployments put something in front of the Vouch server: an AWS ALB, nginx, HAProxy, a
-Kubernetes ingress controller. This chapter covers what has to be configured for that to work
-correctly, and the one setting whose absence degrades security silently.
+Most deployments put something in front of the Vouch server: an AWS Network Load Balancer, nginx,
+HAProxy, a Kubernetes ingress controller. This chapter covers what has to be configured for that to
+work correctly, and the one setting whose absence degrades security silently.
 
 ## Terminate TLS in Vouch where you can
 
@@ -15,7 +15,8 @@ whatever the proxy negotiates, and breaks RFC 8705 certificate-bound tokens outr
 client certificate never reaches Vouch.
 
 Terminate at the proxy only when something else forces it — a corporate WAF requirement, or a
-managed load balancer that cannot pass TCP through. If you do, everything below still applies.
+managed load balancer that cannot pass TCP through, such as an AWS Application Load Balancer. If
+you do, everything below still applies.
 
 ## Trusted proxies
 
@@ -73,7 +74,7 @@ Configure your proxy to pass the original host through:
 
 - **nginx** — `proxy_set_header Host $host;`
 - **HAProxy** — preserved by default
-- **AWS ALB** — preserved by default
+- **AWS NLB (TCP passthrough)** — no HTTP layer, so `Host` is never rewritten
 - **Kubernetes ingress-nginx** — preserved by default
 
 A blanket 421 across every request almost always means the proxy is rewriting `Host` to the
@@ -153,22 +154,65 @@ On the Vouch side, leave `VOUCH_TLS_CERT` and `VOUCH_TLS_KEY` unset, set
 `VOUCH_LISTEN_ADDR=0.0.0.0:3000`, set `VOUCH_BASE_URL=https://auth.example.com` so issued URLs use
 the public scheme and host, and set `VOUCH_TRUSTED_PROXIES` to the nginx host's range.
 
-### AWS Application Load Balancer
+### AWS Network Load Balancer (TCP passthrough — recommended)
 
-Use a TCP (NLB) or TLS-passthrough listener if you can. With an ALB terminating TLS:
+An NLB with TCP listeners forwards bytes untouched, so Vouch terminates TLS itself and keeps its
+cipher policy, its hybrid post-quantum key exchange, and its mTLS listener. Prefer it to an
+Application Load Balancer, which is HTTP-aware and always terminates TLS: that gives up all three
+and breaks RFC 8705 certificate-bound tokens outright, because the client certificate never reaches
+Vouch.
 
-- Target group protocol HTTP, port 3000
-- Health check path **`/health/ready`**, not `/health`
-- Set `VOUCH_TRUSTED_PROXIES` to your VPC or subnet CIDRs — the ALB's addresses are drawn from them
-- Set `VOUCH_BASE_URL` to the public HTTPS URL
+Use three TCP listeners, each forwarding to a **TCP** target group on the same port. A TLS target
+group would terminate at the load balancer and defeat the point.
+
+| Listener | Target group | Carries |
+|----------|--------------|---------|
+| TCP 443 | TCP 443 | HTTPS |
+| TCP 80 | TCP 80 | Vouch's own 308 redirect to HTTPS, plus `/health` |
+| TCP 8443 | TCP 8443 | mTLS, for certificate-bound tokens |
+
+NLB listeners have no redirect action of their own, which is why port 80 forwards to the instances
+and Vouch issues the redirect itself. Omit the 8443 listener only if you do not use
+certificate-bound tokens.
+
+Health-check the 443 target group with protocol **HTTPS** and path **`/health/ready`**. The health
+check's `Host` header is the load balancer node's IP rather than your domain, which is fine — Vouch
+validates `Host` only on the port 80 redirect listener. Do not health-check port 80 instead: it
+serves `/health` but not `/health/ready`, so it reports a live process even when the database is
+unreachable.
+
+On the Vouch side, set `VOUCH_TLS_CERT` and `VOUCH_TLS_KEY`, set `VOUCH_BASE_URL` to the public
+HTTPS URL, and leave `VOUCH_TRUSTED_PROXIES` **unset**.
+
+**Client IP preservation is the setting that bites.** TCP passthrough has no `X-Forwarded-For`, so
+the TCP peer address is the only client identity Vouch ever sees, and `VOUCH_TRUSTED_PROXIES`
+cannot recover it. Preservation is on by default for **instance** targets, but **off by default for
+IP targets on TCP and TLS target groups**. Left off, every request appears to come from a load
+balancer node: all users share one rate-limit bucket and audit events attribute nothing to anyone.
+Set `preserve_client_ip.enabled` to `true` on IP target groups.
+
+If cross-zone load balancing is disabled, register a target in **every** Availability Zone the load
+balancer has a node in. A zone whose node has no local target does not fail fast — it holds the
+connection for several seconds before falling back to another zone, which surfaces as intermittent
+multi-second latency rather than as an error.
 
 ## Checklist
+
+With TCP passthrough:
+
+- [ ] Client IP preservation is on for the target group, and `VOUCH_TRUSTED_PROXIES` is unset
+- [ ] Listeners exist for 443, 80, and 8443 if you use certificate-bound tokens
+- [ ] Health checks use HTTPS on 443, not HTTP on 80
+
+With TLS terminated at the proxy:
 
 - [ ] `VOUCH_TRUSTED_PROXIES` covers your proxy ranges, and nothing wider
 - [ ] The proxy forwards the original `Host`
 - [ ] The proxy appends to `X-Forwarded-For` rather than replacing it
+
+Either way:
+
+- [ ] Health checks target `/health/ready`, not `/health`
 - [ ] `VOUCH_BASE_URL` is the public URL clients use
-- [ ] Health checks target `/health/ready`
-- [ ] Port 8443 is reachable if you use certificate-bound tokens
 - [ ] Proxy timeouts are at least 30 seconds
 - [ ] Audit events at `/admin/audit` show real client IPs

--- a/docs/src/getting-started/overview.md
+++ b/docs/src/getting-started/overview.md
@@ -22,8 +22,7 @@ Before deploying, ensure you have:
                        ▼
               ┌─────────────────┐
               │  Load Balancer  │
-              │  (TLS termination │
-              │   or passthrough) │
+              │ TCP passthrough │
               └────────┬────────┘
                        │
                        ▼

--- a/docs/src/idp/overview.md
+++ b/docs/src/idp/overview.md
@@ -114,24 +114,6 @@ In production deployments using S3-backed configuration, IdPs live under the top
 
 Order in the `idps` array controls login-page button order.
 
-## Migration from legacy variables
-
-The previous flat single-IdP environment variables (`VOUCH_OIDC_ISSUER`, `VOUCH_OIDC_CLIENT_ID`, `VOUCH_OIDC_CLIENT_SECRET`, `VOUCH_OIDC_PROVIDERS`, `VOUCH_SAML_IDP_METADATA_URL`, `VOUCH_SAML_SP_ENTITY_ID`, `VOUCH_SAML_EMAIL_ATTRIBUTE`, `VOUCH_SAML_DOMAIN_ATTRIBUTE`) and the legacy S3 `oidc` / `saml` nested blocks are no longer read by the server. They are silently ignored if still present, but they configure nothing — only the unified `VOUCH_IDPS` / `idps[]` format below is honored. Update each legacy value to its replacement and remove the old one:
-
-| Legacy variable | Replacement |
-|---|---|
-| `VOUCH_OIDC_PROVIDERS=google,entra` | `VOUCH_IDPS=google,entra` |
-| `VOUCH_OIDC_<SLUG>_ISSUER` | `VOUCH_IDP_<SLUG>_ISSUER` (with `VOUCH_IDP_<SLUG>_TYPE=oidc`) |
-| `VOUCH_OIDC_<SLUG>_CLIENT_ID` | `VOUCH_IDP_<SLUG>_CLIENT_ID` |
-| `VOUCH_OIDC_<SLUG>_CLIENT_SECRET` | `VOUCH_IDP_<SLUG>_CLIENT_SECRET` |
-| `VOUCH_OIDC_ISSUER` (single-provider) | `VOUCH_IDPS=<slug>` + `VOUCH_IDP_<SLUG>_*` |
-| `VOUCH_SAML_IDP_METADATA_URL` | `VOUCH_IDP_<SLUG>_METADATA_URL` (with `VOUCH_IDP_<SLUG>_TYPE=saml`) |
-| `VOUCH_SAML_SP_ENTITY_ID` | `VOUCH_IDP_<SLUG>_SP_ENTITY_ID` |
-| `VOUCH_SAML_EMAIL_ATTRIBUTE` | `VOUCH_IDP_<SLUG>_EMAIL_ATTRIBUTE` |
-| `VOUCH_SAML_DOMAIN_ATTRIBUTE` | `VOUCH_IDP_<SLUG>_DOMAIN_ATTRIBUTE` |
-| S3 `{"oidc": {...}}` | S3 `{"idps": [{"id": "...", "type": "oidc", ...}]}` |
-| S3 `{"saml": {...}}` | S3 `{"idps": [{"id": "...", "type": "saml", ...}]}` |
-
 ## Claims and Attribute Mapping
 
 ### OIDC Claims

--- a/docs/src/idp/saml.md
+++ b/docs/src/idp/saml.md
@@ -109,6 +109,3 @@ VOUCH_ALLOWED_DOMAINS=example.com
 **Email not extracted from assertion**
 - Check the SAML assertion attributes using debug logging (`RUST_LOG=vouch_server=debug`)
 - Set `VOUCH_IDP_<SLUG>_EMAIL_ATTRIBUTE` to the exact attribute name used by your IdP
-
-**"Legacy identity-provider configuration detected"**
-- The flat `VOUCH_SAML_*` variables are no longer accepted. Migrate to the per-IdP `VOUCH_IDP_<SLUG>_*` format. See [Overview](overview.md#migration-from-legacy-variables) for the full mapping.

--- a/docs/src/operations/high-availability.md
+++ b/docs/src/operations/high-availability.md
@@ -78,8 +78,11 @@ Covered in [Behind a Reverse Proxy](../configuration/reverse-proxy.md). The two 
 for a multi-instance deployment specifically:
 
 - Health check **`/health/ready`**, not `/health`. An instance that lost its database connection
-  keeps passing `/health` and stays in rotation.
-- Set `VOUCH_TRUSTED_PROXIES`, or all rate limiting collapses onto the load balancer's IP.
+  keeps passing `/health` and stays in rotation. Behind a TCP-passthrough NLB this has to be an
+  HTTPS health check on port 443, because port 80 serves only `/health`.
+- Preserve the client IP, or all rate limiting collapses onto the load balancer's IP. With TCP
+  passthrough that means enabling client IP preservation on the target group; with a proxy that
+  terminates TLS it means setting `VOUCH_TRUSTED_PROXIES`.
 
 ## Graceful shutdown
 

--- a/docs/src/operations/troubleshooting.md
+++ b/docs/src/operations/troubleshooting.md
@@ -111,9 +111,6 @@ redirect. On Linux, binding below 1024 needs `CAP_NET_BIND_SERVICE`.
 - Ensure the server clock is synchronized via NTP — SAML assertions have time-based validity windows (typically 5 minutes of skew tolerance)
 - Check the IdP assertion signing algorithm matches what the server expects
 
-**Enrollment broken after upgrade, and only the old `VOUCH_OIDC_*` / `VOUCH_SAML_*` env vars or S3 `oidc` / `saml` blocks are set**
-- The flat legacy variables and S3 blocks are no longer read by the server — they are silently ignored. Migrate to the unified `VOUCH_IDPS` + `VOUCH_IDP_<SLUG>_*` env vars (or the S3 `idps` array). See [IdP Overview](../idp/overview.md#migration-from-legacy-variables) for the full mapping.
-
 **"Duplicate IdP slug"**
 - Every entry in `VOUCH_IDPS` / `idps[].id` must be unique. Rename one of them.
 

--- a/docs/src/reference/environment-variables.md
+++ b/docs/src/reference/environment-variables.md
@@ -59,10 +59,6 @@ OIDC IdPs auto-discover authorization, token, and JWKS endpoints from `{issuer}/
 | `VOUCH_IDP_<SLUG>_EMAIL_ATTRIBUTE` | No | _(auto-detect)_ | SAML attribute name containing the user's email address. |
 | `VOUCH_IDP_<SLUG>_DOMAIN_ATTRIBUTE` | No | _(none)_ | SAML attribute name containing the user's domain (for domain restriction). |
 
-### Legacy variables (no longer read)
-
-The previous flat single-IdP variables — `VOUCH_OIDC_ISSUER`, `VOUCH_OIDC_CLIENT_ID`, `VOUCH_OIDC_CLIENT_SECRET`, `VOUCH_OIDC_PROVIDERS`, `VOUCH_SAML_IDP_METADATA_URL`, `VOUCH_SAML_SP_ENTITY_ID`, `VOUCH_SAML_EMAIL_ATTRIBUTE`, `VOUCH_SAML_DOMAIN_ATTRIBUTE` — are silently ignored. Setting them configures nothing; only the unified `VOUCH_IDPS` / `VOUCH_IDP_<SLUG>_*` variables above are read. See [IdP Overview](../idp/overview.md#migration-from-legacy-variables) for the field-by-field mapping.
-
 ## Session
 
 | Variable | Required | Default | Description |

--- a/docs/src/reference/s3-config-schema.md
+++ b/docs/src/reference/s3-config-schema.md
@@ -158,8 +158,3 @@ Only `tls.cert` and `tls.key` are applied while the server is running. Every oth
 document takes effect at startup only, and changes to them are ignored — silently — until the
 server restarts. See
 [Configuration Sources](../configuration/sources.md#hot-reloadable-vs-startup-only-fields).
-
-> **Legacy blocks silently ignored:** the previous top-level `oidc` and `saml` blocks (single-IdP
-> nested objects) are no longer read. They configure nothing; only entries inside the `idps` array
-> are honored. See [IdP Overview](../idp/overview.md#migration-from-legacy-variables) for the
-> field-by-field mapping.


### PR DESCRIPTION
## Load balancer guidance

Replaces the AWS Application Load Balancer recipe in `docs/src/configuration/reverse-proxy.md` with a Network Load Balancer one. The ALB section contradicted the chapter's own opening guidance to terminate TLS inside Vouch — an ALB is HTTP-aware and always terminates TLS, which discards the pinned BCP 195 cipher policy and the hybrid post-quantum key exchange, and breaks RFC 8705 certificate-bound tokens because the client certificate never reaches the server.

The new section covers three TCP listeners (443, 80, 8443) forwarding to TCP target groups, and notes that NLB listeners have no redirect action of their own, which is why port 80 forwards to instances and the server issues its own 308.

Two details verified against the code rather than assumed:

- **Health checks must be HTTPS on 443.** `build_redirect_router` (`crates/vouch-server/src/lib.rs:123-128`) serves `/health` but not `/health/ready`, so an HTTP health check on port 80 reports a live process even when the database is unreachable.
- **The health check's `Host` header is the LB node's IP, and that is fine.** The only `MISDIRECTED_REQUEST` in the server is at `lib.rs:156`, on the port 80 redirect router. The main HTTPS router does not validate `Host`.

Also documents client IP preservation. Under TCP passthrough there is no `X-Forwarded-For`, so the TCP peer address is the only client identity the server sees and `VOUCH_TRUSTED_PROXIES` cannot recover it. AWS defaults `preserve_client_ip.enabled` to off for IP targets on TCP and TLS target groups; left off, all users share one rate-limit bucket and audit events attribute nothing.

`docs/src/operations/high-availability.md` previously told operators to set `VOUCH_TRUSTED_PROXIES` or rate limiting collapses onto the load balancer IP. That is correct for a terminating proxy and wrong for passthrough, so it is now split by topology, as is the reverse-proxy checklist.

Two ALB mentions remain: as the named example of a load balancer that cannot pass TCP through, and in the rationale for preferring an NLB.

## Legacy IdP variables

Removes the "Migration from legacy variables" section from `docs/src/idp/overview.md`. The flat `VOUCH_OIDC_*` and `VOUCH_SAML_*` variables and the legacy S3 `oidc` / `saml` blocks appear nowhere in `crates/`, so the mapping tables described variables that configure nothing.

Four pages linked to the removed anchor and are updated: `idp/saml.md`, `operations/troubleshooting.md`, `reference/s3-config-schema.md`, `reference/environment-variables.md`. The `saml.md` entry also documented an error string, "Legacy identity-provider configuration detected", that the server never emits.

The only surviving references are `s3_config.rs` tests asserting the old S3 blocks are dropped by serde.

## Other

Trims the first-administrator description in `docs/src/admin/organizations.md` to the behavior itself, dropping the compare-and-swap race detail and the list of settings that do not exist. The "Plan the first enrollment" callout below it already carries the actionable consequence.

## Verification

`make docs-build` succeeds. No dangling anchors, and no `VOUCH_OIDC_*` / `VOUCH_SAML_*` IdP variables remain in `docs/src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or configuration behavior changes; risk is limited to operators following outdated LB or legacy IdP guidance if docs were wrong—which this PR intends to fix.
> 
> **Overview**
> **Load balancing** — The reverse-proxy guide replaces the AWS ALB recipe with an **NLB TCP passthrough** setup (listeners on 443/80/8443, TCP target groups, TLS terminated in Vouch). It documents **HTTPS health checks on 443** to `/health/ready` (port 80 only exposes `/health`), **unset `VOUCH_TRUSTED_PROXIES`** under passthrough, and **`preserve_client_ip`** for IP targets. ALB is kept only as the example of an HTTP-aware LB that cannot pass TCP through. The deployment overview diagram and **high-availability** load-balancer bullets are aligned so client IP and health checks depend on topology (passthrough vs terminating proxy). The checklist is split the same way.
> 
> **Legacy IdP configuration** — The **migration-from-legacy-variables** section and related callouts are removed from the IdP overview, environment-variable reference, S3 schema, SAML troubleshooting, and general troubleshooting (including a non-existent **"Legacy identity-provider configuration detected"** error). Docs now describe only `VOUCH_IDPS` / `VOUCH_IDP_<SLUG>_*` and the S3 `idps` array.
> 
> **Organizations** — First-administrator text is shortened to the core rule; race/CAS and bootstrap-setting details are dropped in favor of the existing enrollment callout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 447f183c1c60033da549672d58841782163b815b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->