### PR TITLE
docs: document _acme as a reserved S3 config key

### DIFF
--- a/docs/src/reference/s3-config-schema.md
+++ b/docs/src/reference/s3-config-schema.md
@@ -141,6 +141,15 @@ The S3 configuration file is a JSON document with the following schema:
 | `device_code_expires_seconds` | integer | Device code expiration in seconds. |
 | `device_poll_interval_seconds` | integer | Device code polling interval in seconds. |
 
+## Reserved Keys
+
+| Key | Owner | Description |
+|-----|-------|-------------|
+| `_acme` | External certificate renewal process | ACME (Let's Encrypt) account state: `account_key` (base64-encoded PEM), `email`, and `account_uri`. The renewal process reads and writes this key directly in the S3 object when it renews the certificate and updates `tls.cert`/`tls.key`. The server ignores it. |
+
+Do not remove, rename, or hand-edit reserved keys. They are not parsed by the server, but
+external automation depends on them being present in the S3 object.
+
 ## Base64 Encoding
 
 All certificate and key fields in the S3 configuration must be **base64-encoded PEM** strings. To encode a PEM file:


### PR DESCRIPTION
Add a Reserved Keys section to the S3 config schema reference documenting the `_acme` key: ACME (Let's Encrypt) account state owned by the external certificate renewal process, which reads and writes it directly in the S3 object. The server ignores it.

#821 removes the unread `S3AcmeConfig` struct, whose doc comment was the only place in this repo recording that contract. This preserves it in the operator-facing schema reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or configuration parsing impact.
> 
> **Overview**
> Adds a **Reserved Keys** section to the S3 configuration schema reference so operators know `_acme` may appear in the config object.
> 
> The table documents that `_acme` is owned by the external certificate renewal process (ACME/Let's Encrypt account state: `account_key`, `email`, `account_uri`), that renewal writes it alongside `tls.cert`/`tls.key`, and that the Vouch server does not parse it. A short warning states reserved keys must not be removed, renamed, or hand-edited because external automation depends on them.
> 
> This replaces the contract that previously lived only on the removed `S3AcmeConfig` struct (#821).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f918967a4bf7b4b1858f04e21548513fa551e15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->