### PR TITLE
perf(server): batch user lookups on the admin audit page

### DIFF
--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -48,8 +48,8 @@ pub use store::StoreTransaction;
 // Re-export user types and functions
 pub use users::{
     User, clear_user_github_refresh_token, delete_user, get_user_by_email, get_user_by_id,
-    get_user_github_refresh_token, get_users_by_org_paginated, update_user_active_status,
-    update_user_admin_status, update_user_github_identity,
+    get_user_github_refresh_token, get_users_by_ids, get_users_by_org_paginated,
+    update_user_active_status, update_user_admin_status, update_user_github_identity,
 };
 
 // Re-export user test helpers (only available in tests)

--- a/crates/vouch-server/src/db/store.rs
+++ b/crates/vouch-server/src/db/store.rs
@@ -492,6 +492,44 @@ impl DocumentStore {
         }
     }
 
+    /// Get multiple documents by ID in a single query.
+    ///
+    /// IDs with no matching document are simply absent from the result —
+    /// callers should not assume the returned `Vec` has the same length as
+    /// `ids`. An empty `ids` slice returns `Ok(vec![])` without issuing a
+    /// query.
+    ///
+    /// Like `find_all`, a single row that fails to decrypt or deserialize
+    /// fails the whole call rather than being skipped. Callers pass a
+    /// bounded set of IDs — there is no enforced limit here, but SQLite
+    /// caps bind parameters at 32766 and Postgres at 65535 per statement.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if decryption or deserialization fails.
+    pub async fn get_by_ids<T: DocumentType>(&self, ids: &[String]) -> Result<Vec<Document<T>>> {
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let id_values: Vec<sea_query::Value> = ids.iter().map(|id| id.as_str().into()).collect();
+
+        let stmt = Query::select()
+            .columns(DOC_COLUMNS)
+            .from(Documents::Table)
+            .and_where(Expr::col(Documents::Id).is_in(id_values))
+            .and_where(Expr::col(Documents::DocType).eq(T::DOC_TYPE))
+            .to_owned();
+
+        let rows: Vec<RawDocumentRow> = crate::db_fetch_all!(&self.pool, stmt, RawDocumentRow)?;
+
+        let mut results = Vec::with_capacity(rows.len());
+        for row in rows {
+            results.push(raw_to_document::<T>(&self.crypto, row)?);
+        }
+        Ok(results)
+    }
+
     // ========================================================================
     // Find by Index
     // ========================================================================

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -108,6 +108,49 @@ async fn test_user_not_found() {
 }
 
 #[tokio::test]
