### PR TITLE
fix(server): record FIDO2 token issuance; repair cargo-deny skips

### DIFF
--- a/crates/vouch-server/src/services/oidc/fido2_grant.rs
+++ b/crates/vouch-server/src/services/oidc/fido2_grant.rs
@@ -288,6 +288,8 @@ pub(crate) async fn exchange_fido2_assertion(
     .map_err(|e| ServiceError::Internal(format!("Failed to update counter: {e}")))?;
 
     // 8. Log auth event (fire-and-forget)
+    let client_ip = params.client_info.client_ip;
+    let client_user_agent = params.client_info.user_agent.clone();
     let auth_event_params = AuthEventParams {
         user_id: user.id.clone(),
         event_type: AuthEventType::LoginSuccess,
@@ -361,6 +363,21 @@ pub(crate) async fn exchange_fido2_assertion(
         proof,
     )
     .await?;
+
+    // Every access-token grant records an oauth_token_issued audit row.
+    db::record_oauth_event(
+        &state.audit,
+        &state.store,
+        &db::RecordOAuthEventParams {
+            oauth_client_id: &params.client.client.id,
+            event_type: db::OAuthEventType::TokenIssued,
+            user_id: Some(&user.id),
+            ip_address: client_ip,
+            user_agent: client_user_agent.as_deref(),
+            details: Some("grant_type=fido2-assertion"),
+        },
+    )
+    .await;
 
     let token_type = if params.dpop_proof.is_some() {
         "DPoP"

--- a/crates/vouch-tests/tests/fido2_posture_e2e.rs
+++ b/crates/vouch-tests/tests/fido2_posture_e2e.rs
@@ -438,3 +438,53 @@ async fn test_fido2_grant_os_recency_no_posture_denied() {
         "Expected access_denied, got: {error} (full: {json})"
     );
 }
+
+/// A successful FIDO2 grant records an `oauth_token_issued` audit event
+/// carrying the user id and grant type.
+#[tokio::test]
+async fn test_fido2_grant_records_token_issued_audit_event() {
+    let harness = TestHarness::new().await;
+    let user = harness
+        .create_user("issued-audit@example.com")
+        .await
+        .expect("Failed to create user");
+
+    let device = IntegrationMockDevice::new();
+    let _auth_id = register_mock_device_in_db(&harness, &user.id, &user.email, &device).await;
+    let (client, pkcs8) = create_jwt_client(&harness, &user.id).await;
+    let (challenge, state) = get_challenge(&harness).await;
+
+    let (status, json) = exchange_fido2_assertion(AssertionExchange {
+        harness: &harness,
+        device: &device,
+        challenge: &challenge,
+        state_jwt: &state,
+        user_id: &user.id,
+        client: &client,
+        pkcs8: &pkcs8,
+        authorization_details: None,
+    })
+    .await;
+    assert_eq!(status, 200, "FIDO2 grant must succeed: {json}");
+
+    let rows = harness
+        .state
+        .audit
+        .query_events(&db::AuditEventFilter {
+            event_types: Some(vec!["oauth_token_issued".to_string()]),
+            user_id: Some(user.id.clone()),
+            ..Default::default()
+        })
+        .await
+        .expect("query audit events");
+    assert_eq!(
+        rows.len(),
+        1,
+        "the grant must write exactly one oauth_token_issued row"
+    );
+    assert!(
+        rows[0].data.contains("fido2-assertion"),
+        "the audit payload must carry the grant type: {}",
+        rows[0].data
+    );
+}

--- a/deny.toml
+++ b/deny.toml
@@ -100,8 +100,8 @@ skip = [
     { crate = "itertools@0.13.0", reason = "some dependencies still on itertools 0.13" },
     # pastey version split
     { crate = "pastey@0.1.1", reason = "transitive dependency version split" },
-    # rand 0.9 vs 0.10
-    { crate = "rand@0.9.4", reason = "some crates still on rand 0.9" },
+    # rand 0.9 vs 0.10 (a pinned 0.9.4 skip went stale when 0.9.5 shipped)
+    { crate = "rand:>=0.9,<0.10", reason = "some crates still on rand 0.9" },
     { crate = "rand_core:>=0.6,<0.7", reason = "rand 0.8 ecosystem" },
     { crate = "rand_core:>=0.9,<0.10", reason = "rand 0.9 ecosystem" },
     # shlex version split (build-script dependency)
@@ -115,6 +115,17 @@ skip = [
     { crate = "unicode-width:>=0.1,<0.2", reason = "some crates still on unicode-width 0.1" },
     # untrusted version split (ring/aws-lc-rs transitive)
     { crate = "untrusted:>=0.7,<0.8", reason = "webpki/ring transitive" },
+    # base64 0.22 vs 0.23 (sqlx-core/ctap-hid-fido2/headers still on 0.22)
+    { crate = "base64:>=0.22,<0.23", reason = "sqlx and ctap-hid-fido2 still on base64 0.22" },
+    # ssh-key 0.6 pins the ed25519-dalek 2 stack; workspace is on 3
+    { crate = "curve25519-dalek:>=4,<5", reason = "ssh-key 0.6 uses ed25519-dalek 2 (curve25519-dalek 4)" },
+    { crate = "ed25519:>=2,<3", reason = "ssh-key 0.6 uses ed25519 2" },
+    { crate = "ed25519-dalek:>=2,<3", reason = "ssh-key 0.6 uses ed25519-dalek 2" },
+    { crate = "signature:>=2,<3", reason = "ssh-key 0.6 uses signature 2" },
+    # syn 2 vs 3 (async-trait 0.1.92 moved to syn 3; most proc-macros still on 2)
+    { crate = "syn:>=2,<3", reason = "most proc-macros still on syn 2; async-trait pulls syn 3" },
+    # tower-http 0.6 vs 0.7 (reqwest 0.13 still on 0.6; workspace pins 0.7)
+    { crate = "tower-http:>=0.6,<0.7", reason = "reqwest 0.13 still on tower-http 0.6" },
 ]
 skip-tree = [
     # windows-sys bumps frequently; many crates lag behind. Rather than tracking


### PR DESCRIPTION
## What

Two maintenance fixes:

**FIDO2 grant audit gap.** The FIDO2 assertion grant issued access tokens without writing an `oauth_token_issued` audit row, while the authorization-code, device-code, and client-credentials grants all record one. The grant now records the event (user id, client IP/user-agent, `grant_type=fido2-assertion`) after token creation. A new e2e test (`test_fido2_grant_records_token_issued_audit_event`) runs the full grant and asserts the row is written with the grant type in its payload.

**cargo-deny bans drift.** `cargo deny check bans` was failing on main with 8 duplicate-version errors:
- the `rand@0.9.4` skip was pinned to an exact version and stopped matching when rand 0.9.5 shipped — widened to `rand:>=0.9,<0.10`
- new skips for pairs that accumulated unskipped: ssh-key 0.6's ed25519-dalek 2 stack (`curve25519-dalek` 4, `ed25519` 2, `ed25519-dalek` 2, `signature` 2) vs the workspace's 3.x, `base64` 0.22 (sqlx/ctap-hid-fido2) vs 0.23, `syn` 2 vs 3 (async-trait 0.1.92 moved to syn 3), and `tower-http` 0.6 (reqwest 0.13) vs the workspace's 0.7

`cargo deny check bans` passes again. Note: `cargo deny check advisories` currently fails for everyone on cargo-deny 0.19.0 due to an upstream advisory-db entry (`RUSTSEC-0000-0000` mis-filed under `crates/gettext-rs` declaring package `gettext-sys`) — unrelated to this change and not fixable in-repo.

## Testing

- `cargo test -p vouch-tests --test fido2_posture_e2e` — 5 passed (incl. the new test)
- `cargo test -p vouch-server --lib` — 2788 passed
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo deny check bans` — ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds best-effort OAuth audit logging after token issuance (same pattern as other grants) and dependency-policy-only `deny.toml` changes; no auth or token semantics change.
> 
> **Overview**
> **FIDO2 grant audit parity.** Successful FIDO2 assertion grants now write an `oauth_token_issued` audit row (user, client IP/user-agent, `grant_type=fido2-assertion`) after the access token is created, aligning with other OAuth grant paths. Client metadata is captured before `client_info` is consumed by the login-success audit. An e2e test asserts exactly one such event with the grant type in the payload.
> 
> **cargo-deny bans.** `deny.toml` widens the stale `rand@0.9.4` skip to `rand:>=0.9,<0.10` and adds skips for newly surfaced duplicate versions (`base64` 0.22, ssh-key’s ed25519 2.x stack, `syn` 2, `tower-http` 0.6) so `cargo deny check bans` passes again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dec41fd03674b898f432a0d59682d0ea5cac2a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->