### PR TITLE
fix: close empty-region, host-casing, and deactivation gaps

### DIFF
--- a/crates/vouch-cli/src/commands/credential/codecommit.rs
+++ b/crates/vouch-cli/src/commands/credential/codecommit.rs
@@ -56,17 +56,15 @@ async fn get_credential(profile: Option<&str>) -> Result<()> {
         return Ok(());
     }
 
-    // Git's credential protocol includes the port in the `host` field when the
-    // URL explicitly specifies one (e.g., `git-codecommit.us-east-1.amazonaws.com:443`).
-    // `is_codecommit_host` already accepts that form, but libcurl strips the
-    // default `:443` from the HTTP `Host` header it sends to CodeCommit. SigV4
-    // signs the host header value, so signing with the port-annotated hostname
-    // would produce a signature mismatch and a 403 from AWS. Strip the
-    // standard HTTPS port for signing only — the original `host` must be
-    // echoed back to git verbatim so its credential cache can match on
-    // subsequent requests (git uses exact string comparison on `host`, with no
-    // normalization, when looking up cached credentials).
-    let signing_host = strip_default_port(original_host);
+    // SigV4 signs the `Host` header value libcurl actually sends, which is the
+    // canonical form: lowercase hostname with the default `:443` omitted.
+    // Signing the raw `host` git supplied (port-annotated or uppercased) would
+    // produce a signature mismatch and a 403 from AWS. Normalize for signing
+    // only — the original `host` must be echoed back to git verbatim so its
+    // credential cache can match on subsequent requests (git uses exact string
+    // comparison on `host`, with no normalization, when looking up cached
+    // credentials).
+    let signing_host = vouch_common::normalize_git_host(original_host);
 
     // Path is required for signing (useHttpPath must be true in git config)
     let path = input.path.as_deref().ok_or_else(|| {
@@ -77,7 +75,7 @@ async fn get_credential(profile: Option<&str>) -> Result<()> {
         )
     })?;
 
-    let region = extract_region_from_hostname(signing_host)
+    let region = extract_region_from_hostname(&signing_host)
         .context(tr!("err-could-not-extract-region-from-codecommit-hostname"))?;
 
     // Path from git doesn't have leading slash; SigV4 canonical URI requires it
@@ -102,7 +100,7 @@ async fn get_credential(profile: Option<&str>) -> Result<()> {
         return Ok(());
     }
     let creds = get_sts_credentials(&vouch_profile.role_arn).await?;
-    let signed = sign_request(&creds, signing_host, &canonical_path, region);
+    let signed = sign_request(&creds, &signing_host, &canonical_path, region);
 
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
@@ -116,22 +114,6 @@ async fn get_credential(profile: Option<&str>) -> Result<()> {
     )?;
 
     Ok(())
-}
-
-/// Strip the standard HTTPS port (`:443`) from a git credential `host` value.
-///
-/// Git includes the port in `host` whenever the remote URL specifies one
-/// explicitly. The default HTTPS port is removed for SigV4 signing (libcurl
-/// omits `:443` from the `Host` header it sends, so the signed hostname must
-/// match), but the original `host` is still what git caches and looks up.
-/// Non-standard ports are left untouched — they would already have failed
-/// `is_codecommit_host`, so reaching here with one is unexpected.
-///
-/// Split out from [`get_credential`] so the port-stripping decision is
-/// unit-testable without a live Vouch session or network. This mirrors the
-/// `select_region` / `resolve_region` split already used in this file.
-fn strip_default_port(host: &str) -> &str {
-    host.strip_suffix(":443").unwrap_or(host)
 }
 
 /// Run the git remote helper for `codecommit://` URLs.
