### PR TITLE
ci: cache bake deps on GHCR and build CI with thin LTO

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,6 @@ jobs:
           persist-credentials: false
       - name: Setup Rust toolchain
         run: rustup show
-      - name: Setup Rust cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          prefix-key: "v2"
-          shared-key: "fmt"
-          cache-targets: false
-          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo fmt --all --check
 
   clippy:
@@ -122,6 +115,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
+      # Push the shared dependency layer cache to GHCR from main; PR runs
+      # get a read-only token downgrade automatically.
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -175,17 +171,30 @@ jobs:
       - name: Set up Docker Buildx
         if: runner.os == 'Linux'
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - name: Log in to GHCR
+        if: runner.os == 'Linux'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build (Linux)
         if: runner.os == 'Linux'
         uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
         with:
-          targets: ci
+          # `deps` builds nothing extra (its layers are a prefix of `ci`);
+          # it exists so only the reusable dependency layers are exported
+          # to the registry cache, never the per-commit compile layers.
+          targets: |
+            ci
+            deps
         env:
           TARGET: ${{ matrix.target }}
-          # Write the bake layer cache only from main: entries written from
-          # PR/merge-queue refs are readable only by that ref and evict the
-          # shared main-scoped cache. All refs still read main's cache.
+          # Dependency layer cache lives on GHCR, outside the 10 GB GitHub
+          # Actions cache budget. Written only from main so unmerged
+          # dependency trees never enter the shared cache; all refs read it.
+          CACHE_IMAGE: ghcr.io/${{ github.repository }}/buildcache
           WRITE_CACHE: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
       - name: Build # zizmor: ignore[template-injection] — static matrix values
         if: runner.os != 'Linux'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,3 +236,11 @@ lto = true        # Enable full link time optimization for better size reduction
 codegen-units = 1 # Maximize size reduction optimizations
 panic = "abort"   # Terminate process upon panic
 opt-level = "z"   # Optimize for size (more aggressive than "s")
+
+# CI build-check profile: same codegen as release except fat LTO and single
+# codegen unit, which dominate wall-clock time. Shipped binaries (release.yml)
+# always use [profile.release].
+[profile.ci]
+inherits = "release"
+lto = "thin"
+codegen-units = 16

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -26,22 +26,32 @@ WORKDIR /app
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
-# --- Builder: cook dependencies, then build workspace crates ---
-FROM base AS builder
+# --- Deps: cook dependencies from the recipe ---
+# Terminal stage for the bake `deps` cache target: everything through the
+# cook layer is reusable across source changes, so only this stage is
+# exported to the layer cache. The later builder layers change on every
+# commit and are never exported.
+FROM base AS deps
 
 ARG TARGET
+ARG CARGO_PROFILE=release
 
 WORKDIR /app
 RUN rustup target add "${TARGET}"
 
 # Cook dependencies from recipe (cached when only source files change)
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --locked --target "${TARGET}" --recipe-path recipe.json
+RUN cargo chef cook --profile "${CARGO_PROFILE}" --locked --target "${TARGET}" --recipe-path recipe.json
+
+# --- Builder: build workspace crates on top of cooked deps ---
+FROM deps AS builder
 
 # Copy source and build workspace crates (only these recompile)
 COPY . .
 
 # Declare build-time ARGs after the cook layer so changes don't bust the cache
+ARG TARGET
+ARG CARGO_PROFILE=release
 ARG SOURCE_DATE_EPOCH=0
 ARG GENERATE_SBOM=false
 ARG CARGO_PACKAGES="-p vouch-cli -p vouch-agent -p vouch-server"
@@ -54,7 +64,7 @@ RUN touch -d "@${SOURCE_DATE_EPOCH}" \
       crates/vouch-agent/src/main.rs \
       crates/vouch-server/src/main.rs
 
-RUN cargo build --release --locked --target "${TARGET}" ${CARGO_PACKAGES}
+RUN cargo build --profile "${CARGO_PROFILE}" --locked --target "${TARGET}" ${CARGO_PACKAGES}
 
 # Generate SBOM if requested
 RUN if [ "${GENERATE_SBOM}" = "true" ]; then \
