### PR TITLE
refactor(server): canonicalize emails through an Email newtype

### DIFF
--- a/crates/vouch-server/src/crypto/ssh_ca.rs
+++ b/crates/vouch-server/src/crypto/ssh_ca.rs
@@ -325,6 +325,12 @@ impl SshCa {
     /// Returns two principals:
     /// 1. The full email address (user@domain.com)
     /// 2. The username part (user)
+    ///
+    /// Folding stays local rather than using `crate::email::Email` — the
+    /// crypto layer imports no other layer — and stays full-Unicode
+    /// `to_lowercase`: SSH principals are matched by sshd against
+    /// `AuthorizedPrincipals` entries, not against Vouch's ASCII-folded
+    /// email index, so changing the fold would break issued certificates.
     fn extract_principals(email: &str) -> Result<Vec<String>> {
         let email = email.trim().to_lowercase();
 

--- a/crates/vouch-server/src/db/audit.rs
+++ b/crates/vouch-server/src/db/audit.rs
@@ -243,6 +243,17 @@ impl AuditStore {
         Self { pool, crypto }
     }
 
+    /// Blind-index HMAC of an email address, canonicalized first.
+    ///
+    /// The single policy for email correlation keys: insert and query must
+    /// both HMAC the canonical form (`crate::email::Email`) or the same
+    /// address keys differently depending on the casing the IdP or caller
+    /// supplied.
+    fn email_hmac(&self, email: &str) -> String {
+        self.crypto
+            .hmac_index(crate::email::Email::new(email).as_str())
+    }
+
     /// Insert a new audit event.
     ///
     /// `email` is masked to domain-only and HMAC-hashed for correlation.
@@ -258,11 +269,8 @@ impl AuditStore {
         email: Option<&str>,
         data_json: &str,
     ) -> Result<String> {
-        let email_domain = email.and_then(extract_domain);
-        // Normalize the local part to lowercase so the same user's events
-        // correlate across casings returned by the IdP over time. The domain
-        // is normalized by `extract_domain`.
-        let email_hmac = email.map(|e| self.crypto.hmac_index(&e.to_lowercase()));
+        let email_domain = email.and_then(crate::email::Email::domain_of);
+        let email_hmac = email.map(|e| self.email_hmac(e));
 
         self.insert_event_raw(
             kind,
@@ -439,10 +447,10 @@ impl AuditStore {
                 q.and_where(Expr::col(AuditEvents::UserId).eq(uid.as_str()));
             }
             if let Some(ref email) = filter.email {
-                // Normalize to lowercase to match the HMAC computed at insert
-                // time, so lookups correlate regardless of the casing supplied
-                // by the caller or returned by the IdP.
-                let hmac = self.crypto.hmac_index(&email.to_lowercase());
+                // Same canonicalizing HMAC as insert time, so lookups
+                // correlate regardless of the casing supplied by the caller
+                // or returned by the IdP.
+                let hmac = self.email_hmac(email);
                 q.and_where(Expr::col(AuditEvents::EmailHmac).eq(hmac));
             }
             if let Some(ref domains) = filter.email_domains {
@@ -569,17 +577,6 @@ impl std::fmt::Debug for AuditStore {
 // ============================================================================
 // Helpers
 // ============================================================================
-
-/// Extract the domain portion of an email address, normalized to ASCII
-/// lowercase to match the IdP layer's domain normalization. Org domains
-/// are stored lowercase, so a mixed-case domain from an IdP (e.g.
-/// `CORP.Example.COM`) would otherwise fail to match the `email_domain`
-/// filter used by the admin audit page.
-fn extract_domain(email: &str) -> Option<String> {
-    email
-        .rsplit_once('@')
-        .map(|(_, domain)| domain.to_ascii_lowercase())
-}
 
 /// Normalize a `since`/`until`/cleanup-cutoff timestamp bound for
 /// lexicographic comparison against the `created_at` column, by truncating
@@ -806,42 +803,6 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(events.len(), 2);
-    }
-
-    #[test]
-    fn extract_domain_works() {
-        assert_eq!(
-            extract_domain("alice@example.com"),
-            Some("example.com".to_string())
-        );
-        assert_eq!(extract_domain("nodomain"), None);
-        assert_eq!(
-            extract_domain("user@sub.domain.com"),
-            Some("sub.domain.com".to_string())
-        );
-    }
-
-    #[test]
-    fn extract_domain_normalizes_case() {
-        // Mixed-case domains from the IdP must be normalized to ASCII
-        // lowercase so they match the org's stored (lowercase) domain.
-        assert_eq!(
-            extract_domain("Alice@CORP.Example.COM"),
-            Some("corp.example.com".to_string())
-        );
-        assert_eq!(
-            extract_domain("bob@EXAMPLE.COM"),
-            Some("example.com".to_string())
-        );
-        assert_eq!(
-            extract_domain("bob@Example.Com"),
-            Some("example.com".to_string())
-        );
-        // Already-lowercase input is unchanged.
-        assert_eq!(
-            extract_domain("alice@example.com"),
-            Some("example.com".to_string())
-        );
     }
 
     #[tokio::test]

--- a/crates/vouch-server/src/db/documents/user.rs
+++ b/crates/vouch-server/src/db/documents/user.rs
@@ -5,11 +5,16 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::db::document_type::{DocumentType, IndexEntry};
+use crate::email::Email;
 
 /// A Vouch user.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UserDoc {
-    pub email: String,
+    /// Canonical (trimmed, ASCII-lowercased) address. The [`Email`] type
+    /// canonicalizes on construction and deserialization, so the `email`
+    /// index row emitted by [`DocumentType::index_entries`] is normalized
+    /// structurally — no call site can store a mixed-case address.
+    pub email: Email,
     pub name: Option<String>,
     pub org_id: Option<String>,
     pub is_org_admin: bool,
@@ -93,7 +98,7 @@ impl DocumentType for UserDoc {
     fn index_entries(&self) -> Vec<IndexEntry> {
         let mut entries = vec![IndexEntry {
             field: "email",
-            value: self.email.clone(),
+            value: self.email.as_str().to_string(),
         }];
         if let Some(ref org_id) = self.org_id {
             entries.push(IndexEntry {
@@ -146,21 +151,16 @@ impl DocumentType for UserDoc {
 /// custom derivation, avoiding the SHA-1 dependency a version-5 UUID
 /// would pull in.
 ///
-/// The email is ASCII-lowercased inside this function before hashing,
-/// so two casings of the same address always produce the same ID —
-/// a caller that forgets to normalize cannot reopen the cross-case
-/// duplicate-row race. Callers still normalize before storage and
-/// lookup (`create_scim_user` lowercases first), since the stored
-/// `UserDoc.email` and its index row must match the lowercase
-/// convention too.
-pub(crate) fn deterministic_user_id(email: &str) -> String {
+/// Taking [`Email`] (canonical by construction) means two casings of the
+/// same address always produce the same ID — a caller cannot reopen the
+/// cross-case duplicate-row race, because the type system already
+/// normalized the value it must store and index.
+pub(crate) fn deterministic_user_id(email: &Email) -> String {
     use aws_lc_rs::digest::{self, SHA256};
-
-    let email = email.to_ascii_lowercase();
 
     let mut ctx = digest::Context::new(&SHA256);
     ctx.update(b"user_email\0");
-    ctx.update(email.as_bytes());
+    ctx.update(email.as_str().as_bytes());
     let digest = ctx.finish();
 
     let mut bytes = [0u8; 16];
@@ -178,6 +178,7 @@ pub(crate) fn deterministic_user_id(email: &str) -> String {
 mod tests {
     use super::{IdpIdentity, UserDoc, deterministic_user_id, idp_identity_index_value};
     use crate::db::document_type::DocumentType;
+    use crate::email::Email;
 
     #[test]
     fn legacy_user_json_without_idp_identities_deserializes() {
@@ -202,7 +203,7 @@ mod tests {
     #[test]
     fn index_entries_include_one_row_per_idp_identity() {
         let doc = UserDoc {
-            email: "user@example.com".to_string(),
+            email: Email::new("user@example.com"),
             name: None,
             org_id: None,
             is_org_admin: false,
@@ -263,16 +264,16 @@ mod tests {
         // surface a primary-key violation instead of silently creating a
         // second user row.
         assert_eq!(
-            deterministic_user_id("dup@example.com"),
-            deterministic_user_id("dup@example.com"),
+            deterministic_user_id(&Email::new("dup@example.com")),
+            deterministic_user_id(&Email::new("dup@example.com")),
         );
     }
 
     #[test]
     fn deterministic_user_id_differs_for_distinct_emails() {
         assert_ne!(
-            deterministic_user_id("alice@example.com"),
-            deterministic_user_id("bob@example.com"),
+            deterministic_user_id(&Email::new("alice@example.com")),
+            deterministic_user_id(&Email::new("bob@example.com")),
         );
     }
 
@@ -282,7 +283,7 @@ mod tests {
         // `handlers::scim::validate_resource_id`). A deterministic ID
         // that fails to parse would make the user it identifies
         // unaddressable via GET/PATCH/PUT/DELETE.
-        let id = deterministic_user_id("uuid-shape@example.com");
+        let id = deterministic_user_id(&Email::new("uuid-shape@example.com"));
         let parsed = uuid::Uuid::try_parse(&id);
         assert!(
             parsed.is_ok(),
@@ -302,12 +303,12 @@ mod tests {
         // to normalize cannot mint a second user row for the same
         // person via a differently-cased concurrent create.
         assert_eq!(
-            deterministic_user_id("Mixed@Example.com"),
-            deterministic_user_id("mixed@example.com"),
+            deterministic_user_id(&Email::new("Mixed@Example.com")),
+            deterministic_user_id(&Email::new("mixed@example.com")),
         );
         assert_eq!(
-            deterministic_user_id("MIXED@EXAMPLE.COM"),
-            deterministic_user_id("mixed@example.com"),
+            deterministic_user_id(&Email::new("MIXED@EXAMPLE.COM")),
+            deterministic_user_id(&Email::new("mixed@example.com")),
         );
     }
 }

--- a/crates/vouch-server/src/db/enrollment.rs
+++ b/crates/vouch-server/src/db/enrollment.rs
@@ -147,7 +147,7 @@ async fn get_or_create_org(store: &DocumentStore, domain: &str) -> Result<String
 /// [`enroll_user_with_org`] for the full contract.
 async fn resolve_user(
     tx: &mut super::store::StoreTransaction<'_>,
-    email: &str,
+    email: &crate::email::Email,
     name: Option<&str>,
     org_id: Option<&str>,
     is_org_admin: bool,
@@ -173,14 +173,14 @@ async fn resolve_user(
     let existing_user = match bound_user {
         Some(doc) => Some(doc),
         None => tx
-            .find_one::<UserDoc>("email", email)
+            .find_one::<UserDoc>("email", email.as_str())
             .await
             .map_err(|e| ServiceError::from_db_contention(e, "Failed to look up user by email"))?,
     };
 
     let Some(doc) = existing_user else {
         let new_doc = UserDoc {
-            email: email.to_string(),
+            email: email.clone(),
             name: name.map(String::from),
             org_id: org_id.map(String::from),
             is_org_admin,
@@ -197,7 +197,7 @@ async fn resolve_user(
             .map_err(|e| ServiceError::from_db_contention(e, "Failed to insert user"))?;
         return Ok(EnrolledUser {
             id: result.id,
-            email: result.data.email,
+            email: result.data.email.into_string(),
             name: result.data.name,
             org_id: result.data.org_id,
             is_org_admin: result.data.is_org_admin,
@@ -212,7 +212,7 @@ async fn resolve_user(
     if !doc.data.active {
         return Err(EnrollUserError::Deactivated {
             user_id: doc.id,
-            email: doc.data.email,
+            email: doc.data.email.into_string(),
         });
     }
 
@@ -272,7 +272,7 @@ async fn resolve_user(
     }
     Ok(EnrolledUser {
         id: doc.id,
-        email: doc.data.email,
+        email: doc.data.email.into_string(),
         name: doc.data.name,
         org_id: doc.data.org_id,
         is_org_admin: doc.data.is_org_admin,
@@ -353,13 +353,10 @@ pub async fn enroll_user_with_org(
     domain: Option<&str>,
     upstream: Option<&UpstreamLogin>,
 ) -> Result<EnrolledUser, EnrollUserError> {
-    // Normalize email to ASCII lowercase so the lookup matches a
-    // pre-provisioned user regardless of the casing the IdP returned.
-    // `to_ascii_lowercase` only folds A-Z, preserving the byte length and
-    // validity of any internationalized local-part — the same normalization
-    // `extract_domain` already applies to the domain component.
-    let email = email.to_ascii_lowercase();
-    let email = email.as_str();
+    // Canonicalize so the lookup matches a pre-provisioned user regardless
+    // of the casing the IdP returned; see `crate::email::Email` for the
+    // folding policy.
+    let email = crate::email::Email::new(email);
 
     let org_id = match domain {
         Some(domain) => Some(get_or_create_org(store, domain).await?),
@@ -400,7 +397,7 @@ pub async fn enroll_user_with_org(
 
         let user = resolve_user(
             &mut tx,
-            email,
+            &email,
             name,
             org_id.as_deref(),
             is_org_admin,

--- a/crates/vouch-server/src/db/organizations/domains.rs
+++ b/crates/vouch-server/src/db/organizations/domains.rs
@@ -491,8 +491,8 @@ async fn revoke_sessions_for_domain_users(
         let matches = user
             .data
             .email
-            .rsplit_once('@')
-            .is_some_and(|(_, d)| d.eq_ignore_ascii_case(domain));
+            .domain()
+            .is_some_and(|d| d.eq_ignore_ascii_case(domain));
         if !matches {
             continue;
         }
@@ -1733,7 +1733,7 @@ mod tests {
             .unwrap();
 
         let mk_user = |email: &str| UserDoc {
-            email: email.to_string(),
+            email: crate::email::Email::new(email),
             name: None,
             org_id: Some(org.id.clone()),
             is_org_admin: false,

--- a/crates/vouch-server/src/db/scim.rs
+++ b/crates/vouch-server/src/db/scim.rs
@@ -413,7 +413,7 @@ impl From<Document<UserDoc>> for ScimUserRecord {
     fn from(doc: Document<UserDoc>) -> Self {
         Self {
             id: doc.id,
-            email: doc.data.email,
+            email: doc.data.email.into_string(),
             name: doc.data.name,
             created_at: doc.created_at,
             updated_at: doc.updated_at,
@@ -502,9 +502,9 @@ async fn try_indexed_user_lookup(
         if let Some(f) = parse_scim_filter(filter, attr)?
             && f.op == ScimFilterOp::Eq
         {
-            let email_lower = f.value.to_ascii_lowercase();
+            let email = crate::email::Email::new(&f.value);
             let docs = store
-                .find_by_indexes::<UserDoc>(&[("email", &email_lower), ("org_id", org_id)])
+                .find_by_indexes::<UserDoc>(&[("email", email.as_str()), ("org_id", org_id)])
                 .await?;
             return Ok(Some(docs.into_iter().map(ScimUserRecord::from).collect()));
         }
@@ -711,21 +711,17 @@ pub async fn create_scim_user(
 ) -> Result<ScimUserRecord, CreateScimUserError> {
     use super::documents::user::deterministic_user_id;
 
-    // Normalize email to ASCII lowercase so the duplicate check and the
-    // stored row match the casing used by `enroll_user_with_org`. Without
-    // this, a SCIM provision of `Alice@example.com` would not collide with
-    // a subsequent OIDC enrollment as `alice@example.com`, producing two
-    // user records for the same person.
-    let email = email.to_ascii_lowercase();
-    let email = email.as_str();
+    // Canonicalize so the duplicate check and the stored row match the
+    // casing used by `enroll_user_with_org`. Without this, a SCIM provision
+    // of `Alice@example.com` would not collide with a subsequent OIDC
+    // enrollment as `alice@example.com`, producing two user records for the
+    // same person.
+    let email = crate::email::Email::new(email);
 
     // Derived once outside the retried block: stable across retries and
-    // identical for concurrent callers passing the same email in any casing.
-    // `deterministic_user_id` lowercases internally as well, so the
-    // primary-key collision holds even if a future caller skips the
-    // normalization above — which is still required here so the stored
-    // `UserDoc.email` and its index row match the lowercase convention.
-    let user_id = deterministic_user_id(email);
+    // identical for concurrent callers passing the same email in any casing
+    // (`Email` is canonical by construction).
+    let user_id = deterministic_user_id(&email);
 
     // Owned `Option<String>` so the retried async block can borrow it
     // without borrowing `org_id` (a `&str` from the caller's stack frame).
@@ -745,12 +741,12 @@ pub async fn create_scim_user(
                     .get::<OrganizationDoc>(oid)
                     .await?
                     .ok_or(CreateScimUserError::DomainNotOwned)?;
-                // Extract the domain from the already-lowercased email so the
-                // comparison matches the lowercase convention used by
-                // `OrganizationDoc::verified_domains` (additional domains are
-                // stored verbatim from `normalize_domain`, which lowercases;
-                // the primary domain is lowercased by `get_or_create_org`).
-                let (_, candidate_domain) = email.rsplit_once('@').ok_or_else(|| {
+                // `Email::domain` is already canonical (lowercase), matching
+                // the convention used by `OrganizationDoc::verified_domains`
+                // (additional domains are stored verbatim from
+                // `normalize_domain`, which lowercases; the primary domain is
+                // lowercased by `get_or_create_org`).
+                let candidate_domain = email.domain().ok_or_else(|| {
                     CreateScimUserError::Other(anyhow::anyhow!(
                         "invalid email format: no '@' separator"
                     ))
@@ -774,12 +770,16 @@ pub async fn create_scim_user(
         // *different* code path (e.g. `enroll_user_with_org`) that did not use
         // the deterministic ID, so their row has a random UUID v7 ID and would
         // not collide with `user_id`.
-        if tx.find_one::<UserDoc>("email", email).await?.is_some() {
+        if tx
+            .find_one::<UserDoc>("email", email.as_str())
+            .await?
+            .is_some()
+        {
             return Err(CreateScimUserError::DuplicateEmail);
         }
 
         let doc = UserDoc {
-            email: email.to_string(),
+            email: email.clone(),
             name: name.map(String::from),
             org_id: org_id_owned.clone(),
             is_org_admin: false,

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -2721,7 +2721,7 @@ async fn test_create_scim_user_duplicate_email_rejected() {
         .await
         .expect("query by id")
         .expect("user must be findable by its deterministic ID");
-    assert_eq!(by_id.data.email, "dup@example.com");
+    assert_eq!(by_id.data.email.as_str(), "dup@example.com");
     assert!(
         uuid::Uuid::try_parse(&user.id).is_ok(),
         "deterministic user ID must parse as a UUID; got {}",
@@ -3202,7 +3202,7 @@ async fn test_create_scim_user_concurrent_same_email_produces_one_user() {
         .expect("query by id")
         .expect("user must be findable by its deterministic ID");
     assert_eq!(by_id.id, by_email.id);
-    assert_eq!(by_id.data.email, email);
+    assert_eq!(by_id.data.email.as_str(), email);
     // And the ID must be a valid UUID (SCIM resource ID contract).
     assert!(
         uuid::Uuid::try_parse(&by_email.id).is_ok(),
@@ -3279,7 +3279,9 @@ async fn test_create_scim_user_concurrent_mixed_case_same_email_produces_one_use
         "exactly one user row must exist across all casings; got {}",
         all_for_email.len()
     );
-    let expected_id = crate::db::documents::user::deterministic_user_id("case.race@example.com");
+    let expected_id = crate::db::documents::user::deterministic_user_id(&crate::email::Email::new(
+        "case.race@example.com",
+    ));
     let winner = all_for_email.first().expect("one row exists");
     assert_eq!(
         winner.id, expected_id,
@@ -3340,7 +3342,7 @@ async fn test_create_scim_user_blocked_by_preexisting_random_id_user() {
 
     // Seed a user with a random UUID v7 ID, as `enroll_user_with_org` does.
     let seeded = UserDoc {
-        email: email.to_string(),
+        email: crate::email::Email::new(email),
         name: Some("Seeded".to_string()),
         org_id: Some(TEST_ORG_ID.to_string()),
         is_org_admin: false,

--- a/crates/vouch-server/src/db/users.rs
+++ b/crates/vouch-server/src/db/users.rs
@@ -27,7 +27,7 @@ impl From<Document<UserDoc>> for User {
     fn from(doc: Document<UserDoc>) -> Self {
         Self {
             id: doc.id,
-            email: doc.data.email,
+            email: doc.data.email.into_string(),
             name: doc.data.name,
             org_id: doc.data.org_id,
             is_org_admin: doc.data.is_org_admin,
@@ -54,8 +54,8 @@ pub async fn upsert_user(
     email: &str,
     name: Option<&str>,
 ) -> Result<(String, bool)> {
-    let email = email.to_ascii_lowercase();
-    if let Some(doc) = store.find_one::<UserDoc>("email", &email).await? {
+    let email = crate::email::Email::new(email);
+    if let Some(doc) = store.find_one::<UserDoc>("email", email.as_str()).await? {
         return Ok((doc.id, false));
     }
     let user_doc = UserDoc {
@@ -89,8 +89,8 @@ pub async fn upsert_user_with_org(
     org_id: Option<&str>,
     is_org_admin: bool,
 ) -> Result<(String, bool)> {
-    let email = email.to_ascii_lowercase();
-    if let Some(doc) = store.find_one::<UserDoc>("email", &email).await? {
+    let email = crate::email::Email::new(email);
+    if let Some(doc) = store.find_one::<UserDoc>("email", email.as_str()).await? {
         return Ok((doc.id, false));
     }
     let user_doc = UserDoc {
@@ -115,8 +115,8 @@ pub async fn upsert_user_with_org(
 /// callers may pass any casing; user emails are stored lowercase by
 /// `enroll_user_with_org` and `create_scim_user`.
 pub async fn get_user_by_email(store: &DocumentStore, email: &str) -> Result<Option<User>> {
-    let email = email.to_ascii_lowercase();
-    let doc = store.find_one::<UserDoc>("email", &email).await?;
+    let email = crate::email::Email::new(email);
+    let doc = store.find_one::<UserDoc>("email", email.as_str()).await?;
     Ok(doc.map(User::from))
 }
 

--- a/crates/vouch-server/src/email.rs
+++ b/crates/vouch-server/src/email.rs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! Canonical email address handling.
+//!
+//! Vouch treats email addresses as case-insensitive identifiers: storage,
+//! indexed lookup, audit correlation, and domain matching must all agree on
+//! one canonical form or the same address keys differently across
+//! subsystems (the source of the cross-case duplicate-user and
+//! missing-audit-event bugs). [`Email`] is that canonical form; construct
+//! one instead of hand-rolling `to_lowercase()` at call sites.
+
+use serde::{Deserialize, Serialize};
+
+/// An email address in canonical form: trimmed and ASCII-lowercased.
+///
+/// ASCII folding (not full Unicode) is deliberate: stored `UserDoc` index
+/// rows and audit HMAC correlation keys were built with ASCII folding, and
+/// switching would orphan existing non-ASCII rows. RFC 5321 makes the
+/// domain case-insensitive and, in practice, providers treat the local
+/// part the same way.
+///
+/// Deserialization re-canonicalizes, so documents written before this type
+/// existed normalize on read.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct Email(String);
+
+impl Email {
+    /// Canonicalize a raw address: trim surrounding whitespace and
+    /// ASCII-lowercase.
+    pub fn new(raw: impl AsRef<str>) -> Self {
+        Self(raw.as_ref().trim().to_ascii_lowercase())
+    }
+
+    /// The canonical address as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consume into the canonical `String`.
+    #[must_use]
+    pub fn into_string(self) -> String {
+        self.0
+    }
+
+    /// The domain part of this address, if any.
+    ///
+    /// Splits on the **last** `@` (RFC 5321: a quoted local part may itself
+    /// contain `@`), the semantics the org-domain and audit layers already
+    /// used. First-`@` splitting picks the wrong domain for such addresses.
+    #[must_use]
+    pub fn domain(&self) -> Option<&str> {
+        self.0.rsplit_once('@').map(|(_, domain)| domain)
+    }
+
+    /// The canonical (lowercased) domain of a raw address, if any.
+    ///
+    /// For call sites that only need the domain of a `&str` without
+    /// building an [`Email`]. Same last-`@` semantics as [`Self::domain`].
+    #[must_use]
+    pub fn domain_of(raw: &str) -> Option<String> {
+        raw.trim()
+            .rsplit_once('@')
+            .map(|(_, domain)| domain.to_ascii_lowercase())
+    }
+}
+
+impl<'de> Deserialize<'de> for Email {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Self::new(String::deserialize(deserializer)?))
+    }
+}
+
+impl std::fmt::Display for Email {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for Email {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<Email> for String {
+    fn from(email: Email) -> Self {
+        email.0
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
+mod tests {
+    use super::Email;
+
+    #[test]
+    fn new_lowercases_and_trims() {
+        assert_eq!(
+            Email::new("  Alice@Example.COM ").as_str(),
+            "alice@example.com"
+        );
+    }
+
+    #[test]
+    fn new_folds_ascii_only() {
+        // Unicode stays as-is: stored index rows were built with ASCII folding.
+        assert_eq!(
+            Email::new("JÜRGEN@Example.com").as_str(),
+            "jÜrgen@example.com"
+        );
+    }
+
+    #[test]
+    fn domain_splits_on_last_at() {
+        let email = Email::new("\"quoted@local\"@example.com");
+        assert_eq!(email.domain(), Some("example.com"));
+    }
+
+    #[test]
+    fn domain_none_without_at() {
+        assert_eq!(Email::new("not-an-email").domain(), None);
+    }
+
+    #[test]
+    fn domain_of_lowercases() {
+        assert_eq!(
+            Email::domain_of("alice@EXAMPLE.com"),
+            Some("example.com".to_string())
+        );
+        assert_eq!(Email::domain_of("no-domain"), None);
+    }
+
+    #[test]
+    fn deserialize_canonicalizes() {
+        let email: Email = serde_json::from_str("\" Alice@Example.COM \"").expect("deserialize");
+        assert_eq!(email.as_str(), "alice@example.com");
+    }
+
+    #[test]
+    fn serialize_is_transparent() {
+        let json = serde_json::to_string(&Email::new("Bob@Example.com")).expect("serialize");
+        assert_eq!(json, "\"bob@example.com\"");
+    }
+}

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -741,7 +741,7 @@ pub(crate) async fn complete_enrollment_after_identity(
     // logged but never written back: there is no email-change machinery,
     // and downstream artifacts (sessions, certs, audit) must stay
     // consistent with the stored account.
-    if user.email != identity.email.to_ascii_lowercase() {
+    if user.email != crate::email::Email::new(&identity.email).as_str() {
         tracing::warn!(
             user_id = %user.id,
             account_email = %redact_email(&user.email),

--- a/crates/vouch-server/src/handlers/scim/users.rs
+++ b/crates/vouch-server/src/handlers/scim/users.rs
@@ -155,7 +155,7 @@ pub(crate) async fn create_user(
     // version-bumping it via `compare_and_update`), which closes the TOCTOU
     // race with a concurrent `remove_additional_domain` that a standalone
     // pre-check here could not.
-    if email.rsplit_once('@').is_none() {
+    if crate::email::Email::domain_of(&email).is_none() {
         tracing::warn!(
             org_id = %auth.org_id,
             "rejected SCIM user creation: userName is not an email address"

--- a/crates/vouch-server/src/lib.rs
+++ b/crates/vouch-server/src/lib.rs
@@ -17,6 +17,7 @@ pub(crate) mod attestation;
 pub mod config;
 pub mod crypto;
 pub mod db;
+pub(crate) mod email;
 pub(crate) mod error;
 pub mod filters;
 pub(crate) mod geo;
@@ -49,7 +50,10 @@ use std::sync::Arc;
 /// - `"not-an-email"` → `"n***"`
 #[must_use]
 pub(crate) fn redact_email(email: &str) -> String {
-    match email.split_once('@') {
+    // Last `@` (matching `Email::domain`): a quoted local part may contain
+    // `@`, and splitting on the first would print part of the local in the
+    // unredacted "domain" segment.
+    match email.rsplit_once('@') {
         Some((local, domain)) => {
             let first_char = local.chars().next().unwrap_or('*');
             format!("{first_char}***@{domain}")

--- a/crates/vouch-server/src/services/idp/oidc.rs
+++ b/crates/vouch-server/src/services/idp/oidc.rs
@@ -483,11 +483,14 @@ pub(crate) async fn verify_id_token(
     //
     // Normalize to ASCII lowercase so that org lookups match regardless of
     // the case the IdP returned. Org domains are stored lowercase.
+    // `Email::domain_of` splits on the last `@` — the same semantics the
+    // audit and org-domain layers use — where `split('@').nth(1)` picked
+    // the wrong "domain" for a quoted local part containing `@`.
     let is_google = is_google_host(&provider.issuer);
     let domain = if is_google {
         claims.hd.as_deref().map(str::to_ascii_lowercase)
     } else {
-        claims.email.split('@').nth(1).map(str::to_ascii_lowercase)
+        crate::email::Email::domain_of(&claims.email)
     };
 
     // Bind to `claims.iss` (the validated token issuer), not

--- a/crates/vouch-server/src/services/idp/saml/response.rs
+++ b/crates/vouch-server/src/services/idp/saml/response.rs
@@ -591,8 +591,9 @@ fn extract_domain(
         return Some(value.to_ascii_lowercase());
     }
 
-    // Derive from email address
-    email.split('@').nth(1).map(str::to_ascii_lowercase)
+    // Derive from email address (last-`@` split, matching the audit and
+    // org-domain layers)
+    crate::email::Email::domain_of(email)
 }
 
 /// Find the value of a SAML attribute by name.


### PR DESCRIPTION
## Summary

Email case normalization was hand-rolled at ~13 sites with two different folding policies (ASCII `to_ascii_lowercase` in storage, full-Unicode `to_lowercase` in audit HMAC), and domain extraction at 7 sites with two different split semantics (first-`@` in the IdP layer, last-`@` in the audit/org layers). This is the class behind #783/#792/#795/#804/#812/#816 — each fixed one instance, and nothing stopped the next hand-rolled fold.

`crate::email::Email` is now the canonical form: trimmed + ASCII-lowercased on construction **and deserialization** (documents written before this type canonicalize on read), with `domain()`/`domain_of()` splitting on the last `@` (RFC 5321: quoted local parts may contain `@`).

- `UserDoc.email` is `Email` — the `email` index row is normalized structurally; no call site can store a mixed-case address. `User.email` stays `String` (501 consumer sites unchanged).
- `deterministic_user_id(&Email)` — the defensive internal re-fold and its apologetic doc comment are gone; the type system provides the guarantee.
- All fold sites (users, enrollment, SCIM create/lookup/filter, audit insert/query, enroll drift-compare) and all domain sites (IdP OIDC/SAML, audit, org domain revocation, SCIM shape check, `redact_email`) route through the type. `AuditStore::email_hmac()` is the single canonicalizing policy for correlation keys.

Deliberately unchanged, with reasons in code comments: SCIM `match_filter_value` and filter parsing (generic RFC 7644 caseExact semantics for arbitrary attributes, not email canonicalization) and `ssh_ca::extract_principals` (sshd-facing, full-Unicode fold; changing it would break issued certificates).

## Behavior notes

- **IdP domain derivation** now splits on the last `@`, agreeing with the audit/org layers. For addresses with a quoted local part containing `@`, the IdP layer previously derived the wrong org domain. `redact_email` gets the same fix (it printed part of a quoted local in the unredacted domain segment).
- **Audit HMAC folding** changes from Unicode to ASCII for non-ASCII local parts only. Insert and query change together so correlation stays consistent going forward; pre-existing events for non-ASCII addresses no longer correlate. ASCII folding matches the stored `UserDoc` index rows — full-Unicode would have required re-indexing every user document, and this is the documented no-migration tradeoff.
- Legacy documents with mixed-case stored emails (already unreachable by email lookup today) canonicalize on read and self-heal their index row on next write.

## Testing

- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test --all-features` (workspace, includes vouch-tests integration): 4,511 passed, 0 failed
- Existing cross-case regression tests from #804/#816/#835 (duplicate users, SCIM eq filters, domain validation) now exercise the shared type
- Not run: hardware FIDO2 login E2E (requires a YubiKey); enroll/SCIM/OIDC flows are covered in-process by the integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches identity storage, SCIM/OIDC enrollment matching, and audit correlation keys; behavior changes for quoted-local `@` domain derivation and non-ASCII audit HMAC, though core paths are covered by existing regression tests.
> 
> **Overview**
> Introduces **`crate::email::Email`** as the single canonical form (trim + ASCII lowercase on construct and deserialize) with **`domain()` / `domain_of()`** using the **last `@`** split, replacing scattered `to_ascii_lowercase` / `to_lowercase` and mixed first- vs last-`@` domain parsing.
> 
> **`UserDoc.email`** is now **`Email`**, so indexed storage and **`deterministic_user_id(&Email)`** cannot persist or hash mixed-case addresses; API-facing **`User.email`** stays **`String`**. Enrollment, SCIM create/filter/lookup, user DB helpers, and enroll drift checks route through **`Email`**. **`AuditStore::email_hmac()`** HMACs the canonical address for insert and query; domain masking uses **`Email::domain_of`**. OIDC/SAML org domain derivation, SCIM shape checks, org domain session revocation, and **`redact_email`** align on last-`@` semantics.
> 
> **SSH CA principals** and generic SCIM filter case rules are **unchanged** (documented in code). **Audit HMAC** for non-ASCII local parts moves from Unicode to ASCII fold (insert/query together; old events for those addresses no longer correlate).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4f7024353655f4bcd73bdb173d36983b2300940. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->