### PR TITLE
refactor(server): unify session extractors behind one active-user check

### DIFF
--- a/crates/vouch-server/src/handlers/applications/api.rs
+++ b/crates/vouch-server/src/handlers/applications/api.rs
@@ -79,25 +79,7 @@ async fn load_active_user_for_scope(
     user_id: &str,
     wants_org_scope: bool,
 ) -> Result<db::User, ServiceError> {
-    let user = db::get_user_by_id(&state.store, user_id)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to get user: {e}");
-            ServiceError::api(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "db_error",
-                "Internal database error",
-            )
-        })?
-        .ok_or_else(|| ServiceError::api(StatusCode::NOT_FOUND, "not_found", "User not found"))?;
-
-    if !user.active {
-        return Err(ServiceError::api(
-            StatusCode::UNAUTHORIZED,
-            "unauthorized",
-            "User account is deactivated",
-        ));
-    }
+    let user = crate::handlers::session::load_active_user(state, user_id).await?;
 
     // Validate: Organization scope requires user to have an org
     if wants_org_scope && user.org_id.is_none() {

--- a/crates/vouch-server/src/handlers/applications/mod.rs
+++ b/crates/vouch-server/src/handlers/applications/mod.rs
@@ -62,18 +62,11 @@ async fn extract_auth_from_cookie(state: &AppState, jar: &CookieJar) -> Option<A
     // Use shared cookie extraction
     let session = extract_session_from_cookie(state, jar).await.ok()?;
 
-    // Get user info
-    let user = db::get_user_by_id(&state.store, &session.sub)
+    // Missing or deactivated users are unauthenticated — the active-account
+    // invariant is enforced once, in `load_active_user`.
+    let user = super::session::load_active_user(state, &session.sub)
         .await
-        .ok()??;
-
-    // Deactivated users may still hold a live cookie in the window between
-    // `update_user_active_status` and `delete_sessions_for_user` (separate
-    // transactions); treat them as unauthenticated, matching
-    // `get_resource_auth_context`.
-    if !user.active {
-        return None;
-    }
+        .ok()?;
 
     Some(AuthContext {
         authenticated: true,

--- a/crates/vouch-server/src/handlers/credentials.rs
+++ b/crates/vouch-server/src/handlers/credentials.rs
@@ -69,27 +69,7 @@ pub(crate) async fn issue_ssh_certificate(
     .await?;
 
     // Reject deactivated users (defense-in-depth for SCIM deactivation)
-    let user = db::get_user_by_id(&state.store, &token.sub)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to get user by ID: {e}");
-            ServiceError::api(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "db_error",
-                "Internal database error",
-            )
-        })?
-        .ok_or_else(|| {
-            ServiceError::api(StatusCode::NOT_FOUND, "user_not_found", "User not found")
-        })?;
-
-    if !user.active {
-        return Err(ServiceError::api(
-            StatusCode::UNAUTHORIZED,
-            "unauthorized",
-            "User account is deactivated",
-        ));
-    }
+    let user = super::session::load_active_user(&state, &token.sub).await?;
 
     // Certificate validity matches session duration
     let valid_seconds = state.config().session_hours.saturating_mul(3600);
@@ -383,27 +363,7 @@ async fn authorize_aws_token_request(
 
     // Confirm the user is still active. Email and federation claims come from
     // the session snapshot, not from current state.
-    let user = db::get_user_by_id(&state.store, &token.sub)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to get user by ID: {e}");
-            ServiceError::api(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "db_error",
-                "Internal database error",
-            )
-        })?
-        .ok_or_else(|| {
-            ServiceError::api(StatusCode::NOT_FOUND, "user_not_found", "User not found")
-        })?;
-
-    if !user.active {
-        return Err(ServiceError::api(
-            StatusCode::UNAUTHORIZED,
-            "unauthorized",
-            "User account is deactivated",
-        ));
-    }
+    let user = super::session::load_active_user(state, &token.sub).await?;
 
     let user_email = token.email.clone().unwrap_or_else(|| user.email.clone());
 
@@ -659,27 +619,7 @@ pub(crate) async fn get_github_status(
     .await?;
 
     // Get user
-    let user = db::get_user_by_id(&state.store, &token.sub)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to get user by ID: {e}");
-            ServiceError::api(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "db_error",
-                "Internal database error",
-            )
-        })?
-        .ok_or_else(|| {
-            ServiceError::api(StatusCode::NOT_FOUND, "user_not_found", "User not found")
-        })?;
-
-    if !user.active {
-        return Err(ServiceError::api(
-            StatusCode::UNAUTHORIZED,
-            "unauthorized",
-            "User account is deactivated",
-        ));
-    }
+    let user = super::session::load_active_user(&state, &token.sub).await?;
 
     // Check if GitHub App is configured
     let configured = state.github_app.is_some();
