### PR TITLE
fix(cli): validate CodeCommit region partition against the minting role

### DIFF
--- a/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
+++ b/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
@@ -356,6 +356,7 @@ arg-credential-codeartifact-domain-profile-help = Named CodeArtifact domain prof
 arg-credential-codeartifact-profile-help = AWS profile in ~/.aws/config whose role mints the token (distinct from --domain-profile, which names a saved CodeArtifact domain).
 
 credential-codecommit-err-exec-git = failed to exec git remote-http: { $error }
+credential-codecommit-warn-partition-mismatch = vouch: declining CodeCommit credential request: { $error }
 
 ## Shared arg help
 

--- a/crates/vouch-cli/src/commands/credential/codecommit.rs
+++ b/crates/vouch-cli/src/commands/credential/codecommit.rs
@@ -75,7 +75,21 @@ async fn get_credential(profile: Option<&str>) -> Result<()> {
         format!("/{path}")
     };
 
-    let creds = get_sts_credentials(profile).await?;
+    let vouch_profile = resolve_vouch_profile(profile, ProfileOverride::Profile)?;
+    // Credentials are partition-scoped, so signing a request to a host in
+    // another partition is guaranteed a 403. Decline with no output instead of
+    // erroring: git then continues to any other configured credential helper,
+    // which may legitimately serve this host.
+    if let Err(e) =
+        crate::integrations::aws::validate_region_for_role(region, &vouch_profile.role_arn)
+    {
+        vouch_cli::tr_eprintln!(
+            "credential-codecommit-warn-partition-mismatch",
+            error = e.to_string()
+        );
+        return Ok(());
+    }
+    let creds = get_sts_credentials(&vouch_profile.role_arn).await?;
     let signed = sign_request(&creds, host, &canonical_path, region);
 
     let stdout = std::io::stdout();
@@ -120,7 +134,12 @@ pub(crate) async fn run_remote_helper(remote_name: &str, url: &str) -> Result<()
     let path = format!("/v1/repos/{}", parsed.repository);
 
     // The URL profile selects the account, not just the region.
-    let creds = get_sts_credentials(parsed.profile.as_deref()).await?;
+    let vouch_profile = resolve_vouch_profile(parsed.profile.as_deref(), ProfileOverride::Profile)?;
+    // The endpoint above is built from `region` while credentials mint under
+    // the role's partition; a cross-partition pair is guaranteed an opaque
+    // 403 from CodeCommit at git time, so fail now with a clear message.
+    crate::integrations::aws::validate_region_for_role(&region, &vouch_profile.role_arn)?;
+    let creds = get_sts_credentials(&vouch_profile.role_arn).await?;
     let signed = sign_request(&creds, &hostname, &path, &region);
 
     // Percent-encode credentials for URL embedding
@@ -136,17 +155,17 @@ pub(crate) async fn run_remote_helper(remote_name: &str, url: &str) -> Result<()
 /// Get temporary AWS credentials via Vouch OIDC -> STS flow, with caching.
 ///
 /// Reuses the shared `fetch_and_assume` from the AWS credential module to avoid
