### PR TITLE
ci: write bake layer cache only from default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,10 @@ jobs:
           targets: ci
         env:
           TARGET: ${{ matrix.target }}
+          # Write the bake layer cache only from main: entries written from
+          # PR/merge-queue refs are readable only by that ref and evict the
+          # shared main-scoped cache. All refs still read main's cache.
+          WRITE_CACHE: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
       - name: Build # zizmor: ignore[template-injection] — static matrix values
         if: runner.os != 'Linux'
         run: cargo build --release --locked --target ${{ matrix.target }} ${{ matrix.packages }}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -10,6 +10,16 @@ variable "GENERATE_SBOM" {
   default = "false"
 }
 
+variable "WRITE_CACHE" {
+  // "true" only on main-branch CI runs. GHA cache entries written from PR,
+  // merge-queue, or tag refs are readable only by that same ref, so writing
+  // from them burns the repo's 10 GB Actions cache budget (evicting the
+  // shared main-scoped entries every ref restores from) without ever
+  // producing a cache hit. Reads (cache-from) stay enabled everywhere:
+  // any ref may restore caches written from the default branch.
+  default = "false"
+}
+
 group "default" {
   targets = ["ci"]
 }
@@ -29,7 +39,7 @@ target "ci" {
     GENERATE_SBOM     = "false"
   }
   cache-from = ["type=gha,scope=bake-ci-${TARGET}"]
-  cache-to   = ["type=gha,mode=max,ignore-error=true,scope=bake-ci-${TARGET}"]
+  cache-to   = WRITE_CACHE == "true" ? ["type=gha,mode=max,ignore-error=true,scope=bake-ci-${TARGET}"] : []
 }
 
 target "cli" {
@@ -41,7 +51,7 @@ target "cli" {
     GENERATE_SBOM     = GENERATE_SBOM
   }
   cache-from = ["type=gha,scope=bake-cli-${TARGET}"]
-  cache-to   = ["type=gha,mode=max,ignore-error=true,scope=bake-cli-${TARGET}"]
+  cache-to   = WRITE_CACHE == "true" ? ["type=gha,mode=max,ignore-error=true,scope=bake-cli-${TARGET}"] : []
 }
 
 target "server" {
@@ -53,7 +63,7 @@ target "server" {
     GENERATE_SBOM     = GENERATE_SBOM
   }
   cache-from = ["type=gha,scope=bake-server-${TARGET}"]
-  cache-to   = ["type=gha,mode=max,ignore-error=true,scope=bake-server-${TARGET}"]
+  cache-to   = WRITE_CACHE == "true" ? ["type=gha,mode=max,ignore-error=true,scope=bake-server-${TARGET}"] : []
 }
 
 target "reproduce" {


### PR DESCRIPTION
## Summary

The repo's Actions cache is over budget (11.98 GB of the 10 GB cap, 65 entries), so GitHub is LRU-evicting continuously. The largest offenders are 700+ MB buildkit blobs written from PR and merge-queue refs (`refs/pull/807/merge`, `refs/heads/gh-readonly-queue/main/pr-796-*`). GHA cache branch isolation makes those entries readable **only by the ref that wrote them** — they never produce a cache hit for anyone else, and their churn evicts the main-scoped entries every ref restores from. Net effect: every PR's Docker build ran cold (~11–26 min observed during today's batch).

## Change

- `docker-bake.hcl`: new `WRITE_CACHE` variable (default `false`) gating `cache-to` on the `ci`/`cli`/`server` targets. `cache-from` stays enabled everywhere — any ref may restore default-branch caches.
- `ci.yml`: the bake step sets `WRITE_CACHE=true` only when `github.ref == 'refs/heads/main'` (the post-merge push run).

Release builds (tag refs) also stop writing tag-scoped caches, which were equally unreadable by later tags.

## Testing

- `docker buildx bake --print ci` verified both ways: no `cache-to` by default, populated with `WRITE_CACHE=true`.
- `actionlint` and `zizmor` clean on the modified workflow.

After merging, the next push to main warms `bake-ci-{x86_64,aarch64}-unknown-linux-musl`; subsequent PR builds restore from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only caching behavior; no application or security logic changes, with a small risk that non-main bake runs no longer populate cache until the next main push.
> 
> **Overview**
> Stops **PR, merge-queue, and tag** Docker bake runs from pushing GitHub Actions **BuildKit layer caches**, which were ref-isolated (never reused) and were evicting the shared **main** cache past the 10 GB cap.
> 
> **`docker-bake.hcl`** adds a **`WRITE_CACHE`** flag (default `false`) so **`cache-to`** on **`ci`**, **`cli`**, and **`server`** is only set when **`WRITE_CACHE == "true"`**; **`cache-from`** is unchanged so every ref can still restore main’s cache.
> 
> **`ci.yml`** sets **`WRITE_CACHE=true`** only when **`github.ref == 'refs/heads/main'`**, so only post-merge pushes warm **`bake-ci-*`** (and the same pattern applies to **`cli`**/**`server`** when those targets run elsewhere with the default off).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d54eefe24617a954d1bdbbb83560d63091ca90cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->