### PR TITLE
test: hold test and comment mass to the production bar

### DIFF
--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -1335,18 +1335,23 @@ const TEST_ORG_DOMAIN: &str = "example.com";
 /// so every test that provisions a `*@example.com` user against `TEST_ORG_ID`
 /// must seed this org first.
 async fn seed_test_org(store: &DocumentStore) {
-    use crate::db::documents::organization::OrganizationDoc;
-    let doc = OrganizationDoc {
-        domain: TEST_ORG_DOMAIN.to_string(),
+    store
+        .insert_with_id(TEST_ORG_ID, &test_org_doc(TEST_ORG_DOMAIN))
+        .await
+        .expect("seed test org");
+}
+
+/// A minimal org document owning `domain` — no name, creator, additional
+/// domains, or subdomain. The shape every org fixture in this file needs;
+/// construct through here instead of inlining the literal.
+fn test_org_doc(domain: &str) -> crate::db::documents::organization::OrganizationDoc {
+    crate::db::documents::organization::OrganizationDoc {
+        domain: domain.to_string(),
         name: None,
         created_by_user_id: None,
         additional_domains: Vec::new(),
         subdomain: None,
-    };
-    store
-        .insert_with_id(TEST_ORG_ID, &doc)
-        .await
-        .expect("seed test org");
+    }
 }
 
 #[tokio::test]
@@ -1537,20 +1542,10 @@ async fn test_scim_filter_user_name_eq_case_insensitive_is_org_scoped() {
     // `other-org` also needs an org doc because `create_scim_user` validates
     // domain ownership in-transaction; both orgs own `example.com` in this
     // test fixture (the test exercises org scoping, not domain isolation).
-    {
-        use crate::db::documents::organization::OrganizationDoc;
-        let doc = OrganizationDoc {
-            domain: TEST_ORG_DOMAIN.to_string(),
-            name: None,
-            created_by_user_id: None,
-            additional_domains: Vec::new(),
-            subdomain: None,
-        };
-        store
-            .insert_with_id("other-org", &doc)
-            .await
-            .expect("seed other-org");
-    }
+    store
+        .insert_with_id("other-org", &test_org_doc(TEST_ORG_DOMAIN))
+        .await
+        .expect("seed other-org");
 
     create_scim_user(
         &store,
@@ -2992,16 +2987,17 @@ async fn test_create_scim_user_no_org_does_not_touch_org_doc() {
 }
 
 /// Concurrent `create_scim_user` and `remove_additional_domain` must not
-/// produce a user on the removed domain. This test deterministically hits
-/// the TOCTOU window using a barrier: the user-creation task reads the org
-/// doc (seeing the domain as verified), then the removal task removes the
-/// domain (committing before the user-creation's CAS), then the user-creation
-/// task's CAS fails and retries — the retry re-reads the org doc (now without
-/// the domain) and rejects with `DomainNotOwned`.
+/// produce a user on the removed domain.
 ///
-/// Before the fix (domain check outside the transaction), this test would
-/// produce a user on the removed domain because the check would pass before
-/// the removal and the insert would commit after it.
+/// This is a best-effort race, not a deterministic interleaving: the
+/// transactional create path has no injection point, so the two tasks
+/// simply run concurrently and every outcome's invariant is checked. The
+/// `Ok` arm cannot distinguish "creation legitimately committed before the
+/// removal" from the original bug (creation committing after the removal),
+/// so this test alone cannot prove the guard; the deterministic regression
+/// coverage is the sequential rejection tests above, and what this adds is
+/// that no interleaving panics, double-creates, or strands a user row on a
+/// rejected outcome.
 ///
 /// Uses `multi_thread` so the two tasks can run on separate worker threads.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -3120,15 +3116,17 @@ async fn test_create_scim_user_toctou_domain_removal_during_creation() {
         }
     }
 }
+
+/// Regression for the SCIM concurrent-create race: two concurrent
 /// `create_scim_user` calls with the same email must produce exactly one
 /// user row, not two. Before the deterministic-ID fix, each call generated
 /// a fresh random UUID v7 primary key, so neither insert conflicted with the
 /// other and both committed — producing duplicate accounts for the same email.
 ///
-/// The fix derives the user ID from the email (a version-5 name-based UUID),
-/// so the two inserts collide on the `documents` PRIMARY KEY. The losing
-/// insert fails with a unique/primary-key violation, which
-/// `is_unique_violation` maps to the same "UNIQUE constraint failed" error
+/// The fix derives the user ID from the email (an RFC 9562 version-8 UUID
+/// packing a SHA-256 digest), so the two inserts collide on the `documents`
+/// PRIMARY KEY. The losing insert fails with a unique/primary-key violation,
+/// which `is_unique_violation` maps to the same `DuplicateEmail` error
 /// returned by the explicit pre-check; the SCIM handler then returns
 /// `409 Conflict` for the loser.
 ///
@@ -3294,7 +3292,7 @@ async fn test_create_scim_user_concurrent_mixed_case_same_email_produces_one_use
 /// `create_scim_user`, deleted, then re-created with the same email must
 /// receive the same ID — confirming the derivation has no per-process
 /// randomness and that the `documents` PRIMARY KEY collision behaviour is
