### PR TITLE
fix(server): hash the idp_identity index value instead of NUL-joining

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1482,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+checksum = "1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87"
 dependencies = [
  "percent-encoding",
  "time",
@@ -6573,7 +6573,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vouch-agent"
-version = "2026.8.1"
+version = "2026.8.2"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -6604,7 +6604,7 @@ dependencies = [
 
 [[package]]
 name = "vouch-cli"
-version = "2026.8.1"
+version = "2026.8.2"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -6666,7 +6666,7 @@ dependencies = [
 
 [[package]]
 name = "vouch-common"
-version = "2026.8.1"
+version = "2026.8.2"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "vouch-httpsig"
-version = "2026.8.1"
+version = "2026.8.2"
 dependencies = [
  "aws-lc-rs",
  "axum",
@@ -6703,7 +6703,7 @@ dependencies = [
 
 [[package]]
 name = "vouch-i18n"
-version = "2026.8.1"
+version = "2026.8.2"
 dependencies = [
  "anyhow",
  "fluent-bundle",
@@ -6715,7 +6715,7 @@ dependencies = [
 
 [[package]]
 name = "vouch-server"
-version = "2026.8.1"
+version = "2026.8.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6801,7 +6801,7 @@ dependencies = [
 
 [[package]]
 name = "vouch-tests"
-version = "2026.8.1"
+version = "2026.8.2"
 dependencies = [
  "anyhow",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "2026.8.1"
+version = "2026.8.2"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 rust-version = "1.97.1"

--- a/crates/vouch-server/src/db/documents/user.rs
+++ b/crates/vouch-server/src/db/documents/user.rs
@@ -79,13 +79,27 @@ impl UpstreamLogin {
 
 /// Combined index value for the `idp_identity` blind index.
 ///
-/// `issuer` and `subject` are joined with a NUL byte, which cannot
-/// appear in an issuer URL or SAML entity ID, so the encoding is
-/// unambiguous: distinct `(issuer, subject)` pairs never collide. The
-/// store HMACs index values before persisting them, so the pair is a
-/// blind equality key like every other index.
+/// `issuer` and `subject` are hashed together with NUL domain
+/// separators, which cannot appear in an issuer URL or SAML entity ID,
+/// so distinct `(issuer, subject)` pairs never collide. Keeping the
+/// separator inside the digest is what makes the result storable: a NUL
+/// in the index value itself is rejected by Postgres and Aurora DSQL.
+/// Hashing also keeps the raw upstream subject out of the index table
+/// in plaintext development mode.
+///
+/// Same SHA-256-with-domain-separator derivation as
+/// `deterministic_org_id` (`db/enrollment.rs`), [`deterministic_user_id`],
+/// `deterministic_jti_id` (`db/oauth.rs`), and
+/// `deterministic_challenge_state_id` (`db/challenge_states.rs`).
 pub(crate) fn idp_identity_index_value(issuer: &str, subject: &str) -> String {
-    format!("{issuer}\u{0}{subject}")
+    use aws_lc_rs::digest::{self, SHA256};
+
+    let mut ctx = digest::Context::new(&SHA256);
+    ctx.update(b"idp_identity\0");
+    ctx.update(issuer.as_bytes());
+    ctx.update(b"\0");
+    ctx.update(subject.as_bytes());
+    hex::encode(ctx.finish().as_ref())
 }
 
 fn default_active() -> bool {
@@ -240,9 +254,10 @@ mod tests {
 
     #[test]
     fn idp_identity_index_value_distinguishes_issuer_and_subject() {
-        // The NUL separator makes the encoding unambiguous for real
-        // issuer values (URLs / entity IDs, which cannot contain NUL):
-        // moving characters across the boundary changes the value.
+        // The NUL domain separator inside the digest makes the encoding
+        // unambiguous for real issuer values (URLs / entity IDs, which
+        // cannot contain NUL): moving characters across the boundary
+        // changes the value.
         assert_ne!(
             idp_identity_index_value("https://a.example", "sub-1"),
             idp_identity_index_value("https://a.example", "sub-2"),
@@ -251,9 +266,35 @@ mod tests {
             idp_identity_index_value("https://a.example", "sub-1"),
             idp_identity_index_value("https://b.example", "sub-1"),
         );
+        // Shifting the boundary must not collide: the two pairs
+        // concatenate identically, so only the separator keeps them apart.
+        assert_ne!(
+            idp_identity_index_value("https://a.example/x", "sub-1"),
+            idp_identity_index_value("https://a.example/", "xsub-1"),
+        );
+        // The same pair always yields the same key, so the index is a
+        // stable point lookup across processes.
         assert_eq!(
             idp_identity_index_value("https://a.example", "sub-1"),
-            "https://a.example\u{0}sub-1",
+            idp_identity_index_value("https://a.example", "sub-1"),
+        );
+    }
+
+    #[test]
+    fn idp_identity_index_value_is_storable_as_sql_text() {
+        // Postgres and Aurora DSQL reject a NUL in a text value, and
+        // SQLite accepts it silently, so an unstorable index value would
+        // otherwise pass every test here and fail only in production. A
+        // subject carrying its own control characters must not be able
+        // to reintroduce one.
+        let value = idp_identity_index_value("https://a.example", "sub\u{0}\u{1}\n1");
+        assert!(
+            !value.contains(|c: char| c.is_control()),
+            "index value must contain no control characters, got {value:?}"
+        );
+        assert!(
+            value.chars().all(|c| c.is_ascii_hexdigit()),
+            "index value must be plain hex, got {value:?}"
         );
     }
 

--- a/crates/vouch-server/src/db/store.rs
+++ b/crates/vouch-server/src/db/store.rs
@@ -237,7 +237,9 @@ fn raw_to_document<T: DocumentType>(
     })
 }
 
-/// Build an index-value match expression.
+/// Build an index-value match expression against `table`, which is either
+/// `DocumentIndexes::Table` itself or one of the per-criterion join
+/// aliases `find_by_indexes` uses to self-join without name conflicts.
 ///
 /// In HPKE mode, matches both the HMAC-hashed value (new rows) and
 /// the plaintext value (pre-encryption rows) using `IN`. In plaintext
@@ -246,28 +248,13 @@ fn raw_to_document<T: DocumentType>(
 /// This is a temporary migration bridge. Once all rows have been
 /// re-encrypted and their indexes HMAC-hashed (via update-on-read or
 /// background job), this can revert to a simple equality check.
-fn index_value_condition(crypto: &dyn DocumentCrypto, value: &str) -> sea_query::SimpleExpr {
-    let hashed = crypto.hmac_index(value);
-    let col = Expr::col((DocumentIndexes::Table, DocumentIndexes::IndexValue));
-    if hashed == value {
-        col.eq(value.to_string())
-    } else {
-        col.is_in([hashed, value.to_string()])
-    }
-}
-
-/// Like [`index_value_condition`] but references `index_value` through a
-/// join alias instead of the canonical `DocumentIndexes` table name.
-///
-/// Used by `find_by_indexes` to build self-join conditions for each
-/// additional criterion without aliasing conflicts.
-fn index_value_condition_aliased(
+fn index_value_condition<T: sea_query::IntoIden>(
     crypto: &dyn DocumentCrypto,
+    table: T,
     value: &str,
-    alias: &sea_query::Alias,
 ) -> sea_query::SimpleExpr {
     let hashed = crypto.hmac_index(value);
-    let col = Expr::col((alias.clone(), DocumentIndexes::IndexValue));
+    let col = Expr::col((table.into_iden(), DocumentIndexes::IndexValue));
     if hashed == value {
         col.eq(value.to_string())
     } else {
@@ -546,7 +533,7 @@ impl DocumentStore {
         field: &str,
         value: &str,
     ) -> Result<Option<Document<T>>> {
-        let index_cond = index_value_condition(&*self.crypto, value);
+        let index_cond = index_value_condition(&*self.crypto, DocumentIndexes::Table, value);
 
         let stmt = Query::select()
             .columns(DOC_TABLE_COLUMNS)
@@ -580,7 +567,7 @@ impl DocumentStore {
         field: &str,
         value: &str,
     ) -> Result<Vec<Document<T>>> {
-        let index_cond = index_value_condition(&*self.crypto, value);
+        let index_cond = index_value_condition(&*self.crypto, DocumentIndexes::Table, value);
 
         let stmt = Query::select()
             .columns(DOC_TABLE_COLUMNS)
@@ -620,7 +607,7 @@ impl DocumentStore {
         after_id: Option<&str>,
         limit: u64,
     ) -> Result<(Vec<Document<T>>, bool)> {
-        let index_cond = index_value_condition(&*self.crypto, value);
+        let index_cond = index_value_condition(&*self.crypto, DocumentIndexes::Table, value);
 
         let mut query = Query::select();
         query
@@ -692,7 +679,7 @@ impl DocumentStore {
                         .equals((alias.clone(), DocumentIndexes::DocumentId)),
                 )
                 .add(Expr::col((alias.clone(), DocumentIndexes::IndexField)).eq(*field))
-                .add(index_value_condition_aliased(&*self.crypto, value, &alias));
+                .add(index_value_condition(&*self.crypto, alias.clone(), value));
             query.join_as(
                 sea_query::JoinType::InnerJoin,
                 DocumentIndexes::Table,
@@ -1014,7 +1001,7 @@ impl DocumentStore {
     ///
     /// Returns an error if the query fails.
     pub async fn count<T: DocumentType>(&self, field: &str, value: &str) -> Result<i64> {
-        let index_cond = index_value_condition(&*self.crypto, value);
+        let index_cond = index_value_condition(&*self.crypto, DocumentIndexes::Table, value);
 
         let stmt = Query::select()
             .expr_as(
@@ -1140,7 +1127,7 @@ impl DocumentStore {
         offset: u64,
         limit: u64,
     ) -> Result<(Vec<Document<T>>, i64)> {
-        let index_cond = index_value_condition(&*self.crypto, value);
+        let index_cond = index_value_condition(&*self.crypto, DocumentIndexes::Table, value);
 
         let stmt = Query::select()
             .columns(DOC_TABLE_COLUMNS)
@@ -1332,7 +1319,7 @@ impl StoreTransaction<'_> {
         field: &str,
         value: &str,
     ) -> Result<Option<Document<T>>> {
-        let index_cond = index_value_condition(&**self.crypto, value);
+        let index_cond = index_value_condition(&**self.crypto, DocumentIndexes::Table, value);
 
         let stmt = Query::select()
             .columns(DOC_TABLE_COLUMNS)
@@ -1365,7 +1352,7 @@ impl StoreTransaction<'_> {
         field: &str,
         value: &str,
     ) -> Result<Vec<Document<T>>> {
-        let index_cond = index_value_condition(&**self.crypto, value);
+        let index_cond = index_value_condition(&**self.crypto, DocumentIndexes::Table, value);
 
         let stmt = Query::select()
             .columns(DOC_TABLE_COLUMNS)
@@ -1573,7 +1560,7 @@ impl StoreTransaction<'_> {
     ///
     /// Returns an error if the query fails.
     pub async fn count<T: DocumentType>(&mut self, field: &str, value: &str) -> Result<i64> {
-        let index_cond = index_value_condition(&**self.crypto, value);
+        let index_cond = index_value_condition(&**self.crypto, DocumentIndexes::Table, value);
 
         let stmt = Query::select()
             .expr_as(
@@ -1699,23 +1686,7 @@ impl StoreTransaction<'_> {
         crate::tx_execute!(self.tx, delete_idx_stmt)?;
 
         for entry in &indexes {
-            let index_id = uuid::Uuid::now_v7().to_string();
-            let hashed_value = self.crypto.hmac_index(&entry.value);
-            let idx_stmt = Query::insert()
-                .into_table(DocumentIndexes::Table)
-                .columns([
-                    DocumentIndexes::Id,
-                    DocumentIndexes::DocumentId,
-                    DocumentIndexes::IndexField,
-                    DocumentIndexes::IndexValue,
-                ])
-                .values([
-                    index_id.as_str().into(),
-                    id.into(),
-                    entry.field.into(),
-                    hashed_value.as_str().into(),
-                ])?
-                .to_owned();
+            let idx_stmt = build_index_insert(&**self.crypto, id, entry)?;
             crate::tx_execute!(self.tx, idx_stmt)?;
         }
 

--- a/crates/vouch-server/src/db/store/tests.rs
+++ b/crates/vouch-server/src/db/store/tests.rs
@@ -626,7 +626,7 @@ fn index_value_condition_plaintext_emits_eq() {
     use sea_query::SqliteQueryBuilder;
 
     let crypto = PlaintextDocumentCrypto;
-    let expr = index_value_condition(&crypto, "alice@example.com");
+    let expr = index_value_condition(&crypto, DocumentIndexes::Table, "alice@example.com");
 
     let (sql, _) = Query::select()
         .column(DocumentIndexes::IndexValue)
@@ -649,7 +649,7 @@ fn index_value_condition_hpke_emits_in() {
     use sea_query::SqliteQueryBuilder;
 
     let crypto = HashingTestCrypto;
-    let expr = index_value_condition(&crypto, "alice@example.com");
+    let expr = index_value_condition(&crypto, DocumentIndexes::Table, "alice@example.com");
 
     let (sql, _) = Query::select()
         .column(DocumentIndexes::IndexValue)


### PR DESCRIPTION
## Problem

`idp_identity_index_value` joined the upstream issuer and subject with a literal NUL byte:

```rust
format!("{issuer}\u{0}{subject}")
```

That string is bound as a `text` parameter against `document_indexes.index_value` (`TEXT NOT NULL`). Postgres and Aurora DSQL reject any text value containing 0x00 — `invalid byte sequence for encoding "UTF8": 0x00` — while SQLite stores it without complaint.

The separator was hardcoded rather than derived from IdP input, so every call produced a NUL. `resolve_user` runs the binding lookup before any write and OIDC always supplies a subject, so every OIDC login and every SAML login with a persistent NameID failed on those backends:

```
ERROR request{method=GET path=/oauth/callback}: Failed to look up user by upstream identity:
  error returned from database: invalid byte sequence for encoding "UTF8": 0x00
```

It reached production because every `db/` test runs against `sqlite::memory:` and dev.vouch.sh is on SQLite (`config/deploy.yml:39`), while production is Aurora DSQL.

## Change

Hash the pair with SHA-256 and NUL domain separators inside the digest, emitting hex. This is the same derivation used by `deterministic_org_id`, `deterministic_user_id`, `deterministic_jti_id`, and `deterministic_challenge_state_id`. The encoding stays unambiguous for issuer URLs and SAML entity IDs, and the raw upstream subject no longer sits in the index table in plaintext development mode.

A test pins the output to control-character-free hex, so reintroducing a raw separator fails.

Two dedups in `db/store.rs` alongside it: `index_value_condition` and `index_value_condition_aliased` differed only in how the column was referenced and collapse into one function generic over `IntoIden`; the duplicated inline index-insert in `StoreTransaction` now calls `build_index_insert`. Net -24 lines in that file.

## Verification

Against Postgres 17, before the change six of the seven identity-binding tests failed with the production error. The one that passed is the non-durable login, the only case that skips the lookup. After the change all seven pass.

The mechanism was confirmed independently:

```
=# SELECT convert_from('\x6100620073007500620031'::bytea, 'UTF8');
ERROR:  invalid byte sequence for encoding "UTF8": 0x00
```

`make fmt`, `make lint` (zero warnings), `make test` (47 suites), `make test-integration` (26 suites), `prek run` — all clean.

## Migration

None. The binding lookup precedes every write and has always failed on Postgres and DSQL, so no `idp_identity` index row was ever written there. On development SQLite, pre-existing rows in the old format stop matching; the lookup falls through to the email index and the binding in `UserDoc.idp_identities` still drives the conflict check, so no account is locked out. Those rows are rewritten when the document is next updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches identity-binding lookups on every IdP login; SQLite may have old NUL-joined index rows that stop matching until documents are updated, though email fallback limits user impact.
> 
> **Overview**
> Fixes **OIDC/SAML login failures on Postgres and Aurora DSQL** by changing how the `idp_identity` blind index key is derived. Instead of `issuer` + NUL + `subject` (always containing 0x00, which those backends reject as `TEXT`), the key is now **SHA-256 with domain separators**, output as **hex**—aligned with other deterministic index helpers and safe for SQL text columns. Subjects with control characters can no longer leak NUL into the stored index value, and plaintext dev mode no longer keeps raw subjects in the index table.
> 
> **`db/store.rs`** is lightly refactored: one generic `index_value_condition` replaces the table vs alias variants, and `StoreTransaction` index rewrites use shared `build_index_insert`. Workspace version bumps to **2026.8.2** (plus `cookie` patch in the lockfile).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c16be043522373d52d999215758cd6f82d5fbab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->