### PR TITLE
ci: stop passing SOURCE_DATE_EPOCH to the bake ci target

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -57,12 +57,15 @@ target "deps" {
 
 target "ci" {
   inherits = ["_common"]
+  // No SOURCE_DATE_EPOCH here: it is a predefined BuildKit arg that stamps
+  // the epoch into WORKDIR/COPY op digests, forking this target's cache
+  // chain away from `deps` — the only chain published to CACHE_IMAGE. The
+  // Dockerfile's ARG default (0) still governs the builder-stage touch.
   args = {
-    TARGET            = TARGET
-    CARGO_PROFILE     = "ci"
-    CARGO_PACKAGES    = "-p vouch-cli -p vouch-agent -p vouch-server"
-    SOURCE_DATE_EPOCH = "0"
-    GENERATE_SBOM     = "false"
+    TARGET         = TARGET
+    CARGO_PROFILE  = "ci"
+    CARGO_PACKAGES = "-p vouch-cli -p vouch-agent -p vouch-server"
+    GENERATE_SBOM  = "false"
   }
   cache-from = CACHE_IMAGE != "" ? ["type=registry,ref=${CACHE_IMAGE}:deps-ci-${TARGET}"] : []
   cache-to   = []


### PR DESCRIPTION
## Summary

The `ci` bake target passed `SOURCE_DATE_EPOCH="0"` while `deps` — the only target that publishes the GHCR registry cache — did not. `SOURCE_DATE_EPOCH` is a predefined BuildKit frontend arg that stamps the epoch into `WORKDIR`/`COPY` op digests, so the two targets' cache chains forked at the first `WORKDIR` and the `ci` solve could never match the cache written from main. Every PR and main build re-cooked all dependencies (~30 min instead of ~13), and main runs cooked them twice concurrently.

Evidence, from the `Build (linux-arm64)` job of main run 31191364142, both targets in one bake invocation: the base stage (no file ops) shared one vertex per step, while everything from `WORKDIR` onward appeared twice — `[deps deps 4/4] cargo chef cook → CACHED` next to `[ci deps 4/4] cargo chef cook` recompiling 612 crates.

## Change

Remove `SOURCE_DATE_EPOCH` from the `ci` target's args in `docker-bake.hcl`, with a comment stating the constraint. The `ci` chain is now identical to the `deps` chain, so the two solves dedup into shared vertices and PR builds hit the cache already published from main — no repopulation needed. The builder-stage `touch` is unchanged via the Dockerfile `ARG` default, and CI's local output is never tarred or checksummed, so exported-file mtimes do not matter. Release targets are untouched.

## Verification

- `docker buildx bake --print ci deps`: resolved `ci` args no longer include `SOURCE_DATE_EPOCH`; remaining differences are builder-stage-only args, which the run logs show do not affect the cached stages.
- This PR's own `Build (linux-amd64/arm64)` jobs should show `cargo chef cook … CACHED` and drop to ~12–15 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/docker-bake configuration only; release targets still set SOURCE_DATE_EPOCH and behavior change is limited to faster cache reuse for dependency layers.
> 
> **Overview**
> Removes **`SOURCE_DATE_EPOCH="0"`** from the **`ci`** bake target in `docker-bake.hcl` and documents why it must stay unset there. BuildKit treats that arg as a frontend knob that changes **`WORKDIR`/`COPY`** digests, so **`ci`** and **`deps`** were solving separate dependency-layer chains even when built together; **`deps`** alone publishes the shared GHCR cache, so PR/main **`ci`** builds could not reuse those layers and kept re-running **`cargo chef cook`** (~30 min vs ~12–15 min).
> 
> **`cli`**, **`server`**, and **`reproduce`** still pass **`SOURCE_DATE_EPOCH`** for reproducible release artifacts. The Dockerfile **`ARG`** default still applies for builder-stage touches; only the bake override for **`ci`** is dropped so **`ci`** and **`deps`** share the same cached dependency vertices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f0a7aaed704570c4820c9d5b5fb6f371b85808a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->