### PR TITLE
ci: build Linux with plain cargo and drop the layer-cache stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,10 +113,11 @@ jobs:
     # on main after each merge, so platform-build breakage surfaces there.
     if: github.event_name != 'merge_group'
     runs-on: ${{ matrix.runner }}
-    # Linux musl builds run in the same Alpine image as Dockerfile.build
-    # with plain cargo, like every other platform. The bake targets and
-    # Dockerfile.build are reserved for reproducible release builds.
-    container: ${{ matrix.container }}
+    # Linux rows build musl inside the same Alpine image Dockerfile.build
+    # uses, via a single docker run — the closest PR-time approximation of
+    # the release build. The runner cannot exec JavaScript actions
+    # (checkout, rust-cache) inside musl containers on arm64, so checkout
+    # and caching stay on the VM and only cargo runs in the container.
     permissions:
       contents: read
     strategy:
@@ -125,18 +126,14 @@ jobs:
         include:
           - name: linux-amd64
             runner: ubuntu-latest
-            container: rust:1.97.1-alpine
             target: x86_64-unknown-linux-musl
             profile: ci
             packages: "-p vouch-cli -p vouch-agent -p vouch-server"
-            install: apk add --no-cache musl-dev pkgconfig cmake make go clang linux-headers openssl-dev openssl-libs-static perl eudev-dev
           - name: linux-arm64
             runner: ubuntu-24.04-arm
-            container: rust:1.97.1-alpine
             target: aarch64-unknown-linux-musl
             profile: ci
             packages: "-p vouch-cli -p vouch-agent -p vouch-server"
-            install: apk add --no-cache musl-dev pkgconfig cmake make go clang linux-headers openssl-dev openssl-libs-static perl eudev-dev
           - name: macos-arm64
             runner: macos-latest
             target: aarch64-apple-darwin
@@ -164,17 +161,8 @@ jobs:
       - name: Install system dependencies
         if: matrix.install != ''
         run: ${{ matrix.install }} # zizmor: ignore[template-injection] — static matrix value
-      - name: Set musl build environment
-        if: runner.os == 'Linux'
-        run: |
-          {
-            echo "AWS_LC_FIPS_SYS_CC=clang"
-            echo "AWS_LC_FIPS_SYS_CXX=clang++"
-            echo "OPENSSL_STATIC=1"
-            echo "OPENSSL_LIB_DIR=/usr/lib"
-            echo "OPENSSL_INCLUDE_DIR=/usr/include"
-          } >> "$GITHUB_ENV"
       - name: Setup Rust toolchain
+        if: runner.os != 'Linux'
         run: |
           rustup show
           rustup target add ${{ matrix.target }}
@@ -188,7 +176,21 @@ jobs:
         if: matrix.rustflags
         shell: bash
         run: echo "RUSTFLAGS=${{ matrix.rustflags }}" >> "$GITHUB_ENV"
+      - name: Build (Linux musl) # zizmor: ignore[template-injection] — static matrix values
+        if: runner.os == 'Linux'
+        run: |
+          docker run --rm -v "$PWD:/work" -w /work \
+            -v "$HOME/.cargo/registry:/usr/local/cargo/registry" \
+            -e CARGO_TERM_COLOR -e CARGO_BUILD_WARNINGS \
+            -e AWS_LC_FIPS_SYS_CC=clang -e AWS_LC_FIPS_SYS_CXX=clang++ \
+            -e OPENSSL_STATIC=1 -e OPENSSL_LIB_DIR=/usr/lib -e OPENSSL_INCLUDE_DIR=/usr/include \
+            rust:1.97.1-alpine sh -ec '
+              apk add --no-cache musl-dev pkgconfig cmake make go clang linux-headers openssl-dev openssl-libs-static perl eudev-dev
+              cargo build --profile ${{ matrix.profile }} --locked --target ${{ matrix.target }} ${{ matrix.packages }}
+            '
+          sudo chown -R "$(id -u):$(id -g)" target "$HOME/.cargo/registry"
       - name: Build # zizmor: ignore[template-injection] — static matrix values