@@ -62,11 +72,12 @@ RUN if [ "${GENERATE_SBOM}" = "true" ]; then \
       && cargo cyclonedx --target "${TARGET}" --format json; \
     fi
 
-# Collect only release binaries and SBOMs
-RUN mkdir -p "/out/target/${TARGET}/release" \
+# Collect only built binaries and SBOMs (cargo's output dir is named after
+# the profile: release/ for the release profile, ci/ for the ci profile)
+RUN mkdir -p "/out/target/${TARGET}/${CARGO_PROFILE}" \
     && for bin in vouch vouch-agent vouch-server; do \
-         if [ -f "target/${TARGET}/release/${bin}" ]; then \
-           cp "target/${TARGET}/release/${bin}" "/out/target/${TARGET}/release/"; \
+         if [ -f "target/${TARGET}/${CARGO_PROFILE}/${bin}" ]; then \
+           cp "target/${TARGET}/${CARGO_PROFILE}/${bin}" "/out/target/${TARGET}/${CARGO_PROFILE}/"; \
          fi; \
        done \
     && find crates/ -name "*cdx.json" 2>/dev/null | while read -r f; do \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -10,13 +10,22 @@ variable "GENERATE_SBOM" {
   default = "false"
 }
 
+variable "CACHE_IMAGE" {
+  // Registry ref for the shared dependency layer cache, e.g.
+  // ghcr.io/vouch-sh/vouch/buildcache. Registry storage keeps the multi-GB
+  // Rust layer cache out of the repo's 10 GB GitHub Actions cache budget.
+  // Empty (local builds) disables the remote cache; the local BuildKit
+  // layer cache still applies.
+  default = ""
+}
+
 variable "WRITE_CACHE" {
-  // "true" only on main-branch CI runs. GHA cache entries written from PR,
-  // merge-queue, or tag refs are readable only by that same ref, so writing
-  // from them burns the repo's 10 GB Actions cache budget (evicting the
-  // shared main-scoped entries every ref restores from) without ever
-  // producing a cache hit. Reads (cache-from) stay enabled everywhere:
-  // any ref may restore caches written from the default branch.
+  // "true" only on main-branch CI runs. The deps cache is shared by every
+  // ref, so only post-merge builds may publish it: PR and merge-queue runs
+  // read the cache but never write, keeping unmerged dependency trees out
+  // of the shared cache. For the remaining GHA-backed scopes (cli/server),
+  // ref-scoped writes would also burn the 10 GB Actions cache budget
+  // without ever producing a cache hit.
   default = "false"
 }
 
@@ -30,16 +39,33 @@ target "_common" {
   output     = ["type=local,dest=."]
 }
 
