### PR TITLE
fix(cli): print SSH certificate serials without precision loss

### DIFF
--- a/crates/vouch-cli/src/commands/credential/ssh.rs
+++ b/crates/vouch-cli/src/commands/credential/ssh.rs
@@ -369,7 +369,7 @@ pub(crate) async fn run(server: &str, key_path: Option<&str>, force: bool) -> Re
         tr_println!(
             "credential-ssh-cached-display",
             cert_path = result.cert_path.display().to_string(),
-            serial = result.response.serial,
+            serial = result.response.serial.to_string(),
             principals = result.response.principals.join(", "),
             remaining = format_duration(result.response.valid_for_seconds),
         );
@@ -392,7 +392,7 @@ pub(crate) async fn run(server: &str, key_path: Option<&str>, force: bool) -> Re
     tr_println!(
         "credential-ssh-issued-display",
         cert_path = result.cert_path.display().to_string(),
-        serial = result.response.serial,
+        serial = result.response.serial.to_string(),
         principals = result.response.principals.join(", "),
         valid_for = format_duration(result.response.valid_for_seconds),
     );

--- a/crates/vouch-cli/src/i18n/mod.rs
+++ b/crates/vouch-cli/src/i18n/mod.rs
@@ -239,6 +239,26 @@ macro_rules! tr_eprintln {
 mod tests {
     use super::*;
 
+    /// SSH certificate serials are random `u64`, so they routinely exceed the
+    /// 2^53 a Fluent number can hold exactly. They identify a certificate for
+    /// revocation, so every digit has to survive rendering — hence the
+    /// `.to_string()` at the call sites rather than passing the integer.
+    #[test]
+    fn ssh_serial_renders_every_digit() {
+        let serial: u64 = 9_110_598_395_386_437_425;
+        let rendered = crate::tr_args!(
+            "credential-ssh-issued-display",
+            cert_path = "/tmp/id_ed25519_vouch-cert.pub",
+            serial = serial.to_string(),
+            principals = "jplock",
+            valid_for = "8h 0m",
+        );
+        assert!(
+            rendered.contains("9110598395386437425"),
+            "serial lost precision or was grouped: {rendered}"
+        );
+    }
+
     #[test]
     fn preresolve_cli_lang_space_form() {
         let argv: Vec<&OsStr> = ["vouch", "--lang", "fr-FR", "enroll"]


### PR DESCRIPTION
## What this does

`vouch credential ssh` passed the certificate serial to Fluent as a `u64`, which becomes an f64-backed `FluentValue::Number`. SSH serials are random `u64` and routinely exceed 2^53, so the printed value was rounded.

Observed on dev against a single certificate:

```
vouch status:          Serial: 9110598395386437425
vouch credential ssh:  Serial: 9110598395386438000
```

Serials identify a certificate for revocation, so a rounded value sent to `/v1/credentials/ssh/krl/{serial}` matches nothing — revocation would silently target no certificate. `vouch status` was unaffected because `integrations/ssh.rs` stringifies before display.

## Changes

Stringify the serial at both call sites in `commands/credential/ssh.rs` (cached and freshly-issued display blocks). This is what `tr_args!` already documents for identifiers that must not be locale-grouped:

> anything else (`bool`, `Path::Display`, `anyhow::Error`, `reqwest::StatusCode`, jiff timestamps, identifiers like a PID that should not be locale-grouped) must be stringified at the call site

A regression test renders the message with a serial above 2^53 and asserts every digit survives. It was mutation-checked: passing the raw `u64` fails it.

I swept the CLI and agent — these were the only two places a serial reached Fluent.

## Testing

4604 workspace tests pass; `clippy --all-targets --all-features -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only fix at two CLI call sites plus a test; no auth, issuance, or API behavior changes.
> 
> **Overview**
> **`vouch credential ssh`** now passes the certificate **serial** to Fluent as a **string** instead of a raw **`u64`**, in both the cached-cert and freshly-issued display paths.
> 
> SSH serials are random 64-bit values and often exceed **2^53**, so Fluent’s f64-backed numbers were rounding what users saw (e.g. `…437425` → `…438000`). That mismatch matters because the serial is used for revocation (`/v1/credentials/ssh/krl/{serial}`); a rounded value would not match the real cert.
> 
> A regression test renders **`credential-ssh-issued-display`** with a serial above **2^53** and asserts every digit appears in the output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 088d790c78ba081f7e4ed0c511fb36b1d860b40d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->