@@ -239,6 +221,8 @@ async fn get_sts_credentials(role_arn: &str) -> Result<StsCredentials> {
 /// 4. `AWS_DEFAULT_REGION` env var
 /// 5. `AWS_REGION` env var
 /// 6. Default: `us-east-1`
+///
+/// Empty environment values are treated as unset.
 fn resolve_region(url_region: Option<&str>, profile: Option<&str>) -> Result<String> {
     if let Some(region) = url_region {
         return Ok(region.to_string());
@@ -251,11 +235,7 @@ fn resolve_region(url_region: Option<&str>, profile: Option<&str>) -> Result<Str
         }
     }
 
-    // Check environment variables
-    if let Ok(r) = std::env::var("AWS_DEFAULT_REGION") {
-        return Ok(r);
-    }
-    if let Ok(r) = std::env::var("AWS_REGION") {
+    if let Some(r) = crate::integrations::aws::env_region() {
         return Ok(r);
     }
 
@@ -497,18 +477,19 @@ region = ap-southeast-2
         assert_eq!(percent_encode("50%done"), "50%25done");
     }
 
-    // -- strip_default_port: SigV4 signing host vs. git cache key --
+    // -- normalize_git_host: SigV4 signing host vs. git cache key --
 
-    /// The standard HTTPS port is stripped for SigV4 signing so the signed
-    /// hostname matches the `Host` header libcurl sends (which omits `:443`).
+    /// The signing host is the canonical form of whatever git supplied: the
+    /// default HTTPS port stripped and the hostname lowercased, matching the
+    /// `Host` header libcurl sends.
     #[test]
-    fn test_strip_default_port_removes_443() {
+    fn test_signing_host_is_canonical() {
         assert_eq!(
-            strip_default_port("git-codecommit.us-east-1.amazonaws.com:443"),
+            vouch_common::normalize_git_host("git-codecommit.us-east-1.amazonaws.com:443"),
             "git-codecommit.us-east-1.amazonaws.com"
         );
         assert_eq!(
-            strip_default_port("git-codecommit.cn-north-1.amazonaws.com.cn:443"),
+            vouch_common::normalize_git_host("GIT-CODECOMMIT.CN-NORTH-1.AMAZONAWS.COM.CN:443"),
             "git-codecommit.cn-north-1.amazonaws.com.cn"
         );
     }
@@ -520,11 +501,11 @@ region = ap-southeast-2
     #[test]
     fn test_strip_default_port_keeps_non_standard_port() {
         assert_eq!(
-            strip_default_port("git-codecommit.us-east-1.amazonaws.com:8443"),
+            vouch_common::normalize_git_host("git-codecommit.us-east-1.amazonaws.com:8443"),
             "git-codecommit.us-east-1.amazonaws.com:8443"
         );
         assert_eq!(
-            strip_default_port("git-codecommit.us-east-1.amazonaws.com:80"),
+            vouch_common::normalize_git_host("git-codecommit.us-east-1.amazonaws.com:80"),
             "git-codecommit.us-east-1.amazonaws.com:80"
         );
     }
@@ -543,7 +524,7 @@ region = ap-southeast-2
     #[test]
     fn get_credential_returns_original_host_to_git_but_signs_with_stripped() {
         let original_host = "git-codecommit.us-east-1.amazonaws.com:443";
-        let signing_host = strip_default_port(original_host);
+        let signing_host = vouch_common::normalize_git_host(original_host);
 
         // The signing host fed to `sign_request` / `extract_region_from_hostname`
         // drops the default port so the SigV4 signature matches libcurl's Host

--- a/crates/vouch-cli/src/commands/credential/github.rs
+++ b/crates/vouch-cli/src/commands/credential/github.rs
@@ -20,15 +20,12 @@ use crate::session::resolve_session;
 
 /// Check if the host is a GitHub host.
 ///
-/// Git's credential protocol includes the port in the `host` field when the
-/// URL explicitly specifies one (e.g., `github.com:443`). The standard HTTPS
-/// port is stripped before matching so that explicit `:443` doesn't cause the
-/// host check — and thus the entire credential helper — to fail silently.
-/// Non-standard ports are intentionally not stripped: the helper should
-/// decline to provide GitHub credentials for them.
+/// The host is normalized via [`vouch_common::normalize_git_host`] (explicit
+/// `:443` stripped, hostname lowercased) before matching; non-standard ports
+/// are intentionally rejected — the helper should decline to provide GitHub
+/// credentials for them.
 fn is_github_host(host: &str) -> bool {
-    let host = host.strip_suffix(":443").unwrap_or(host);
-    let host = host.to_lowercase();
+    let host = vouch_common::normalize_git_host(host);
     host == "github.com"
         || host.ends_with(".github.com")
         || host.ends_with(".ghe.com")

--- a/crates/vouch-cli/src/integrations/aws/codecommit.rs
+++ b/crates/vouch-cli/src/integrations/aws/codecommit.rs
@@ -259,15 +259,13 @@ const CODECOMMIT_DOMAINS: &[&str] = &[
 
 /// Check if a hostname is a CodeCommit host in any partition.
 ///
-/// Git's credential protocol includes the port in the `host` field when the
-/// URL explicitly specifies one (e.g., `git-codecommit.us-east-1.amazonaws.com:443`).
-/// The standard HTTPS port is stripped before matching so that explicit `:443`
-/// doesn't cause the host check — and thus the entire credential helper — to
-/// fail silently. Non-standard ports are intentionally not stripped: the helper
-/// should decline to provide CodeCommit credentials for them.
+/// The host is normalized via [`vouch_common::normalize_git_host`] (explicit
+/// `:443` stripped, hostname lowercased) before matching; non-standard ports
+/// are intentionally rejected — the helper should decline to provide
+/// CodeCommit credentials for them.
 #[must_use]
 pub(crate) fn is_codecommit_host(host: &str) -> bool {
-    let host = host.strip_suffix(":443").unwrap_or(host);
+    let host = vouch_common::normalize_git_host(host);
     if !host.starts_with("git-codecommit.") {
         return false;
     }
@@ -513,6 +511,18 @@ mod tests {
         ));
         assert!(is_codecommit_host(
             "git-codecommit.cn-north-1.amazonaws.com.cn:443"
+        ));
+    }
+
+    /// DNS hostnames are case-insensitive and git passes through whatever the
+    /// remote URL contained, so an uppercased host must still match — the
+    /// GitHub helper already did this, and the divergence made the CodeCommit
+    /// helper silently decline uppercase remotes.
+    #[test]
+    fn test_is_codecommit_host_case_insensitive() {
+        assert!(is_codecommit_host("GIT-CODECOMMIT.US-EAST-1.AMAZONAWS.COM"));
+        assert!(is_codecommit_host(
+            "Git-CodeCommit.Us-East-1.Amazonaws.Com:443"
         ));
     }
 

--- a/crates/vouch-cli/src/integrations/aws/config.rs
+++ b/crates/vouch-cli/src/integrations/aws/config.rs
@@ -82,7 +82,11 @@ impl AwsConfig {
         Some(AwsProfile {
             name: name.to_string(),
             credential_process: section.get("credential_process").map(|s| s.to_string()),
-            region: section.get("region").map(|s| s.to_string()),
+            // A bare `region =` line means unset, matching the env-var handling
+            // in `env_region` — an empty region would otherwise short-circuit
+            // the fallback chain and build endpoints like
+            // `https://sts..amazonaws.com`.
+            region: vouch_common::env::non_empty(section.get("region").map(|s| s.to_string())),
             output: section.get("output").map(|s| s.to_string()),
         })
     }
@@ -139,7 +143,8 @@ impl AwsConfig {
         AwsProfile {
             name,
             credential_process: props.get("credential_process").map(|s| s.to_string()),
-            region: props.get("region").map(|s| s.to_string()),
+            // Bare `region =` means unset — see `get_profile`.
+            region: vouch_common::env::non_empty(props.get("region").map(|s| s.to_string())),
             output: props.get("output").map(|s| s.to_string()),
         }
     }
@@ -384,6 +389,26 @@ credential_process = vouch credential aws --role arn:aws:iam::123456789012:role/
                     .to_string()
             )
         );
+        assert_eq!(profile.region, None);
+    }
+
+    #[test]
+    fn test_get_profile_empty_region_is_unset() {
+        let content = r#"
+[profile vouch]
+credential_process = vouch credential aws --role arn:aws:iam::123456789012:role/MyRole
+region =
+"#;
+        let file = create_temp_config(content);
+        let config = AwsConfig::load_from(file.path().to_path_buf()).unwrap();
+
+        let profile = config.get_profile("vouch").expect("profile should exist");
+        assert_eq!(profile.region, None);
+
+        let vouch_profiles = config.find_all_vouch_profiles();
+        let profile = vouch_profiles
+            .first()
+            .expect("vouch profile should be found");
         assert_eq!(profile.region, None);
     }
 

--- a/crates/vouch-cli/src/integrations/aws/mod.rs
+++ b/crates/vouch-cli/src/integrations/aws/mod.rs
@@ -175,15 +175,17 @@ fn find_region(region: Option<&str>, profile_name: Option<&str>) -> anyhow::Resu
         }
     }
 