+// Dependency layers only (through `cargo chef cook`). Built alongside `ci`
+// in CI so the reusable layers can be published to the registry cache
+// without also exporting the per-commit source and workspace-compile
+// layers, which change on every push and can never produce a cache hit.
+target "deps" {
+  inherits = ["_common"]
+  target   = "deps"
+  output   = ["type=cacheonly"]
+  args = {
+    TARGET        = TARGET
+    CARGO_PROFILE = "ci"
+  }
+  cache-from = CACHE_IMAGE != "" ? ["type=registry,ref=${CACHE_IMAGE}:deps-ci-${TARGET}"] : []
+  cache-to   = CACHE_IMAGE != "" && WRITE_CACHE == "true" ? ["type=registry,ref=${CACHE_IMAGE}:deps-ci-${TARGET},mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true"] : []
+}
+
 target "ci" {
   inherits = ["_common"]
   args = {
     TARGET            = TARGET
+    CARGO_PROFILE     = "ci"
     CARGO_PACKAGES    = "-p vouch-cli -p vouch-agent -p vouch-server"
     SOURCE_DATE_EPOCH = "0"
     GENERATE_SBOM     = "false"
   }
-  cache-from = ["type=gha,scope=bake-ci-${TARGET}"]
-  cache-to   = WRITE_CACHE == "true" ? ["type=gha,mode=max,ignore-error=true,scope=bake-ci-${TARGET}"] : []
+  cache-from = CACHE_IMAGE != "" ? ["type=registry,ref=${CACHE_IMAGE}:deps-ci-${TARGET}"] : []
+  cache-to   = []
 }
 
 target "cli" {


### PR DESCRIPTION
## Summary

The repo's 10 GB Actions cache budget was fully consumed (9.9 GB of 100 entries, all on `main`). Every main push exported 2–3 GB of per-commit bake layers (`COPY . .` + workspace compile) that can never produce a cache hit, evicting the entries that can — large blobs written by one push were evicted within about an hour by the next. Warm Linux bake builds were still 10–11 minutes; cold ones (after a lockfile change) 19–22 minutes.

## Changes

- **Split `Dockerfile.build` at the cargo-chef cook boundary.** A new `deps` stage/bake target ends at `cargo chef cook` and is the only thing exported to the layer cache (`output=cacheonly`). The `ci` target reads that cache and writes nothing, so per-commit source and compile layers are no longer uploaded anywhere.
- **Move the deps layer cache to GHCR** (`type=registry`, `ghcr.io/vouch-sh/vouch/buildcache:deps-ci-<target>`), taking it out of the 10 GB Actions cache budget entirely. Writes remain main-only via the existing `WRITE_CACHE` guard; the build job logs in to GHCR with `GITHUB_TOKEN` (`packages: write`, auto-downgraded to read on PRs). With `CACHE_IMAGE` unset (local `make bake-*`), no remote cache is configured.
- **Add `[profile.ci]`** — inherits release but with `lto = "thin"` and `codegen-units = 16`. The bake `ci` target builds with it; `release.yml` and the `reproduce` target keep the full release profile, so shipped binaries are unchanged.
- **Drop the fmt job's rust-cache step** — `cargo fmt` compiles nothing, so the 130 MB entry bought nothing.

## Expected effect

- Actions cache usage drops by ~4 GB, ending eviction pressure on the Swatinem rust-caches.
- GHCR cache writes only happen when `Cargo.lock`/manifests change, not on every push.
- Linux bake builds skip fat LTO + single-codegen-unit codegen, the largest share of warm build time.

## Post-merge

The first main run creates the `buildcache` package on GHCR as **private**; making it public lets fork PRs restore the cache too. The orphaned `bake-ci-*` Actions cache entries age out on their own within 7 days.

## Validation

- `docker buildx bake --print` verified for both targets, with and without `CACHE_IMAGE`/`WRITE_CACHE` set
- `actionlint` and `zizmor` clean on the modified workflow
- `cargo check --profile ci` compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI build caching, GHCR permissions, and which Cargo profile Linux bake uses; shipped release binaries are unchanged but misconfiguration could weaken cache isolation or slow/fail builds.
> 
> **Overview**
> **Moves Linux bake dependency caching off the 10 GB Actions cache** and **speeds CI compile** without changing release artifacts.
> 
> `Dockerfile.build` now stops reusable layers at a dedicated **`deps`** stage (through `cargo chef cook`); the **`ci`** bake target builds on top but no longer writes cache entries. CI runs **`deps` + `ci`** so only dependency layers are pushed to **`ghcr.io/.../buildcache`** (`CACHE_IMAGE`), with writes still gated by **`WRITE_CACHE` on main**; the build job logs into GHCR (`packages: write`). The **`ci`** target reads that registry cache and sets **`cache-to` to empty**, avoiding per-commit layer uploads that were evicting shared GHA cache.
> 
> Adds **`[profile.ci]`** (thin LTO, 16 codegen units) and wires bake **`ci`/`deps`** to **`CARGO_PROFILE=ci`**; **`cli`/`server`/`reproduce`** still default to full **`release`** in the Dockerfile.
> 
> Removes the **fmt** job’s **Swatinem/rust-cache** step since **`cargo fmt`** does not compile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94a6e6e183729844a6be6aafb0d587c3cb08ba1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->