### PR TITLE
ci: fast merge-group gates and default-branch-only bake cache writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,20 @@ jobs:
           path: target/${{ matrix.target }}/release/vouch.exe
           retention-days: 7
 
+  # Satisfies the required "Build (linux-amd64)" check in merge groups,
+  # where the real build matrix is skipped. A job-level skip of a matrix
+  # job never expands the matrix, so it reports one check literally named
+  # "Build (${{ matrix.name }})" — the required name never reports and the
+  # queue waits forever. This shim reports the exact required name and
+  # exits immediately; its `if` is mutually exclusive with the build job's.
+  build-merge-group-shim:
+    name: Build (linux-amd64)
+    if: github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - run: echo "Build matrix runs on PR heads and main pushes; skipped in merge groups."
+
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,10 @@ jobs:
           targets: ci
         env:
           TARGET: ${{ matrix.target }}
+          # Write the bake layer cache only from main: entries written from
+          # PR/merge-queue refs are readable only by that ref and evict the
+          # shared main-scoped cache. All refs still read main's cache.
+          WRITE_CACHE: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
       - name: Build # zizmor: ignore[template-injection] — static matrix values
         if: runner.os != 'Linux'
         run: cargo build --release --locked --target ${{ matrix.target }} ${{ matrix.packages }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,11 @@ jobs:
 
   build:
     name: Build (${{ matrix.name }})
+    # Skipped in merge groups: the queue gates on the fast checks (fmt,
+    # clippy, unit tests, cargo-deny) and a skipped required check counts
+    # as satisfied. The full build matrix still runs on every PR head and
+    # on main after each merge, so platform-build breakage surfaces there.
+    if: github.event_name != 'merge_group'
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -10,6 +10,16 @@ variable "GENERATE_SBOM" {
   default = "false"
 }
 
+variable "WRITE_CACHE" {
+  // "true" only on main-branch CI runs. GHA cache entries written from PR,
+  // merge-queue, or tag refs are readable only by that same ref, so writing
+  // from them burns the repo's 10 GB Actions cache budget (evicting the
+  // shared main-scoped entries every ref restores from) without ever
+  // producing a cache hit. Reads (cache-from) stay enabled everywhere:
+  // any ref may restore caches written from the default branch.
+  default = "false"
+}
+
 group "default" {
   targets = ["ci"]
 }
@@ -29,7 +39,7 @@ target "ci" {
     GENERATE_SBOM     = "false"
   }
   cache-from = ["type=gha,scope=bake-ci-${TARGET}"]
-  cache-to   = ["type=gha,mode=max,ignore-error=true,scope=bake-ci-${TARGET}"]
+  cache-to   = WRITE_CACHE == "true" ? ["type=gha,mode=max,ignore-error=true,scope=bake-ci-${TARGET}"] : []
 }
 
 target "cli" {
@@ -41,7 +51,7 @@ target "cli" {
     GENERATE_SBOM     = GENERATE_SBOM
   }
   cache-from = ["type=gha,scope=bake-cli-${TARGET}"]
-  cache-to   = ["type=gha,mode=max,ignore-error=true,scope=bake-cli-${TARGET}"]
+  cache-to   = WRITE_CACHE == "true" ? ["type=gha,mode=max,ignore-error=true,scope=bake-cli-${TARGET}"] : []
 }
 
 target "server" {
@@ -53,7 +63,7 @@ target "server" {
     GENERATE_SBOM     = GENERATE_SBOM
   }
   cache-from = ["type=gha,scope=bake-server-${TARGET}"]
-  cache-to   = ["type=gha,mode=max,ignore-error=true,scope=bake-server-${TARGET}"]
+  cache-to   = WRITE_CACHE == "true" ? ["type=gha,mode=max,ignore-error=true,scope=bake-server-${TARGET}"] : []
 }
 
 target "reproduce" {


### PR DESCRIPTION
## Summary

Two CI-throughput fixes for the merge queue, informed by today's 13-PR Detail batch.

### 1. Skip the build matrix in merge groups

Merge-group CI re-ran the full multi-platform build matrix per speculative group, making the ~11-26 min `Build (linux-amd64)` Docker build the queue's bottleneck. The `build` job now skips `merge_group` events (a skipped required check counts as satisfied — already relied on by `Dependency Review`). The queue gates on Format, Clippy, Unit Tests linux/macos/windows, and cargo-deny. The full matrix still runs on every PR head (required before queue entry) and on main after each merge.

### 2. Write the bake layer cache only from main

The Actions cache was over budget (11.98 GB of the 10 GB cap), with 700+ MB buildkit blobs written from PR and merge-queue refs — entries readable **only by the ref that wrote them** due to branch isolation. They never produced a hit for anyone and their churn evicted the main-scoped entries every ref restores from, leaving all PR Docker builds cold. A new `WRITE_CACHE` bake variable (default `false`) gates `cache-to` on the `ci`/`cli`/`server` targets; ci.yml enables it only on main pushes. `cache-from` stays enabled everywhere. Tag-ref release builds also stop writing (equally unreadable by later tags).

## Testing

- `docker buildx bake --print ci` verified both ways: no `cache-to` by default, populated with `WRITE_CACHE=true`.
- `actionlint` and `zizmor` clean on the modified workflow.

After this merges, the next main push warms `bake-ci-{x86_64,aarch64}-unknown-linux-musl` and subsequent PR builds restore from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Merge groups no longer run full platform builds before merge (relying on PR-head builds and main), which trades queue speed for slightly later detection of cross-platform build failures.
> 
> **Overview**
> **Merge queue throughput:** The multi-platform `build` matrix no longer runs on `merge_group` events; the queue relies on fmt, clippy, unit tests, and cargo-deny instead. A new **`build-merge-group-shim`** job reports the required **Build (linux-amd64)** check name during merge groups so the queue does not hang (skipping the matrix job alone would not satisfy that required check name).
> 
> **Docker bake cache:** **`WRITE_CACHE`** in `docker-bake.hcl` gates `cache-to` on the `ci`, `cli`, and `server` targets; CI sets it to `true` only on **`refs/heads/main`**. PR and merge-queue runs still **`cache-from`** main’s layers but stop writing ref-isolated entries that were evicting the shared cache budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f5f11c2cf567c8a505d32be754c4db1a7f806ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->