### PR TITLE
refactor(server): centralize auth wire helpers; SCIM OCC exhaustion is 503

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6740,7 +6740,6 @@ dependencies = [
  "ed25519-dalek 3.0.0",
  "flate2",
  "governor",
- "headers",
  "hex",
  "hickory-resolver",
  "http 1.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,6 @@ flate2 = { version = "=1.1.9", default-features = false }
 gethostname = { version = "=1.1.0", default-features = false }
 governor = { version = "=0.10.4", default-features = false }
 ipnet = { version = "=2.12.1", default-features = false }
-headers = { version = "=0.4.1", default-features = false }
 hex = { version = "=0.4.3", default-features = false }
 hickory-resolver = { version = "=0.26.1", default-features = false }
 http = { version = "=1.5.0", default-features = false }

--- a/crates/vouch-server/Cargo.toml
+++ b/crates/vouch-server/Cargo.toml
@@ -44,7 +44,6 @@ dotenvy = { workspace = true }
 ed25519-dalek = { workspace = true }
 flate2 = { workspace = true, features = ["rust_backend"] }
 governor = { workspace = true, features = ["std"] }
-headers = { workspace = true }
 hex = { workspace = true, features = ["std"] }
 hickory-resolver = { workspace = true, features = ["dnssec-aws-lc-rs", "https-aws-lc-rs", "system-config", "tokio", "webpki-roots"] }
 http = { workspace = true }

--- a/crates/vouch-server/src/error.rs
+++ b/crates/vouch-server/src/error.rs
@@ -370,17 +370,21 @@ impl ServiceError {
 
     /// Build a `WWW-Authenticate` header value for RFC 9470 step-up challenges.
     fn build_www_authenticate(acr_values: &Option<String>, max_age: &Option<u64>) -> String {
-        let mut parts = vec![
-            "Bearer error=\"insufficient_user_authentication\"".to_string(),
-            "error_description=\"A recent authentication is required\"".to_string(),
+        let mut params = vec![
+            ("error", "insufficient_user_authentication".to_string()),
+            (
+                "error_description",
+                "A recent authentication is required".to_string(),
+            ),
         ];
         if let Some(acr) = acr_values {
-            parts.push(format!("acr_values=\"{acr}\""));
+            params.push(("acr_values", acr.clone()));
         }
         if let Some(age) = max_age {
-            parts.push(format!("max_age=\"{age}\""));
+            params.push(("max_age", age.to_string()));
         }
-        parts.join(", ")
+        let params: Vec<(&str, &str)> = params.iter().map(|(n, v)| (*n, v.as_str())).collect();
+        crate::http::bearer_challenge(&params)
     }
 
     /// Convert to a standard API error response.

--- a/crates/vouch-server/src/handlers/admin/audit_api.rs
+++ b/crates/vouch-server/src/handlers/admin/audit_api.rs
@@ -152,13 +152,7 @@ async fn authenticate(
         ));
     };
 
-    // RFC 9110 Section 11.1: the auth-scheme token is case-insensitive, so
-    // `BEARER`, `bearer`, and `BeArEr` must all match like `Bearer`. Split
-    // on the first space and compare the scheme with `eq_ignore_ascii_case`
-    // rather than hard-coding a small set of casings via `strip_prefix`.
-    if let Some((scheme, token)) = auth_header.split_once(' ')
-        && scheme.eq_ignore_ascii_case("bearer")
-    {
+    if let Some(token) = crate::http::strip_auth_scheme(auth_header, "Bearer") {
         let token_hash = hex::encode(digest::digest(&SHA256, token.as_bytes()));
         let token_record = db::get_scim_token_by_hash(&state.store, &token_hash)
             .await
@@ -207,11 +201,8 @@ async fn authenticate(
     // doesn't match a known bearer scheme is a hard 401 here rather than
     // being allowed to fall through to that cookie fallback.
     //
-    // RFC 9110 Section 11.1: scheme matching is case-insensitive, so
-    // `bearer`, `BEARER`, `dpop`, and `DPOP` are all valid here.
-    let scheme_valid = auth_header.split_once(' ').is_some_and(|(scheme, _)| {
-        scheme.eq_ignore_ascii_case("dpop") || scheme.eq_ignore_ascii_case("bearer")
-    });
+    let scheme_valid = crate::http::strip_auth_scheme(auth_header, "DPoP").is_some()
+        || crate::http::strip_auth_scheme(auth_header, "Bearer").is_some();
     if !scheme_valid {
         return Err(ServiceError::api(
             StatusCode::UNAUTHORIZED,

--- a/crates/vouch-server/src/handlers/auth.rs
+++ b/crates/vouch-server/src/handlers/auth.rs
@@ -38,10 +38,12 @@ pub(crate) async fn status(
     // with `eq_ignore_ascii_case` rather than hard-coding casings via
     // `starts_with`. An unrecognized scheme (or no header at all) yields
     // `authenticated: false` — this endpoint never 401s.
-    let token = match auth_header.and_then(|h| h.split_once(' ')) {
-        Some((scheme, tok)) if scheme.eq_ignore_ascii_case("bearer") => tok,
-        Some((scheme, tok)) if scheme.eq_ignore_ascii_case("dpop") => tok,
-        _ => {
+    let token = match auth_header.and_then(|h| {
+        crate::http::strip_auth_scheme(h, "Bearer")
+            .or_else(|| crate::http::strip_auth_scheme(h, "DPoP"))
+    }) {
+        Some(tok) => tok,
+        None => {
             return Ok(Json(SessionStatus {
                 authenticated: false,
                 email: None,

--- a/crates/vouch-server/src/handlers/oidc/register.rs
+++ b/crates/vouch-server/src/handlers/oidc/register.rs
@@ -99,7 +99,7 @@ pub(crate) async fn read_client(
     Path(client_id): Path<String>,
     headers: HeaderMap,
 ) -> Response {
-    let token = match extract_bearer_token(&headers) {
+    let token = match crate::http::bearer_token(&headers) {
         Some(t) => t,
         None => return missing_token_response(),
     };
@@ -131,7 +131,7 @@ pub(crate) async fn update_client(
     headers: HeaderMap,
     Json(request): Json<RegistrationRequest>,
 ) -> Response {
-    let token = match extract_bearer_token(&headers) {
+    let token = match crate::http::bearer_token(&headers) {
         Some(t) => t,
         None => return missing_token_response(),
     };
@@ -161,7 +161,7 @@ pub(crate) async fn delete_client(
     Path(client_id): Path<String>,
     headers: HeaderMap,
 ) -> Response {
-    let token = match extract_bearer_token(&headers) {
+    let token = match crate::http::bearer_token(&headers) {
         Some(t) => t,
         None => return missing_token_response(),
     };
@@ -170,34 +170,6 @@ pub(crate) async fn delete_client(
         Ok(()) => StatusCode::NO_CONTENT.into_response(),
         Err(e) => into_registration_response(e),
     }
-}
-
-/// Extract a Bearer token from the Authorization header.
-fn extract_bearer_token(headers: &HeaderMap) -> Option<&str> {
-    let value = headers
-        .get(axum::http::header::AUTHORIZATION)?
-        .to_str()
-        .ok()?;
-    // RFC 9110 Section 11.1: the auth-scheme token is case-insensitive, so
-    // `BEARER`, `bearer`, and `BeArEr` must all match like `Bearer`.
-    let (scheme, token) = value.split_once(' ')?;
-    scheme.eq_ignore_ascii_case("bearer").then_some(token)
-}
-
-/// Build the RFC 6750 Section 3.1 `WWW-Authenticate` challenge returned when a
-/// bearer token is missing from (or invalid for) an RFC 7592 registration
-/// endpoint. The `error` and `error_description` parameters mirror the JSON
-/// body so OAuth client libraries can rely on either source.
-fn bearer_challenge(error: &str, description: &str) -> String {
-    // RFC 6750 Section 3 limits challenge parameter values to
-    // %x20-21 / %x23-5B / %x5D-7E — no double quote, no backslash. Strip
-    // anything outside that set so a future description cannot produce a
-    // malformed (or quote-escaping) challenge.
-    let description: String = description
-        .chars()
-        .filter(|c| (' '..='!').contains(c) || ('#'..='[').contains(c) || (']'..='~').contains(c))
-        .collect();
-    format!("Bearer error=\"{error}\", error_description=\"{description}\"")
 }
 
 /// Build a 401 response for a missing bearer token on an RFC 7592 endpoint.
@@ -212,7 +184,10 @@ fn bearer_challenge(error: &str, description: &str) -> String {
 fn missing_token_response() -> Response {
     (
         StatusCode::UNAUTHORIZED,
-        [(axum::http::header::WWW_AUTHENTICATE, "Bearer")],
+        [(
+            axum::http::header::WWW_AUTHENTICATE,
+            crate::http::bearer_challenge(&[]),
+        )],
     )
         .into_response()
 }
@@ -230,7 +205,12 @@ fn into_registration_response(err: crate::error::ServiceError) -> Response {
             .error_description
             .clone()
             .unwrap_or_else(|| "Invalid or expired token".to_string());
-        let www_auth = bearer_challenge(json.error.as_str(), description.as_str());
+        // The `error` and `error_description` parameters mirror the JSON body
+        // so OAuth client libraries can rely on either source (RFC 6750 §3.1).
+        let www_auth = crate::http::bearer_challenge(&[
+            ("error", json.error.as_str()),
+            ("error_description", description.as_str()),
+        ]);
         (
             status,
             [(
@@ -248,7 +228,6 @@ fn into_registration_response(err: crate::error::ServiceError) -> Response {
 
 #[cfg(test)]
 #[expect(
-    clippy::expect_used,
     clippy::unwrap_used,
     clippy::indexing_slicing,
     reason = "test code: panic on assertion failure is acceptable"
@@ -256,40 +235,6 @@ fn into_registration_response(err: crate::error::ServiceError) -> Response {
 mod tests {
     use super::*;
     use crate::error::OAuthErrorCode;
-
-    fn headers_with_auth(value: &str) -> HeaderMap {
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            axum::http::header::AUTHORIZATION,
-            value.parse().expect("valid header value"),
-        );
-        headers
-    }
-
-    /// RFC 9110 Section 11.1: the auth-scheme token is case-insensitive, so
-    /// `BEARER`, `bearer`, and `BeArEr` must all match like `Bearer` when
-    /// extracting the RFC 7592 registration access token.
-    #[test]
-    fn extract_bearer_token_accepts_scheme_case_variants() {
-        for scheme in ["Bearer", "BEARER", "bearer", "BeArEr"] {
-            let headers = headers_with_auth(&format!("{scheme} reg-token"));
-            assert_eq!(
-                extract_bearer_token(&headers),
-                Some("reg-token"),
-                "{scheme} scheme must be accepted (RFC 9110 case-insensitivity)"
-            );
-        }
-    }
-
-    #[test]
-    fn extract_bearer_token_rejects_unrecognized_scheme_or_missing_header() {
-        assert_eq!(
-            extract_bearer_token(&headers_with_auth("Basic dXNlcjpwYXNz")),
-            None
-        );
-        assert_eq!(extract_bearer_token(&headers_with_auth("Bearer")), None);
-        assert_eq!(extract_bearer_token(&HeaderMap::new()), None);
-    }
 
     /// RFC 6750 §3.1: when the request lacks any authentication
     /// information, the `WWW-Authenticate` challenge SHOULD NOT include

--- a/crates/vouch-server/src/handlers/oidc/userinfo.rs
+++ b/crates/vouch-server/src/handlers/oidc/userinfo.rs
@@ -94,22 +94,16 @@ pub(crate) async fn userinfo(
     };
 
     let (token, is_dpop_scheme) = if let Some(ref auth_header) = auth_header_value {
-        // RFC 9110 Section 11.1: auth-scheme is case-insensitive.
-        // Compare the scheme in lowercase but extract the token from the original
-        // header since JWT tokens are case-sensitive (base64url encoding).
-        let scheme_and_token = auth_header.split_once(' ');
-        match scheme_and_token {
-            Some((scheme, tok)) if scheme.eq_ignore_ascii_case("dpop") => (tok.to_string(), true),
-            Some((scheme, tok)) if scheme.eq_ignore_ascii_case("bearer") => {
-                (tok.to_string(), false)
-            }
-            _ => {
-                return oauth_error(
-                    StatusCode::UNAUTHORIZED,
-                    "invalid_token",
-                    "Unsupported authorization scheme. Use Bearer or DPoP",
-                );
-            }
+        if let Some(tok) = crate::http::strip_auth_scheme(auth_header, "DPoP") {
+            (tok.to_string(), true)
+        } else if let Some(tok) = crate::http::strip_auth_scheme(auth_header, "Bearer") {
+            (tok.to_string(), false)
+        } else {
+            return oauth_error(
+                StatusCode::UNAUTHORIZED,
+                "invalid_token",
+                "Unsupported authorization scheme. Use Bearer or DPoP",
+            );
         }
     } else if let Some(ref ft) = form_token {
         // RFC 6750 Section 2.2: POST body access_token (Bearer only, no DPoP)
@@ -120,7 +114,7 @@ pub(crate) async fn userinfo(
         // an error code or other error information.
         return (
             StatusCode::UNAUTHORIZED,
-            [(header::WWW_AUTHENTICATE, "Bearer")],
+            [(header::WWW_AUTHENTICATE, crate::http::bearer_challenge(&[]))],
         )
             .into_response();
     };
@@ -460,7 +454,8 @@ fn oauth_error(status: StatusCode, error: &str, description: &str) -> Response {
 
     if status == StatusCode::UNAUTHORIZED {
         // RFC 6750 Section 3: Include WWW-Authenticate header on 401 responses
-        let www_auth = format!("Bearer error=\"{error}\", error_description=\"{description}\"");
+        let www_auth =
+            crate::http::bearer_challenge(&[("error", error), ("error_description", description)]);
         (status, [("WWW-Authenticate", www_auth.as_str())], body).into_response()
     } else {
         (status, body).into_response()

--- a/crates/vouch-server/src/handlers/scim/mod.rs
+++ b/crates/vouch-server/src/handlers/scim/mod.rs
@@ -140,20 +140,12 @@ pub(crate) async fn authenticate_scim(
             )
         })?;
 
-    // RFC 9110 Section 11.1: the auth-scheme token is case-insensitive, so
-    // `BEARER`, `bearer`, and `BeArEr` must all match like `Bearer`. Split
-    // on the first space and compare the scheme with `eq_ignore_ascii_case`
-    // rather than hard-coding a small set of casings via `strip_prefix`.
-    let token = auth_header
-        .split_once(' ')
-        .filter(|(scheme, _)| scheme.eq_ignore_ascii_case("bearer"))
-        .map(|(_, token)| token)
-        .ok_or_else(|| {
-            (
-                StatusCode::UNAUTHORIZED,
-                Json(ScimError::new(401, "Invalid Authorization header format")),
-            )
-        })?;
+    let token = crate::http::strip_auth_scheme(auth_header, "Bearer").ok_or_else(|| {
+        (
+            StatusCode::UNAUTHORIZED,
+            Json(ScimError::new(401, "Invalid Authorization header format")),
+        )
+    })?;
     let token_hash = hex::encode(digest::digest(&SHA256, token.as_bytes()));
 
     // Verify token exists and is valid

--- a/crates/vouch-server/src/handlers/scim/tests.rs
+++ b/crates/vouch-server/src/handlers/scim/tests.rs
@@ -2204,3 +2204,71 @@ async fn test_user_last_modified_uses_db_updated_at_not_created_at() {
         "meta.lastModified must not fall back to created_at after a modification"
     );
 }
+
+// ============================================================================
+// create_scim_user_error_response — every arm has a test that triggers it
+// ============================================================================
+
+/// Read a response body as JSON (2 MB cap is far above any SCIM error body).
+async fn error_body(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), 2 * 1024 * 1024)
+        .await
+        .expect("read body");
+    serde_json::from_slice(&bytes).expect("parse body")
+}
+
+#[tokio::test]
+async fn create_error_domain_not_owned_maps_to_400_invalid_value() {
+    let resp = super::users::create_scim_user_error_response(
+        "org-1",
+        "a@b.example",
+        crate::db::CreateScimUserError::DomainNotOwned,
+    );
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = error_body(resp).await;
+    assert_eq!(body["scimType"], "invalidValue");
+}
+
+#[tokio::test]
+async fn create_error_duplicate_email_maps_to_409_uniqueness() {
+    let resp = super::users::create_scim_user_error_response(
+        "org-1",
+        "a@b.example",
+        crate::db::CreateScimUserError::DuplicateEmail,
+    );
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    let body = error_body(resp).await;
+    assert_eq!(body["scimType"], "uniqueness");
+}
+
+/// OCC retry exhaustion is transient backpressure (concurrent provisioning
+/// or domain churn colliding on the org doc), not a server fault: the
+/// client must see 503 + Retry-After so IdP provisioners retry, not 500.
+#[tokio::test]
+async fn create_error_occ_conflict_maps_to_503_with_retry_after() {
+    let resp = super::users::create_scim_user_error_response(
+        "org-1",
+        "a@b.example",
+        crate::db::CreateScimUserError::OccConflict,
+    );
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(
+        resp.headers()
+            .get(axum::http::header::RETRY_AFTER)
+            .and_then(|v| v.to_str().ok()),
+        Some("1"),
+        "503 must carry Retry-After so provisioners back off and retry"
+    );
+    let body = error_body(resp).await;
+    assert_eq!(body["status"], "503");
+}
+
+#[tokio::test]
+async fn create_error_other_maps_to_500() {
+    let resp = super::users::create_scim_user_error_response(
+        "org-1",
+        "a@b.example",
+        crate::db::CreateScimUserError::Other(anyhow::anyhow!("db down")),
+    );
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}

--- a/crates/vouch-server/src/handlers/scim/users.rs
+++ b/crates/vouch-server/src/handlers/scim/users.rs
@@ -117,6 +117,74 @@ pub(crate) async fn list_users(
     .into_response()
 }
 
+/// Map a [`db::CreateScimUserError`] onto its SCIM wire response.
+///
+/// Split from the create handler so every error arm — including the 503
+/// backpressure mapping — has a test that triggers it directly.
+pub(super) fn create_scim_user_error_response(
+    org_id: &str,
+    email: &str,
+    err: db::CreateScimUserError,
+) -> Response {
+    match err {
+        db::CreateScimUserError::DomainNotOwned => {
+            tracing::warn!(
+                org_id = %org_id,
+                email = %redact_email(email),
+                "rejected SCIM user creation: email domain is not verified for this organization"
+            );
+            (
+                StatusCode::BAD_REQUEST,
+                Json(
+                    ScimError::new(400, "Email domain is not verified for this organization")
+                        .with_type("invalidValue"),
+                ),
+            )
+                .into_response()
+        }
+        db::CreateScimUserError::DuplicateEmail => {
+            tracing::debug!(
+                org_id = %org_id,
+                email = %redact_email(email),
+                "rejected SCIM user creation: user already exists"
+            );
+            (
+                StatusCode::CONFLICT,
+                Json(ScimError::new(409, "User already exists").with_type("uniqueness")),
+            )
+                .into_response()
+        }
+        db::CreateScimUserError::OccConflict => {
+            // The org doc is the OCC serialization point for user creation
+            // (domain validation version-bumps it), so bulk provisioning or
+            // concurrent domain churn can exhaust the retry budget. That is
+            // transient backpressure, not a server fault: return 503 with
+            // Retry-After — IdP provisioners (Okta, Entra) retry on 503.
+            tracing::warn!(
+                org_id = %org_id,
+                "SCIM user creation exhausted OCC retries (concurrent provisioning or domain churn)"
+            );
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                [(axum::http::header::RETRY_AFTER, "1")],
+                Json(ScimError::new(
+                    503,
+                    "Concurrent modification, retry the request",
+                )),
+            )
+                .into_response()
+        }
+        db::CreateScimUserError::Other(e) => {
+            tracing::error!("Failed to create user: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ScimError::new(500, "Failed to create user")),
+            )
+                .into_response()
+        }
+    }
+}
+
 /// POST /scim/v2/Users (RFC 7644 Section 3.3).
 ///
 /// Creates a new User resource. Returns 201 Created on success,
@@ -193,41 +261,7 @@ pub(crate) async fn create_user(
     .await
     {
         Ok(u) => u,
-        Err(db::CreateScimUserError::DomainNotOwned) => {
-            tracing::warn!(
-                org_id = %auth.org_id,
-                email = %redact_email(&email),
-                "rejected SCIM user creation: email domain is not verified for this organization"
-            );
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(
-                    ScimError::new(400, "Email domain is not verified for this organization")
-                        .with_type("invalidValue"),
-                ),
-            )
-                .into_response();
-        }
-        Err(db::CreateScimUserError::DuplicateEmail) => {
-            tracing::debug!(
-                org_id = %auth.org_id,
-                email = %redact_email(&email),
-                "rejected SCIM user creation: user already exists"
-            );
-            return (
-                StatusCode::CONFLICT,
-                Json(ScimError::new(409, "User already exists").with_type("uniqueness")),
-            )
-                .into_response();
-        }
-        Err(e) => {
-            tracing::error!("Failed to create user: {e}");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ScimError::new(500, "Failed to create user")),
-            )
-                .into_response();
-        }
+        Err(e) => return create_scim_user_error_response(&auth.org_id, &email, e),
     };
 
     // Audit log

--- a/crates/vouch-server/src/handlers/session.rs
+++ b/crates/vouch-server/src/handlers/session.rs
@@ -359,18 +359,11 @@ fn extract_token_from_request(
 
     // Check Authorization header
     if let Some(auth_value) = headers.get(AUTHORIZATION).and_then(|v| v.to_str().ok()) {
-        // RFC 9110 Section 11.1: the auth-scheme token is case-insensitive,
-        // so `BEARER`, `bearer`, and `BeArEr` must all match like `Bearer`,
-        // and likewise for `DPoP`. Split on the first space and compare the
-        // scheme with `eq_ignore_ascii_case` rather than hard-coding a small
-        // set of casings via `strip_prefix`.
-        if let Some((scheme, token)) = auth_value.split_once(' ') {
-            if scheme.eq_ignore_ascii_case("dpop") {
-                return Ok((token.to_string(), AuthScheme::DPoP));
-            }
-            if scheme.eq_ignore_ascii_case("bearer") {
-                return Ok((token.to_string(), AuthScheme::Bearer));
-            }
+        if let Some(token) = crate::http::strip_auth_scheme(auth_value, "DPoP") {
+            return Ok((token.to_string(), AuthScheme::DPoP));
+        }
+        if let Some(token) = crate::http::strip_auth_scheme(auth_value, "Bearer") {
+            return Ok((token.to_string(), AuthScheme::Bearer));
         }
     }
 

--- a/crates/vouch-server/src/http.rs
+++ b/crates/vouch-server/src/http.rs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! HTTP authentication wire helpers (RFC 9110 / RFC 6750).
+//!
+//! Crate-root shared module (like `config` and `email`): importable from
+//! every layer, so handlers and infra parse and build `Authorization` /
+//! `WWW-Authenticate` values through one implementation.
+
+/// Extract the token from an `Authorization` header value when its
+/// auth-scheme matches `scheme`.
+///
+/// RFC 9110 Section 11.1: the auth-scheme token is case-insensitive, so
+/// `BEARER`, `bearer`, and `BeArEr` all match `Bearer` (likewise `DPoP`).
+/// This is the single scheme matcher — comparing schemes by hand at call
+/// sites is how non-canonical casings ended up accepted by token auth but
+/// rejected by signature key resolution.
+#[must_use]
+pub(crate) fn strip_auth_scheme<'a>(header_value: &'a str, scheme: &str) -> Option<&'a str> {
+    let (value_scheme, token) = header_value.split_once(' ')?;
+    value_scheme.eq_ignore_ascii_case(scheme).then_some(token)
+}
+
+/// Extract a Bearer token from a request's `Authorization` header.
+///
+/// Composes the header lookup with [`strip_auth_scheme`] for the common
+/// bearer-only case. Callers that must distinguish a missing header from a
+/// wrong scheme (for distinct error messages), or that also accept `DPoP`,
+/// use [`strip_auth_scheme`] directly.
+#[must_use]
+pub(crate) fn bearer_token(headers: &axum::http::HeaderMap) -> Option<&str> {
+    let value = headers
+        .get(axum::http::header::AUTHORIZATION)?
+        .to_str()
+        .ok()?;
+    strip_auth_scheme(value, "Bearer")
+}
+
+/// Filter a challenge parameter value to RFC 6750 Section 3's permitted set
+/// (%x20-21 / %x23-5B / %x5D-7E — no double quote, no backslash, no control
+/// characters), so no value can produce a malformed or quote-escaping
+/// challenge.
+pub(crate) fn sanitize_challenge_value(value: &str) -> String {
+    let mut sanitized = String::with_capacity(value.len());
+    for c in value.chars() {
+        if (' '..='!').contains(&c) || ('#'..='[').contains(&c) || (']'..='~').contains(&c) {
+            sanitized.push(c);
+        }
+    }
+    sanitized
+}
+
+/// Build an RFC 6750 Section 3 `WWW-Authenticate: Bearer ...` challenge.
+///
+/// Every parameter value passes through [`sanitize_challenge_value`]. This is
+/// the single constructor for bearer challenges — do not `format!` one by
+/// hand; the sanitization only guards values that go through here.
+///
+/// Empty `params` produce the bare `Bearer` challenge used when a request
+/// carries no credentials at all: RFC 6750 Section 3.1 says that response
+/// SHOULD NOT include error information, and the bare scheme is valid under
+/// RFC 9110 Section 11.6.1's challenge grammar (auth-params are optional).
+pub(crate) fn bearer_challenge(params: &[(&str, &str)]) -> String {
+    if params.is_empty() {
+        return "Bearer".to_string();
+    }
+    let mut rendered = Vec::with_capacity(params.len());
+    for (name, value) in params {
+        let value = sanitize_challenge_value(value);
+        rendered.push(format!("{name}=\"{value}\""));
+    }
+    format!("Bearer {}", rendered.join(", "))
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
+mod tests {
+    use super::{bearer_token, strip_auth_scheme};
+    use axum::http::HeaderMap;
+
+    fn headers_with_auth(value: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            value.parse().expect("valid header value"),
+        );
+        headers
+    }
+
+    #[test]
+    fn bearer_token_accepts_scheme_case_variants() {
+        for scheme in ["Bearer", "BEARER", "bearer", "BeArEr"] {
+            let headers = headers_with_auth(&format!("{scheme} reg-token"));
+            assert_eq!(
+                bearer_token(&headers),
+                Some("reg-token"),
+                "{scheme} scheme must be accepted (RFC 9110 case-insensitivity)"
+            );
+        }
+    }
+
+    #[test]
+    fn bearer_token_rejects_unrecognized_scheme_or_missing_header() {
+        assert_eq!(bearer_token(&headers_with_auth("Basic dXNlcjpwYXNz")), None);
+        assert_eq!(bearer_token(&headers_with_auth("Bearer")), None);
+        assert_eq!(bearer_token(&HeaderMap::new()), None);
+    }
+
+    #[test]
+    fn matches_scheme_case_insensitively() {
+        assert_eq!(strip_auth_scheme("Bearer tok", "Bearer"), Some("tok"));
+        assert_eq!(strip_auth_scheme("BEARER tok", "Bearer"), Some("tok"));
+        assert_eq!(strip_auth_scheme("bEaReR tok", "Bearer"), Some("tok"));
+        assert_eq!(strip_auth_scheme("DPOP tok", "DPoP"), Some("tok"));
+    }
+
+    #[test]
+    fn rejects_other_schemes() {
+        assert_eq!(strip_auth_scheme("Basic dXNlcg==", "Bearer"), None);
+        assert_eq!(strip_auth_scheme("Bearer tok", "DPoP"), None);
+    }
+
+    #[test]
+    fn rejects_missing_token_separator() {
+        assert_eq!(strip_auth_scheme("Bearer", "Bearer"), None);
+        assert_eq!(strip_auth_scheme("", "Bearer"), None);
+    }
+
+    #[test]
+    fn preserves_token_case() {
+        // The token itself is case-sensitive (base64url) and may contain
+        // further spaces; only the first space splits scheme from token.
+        assert_eq!(
+            strip_auth_scheme("Bearer AbC. dEf", "Bearer"),
+            Some("AbC. dEf")
+        );
+    }
+
+    #[test]
+    fn bearer_challenge_formats_params() {
+        assert_eq!(
+            super::bearer_challenge(&[("error", "invalid_token"), ("error_description", "bad")]),
+            "Bearer error=\"invalid_token\", error_description=\"bad\""
+        );
+    }
+
+    #[test]
+    fn bearer_challenge_empty_params_is_bare_scheme() {
+        assert_eq!(super::bearer_challenge(&[]), "Bearer");
+    }
+
+    #[test]
+    fn bearer_challenge_sanitizes_values() {
+        // A quote or backslash in a value must not escape the quoted-string.
+        let challenge = super::bearer_challenge(&[("error_description", "a\"b\\c\u{7}d")]);
+        assert_eq!(challenge, "Bearer error_description=\"abcd\"");
+    }
+
+    #[test]
+    fn sanitize_keeps_permitted_ascii() {
+        assert_eq!(
+            super::sanitize_challenge_value("Use Bearer or DPoP (RFC 9449)!"),
+            "Use Bearer or DPoP (RFC 9449)!"
+        );
+    }
+}

--- a/crates/vouch-server/src/infra/httpsig.rs
+++ b/crates/vouch-server/src/infra/httpsig.rs
@@ -158,16 +158,10 @@ impl KeyResolver for OAuthClientKeyResolver {
 fn extract_client_id(headers: &http::HeaderMap, _state: &AppState) -> Option<String> {
     let auth_header = headers.get("authorization")?.to_str().ok()?;
 
-    // RFC 9110 Section 11.1: the auth-scheme token is case-insensitive, so
-    // `BEARER`, `bearer`, and `BeArEr` must all match like `Bearer`, and
-    // likewise for `DPoP`. Must stay in sync with the schemes accepted by
-    // `handlers/session.rs::extract_token_from_request`, or a request with a
-    // non-canonical scheme casing would pass token auth but fail signature
-    // key resolution on signature-required `/v1/*` routes.
-    let (scheme, token) = auth_header.split_once(' ')?;
-    if !scheme.eq_ignore_ascii_case("dpop") && !scheme.eq_ignore_ascii_case("bearer") {
-        return None;
-    }
+    // Accepts the same schemes as `extract_token_from_request` — both go
+    // through the shared matcher, so they cannot drift.
+    let token = crate::http::strip_auth_scheme(auth_header, "DPoP")
+        .or_else(|| crate::http::strip_auth_scheme(auth_header, "Bearer"))?;
 
     // Parse JWT payload (second segment) without verification
     let parts: Vec<&str> = token.split('.').collect();

--- a/crates/vouch-server/src/infra/metrics.rs
+++ b/crates/vouch-server/src/infra/metrics.rs
@@ -42,11 +42,8 @@ pub fn install_recorder()
 
 /// Extract the bearer token from an `Authorization` header value.
 fn extract_bearer_token(headers: &HeaderMap) -> Option<&str> {
-    let value = headers.get("authorization")?.to_str().ok()?;
-    // RFC 9110 Section 11.1: the auth-scheme token is case-insensitive, so
-    // `BEARER`, `bearer`, and `BeArEr` must all match like `Bearer`.
-    let (scheme, token) = value.split_once(' ')?;
-    if !scheme.eq_ignore_ascii_case("bearer") || token.is_empty() {
+    let token = crate::http::bearer_token(headers)?;
+    if token.is_empty() {
         return None;
     }
     Some(token)

--- a/crates/vouch-server/src/infra/resource_metadata.rs
+++ b/crates/vouch-server/src/infra/resource_metadata.rs
@@ -77,12 +77,13 @@ pub async fn layer(State(state): State<Arc<AppState>>, req: Request, next: Next)
 /// ASCII), but as a defense-in-depth measure we strip `\` and `"`
 /// from the URL before interpolation.
 fn append_resource_metadata(headers: &mut axum::http::HeaderMap, url: &str) {
-    let sanitized_url = sanitize_for_quoted_string(url);
+    let sanitized_url = crate::http::sanitize_challenge_value(url);
     let parameter = format!("{RESOURCE_METADATA_PARAM}=\"{sanitized_url}\"");
 
     match headers.get(WWW_AUTHENTICATE) {
         None => {
-            if let Ok(value) = HeaderValue::from_str(&format!("Bearer {parameter}")) {
+            let challenge = crate::http::bearer_challenge(&[(RESOURCE_METADATA_PARAM, url)]);
+            if let Ok(value) = HeaderValue::from_str(&challenge) {
                 headers.insert(WWW_AUTHENTICATE, value);
             }
         }
@@ -159,20 +160,6 @@ fn has_resource_metadata_parameter(header: &str) -> bool {
         i = i.saturating_add(1);
     }
     false
-}
-
-/// Strip characters that would break an RFC 7235 `quoted-string`.
-///
-/// `quoted-string` forbids unescaped `"` and `\` and bare control
-/// characters. URLs produced by `format!("{base_url}{suffix}")`
-/// never legitimately contain any of these, so removal is a safe
-/// conservative choice that also prevents accidental header
-/// injection if `base_url` is ever misconfigured.
-fn sanitize_for_quoted_string(value: &str) -> String {
-    value
-        .chars()
-        .filter(|c| !c.is_control() && *c != '"' && *c != '\\')
-        .collect()
 }
 
 #[cfg(test)]
@@ -287,7 +274,7 @@ mod tests {
     #[test]
     fn sanitize_strips_quotes_and_backslashes() {
         let raw = "https://bad\"example.com\\/foo";
-        let cleaned = sanitize_for_quoted_string(raw);
+        let cleaned = crate::http::sanitize_challenge_value(raw);
         assert!(!cleaned.contains('"'));
         assert!(!cleaned.contains('\\'));
     }

--- a/crates/vouch-server/src/lib.rs
+++ b/crates/vouch-server/src/lib.rs
@@ -22,6 +22,7 @@ pub(crate) mod error;
 pub mod filters;
 pub(crate) mod geo;
 pub(crate) mod handlers;
+pub(crate) mod http;
 pub mod infra;
 pub mod services;
 

--- a/docs/src/admin/scim.md
+++ b/docs/src/admin/scim.md
@@ -110,6 +110,18 @@ curl -X DELETE https://auth.example.com/scim/v2/Users/usr_abc123 \
 - Bound to specific organization
 - Minimum 256 bits of entropy
 
+## Concurrent Provisioning
+
+User creation validates domain ownership inside a transaction keyed on the
+organization record, so heavy concurrent provisioning (an IdP bulk-syncing
+many users at once) or simultaneous domain changes can occasionally collide.
+When the server exhausts its internal retries it responds with
+`503 Service Unavailable` and a `Retry-After` header rather than an error:
+this is transient backpressure, not a fault. Okta and Entra retry such
+responses automatically; no operator action is needed unless 503s persist,
+which indicates sustained contention on the organization (for example, a
+domain-management script running during a bulk sync).
+
 ## SCIM Audit Logging
 
 All SCIM operations are logged for compliance and security monitoring:


### PR DESCRIPTION
## Summary

Third of the class-fix series (#869, #872, #874). Two more scattered wire-protocol invariants get single implementations, and one silently-chosen operator-facing behavior from #835 gets its agreed fix.

**New crate-root `http.rs`** (RFC 9110 / RFC 6750 wire helpers — a root shared module like `config.rs`/`email.rs`, importable from both handlers and infra, which the layer contract requires since `httpsig.rs` and `metrics.rs` consume these too):

- `strip_auth_scheme` — the single case-insensitive `Authorization` scheme matcher. Replaces ten hand-rolled `eq_ignore_ascii_case` checks across eight files (the class #836 patched at seven sites), including the `infra/httpsig.rs` "must stay in sync with handlers/session.rs" comment — they now cannot drift.
- `bearer_token` — header lookup composed with the matcher. `register.rs` and `metrics.rs` drop their private `extract_bearer_token` helpers. SCIM and audit-API auth keep `strip_auth_scheme` directly because they distinguish missing-header from wrong-scheme errors; dual-scheme sites (session, auth, userinfo, httpsig) need to know which scheme matched.
- `bearer_challenge` + `sanitize_challenge_value` — the single sanitized `WWW-Authenticate` constructor. The RFC 6750 §3 charset filtering that previously guarded only the RFC 7592 registration challenge now covers userinfo's challenge, the RFC 9470 step-up builder, and the RFC 9728 `resource_metadata` middleware (whose weaker local sanitizer is deleted). Bare `Bearer` challenges route through it too, with the RFC 9110 §11.6.1 vs RFC 6750 §3 validity rationale documented on the empty-params branch.

**SCIM OCC exhaustion → 503 + Retry-After.** #835 made every SCIM user creation version-bump the org doc, so bulk provisioning or concurrent domain churn can exhaust the retry budget — previously surfacing as HTTP 500. That is transient backpressure, not a fault: the create path now returns `503` with `Retry-After: 1`, which Okta/Entra retry automatically. The mapping is extracted as `create_scim_user_error_response` with a test per arm, and `docs/src/admin/scim.md` gains a Concurrent Provisioning section.

**Dead `headers` dependency removed** (workspace + crate). It has been unused since the FAPI 2.0 migration (`925b9e4e`, February) deleted the `TypedHeader<Authorization<Bearer>>` extractors — DPoP required dual-scheme parsing the typed API cannot express. That migration is also where the hand-rolled scheme-check drift began; `strip_auth_scheme` is its missing piece.

## Testing

- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test --all-features` (workspace incl. vouch-tests): 4,523 passed, 0 failed
- New: `http.rs` unit tests (scheme matching, token case preservation, challenge formatting/sanitization, bare-scheme case) and four `create_scim_user_error_response` arm tests, the 503 one asserting the `Retry-After` header
- Existing #836 case-variant regression tests and #857/#866 challenge tests now exercise the shared implementations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth header parsing and OAuth/SCIM 401 challenge wiring across many endpoints; behavior should be equivalent but any regression affects all Bearer/DPoP clients. SCIM 503 mapping is a deliberate contract change that improves IdP retry behavior but changes status codes for OCC exhaustion.
> 
> **Overview**
> Introduces crate-root **`http.rs`** so RFC 9110 scheme matching and RFC 6750 `WWW-Authenticate` construction live in one place. Handlers and infra (`session`, `userinfo`, `audit_api`, SCIM, OIDC register, `httpsig`, `metrics`, step-up errors, `resource_metadata`) replace duplicated `split_once` / `format!` logic with **`strip_auth_scheme`**, **`bearer_token`**, and **`bearer_challenge`** (plus shared **`sanitize_challenge_value`** for challenge parameters).
> 
> Removes the unused **`headers`** workspace dependency.
> 
> **SCIM user create:** when **`CreateScimUserError::OccConflict`** is returned after OCC retries are exhausted, the API now responds with **503** and **`Retry-After: 1`** instead of 500. Error mapping is extracted to **`create_scim_user_error_response`** with per-arm tests; admin SCIM docs add a concurrent provisioning note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90e75de9ea28e44521f38435b033bdd0de83d8df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->