+        if: runner.os != 'Linux'
         run: cargo build --profile ${{ matrix.profile }} --locked --target ${{ matrix.target }} ${{ matrix.packages }}
       - name: Upload Windows binary
         if: runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,35 +113,47 @@ jobs:
     # on main after each merge, so platform-build breakage surfaces there.
     if: github.event_name != 'merge_group'
     runs-on: ${{ matrix.runner }}
+    # Linux musl builds run in the same Alpine image as Dockerfile.build
+    # with plain cargo, like every other platform. The bake targets and
+    # Dockerfile.build are reserved for reproducible release builds.
+    container: ${{ matrix.container }}
     permissions:
       contents: read
-      # Push the shared dependency layer cache to GHCR from main; PR runs
-      # get a read-only token downgrade automatically.
-      packages: write
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: linux-amd64
             runner: ubuntu-latest
+            container: rust:1.97.1-alpine
             target: x86_64-unknown-linux-musl
+            profile: ci
+            packages: "-p vouch-cli -p vouch-agent -p vouch-server"
+            install: apk add --no-cache musl-dev pkgconfig cmake make go clang linux-headers openssl-dev openssl-libs-static perl eudev-dev
           - name: linux-arm64
             runner: ubuntu-24.04-arm
+            container: rust:1.97.1-alpine
             target: aarch64-unknown-linux-musl
+            profile: ci
+            packages: "-p vouch-cli -p vouch-agent -p vouch-server"
+            install: apk add --no-cache musl-dev pkgconfig cmake make go clang linux-headers openssl-dev openssl-libs-static perl eudev-dev
           - name: macos-arm64
             runner: macos-latest
             target: aarch64-apple-darwin
+            profile: release
             packages: "-p vouch-cli -p vouch-agent"
             install: brew install go
           - name: windows-amd64
             runner: windows-latest
             target: x86_64-pc-windows-msvc
+            profile: release
             packages: "-p vouch-cli"
             install: ""
             rustflags: "-C target-feature=+crt-static"
           - name: windows-arm64
             runner: windows-latest
             target: aarch64-pc-windows-msvc
+            profile: release
             packages: "-p vouch-cli"
             install: ""
             rustflags: "-C target-feature=+crt-static"
@@ -152,13 +164,21 @@ jobs:
       - name: Install system dependencies
         if: matrix.install != ''
         run: ${{ matrix.install }} # zizmor: ignore[template-injection] — static matrix value
+      - name: Set musl build environment
+        if: runner.os == 'Linux'
+        run: |
+          {
+            echo "AWS_LC_FIPS_SYS_CC=clang"
+            echo "AWS_LC_FIPS_SYS_CXX=clang++"
+            echo "OPENSSL_STATIC=1"
+            echo "OPENSSL_LIB_DIR=/usr/lib"
+            echo "OPENSSL_INCLUDE_DIR=/usr/include"
+          } >> "$GITHUB_ENV"
       - name: Setup Rust toolchain
-        if: runner.os != 'Linux'
         run: |
           rustup show
           rustup target add ${{ matrix.target }}
       - name: Setup Rust cache
-        if: runner.os != 'Linux'
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           prefix-key: "v2"
@@ -168,37 +188,8 @@ jobs:
         if: matrix.rustflags
         shell: bash
         run: echo "RUSTFLAGS=${{ matrix.rustflags }}" >> "$GITHUB_ENV"
-      - name: Set up Docker Buildx
-        if: runner.os == 'Linux'
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-      - name: Log in to GHCR
-        if: runner.os == 'Linux'
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build (Linux)
-        if: runner.os == 'Linux'
-        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
-        with:
-          # `deps` builds nothing extra (its layers are a prefix of `ci`);
-          # it exists so only the reusable dependency layers are exported
-          # to the registry cache, never the per-commit compile layers.
-          targets: |
-            ci
-            deps
-        env:
-          TARGET: ${{ matrix.target }}
-          # Dependency layer cache lives on GHCR, outside the 10 GB GitHub
-          # Actions cache budget. Written only from main so unmerged
-          # dependency trees never enter the shared cache; all refs read it.
-          CACHE_IMAGE: ghcr.io/${{ github.repository }}/buildcache
-          WRITE_CACHE: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
       - name: Build # zizmor: ignore[template-injection] — static matrix values