+async fn test_get_users_by_ids_multiple_found_and_some_missing() {
+    let (store, _audit) = test_db().await;
+
+    let (id1, _) = upsert_user(&store, "alice@example.com", Some("Alice"))
+        .await
+        .expect("Failed to create user");
+    let (id2, _) = upsert_user(&store, "bob@example.com", Some("Bob"))
+        .await
+        .expect("Failed to create user");
+
+    let ids = vec![id1.clone(), id2.clone(), "nonexistent-id".to_string()];
+    let users = get_users_by_ids(&store, &ids)
+        .await
+        .expect("Query should succeed");
+
+    assert_eq!(
+        users.len(),
+        2,
+        "a missing id should simply be absent, not an error"
+    );
+    assert_eq!(
+        users.get(&id1).map(|u| u.email.as_str()),
+        Some("alice@example.com")
+    );
+    assert_eq!(
+        users.get(&id2).map(|u| u.email.as_str()),
+        Some("bob@example.com")
+    );
+    assert!(!users.contains_key("nonexistent-id"));
+}
+
+#[tokio::test]
+async fn test_get_users_by_ids_empty_input_returns_empty_map() {
+    let (store, _audit) = test_db().await;
+
+    let users = get_users_by_ids(&store, &[])
+        .await
+        .expect("Query should succeed");
+
+    assert!(users.is_empty());
+}
+
+#[tokio::test]
 async fn test_session_lifecycle() {
     let (store, _audit) = test_db().await;
 

--- a/crates/vouch-server/src/db/users.rs
+++ b/crates/vouch-server/src/db/users.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! User database operations.
 
+use std::collections::HashMap;
+
 use super::document_type::Document;
 use super::documents::user::UserDoc;
 use super::store::DocumentStore;
@@ -120,6 +122,25 @@ pub async fn get_user_by_email(store: &DocumentStore, email: &str) -> Result<Opt
 pub async fn get_user_by_id(store: &DocumentStore, user_id: &str) -> Result<Option<User>> {
     let doc = store.get::<UserDoc>(user_id).await?;
     Ok(doc.map(User::from))
+}
+
+/// Get multiple users by ID in a single query.
+///
+/// Returns a map keyed by user ID. IDs with no matching user are simply
+/// absent from the map — not an error. An empty `ids` slice returns an
+/// empty map without issuing a query.
+pub async fn get_users_by_ids(
+    store: &DocumentStore,
+    ids: &[String],
+) -> Result<HashMap<String, User>> {
+    if ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let docs = store.get_by_ids::<UserDoc>(ids).await?;
+    Ok(docs
+        .into_iter()
+        .map(|doc| (doc.id.clone(), User::from(doc)))
+        .collect())
 }
 
 /// Delete a user and all associated data atomically.

--- a/crates/vouch-server/src/handlers/admin/audit.rs
+++ b/crates/vouch-server/src/handlers/admin/audit.rs
@@ -12,6 +12,7 @@ use axum::response::{IntoResponse, Redirect, Response};
 use axum_extra::extract::cookie::CookieJar;
 use jiff::Timestamp;
 use serde::Deserialize;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use crate::filters;
@@ -162,13 +163,28 @@ pub(crate) async fn admin_audit_page(
         }
     };
 
