### PR TITLE
chore(httpsig): remove unused key_id from Ed25519Verifier

### DIFF
--- a/crates/vouch-httpsig/src/algorithm/ed25519.rs
+++ b/crates/vouch-httpsig/src/algorithm/ed25519.rs
@@ -48,7 +48,6 @@ impl Ed25519Signer {
     pub fn verifier(&self) -> Ed25519Verifier {
         Ed25519Verifier {
             public_key: self.key_pair.public_key().as_ref().to_vec(),
-            key_id: self.key_id.clone(),
         }
     }
 }
@@ -80,23 +79,15 @@ impl SigningAlgorithm for Ed25519Signer {
 #[derive(Debug, Clone)]
 pub struct Ed25519Verifier {
     public_key: Vec<u8>,
-    key_id: String,
 }
 
 impl Ed25519Verifier {
     /// Create a verifier from a raw 32-byte Ed25519 public key.
     #[must_use]
-    pub fn new(public_key: &[u8], key_id: &str) -> Self {
+    pub fn new(public_key: &[u8]) -> Self {
         Self {
             public_key: public_key.to_vec(),
-            key_id: key_id.to_string(),
         }
-    }
-
-    /// Return the key identifier.
-    #[must_use]
-    pub fn key_id(&self) -> &str {
-        &self.key_id
     }
 }
 

--- a/crates/vouch-httpsig/tests/rfc9421_vectors.rs
+++ b/crates/vouch-httpsig/tests/rfc9421_vectors.rs
@@ -454,8 +454,7 @@ fn test_b26_ed25519_verify_signature() {
     let pub_key_bytes = &pub_spki_der[12..];
     assert_eq!(pub_key_bytes.len(), 32);
 
-    let verifier =
-        vouch_httpsig::algorithm::ed25519::Ed25519Verifier::new(pub_key_bytes, "test-key-ed25519");
+    let verifier = vouch_httpsig::algorithm::ed25519::Ed25519Verifier::new(pub_key_bytes);
 
     let expected_sig_bytes = STANDARD.decode(expected_sig).unwrap();
     vouch_httpsig::algorithm::VerifyingAlgorithm::verify(&verifier, &base, &expected_sig_bytes)
@@ -545,8 +544,7 @@ fn test_b4_transform_verify_ed25519_signature() {
     let pub_spki_der = STANDARD.decode(&pub_pem_body).unwrap();
     let pub_key_bytes = &pub_spki_der[12..];
 
-    let verifier =
-        vouch_httpsig::algorithm::ed25519::Ed25519Verifier::new(pub_key_bytes, "test-key-ed25519");
+    let verifier = vouch_httpsig::algorithm::ed25519::Ed25519Verifier::new(pub_key_bytes);
 
     let sig_b64 =
         "ZT1kooQsEHpZ0I1IjCqtQppOmIqlJPeo7DHR3SoMn0s5JZ1eRGS0A+vyYP9t/LXlh5QMFFQ6cpLt2m0pmj3NDA==";
@@ -593,8 +591,7 @@ fn test_b4_transform_modified_method_fails() {
     let pub_spki_der = STANDARD.decode(&pub_pem_body).unwrap();
     let pub_key_bytes = &pub_spki_der[12..];
 
-    let verifier =
-        vouch_httpsig::algorithm::ed25519::Ed25519Verifier::new(pub_key_bytes, "test-key-ed25519");
+    let verifier = vouch_httpsig::algorithm::ed25519::Ed25519Verifier::new(pub_key_bytes);
 
     let sig_b64 =
         "ZT1kooQsEHpZ0I1IjCqtQppOmIqlJPeo7DHR3SoMn0s5JZ1eRGS0A+vyYP9t/LXlh5QMFFQ6cpLt2m0pmj3NDA==";


### PR DESCRIPTION
Remove the dead `key_id` field, `key_id()` accessor, and `key_id` constructor parameter from `Ed25519Verifier`, plus the matching initializer in `Ed25519Signer::verifier()`.

Follow-up to #760, which made the same removal for `EcdsaP256Verifier`. `Ed25519Verifier` carried identical dead code that #760 left in place, so the two verifier constructors had diverged.

The `VerifyingAlgorithm` trait (`algorithm/mod.rs`) declares only `algorithm_id` and `verify` — no `key_id`. The field's only reader was the inherent `Ed25519Verifier::key_id()` accessor, which had zero callers. The three RFC 9421 Appendix B test call sites passed `"test-key-ed25519"` solely to populate a field nothing consulted.

`Ed25519Signer` keeps its own `key_id`: that one is live via `SigningAlgorithm::key_id`, which `sign.rs` uses to populate the `keyid` signature parameter. Same for `HmacSha256Key`, which implements both traits from one type.

Both verifier constructors are now `new(&public_key)`.

## Verification

- `cargo test -p vouch-httpsig --test rfc9421_vectors` — 12 passed, including the three Ed25519 vectors that exercise the changed constructor against the spec's fixed test data
- `make lint` — clean
- `make test` — 4211 passed, 0 failed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small API cleanup with no changes to crypto verify logic; only test call sites and dead fields are affected.
> 
> **Overview**
> Aligns **`Ed25519Verifier`** with **`EcdsaP256Verifier`** by dropping unused **`key_id`** storage: the struct field, **`key_id()`**, and the **`key_id`** argument on **`new`**. **`Ed25519Signer::verifier()`** no longer copies a signer key id into the verifier.
> 
> **`Ed25519Signer`** still keeps **`key_id`** for signing (e.g. **`keyid`** in signature params). Verification behavior is unchanged; RFC 9421 vector tests now construct verifiers with **`Ed25519Verifier::new(pub_key_bytes)`** only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b27a865a2dc8d0c6fddf252f72139dcd3ab071b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->