-        if: runner.os != 'Linux'
-        run: cargo build --release --locked --target ${{ matrix.target }} ${{ matrix.packages }}
+        run: cargo build --profile ${{ matrix.profile }} --locked --target ${{ matrix.target }} ${{ matrix.packages }}
       - name: Upload Windows binary
         if: runner.os == 'Windows'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/package-cleanup.yml
+++ b/.github/workflows/package-cleanup.yml
@@ -1,10 +1,10 @@
 name: Package Cleanup
 
-# Both BuildKit registry caches overwrite a tag on every write, orphaning the
+# The Kamal deploy cache overwrites a tag on every write, orphaning the
 # previous cache manifest as an untagged version that cache-from can never
 # pull again. Untagged versions are pure storage cost; delete them weekly.
 #
-# Only the two cache packages are cleaned. The vouch server image and the
+# Only the cache package is cleaned. The vouch server image and the
 # Helm chart are multi-platform indexes whose child manifests appear as
 # untagged versions — deleting those would corrupt the tagged index.
 
@@ -22,17 +22,10 @@ jobs:
     permissions:
       packages: write
     steps:
-      - name: Clean vouch/buildcache (CI deps cache)
-        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
-        with:
-          package-name: vouch/buildcache
-          package-type: container
-          delete-only-untagged-versions: "true"
       # Kamal's deploy cache is not published from this repo's workflows, so
       # GITHUB_TOKEN can only delete from it after the package grants this
       # repo the Admin role: package settings -> Manage Actions access.
       - name: Clean vouch-build-cache (Kamal deploy cache)
-        if: ${{ !cancelled() }}
         uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
         with:
           package-name: vouch-build-cache

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -3,10 +3,6 @@
 # Multi-stage Dockerfile for producing static musl binaries.
 # Used by docker-bake.hcl targets (ci, cli, server, reproduce).
 # The existing Dockerfile (server Docker image) is NOT replaced by this file.
-#
-# Uses cargo-chef to cache dependency compilation. Only workspace crates
-# are recompiled when source changes — dependencies are cached as long as
-# Cargo.toml/Cargo.lock stay the same.
 
 FROM rust:1.97.1-alpine AS base
 RUN apk add --no-cache musl-dev pkgconfig cmake make go clang linux-headers \
@@ -17,44 +13,19 @@ ENV OPENSSL_STATIC=1
 ENV OPENSSL_LIB_DIR=/usr/lib
 ENV OPENSSL_INCLUDE_DIR=/usr/include
 
-# Install cargo-chef (cached with base OS layer)
-RUN cargo install cargo-chef --locked
+# --- Builder ---
+FROM base AS builder
 
-# --- Planner: compute dependency recipe ---
-FROM base AS planner
-WORKDIR /app
-COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
-
-# --- Deps: cook dependencies from the recipe ---
-# Terminal stage for the bake `deps` cache target: everything through the
-# cook layer is reusable across source changes, so only this stage is
-# exported to the layer cache. The later builder layers change on every
-# commit and are never exported.
-FROM base AS deps
-
-ARG TARGET
-ARG CARGO_PROFILE=release
-
-WORKDIR /app
-RUN rustup target add "${TARGET}"
-
-# Cook dependencies from recipe (cached when only source files change)
-COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --profile "${CARGO_PROFILE}" --locked --target "${TARGET}" --recipe-path recipe.json
-
-# --- Builder: build workspace crates on top of cooked deps ---
-FROM deps AS builder
-
-# Copy source and build workspace crates (only these recompile)
-COPY . .
-
-# Declare build-time ARGs after the cook layer so changes don't bust the cache
 ARG TARGET
 ARG CARGO_PROFILE=release
 ARG SOURCE_DATE_EPOCH=0
 ARG GENERATE_SBOM=false
 ARG CARGO_PACKAGES="-p vouch-cli -p vouch-agent -p vouch-server"
+
+WORKDIR /app
+RUN rustup target add "${TARGET}"
+
+COPY . .
 
 # Touch entry-point files for reproducible builds
 RUN touch -d "@${SOURCE_DATE_EPOCH}" \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -10,25 +10,6 @@ variable "GENERATE_SBOM" {
   default = "false"
 }
 