-/// not an arte fact of a single test run.
+/// not an artifact of a single test run.
 #[tokio::test]
 async fn test_create_scim_user_deterministic_id_is_stable_across_recreate() {
     use crate::db::documents::user::UserDoc;
@@ -3417,43 +3415,28 @@ async fn test_create_scim_user_concurrent_same_email_produces_one_user_postgres(
         panic!("VOUCH_TEST_POSTGRES_URL must point to a Postgres database");
     };
 
-    // The bundled Postgres migrations use `CREATE INDEX ASYNC`, which is
-    // DSQL-specific syntax. For vanilla PostgreSQL we create the schema
-    // inline with standard `CREATE INDEX`. This mirrors the migration files
-    // in `migrations/postgres/` with the `ASYNC` keyword removed.
-    sqlx::raw_sql(
-        r#"
-        CREATE TABLE IF NOT EXISTS documents (
-            id TEXT PRIMARY KEY,
-            doc_type TEXT NOT NULL,
-            schema_version INTEGER NOT NULL DEFAULT 1,
-            encapped_key TEXT,
-            data TEXT NOT NULL,
-            expires_at TEXT,
-            created_at TEXT NOT NULL,
-            updated_at TEXT NOT NULL,
-            version INTEGER NOT NULL DEFAULT 1,
-            last_used_at TEXT
-        );
-        CREATE TABLE IF NOT EXISTS document_indexes (
-            id TEXT PRIMARY KEY,
-            document_id TEXT NOT NULL,
-            index_field TEXT NOT NULL,
-            index_value TEXT NOT NULL,
-            UNIQUE(document_id, index_field, index_value)
-        );
-        CREATE INDEX IF NOT EXISTS idx_documents_doc_type ON documents(doc_type);
-        CREATE INDEX IF NOT EXISTS idx_documents_expires_at ON documents(expires_at);
-        CREATE INDEX IF NOT EXISTS idx_documents_doc_type_created ON documents(doc_type, created_at);
-        CREATE INDEX IF NOT EXISTS idx_document_indexes_lookup ON document_indexes(index_field, index_value);
-        CREATE INDEX IF NOT EXISTS idx_document_indexes_document_id ON document_indexes(document_id);
-        CREATE INDEX IF NOT EXISTS idx_document_indexes_covering ON document_indexes(index_field, index_value, document_id);
-        CREATE INDEX IF NOT EXISTS idx_documents_cleanup ON documents(doc_type, expires_at);
-        "#,
-    )
-    .execute(p)
-    .await
-    .expect("create Postgres schema");
+    // Apply the real Postgres migrations rather than an inline schema copy,
+    // so schema drift breaks this test instead of silently passing. Two
+    // vanilla-PostgreSQL adaptations: the files target Aurora DSQL, whose
+    // `CREATE INDEX ASYNC` syntax vanilla Postgres rejects, and a reused
+    // test database needs idempotent DDL (`IF NOT EXISTS`).
+    let migrations_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/migrations/postgres");
+    let mut migration_files: Vec<_> = std::fs::read_dir(migrations_dir)
+        .expect("read migrations/postgres")
+        .map(|entry| entry.expect("read migration entry").path())
+        .collect();
+    migration_files.sort();
+    for file in migration_files {
+        let sql = std::fs::read_to_string(&file)
+            .expect("read migration file")
+            .replace("CREATE INDEX ASYNC ", "CREATE INDEX IF NOT EXISTS ")
+            .replace("CREATE TABLE ", "CREATE TABLE IF NOT EXISTS ");
+        // Migration files are repo-owned trusted content, not user input.
+        sqlx::raw_sql(sqlx::AssertSqlSafe(sql))
+            .execute(p)
+            .await
+            .unwrap_or_else(|e| panic!("apply Postgres migration {}: {e}", file.display()));
+    }
 
     let crypto: std::sync::Arc<dyn crate::crypto::document_crypto::DocumentCrypto> =
         std::sync::Arc::new(crate::crypto::document_crypto::PlaintextDocumentCrypto);
@@ -3463,13 +3446,7 @@ async fn test_create_scim_user_concurrent_same_email_produces_one_user_postgres(
     // domain-ownership check reads. `pg-test-org` owns `example.com`.
     {
         use crate::db::documents::organization::OrganizationDoc;
-        let org_doc = OrganizationDoc {
-            domain: "example.com".to_string(),
-            name: None,
-            created_by_user_id: None,
-            additional_domains: Vec::new(),
-            subdomain: None,
-        };
+        let org_doc = test_org_doc("example.com");
         // Clean up any leftover org from a previous run before inserting.
         if let Some(existing) = store
             .get::<OrganizationDoc>("pg-test-org")
@@ -5307,14 +5284,10 @@ async fn test_enroll_promotes_admin_for_org_without_one() {
 
     // Seed an org row with no admin (e.g. previous enrollee crashed
     // mid-flow before Step 4 ran).
-    let seed_doc = OrganizationDoc {
-        domain: domain.to_string(),
-        name: None,
-        created_by_user_id: None,
-        additional_domains: Vec::new(),
-        subdomain: None,
-    };
-    store.insert(&seed_doc).await.expect("seed org row");
+    store
+        .insert(&test_org_doc(domain))
+        .await
+        .expect("seed org row");
 
     let user = enroll_user_with_org(
         &store,
@@ -7592,7 +7565,6 @@ async fn test_revoke_expired_secret_allowed_when_valid_remains() {
 /// of creating a duplicate.
 #[tokio::test]
 async fn test_enroll_finds_scim_user_with_different_email_casing() {
-    use crate::db::documents::organization::OrganizationDoc;
     use crate::db::{create_scim_user, enroll_user_with_org};
 
     let (store, _audit) = test_db().await;
@@ -7600,16 +7572,11 @@ async fn test_enroll_finds_scim_user_with_different_email_casing() {
 
     // Org is required for SCIM token binding and is the one OIDC enrollment
     // will resolve to via the (lowercased) domain.
-    let org_id = {
-        let org_doc = OrganizationDoc {
-            domain: domain.to_string(),
-            name: None,
-            created_by_user_id: None,
-            additional_domains: Vec::new(),
-            subdomain: None,
-        };
-        store.insert(&org_doc).await.expect("org insert").id
-    };
+    let org_id = store
+        .insert(&test_org_doc(domain))
+        .await
+        .expect("org insert")
+        .id;
 
     // 1. SCIM creates a user with a mixed-case email, as an IdP directory
     //    API might return it.
@@ -7757,7 +7724,7 @@ async fn test_enroll_twice_with_different_email_casing_reuses_user() {
 async fn test_get_user_by_email_is_case_insensitive() {
     let (store, _audit) = test_db().await;
 
-    // Store via the test helper with a lowercase email.
+    // The test helper canonicalizes to lowercase before storing.
     let (user_id, _) = upsert_user(&store, "Carol@example.com", Some("Carol"))
         .await
         .expect("upsert user");

--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -1242,7 +1242,6 @@ mod tests {
         device_code_hash: String,
         body: String,
         token_hash: String,
-        user_id: String,
     }
 
     async fn setup_race(setup_label: &str) -> (axum::Router, Arc<AppState>, RaceSetup) {
@@ -1299,16 +1298,16 @@ mod tests {
                 device_code_hash,
                 body,
                 token_hash,
-                user_id: user.id,
             },
         )
     }
 
-    /// The race-loser `AlreadyConsumed` path must revoke all of the user's
-    /// pre-existing OAuth sessions, matching the authorization code flow's
-    /// defensive posture.
+    /// Two concurrent consumes of the same device code: exactly one wins and
+    /// the loser sees `AlreadyConsumed` — the signal the handler maps to
+    /// session revocation (verified end-to-end by
+    /// `test_device_code_race_loser_revokes_sessions_via_handler`).
     #[tokio::test]
-    async fn test_device_code_race_loser_revokes_sessions() {
+    async fn test_device_code_concurrent_consume_single_winner() {
         use crate::db::claim::ClaimError;
 
         let (_app, state, setup) = setup_race("revoke").await;
@@ -1339,25 +1338,6 @@ mod tests {
                 );
             }
         }
-
-        // Simulate what the handler does on the AlreadyConsumed branch:
-        // revoke all OAuth sessions for the user that authorized the device
-        // code (request.user_id, captured here as setup.user_id).
-        let count = crate::db::delete_oauth_sessions_for_user(&state.store, &setup.user_id)
-            .await
-            .expect("delete sessions");
-        assert!(count > 0, "should have revoked at least one session");
-        state.session_cache.invalidate_for_user(&setup.user_id);
-
-        // The pre-existing session must now be gone.
-        let session =
-            crate::db::get_session_by_token_hash(&state.store, &setup.token_hash, Timestamp::now())
-                .await
-                .expect("session lookup");
-        assert!(
-            session.is_none(),
-            "race-loser AlreadyConsumed must revoke pre-existing sessions"
-        );
     }
 
     /// End-to-end: when two concurrent `/oauth/token` device-code polls

--- a/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
@@ -72,33 +72,6 @@ fn sign_jwt_assertion(
     format!("{header_b64}.{claims_b64}.{sig_b64}")
 }
 
-/// Build a `private_key_jwt` client assertion (RFC 7523 Section 2.2).
-///
-/// Per RFC 7523, the audience must be the token endpoint URL even when the
-/// assertion is used at the PAR endpoint.
-fn build_client_assertion(
-    client_id: &str,
-    audience: &str,
-    pkcs8_bytes: &[u8],
-    jti: Option<&str>,
-) -> String {
-    let now = jiff::Timestamp::now().as_second();
-    let header = serde_json::json!({
-        "alg": "ES256",
-        "typ": "JWT",
-        "kid": "test-key-1"
-    });
-    let mut claims = serde_json::json!({
-        "iss": client_id,
-        "sub": client_id,
-        "aud": audience,
-        "iat": now,
-        "exp": now + 60
-    });
-    claims["jti"] = serde_json::json!(jti.unwrap_or(&uuid::Uuid::now_v7().to_string()));
-    sign_jwt_assertion(pkcs8_bytes, &header, &claims)
-}
-
 /// Build a signed JAR Request Object JWT (RFC 9101).
 fn build_request_object(
     client_id: &str,

--- a/crates/vouch-server/src/handlers/oidc/tests/fido2_grant.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/fido2_grant.rs
@@ -794,39 +794,3 @@ async fn test_client_assertion_jti_committed_on_success_and_rejected_on_replay()
 // ========================================================================
 // Helpers local to this module
 // ========================================================================
-
-/// Build a `private_key_jwt` client assertion for the token endpoint.
-fn build_client_assertion(
-    client_id: &str,
-    audience: &str,
-    pkcs8_bytes: &[u8],
-    jti: Option<&str>,
-) -> String {
-    use aws_lc_rs::signature::{ECDSA_P256_SHA256_FIXED_SIGNING, EcdsaKeyPair};
-
-    let key_pair = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, pkcs8_bytes)
-        .expect("Failed to parse key");
-
-    let now = jiff::Timestamp::now().as_second();
-    let header = serde_json::json!({ "alg": "ES256", "typ": "JWT", "kid": "test-key-1" });
-    let claims = serde_json::json!({
-        "iss": client_id,
-        "sub": client_id,
-        "aud": audience,
-        "iat": now,
-        "exp": now + 60,
-        "jti": jti.map_or_else(|| uuid::Uuid::now_v7().to_string(), str::to_string)
-    });
-
-    let header_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&header).unwrap());
-    let claims_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&claims).unwrap());
-    let signing_input = format!("{header_b64}.{claims_b64}");
-
-    let rng = aws_lc_rs::rand::SystemRandom::new();
-    let sig = key_pair
-        .sign(&rng, signing_input.as_bytes())
-        .expect("Failed to sign");
-    let sig_b64 = URL_SAFE_NO_PAD.encode(sig.as_ref());
-
-    format!("{header_b64}.{claims_b64}.{sig_b64}")
-}

--- a/crates/vouch-server/src/handlers/oidc/tests/helpers.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/helpers.rs
@@ -176,33 +176,7 @@ pub(super) async fn create_test_jwt_client(
     (client, pkcs8_bytes)
 }
 
-/// Build a JWT assertion for `private_key_jwt` client auth (RFC 7523 Section 2.2).
-pub(super) fn build_client_assertion(
-    client_id: &str,
-    audience: &str,
-    pkcs8_bytes: &[u8],
-    jti: Option<&str>,
-) -> String {
-    let now = jiff::Timestamp::now().as_second();
-    let header = serde_json::json!({
-        "alg": "ES256",
-        "typ": "JWT",
-        "kid": "test-key-1"
-    });
-    let mut claims = serde_json::json!({
-        "iss": client_id,
-        "sub": client_id,
-        "aud": audience,
-        "iat": now,
-        "exp": now + 60
-    });
-    if let Some(jti_val) = jti {
-        claims["jti"] = serde_json::json!(jti_val);
-    } else {
-        claims["jti"] = serde_json::json!(uuid::Uuid::now_v7().to_string());
-    }
-    sign_jwt_assertion(pkcs8_bytes, &header, &claims)
-}
+pub(super) use crate::test_utils::build_client_assertion;
 
 /// Build a JWT assertion for `private_key_jwt` client auth, deliberately
 /// omitting the `jti` claim. RFC 7523 §3 makes `jti` OPTIONAL for non-FAPI
@@ -417,4 +391,42 @@ pub(super) async fn acquire_dpop_nonce(
         .to_str()
         .expect("DPoP-Nonce must be valid UTF-8")
         .to_string()
+}
+
+/// The response's `WWW-Authenticate` value, or `""` when absent.
+pub(super) fn www_authenticate(response: &HttpResponse) -> &str {
+    response
+        .headers
+        .get("www-authenticate")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+}
+
+/// RFC 6750 §3.1: a 401 for a request carrying an invalid, expired, or
+/// revoked token must challenge with `error="invalid_token"`.
+pub(super) fn assert_invalid_token_challenge(response: &HttpResponse) {
+    let www_auth = www_authenticate(response);
+    assert!(
+        www_auth.contains("invalid_token"),
+        "WWW-Authenticate must contain error=\"invalid_token\": {www_auth}"
+    );
+}
+
+/// RFC 6750 §3.1 + RFC 9728 §5.2: a 401 for a request with no credentials
+/// at all is a bare `Bearer` challenge — no error information — that still
+/// advertises the `resource_metadata` pointer for client discovery.
+pub(super) fn assert_bare_bearer_challenge(response: &HttpResponse) {
+    let www_auth = www_authenticate(response);
+    assert!(
+        www_auth.starts_with("Bearer"),
+        "WWW-Authenticate must be a Bearer challenge: {www_auth}"
+    );
+    assert!(
+        !www_auth.contains("error="),
+        "missing credentials must not include an error parameter: {www_auth}"
+    );
+    assert!(
+        www_auth.contains("resource_metadata="),
+        "missing credentials must still advertise resource_metadata (RFC 9728 §5.2): {www_auth}"
+    );
 }

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7523.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7523.rs
@@ -79,34 +79,6 @@ async fn create_test_jwt_client(
     (client, pkcs8_bytes)
 }
 
-/// Build a JWT assertion for private_key_jwt client auth (RFC 7523 Section 2.2).
-fn build_client_assertion(
-    client_id: &str,
-    audience: &str,
-    pkcs8_bytes: &[u8],
-    jti: Option<&str>,
-) -> String {
-    let now = jiff::Timestamp::now().as_second();
-    let header = serde_json::json!({
-        "alg": "ES256",
-        "typ": "JWT",
-        "kid": "test-key-1"
-    });
-    let mut claims = serde_json::json!({
-        "iss": client_id,
-        "sub": client_id,
-        "aud": audience,
-        "iat": now,
-        "exp": now + 60
-    });
-    if let Some(jti_val) = jti {
-        claims["jti"] = serde_json::json!(jti_val);
-    } else {
-        claims["jti"] = serde_json::json!(uuid::Uuid::now_v7().to_string());
-    }
-    sign_jwt_assertion(pkcs8_bytes, &header, &claims)
-}
-
 // ========================================================================
 // P1: RFC 7523 §2.2 — JWT Profile for Client Authentication
 //

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7591.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7591.rs
@@ -105,16 +105,7 @@ async fn test_rfc7591_register_rejects_expired_token() {
         "Revoked token must return invalid_token (RFC 6750): {}",
         response.body
     );
-    // RFC 6750 §3.1: WWW-Authenticate MUST carry error="invalid_token".
-    let www_auth = response
-        .headers
-        .get("www-authenticate")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
-    assert!(
-        www_auth.contains("invalid_token"),
-        "WWW-Authenticate must contain error=\"invalid_token\": {www_auth}"
-    );
+    assert_invalid_token_challenge(&response);
 }
 
 #[tokio::test]
@@ -148,15 +139,7 @@ async fn test_rfc7591_register_rejects_invalid_jwt() {
         "Invalid JWT must return invalid_token (RFC 6750): {}",
         response.body
     );
-    let www_auth = response
-        .headers
-        .get("www-authenticate")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
-    assert!(
-        www_auth.contains("invalid_token"),
-        "WWW-Authenticate must contain error=\"invalid_token\": {www_auth}"
-    );
+    assert_invalid_token_challenge(&response);
 }
 
 // ========================================================================

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7592.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7592.rs
@@ -168,34 +168,7 @@ async fn test_rfc7592_put_missing_bearer_token() {
     )
     .await;
     assert_eq!(response.status, StatusCode::UNAUTHORIZED);
-    // RFC 6750 §3.1: when the request lacks any authentication
-    // information, the WWW-Authenticate challenge SHOULD NOT include
-    // an error code or other error information. The `invalid_token`
-    // error is reserved for requests that carry a token that is
-    // expired/revoked/malformed.
-    let www_auth = response
-        .headers
-        .get("www-authenticate")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
-    assert!(
-        www_auth.starts_with("Bearer"),
-        "WWW-Authenticate must be a Bearer challenge: {www_auth}"
-    );
-    assert!(
-        !www_auth.contains("error="),
-        "Missing bearer must not include an error parameter: {www_auth}"
-    );
-    assert!(
-        !www_auth.contains("invalid_token"),
-        "Missing bearer must not include invalid_token: {www_auth}"
-    );
-    // RFC 9728 §5.2: the resource_metadata middleware still appends its
-    // pointer so unauthenticated callers can discover the metadata document.
-    assert!(
-        www_auth.contains("resource_metadata="),
-        "Missing bearer must still advertise resource_metadata (RFC 9728 §5.2): {www_auth}"
-    );
+    assert_bare_bearer_challenge(&response);
     // RFC 6750 §3.1: no error information, so no JSON error body.
     assert!(
         response.body.is_empty(),
@@ -233,15 +206,7 @@ async fn test_rfc7592_put_invalid_bearer_token() {
         "Invalid bearer must return invalid_token: {}",
         response.body
     );
-    let www_auth = response
-        .headers
-        .get("www-authenticate")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
-    assert!(
-        www_auth.contains("invalid_token"),
-        "WWW-Authenticate must contain error=\"invalid_token\": {www_auth}"
-    );
+    assert_invalid_token_challenge(&response);
 }
 
 #[tokio::test]
@@ -277,34 +242,7 @@ async fn test_rfc7592_get_missing_bearer_token() {
 
     let response = http_get_full(&app, &format!("/oauth/register/{client_id}"), &[]).await;
     assert_eq!(response.status, StatusCode::UNAUTHORIZED);
-    // RFC 6750 §3.1: when the request lacks any authentication
-    // information, the WWW-Authenticate challenge SHOULD NOT include
-    // an error code or other error information. The `invalid_token`
-    // error is reserved for requests that carry a token that is
-    // expired/revoked/malformed.
-    let www_auth = response
-        .headers
-        .get("www-authenticate")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
-    assert!(
-        www_auth.starts_with("Bearer"),
-        "WWW-Authenticate must be a Bearer challenge: {www_auth}"
-    );
-    assert!(
-        !www_auth.contains("error="),
-        "Missing bearer must not include an error parameter: {www_auth}"
-    );
-    assert!(
-        !www_auth.contains("invalid_token"),
-        "Missing bearer must not include invalid_token: {www_auth}"
-    );
-    // RFC 9728 §5.2: the resource_metadata middleware still appends its
-    // pointer so unauthenticated callers can discover the metadata document.
-    assert!(
-        www_auth.contains("resource_metadata="),
-        "Missing bearer must still advertise resource_metadata (RFC 9728 §5.2): {www_auth}"
-    );
+    assert_bare_bearer_challenge(&response);
     // RFC 6750 §3.1: no error information, so no JSON error body.
     assert!(
         response.body.is_empty(),
@@ -333,15 +271,7 @@ async fn test_rfc7592_get_invalid_bearer_token() {
         "Invalid bearer must return invalid_token: {}",
         response.body
     );
-    let www_auth = response
-        .headers
-        .get("www-authenticate")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
-    assert!(
-        www_auth.contains("invalid_token"),
-        "WWW-Authenticate must contain error=\"invalid_token\": {www_auth}"
-    );
+    assert_invalid_token_challenge(&response);
 }
 
 // =========================================================================
@@ -386,34 +316,7 @@ async fn test_rfc7592_delete_client_missing_bearer_token() {
     // DELETE without Authorization header — expect 401
     let response = http_delete_full(&app, &format!("/oauth/register/{client_id}"), &[]).await;
     assert_eq!(response.status, StatusCode::UNAUTHORIZED);
-    let www_auth = response
-        .headers
-        .get("www-authenticate")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
-    assert!(
-        www_auth.starts_with("Bearer"),
-        "WWW-Authenticate must be a Bearer challenge: {www_auth}"
-    );
-    // RFC 6750 §3.1: when the request lacks any authentication
-    // information, the WWW-Authenticate challenge SHOULD NOT include
-    // an error code or other error information. The `invalid_token`
-    // error is reserved for requests that carry a token that is
-    // expired/revoked/malformed.
-    assert!(
-        !www_auth.contains("error="),
-        "Missing bearer must not include an error parameter: {www_auth}"
-    );
-    assert!(
-        !www_auth.contains("invalid_token"),
-        "Missing bearer must not include invalid_token: {www_auth}"
-    );
-    // RFC 9728 §5.2: the resource_metadata middleware still appends its
-    // pointer so unauthenticated callers can discover the metadata document.
-    assert!(
-        www_auth.contains("resource_metadata="),
-        "Missing bearer must still advertise resource_metadata (RFC 9728 §5.2): {www_auth}"
-    );
+    assert_bare_bearer_challenge(&response);
     // RFC 6750 §3.1: no error information, so no JSON error body.
     assert!(
         response.body.is_empty(),
@@ -443,15 +346,7 @@ async fn test_rfc7592_delete_client_invalid_bearer_token() {
         "Invalid bearer must return invalid_token: {}",
         response.body
     );
-    let www_auth = response
-        .headers
-        .get("www-authenticate")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
-    assert!(
-        www_auth.contains("invalid_token"),
-        "WWW-Authenticate must contain error=\"invalid_token\": {www_auth}"
-    );
+    assert_invalid_token_challenge(&response);
 }
 
 #[tokio::test]

--- a/crates/vouch-server/src/handlers/scim/tests.rs
+++ b/crates/vouch-server/src/handlers/scim/tests.rs
@@ -2078,8 +2078,8 @@ async fn test_user_meta_last_modified_differs_after_patch() {
         .expect("meta.created")
         .to_string();
 
-    // Wait so the PATCH timestamp is strictly greater even on coarse clocks.
-    tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+    // No wait needed: the store writes `Timestamp::now()` at nanosecond
+    // precision, so sequential writes always produce distinct timestamps.
 
     // PATCH: toggle active from true -> false.
     let (status, body) = http_request(
@@ -2155,9 +2155,8 @@ async fn test_user_last_modified_uses_db_updated_at_not_created_at() {
     .expect("create_scim_user");
     let created_at = created.created_at;
 
-    // Advance the clock past second granularity so the modify timestamp is
-    // observably different even on coarse clocks.
-    tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+    // No wait needed: the store writes `Timestamp::now()` at nanosecond
+    // precision, so the modify timestamp is always strictly greater.
 
     let found = db::update_scim_user(
         &state.store,

--- a/crates/vouch-server/src/services/posture.rs
+++ b/crates/vouch-server/src/services/posture.rs
@@ -717,6 +717,15 @@ mod tests {
         }
     }
 
+    /// The CEL expression of a preconfigured policy, by slug.
+    fn preconfigured_expression(slug: PreconfiguredSlug) -> &'static str {
+        PRECONFIGURED_POLICIES
+            .iter()
+            .find(|p| p.slug == slug)
+            .unwrap()
+            .cel_expression
+    }
+
     fn minimal_posture() -> DevicePosture {
         DevicePosture::new()
     }
@@ -797,11 +806,7 @@ mod tests {
     fn test_evaluate_os_recency_macos_pass() {
         let posture = sample_posture();
         let ctx = build_cel_context(&posture);
-        let expr = PRECONFIGURED_POLICIES
-            .iter()
-            .find(|p| p.slug == PreconfiguredSlug::OsRecency)
-            .unwrap()
-            .cel_expression;
+        let expr = preconfigured_expression(PreconfiguredSlug::OsRecency);
         assert!(evaluate_cel(expr, &ctx));
     }
 
@@ -811,11 +816,7 @@ mod tests {
         let mut posture = sample_posture();
         posture.os_version = Some("13.7.0".to_string());
         let ctx = build_cel_context(&posture);
-        let expr = PRECONFIGURED_POLICIES
-            .iter()
-            .find(|p| p.slug == PreconfiguredSlug::OsRecency)
-            .unwrap()
-            .cel_expression;
+        let expr = preconfigured_expression(PreconfiguredSlug::OsRecency);
         assert!(!evaluate_cel(expr, &ctx));
     }
 
@@ -824,11 +825,7 @@ mod tests {
         let mut posture = minimal_posture();
         posture.os = Some(OperatingSystem::Linux);
         let ctx = build_cel_context(&posture);
-        let expr = PRECONFIGURED_POLICIES
-            .iter()
-            .find(|p| p.slug == PreconfiguredSlug::OsRecency)
-            .unwrap()
-            .cel_expression;
+        let expr = preconfigured_expression(PreconfiguredSlug::OsRecency);
         // Linux is not covered by the preconfigured os_recency policy;
         // admins should create per-distro custom policies instead.
         assert!(!evaluate_cel(expr, &ctx));
@@ -862,11 +859,7 @@ mod tests {
         let mut posture = sample_posture();
         posture.os_version = Some("15.3.1".to_string());
         let ctx = build_cel_context(&posture);
-        let expr = PRECONFIGURED_POLICIES
-            .iter()
-            .find(|p| p.slug == PreconfiguredSlug::OsRecency)
-            .unwrap()
-            .cel_expression;
+        let expr = preconfigured_expression(PreconfiguredSlug::OsRecency);
         assert!(
             evaluate_cel(expr, &ctx),
             "macOS 15.3.1 (Sequoia) must pass OsRecency (>= 14.0.0)"
@@ -879,11 +872,7 @@ mod tests {
         let mut posture = sample_posture();
         posture.os_version = Some("13.7.0".to_string());
         let ctx = build_cel_context(&posture);
-        let expr = PRECONFIGURED_POLICIES
-            .iter()
-            .find(|p| p.slug == PreconfiguredSlug::OsRecency)
-            .unwrap()
-            .cel_expression;
+        let expr = preconfigured_expression(PreconfiguredSlug::OsRecency);
         assert!(
             !evaluate_cel(expr, &ctx),
             "macOS 13.7.0 (Ventura) must fail OsRecency (< 14.0.0)"
@@ -908,11 +897,7 @@ mod tests {
         posture.os_build = Some("26100".to_string());
 
         let ctx = build_cel_context(&posture);
-        let expr = PRECONFIGURED_POLICIES
-            .iter()
-            .find(|p| p.slug == PreconfiguredSlug::OsRecency)
-            .unwrap()
-            .cel_expression;
+        let expr = preconfigured_expression(PreconfiguredSlug::OsRecency);
         assert!(
             evaluate_cel(expr, &ctx),
             "Windows 11 24H2 (build 26100) must pass OsRecency even though \
@@ -931,11 +916,7 @@ mod tests {
         posture.os_build = Some("22631".to_string()); // 23H2
 
         let ctx = build_cel_context(&posture);
-        let expr = PRECONFIGURED_POLICIES
-            .iter()
-            .find(|p| p.slug == PreconfiguredSlug::OsRecency)
-            .unwrap()
-            .cel_expression;
+        let expr = preconfigured_expression(PreconfiguredSlug::OsRecency);
         assert!(
             !evaluate_cel(expr, &ctx),
             "Windows 11 23H2 (build 22631) must fail OsRecency (< 26100)"
@@ -954,11 +935,7 @@ mod tests {
         posture.os_build = Some("26100".to_string());
 
         let ctx = build_cel_context(&posture);
-        let expr = PRECONFIGURED_POLICIES
-            .iter()
-            .find(|p| p.slug == PreconfiguredSlug::OsRecency)
-            .unwrap()
-            .cel_expression;
+        let expr = preconfigured_expression(PreconfiguredSlug::OsRecency);
         assert!(
             evaluate_cel(expr, &ctx),
             "Windows with a compliant os_build but missing os_version must pass"
@@ -980,11 +957,7 @@ mod tests {
         posture.os_build = Some("22631".to_string()); // 23H2
 
         let ctx = build_cel_context(&posture);
-        let expr = PRECONFIGURED_POLICIES
-            .iter()
-            .find(|p| p.slug == PreconfiguredSlug::OsRecency)
-            .unwrap()
-            .cel_expression;
+        let expr = preconfigured_expression(PreconfiguredSlug::OsRecency);
         assert!(
             !evaluate_cel(expr, &ctx),
             "Windows OsRecency must compare os_build, not os_version"

--- a/crates/vouch-server/src/test_utils.rs
+++ b/crates/vouch-server/src/test_utils.rs
@@ -1670,3 +1670,46 @@ pub async fn make_test_access_token(key: &OidcSigningKey) -> String {
     };
     key.sign_access_token_jwt(&claims).await.expect("sign")
 }
+
+/// Build a JWT assertion for `private_key_jwt` client auth (RFC 7523
+/// Section 2.2), signed ES256 with `kid: "test-key-1"`.
+///
+/// `jti: None` generates a fresh UUID so repeated calls do not trip replay
+/// protection; pass `Some(..)` to exercise replay handling deliberately.
+#[must_use]
+pub fn build_client_assertion(
+    client_id: &str,
+    audience: &str,
+    pkcs8_bytes: &[u8],
+    jti: Option<&str>,
+) -> String {
+    use aws_lc_rs::signature::{ECDSA_P256_SHA256_FIXED_SIGNING, EcdsaKeyPair};
+    use base64::Engine;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+    let key_pair = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, pkcs8_bytes)
+        .expect("parse ES256 key");
+
+    let now = jiff::Timestamp::now().as_second();
+    let header = serde_json::json!({ "alg": "ES256", "typ": "JWT", "kid": "test-key-1" });
+    let claims = serde_json::json!({
+        "iss": client_id,
+        "sub": client_id,
+        "aud": audience,
+        "iat": now,
+        "exp": now.saturating_add(60),
+        "jti": jti.map_or_else(|| uuid::Uuid::now_v7().to_string(), str::to_string)
+    });
+
+    let header_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&header).expect("encode header"));
+    let claims_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&claims).expect("encode claims"));
+    let signing_input = format!("{header_b64}.{claims_b64}");
+
+    let rng = aws_lc_rs::rand::SystemRandom::new();
+    let sig = key_pair
+        .sign(&rng, signing_input.as_bytes())
+        .expect("sign assertion");
+    let sig_b64 = URL_SAFE_NO_PAD.encode(sig.as_ref());
+
+    format!("{header_b64}.{claims_b64}.{sig_b64}")
+}

--- a/crates/vouch-tests/tests/fido2_posture_e2e.rs
+++ b/crates/vouch-tests/tests/fido2_posture_e2e.rs
@@ -15,40 +15,7 @@ use vouch_tests::{IntegrationMockDevice, TestHarness};
 // ── Helpers ──────────────────────────────────────────────────────────────
 
 /// Build a `private_key_jwt` client assertion (ES256 JWT) for the token endpoint.
-fn build_client_assertion(
-    client_id: &str,
-    audience: &str,
-    pkcs8_bytes: &[u8],
-    jti: Option<&str>,
-) -> String {
-    use aws_lc_rs::signature::{ECDSA_P256_SHA256_FIXED_SIGNING, EcdsaKeyPair};
-
-    let key_pair = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, pkcs8_bytes)
-        .expect("Failed to parse key");
-
-    let now = jiff::Timestamp::now().as_second();
-    let header = serde_json::json!({ "alg": "ES256", "typ": "JWT", "kid": "test-key-1" });
-    let claims = serde_json::json!({
-        "iss": client_id,
-        "sub": client_id,
-        "aud": audience,
-        "iat": now,
-        "exp": now + 60,
-        "jti": jti.map_or_else(|| uuid::Uuid::now_v7().to_string(), str::to_string)
-    });
-
-    let header_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&header).unwrap());
-    let claims_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&claims).unwrap());
-    let signing_input = format!("{header_b64}.{claims_b64}");
-
-    let rng = aws_lc_rs::rand::SystemRandom::new();
-    let sig = key_pair
-        .sign(&rng, signing_input.as_bytes())
-        .expect("Failed to sign");
-    let sig_b64 = URL_SAFE_NO_PAD.encode(sig.as_ref());
-
-    format!("{header_b64}.{claims_b64}.{sig_b64}")
-}
+use vouch_server::test_utils::build_client_assertion;
 
 /// Create an OAuth client configured for `private_key_jwt` with inline JWKS.
 async fn create_jwt_client(
@@ -149,17 +116,31 @@ async fn get_challenge(harness: &TestHarness) -> (Vec<u8>, String) {
     (challenge, state)
 }
 
+/// Everything a FIDO2 assertion exchange needs, bundled so call sites read
+/// as named fields instead of eight positional arguments.
+struct AssertionExchange<'a> {
+    harness: &'a TestHarness,
+    device: &'a IntegrationMockDevice,
+    challenge: &'a [u8],
+    state_jwt: &'a str,
+    user_id: &'a str,
+    client: &'a vouch_server::test_utils::TestOAuthClient,
+    pkcs8: &'a [u8],
+    authorization_details: Option<&'a str>,
+}
+
 /// Build the assertion payload and exchange it for an access token.
-#[allow(clippy::too_many_arguments)]
 async fn exchange_fido2_assertion(
-    harness: &TestHarness,
-    device: &IntegrationMockDevice,
-    challenge: &[u8],
-    state_jwt: &str,
-    user_id: &str,
-    client: &vouch_server::test_utils::TestOAuthClient,
-    pkcs8: &[u8],
-    authorization_details: Option<&str>,
+    AssertionExchange {
+        harness,
+        device,
+        challenge,
+        state_jwt,
+        user_id,
+        client,
+        pkcs8,
+        authorization_details,
+    }: AssertionExchange<'_>,
 ) -> (u16, serde_json::Value) {
     // The mock device signs the assertion
     let auth_result = device
@@ -263,16 +244,16 @@ async fn test_fido2_grant_windows_24h2_os_recency_passes() {
     .to_string();
 
     // Exchange the FIDO2 assertion with the posture data
-    let (status, json) = exchange_fido2_assertion(
-        &harness,
-        &device,
-        &challenge,
-        &state,
-        &user.id,
-        &client,
-        &pkcs8,
-        Some(&posture_json),
-    )
+    let (status, json) = exchange_fido2_assertion(AssertionExchange {
+        harness: &harness,
+        device: &device,
+        challenge: &challenge,
+        state_jwt: &state,
+        user_id: &user.id,
+        client: &client,
+        pkcs8: &pkcs8,
+        authorization_details: Some(&posture_json),
+    })
     .await;
 
     assert_eq!(
@@ -323,16 +304,16 @@ async fn test_fido2_grant_windows_23h2_os_recency_denied() {
     }])
     .to_string();
 
-    let (status, json) = exchange_fido2_assertion(
-        &harness,
-        &device,
-        &challenge,
-        &state,
-        &user.id,
-        &client,
-        &pkcs8,
-        Some(&posture_json),
-    )
+    let (status, json) = exchange_fido2_assertion(AssertionExchange {
+        harness: &harness,
+        device: &device,
+        challenge: &challenge,
+        state_jwt: &state,
+        user_id: &user.id,
+        client: &client,
+        pkcs8: &pkcs8,
+        authorization_details: Some(&posture_json),
+    })
     .await;
 
     assert_eq!(
@@ -383,16 +364,16 @@ async fn test_fido2_grant_macos_15_os_recency_passes() {
     }])
     .to_string();
 
-    let (status, json) = exchange_fido2_assertion(
-        &harness,
-        &device,
-        &challenge,
-        &state,
-        &user.id,
-        &client,
-        &pkcs8,
-        Some(&posture_json),
-    )
+    let (status, json) = exchange_fido2_assertion(AssertionExchange {
+        harness: &harness,
+        device: &device,
+        challenge: &challenge,
+        state_jwt: &state,
+        user_id: &user.id,
+        client: &client,
+        pkcs8: &pkcs8,
+        authorization_details: Some(&posture_json),
+    })
     .await;
 
     assert_eq!(
@@ -435,9 +416,16 @@ async fn test_fido2_grant_os_recency_no_posture_denied() {
     let (challenge, state) = get_challenge(&harness).await;
 
     // No authorization_details — posture data is required
-    let (status, json) = exchange_fido2_assertion(
-        &harness, &device, &challenge, &state, &user.id, &client, &pkcs8, None,
-    )
+    let (status, json) = exchange_fido2_assertion(AssertionExchange {
+        harness: &harness,
+        device: &device,
+        challenge: &challenge,
+        state_jwt: &state,
+        user_id: &user.id,
+        client: &client,
+        pkcs8: &pkcs8,
+        authorization_details: None,
+    })
     .await;
 
     assert_eq!(


### PR DESCRIPTION
## Summary

Fifth of the cleanup series (#869, #872, #874, #877). The audit of the merged Detail-app PRs found the test/comment mass growing ~6× faster than production code without being held to the same bar: tests that cannot fail for the claim they make, comments describing code that doesn't exist, copy-pasted fixtures, and avoidable wall-clock sleeps. Net **−251 lines**, all test-side.

**Tests that could not fail for their claim:**

- `test_device_code_race_loser_revokes_sessions` performed the revocation in its own test body ("Simulate what the handler does…") and then asserted it happened — reverting the production fix left it green. The self-fulfilling half is deleted; the remainder is renamed `test_device_code_concurrent_consume_single_winner` (the OCC semantics it genuinely verifies), and the existing E2E handler test remains the revocation coverage.
- The SCIM TOCTOU test's doc claimed it "deterministically hits the TOCTOU window using a barrier" — there is no barrier, and its `Ok` arm cannot distinguish a legitimate race win from the original bug. The doc now states exactly what the race can and cannot prove and points at the sequential rejection tests for the deterministic coverage.
- The Postgres snapshot-isolation test hand-copied the schema as inline DDL (its own comment acknowledged mirroring `migrations/postgres/`), so schema drift passed silently. It now reads the real migration files at runtime (`CREATE INDEX ASYNC` → `CREATE INDEX IF NOT EXISTS`, `CREATE TABLE` → idempotent) — drift now fails the test.

**Untrue comments:** the "version-5 name-based UUID" claim (it's v8 — the implementation's own docs explain v5 was rejected to avoid SHA-1), the doc line clobbered by #835's insertion (restored, stale error reference corrected), "arte fact" → artifact, and the lowercase-email fixture comment.

**Fixture dedup:** `test_org_doc(domain)` replaces five inlined `OrganizationDoc` literals; `assert_invalid_token_challenge` / `assert_bare_bearer_challenge` replace eight pasted `WWW-Authenticate` extraction+assert blocks in rfc7591/rfc7592; `preconfigured_expression(slug)` replaces nine identical policy lookups in posture tests; `build_client_assertion` collapses from five copies to one `pub` helper in `test_utils` (shared by vouch-server's OIDC tests and vouch-tests); `exchange_fido2_assertion` takes an `AssertionExchange` params struct, removing the only bare `#[allow]` in vouch-tests.

**Sleeps:** both 1,100 ms sleeps in the SCIM lastModified tests are gone — the store writes nanosecond-precision timestamps, so sequential writes always differ. Those tests now run in 0.26 s instead of ~2.5 s.

## Testing

- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test --all-features` (workspace incl. vouch-tests): 4,523 passed, 0 failed
- The sleep-free timestamp tests and the renamed device race test were run individually to confirm they pass without their removed props

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to tests and test utilities; no production auth or data-path behavior is modified.
> 
> **Overview**
> This PR raises the bar on **test-side** code only (~251 lines removed): it fixes tests and comments that overstated what they proved, centralizes duplicated helpers, and drops unnecessary sleeps.
> 
> **Honesty fixes:** The device-code race test no longer simulates handler revocation in the test body (which could stay green if production regressed); it is renamed to assert only single-winner OCC, with E2E coverage left for session revocation. SCIM TOCTOU docs no longer claim a deterministic barrier. The Postgres isolation test applies real `migrations/postgres` files (with vanilla-Postgres tweaks) instead of inline DDL so schema drift fails the test.
> 
> **Dedup:** `test_org_doc`, shared `build_client_assertion` in `test_utils`, RFC 6750 `WWW-Authenticate` assert helpers, `preconfigured_expression` for posture CEL tests, and an `AssertionExchange` struct for FIDO2 e2e calls.
> 
> **Other:** SCIM lastModified tests drop 1.1s sleeps (nanosecond timestamps). Comments corrected (e.g. RFC 9562 v8 user IDs, typo *artefact*).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab18e9b3f58d9748f58812add2094dc06bbd95b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->