@@ -760,27 +700,7 @@ pub(crate) async fn get_github_token(
     .await?;
 
     // Get user
-    let user = db::get_user_by_id(&state.store, &token.sub)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to get user by ID: {e}");
-            ServiceError::api(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "db_error",
-                "Internal database error",
-            )
-        })?
-        .ok_or_else(|| {
-            ServiceError::api(StatusCode::NOT_FOUND, "user_not_found", "User not found")
-        })?;
-
-    if !user.active {
-        return Err(ServiceError::api(
-            StatusCode::UNAUTHORIZED,
-            "unauthorized",
-            "User account is deactivated",
-        ));
-    }
+    let user = super::session::load_active_user(&state, &token.sub).await?;
 
     // Verify user has an organization
     let org_id = user.org_id.as_ref().ok_or_else(|| {

--- a/crates/vouch-server/src/handlers/keys.rs
+++ b/crates/vouch-server/src/handlers/keys.rs
@@ -109,20 +109,7 @@ pub(crate) async fn register_start(
         )
     })?;
 
-    // Verify user exists (should always exist if they have a valid session)
-    let user = db::get_user_by_id(&state.store, &token.sub)
-        .await?
-        .ok_or_else(|| {
-            ServiceError::api(StatusCode::NOT_FOUND, "user_not_found", "User not found")
-        })?;
-
-    if !user.active {
-        return Err(ServiceError::api(
-            StatusCode::UNAUTHORIZED,
-            "unauthorized",
-            "User account is deactivated",
-        ));
-    }
+    let user = super::session::load_active_user(&state, &token.sub).await?;
 
     tracing::info!(
         "Registration start for authenticated user: {} (adding key: {})",

--- a/crates/vouch-server/src/handlers/session.rs
+++ b/crates/vouch-server/src/handlers/session.rs
@@ -390,20 +390,20 @@ fn extract_token_from_request(
 // Shared Auth Extraction Helpers
 // ============================================================================
 
-/// Extract authenticated user and their org_id.
+/// Load the user for a validated token subject, rejecting missing or
+/// deactivated accounts.
 ///
-/// Returns `(user, org_id)` or an error if not authenticated or no org.
-pub(crate) async fn extract_user_with_org(
+/// This is the single enforcement point for the account-active invariant on
+/// the session path: every extractor that turns a validated token or cookie
+/// into a user must obtain that user through here, so a deactivated account
+/// cannot authenticate anywhere — including during the window between
+/// `update_user_active_status` and `delete_sessions_for_user`, which commit
+/// in separate transactions.
+pub(crate) async fn load_active_user(
     state: &AppState,
-    headers: &axum::http::HeaderMap,
-    jar: &CookieJar,
-    method: &str,
-    uri: &str,
-    client_cert: Option<&crate::services::oidc::mtls::ClientCertificate>,
-) -> Result<(db::User, String), ServiceError> {
-    let token = extract_resource_token(state, headers, jar, method, uri, client_cert).await?;
-
-    let user = db::get_user_by_id(&state.store, &token.sub)
+    user_id: &str,
+) -> Result<db::User, ServiceError> {
+    let user = db::get_user_by_id(&state.store, user_id)
         .await?
         .ok_or_else(|| {
             ServiceError::api(StatusCode::UNAUTHORIZED, "unauthorized", "User not found")
@@ -416,6 +416,23 @@ pub(crate) async fn extract_user_with_org(
             "User account is deactivated",
         ));
     }
+
+    Ok(user)
+}
+
+/// Extract authenticated user and their org_id.
+///
+/// Returns `(user, org_id)` or an error if not authenticated or no org.
+pub(crate) async fn extract_user_with_org(
+    state: &AppState,
+    headers: &axum::http::HeaderMap,
+    jar: &CookieJar,
+    method: &str,
+    uri: &str,
+    client_cert: Option<&crate::services::oidc::mtls::ClientCertificate>,
+) -> Result<(db::User, String), ServiceError> {
+    let token = extract_resource_token(state, headers, jar, method, uri, client_cert).await?;
+    let user = load_active_user(state, &token.sub).await?;
 
     let org_id = user.org_id.clone().ok_or_else(|| {
         ServiceError::api(
@@ -431,8 +448,8 @@ pub(crate) async fn extract_user_with_org(
 /// Extract and validate an org admin from the access token.
 ///
 /// Returns the user and their org_id if they are an org admin.
-/// Reuses `extract_user_with_org` for token validation and user lookup,
-/// then adds active-status and admin-role checks.
+/// Reuses `extract_user_with_org` for token validation and the
+/// active-user lookup, then adds the admin-role check.
 pub(crate) async fn extract_org_admin(
     state: &AppState,
     headers: &axum::http::HeaderMap,
@@ -443,14 +460,6 @@ pub(crate) async fn extract_org_admin(
 ) -> Result<(db::User, String), ServiceError> {
     let (user, org_id) =
         extract_user_with_org(state, headers, jar, method, uri, client_cert).await?;
-
-    if !user.active {
-        return Err(ServiceError::api(
-            StatusCode::UNAUTHORIZED,
-            "unauthorized",
-            "User account is deactivated",
-        ));
-    }
 
     if !user.is_org_admin {
         return Err(ServiceError::api(
@@ -529,10 +538,10 @@ pub(crate) async fn get_resource_auth_context(state: &AppState, jar: &CookieJar)
     let user_email = decoded.email().map(String::from);
 
     // Look up user to check active status, org membership, and admin status
-    let (has_org, is_org_admin) = match db::get_user_by_id(&state.store, &user_id).await {
-        Ok(Some(user)) if user.active => (user.org_id.is_some(), user.is_org_admin),
-        _ => return AuthContext::unauthenticated(),
+    let Ok(user) = load_active_user(state, &user_id).await else {
+        return AuthContext::unauthenticated();
     };
+    let (has_org, is_org_admin) = (user.org_id.is_some(), user.is_org_admin);
 
     AuthContext {
         authenticated: true,


### PR DESCRIPTION
## Summary

Follow-on to #869. The deactivated-user invariant was enforced by independent checks across the session path — the pattern that let the #862/#869 gaps happen (a new call site forgets the check, or an author re-checks defensively because they can't tell whether upstream did).

`load_active_user` in `handlers/session.rs` is now the single "load user, reject missing or deactivated" step on the session path, and every session-path consumer routes through it:

- `extract_user_with_org` — lookup + active check replaced by the shared step
- `get_resource_auth_context` — same
- `extract_auth_from_cookie` (applications web UI) — same
- `load_active_user_for_scope` (applications API) — shrinks to the shared step plus its org-scope rule
- `extract_org_admin` — the redundant re-check (35 lines after `extract_user_with_org` had already checked) is removed
- `handlers/credentials.rs` — four verbatim 21-line lookup/active blocks (SSH certificate, AWS token, GitHub status, GitHub token) replaced with one line each
- `handlers/keys.rs` — same for key registration

Deliberately still local: the OAuth/token-issuance service layer (`services/oidc/token.rs`, `exchange.rs`, `introspection.rs`, `services/auth.rs`) uses OAuth error envelopes; `handlers/device.rs`'s check is a grant path that returns `invalid_grant` and burns the consumed device code; `handlers/enroll.rs`'s conditions gate re-enrollment of an existing account, not token-subject authentication.

## Behavior notes

Previously divergent error envelopes unify with the session path:

- Valid token whose user record was deleted: **401 `unauthorized`** (was 404 `not_found` on the applications API, 404 `user_not_found` on the credential/key endpoints)
- Store failure during the user lookup: standard internal-error envelope (was a bespoke 500 `db_error`)

No test or CLI code matches on the old shapes; the `"User account is deactivated"` messages that tests assert are unchanged.

## Testing

- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test -p vouch-server --all-features`: 2,778 passed, 0 failed
- `cargo test --package vouch-tests`: passed
- The invariant stays mutation-covered through the central path: `deactivated_user_cookie_is_unauthenticated` (#869), `test_create_application_rejects_deactivated_user`, `test_update_application_rejects_deactivated_user`, and the cookie-session tests all exercise `load_active_user`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth and credential issuance paths across many handlers; behavior is mostly equivalent but error envelopes on application create/update shifted slightly for missing users and DB failures.
> 
> **Overview**
> Centralizes the **account must be active** rule in `handlers/session::load_active_user`, so every path that turns a validated token or cookie into a `User` goes through one lookup plus active check (including the gap between SCIM deactivation and session deletion).
> 
> **Session helpers** (`extract_user_with_org`, `get_resource_auth_context`, `extract_org_admin`) now call `load_active_user`; the redundant second active check in `extract_org_admin` is removed.
> 
> **Handlers** in applications (API scope loader + cookie auth), credentials (SSH, AWS, GitHub), and keys (`register_start`) drop inline `get_user_by_id` + `!user.active` blocks in favor of the shared helper.
> 
> On application create/update, a valid token for a **deleted** user now returns **401 `unauthorized`** (was 404 `not_found`); DB errors on lookup use the standard internal-error path (was a custom 500 `db_error`). Deactivated-user messages are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88cb337b5ec49b3791b1bc0040923ac7256162e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->