-variable "CACHE_IMAGE" {
-  // Registry ref for the shared dependency layer cache, e.g.
-  // ghcr.io/vouch-sh/vouch/buildcache. Registry storage keeps the multi-GB
-  // Rust layer cache out of the repo's 10 GB GitHub Actions cache budget.
-  // Empty (local builds) disables the remote cache; the local BuildKit
-  // layer cache still applies.
-  default = ""
-}
-
-variable "WRITE_CACHE" {
-  // "true" only on main-branch CI runs. The deps cache is shared by every
-  // ref, so only post-merge builds may publish it: PR and merge-queue runs
-  // read the cache but never write, keeping unmerged dependency trees out
-  // of the shared cache. For the remaining GHA-backed scopes (cli/server),
-  // ref-scoped writes would also burn the 10 GB Actions cache budget
-  // without ever producing a cache hit.
-  default = "false"
-}
-
 group "default" {
   targets = ["ci"]
 }
@@ -39,41 +20,17 @@ target "_common" {
   output     = ["type=local,dest=."]
 }
 
-// Dependency layers only (through `cargo chef cook`). Built alongside `ci`
-// in CI so the reusable layers can be published to the registry cache
-// without also exporting the per-commit source and workspace-compile
-// layers, which change on every push and can never produce a cache hit.
-target "deps" {
-  inherits = ["_common"]
-  target   = "deps"
-  output   = ["type=cacheonly"]
-  args = {
-    TARGET        = TARGET
-    CARGO_PROFILE = "ci"
-  }
-  cache-from = CACHE_IMAGE != "" ? ["type=registry,ref=${CACHE_IMAGE}:deps-ci-${TARGET}"] : []
-  // zstd shrinks the multi-hundred-MB cook layers and decompresses faster
-  // than gzip on import; force-compression re-encodes blobs that already
-  // exist as gzip, so the published cache converges to zstd instead of
-  // reusing the old blobs forever. Smaller pulls also reduce exposure to
-  // GHCR secondary rate limits, which have failed PR builds mid-pull.
-  cache-to   = CACHE_IMAGE != "" && WRITE_CACHE == "true" ? ["type=registry,ref=${CACHE_IMAGE}:deps-ci-${TARGET},mode=max,image-manifest=true,oci-mediatypes=true,compression=zstd,force-compression=true,ignore-error=true"] : []
-}
-
 target "ci" {
   inherits = ["_common"]
   // No SOURCE_DATE_EPOCH here: it is a predefined BuildKit arg that stamps
-  // the epoch into WORKDIR/COPY op digests, forking this target's cache
-  // chain away from `deps` — the only chain published to CACHE_IMAGE. The
-  // Dockerfile's ARG default (0) still governs the builder-stage touch.
+  // the epoch into WORKDIR/COPY op digests, forking the layer-cache chain.
+  // The Dockerfile's ARG default (0) still governs the builder-stage touch.
   args = {
     TARGET         = TARGET
     CARGO_PROFILE  = "ci"
     CARGO_PACKAGES = "-p vouch-cli -p vouch-agent -p vouch-server"
     GENERATE_SBOM  = "false"
   }
-  cache-from = CACHE_IMAGE != "" ? ["type=registry,ref=${CACHE_IMAGE}:deps-ci-${TARGET}"] : []
-  cache-to   = []
 }
 
 target "cli" {
@@ -84,8 +41,6 @@ target "cli" {
     SOURCE_DATE_EPOCH = SOURCE_DATE_EPOCH
     GENERATE_SBOM     = GENERATE_SBOM
   }
-  cache-from = ["type=gha,scope=bake-cli-${TARGET}"]
-  cache-to   = WRITE_CACHE == "true" ? ["type=gha,mode=max,ignore-error=true,scope=bake-cli-${TARGET}"] : []
 }
 
 target "server" {
@@ -96,8 +51,6 @@ target "server" {
     SOURCE_DATE_EPOCH = SOURCE_DATE_EPOCH
     GENERATE_SBOM     = GENERATE_SBOM
   }
-  cache-from = ["type=gha,scope=bake-server-${TARGET}"]
-  cache-to   = WRITE_CACHE == "true" ? ["type=gha,mode=max,ignore-error=true,scope=bake-server-${TARGET}"] : []
 }
 
 target "reproduce" {
@@ -108,7 +61,4 @@ target "reproduce" {
     SOURCE_DATE_EPOCH = SOURCE_DATE_EPOCH
     GENERATE_SBOM     = "false"
   }
-  // Read from the cli cache but never write, to avoid polluting it.
-  cache-from = ["type=gha,scope=bake-cli-${TARGET}"]
-  cache-to   = []
 }


