### PR TITLE
ci: compress the GHCR deps cache with zstd

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -52,7 +52,12 @@ target "deps" {
     CARGO_PROFILE = "ci"
   }
   cache-from = CACHE_IMAGE != "" ? ["type=registry,ref=${CACHE_IMAGE}:deps-ci-${TARGET}"] : []
-  cache-to   = CACHE_IMAGE != "" && WRITE_CACHE == "true" ? ["type=registry,ref=${CACHE_IMAGE}:deps-ci-${TARGET},mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true"] : []
+  // zstd shrinks the multi-hundred-MB cook layers and decompresses faster
+  // than gzip on import; force-compression re-encodes blobs that already
+  // exist as gzip, so the published cache converges to zstd instead of
+  // reusing the old blobs forever. Smaller pulls also reduce exposure to
+  // GHCR secondary rate limits, which have failed PR builds mid-pull.
+  cache-to   = CACHE_IMAGE != "" && WRITE_CACHE == "true" ? ["type=registry,ref=${CACHE_IMAGE}:deps-ci-${TARGET},mode=max,image-manifest=true,oci-mediatypes=true,compression=zstd,force-compression=true,ignore-error=true"] : []
 }
 
 target "ci" {


### PR DESCRIPTION
## Summary

The cooked-dependency cache layers are multi-hundred-MB per target (760 MB for arm64) and every Linux CI job pulls them from GHCR. A burst of runs tripped GitHub's secondary rate limit mid-pull on PR #874: one build failed outright while materializing the layer, and the other silently fell back to a full dependency rebuild.

## Change

Add `compression=zstd,force-compression=true` to the `deps` target's registry `cache-to` in `docker-bake.hcl`. zstd shrinks the blobs and decompresses faster than gzip on import — fewer bytes and fewer ranged requests against the rate limit, and quicker layer extraction in every job. `force-compression` re-encodes blobs that already exist as gzip so the published cache converges to zstd instead of reusing the old blobs forever; unchanged blobs are not re-uploaded.

Cost: main-push cache exports pay a zstd compression pass. PR runs pick up the smaller cache after the first main push re-publishes it.

## Verification

- `TARGET=... WRITE_CACHE=true docker buildx bake --print deps` shows the resolved `cache-to` carrying `compression=zstd` and `force-compression=true`.
- After merge, the first main run's `exporting cache to registry` step re-writes the layers; subsequent PR runs pull visibly smaller blobs in the `cargo chef cook` materialization step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/build-cache configuration only; no application, auth, or runtime behavior changes.
> 
> **Overview**
> The **`deps`** bake target’s registry **`cache-to`** now uses **`compression=zstd`** and **`force-compression=true`**, so published `cargo chef cook` layers are smaller and decompress faster on pull than the previous default (gzip).
> 
> **`force-compression`** re-encodes existing gzip blobs on export so the shared GHCR cache migrates to zstd instead of keeping old blobs indefinitely. The intent is fewer bytes and ranged requests per CI job, which reduces exposure to **GHCR secondary rate limits** that have caused failed or fallback full rebuilds on large cache pulls.
> 
> Only main runs with **`WRITE_CACHE=true`** pay the extra compression on export; PR jobs keep read-only cache use unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f229e6575b57dd931657d8977146e2873cf9366b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->