### PR TITLE
fix(server): require key possession before releasing enroll sessions

### DIFF
--- a/crates/vouch-server/src/db/device_auth.rs
+++ b/crates/vouch-server/src/db/device_auth.rs
@@ -23,6 +23,10 @@ pub struct DeviceAuthRequest {
     pub user_id: Option<String>,
     pub user_email: Option<String>,
     pub authenticator_id: Option<String>,
+    /// Whether the approving browser session completed a WebAuthn ceremony.
+    /// The device-code grant issues its token with this as the
+    /// `hardware_verified` claim.
+    pub hardware_verified: bool,
     pub expires_at: Timestamp,
     pub interval_seconds: i32,
     pub last_poll_at: Option<Timestamp>,
@@ -40,6 +44,7 @@ impl From<Document<DeviceAuthRequestDoc>> for DeviceAuthRequest {
             user_id: doc.data.user_id,
             user_email: doc.data.user_email,
             authenticator_id: doc.data.authenticator_id,
+            hardware_verified: doc.data.hardware_verified,
             expires_at: doc.data.expires_at,
             interval_seconds: doc.data.interval_seconds,
             last_poll_at: doc.data.last_poll_at,
@@ -120,6 +125,7 @@ pub async fn create_device_auth_request(
         user_id: None,
         user_email: None,
         authenticator_id: None,
+        hardware_verified: false,
         expires_at,
         interval_seconds,
         last_poll_at: None,
@@ -164,6 +170,20 @@ pub(crate) async fn get_device_auth_by_id(
     Ok(doc.map(DeviceAuthRequest::from))
 }
 
+/// Inputs for [`authorize_device_auth`].
+pub struct AuthorizeDeviceAuthParams<'a> {
+    /// ID of the pending device authorization request.
+    pub id: &'a str,
+    pub user_id: &'a str,
+    pub user_email: &'a str,
+    /// Authenticator that approved the request.
+    pub authenticator_id: &'a str,
+    /// Whether the approving browser session completed a WebAuthn ceremony.
+    /// Recorded on the request so the device-code grant issues its token with
+    /// a `hardware_verified` claim that reflects what actually happened.
+    pub hardware_verified: bool,
+}
+
 /// Authorize a device auth request.
 ///
 /// Uses `compare_and_update` (OCC) so two concurrent authorization
@@ -173,11 +193,16 @@ pub(crate) async fn get_device_auth_by_id(
 /// each clobbering the other's user attribution.
 pub async fn authorize_device_auth(
     store: &DocumentStore,
-    id: &str,
-    user_id: &str,
-    user_email: &str,
-    authenticator_id: &str,
+    params: AuthorizeDeviceAuthParams<'_>,
 ) -> Result<()> {
+    let AuthorizeDeviceAuthParams {
+        id,
+        user_id,
+        user_email,
+        authenticator_id,
+        hardware_verified,
+    } = params;
+
     if id.is_empty() {
         bail!("authorize_device_auth called with empty id");
     }
@@ -206,6 +231,7 @@ pub async fn authorize_device_auth(
     data.user_id = Some(user_id.to_string());
     data.user_email = Some(user_email.to_string());
     data.authenticator_id = Some(authenticator_id.to_string());
+    data.hardware_verified = hardware_verified;
     let won = store.compare_and_update(id, version, &data).await?;
     if !won {
         bail!(

--- a/crates/vouch-server/src/db/documents/device_auth.rs
+++ b/crates/vouch-server/src/db/documents/device_auth.rs
@@ -35,8 +35,8 @@ pub struct DeviceAuthRequestDoc {
     /// with a WebAuthn ceremony. The device-code grant copies this onto the
     /// issued token's `hardware_verified` claim, so an approval that never
     /// exercised the authenticator cannot mint a token asserting it did.
-    /// Defaults to `false` so documents written before this field existed
-    /// (rolling deploy) are treated as unverified.
+    /// Absent from documents written by an older server during a rolling
+    /// deploy; the default treats those as unverified.
     #[serde(default)]
     pub hardware_verified: bool,
     pub expires_at: Timestamp,

--- a/crates/vouch-server/src/db/documents/device_auth.rs
+++ b/crates/vouch-server/src/db/documents/device_auth.rs
@@ -31,6 +31,14 @@ pub struct DeviceAuthRequestDoc {
     pub user_id: Option<String>,
     pub user_email: Option<String>,
     pub authenticator_id: Option<String>,
+    /// Whether the approving browser session proved possession of the key
+    /// with a WebAuthn ceremony. The device-code grant copies this onto the
+    /// issued token's `hardware_verified` claim, so an approval that never
+    /// exercised the authenticator cannot mint a token asserting it did.
+    /// Defaults to `false` so documents written before this field existed
+    /// (rolling deploy) are treated as unverified.
+    #[serde(default)]
+    pub hardware_verified: bool,
     pub expires_at: Timestamp,
     pub interval_seconds: i32,
     pub last_poll_at: Option<Timestamp>,

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -97,17 +97,13 @@ pub use organizations::create_organization;
 
 // Re-export device auth types and functions
 pub use device_auth::{
-    DeviceAuthRequest, DeviceAuthStatus, OidcState, authorize_device_auth,
-    create_device_auth_request, create_oidc_state, delete_expired_device_auth_requests,
-    delete_expired_oidc_states, deny_device_auth, get_device_auth_by_code_hash,
-    get_device_auth_by_user_code, get_oidc_state, try_consume_device_auth, try_consume_oidc_state,
-    update_device_auth_poll_time,
+    AuthorizeDeviceAuthParams, DeviceAuthRequest, DeviceAuthStatus, OidcState,
+    authorize_device_auth, create_device_auth_request, create_oidc_state,
+    delete_expired_device_auth_requests, delete_expired_oidc_states, deny_device_auth,
+    get_device_auth_by_code_hash, get_device_auth_by_user_code, get_oidc_state,
+    try_consume_device_auth, try_consume_oidc_state, update_device_auth_poll_time,
 };
-pub(crate) use device_auth::{DeviceCodeClaim, OidcStateClaim};
-
-// Re-export device auth test helpers (only available in tests)
-#[cfg(test)]
-pub(crate) use device_auth::get_device_auth_by_id;
+pub(crate) use device_auth::{DeviceCodeClaim, OidcStateClaim, get_device_auth_by_id};
 
 // Re-export audit event types (used by integration tests and the handlers)
 pub use audit::{AuditEvent, AuditEventFilter, AuditEventKind, Retention};

--- a/crates/vouch-server/src/db/tests/concurrency.rs
+++ b/crates/vouch-server/src/db/tests/concurrency.rs
@@ -86,9 +86,18 @@ async fn test_device_auth_consume_concurrent() {
     )
     .await
     .expect("create authenticator");
-    authorize_device_auth(&store, &id, &user_id, "race-device@example.com", &auth_id)
-        .await
-        .expect("authorize");
+    authorize_device_auth(
+        &store,
+        AuthorizeDeviceAuthParams {
+            id: &id,
+            user_id: &user_id,
+            user_email: "race-device@example.com",
+            authenticator_id: &auth_id,
+            hardware_verified: true,
+        },
+    )
+    .await
+    .expect("authorize");
 
     let store_a = store.clone();
     let store_b = store.clone();
@@ -249,20 +258,26 @@ async fn test_authorize_device_auth_concurrent() {
         async move {
             authorize_device_auth(
                 &store_a,
-                &id_a,
-                &uid_a,
-                "race-authorize@example.com",
-                &aid_a,
+                AuthorizeDeviceAuthParams {
+                    id: &id_a,
+                    user_id: &uid_a,
+                    user_email: "race-authorize@example.com",
+                    authenticator_id: &aid_a,
+                    hardware_verified: true,
+                },
             )
             .await
         },
         async move {
             authorize_device_auth(
                 &store_b,
-                &id_b,
-                &uid_b,
-                "race-authorize@example.com",
-                &aid_b,
+                AuthorizeDeviceAuthParams {
+                    id: &id_b,
+                    user_id: &uid_b,
+                    user_email: "race-authorize@example.com",
+                    authenticator_id: &aid_b,
+                    hardware_verified: true,
+                },
             )
             .await
         },
@@ -1020,10 +1035,13 @@ async fn test_delete_authenticator_clears_device_auth_reference() {
     // Authorize to bind the authenticator_id.
     authorize_device_auth(
         &store,
-        &request_id,
-        &user_id,
-        "cascade@example.com",
-        &auth_id,
+        AuthorizeDeviceAuthParams {
+            id: &request_id,
+            user_id: &user_id,
+            user_email: "cascade@example.com",
+            authenticator_id: &auth_id,
+            hardware_verified: true,
+        },
     )
     .await
     .expect("authorize device auth");

--- a/crates/vouch-server/src/db/tests/device_auth.rs
+++ b/crates/vouch-server/src/db/tests/device_auth.rs
@@ -114,9 +114,18 @@ async fn test_device_auth_authorization_flow() {
     assert_eq!(request.status, DeviceAuthStatus::Pending);
 
     // Authorize the request
-    authorize_device_auth(&store, &id, &user_id, &user.email, &auth_id)
-        .await
-        .expect("Failed to authorize");
+    authorize_device_auth(
+        &store,
+        AuthorizeDeviceAuthParams {
+            id: &id,
+            user_id: &user_id,
+            user_email: &user.email,
+            authenticator_id: &auth_id,
+            hardware_verified: true,
+        },
+    )
+    .await
+    .expect("Failed to authorize");
 
     // Verify status changed to authorized
     let request = get_device_auth_by_id(&store, &id)
@@ -213,9 +222,18 @@ async fn test_try_consume_device_auth_authorized_succeeds() {
     .await
     .expect("auth");
 
-    authorize_device_auth(&store, &id, &user_id, "consume@example.com", &auth_id)
-        .await
-        .expect("authorize");
+    authorize_device_auth(
+        &store,
+        AuthorizeDeviceAuthParams {
+            id: &id,
+            user_id: &user_id,
+            user_email: "consume@example.com",
+            authenticator_id: &auth_id,
+            hardware_verified: true,
+        },
+    )
+    .await
+    .expect("authorize");
 
     // Consume — claim binding satisfies #[must_use].
     let _claim = try_consume_device_auth(&store, device_code_hash)
@@ -266,9 +284,18 @@ async fn test_try_consume_device_auth_already_consumed_returns_false() {
     .await
     .expect("auth");
 
-    authorize_device_auth(&store, &id, &user_id, "double@example.com", &auth_id)
-        .await
-        .expect("authorize");
+    authorize_device_auth(
+        &store,
+        AuthorizeDeviceAuthParams {
+            id: &id,
+            user_id: &user_id,
+            user_email: "double@example.com",
+            authenticator_id: &auth_id,
+            hardware_verified: true,
+        },
+    )
+    .await
+    .expect("authorize");
 
     let _first = try_consume_device_auth(&store, device_code_hash)
         .await
@@ -335,9 +362,18 @@ async fn test_try_consume_device_auth_expired_returns_false() {
     .await
     .expect("auth");
 
-    authorize_device_auth(&store, &id, &user_id, "expired@example.com", &auth_id)
-        .await
-        .expect("authorize");
+    authorize_device_auth(
+        &store,
+        AuthorizeDeviceAuthParams {
+            id: &id,
+            user_id: &user_id,
+            user_email: "expired@example.com",
+            authenticator_id: &auth_id,
+            hardware_verified: true,
+        },
+    )
+    .await
+    .expect("authorize");
 
     let consumed = try_consume_device_auth(&store, device_code_hash).await;
     assert!(
@@ -400,11 +436,30 @@ async fn test_double_authorization_should_fail() {
     .await
     .expect("create");
 
-    authorize_device_auth(&store, &id, "user_a", "a@example.com", "auth_a")
-        .await
-        .expect("first authorization should succeed");
+    authorize_device_auth(
+        &store,
+        AuthorizeDeviceAuthParams {
+            id: &id,
+            user_id: "user_a",
+            user_email: "a@example.com",
+            authenticator_id: "auth_a",
+            hardware_verified: true,
+        },
+    )
+    .await
+    .expect("first authorization should succeed");
 
-    let result = authorize_device_auth(&store, &id, "user_b", "b@example.com", "auth_b").await;
+    let result = authorize_device_auth(
+        &store,
+        AuthorizeDeviceAuthParams {
+            id: &id,
+            user_id: "user_b",
+            user_email: "b@example.com",
+            authenticator_id: "auth_b",
+            hardware_verified: true,
+        },
+    )
+    .await;
     assert!(result.is_err(), "second authorization should fail");
 
     // Original user must be preserved
@@ -433,7 +488,17 @@ async fn test_authorize_after_deny_should_fail() {
 
     deny_device_auth(&store, &id).await.expect("deny succeeds");
 
-    let result = authorize_device_auth(&store, &id, "user_a", "a@example.com", "auth_a").await;
+    let result = authorize_device_auth(
+        &store,
+        AuthorizeDeviceAuthParams {
+            id: &id,
+            user_id: "user_a",
+            user_email: "a@example.com",
+            authenticator_id: "auth_a",
+            hardware_verified: true,
+        },
+    )
+    .await;
     assert!(result.is_err(), "authorize after deny should fail");
 
     let req = get_device_auth_by_id(&store, &id)
@@ -459,9 +524,18 @@ async fn test_deny_after_authorize_should_fail() {
     .await
     .expect("create");
 
-    authorize_device_auth(&store, &id, "user_a", "a@example.com", "auth_a")
-        .await
-        .expect("authorize succeeds");
+    authorize_device_auth(
+        &store,
+        AuthorizeDeviceAuthParams {
+            id: &id,
+            user_id: "user_a",
+            user_email: "a@example.com",
+            authenticator_id: "auth_a",
+            hardware_verified: true,
+        },
+    )
+    .await
+    .expect("authorize succeeds");
 
     let result = deny_device_auth(&store, &id).await;
     assert!(result.is_err(), "deny after authorize should fail");

--- a/crates/vouch-server/src/handlers/applications/api.rs
+++ b/crates/vouch-server/src/handlers/applications/api.rs
@@ -6,14 +6,7 @@
 
 use crate::AppState;
 use crate::db::{self, AccessScope, OAuthEventType, UpdateOAuthClientParams};
-use axum::extract::OriginalUri;
-use axum::http::Method;
-use axum::{
-    Json,
-    extract::State,
-    http::{HeaderMap, StatusCode},
-};
-use axum_extra::extract::cookie::CookieJar;
+use axum::{Json, extract::State, http::StatusCode};
 use std::sync::Arc;
 
 use super::generate_client_secret;
@@ -28,31 +21,16 @@ use super::validate::{
     validate_update_format,
 };
 use crate::error::ServiceError;
-use crate::handlers::extractors::OptionalClientCert;
 use crate::handlers::hash_token;
-use crate::handlers::session::extract_resource_token;
+use crate::handlers::session::AuthenticatedToken;
 use crate::handlers::{ValidPath, ValidUuid};
 
 /// List user's applications (API).
 /// GET /api/v1/applications
 pub(crate) async fn list_applications_api(
-    method: Method,
-    uri: OriginalUri,
-    headers: HeaderMap,
-    jar: CookieJar,
     State(state): State<Arc<AppState>>,
-    client_cert: OptionalClientCert,
+    AuthenticatedToken(token): AuthenticatedToken,
 ) -> Result<Json<ListApplicationsResponse>, ServiceError> {
-    let token = extract_resource_token(
-        &state,
-        &headers,
-        &jar,
-        method.as_str(),
-        uri.path(),
-        client_cert.0.as_ref(),
-    )
-    .await?;
-
     let applications = db::get_oauth_clients_for_user(&state.store, &token.sub)
         .await
         .map_err(|e| {
@@ -96,12 +74,8 @@ async fn load_active_user_for_scope(
 /// Create a new application (API).
 /// POST /api/v1/applications
 pub(crate) async fn create_application_api(
-    method: Method,
-    uri: OriginalUri,
-    headers: HeaderMap,
-    jar: CookieJar,
     State(state): State<Arc<AppState>>,
-    client_cert: OptionalClientCert,
+    token: Result<AuthenticatedToken, ServiceError>,
     Json(req): Json<CreateApplicationRequest>,
 ) -> Result<Json<CreateApplicationResponse>, ServiceError> {
     // ── Pure format validation first — no DB cost for malformed requests ──
@@ -124,15 +98,10 @@ pub(crate) async fn create_application_api(
     let is_fapi = validated.is_fapi;
 
     // ── Authentication — validated input is good, now check credentials ──
-    let token = extract_resource_token(
-        &state,
-        &headers,
-        &jar,
-        method.as_str(),
-        uri.path(),
-        client_cert.0.as_ref(),
-    )
-    .await?;
+    // Deferred so a malformed body still answers 400 rather than 401; an
+    // unauthenticated request costs no DB lookup either way, because token
+    // extraction fails before touching the store when no credential is sent.
+    let AuthenticatedToken(token) = token?;
 
     // Parse access scope (default to personal if not provided)
     let access_scope = req
@@ -236,24 +205,10 @@ pub(crate) async fn create_application_api(
 /// Get application details (API).
 /// GET /api/v1/applications/:id
 pub(crate) async fn get_application_api(
-    method: Method,
-    uri: OriginalUri,
-    headers: HeaderMap,
-    jar: CookieJar,
     State(state): State<Arc<AppState>>,
-    client_cert: OptionalClientCert,
+    AuthenticatedToken(token): AuthenticatedToken,
     ValidPath(app_id): ValidPath<ValidUuid>,
 ) -> Result<Json<ApplicationResponse>, ServiceError> {
-    let token = extract_resource_token(
-        &state,
-        &headers,
-        &jar,
-        method.as_str(),
-        uri.path(),
-        client_cert.0.as_ref(),
-    )
-    .await?;
-
     let client = db::get_oauth_client_by_id(&state.store, &app_id)
         .await
         .map_err(|e| {
@@ -282,17 +237,9 @@ pub(crate) async fn get_application_api(
 
 /// Update an application (API).
 /// PATCH /api/v1/applications/:id
-#[expect(
-    clippy::too_many_arguments,
-    reason = "axum handler signature: extractors are positional parameters"
-)]
 pub(crate) async fn update_application_api(
-    method: Method,
-    uri: OriginalUri,
-    headers: HeaderMap,
-    jar: CookieJar,
     State(state): State<Arc<AppState>>,
-    client_cert: OptionalClientCert,
+    token: Result<AuthenticatedToken, ServiceError>,
     ValidPath(app_id): ValidPath<ValidUuid>,
     Json(req): Json<UpdateApplicationRequest>,
 ) -> Result<Json<ApplicationResponse>, ServiceError> {
@@ -308,15 +255,10 @@ pub(crate) async fn update_application_api(
     })?;
 
     // ── Authentication — validated input is good, now check credentials ──
-    let token = extract_resource_token(
-        &state,
-        &headers,
-        &jar,
-        method.as_str(),
-        uri.path(),
-        client_cert.0.as_ref(),
-    )
-    .await?;
+    // Deferred so a malformed body still answers 400 rather than 401; an
+    // unauthenticated request costs no DB lookup either way, because token
+    // extraction fails before touching the store when no credential is sent.
+    let AuthenticatedToken(token) = token?;
 
     // Get existing application
     let client = db::get_oauth_client_by_id(&state.store, &app_id)
@@ -442,24 +384,10 @@ pub(crate) async fn update_application_api(
 /// Delete an application (API).
 /// DELETE /api/v1/applications/:id
 pub(crate) async fn delete_application_api(
-    method: Method,
-    uri: OriginalUri,
-    headers: HeaderMap,
-    jar: CookieJar,
     State(state): State<Arc<AppState>>,
-    client_cert: OptionalClientCert,
+    AuthenticatedToken(token): AuthenticatedToken,
     ValidPath(app_id): ValidPath<ValidUuid>,
 ) -> Result<StatusCode, ServiceError> {
-    let token = extract_resource_token(
-        &state,
-        &headers,
-        &jar,
-        method.as_str(),
-        uri.path(),
-        client_cert.0.as_ref(),
-    )
-    .await?;
-
     // Verify ownership
     let client = db::get_oauth_client_by_id(&state.store, &app_id)
         .await
@@ -501,30 +429,12 @@ pub(crate) async fn delete_application_api(
 
 /// Add a new client secret (API).
 /// POST /api/v1/applications/:id/secrets
-#[expect(
-    clippy::too_many_arguments,
-    reason = "axum handler signature: extractors are positional parameters"
-)]
 pub(crate) async fn add_secret_api(
-    method: Method,
-    uri: OriginalUri,
-    headers: HeaderMap,
-    jar: CookieJar,
     State(state): State<Arc<AppState>>,
-    client_cert: OptionalClientCert,
+    AuthenticatedToken(token): AuthenticatedToken,
     ValidPath(app_id): ValidPath<ValidUuid>,
     Json(req): Json<AddSecretRequest>,
 ) -> Result<(StatusCode, Json<AddSecretResponse>), ServiceError> {
-    let token = extract_resource_token(
-        &state,
-        &headers,
-        &jar,
-        method.as_str(),
-        uri.path(),
-        client_cert.0.as_ref(),
-    )
-    .await?;
-
     let client = db::get_oauth_client_by_id(&state.store, &app_id)
         .await
         .map_err(|e| {
@@ -611,24 +521,10 @@ pub(crate) async fn add_secret_api(
 /// List secrets for an application (API).
 /// GET /api/v1/applications/:id/secrets
 pub(crate) async fn list_secrets_api(
-    method: Method,
-    uri: OriginalUri,
-    headers: HeaderMap,
-    jar: CookieJar,
     State(state): State<Arc<AppState>>,
-    client_cert: OptionalClientCert,
+    AuthenticatedToken(token): AuthenticatedToken,
     ValidPath(app_id): ValidPath<ValidUuid>,
 ) -> Result<Json<ListSecretsResponse>, ServiceError> {
-    let token = extract_resource_token(
-        &state,
-        &headers,
-        &jar,
-        method.as_str(),
-        uri.path(),
-        client_cert.0.as_ref(),
-    )
-    .await?;
-
     let client = db::get_oauth_client_by_id(&state.store, &app_id)
         .await
         .map_err(|e| {
@@ -682,24 +578,10 @@ pub(crate) async fn list_secrets_api(
 /// Delete (revoke) a secret (API).
 /// DELETE /api/v1/applications/:id/secrets/:secret_id
 pub(crate) async fn delete_secret_api(
-    method: Method,
-    uri: OriginalUri,
-    headers: HeaderMap,
-    jar: CookieJar,
     State(state): State<Arc<AppState>>,
-    client_cert: OptionalClientCert,
+    AuthenticatedToken(token): AuthenticatedToken,
     ValidPath((app_id, secret_id)): ValidPath<(ValidUuid, ValidUuid)>,
 ) -> Result<StatusCode, ServiceError> {
-    let token = extract_resource_token(
-        &state,
-        &headers,
-        &jar,
-        method.as_str(),
-        uri.path(),
-        client_cert.0.as_ref(),
-    )
-    .await?;
-
     let client = db::get_oauth_client_by_id(&state.store, &app_id)
         .await
         .map_err(|e| {
@@ -806,24 +688,10 @@ pub(crate) async fn delete_secret_api(
 /// Revoke all tokens for an application (API).
 /// `POST /api/v1/applications/:id/revoke`
 pub(crate) async fn revoke_tokens_api(
-    method: Method,
-    uri: OriginalUri,
-    headers: HeaderMap,
-    jar: CookieJar,
     State(state): State<Arc<AppState>>,
-    client_cert: OptionalClientCert,
+    AuthenticatedToken(token): AuthenticatedToken,
     ValidPath(app_id): ValidPath<ValidUuid>,
 ) -> Result<StatusCode, ServiceError> {
-    let token = extract_resource_token(
-        &state,
-        &headers,
-        &jar,
-        method.as_str(),
-        uri.path(),
-        client_cert.0.as_ref(),
-    )
-    .await?;
-
     // Verify ownership
     let client = db::get_oauth_client_by_id(&state.store, &app_id)
         .await

--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -192,15 +192,26 @@ pub(crate) struct LoginQuery {
 /// token when an already-enrolled user runs `vouch enroll`; the assertion in
 /// [`browser_login_complete`] is what authorizes it.
 ///
-/// Returns `None` when there is no session cookie, no enrollment session for
-/// it, or the enrollment session carries no device authorization.
-async fn pending_device_auth(state: &AppState, jar: &CookieJar) -> Option<db::EnrollmentSession> {
-    let token = jar.get(vouch_common::SESSION_COOKIE_NAME)?.value();
-    let session = db::get_enrollment_session_by_token_hash(&state.store, &hash_token(token))
-        .await
-        .ok()
-        .flatten()?;
-    session.device_auth_id.is_some().then_some(session)
+/// `Ok(None)` when there is no session cookie, no enrollment session for it, or
+/// the enrollment session carries no device authorization — all ordinary for a
+/// plain login.
+///
+/// # Errors
+///
+/// Propagates storage failures instead of reporting them as "nothing pending".
+/// Collapsing the two would strand the waiting CLI: the caller could skip the
+/// assertion form, or issue a session while the device request stays pending,
+/// with nothing on screen to explain why.
+async fn pending_device_auth(
+    state: &AppState,
+    jar: &CookieJar,
+) -> Result<Option<db::EnrollmentSession>, ServiceError> {
+    let Some(cookie) = jar.get(vouch_common::SESSION_COOKIE_NAME) else {
+        return Ok(None);
+    };
+    let session =
+        db::get_enrollment_session_by_token_hash(&state.store, &hash_token(cookie.value())).await?;
+    Ok(session.filter(|s| s.device_auth_id.is_some()))
 }
 
 pub(crate) async fn login_page(
@@ -234,11 +245,21 @@ pub(crate) async fn login_page(
     // forced re-auth.
     // A session created by `vouch enroll` for an already-enrolled user is
     // authenticated but not hardware-verified, and a CLI is waiting on the
-    // assertion. Skipping the form here would leave it polling forever.
+    // assertion. Skipping the form here would leave it polling forever, so a
+    // lookup failure forces the form too: rendering it needlessly costs the
+    // user one touch, skipping it strands the CLI until it times out.
+    let device_auth_pending = match pending_device_auth(&state, &jar).await {
+        Ok(pending) => pending.is_some(),
+        Err(e) => {
+            tracing::error!("Failed to check for a pending device authorization: {e}");
+            true
+        }
+    };
+
     let requires_reauth = pending
         .as_ref()
         .is_some_and(|p| p.prompt.as_deref() == Some("login") || p.max_age.is_some())
-        || pending_device_auth(&state, &jar).await.is_some();
+        || device_auth_pending;
 
     if auth.authenticated && !requires_reauth {
         if let Some(ref pending_id) = query.pending_auth {
@@ -694,10 +715,10 @@ pub(crate) async fn browser_login_complete(
     let new_counter = verification_result.new_counter.cast_signed();
     db::update_authenticator_counter(&state.store, &authenticator.id, new_counter).await?;
 
-    // Release a CLI waiting on `vouch enroll`. The assertion just verified is
-    // the possession proof the upstream IdP sign-in could not provide, so the
-    // device authorization is approved here rather than at IdP callback.
-    if let Some(enrollment) = pending_device_auth(&state, &jar).await
+    // Release a CLI waiting on `vouch enroll`: the assertion just verified is
+    // the possession proof the upstream IdP sign-in cannot provide, so the
+    // device authorization is authorized from here.
+    if let Some(enrollment) = pending_device_auth(&state, &jar).await?
         && let Some(ref device_auth_id) = enrollment.device_auth_id
     {
         // The enrollment session must belong to whoever just asserted;
@@ -1081,6 +1102,58 @@ mod tests {
         assert!(
             location.contains("/oauth/authorize"),
             "Should redirect to /oauth/authorize: {location}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_login_page_shows_form_when_device_auth_pending() {
+        // A returning user running `vouch enroll` arrives here already
+        // carrying a session cookie. Redirecting them away because they look
+        // authenticated would leave the CLI polling until it times out — the
+        // assertion is what authorizes the waiting device request.
+        let (app, state) = crate::test_utils::test_app().await;
+
+        let user =
+            crate::test_utils::create_test_user(&state.store, "cli-assert@example.com").await;
+        let auth_id = crate::test_utils::create_test_authenticator(&state.store, &user.id).await;
+        let session_token =
+            crate::test_utils::create_test_session(&state, &user.id, &user.email, &auth_id).await;
+
+        let expires: jiff::Timestamp = "2099-12-31T23:59:59Z".parse().expect("valid timestamp");
+        let device_auth_id = crate::db::create_device_auth_request(
+            &state.store,
+            "login-page-device-hash",
+            "LGPG-CODE",
+            None,
+            expires,
+            0,
+        )
+        .await
+        .expect("create device auth");
+
+        crate::db::create_enrollment_session(
+            &state.store,
+            &user.id,
+            &user.email,
+            &crate::crypto::hash_token(&session_token),
+            Some(&device_auth_id),
+            expires,
+        )
+        .await
+        .expect("create enrollment session");
+
+        let resp = crate::test_utils::http_get_full(
+            &app,
+            "/login",
+            &[("Cookie", &format!("__Host-vouch_session={session_token}"))],
+        )
+        .await;
+
+        assert_eq!(
+            resp.status,
+            axum::http::StatusCode::OK,
+            "an authenticated session with a device authorization waiting must \
+             still be shown the assertion form, got a redirect"
         );
     }
 

--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -21,6 +21,7 @@
 
 use crate::AppState;
 use crate::crypto::generate_challenge;
+use crate::crypto::hash_token;
 use crate::db::ClientInfo;
 use crate::db::{self, AuthEventParams, AuthEventType};
 use crate::error::ServiceError;
@@ -186,6 +187,22 @@ pub(crate) struct LoginQuery {
     pending_auth: Option<String>,
 }
 
+/// The pending CLI device authorization this browser session must release, if
+/// any. `complete_enrollment_after_identity` records it against the session
+/// token when an already-enrolled user runs `vouch enroll`; the assertion in
+/// [`browser_login_complete`] is what authorizes it.
+///
+/// Returns `None` when there is no session cookie, no enrollment session for
+/// it, or the enrollment session carries no device authorization.
+async fn pending_device_auth(state: &AppState, jar: &CookieJar) -> Option<db::EnrollmentSession> {
+    let token = jar.get(vouch_common::SESSION_COOKIE_NAME)?.value();
+    let session = db::get_enrollment_session_by_token_hash(&state.store, &hash_token(token))
+        .await
+        .ok()
+        .flatten()?;
+    session.device_auth_id.is_some().then_some(session)
+}
+
 pub(crate) async fn login_page(
     State(state): State<Arc<AppState>>,
     axum::extract::Query(query): axum::extract::Query<LoginQuery>,
@@ -215,9 +232,13 @@ pub(crate) async fn login_page(
     // re-authentication when the session age exceeds the requested value.
     // Only skip the login form when the pending auth does NOT require
     // forced re-auth.
+    // A session created by `vouch enroll` for an already-enrolled user is
+    // authenticated but not hardware-verified, and a CLI is waiting on the
+    // assertion. Skipping the form here would leave it polling forever.
     let requires_reauth = pending
         .as_ref()
-        .is_some_and(|p| p.prompt.as_deref() == Some("login") || p.max_age.is_some());
+        .is_some_and(|p| p.prompt.as_deref() == Some("login") || p.max_age.is_some())
+        || pending_device_auth(&state, &jar).await.is_some();
 
     if auth.authenticated && !requires_reauth {
         if let Some(ref pending_id) = query.pending_auth {
@@ -380,7 +401,7 @@ pub(crate) async fn browser_login_complete(
     State(state): State<Arc<AppState>>,
     client_info: ClientInfo,
     headers: HeaderMap,
-    _jar: CookieJar,
+    jar: CookieJar,
     Json(req): Json<BrowserLoginCompleteRequest>,
 ) -> Result<Response, ServiceError> {
     // ── Phase 1: Origin header validation ────────────────────────────────
@@ -672,6 +693,57 @@ pub(crate) async fn browser_login_complete(
     // approach 2^31 uses, and bitwise reinterpret preserves DB monotonicity comparisons.
     let new_counter = verification_result.new_counter.cast_signed();
     db::update_authenticator_counter(&state.store, &authenticator.id, new_counter).await?;
+
+    // Release a CLI waiting on `vouch enroll`. The assertion just verified is
+    // the possession proof the upstream IdP sign-in could not provide, so the
+    // device authorization is approved here rather than at IdP callback.
+    if let Some(enrollment) = pending_device_auth(&state, &jar).await
+        && let Some(ref device_auth_id) = enrollment.device_auth_id
+    {
+        // The enrollment session must belong to whoever just asserted;
+        // otherwise a stale cookie would approve another user's device
+        // authorization using this user's hardware proof.
+        if enrollment.user_id == user.id {
+            db::authorize_device_auth(
+                &state.store,
+                db::AuthorizeDeviceAuthParams {
+                    id: device_auth_id,
+                    user_id: &user.id,
+                    user_email: &user.email,
+                    authenticator_id: &authenticator.id,
+                    hardware_verified: true,
+                },
+            )
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to authorize device auth '{device_auth_id}': {e}");
+                ServiceError::api(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "device_auth_failed",
+                    "Failed to complete CLI authorization",
+                )
+            })?;
+
+            db::spawn_audit_event(
+                &state.audit,
+                AuthEventParams {
+                    user_id: user.id.clone(),
+                    event_type: AuthEventType::DeviceAuthApproved,
+                    authenticator_id: Some(authenticator.id.clone()),
+                    success: true,
+                    client: client_info.clone(),
+                    ..AuthEventParams::default()
+                },
+                Some(user.email.clone()),
+            );
+        } else {
+            tracing::warn!(
+                target: "security",
+                "Enrollment session belongs to a different user than the one asserting; \
+                 refusing to approve the device authorization"
+            );
+        }
+    }
 
     // Issue an OAuth access token (RFC 9068) — the server acts as both issuer and audience
     let client_id = state.config().base_url.clone();

--- a/crates/vouch-server/src/handlers/credentials.rs
+++ b/crates/vouch-server/src/handlers/credentials.rs
@@ -10,10 +10,8 @@ use crate::error::ServiceError;
 use crate::services::integrations::aws::{AwsError, issue_aws_token};
 use crate::services::integrations::github::{GitHubInstallationId, minimal_git_permissions};
 use crate::services::oidc;
-use axum::extract::{OriginalUri, Query};
-use axum::http::Method;
-use axum::{Json, extract::State, http::HeaderMap, http::StatusCode};
-use axum_extra::extract::cookie::CookieJar;
+use axum::extract::Query;
+use axum::{Json, extract::State, http::StatusCode};
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -22,8 +20,7 @@ use vouch_common::{
     SshCaPublicKeyResponse, SshCertificateRequest, SshCertificateResponse,
 };
 
-use super::extractors::OptionalClientCert;
-use super::session::{extract_resource_token, extract_resource_token_with_email};
+use super::session::{AuthenticatedToken, HardwareVerifiedToken};
 use crate::db::ClientInfo;
 use crate::redact_email;
 use crate::services::auth::ValidatedResourceToken;
@@ -34,18 +31,10 @@ use crate::services::auth::ValidatedResourceToken;
 ///
 /// Requires Bearer token authentication. Signs the provided SSH public key
 /// as a user certificate with principals extracted from the user's email.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "axum handler signature: extractors are positional parameters"
-)]
 pub(crate) async fn issue_ssh_certificate(
-    method: Method,
-    uri: OriginalUri,
-    headers: HeaderMap,
-    jar: CookieJar,
     State(state): State<Arc<AppState>>,
-    client_cert: OptionalClientCert,
     client_info: ClientInfo,
+    HardwareVerifiedToken(token): HardwareVerifiedToken,
     Json(request): Json<SshCertificateRequest>,
 ) -> Result<Json<SshCertificateResponse>, ServiceError> {
     // Check config before auth — zero-cost in-memory check avoids DB queries
@@ -57,16 +46,7 @@ pub(crate) async fn issue_ssh_certificate(
         ));
     }
 
-    // Validate token and get user email + user_id
-    let (token, user_email) = extract_resource_token_with_email(
-        &state,
-        &headers,
-        &jar,
-        method.as_str(),
-        uri.path(),
-        client_cert.0.as_ref(),
-    )
-    .await?;
+    let user_email = super::session::resolve_token_email(&state, &token).await?;
 
     // Reject deactivated users (defense-in-depth for SCIM deactivation)
     let user = super::session::load_active_user(&state, &token.sub).await?;
@@ -325,42 +305,18 @@ pub(crate) struct SshRevocationCheckResponse {
 // AWS Token Endpoint
 // ============================================================================
 
-/// Shared preamble for the AWS credential endpoints: authenticate the request,
-/// require a hardware-verified session, confirm the user is active, and resolve
-/// the user's email.
+/// Shared preamble for the AWS credential endpoints: confirm the user is active
+/// and resolve the user's email and issuer.
 ///
 /// AWS federation mints an OIDC token whose claims hardcode
 /// `hardware_verified: true`, so the *current session* must itself be
 /// hardware-verified — otherwise a non-verified bootstrap session could be
-/// laundered into a verified assertion (#451). The gate is on the access-token
-/// `hardware_verified` claim, not `authenticator_id` (a re-enrollment bootstrap
-/// session can have an `authenticator_id` while `hardware_verified` is false).
+/// laundered into a verified assertion (#451). That requirement is carried by
+/// the [`HardwareVerifiedToken`] the caller had to extract.
 async fn authorize_aws_token_request(
     state: &Arc<AppState>,
-    headers: &HeaderMap,
-    jar: &CookieJar,
-    method: &Method,
-    path: &str,
-    client_cert: &OptionalClientCert,
+    token: ValidatedResourceToken,
 ) -> Result<AwsIssuanceContext, ServiceError> {
-    let token = extract_resource_token(
-        state,
-        headers,
-        jar,
-        method.as_str(),
-        path,
-        client_cert.0.as_ref(),
-    )
-    .await?;
-
-    if !token.hardware_verified {
-        return Err(ServiceError::api(
-            StatusCode::FORBIDDEN,
-            "hardware_required",
-            "AWS federation requires a hardware-verified session - run 'vouch login' to authenticate with your security key",
-        ));
-    }
-
     // Confirm the user is still active. Email and federation claims come from
     // the session snapshot, not from current state.
     let user = super::session::load_active_user(state, &token.sub).await?;
@@ -495,28 +451,18 @@ fn validate_pinned_role(role_arn: &str) -> Result<(), ServiceError> {
 /// When the DPoP proof includes a `source` custom claim (e.g., "claude-code"),
 /// the issued token includes AI-specific session tags (`vouch:AccessType=AI`,
 /// `vouch:Agent=<agent>`) for CloudTrail differentiation and IAM condition keys.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "axum handler signature: extractors are positional parameters"
-)]
 pub(crate) async fn get_aws_token(
-    method: Method,
-    uri: OriginalUri,
-    headers: HeaderMap,
-    jar: CookieJar,
     State(state): State<Arc<AppState>>,
     Query(params): Query<AwsTokenParams>,
-    client_cert: OptionalClientCert,
     client_info: ClientInfo,
+    HardwareVerifiedToken(token): HardwareVerifiedToken,
 ) -> Result<Json<AwsTokenResponse>, ServiceError> {
     let pinned_role = params.role_arn.as_deref();
     if let Some(role_arn) = pinned_role {
         validate_pinned_role(role_arn)?;
     }
 
-    let ctx =
-        authorize_aws_token_request(&state, &headers, &jar, &method, uri.path(), &client_cert)
-            .await?;
+    let ctx = authorize_aws_token_request(&state, token).await?;
 
     // Issue AWS token using the session-time snapshot of aaguid and org domain.
     // Sign with the org's own RS256 key when it has a claimed subdomain, so the
@@ -600,24 +546,9 @@ pub(crate) async fn get_aws_token(
 ///
 /// Returns whether GitHub is configured and connected for the user's organization.
 pub(crate) async fn get_github_status(
-    method: Method,
-    uri: OriginalUri,
-    headers: HeaderMap,
-    jar: CookieJar,
     State(state): State<Arc<AppState>>,
-    client_cert: OptionalClientCert,
+    AuthenticatedToken(token): AuthenticatedToken,
 ) -> Result<Json<GitHubStatusResponse>, ServiceError> {
-    // Validate token
-    let token = extract_resource_token(
-        &state,
-        &headers,
-        &jar,
-        method.as_str(),
-        uri.path(),
-        client_cert.0.as_ref(),
-    )
-    .await?;
-
     // Get user
     let user = super::session::load_active_user(&state, &token.sub).await?;
 
@@ -662,21 +593,13 @@ pub(crate) async fn get_github_status(
 /// with Git operations. The token is scoped to the user's organization's
 /// GitHub installation with minimal permissions (contents:write, metadata:read).
 #[expect(
-    clippy::too_many_arguments,
-    reason = "axum handler signature: extractors are positional parameters"
-)]
-#[expect(
     clippy::too_many_lines,
     reason = "sequential GitHub installation token validation and issuance"
 )]
 pub(crate) async fn get_github_token(
-    method: Method,
-    uri: OriginalUri,
     client_info: ClientInfo,
-    headers: HeaderMap,
-    jar: CookieJar,
     State(state): State<Arc<AppState>>,
-    client_cert: OptionalClientCert,
+    HardwareVerifiedToken(token): HardwareVerifiedToken,
     Json(request): Json<GitHubTokenRequest>,
 ) -> Result<Json<GitHubTokenResponse>, ServiceError> {
     // Check config before auth — zero-cost in-memory check avoids DB queries
@@ -687,17 +610,6 @@ pub(crate) async fn get_github_token(
             "GitHub App is not configured",
         )
     })?;
-
-    // Validate token
-    let token = extract_resource_token(
-        &state,
-        &headers,
-        &jar,
-        method.as_str(),
-        uri.path(),
-        client_cert.0.as_ref(),
-    )
-    .await?;
 
     // Get user
     let user = super::session::load_active_user(&state, &token.sub).await?;

--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -1565,15 +1565,39 @@ mod tests {
     #[tokio::test]
     async fn test_device_grant_without_ceremony_cannot_reach_credentials() {
         let (app, token) = device_token_for_approval("unverified", false).await;
+        let auth = format!("Bearer {token}");
 
+        // Every credential endpoint, not just the one that happened to carry a
+        // check: the requirement now rides on `HardwareVerifiedToken`.
         let (status, body) = http_get(
             &app,
             "/v1/credentials/aws/token",
-            &[("Authorization", &format!("Bearer {token}"))],
+            &[("Authorization", &auth)],
         )
         .await;
+        assert_eq!(status, StatusCode::FORBIDDEN, "aws: {body}");
+        let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+        assert_eq!(error["code"], "hardware_required");
 
-        assert_eq!(status, StatusCode::FORBIDDEN, "body: {body}");
+        let (status, body) = http_post_json(
+            &app,
+            "/v1/credentials/ssh",
+            r#"{"public_key":"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA test"}"#,
+            &[("Authorization", &auth)],
+        )
+        .await;
+        assert_eq!(status, StatusCode::FORBIDDEN, "ssh: {body}");
+        let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+        assert_eq!(error["code"], "hardware_required");
+
+        let (status, body) = http_post_json(
+            &app,
+            "/v1/credentials/github/token",
+            r#"{"repositories":["owner/repo"]}"#,
+            &[("Authorization", &auth)],
+        )
+        .await;
+        assert_eq!(status, StatusCode::FORBIDDEN, "github: {body}");
         let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
         assert_eq!(error["code"], "hardware_required");
     }

--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -411,11 +411,9 @@ pub(crate) async fn device_token(
                     act: None,
                     audience: None,
                     auth_time: Some(now_secs),
-                    // Mirrors how the browser approved this request. Asserting
-                    // `Verified` unconditionally would let an approval that
-                    // never exercised the authenticator mint a token claiming
-                    // it did, which is exactly what the credential endpoints
-                    // gate on.
+                    // Mirrors how the browser approved this request, so the
+                    // claim the credential endpoints gate on reflects whether
+                    // the authenticator was actually exercised.
                     hardware_verification: if request.hardware_verified {
                         crate::services::auth::HardwareVerification::Verified
                     } else {
@@ -1558,17 +1556,15 @@ mod tests {
     }
 
     /// A device authorization approved without a WebAuthn ceremony — what an
-    /// upstream-IdP sign-in alone can produce — must not mint a token that
-    /// passes the credential endpoints' hardware gate. The grant used to
-    /// hardcode `HardwareVerification::Verified`, so `vouch enroll` handed a
-    /// returning user SSH and AWS credentials with the key untouched.
+    /// upstream-IdP sign-in alone produces — must not mint a token that clears
+    /// the credential endpoints' hardware gate.
     #[tokio::test]
     async fn test_device_grant_without_ceremony_cannot_reach_credentials() {
         let (app, token) = device_token_for_approval("unverified", false).await;
         let auth = format!("Bearer {token}");
 
-        // Every credential endpoint, not just the one that happened to carry a
-        // check: the requirement now rides on `HardwareVerifiedToken`.
+        // Every credential endpoint, since the requirement rides on
+        // `HardwareVerifiedToken` rather than a per-handler check.
         let (status, body) = http_get(
             &app,
             "/v1/credentials/aws/token",

--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -411,7 +411,16 @@ pub(crate) async fn device_token(
                     act: None,
                     audience: None,
                     auth_time: Some(now_secs),
-                    hardware_verification: crate::services::auth::HardwareVerification::Verified,
+                    // Mirrors how the browser approved this request. Asserting
+                    // `Verified` unconditionally would let an approval that
+                    // never exercised the authenticator mint a token claiming
+                    // it did, which is exactly what the credential endpoints
+                    // gate on.
+                    hardware_verification: if request.hardware_verified {
+                        crate::services::auth::HardwareVerification::Verified
+                    } else {
+                        crate::services::auth::HardwareVerification::NotVerified
+                    },
                     session_purpose: crate::db::SessionPurpose::OAuthAccessToken,
                     authorization_details: None,
                     hardware_aaguid: hardware_aaguid.as_deref(),
@@ -805,9 +814,18 @@ mod tests {
         let user = create_test_user(&state.store, "device-success@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
 
-        crate::db::authorize_device_auth(&state.store, &id, &user.id, &user.email, &auth_id)
-            .await
-            .expect("Failed to authorize device");
+        crate::db::authorize_device_auth(
+            &state.store,
+            crate::db::AuthorizeDeviceAuthParams {
+                id: &id,
+                user_id: &user.id,
+                user_email: &user.email,
+                authenticator_id: &auth_id,
+                hardware_verified: true,
+            },
+        )
+        .await
+        .expect("Failed to authorize device");
 
         // Poll for token
         let (status, body) = http_post_form(
@@ -1034,9 +1052,18 @@ mod tests {
         let user = create_test_user(&state.store, "single-use@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
 
-        crate::db::authorize_device_auth(&state.store, &id, &user.id, &user.email, &auth_id)
-            .await
-            .expect("authorize device");
+        crate::db::authorize_device_auth(
+            &state.store,
+            crate::db::AuthorizeDeviceAuthParams {
+                id: &id,
+                user_id: &user.id,
+                user_email: &user.email,
+                authenticator_id: &auth_id,
+                hardware_verified: true,
+            },
+        )
+        .await
+        .expect("authorize device");
 
         // First poll — should succeed
         let body = format!(
@@ -1085,9 +1112,18 @@ mod tests {
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
 
         // Authorize then consume
-        crate::db::authorize_device_auth(&state.store, &id, &user.id, &user.email, &auth_id)
-            .await
-            .expect("authorize");
+        crate::db::authorize_device_auth(
+            &state.store,
+            crate::db::AuthorizeDeviceAuthParams {
+                id: &id,
+                user_id: &user.id,
+                user_email: &user.email,
+                authenticator_id: &auth_id,
+                hardware_verified: true,
+            },
+        )
+        .await
+        .expect("authorize");
 
         let _claim = crate::db::try_consume_device_auth(&state.store, &device_code_hash)
             .await
@@ -1135,9 +1171,18 @@ mod tests {
         let user = create_test_user(&state.store, "revoke@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
 
-        crate::db::authorize_device_auth(&state.store, &id, &user.id, &user.email, &auth_id)
-            .await
-            .expect("authorize");
+        crate::db::authorize_device_auth(
+            &state.store,
+            crate::db::AuthorizeDeviceAuthParams {
+                id: &id,
+                user_id: &user.id,
+                user_email: &user.email,
+                authenticator_id: &auth_id,
+                hardware_verified: true,
+            },
+        )
+        .await
+        .expect("authorize");
 
         // First poll — get a real token
         let body = format!(
@@ -1268,9 +1313,18 @@ mod tests {
         let user = create_test_user(&state.store, &format!("{setup_label}@example.com")).await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
 
-        crate::db::authorize_device_auth(&state.store, &id, &user.id, &user.email, &auth_id)
-            .await
-            .expect("authorize device");
+        crate::db::authorize_device_auth(
+            &state.store,
+            crate::db::AuthorizeDeviceAuthParams {
+                id: &id,
+                user_id: &user.id,
+                user_email: &user.email,
+                authenticator_id: &auth_id,
+                hardware_verified: true,
+            },
+        )
+        .await
+        .expect("authorize device");
 
         // Create a pre-existing OAuth session for the user. Its survival
         // after a race-loser AlreadyConsumed is the regression we test for.
@@ -1415,9 +1469,18 @@ mod tests {
 
         let user = create_test_user(&state.store, "device-deactivated@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        crate::db::authorize_device_auth(&state.store, &id, &user.id, &user.email, &auth_id)
-            .await
-            .expect("authorize device");
+        crate::db::authorize_device_auth(
+            &state.store,
+            crate::db::AuthorizeDeviceAuthParams {
+                id: &id,
+                user_id: &user.id,
+                user_email: &user.email,
+                authenticator_id: &auth_id,
+                hardware_verified: true,
+            },
+        )
+        .await
+        .expect("authorize device");
 
         crate::db::update_user_active_status(&state.store, &user.id, false)
             .await
@@ -1438,6 +1501,105 @@ mod tests {
         assert!(
             !resp.contains("access_token"),
             "no token may be issued: {resp}"
+        );
+    }
+
+    /// Exchange a device code whose authorization recorded
+    /// `hardware_verified`, and return the issued access token.
+    async fn device_token_for_approval(
+        label: &str,
+        hardware_verified: bool,
+    ) -> (axum::Router, String) {
+        let (app, state) = test_app().await;
+
+        let device_code = format!("test_hwv_{label}");
+        let expires_at = Timestamp::now()
+            .checked_add(Span::new().hours(1))
+            .expect("expiry");
+        let id = crate::db::create_device_auth_request(
+            &state.store,
+            &hash_device_code(&device_code),
+            "HWV-CODE",
+            None,
+            expires_at,
+            0,
+        )
+        .await
+        .expect("create device auth");
+
+        let user = create_test_user(&state.store, &format!("{label}@example.com")).await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        crate::db::authorize_device_auth(
+            &state.store,
+            crate::db::AuthorizeDeviceAuthParams {
+                id: &id,
+                user_id: &user.id,
+                user_email: &user.email,
+                authenticator_id: &auth_id,
+                hardware_verified,
+            },
+        )
+        .await
+        .expect("authorize device");
+
+        let body = format!(
+            "grant_type=urn:ietf:params:oauth:grant-type:\
+             device_code&device_code={device_code}"
+        );
+        let (status, resp) = http_post_form(&app, "/oauth/token", &body, &[]).await;
+        assert_eq!(status, StatusCode::OK, "device grant should issue: {resp}");
+        let json: serde_json::Value = serde_json::from_str(&resp).expect("Valid JSON");
+        let token = json["access_token"]
+            .as_str()
+            .expect("access_token")
+            .to_string();
+
+        (app, token)
+    }
+
+    /// A device authorization approved without a WebAuthn ceremony — what an
+    /// upstream-IdP sign-in alone can produce — must not mint a token that
+    /// passes the credential endpoints' hardware gate. The grant used to
+    /// hardcode `HardwareVerification::Verified`, so `vouch enroll` handed a
+    /// returning user SSH and AWS credentials with the key untouched.
+    #[tokio::test]
+    async fn test_device_grant_without_ceremony_cannot_reach_credentials() {
+        let (app, token) = device_token_for_approval("unverified", false).await;
+
+        let (status, body) = http_get(
+            &app,
+            "/v1/credentials/aws/token",
+            &[("Authorization", &format!("Bearer {token}"))],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::FORBIDDEN, "body: {body}");
+        let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+        assert_eq!(error["code"], "hardware_required");
+    }
+
+    /// The companion case: an approval that did complete a ceremony still
+    /// clears the hardware gate. Reaching the issuer's missing RSA key proves
+    /// the request got past it — this app has no signing key configured.
+    #[tokio::test]
+    async fn test_device_grant_with_ceremony_passes_hardware_gate() {
+        let (app, token) = device_token_for_approval("verified", true).await;
+
+        let (status, body) = http_get(
+            &app,
+            "/v1/credentials/aws/token",
+            &[("Authorization", &format!("Bearer {token}"))],
+        )
+        .await;
+
+        assert_ne!(
+            status,
+            StatusCode::FORBIDDEN,
+            "hardware-verified approval must clear the gate: {body}"
+        );
+        assert!(
+            !body.contains("hardware_required"),
+            "gate must not reject a verified approval: {body}"
         );
     }
 }

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -858,67 +858,58 @@ pub(crate) async fn complete_enrollment_after_identity(
 
     // Handle CLI-initiated device auth flow. Direct browser sign-ins carry
     // no device_auth_id in the OIDC state (see direct_enroll_start).
-    if let Some(device_auth_id) = stored_state.device_auth_id.as_deref() {
-        if let Some(ref auth_id) = authenticator_id {
-            // User already has a registered key — authorize the device auth
-            // immediately so the CLI stops polling.
-            if let Err(e) = db::authorize_device_auth(
-                &state.store,
-                device_auth_id,
-                &user.id,
-                &user.email,
-                auth_id,
-            )
-            .await
-            {
-                // Surface the failure instead of redirecting to the keys page
-                // as though sign-in succeeded: the device auth was never
-                // approved, so the waiting CLI would poll until it timed out
-                // with nothing on screen to explain why.
-                tracing::error!("Failed to authorize device auth: {}", e);
-                return ErrorTemplate {
-                    title: Tr::new("error-heading").to_string(),
-                    message: Tr::new("enroll-error-device-auth-approve-failed").to_string(),
-                    back_url: None,
-                }
-                .into_response();
-            }
+    //
+    // Either way the CLI is released by a key ceremony, never by the IdP
+    // sign-in alone: that authenticates the person, not the hardware, so
+    // approving here would hand out a credential-capable token for a key
+    // nobody touched.
+    let mut require_assertion = false;
 
-            let event = db::AuthEventParams {
-                user_id: user.id.clone(),
-                event_type: db::AuthEventType::DeviceAuthApproved,
-                authenticator_id: Some(auth_id.clone()),
-                success: true,
-                client: client_info,
-                ..Default::default()
-            };
-            db::spawn_audit_event(&state.audit, event, Some(user.email.clone()));
-        } else {
-            // No key yet — store the device_auth_id in an enrollment session
-            // so browser_register_complete can authorize it after WebAuthn registration.
-            if let Err(e) = db::create_enrollment_session(
-                &state.store,
-                &user.id,
-                &user.email,
-                &token_hash,
-                Some(device_auth_id),
-                expires,
-            )
+    if let Some(device_auth_id) = stored_state.device_auth_id.as_deref() {
+        // Refuse before the key ceremony if the request the CLI is waiting on
+        // is gone or already settled — the row expired and was reclaimed, or
+        // the callback was submitted twice. Continuing would walk the user
+        // through a touch that could never release the CLI (#746).
+        let pending = db::get_device_auth_by_id(&state.store, device_auth_id)
             .await
-            {
-                // Without this row browser_register_complete cannot authorize
-                // the device auth after WebAuthn registration, so continuing
-                // would walk the user through enrolling a key that could never
-                // release the waiting CLI.
-                tracing::error!("Failed to create enrollment session for CLI: {}", e);
-                return ErrorTemplate {
-                    title: Tr::new("error-heading").to_string(),
-                    message: Tr::new("enroll-error-session-create-failed").to_string(),
-                    back_url: None,
-                }
-                .into_response();
+            .ok()
+            .flatten()
+            .is_some_and(|r| r.status == db::DeviceAuthStatus::Pending);
+        if !pending {
+            tracing::error!("Device auth '{device_auth_id}' is missing or already settled");
+            return ErrorTemplate {
+                title: Tr::new("error-heading").to_string(),
+                message: Tr::new("enroll-error-device-auth-approve-failed").to_string(),
+                back_url: None,
             }
+            .into_response();
         }
+
+        // Carry the device_auth_id in an enrollment session so whichever
+        // ceremony follows can authorize it: browser_register_complete after
+        // a first-key registration, browser_login_complete after an assertion.
+        if let Err(e) = db::create_enrollment_session(
+            &state.store,
+            &user.id,
+            &user.email,
+            &token_hash,
+            Some(device_auth_id),
+            expires,
+        )
+        .await
+        {
+            // Without this row neither ceremony can authorize the device
+            // auth, so continuing would walk the user through a key
+            // ceremony that could never release the waiting CLI.
+            tracing::error!("Failed to create enrollment session for CLI: {}", e);
+            return ErrorTemplate {
+                title: Tr::new("error-heading").to_string(),
+                message: Tr::new("enroll-error-session-create-failed").to_string(),
+                back_url: None,
+            }
+            .into_response();
+        }
+        require_assertion = authenticator_id.is_some();
     } else if authenticator_id.is_some() {
         // Returning user signing in directly via the website (upstream IdP,
         // no CLI). No FIDO2 assertion happened, so authenticator_id stays
@@ -938,15 +929,23 @@ pub(crate) async fn complete_enrollment_after_identity(
     // marked the row `consumed_at = Some(now)` (replay-blocking) and
     // `delete_expired_oidc_states` will reclaim the row at expiry.
 
-    tracing::info!("Session created for user: {}", redact_email(&user.email));
-    tracing::debug!("Setting session cookie and redirecting to /enroll/keys");
+    // A returning user with a CLI waiting goes to the login page to assert
+    // with their key; everyone else lands on the keys page, where a
+    // first-time enrollee registers one.
+    let destination = if require_assertion {
+        "/login"
+    } else {
+        "/enroll/keys"
+    };
 
-    // Create session cookie and redirect to keys page
+    tracing::info!("Session created for user: {}", redact_email(&user.email));
+    tracing::debug!("Setting session cookie and redirecting to {destination}");
+
     let cookie = create_session_cookie(token.expose_secret(), session_hours.saturating_mul(3600));
 
     Response::builder()
         .status(StatusCode::SEE_OTHER)
-        .header(header::LOCATION, "/enroll/keys")
+        .header(header::LOCATION, destination)
         .header(header::SET_COOKIE, cookie.to_string())
         .body(Body::empty())
         .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
@@ -1578,10 +1577,14 @@ pub(crate) async fn browser_register_complete(
     } else {
         db::authorize_device_auth(
             &state.store,
-            &reg_state.device_auth_id,
-            &reg_state.user_id.to_string(),
-            &reg_state.user_email,
-            &authenticator_id,
+            db::AuthorizeDeviceAuthParams {
+                id: &reg_state.device_auth_id,
+                user_id: &reg_state.user_id.to_string(),
+                user_email: &reg_state.user_email,
+                authenticator_id: &authenticator_id,
+                // The WebAuthn registration ceremony just completed above.
+                hardware_verified: true,
+            },
         )
         .await
         .inspect_err(|e| {

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -860,9 +860,7 @@ pub(crate) async fn complete_enrollment_after_identity(
     // no device_auth_id in the OIDC state (see direct_enroll_start).
     //
     // Either way the CLI is released by a key ceremony, never by the IdP
-    // sign-in alone: that authenticates the person, not the hardware, so
-    // approving here would hand out a credential-capable token for a key
-    // nobody touched.
+    // sign-in alone, which authenticates the person rather than the hardware.
     let mut require_assertion = false;
 
     if let Some(device_auth_id) = stored_state.device_auth_id.as_deref() {

--- a/crates/vouch-server/src/handlers/enroll/tests.rs
+++ b/crates/vouch-server/src/handlers/enroll/tests.rs
@@ -404,6 +404,92 @@ async fn test_direct_web_signin_returning_user_logs_login_success_with_ip() {
 }
 
 #[tokio::test]
+async fn test_cli_enroll_returning_user_requires_assertion_before_approval() {
+    // `vouch enroll` by a user who already has a key: the upstream IdP
+    // sign-in authenticates the person, not the hardware, so the pending
+    // device authorization must stay Pending and the browser must be sent
+    // to /login to assert. Approving here released a full-scope,
+    // credential-capable token with the key untouched.
+    let state = test_app_state().await;
+    let user = create_test_user(&state.store, "cli-returning@example.com").await;
+    create_test_authenticator(&state.store, &user.id).await;
+
+    let device_code_hash = "cli-returning-device-code-hash";
+    let expires_at: jiff::Timestamp = "2099-12-31T23:59:59Z".parse().expect("valid timestamp");
+    let device_auth_id = crate::db::create_device_auth_request(
+        &state.store,
+        device_code_hash,
+        "CLI-RTRN",
+        None,
+        expires_at,
+        0,
+    )
+    .await
+    .expect("create_device_auth_request");
+
+    let (stored, claim) =
+        seed_and_consume_oidc_state(&state, "cli-returning-state", Some(&device_auth_id)).await;
+
+    let identity = IdentityResult {
+        email: "cli-returning@example.com".to_string(),
+        domain: Some("example.com".to_string()),
+        upstream: None,
+    };
+
+    let resp =
+        complete_enrollment_after_identity(&state, &stored, identity, claim, ClientInfo::default())
+            .await;
+
+    assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+    let location = resp
+        .headers()
+        .get(axum::http::header::LOCATION)
+        .and_then(|v| v.to_str().ok())
+        .expect("redirect location");
+    assert_eq!(
+        location, "/login",
+        "a returning user must be sent to assert with their key"
+    );
+
+    let request = crate::db::get_device_auth_by_code_hash(&state.store, device_code_hash)
+        .await
+        .expect("device auth lookup")
+        .expect("device auth exists");
+    assert_eq!(
+        request.status,
+        crate::db::DeviceAuthStatus::Pending,
+        "IdP sign-in alone must not release the waiting CLI"
+    );
+    assert!(!request.hardware_verified);
+
+    let approvals = state
+        .audit
+        .query_events(&crate::db::AuditEventFilter {
+            event_types: Some(vec!["device_auth_approved".to_string()]),
+            ..Default::default()
+        })
+        .await
+        .expect("query audit events");
+    assert!(
+        approvals.is_empty(),
+        "no approval may be recorded before the assertion"
+    );
+
+    let logins = state
+        .audit
+        .query_events(&crate::db::AuditEventFilter {
+            event_types: Some(vec!["login_success".to_string()]),
+            ..Default::default()
+        })
+        .await
+        .expect("query audit events");
+    assert!(
+        logins.is_empty(),
+        "an IdP sign-in that still owes an assertion is not a completed login"
+    );
+}
+
+#[tokio::test]
 async fn test_identity_conflict_renders_error_and_audits() {
     // An IdP login whose asserted (issuer, subject) does not match the
     // subject already bound to the account with this email must be
@@ -541,75 +627,6 @@ async fn test_lazy_bind_emits_identity_bound_event() {
     let event = events.first().expect("identity_bound event");
     let data: serde_json::Value = serde_json::from_str(&event.data).expect("event data JSON");
     assert_eq!(data["idp_issuer"], issuer);
-}
-
-#[tokio::test]
-async fn test_cli_device_auth_immediate_approval_records_client_ip() {
-    // CLI-initiated flow (real device_auth_id) by a user who already has
-    // a passkey: the immediate approval authorizes the device auth and
-    // the device_auth_approved event carries the client IP.
-    let state = test_app_state().await;
-    let user = create_test_user(&state.store, "cli-returning@example.com").await;
-    let auth_id = create_test_authenticator(&state.store, &user.id).await;
-
-    let expires_at: jiff::Timestamp = "2099-12-31T23:59:59Z".parse().expect("valid timestamp");
-    let device_auth_id = crate::db::create_device_auth_request(
-        &state.store,
-        "cli-flow-device-hash",
-        "CLFW-CDGH",
-        None,
-        expires_at,
-        5,
-    )
-    .await
-    .expect("create_device_auth_request");
-
-    let (stored, claim) =
-        seed_and_consume_oidc_state(&state, "cli-flow-state", Some(&device_auth_id)).await;
-
-    let client_info = ClientInfo {
-        client_ip: Some("198.51.100.9".parse().expect("valid IP")),
-        ..Default::default()
-    };
-    let identity = IdentityResult {
-        email: "cli-returning@example.com".to_string(),
-        domain: Some("example.com".to_string()),
-        upstream: None,
-    };
-
-    let resp =
-        complete_enrollment_after_identity(&state, &stored, identity, claim, client_info).await;
-    assert_eq!(resp.status(), StatusCode::SEE_OTHER);
-
-    let events = wait_for_audit_events(&state, "device_auth_approved", &user.id).await;
-    assert_eq!(
-        events.len(),
-        1,
-        "immediate approval -> one device_auth_approved"
-    );
-    let event = events.first().expect("device_auth_approved event");
-    let data: serde_json::Value = serde_json::from_str(&event.data).expect("event data JSON");
-    assert_eq!(data["client_ip"], "198.51.100.9");
-    assert_eq!(data["authenticator_id"], auth_id.as_str());
-
-    let device_auth = crate::db::get_device_auth_by_user_code(&state.store, "CLFW-CDGH")
-        .await
-        .expect("get device auth")
-        .expect("device auth exists");
-    assert_eq!(device_auth.status, crate::db::DeviceAuthStatus::Authorized);
-
-    let logins = state
-        .audit
-        .query_events(&crate::db::AuditEventFilter {
-            event_types: Some(vec!["login_success".to_string()]),
-            ..Default::default()
-        })
-        .await
-        .expect("query audit events");
-    assert!(
-        logins.is_empty(),
-        "a CLI approval is not additionally recorded as a website login"
-    );
 }
 
 // Regression for #746: if the device auth cannot be authorized — the row

--- a/crates/vouch-server/src/handlers/enroll/tests.rs
+++ b/crates/vouch-server/src/handlers/enroll/tests.rs
@@ -407,9 +407,8 @@ async fn test_direct_web_signin_returning_user_logs_login_success_with_ip() {
 async fn test_cli_enroll_returning_user_requires_assertion_before_approval() {
     // `vouch enroll` by a user who already has a key: the upstream IdP
     // sign-in authenticates the person, not the hardware, so the pending
-    // device authorization must stay Pending and the browser must be sent
-    // to /login to assert. Approving here released a full-scope,
-    // credential-capable token with the key untouched.
+    // device authorization stays Pending and the browser is sent to /login
+    // to assert.
     let state = test_app_state().await;
     let user = create_test_user(&state.store, "cli-returning@example.com").await;
     create_test_authenticator(&state.store, &user.id).await;

--- a/crates/vouch-server/src/handlers/keys.rs
+++ b/crates/vouch-server/src/handlers/keys.rs
@@ -6,14 +6,11 @@ use crate::db::{self};
 use crate::error::ServiceError;
 use crate::redact_email;
 use crate::services::keys as key_svc;
-use axum::extract::OriginalUri;
-use axum::http::Method;
 use axum::{
     Json,
     extract::{Path, State},
-    http::{HeaderMap, StatusCode},
+    http::StatusCode,
 };
-use axum_extra::extract::cookie::CookieJar;
 use base64::Engine;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -25,8 +22,7 @@ use vouch_common::{
     fido2_types::Challenge,
 };
 
-use super::extractors::OptionalClientCert;
-use super::session::extract_resource_token;
+use super::session::AuthenticatedToken;
 use super::{generate_challenge, validate_registration_attestation};
 use crate::crypto::webauthn_verify;
 
@@ -84,23 +80,10 @@ impl RegistrationState {
 /// (`vouch enroll`) to register their first key. After that, they can add
 /// additional keys via this endpoint after logging in with an existing key.
 pub(crate) async fn register_start(
-    method: Method,
-    uri: OriginalUri,
-    headers: HeaderMap,
-    jar: CookieJar,
     State(state): State<Arc<AppState>>,
-    client_cert: OptionalClientCert,
+    AuthenticatedToken(token): AuthenticatedToken,
     Json(req): Json<RegisterStartRequest>,
 ) -> Result<Json<RegisterStartResponse>, ServiceError> {
-    let token = extract_resource_token(
-        &state,
-        &headers,
-        &jar,
-        method.as_str(),
-        uri.path(),
-        client_cert.0.as_ref(),
-    )
-    .await?;
     let user_id = Uuid::parse_str(&token.sub).map_err(|e| {
         ServiceError::api(
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -342,23 +325,9 @@ pub(crate) async fn register_complete(
 
 /// List all registered keys for the authenticated user.
 pub(crate) async fn list_keys(
-    method: Method,
-    uri: OriginalUri,
-    headers: HeaderMap,
-    jar: CookieJar,
     State(state): State<Arc<AppState>>,
-    client_cert: OptionalClientCert,
+    AuthenticatedToken(token): AuthenticatedToken,
 ) -> Result<Json<ListKeysResponse>, ServiceError> {
-    let token = extract_resource_token(
-        &state,
-        &headers,
-        &jar,
-        method.as_str(),
-        uri.path(),
-        client_cert.0.as_ref(),
-    )
-    .await?;
-
     let keys =
         key_svc::list_keys_for_user(&state.store, &token.sub, token.authenticator_id.as_deref())
             .await?;
@@ -367,17 +336,9 @@ pub(crate) async fn list_keys(
 }
 
 /// Rename a registered key.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "axum handler signature: extractors are positional parameters"
-)]
 pub(crate) async fn rename_key(
-    method: Method,
-    uri: OriginalUri,
-    headers: HeaderMap,
-    jar: CookieJar,
     State(state): State<Arc<AppState>>,
-    client_cert: OptionalClientCert,
+    AuthenticatedToken(token): AuthenticatedToken,
     Path(key_id): Path<String>,
     Json(req): Json<RenameKeyRequest>,
 ) -> Result<Json<RenameKeyResponse>, ServiceError> {
@@ -398,33 +359,15 @@ pub(crate) async fn rename_key(
         ));
     }
 
-    let token = extract_resource_token(
-        &state,
-        &headers,
-        &jar,
-        method.as_str(),
-        uri.path(),
-        client_cert.0.as_ref(),
-    )
-    .await?;
-
     let message = key_svc::rename_key(&state.store, &token.sub, &key_id, name).await?;
 
     Ok(Json(RenameKeyResponse { message }))
 }
 
 /// Delete a registered key.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "axum handler signature: extractors are positional parameters"
-)]
 pub(crate) async fn delete_key(
-    method: Method,
-    uri: OriginalUri,
-    headers: HeaderMap,
-    jar: CookieJar,
     State(state): State<Arc<AppState>>,
-    client_cert: OptionalClientCert,
+    AuthenticatedToken(token): AuthenticatedToken,
     client_info: db::ClientInfo,
     Path(key_id): Path<String>,
 ) -> Result<Json<DeleteKeyResponse>, ServiceError> {
@@ -437,15 +380,6 @@ pub(crate) async fn delete_key(
         ));
     }
 
-    let token = extract_resource_token(
-        &state,
-        &headers,
-        &jar,
-        method.as_str(),
-        uri.path(),
-        client_cert.0.as_ref(),
-    )
-    .await?;
     // Use auth_time as the freshness anchor; default to epoch (always stale) if absent
     key_svc::require_fresh_timestamp(
         token.auth_time.unwrap_or(0),

--- a/crates/vouch-server/src/handlers/oidc/register.rs
+++ b/crates/vouch-server/src/handlers/oidc/register.rs
@@ -13,18 +13,18 @@
 //!   with a valid FIDO2 key (hardware-bound) to obtain any token.
 
 use crate::AppState;
+use crate::error::ServiceError;
+use crate::handlers::session::OptionalAuthenticatedToken;
 use crate::services::oidc::registration::{
     RegistrationRequest, delete_client_configuration, read_client_configuration, register_client,
     update_client_configuration,
 };
-use axum::extract::OriginalUri;
 use axum::{
     Json,
     extract::{Path, State},
-    http::{HeaderMap, Method, StatusCode},
+    http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
-use axum_extra::extract::cookie::CookieJar;
 use std::sync::Arc;
 
 /// POST /oauth/register — RFC 7591 Dynamic Client Registration.
@@ -35,38 +35,18 @@ use std::sync::Arc;
 ///
 /// Returns 201 Created with the client information response.
 pub(crate) async fn register(
-    method: Method,
-    uri: OriginalUri,
     State(state): State<Arc<AppState>>,
-    headers: HeaderMap,
+    token: Result<OptionalAuthenticatedToken, ServiceError>,
     Json(request): Json<RegistrationRequest>,
 ) -> Response {
-    // Try to extract user from Bearer token (optional for open registration).
-    // We detect whether a token was even provided by checking the Authorization header.
-    let has_auth = headers.contains_key(axum::http::header::AUTHORIZATION);
-
-    let user_id = if has_auth {
-        let jar = CookieJar::default();
-        match crate::handlers::session::extract_resource_token(
-            &state,
-            &headers,
-            &jar,
-            method.as_str(),
-            uri.path(),
-            None,
-        )
-        .await
-        {
-            Ok(token) => Some(token.sub),
-            // RFC 7592 §2 / RFC 6750 §3.1: `extract_resource_token` returns
-            // `ServiceError::Api` with code `invalid_token` for any bearer-token
-            // validation failure. Propagate that error so the response carries
-            // `invalid_token` (not `invalid_client`), the correct 401 status,
-            // and a `WWW-Authenticate` challenge.
-            Err(e) => return into_registration_response(e),
-        }
-    } else {
-        None // Open registration — no user association
+    // Authentication is optional here, but a token that fails validation is an
+    // error rather than an anonymous request. RFC 7592 §2 / RFC 6750 §3.1: the
+    // rejection carries code `invalid_token` (not `invalid_client`), a 401, and
+    // a `WWW-Authenticate` challenge — propagate it rather than falling back to
+    // open registration.
+    let user_id = match token {
+        Ok(OptionalAuthenticatedToken(token)) => token.map(|t| t.sub),
+        Err(e) => return into_registration_response(e),
     };
 
     // Delegate to service layer

--- a/crates/vouch-server/src/handlers/session.rs
+++ b/crates/vouch-server/src/handlers/session.rs
@@ -6,8 +6,10 @@ use crate::crypto::hash_token;
 use crate::db;
 use crate::error::ServiceError;
 use crate::services::auth::ValidatedResourceToken;
+use axum::extract::FromRequestParts;
 use axum::http::StatusCode;
 use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
+use std::sync::Arc;
 use subtle::ConstantTimeEq;
 use time::Duration;
 
@@ -71,7 +73,7 @@ impl AuthContext {
 /// used for DPoP proof validation and audience coverage. Pass empty strings
 /// for cookie-only paths where DPoP validation is skipped (an empty `uri`
 /// means only deployment-root audiences pass the coverage check).
-pub(crate) async fn extract_resource_token(
+async fn extract_resource_token(
     state: &AppState,
     headers: &axum::http::HeaderMap,
     jar: &CookieJar,
@@ -288,32 +290,157 @@ fn enforce_audience_coverage(
     ))
 }
 
-/// Extract resource token and also fetch the user email from DB.
+// ============================================================================
+// Token Extractors
+// ============================================================================
+//
+// `extract_resource_token` is private to this module. The only ways a handler
+// can obtain a validated token are the two extractors below, so the strength of
+// authentication a route accepts is stated in its signature rather than left to
+// a check the handler remembers to write. `HardwareVerifiedToken` is the reason
+// the split exists: credential issuance must not run on a session that never
+// exercised the security key.
+
+/// An access token that passed validation.
 ///
-/// Convenience function for handlers that need the user email.
-pub(crate) async fn extract_resource_token_with_email(
+/// Says nothing about *how* the user authenticated — an enrollment bootstrap
+/// session satisfies this. Handlers that mint credentials want
+/// [`HardwareVerifiedToken`] instead.
+pub(crate) struct AuthenticatedToken(pub(crate) ValidatedResourceToken);
+
+/// An access token whose session proved possession of the user's security key.
+///
+/// The only constructor is the extractor below, which rejects the request when
+/// the `hardware_verified` claim is false. A handler naming this type cannot
+/// run without the proof.
+///
+/// The gate is on `hardware_verified` rather than `authenticator_id`: the latter
+/// only means the user has a key on record, which an enrollment session carries
+/// while `hardware_verified` is false.
+pub(crate) struct HardwareVerifiedToken(pub(crate) ValidatedResourceToken);
+
+/// Run the shared validation for both extractors.
+///
+/// The path comes from `OriginalUri` so it is the path the client actually
+/// requested: `extract_resource_token` feeds it to RFC 8707 audience coverage
+/// and to the DPoP `htu` comparison, both of which must see the request as sent
+/// rather than a matched route template.
+async fn extract_token_from_parts(
+    parts: &mut http::request::Parts,
+    state: &Arc<AppState>,
+) -> Result<ValidatedResourceToken, ServiceError> {
+    let axum::extract::OriginalUri(uri) =
+        axum::extract::OriginalUri::from_request_parts(parts, state)
+            .await
+            .unwrap_or_else(|infallible| match infallible {});
+    let client_cert = super::extractors::OptionalClientCert::from_request_parts(parts, state)
+        .await
+        .unwrap_or_else(|infallible| match infallible {});
+    let jar = CookieJar::from_headers(&parts.headers);
+
+    extract_resource_token(
+        state,
+        &parts.headers,
+        &jar,
+        parts.method.as_str(),
+        uri.path(),
+        client_cert.0.as_ref(),
+    )
+    .await
+}
+
+impl axum::extract::FromRequestParts<Arc<AppState>> for AuthenticatedToken {
+    type Rejection = ServiceError;
+
+    async fn from_request_parts(
+        parts: &mut http::request::Parts,
+        state: &Arc<AppState>,
+    ) -> Result<Self, Self::Rejection> {
+        Ok(Self(extract_token_from_parts(parts, state).await?))
+    }
+}
+
+/// An access token when the request offered one, for endpoints where
+/// authentication is optional (RFC 7591 open client registration).
+///
+/// `None` means no `Authorization` header was sent. A header carrying an
+/// invalid token is an **error**, not an absence — otherwise a rejected token
+/// would silently downgrade to an anonymous request. `Option<AuthenticatedToken>`
+/// cannot express this, which is why this is its own type.
+///
+/// Only the `Authorization` header is consulted: a browser session cookie must
+/// not authenticate a client registration.
+pub(crate) struct OptionalAuthenticatedToken(pub(crate) Option<ValidatedResourceToken>);
+
+impl axum::extract::FromRequestParts<Arc<AppState>> for OptionalAuthenticatedToken {
+    type Rejection = ServiceError;
+
+    async fn from_request_parts(
+        parts: &mut http::request::Parts,
+        state: &Arc<AppState>,
+    ) -> Result<Self, Self::Rejection> {
+        if !parts
+            .headers
+            .contains_key(axum::http::header::AUTHORIZATION)
+        {
+            return Ok(Self(None));
+        }
+        let axum::extract::OriginalUri(uri) =
+            axum::extract::OriginalUri::from_request_parts(parts, state)
+                .await
+                .unwrap_or_else(|infallible| match infallible {});
+        let token = extract_resource_token(
+            state,
+            &parts.headers,
+            &CookieJar::default(),
+            parts.method.as_str(),
+            uri.path(),
+            None,
+        )
+        .await?;
+        Ok(Self(Some(token)))
+    }
+}
+
+impl axum::extract::FromRequestParts<Arc<AppState>> for HardwareVerifiedToken {
+    type Rejection = ServiceError;
+
+    async fn from_request_parts(
+        parts: &mut http::request::Parts,
+        state: &Arc<AppState>,
+    ) -> Result<Self, Self::Rejection> {
+        let token = extract_token_from_parts(parts, state).await?;
+        if !token.hardware_verified {
+            tracing::warn!(
+                target: "security",
+                path = %parts.uri.path(),
+                "Refusing a session that is not hardware-verified"
+            );
+            return Err(ServiceError::api(
+                StatusCode::FORBIDDEN,
+                "hardware_required",
+                "This credential requires a hardware-verified session - run 'vouch login' to authenticate with your security key",
+            ));
+        }
+        Ok(Self(token))
+    }
+}
+
+/// Email for a validated token: the `email` claim when present, else the user
+/// record.
+pub(super) async fn resolve_token_email(
     state: &AppState,
-    headers: &axum::http::HeaderMap,
-    jar: &CookieJar,
-    method: &str,
-    uri: &str,
-    client_cert: Option<&crate::services::oidc::mtls::ClientCertificate>,
-) -> Result<(ValidatedResourceToken, String), ServiceError> {
-    let token = extract_resource_token(state, headers, jar, method, uri, client_cert).await?;
-
-    // If token already has email, use it; otherwise look up from DB
-    let email = if let Some(ref email) = token.email {
-        email.clone()
-    } else {
-        let user = db::get_user_by_id(&state.store, &token.sub)
-            .await?
-            .ok_or_else(|| {
-                ServiceError::api(StatusCode::NOT_FOUND, "user_not_found", "User not found")
-            })?;
-        user.email
-    };
-
-    Ok((token, email))
+    token: &ValidatedResourceToken,
+) -> Result<String, ServiceError> {
+    if let Some(ref email) = token.email {
+        return Ok(email.clone());
+    }
+    let user = db::get_user_by_id(&state.store, &token.sub)
+        .await?
+        .ok_or_else(|| {
+            ServiceError::api(StatusCode::NOT_FOUND, "user_not_found", "User not found")
+        })?;
+    Ok(user.email)
 }
 
 /// Extract and validate an OAuth access token from the session cookie only.

--- a/crates/vouch-server/tests/arch_boundaries.rs
+++ b/crates/vouch-server/tests/arch_boundaries.rs
@@ -344,10 +344,9 @@ const CREDENTIAL_HANDLERS_WITHOUT_HARDWARE: &[(&str, &str)] = &[
 
 /// Every credential-issuing handler proves key possession through its type.
 ///
-/// `vouch enroll` once released a credential-capable token for a key nobody
-/// touched, and the check that would have caught it existed on the AWS endpoint
-/// but not on SSH or GitHub. Requiring the type rather than a call means the
-/// omission cannot recur silently.
+/// Requiring the type rather than a call means an endpoint cannot issue
+/// credentials while silently omitting the check: the proof is part of the
+/// signature, so a handler that wants the weaker token has to name it.
 #[test]
 fn credential_handlers_require_hardware_verified_token() -> Result<(), Box<dyn std::error::Error>> {
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/handlers/credentials.rs");

--- a/crates/vouch-server/tests/arch_boundaries.rs
+++ b/crates/vouch-server/tests/arch_boundaries.rs
@@ -315,3 +315,101 @@ fn brace_group_idents(group: &str) -> Vec<String> {
     }
     idents
 }
+
+/// Credential handlers that legitimately run without proof of key possession.
+///
+/// Everything else in `handlers/credentials.rs` must take a
+/// `HardwareVerifiedToken`. The list is deny-by-default on purpose: a new
+/// credential endpoint fails this test until it either takes the strong token
+/// or is named here, which puts the decision in front of a reviewer instead of
+/// leaving it to a check someone remembered to write.
+const CREDENTIAL_HANDLERS_WITHOUT_HARDWARE: &[(&str, &str)] = &[
+    (
+        "get_ssh_ca_public_key",
+        "publishes the CA public key, unauthenticated",
+    ),
+    (
+        "get_ssh_krl",
+        "publishes the revocation list, unauthenticated",
+    ),
+    (
+        "check_ssh_revocation",
+        "revocation lookup by serial, unauthenticated",
+    ),
+    (
+        "get_github_status",
+        "reports whether the org has GitHub connected; issues no credential",
+    ),
+];
+
+/// Every credential-issuing handler proves key possession through its type.
+///
+/// `vouch enroll` once released a credential-capable token for a key nobody
+/// touched, and the check that would have caught it existed on the AWS endpoint
+/// but not on SSH or GitHub. Requiring the type rather than a call means the
+/// omission cannot recur silently.
+#[test]
+fn credential_handlers_require_hardware_verified_token() -> Result<(), Box<dyn std::error::Error>> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/handlers/credentials.rs");
+    let content = fs::read_to_string(&path)?;
+    let cutoff = test_module_cutoff(&content);
+    let scannable = content.get(..cutoff).unwrap_or(&content);
+
+    let mut violations = Vec::new();
+    let mut used_exemptions = vec![false; CREDENTIAL_HANDLERS_WITHOUT_HARDWARE.len()];
+
+    let mut rest = scannable;
+    while let Some(pos) = rest.find("pub(crate) async fn ") {
+        let after = rest
+            .get(pos.saturating_add("pub(crate) async fn ".len())..)
+            .unwrap_or("");
+        let name: String = after
+            .chars()
+            .take_while(|c| c.is_alphanumeric() || *c == '_')
+            .collect();
+        // Parameter list ends at the return arrow.
+        let params = after.split("->").next().unwrap_or("");
+
+        if let Some(idx) = CREDENTIAL_HANDLERS_WITHOUT_HARDWARE
+            .iter()
+            .position(|(exempt, _)| *exempt == name)
+        {
+            if let Some(flag) = used_exemptions.get_mut(idx) {
+                *flag = true;
+            }
+            if params.contains("HardwareVerifiedToken") {
+                violations.push(format!(
+                    "{name} is listed as not needing hardware verification but takes \
+                     HardwareVerifiedToken — remove it from the exemption list"
+                ));
+            }
+        } else if !params.contains("HardwareVerifiedToken") {
+            violations.push(format!(
+                "{name} issues credentials but does not take HardwareVerifiedToken; \
+                 add the extractor, or list it in CREDENTIAL_HANDLERS_WITHOUT_HARDWARE \
+                 with a reason if it genuinely issues nothing"
+            ));
+        }
+
+        rest = after;
+    }
+
+    for (idx, (name, reason)) in CREDENTIAL_HANDLERS_WITHOUT_HARDWARE.iter().enumerate() {
+        if !used_exemptions.get(idx).copied().unwrap_or(false) {
+            violations.push(format!(
+                "stale exemption: handler '{name}' ({reason}) no longer exists"
+            ));
+        }
+    }
+
+    if violations.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "{} credential-handler violation(s):\n{}",
+            violations.len(),
+            violations.join("\n")
+        )
+        .into())
+    }
+}

--- a/crates/vouch-tests/src/harness.rs
+++ b/crates/vouch-tests/src/harness.rs
@@ -459,13 +459,16 @@ impl TestHarness {
             .await?
             .ok_or_else(|| anyhow::anyhow!("Device auth request not found"))?;
 
-        // Authorize it
+        // Authorize it as the browser assertion flow does.
         vouch_server::db::authorize_device_auth(
             &self.state.store,
-            &request.id,
-            user_id,
-            email,
-            auth_id,
+            vouch_server::db::AuthorizeDeviceAuthParams {
+                id: &request.id,
+                user_id,
+                user_email: email,
+                authenticator_id: auth_id,
+                hardware_verified: true,
+            },
         )
         .await?;
 

--- a/deny.toml
+++ b/deny.toml
@@ -17,12 +17,14 @@ targets = [
 
 [advisories]
 ignore = [
-    # proc-macro-error2 is unmaintained, but pulled in transitively by
-    # `i18n-embed-fl` v0.10.0. No safe upgrade is available upstream; the
-    # advisory is informational only (no known vulnerability). Re-evaluate
-    # when `i18n-embed-fl` drops the dependency or a maintained fork lands.
-    # https://rustsec.org/advisories/RUSTSEC-2026-0173
-    "RUSTSEC-2026-0173",
+    # smartstring is unmaintained (repository archived 2026-05-03), reached
+    # transitively through `rhai` -> `amzn-dogwood-language`. No safe upgrade
+    # exists and the advisory reports no vulnerability. The policy engine
+    # registers no Rhai providers, so the scripting surface that pulls this in
+    # is not exercised at runtime. Re-evaluate when Dogwood's rhai dependency
+    # moves to compact_str/smol_str.
+    # https://rustsec.org/advisories/RUSTSEC-2026-0249
+    "RUSTSEC-2026-0249",
 ]
 
 [licenses]


### PR DESCRIPTION
## What this does

`vouch enroll` released a full-scope, credential-capable token to a user who already had a key registered, without any WebAuthn ceremony. Three things combined:

- The device-code grant issued every token with `HardwareVerification::Verified` regardless of how the browser approved it, so the claim credential endpoints gate on was not trustworthy.
- The IdP callback authorized a returning user's pending device request as soon as upstream identity was established — that authenticates the person, not the hardware.
- Only the AWS endpoint checked the claim, and it was reached with a token that asserted verification falsely.

## Changes

**Device authorization records how it was approved.** `DeviceAuthRequestDoc` gains `hardware_verified` (defaults false, so rows written before this field read as unverified), `AuthorizeDeviceAuthParams` replaces five positional arguments, and the grant copies the recorded value onto the token instead of hardcoding `Verified`.

**Enrollment requires the key.** A returning user is redirected to `/login` to assert; `browser_login_complete` authorizes the pending device request once the assertion verifies, after checking the enrollment session belongs to the user who asserted. A missing or already-settled request is refused before the ceremony rather than after it (#746).

**Hardware verification is a type.** `extract_resource_token` is now private to `handlers::session`, so the only ways to obtain a validated token are `AuthenticatedToken`, `HardwareVerifiedToken`, and `OptionalAuthenticatedToken`. Credential handlers take the hardware-verified one and cannot run without the proof. `OptionalAuthenticatedToken` covers RFC 7591 open registration, where authentication is optional but a token that fails validation is an error rather than an anonymous request — a distinction `Option<AuthenticatedToken>` would swallow.

An arch-boundary rule requires every handler in `credentials.rs` to take `HardwareVerifiedToken` unless listed with a reason, and fails on stale entries so the list can only shrink.

## Behavior changes

- `vouch enroll` now requires a touch for an already-enrolled user.
- SSH and GitHub endpoints answer 403 before their 503 "not configured" checks, so an unauthenticated caller no longer learns whether the SSH CA or GitHub App is configured.
- `create_application_api` and `update_application_api` take `Result<AuthenticatedToken, _>` to preserve validation-before-auth (a malformed body still answers 400, not 401).

## Testing

4604 workspace tests pass; `clippy --all-targets --all-features -- -D warnings` clean. The device-grant regression test asserts all three credential endpoints return 403 for a token from an unverified approval, and was mutation-checked — reverting the grant fix makes it fail. The arch rule was mutation-checked the same way. DPoP (82) and RFC 9449/audience (103) tests pass, since the extractors changed how the request path reaches `htu` validation and RFC 8707 audience coverage.

Absorbing `method`, `uri`, `headers`, `jar`, and `client_cert` into the extractors retired five `too_many_arguments` escapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication, device-code token claims, and credential issuance gates—core security paths where mistakes could allow privilege escalation or break CLI enroll.
> 
> **Overview**
> Closes a gap where **`vouch enroll`** could mint a full-scope device token for users who already had a key **without a WebAuthn ceremony**, because the device grant always set **`hardware_verified`** and the IdP callback could approve the pending device request immediately.
> 
> **Device auth records how approval happened.** Pending requests store **`hardware_verified`** (serde default for rolling deploy). **`authorize_device_auth`** takes **`AuthorizeDeviceAuthParams`**; the device-code grant copies that flag onto the issued token instead of hardcoding verified.
> 
> **CLI enroll now requires a touch.** After IdP sign-in, returning users with a pending device request are sent to **`/login`** (login page no longer skips the form when an enrollment session ties the cookie to a device auth). **`browser_login_complete`** authorizes the device request with **`hardware_verified: true`** only after assertion, with an enrollment-session user match check. First-key registration still authorizes from **`browser_register_complete`**. Stale or non-pending device rows are rejected before ceremonies (#746).
> 
> **Hardware proof is enforced by types.** **`extract_resource_token`** is module-private; handlers use **`AuthenticatedToken`**, **`HardwareVerifiedToken`**, or **`OptionalAuthenticatedToken`**. AWS/SSH/GitHub issuance requires **`HardwareVerifiedToken`**; an arch test in **`credentials.rs`** enforces that. Create/update application APIs defer auth via **`Result<AuthenticatedToken, _>`** so validation still returns 400 before 401.
> 
> Regression tests cover unverified device approvals blocked at credential endpoints and login-page behavior when device auth is pending.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ca6adf5b3feb4d11b5a247faae91a2388af94f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->