-/// duplicating the OIDC → STS logic, and wraps it with the agent credential cache.
-async fn get_sts_credentials(profile: Option<&str>) -> Result<StsCredentials> {
+/// duplicating the OIDC → STS logic, and wraps it with the agent credential
+/// cache. The role is resolved by the caller so both CodeCommit flows can
+/// validate the target region's partition against it before signing anything.
+async fn get_sts_credentials(role_arn: &str) -> Result<StsCredentials> {
     let session = crate::session::resolve_session()
         .await
         .context(tr!("err-not-configured-run-vouch-enroll-first"))?;
 
     let server = session.server_url;
 
-    let role_arn = resolve_vouch_profile(profile, ProfileOverride::Profile)?.role_arn;
-
-    let data = super::aws::get_aws_credentials(&server, &role_arn).await?;
+    let data = super::aws::get_aws_credentials(&server, role_arn).await?;
 
     // Extract STS credentials from the cached JSON
     let access_key_id = data
@@ -225,7 +244,7 @@ fn resolve_region(url_region: Option<&str>, profile: Option<&str>) -> Result<Str
 /// Implements priorities 2 and 3 of [`resolve_region`]: the specified
 /// profile's region, then the resolved Vouch profile's region. The Vouch
 /// profile is resolved with the same `explicit` -> `$AWS_PROFILE` -> sole
-/// profile ordering used for role resolution in `get_sts_credentials`, so a
+/// profile ordering used for role resolution in [`run_remote_helper`], so a
 /// machine with several Vouch profiles never borrows an unrelated profile's
 /// region — region and credentials come from the same profile. Returns `None`
 /// when neither source names a region, leaving the caller to fall back to env
@@ -245,7 +264,7 @@ fn select_region(
 
     // Priority 3: the Vouch profile that mints the credentials. Resolved with
     // the explicit profile first so region follows the same account as the
-    // role resolved by `get_sts_credentials`; an ambiguous or missing choice
+    // role resolved for credential minting; an ambiguous or missing choice
     // is not fatal here — region still has an env/us-east-1 fallback.
     let vouch_profile =
         select_vouch_profile(config, profile, env_profile, ProfileOverride::Profile).ok()?;

--- a/crates/vouch-cli/src/integrations/aws/mod.rs
+++ b/crates/vouch-cli/src/integrations/aws/mod.rs
@@ -220,6 +220,24 @@ fn validate_region_partition(
     )))
 }
 
+/// Validate that a region belongs to the same AWS partition as a role ARN.
+///
+/// Thin wrapper over [`validate_region_partition`] for callers that hold the
+/// ARN string rather than an already-parsed partition — region/ARN pairs that
+/// only meet at a service call, such as the CodeCommit helpers, where the
+/// endpoint is built from the region while credentials mint under the role's
+/// partition.
+///
+/// # Errors
+///
+/// Returns a [`CliError::ConfigError`] when the ARN's partition cannot be
+/// parsed or the region belongs to a different partition.
+pub(crate) fn validate_region_for_role(region: &str, role_arn: &str) -> Result<(), CliError> {
+    let arn_partition = vouch_common::aws::Partition::from_arn(role_arn)
+        .map_err(|_| CliError::ConfigError(tr!("aws-console-err-invalid-role-arn")))?;
+    validate_region_partition(region, arn_partition)
+}
+
 /// Resolve the AWS region, checking profile config then environment variables.
 ///
 /// When `role_arn` is provided, validates that the resolved region belongs
@@ -237,10 +255,7 @@ pub(crate) fn resolve_region(
         return Err(no_region_error().into());
     };
     if let Some(arn) = role_arn {
-        let arn_partition = vouch_common::aws::Partition::from_arn(arn).map_err(|_| {
-            crate::exit_code::CliError::ConfigError(tr!("aws-console-err-invalid-role-arn"))
-        })?;
-        validate_region_partition(&resolved, arn_partition)?;
+        validate_region_for_role(&resolved, arn)?;
     }
     Ok(resolved)
 }
@@ -1114,5 +1129,36 @@ credential_process = vouch credential aws --role arn:aws:iam::111:role/X
             matches!(err, CliError::ConfigError(_)),
             "expected CliError::ConfigError, got: {err:?}"
         );
