### PR TITLE
ci: run required checks on merge_group for merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

Adds the `merge_group` trigger to `ci.yml` so all eight required status checks (Format, Clippy, Unit Tests linux/macos/windows, Build linux-amd64, License & Advisory Check, Dependency Review) report on merge-queue groups. This is the prerequisite for enabling a merge queue on `main` — without it, queued PRs would stall until the check-response timeout.

No other workflow changes are needed:

- The **Dependency Review** job keeps its `pull_request`-only condition: on `merge_group` it reports `skipped`, which satisfies the required check, and the action already ran on each constituent PR.
- **Security Scan** stays `push`-only and is not a required check.
- The concurrency group keys on `github.ref`; merge groups run on unique `gh-readonly-queue/` refs, so there are no collisions.

The merge-queue rule itself is added to the `main` ruleset after this merges (squash method, ALLGREEN grouping, 5-entry batches, 5-minute coalescing window, 60-minute check timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow trigger addition with no changes to build, test, or security job behavior.
> 
> **Overview**
> Adds **`merge_group`** to the CI workflow triggers so the same jobs that gate `pull_request` and `push` to `main` also run when GitHub enqueues a merge group. That lets required status checks (format, Clippy, tests, builds, license/advisory, etc.) complete for merge-queue entries instead of timing out.
> 
> No job logic changes in this diff: **Dependency Review** stays `pull_request`-only (skipped on merge groups, which still satisfies the required check), and **Security Scan** remains `push`-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5d7be9c20ed1c64fbb87268b3d96f6b11c4bcff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->