-    // Bounded by AUDIT_PAGE_SIZE (50) — one extra lookup per
-    // member-management row to resolve the target's current email, an
-    // acceptable cost for an admin-only, infrequently-loaded page.
+    // Batch-resolve every member-management row's target email in a single
+    // query instead of one lookup per row (bounded by AUDIT_PAGE_SIZE = 50).
+    let target_ids: Vec<String> = audit_events
+        .iter()
+        .filter(|e| MEMBER_EVENT_TYPES.contains(&e.event_type.as_str()))
+        .filter_map(|e| TargetFields::from_json(&e.data).target_user_id)
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+
+    let target_users = match db::get_users_by_ids(&state.store, &target_ids).await {
+        Ok(map) => map,
+        Err(e) => {
+            tracing::error!("Failed to batch-resolve audit target users: {e}");
+            HashMap::new()
+        }
+    };
+
     let mut events: Vec<AuditRow> = Vec::with_capacity(audit_events.len());
     for e in &audit_events {
         let geo = GeoFields::from_json(&e.data);
-        let target_email = resolve_target_email(&state, e).await;
+        let target_email = resolve_target_email(&target_users, e);
         events.push(AuditRow {
             id: e.id.clone(),
             event_type: e.event_type.clone(),
@@ -233,15 +249,17 @@ impl TargetFields {
 }
 
 /// Resolve a member-management event's target to a display email via
-/// `target_user_id`, looked up fresh rather than stored raw in `data`.
+/// `target_user_id`, looked up in a map pre-fetched once per page load
+/// (`admin_audit_page` batches all target IDs into a single
+/// `db::get_users_by_ids` call) rather than stored raw in `data`.
 ///
 /// Falls back to the event's own `email_domain`/`email_hmac` columns —
 /// stamped from the target's email at write time — when the target no
 /// longer exists. This is not a rare case: `admin_remove_user` events are
 /// written *after* the target is deleted, so that fallback always applies
 /// for removals.
-async fn resolve_target_email(
-    state: &AppState,
+fn resolve_target_email(
+    target_users: &HashMap<String, db::User>,
     event: &crate::db::audit::AuditEvent,
 ) -> Option<String> {
     if !MEMBER_EVENT_TYPES.contains(&event.event_type.as_str()) {
@@ -249,8 +267,8 @@ async fn resolve_target_email(
     }
     let target_user_id = TargetFields::from_json(&event.data).target_user_id?;
 
-    if let Ok(Some(user)) = db::get_user_by_id(&state.store, &target_user_id).await {
-        return Some(user.email);
+    if let Some(user) = target_users.get(&target_user_id) {
+        return Some(user.email.clone());
     }
 
     match (event.email_domain.as_deref(), event.email_hmac.as_deref()) {
@@ -589,14 +607,66 @@ mod tests {
         );
     }
 
-    // ---- resolve_target_email ----
-
     #[tokio::test]
-    async fn resolve_target_email_resolves_live_user() {
-        let state = test_app_state().await;
+    async fn test_audit_page_resolves_duplicate_targets_consistently() {
+        // Two member-management events referencing the same target_user_id
+        // must both resolve to that target's email.
+        let (app, state) = test_app().await;
         let org = create_test_org(&state.store, "example.com").await;
+        let admin = create_test_user_in_org(&state.store, "admin@example.com", &org.id, true).await;
         let target =
             create_test_user_in_org(&state.store, "target@example.com", &org.id, false).await;
+        let auth_id = create_test_authenticator(&state.store, &admin.id).await;
+        let token = create_test_session(&state, &admin.id, &admin.email, &auth_id).await;
+        let cookie = format!("{}={token}", vouch_common::SESSION_COOKIE_NAME);
+
+        let data = serde_json::json!({ "target_user_id": target.id }).to_string();
+        state
+            .audit
+            .insert_event(
+                crate::db::audit::AuditEventKind::AdminPromote,
+                Some(&admin.id),
+                Some(&admin.email),
+                &data,
+            )
+            .await
+            .unwrap();
+        state
+            .audit
+            .insert_event(
+                crate::db::audit::AuditEventKind::AdminDemote,
+                Some(&admin.id),
+                Some(&admin.email),
+                &data,
+            )
+            .await
+            .unwrap();
+
+        let (status, body) = http_get(&app, "/admin/audit", &[("Cookie", &cookie)]).await;
+        assert_eq!(status, StatusCode::OK, "admin should get 200");
+        let occurrences = body.matches("target@example.com").count();
+        assert_eq!(
+            occurrences, 2,
+            "both duplicate-target events should resolve to the shared target's email; body:\n{body}"
+        );
+    }
+
+    // ---- resolve_target_email ----
+
+    #[test]
+    fn resolve_target_email_resolves_live_user() {
+        let target = db::User {
+            id: "target-id".to_string(),
+            email: "target@example.com".to_string(),
+            name: None,
+            org_id: None,
+            is_org_admin: false,
+            active: true,
+            external_id: None,
+            github_id: None,
+            github_login: None,
+            github_refresh_token: None,
+        };
 
         let data =
             serde_json::json!({ "action": "promote", "target_user_id": target.id }).to_string();
@@ -610,13 +680,16 @@ mod tests {
             created_at: Timestamp::now(),
         };
 
-        let resolved = resolve_target_email(&state, &event).await;
+        let mut target_users = HashMap::new();
+        target_users.insert(target.id.clone(), target);
+
+        let resolved = resolve_target_email(&target_users, &event);
         assert_eq!(resolved.as_deref(), Some("target@example.com"));
     }
 
-    #[tokio::test]
-    async fn resolve_target_email_falls_back_when_user_is_gone() {
-        let state = test_app_state().await;
+    #[test]
+    fn resolve_target_email_falls_back_when_user_is_gone() {
+        let target_users = HashMap::new();
 
         let data =
             serde_json::json!({ "action": "remove_user", "target_user_id": "nonexistent-id" })
@@ -631,7 +704,7 @@ mod tests {
             created_at: Timestamp::now(),
         };
 
-        let resolved = resolve_target_email(&state, &event).await;
+        let resolved = resolve_target_email(&target_users, &event);
         let resolved = resolved.expect("fallback must produce a display string");
         assert!(
             resolved.contains("example.com"),
@@ -643,9 +716,9 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn resolve_target_email_is_none_for_non_member_event_types() {
-        let state = test_app_state().await;
+    #[test]
+    fn resolve_target_email_is_none_for_non_member_event_types() {
+        let target_users = HashMap::new();
         let event = crate::db::audit::AuditEvent {
             id: "evt-3".to_string(),
             event_type: "login_success".to_string(),
@@ -656,7 +729,7 @@ mod tests {
             created_at: Timestamp::now(),
         };
 
-        assert_eq!(resolve_target_email(&state, &event).await, None);
+        assert_eq!(resolve_target_email(&target_users, &event), None);
     }
 
     // ---- audit_filter_event_types helper tests ----


### PR DESCRIPTION
Supersedes #827 (stacked branch re-created cleanly on main after #825's squash-merge).

## Summary

The admin audit page's display-time email resolution (added in #825's privacy fix) issued one DB point lookup per member-action event in a sequential render loop — up to 50 queries per page, ~50-250ms of added round-trip latency on Aurora DSQL, with duplicate targets fetched repeatedly (an admin filtering to deactivations after a bulk offboarding hits exactly this).

This PR batches it:

- `DocumentStore::get_by_ids<T>` — generic batch select following the existing `get`/`find_all` conventions (same doc_type predicate, bound parameters, per-row decrypt). Intended for reuse by the member-list resolution follow-up flagged in #825's review.
- `db::get_users_by_ids` — typed wrapper returning `HashMap<String, User>`; empty input issues no query, missing ids are simply absent.
- `admin_audit_page` collects the distinct target ids before the render loop and resolves each row from the map; `resolve_target_email` is now synchronous. The render loop contains no awaits.

Worst case per page render drops from ~53 sequential round trips to 4. The JSON/NDJSON/OCSF API path never resolved emails and is unaffected.

## Behavior note

If any fetched user document fails to decrypt, the batch errors as a whole and every member row on the page falls back to the removed-user rendering — the previous per-row path degraded only the affected row. This matches the store's `find_all` error convention and manifests only under partial data corruption on a human-facing display page; documented on `get_by_ids`.

## Verification

`cargo clippy --all-targets --all-features -- -D warnings` clean; touched suites green (`handlers::admin::audit` 29, `db::store` 21, `db::tests` 151, `arch_boundaries`); full `cargo test --all-features` workspace green. Fallback strings verified byte-identical against the pre-change code. Reviewed through adversarial critique (verdict: minor, all action items closed) and code review (approved). Rebased onto main post-#825 with zero conflicts; the pre-push hook re-ran clippy and the full workspace test suite against the rebased tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Admin-only display optimization with tests; batch decrypt failure only broadens removed-user fallback on the audit UI, not auth or data writes.
> 
> **Overview**
> Replaces **per-row user lookups** on the admin audit HTML page with **one batched fetch** of distinct `target_user_id` values (up to the page size of 50), cutting worst-case round trips from dozens of sequential queries to a single extra read.
> 
> Adds reusable **`DocumentStore::get_by_ids`** and **`db::get_users_by_ids`** (`HashMap` by id; empty input skips the query; missing ids are omitted). **`resolve_target_email`** is now synchronous and reads from that map; on batch failure the page logs and uses an empty map so member rows still get the existing removed-user fallback strings.
> 
> **Behavior change:** if any document in the batch fails decrypt/deserialize, the whole batch errors (aligned with `find_all`); the audit handler treats that as “no live users” for display rather than failing the page. API audit export paths are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 169411396209dd880ec52e5a981850710ea83496. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->