+    }
+
+    /// Matching region/ARN partition pairs pass for commercial, China, and
+    /// GovCloud roles.
+    #[test]
+    fn validate_region_for_role_accepts_matching_partitions() {
+        validate_region_for_role("us-east-1", "arn:aws:iam::123456789012:role/demo").unwrap();
+        validate_region_for_role("cn-north-1", "arn:aws-cn:iam::123456789012:role/demo").unwrap();
+        validate_region_for_role(
+            "us-gov-west-1",
+            "arn:aws-us-gov:iam::123456789012:role/demo",
+        )
+        .unwrap();
+    }
+
+    /// The CodeCommit failure mode: a region in one partition with a role ARN
+    /// in another must be rejected before any request is signed.
+    #[test]
+    fn validate_region_for_role_rejects_cross_partition() {
+        let err = validate_region_for_role("cn-north-1", "arn:aws:iam::123456789012:role/demo")
+            .expect_err("commercial role must not pair with a China region");
+        let msg = err.to_string();
+        assert!(msg.contains("cn-north-1"), "{msg}");
+    }
+
+    /// An ARN whose partition cannot be parsed is a configuration error, not
+    /// a silently skipped check.
+    #[test]
+    fn validate_region_for_role_rejects_unparsable_arn() {
+        validate_region_for_role("us-east-1", "not-an-arn")
+            .expect_err("unparsable ARN cannot be validated");
     }
 }


### PR DESCRIPTION
## What

Extends the partition validation from #814 to the CodeCommit helpers, the one remaining flow where a region and a role ARN from different AWS partitions met only at the service call and failed with an opaque 403 at git time.

- New shared `aws::validate_region_for_role(region, role_arn)` in `integrations/aws/mod.rs` (wraps the existing `validate_region_partition`; `resolve_region` now uses it too).
- `git-remote-codecommit` (`run_remote_helper`): validates the resolved region (URL > profile > env > `us-east-1` default) against the minting role's partition and fails at invocation with the existing partition-mismatch message.
- Credential helper (`get_credential`): on mismatch, declines without emitting credentials (stderr note, exit 0) so git's credential-helper chain continues to any other configured helper — it never aborts the chain.
- `get_sts_credentials` now takes the resolved role ARN; both flows resolve the profile once and validate before anything is signed.

## Regression analysis

CodeCommit is a working production flow; this change is validation-only:

- Region resolution priority, hostname construction, signing, and caching are untouched.
- Matching region/role partitions — every currently-working configuration — pass validation unchanged. `Partition::from_region` maps unknown regions to commercial, so new commercial regions keep working (covered by existing tests).
- The combinations now rejected early (cross-partition region/role) are guaranteed to fail today with a 403 after signing; no working case is blocked.
- The credential helper deliberately declines instead of erroring so a chain like vouch + `store` (static CodeCommit git credentials in another partition) keeps working — previously vouch injected known-bad credentials into that chain.
- Error-message precedence shifts slightly on misconfigured machines: profile-resolution errors now surface before the "run vouch enroll" hint in these two flows.

## Testing

- `cargo test -p vouch-cli`: 777 passed, 0 failed (includes 3 new `validate_region_for_role` tests: matching partitions per partition, cross-partition rejection, unparsable ARN).
- Mutation check: replacing `validate_region_for_role` with a no-op fails exactly the two negative tests.
- `cargo clippy -p vouch-cli --all-targets --all-features -- -D warnings`: clean. `cargo fmt --check`: clean.
- i18n completeness test passes with the new `credential-codecommit-warn-partition-mismatch` catalog entry.

Related: #811 (same failure class in `setup ssm`, fixed by #814).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live git/CodeCommit credential paths; behavior change is validation-only for matching configs, but the credential helper’s soft-decline vs hard-error split affects multi-helper setups.
> 
> **Overview**
> Extends AWS **region vs role partition** validation to CodeCommit—the path where the endpoint comes from the resolved region but STS credentials follow the minting role, which previously surfaced as opaque **403** at git time.
> 
> Adds **`aws::validate_region_for_role`** (wraps existing `validate_region_partition`; **`resolve_region`** now calls it too). Both CodeCommit flows resolve the Vouch profile once, validate, then mint credentials via **`get_sts_credentials(role_arn)`** instead of re-resolving inside STS fetch.
> 
> **`git-remote-codecommit`**: rejects cross-partition region/role pairs up front with the existing partition-mismatch message. **Credential helper `get`**: on mismatch, logs **`credential-codecommit-warn-partition-mismatch`** to stderr and returns success **without** credentials so git can try the next helper in the chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6a5d560429a7525bd5d928e9031683438ca7d20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->