### PR TITLE
ci: delete untagged cache package versions weekly

### DIFF
--- a/.github/workflows/package-cleanup.yml
+++ b/.github/workflows/package-cleanup.yml
@@ -1,0 +1,40 @@
+name: Package Cleanup
+
+# Both BuildKit registry caches overwrite a tag on every write, orphaning the
+# previous cache manifest as an untagged version that cache-from can never
+# pull again. Untagged versions are pure storage cost; delete them weekly.
+#
+# Only the two cache packages are cleaned. The vouch server image and the
+# Helm chart are multi-platform indexes whose child manifests appear as
+# untagged versions — deleting those would corrupt the tagged index.
+
+on:
+  schedule:
+    - cron: "0 3 * * 0"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  delete-untagged:
+    name: Delete untagged cache versions
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Clean vouch/buildcache (CI deps cache)
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
+        with:
+          package-name: vouch/buildcache
+          package-type: container
+          delete-only-untagged-versions: "true"
+      # Kamal's deploy cache is not published from this repo's workflows, so
+      # GITHUB_TOKEN can only delete from it after the package grants this
+      # repo the Admin role: package settings -> Manage Actions access.
+      - name: Clean vouch-build-cache (Kamal deploy cache)
+        if: ${{ !cancelled() }}
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
+        with:
+          package-name: vouch-build-cache
+          package-type: container
+          delete-only-untagged-versions: "true"


### PR DESCRIPTION
## Summary

Both BuildKit registry caches overwrite a tag on every write, orphaning the previous cache manifest as an untagged version that `cache-from` can never pull again. The Kamal deploy cache (`vouch-build-cache`) has accumulated ~209 untagged versions of billed private GHCR storage; the new CI deps cache (`vouch/buildcache`, #870) will accumulate the same way whenever the dependency layers change.

## Changes

Adds `.github/workflows/package-cleanup.yml`:

- Deletes **all untagged versions** of `vouch/buildcache` and `vouch-build-cache` every Sunday 03:00 UTC, with `workflow_dispatch` for immediate manual runs.
- The two steps are independent — a failure on one does not skip the other.
- `actions/delete-package-versions` pinned to the v5.0.0 commit SHA; job permissions limited to `packages: write`.

The `vouch` server image and `charts/vouch-server` packages are deliberately excluded: they are multi-platform indexes whose child manifests appear as untagged versions, and deleting those would corrupt the tagged index.

## Post-merge

`vouch-build-cache` is not linked to any repository, so `GITHUB_TOKEN` cannot delete from it until the package grants this repo the **Admin** role: package settings → Manage Actions access → add `vouch-sh/vouch`. Until then that step fails visibly while the `vouch/buildcache` step still succeeds. After granting access, trigger the workflow manually once to reclaim the existing backlog.

## Validation

- `actionlint` and `zizmor` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only GHCR housekeeping with explicit package scope; main caveat is ensuring only cache packages are targeted so multi-platform image indexes are not affected.
> 
> **Overview**
> Adds a scheduled GitHub Actions workflow to **reclaim GHCR storage** from BuildKit registry caches that leave behind untagged manifests on every cache write.
> 
> **`package-cleanup.yml`** runs weekly (Sunday 03:00 UTC) and on `workflow_dispatch`, using pinned `actions/delete-package-versions` with `delete-only-untagged-versions` for **`vouch/buildcache`** (CI deps cache) and **`vouch-build-cache`** (Kamal deploy cache). Job permissions are scoped to `packages: write`; the Kamal step uses `if: !cancelled()` so one failure does not skip the other.
> 
> Server image and Helm chart packages are **not** touched—multi-platform indexes would look like untagged children and could be corrupted if cleaned the same way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49d1d931b397aaceb6c78b03182fcd6c36f3731c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->