### PR DESCRIPTION
## Summary

PR CI reused the release Docker machinery (bake + cargo-chef + `Dockerfile.build`) as a build smoke test, and the stack bolted on to make that fast kept failing: bake target pairs whose cache chains forked (#873), GHCR blob pulls tripping secondary rate limits mid-build (failed one PR #874 build outright, silently un-cached another), and a weekly cron (#871) to sweep orphaned cache manifests.

## Change

**`.github/workflows/ci.yml`** — Linux musl builds are now ordinary matrix rows like every other platform: `rust:1.97.1-alpine` as the job container (same image `Dockerfile.build` uses), plain `cargo build --profile ci` (keeps thin LTO), and rust-cache restored on PRs / saved from main. Buildx, GHCR login, the bake step, and `packages: write` are removed. Check names are unchanged, so required checks and the merge-group shim are untouched.

**`docker-bake.hcl`** — the `deps` cache-export target, the `CACHE_IMAGE`/`WRITE_CACHE` variables, and all `cache-from`/`cache-to` config are deleted. The gha scopes on `cli`/`server`/`reproduce` were only written when `WRITE_CACHE=true`, which no workflow ever set — they were dead config and every release build already ran uncached.

**`Dockerfile.build`** — cargo-chef (planner + deps stages) is removed; the file is now base → builder → output. Chef existed to make dependency compilation a cacheable layer, and nowhere that runs this file has a layer cache anymore. It cost every release job a from-source `cargo install cargo-chef` plus recipe bookkeeping for zero reuse; the builder stage's build steps (touch, cargo build, SBOM, collect) are unchanged, so release artifacts and reproducibility verification are unaffected.

**`.github/workflows/package-cleanup.yml`** — the `vouch/buildcache` cleanup step is removed; the Kamal deploy-cache step remains.

## Notes

- The first Linux builds after merge compile everything once (rust-cache is empty until a main push saves it); PRs restore from main's cache after that.
- The orphaned `vouch/buildcache` GHCR package can be deleted manually in package settings.

## Verification

- `actionlint` and `zizmor` clean on both workflows; `docker buildx build --check -f Dockerfile.build` passes; `docker buildx bake --print` resolves all remaining targets.
- Repo-wide sweep confirms no references remain to `CACHE_IMAGE`, `WRITE_CACHE`, `buildcache`, or the `deps` bake target; release.yml uses only the kept `cli`/`server`/`reproduce` targets.
- This PR's own `Build (linux-amd64/arm64)` checks exercise the new container builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Linux CI no longer exercises bake/GHCR caching, so musl breakage or slower cold builds may show up only after merge until rust-cache warms; release bake paths are simplified but builder steps for artifacts are unchanged.
> 
> **Overview**
> **Replaces** the Linux PR build path that went through Docker Buildx, bake, GHCR `buildcache`, and cargo-chef with matrix rows that run `cargo build --profile ci` inside `rust:1.97.1-alpine` via `docker run`, while checkout and **Swatinem/rust-cache** stay on the host. Buildx, GHCR login, and `packages: write` are removed; non-Linux matrix rows switch from hard-coded `--release` to per-row `profile` (`ci` vs `release`).
> 
> **Strips** the registry/GHA caching layer from **`docker-bake.hcl`** (`deps` target, `CACHE_IMAGE` / `WRITE_CACHE`, all `cache-from` / `cache-to`) and **simplifies `Dockerfile.build`** to base → builder (no planner/cook stages), since nothing consuming that file still publishes reusable dependency layers.
> 
> **Package cleanup** no longer sweeps the orphaned `vouch/buildcache` GHCR package; Kamal deploy-cache cleanup is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c143b97ecf4dbff0948cd0d8ebd5016cb1e3770f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->