-    // Check environment variables
-    if let Ok(r) = std::env::var("AWS_DEFAULT_REGION") {
-        return Ok(Some(r));
-    }
-    if let Ok(r) = std::env::var("AWS_REGION") {
-        return Ok(Some(r));
-    }
+    Ok(env_region())
+}
 
-    Ok(None)
+/// Region from the process environment, treating empty values as unset.
+///
+/// An empty `AWS_REGION=""` must fall through to the next source instead of
+/// producing endpoints like `https://sts..amazonaws.com`. `AWS_DEFAULT_REGION`
+/// keeps its historical precedence over `AWS_REGION` here.
+pub(crate) fn env_region() -> Option<String> {
+    vouch_common::env::non_empty_env("AWS_DEFAULT_REGION")
+        .or_else(|| vouch_common::env::non_empty_env("AWS_REGION"))
 }
 
 /// The error returned when no region could be determined from any source.

--- a/crates/vouch-common/src/env.rs
+++ b/crates/vouch-common/src/env.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! Environment and configuration value helpers.
+
+/// Treat an empty string as absent.
+///
+/// Fallback chains must progress past values that are set but empty
+/// (`AWS_REGION=""`), otherwise the empty string overrides every later source
+/// and surfaces far away as malformed output (e.g. an STS endpoint of
+/// `https://sts..amazonaws.com`).
+#[must_use]
+pub fn non_empty(value: Option<String>) -> Option<String> {
+    value.filter(|s| !s.is_empty())
+}
+
+/// Read an environment variable, treating unset and empty as equivalent.
+#[must_use]
+pub fn non_empty_env(name: &str) -> Option<String> {
+    non_empty(std::env::var(name).ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_empty_passes_values_through() {
+        assert_eq!(
+            non_empty(Some("us-east-1".to_string())),
+            Some("us-east-1".to_string())
+        );
+    }
+
+    #[test]
+    fn non_empty_treats_empty_as_absent() {
+        assert_eq!(non_empty(Some(String::new())), None);
+    }
+
+    #[test]
+    fn non_empty_passes_none_through() {
+        assert_eq!(non_empty(None), None);
+    }
+
+    #[test]
+    fn non_empty_env_unset_is_none() {
+        assert_eq!(non_empty_env("VOUCH_TEST_ENV_VAR_THAT_IS_NEVER_SET"), None);
+    }
+}

--- a/crates/vouch-common/src/lib.rs
+++ b/crates/vouch-common/src/lib.rs
@@ -7,6 +7,7 @@ pub mod aws;
 pub(crate) mod cookie;
 pub mod dns;
 pub mod encoding;
+pub mod env;
 pub(crate) mod error;
 pub mod fido2_types;
 pub mod fixtures;
@@ -45,7 +46,9 @@ pub use api::{
 };
 pub use cookie::{SessionCookie, clear_cookie, cookie_path, write_cookie};
 pub use error::ApiError;
-pub use url::{UrlSecurity, check_url_security, is_loopback_host};
+pub use url::{
+    UrlSecurity, check_url_security, is_loopback_host, normalize_git_host, strip_default_https_port,
+};
 
 /// Session cookie name with `__Host-` prefix (RFC 6265bis).
 ///

--- a/crates/vouch-common/src/url.rs
+++ b/crates/vouch-common/src/url.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//! URL security validation for server connections.
+//! URL security validation and host normalization.
 
 use url::Url;
 
@@ -98,9 +98,69 @@ pub fn is_loopback_host(host: &str) -> bool {
     false
 }
 
+/// Strip the default HTTPS port (`:443`) from a `host[:port]` value.
+///
+/// Non-standard ports are preserved so that callers matching or signing hosts
+/// treat them as distinct.
+#[must_use]
+pub fn strip_default_https_port(host: &str) -> &str {
+    host.strip_suffix(":443").unwrap_or(host)
+}
+
+/// Normalize a git credential `host` value for matching.
+///
+/// Git's credential protocol passes through whatever the remote URL contained,
+/// so the same host can arrive as `GitHub.com`, `github.com:443`, etc. An
+/// explicit default HTTPS port is stripped and the hostname ASCII-lowercased
+/// (DNS names are case-insensitive per RFC 4343); comparing raw values makes a
+/// credential helper silently decline requests it should serve. Non-standard
+/// ports are intentionally preserved so helpers decline them.
+#[must_use]
+pub fn normalize_git_host(host: &str) -> String {
+    strip_default_https_port(host).to_ascii_lowercase()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn strip_default_https_port_removes_443() {
+        assert_eq!(strip_default_https_port("github.com:443"), "github.com");
+    }
+
+    #[test]
+    fn strip_default_https_port_keeps_bare_host() {
+        assert_eq!(strip_default_https_port("github.com"), "github.com");
+    }
+
+    #[test]
+    fn strip_default_https_port_keeps_non_standard_ports() {
+        assert_eq!(
+            strip_default_https_port("github.com:8443"),
+            "github.com:8443"
+        );
+        assert_eq!(strip_default_https_port("github.com:80"), "github.com:80");
+    }
+
+    #[test]
+    fn normalize_git_host_lowercases() {
+        assert_eq!(normalize_git_host("GitHub.com"), "github.com");
+        assert_eq!(
+            normalize_git_host("GIT-CODECOMMIT.US-EAST-1.AMAZONAWS.COM"),
+            "git-codecommit.us-east-1.amazonaws.com"
+        );
+    }
+
+    #[test]
+    fn normalize_git_host_strips_port_and_lowercases() {
+        assert_eq!(normalize_git_host("GitHub.com:443"), "github.com");
+    }
+
+    #[test]
+    fn normalize_git_host_keeps_non_standard_ports() {
+        assert_eq!(normalize_git_host("GitHub.com:8443"), "github.com:8443");
+    }
 
     #[test]
     fn https_is_secure() {

--- a/crates/vouch-server/src/config.rs
+++ b/crates/vouch-server/src/config.rs
@@ -851,27 +851,14 @@ impl ServerConfig {
         // a blank `Region::new("")` — see `aws_config_loader`. The same
         // empty-means-unset pattern is already used by `ssh_ca_key_path` and
         // `allowed_domains` below.
-        let aws_region = args
-            .aws_region
-            .filter(|s| !s.is_empty())
-            .or_else(|| {
-                std::env::var("AWS_DEFAULT_REGION")
-                    .ok()
-                    .filter(|s| !s.is_empty())
-            })
+        let aws_region = vouch_common::env::non_empty(args.aws_region)
+            .or_else(|| vouch_common::env::non_empty_env("AWS_DEFAULT_REGION"))
             .or_else(|| instance.map(|b| b.region.clone()));
-        let aws_az = args
-            .aws_az
-            .filter(|s| !s.is_empty())
+        let aws_az = vouch_common::env::non_empty(args.aws_az)
             .or_else(|| instance.map(|b| b.availability_zone.clone()));
-        let aws_partition = args
-            .aws_partition
-            .filter(|s| !s.is_empty())
+        let aws_partition = vouch_common::env::non_empty(args.aws_partition)
             .or_else(|| instance.and_then(|b| b.partition.clone()));
-        let aws_use_fips_endpoint = args
-            .aws_use_fips_endpoint
-            .as_deref()
-            .filter(|s| !s.is_empty())
+        let aws_use_fips_endpoint = vouch_common::env::non_empty(args.aws_use_fips_endpoint)
             .map(|v| v.eq_ignore_ascii_case("true"));
 
         let base_url = derive_base_url(args.base_url, &args.rp_id, &args.listen_addr);
@@ -958,7 +945,7 @@ impl ServerConfig {
             tls_key: args.tls_key.map(SecretString::from),
             s3_config_bucket: args.s3_config_bucket,
             s3_config_key: args.s3_config_key,
-            s3_config_region: args.s3_config_region.filter(|s| !s.is_empty()),
+            s3_config_region: vouch_common::env::non_empty(args.s3_config_region),
             s3_config_poll_interval: args.s3_config_poll_interval,
             aws_region,
             aws_az,

--- a/crates/vouch-server/src/handlers/applications/mod.rs
+++ b/crates/vouch-server/src/handlers/applications/mod.rs
@@ -67,6 +67,14 @@ async fn extract_auth_from_cookie(state: &AppState, jar: &CookieJar) -> Option<A
         .await
         .ok()??;
 
+    // Deactivated users may still hold a live cookie in the window between
+    // `update_user_active_status` and `delete_sessions_for_user` (separate
+    // transactions); treat them as unauthenticated, matching
+    // `get_resource_auth_context`.
+    if !user.active {
+        return None;
+    }
+
     Some(AuthContext {
         authenticated: true,
         user_id: Some(session.sub),
@@ -162,5 +170,44 @@ fn validate_redirect_uris(uris: &[String]) -> Result<(), Vec<String>> {
         Ok(())
     } else {
         Err(invalid)
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
+mod tests {
+    use axum_extra::extract::cookie::{Cookie, CookieJar};
+
+    use crate::test_utils::*;
+
+    /// A deactivated user whose session has not yet been swept must be treated
+    /// as unauthenticated by the web UI, matching `get_resource_auth_context`
+    /// on the API path.
+    #[tokio::test]
+    async fn deactivated_user_cookie_is_unauthenticated() {
+        let state = test_app_state().await;
+        let user = create_test_user(&state.store, "deactivated-web@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let jar = CookieJar::new().add(Cookie::new(vouch_common::SESSION_COOKIE_NAME, token));
+
+        let auth = super::extract_auth_from_cookie(&state, &jar).await;
+        assert!(
+            auth.is_some(),
+            "active user with a valid cookie must authenticate"
+        );
+
+        crate::db::update_user_active_status(&state.store, &user.id, false)
+            .await
+            .expect("deactivate user");
+
+        let auth = super::extract_auth_from_cookie(&state, &jar).await;
+        assert!(
+            auth.is_none(),
+            "deactivated user must be unauthenticated even while the session still exists"
+        );
     }
 }

--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -161,6 +161,40 @@ pub(crate) async fn device_code(
     }))
 }
 
+/// Revoke all OAuth sessions for the user that authorized a replayed device
+/// code, and drop them from the session cache.
+///
+/// The caller is already returning `invalid_grant` for the replay; a failed
+/// revocation must not mask that response, but it is a security event that
+/// must stay visible, so it is logged at error level rather than propagated.
+async fn revoke_sessions_for_device_replay(state: &AppState, user_id: &str) {
+    tracing::warn!(
+        target: "security",
+        "Device code replay detected — revoking tokens for user"
+    );
+    match db::delete_oauth_sessions_for_user(&state.store, user_id).await {
+        Ok(count) => {
+            if count > 0 {
+                state.session_cache.invalidate_for_user(user_id);
+                tracing::warn!(
+                    target: "security",
+                    user_id = %user_id,
+                    revoked_count = count,
+                    "Revoked tokens due to device code replay"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::error!(
+                target: "security",
+                user_id = %user_id,
+                error = %e,
+                "Failed to revoke tokens after device code replay"
+            );
+        }
+    }
+}
+
 /// Poll for device token (RFC 8628 Section 3.4).
 /// POST /oauth/token
 ///
@@ -253,22 +287,7 @@ pub(crate) async fn device_token(
             // RFC 8628 Section 3.5: Device code already used.
             // Replay detected — revoke all tokens for the affected user.
             if let Some(ref user_id) = request.user_id {
-                tracing::warn!(
-                    target: "security",
-                    "Device code replay detected \
-                     — revoking tokens for user"
-                );
-                if let Ok(count) = db::delete_oauth_sessions_for_user(&state.store, user_id).await
-                    && count > 0
-                {
-                    state.session_cache.invalidate_for_user(user_id);
-                    tracing::warn!(
-                        target: "security",
-                        user_id = %user_id,
-                        revoked_count = count,
-                        "Revoked tokens due to device code replay"
-                    );
-                }
+                revoke_sessions_for_device_replay(&state, user_id).await;
             }
             Err(oauth_error(
                 StatusCode::BAD_REQUEST,
@@ -295,23 +314,7 @@ pub(crate) async fn device_token(
                     Ok(claim) => claim,
                     Err(db::claim::ClaimError::AlreadyConsumed) => {
                         if let Some(ref user_id) = request.user_id {
-                            tracing::warn!(
-                                target: "security",
-                                "Device code replay detected \
-                                 — revoking tokens for user"
-                            );
-                            if let Ok(count) =
-                                db::delete_oauth_sessions_for_user(&state.store, user_id).await
-                                && count > 0
-                            {
-                                state.session_cache.invalidate_for_user(user_id);
-                                tracing::warn!(
-                                    target: "security",
-                                    user_id = %user_id,
-                                    revoked_count = count,
-                                    "Revoked tokens due to device code replay"
-                                );
-                            }
+                            revoke_sessions_for_device_replay(&state, user_id).await;
                         }
                         return Err(oauth_error(
                             StatusCode::BAD_REQUEST,


### PR DESCRIPTION
## Summary

Three bug classes fixed by recent PRs (#781/#815, #841/#853/#863/#865, #838/#850/#846/#862) each left sibling call sites unfixed. This PR centralizes each invariant and fixes the remaining sites, plus one adjacent logging gap.

**Empty AWS region values are treated as unset everywhere.** New `vouch_common::env::{non_empty, non_empty_env}` helpers back a shared `env_region()` used by both CLI region resolvers (`find_region`, CodeCommit `resolve_region`), which previously returned `AWS_REGION=""` verbatim and built endpoints like `https://sts..amazonaws.com`. `AwsConfig` profile parsing now treats a bare `region =` line as unset (same class at the parse layer), and the server config fallback chain uses the same helpers in place of five inline filters.

**Git credential hosts are normalized once.** `vouch_common::normalize_git_host` (strip explicit `:443`, ASCII-lowercase) replaces the three hand-rolled copies. `is_codecommit_host` now matches uppercase hosts — it previously lacked the `to_lowercase()` its GitHub sibling had, so uppercase CodeCommit remotes made the helper silently decline. The SigV4 signing host is canonicalized to match the `Host` header libcurl sends; the original host is still echoed back to git verbatim for its credential cache.

**Deactivated users are rejected by the applications web UI.** `extract_auth_from_cookie` now checks `user.active`, matching `get_resource_auth_context` on the API path — the eight handlers in `applications/web.rs` previously authenticated deactivated users during the deactivation/session-sweep window (#862's class, in a file it didn't touch).

**Failed device-code replay revocations are logged.** The two verbatim-duplicated revocation blocks in `handlers/device.rs` are now one helper, and a failed `delete_oauth_sessions_for_user` logs at error level instead of being silently swallowed.

## Testing

- `cargo test --all-features`: 4,506 passed, 0 failed (run via cargo directly; `make test` currently exports `.env` into the test process and trips the non-hermetic bootstrap-overlay test on any branch — already fixed by `matches_ignoring_process_env` in #867)
- `cargo test --package vouch-tests`: passed
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- Each new regression test was verified to fail with its fix reverted:
  - `test_is_codecommit_host_case_insensitive` — fails without host lowercasing
  - `test_get_profile_empty_region_is_unset` — fails without the parse-layer filter
  - `deactivated_user_cookie_is_unauthenticated` — fails without the `user.active` check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches AWS credential signing, OAuth device-flow revocation, and session auth for deactivated users—security-sensitive but narrowly defensive with regression tests.
> 
> **Overview**
> Centralizes three invariants that were only fixed in some call sites and wires the remaining paths to match.
> 
> **Empty AWS regions** — New `vouch_common::env::{non_empty, non_empty_env}` treat `""` as unset. CLI region resolution uses shared `env_region()`; `~/.aws/config` bare `region =` lines no longer poison the chain; server config replaces inline empty filters for AWS/S3 settings.
> 
> **Git credential hosts** — `normalize_git_host` (strip `:443`, ASCII-lowercase) replaces duplicated logic in GitHub/CodeCommit helpers. CodeCommit host detection and SigV4 signing now accept uppercase remotes; git still gets the **original** `host` for credential cache keys.
> 
> **Server auth** — Applications web UI cookie auth rejects inactive users (aligned with the API). Device-code replay revocation is one helper; failed token revocation logs at error instead of being swallowed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dc861cdd305008243b63ccd12e82f292ac51e2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->