### PR TITLE
fix(scim): make group member writes atomic

### DIFF
--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -113,12 +113,12 @@ pub use config::{AuthEventParams, AuthEventType, ClientInfo, spawn_audit_event};
 
 // Re-export SCIM types and functions
 pub use scim::{
-    CreateScimTokenParams, CreateScimUserError, ScimFilterError, ScimGroupRecord, ScimScope,
-    ScimScopeSet, ScimToken, ScimUserRecord, add_scim_group_member, create_scim_group,
-    create_scim_token, create_scim_user, delete_expired_scim_tokens, delete_scim_group,
-    delete_scim_token, get_scim_group, get_scim_group_members, get_scim_token_by_hash,
-    get_scim_user, insert_scim_audit, list_scim_groups, list_scim_tokens, list_scim_users,
-    remove_scim_group_member, replace_scim_group_members, update_scim_group,
+    CreateScimTokenParams, CreateScimUserError, GroupMembersError, ScimFilterError,
+    ScimGroupRecord, ScimScope, ScimScopeSet, ScimToken, ScimUserRecord, add_scim_group_members,
+    create_scim_group, create_scim_token, create_scim_user, delete_expired_scim_tokens,
+    delete_scim_group, delete_scim_token, get_scim_group, get_scim_group_members,
+    get_scim_token_by_hash, get_scim_user, insert_scim_audit, list_scim_groups, list_scim_tokens,
+    list_scim_users, remove_scim_group_member, replace_scim_group_members, update_scim_group,
     update_scim_token_last_used, update_scim_user,
 };
 

--- a/crates/vouch-server/src/db/pool.rs
+++ b/crates/vouch-server/src/db/pool.rs
@@ -444,7 +444,8 @@ impl RetryableError for anyhow::Error {
 /// `anyhow::Error` retries on transient DSQL errors (`is_retryable_db_error`);
 /// `ServiceError` retries only on the `OccConflict` variant.
 ///
-/// Usage: `with_dsql_retry!(async { ... }).await`
+/// Usage: `with_dsql_retry!(async { ... })` — the macro awaits the body
+/// itself; the whole expression evaluates to the final `Result`.
 #[macro_export]
 macro_rules! with_dsql_retry {
     ($body:expr) => {{

--- a/crates/vouch-server/src/db/scim.rs
+++ b/crates/vouch-server/src/db/scim.rs
@@ -1028,20 +1028,49 @@ impl From<Document<ScimGroupDoc>> for ScimGroupRecord {
     }
 }
 
-/// Create a new SCIM group bound to the caller's org.
+/// Create a new SCIM group and its initial members atomically, bound to
+/// the caller's org.
+///
+/// Either the group and every membership row commit together, or nothing
+/// does — an invalid member value cannot leave a half-created group
+/// behind. Duplicate `member_user_ids` are collapsed to one row. The group
+/// is brand-new inside the transaction, so no concurrent writer can hold
+/// its id and no OCC version bump is needed. On a retryable failure the
+/// re-run generates a fresh group id (ids are not stable across attempts).
+///
+/// Cross-org `user_id` values become inert references — they are filtered
+/// out when reading the group's members.
 pub async fn create_scim_group(
     store: &DocumentStore,
     org_id: &str,
     display_name: &str,
     external_id: Option<&str>,
+    member_user_ids: &[String],
 ) -> Result<ScimGroupRecord> {
-    let doc = ScimGroupDoc {
-        org_id: org_id.to_string(),
-        display_name: display_name.to_string(),
-        external_id: external_id.map(String::from),
-    };
-    let result = store.insert(&doc).await?;
-    Ok(ScimGroupRecord::from(result))
+    crate::with_dsql_retry!(async {
+        let mut tx = store.begin().await?;
+
+        let doc = ScimGroupDoc {
+            org_id: org_id.to_string(),
+            display_name: display_name.to_string(),
+            external_id: external_id.map(String::from),
+        };
+        let group = tx.insert(&doc).await?;
+
+        let mut seen = std::collections::BTreeSet::new();
+        for user_id in member_user_ids {
+            if seen.insert(user_id.as_str()) {
+                tx.insert(&ScimGroupMemberDoc {
+                    group_id: group.id.clone(),
+                    user_id: user_id.clone(),
+                })
+                .await?;
+            }
+        }
+
+        tx.commit().await?;
+        Ok(ScimGroupRecord::from(group))
+    })
 }
 
 /// Get a SCIM group by ID, scoped to the caller's org.
@@ -1253,38 +1282,92 @@ pub async fn delete_scim_group(store: &DocumentStore, id: &str, org_id: &str) ->
     })
 }
 
-/// Add a member to a SCIM group, scoped to the caller's org.
+/// Errors returned by [`add_scim_group_members`] and
+/// [`replace_scim_group_members`].
 ///
-/// Verifies the group is in the caller's org (single indexed lookup,
-/// not per-user) and then inserts the membership row. Cross-org
-/// `user_id` values become inert references — they are filtered out
-/// when reading the group's members.
+/// Business-rejection variants are terminal (not retried); `OccConflict` and
+/// DB-retryable `Other` errors are re-run by `with_dsql_retry!`.
+#[derive(Debug, thiserror::Error)]
+pub enum GroupMembersError {
+    /// The group doesn't exist or belongs to a different org. The SCIM
+    /// handler maps this to `404 Not Found`.
+    #[error("group not found")]
+    GroupNotFound,
+    /// OCC version race on the group doc; retried by `with_dsql_retry!`,
+    /// reaches callers only when the retry budget is exhausted.
+    #[error("group was modified concurrently; please retry")]
+    OccConflict,
+    /// Database or unexpected infrastructure failure.
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+impl crate::db::pool::RetryableError for GroupMembersError {
+    fn is_retryable(&self) -> bool {
+        match self {
+            Self::OccConflict => true,
+            Self::Other(e) => crate::db::pool::is_retryable_db_error(e),
+            Self::GroupNotFound => false,
+        }
+    }
+}
+
+/// Add members to a SCIM group atomically, scoped to the caller's org.
 ///
-/// Returns `Ok(false)` if the group doesn't exist OR belongs to a
-/// different org.
-pub async fn add_scim_group_member(
+/// Either every missing membership row commits, or none do. Members
+/// already in the group (and duplicates within `user_ids`) are skipped, so
+/// the operation is idempotent. The group doc is version-bumped via
+/// `compare_and_update` so concurrent member mutations of the same group
+/// collide on its row and `with_dsql_retry!` re-runs the loser against
+/// fresh state — without the bump, two snapshot-isolated writers adding
+/// the same user would both see it missing and both insert it, and a
+/// concurrent [`delete_scim_group`] could commit its cascade between this
+/// transaction's read and write, leaving orphan membership rows.
+///
+/// Cross-org `user_id` values become inert references — they are filtered
+/// out when reading the group's members.
+pub async fn add_scim_group_members(
     store: &DocumentStore,
     group_id: &str,
     org_id: &str,
-    user_id: &str,
-) -> Result<bool> {
-    if get_scim_group(store, group_id, org_id).await?.is_none() {
-        return Ok(false);
-    }
+    user_ids: &[String],
+) -> Result<(), GroupMembersError> {
+    crate::with_dsql_retry!(async {
+        let mut tx = store.begin().await?;
 
-    let existing = store
-        .find_by_indexes::<ScimGroupMemberDoc>(&[("group_id", group_id), ("user_id", user_id)])
-        .await?;
-
-    if existing.is_empty() {
-        let doc = ScimGroupMemberDoc {
-            group_id: group_id.to_string(),
-            user_id: user_id.to_string(),
+        let Some(group) = tx.get::<ScimGroupDoc>(group_id).await? else {
+            return Err(GroupMembersError::GroupNotFound);
         };
-        store.insert(&doc).await?;
-    }
+        if group.data.org_id != org_id {
+            return Err(GroupMembersError::GroupNotFound);
+        }
 
-    Ok(true)
+        let mut seen: std::collections::BTreeSet<String> = tx
+            .find_all::<ScimGroupMemberDoc>("group_id", group_id)
+            .await?
+            .into_iter()
+            .map(|doc| doc.data.user_id)
+            .collect();
+        for user_id in user_ids {
+            if seen.insert(user_id.clone()) {
+                tx.insert(&ScimGroupMemberDoc {
+                    group_id: group_id.to_string(),
+                    user_id: user_id.clone(),
+                })
+                .await?;
+            }
+        }
+
+        if !tx
+            .compare_and_update(group_id, group.version, &group.data)
+            .await?
+        {
+            return Err(GroupMembersError::OccConflict);
+        }
+
+        tx.commit().await?;
+        Ok(())
+    })
 }
 
 /// Remove a member from a SCIM group, scoped to the caller's org.
@@ -1349,37 +1432,52 @@ pub async fn get_scim_group_members(
 /// Replace all members of a SCIM group atomically, scoped to the
 /// caller's org.
 ///
-/// Verifies the group is in the caller's org (single indexed lookup,
-/// not per-user). Cross-org `user_id` values in `user_ids` become
-/// inert references that are filtered out at read time.
-///
-/// Returns `Ok(false)` if the group doesn't exist OR belongs to a
-/// different org.
+/// The org-scope check runs inside the transaction, and the group doc is
+/// version-bumped via `compare_and_update` for the same reason as
+/// [`add_scim_group_members`]: it inserts membership rows, so a concurrent
+/// member mutation of the same group must collide rather than interleave
+/// (two snapshot-isolated replaces could otherwise both commit their sets,
+/// duplicating any shared user). Duplicate `user_ids` are collapsed to one
+/// row. Cross-org `user_id` values become inert references that are
+/// filtered out at read time.
 pub async fn replace_scim_group_members(
     store: &DocumentStore,
     group_id: &str,
     org_id: &str,
     user_ids: &[String],
-) -> Result<bool> {
-    if get_scim_group(store, group_id, org_id).await?.is_none() {
-        return Ok(false);
-    }
-
+) -> Result<(), GroupMembersError> {
     crate::with_dsql_retry!(async {
         let mut tx = store.begin().await?;
+
+        let Some(group) = tx.get::<ScimGroupDoc>(group_id).await? else {
+            return Err(GroupMembersError::GroupNotFound);
+        };
+        if group.data.org_id != org_id {
+            return Err(GroupMembersError::GroupNotFound);
+        }
 
         tx.delete_by_index::<ScimGroupMemberDoc>("group_id", group_id)
             .await?;
 
+        let mut seen = std::collections::BTreeSet::new();
         for user_id in user_ids {
-            let doc = ScimGroupMemberDoc {
-                group_id: group_id.to_string(),
-                user_id: user_id.clone(),
-            };
-            tx.insert(&doc).await?;
+            if seen.insert(user_id.as_str()) {
+                tx.insert(&ScimGroupMemberDoc {
+                    group_id: group_id.to_string(),
+                    user_id: user_id.clone(),
+                })
+                .await?;
+            }
+        }
+
+        if !tx
+            .compare_and_update(group_id, group.version, &group.data)
+            .await?
+        {
+            return Err(GroupMembersError::OccConflict);
         }
 
         tx.commit().await?;
-        Ok(true)
+        Ok(())
     })
 }

--- a/crates/vouch-server/src/db/tests/occ_modify.rs
+++ b/crates/vouch-server/src/db/tests/occ_modify.rs
@@ -424,7 +424,7 @@ async fn test_update_scim_group_only_intended_fields_change() {
 
     let (store, _audit) = test_db().await;
 
-    let group = create_scim_group(&store, TEST_ORG_ID, "OriginalName", Some("ext-123"))
+    let group = create_scim_group(&store, TEST_ORG_ID, "OriginalName", Some("ext-123"), &[])
         .await
         .expect("create_scim_group");
 
@@ -472,7 +472,7 @@ async fn test_update_scim_group_only_intended_fields_change() {
 async fn test_update_scim_group_wrong_org_returns_false() {
     let (store, _audit) = test_db().await;
 
-    let group = create_scim_group(&store, TEST_ORG_ID, "GroupToProtect", None)
+    let group = create_scim_group(&store, TEST_ORG_ID, "GroupToProtect", None, &[])
         .await
         .expect("create_scim_group");
 
@@ -794,7 +794,7 @@ async fn test_update_scim_group_concurrent_org_change_reports_not_applied() {
     use crate::db::documents::scim::ScimGroupDoc;
 
     let (store, _audit) = test_db().await;
-    let group = create_scim_group(&store, TEST_ORG_ID, "GroupBefore", None)
+    let group = create_scim_group(&store, TEST_ORG_ID, "GroupBefore", None, &[])
         .await
         .expect("create_scim_group");
 

--- a/crates/vouch-server/src/db/tests/scim_groups.rs
+++ b/crates/vouch-server/src/db/tests/scim_groups.rs
@@ -17,7 +17,7 @@ async fn test_scim_group_lifecycle() {
     let (store, _audit) = test_db().await;
 
     // Create
-    let group = create_scim_group(&store, TEST_ORG_ID, "Engineering", Some("ext-grp-1"))
+    let group = create_scim_group(&store, TEST_ORG_ID, "Engineering", Some("ext-grp-1"), &[])
         .await
         .expect("create_scim_group failed");
     assert!(!group.id.is_empty());
@@ -79,7 +79,7 @@ async fn test_scim_group_member_add_remove() {
     let (store, _audit) = test_db().await;
     seed_test_org(&store).await;
 
-    let group = create_scim_group(&store, TEST_ORG_ID, "Beta", None)
+    let group = create_scim_group(&store, TEST_ORG_ID, "Beta", None, &[])
         .await
         .expect("create group");
     let user = create_scim_user(
@@ -94,9 +94,14 @@ async fn test_scim_group_member_add_remove() {
     .expect("create user");
 
     // Add member
-    let _ = add_scim_group_member(&store, &group.id, TEST_ORG_ID, &user.id)
-        .await
-        .expect("add_scim_group_member failed");
+    add_scim_group_members(
+        &store,
+        &group.id,
+        TEST_ORG_ID,
+        std::slice::from_ref(&user.id),
+    )
+    .await
+    .expect("add_scim_group_members failed");
 
     // Member appears in group
     let members = get_scim_group_members(&store, &group.id, TEST_ORG_ID)
@@ -107,9 +112,14 @@ async fn test_scim_group_member_add_remove() {
     assert_eq!(members[0].id, user.id);
 
     // Add again is idempotent
-    let _ = add_scim_group_member(&store, &group.id, TEST_ORG_ID, &user.id)
-        .await
-        .expect("idempotent add failed");
+    add_scim_group_members(
+        &store,
+        &group.id,
+        TEST_ORG_ID,
+        std::slice::from_ref(&user.id),
+    )
+    .await
+    .expect("idempotent add failed");
     let members_after = get_scim_group_members(&store, &group.id, TEST_ORG_ID)
         .await
         .expect("get members")
@@ -145,7 +155,7 @@ async fn test_scim_group_replace_members() {
     let (store, _audit) = test_db().await;
     seed_test_org(&store).await;
 
-    let group = create_scim_group(&store, TEST_ORG_ID, "Gamma", None)
+    let group = create_scim_group(&store, TEST_ORG_ID, "Gamma", None, &[])
         .await
         .expect("create group");
     let user1 = create_scim_user(
@@ -180,7 +190,7 @@ async fn test_scim_group_replace_members() {
     .expect("create user3");
 
     // Start with user1 and user2
-    let _ = replace_scim_group_members(
+    replace_scim_group_members(
         &store,
         &group.id,
         TEST_ORG_ID,
@@ -195,7 +205,7 @@ async fn test_scim_group_replace_members() {
     assert_eq!(members.len(), 2);
 
     // Replace with just user3
-    let _ = replace_scim_group_members(
+    replace_scim_group_members(
         &store,
         &group.id,
         TEST_ORG_ID,
@@ -211,7 +221,7 @@ async fn test_scim_group_replace_members() {
     assert_eq!(members_after[0].id, user3.id);
 
     // Replace with empty list
-    let _ = replace_scim_group_members(&store, &group.id, TEST_ORG_ID, &[])
+    replace_scim_group_members(&store, &group.id, TEST_ORG_ID, &[])
         .await
         .expect("replace with empty");
     let empty = get_scim_group_members(&store, &group.id, TEST_ORG_ID)
@@ -226,7 +236,7 @@ async fn test_scim_group_delete_cascades_members() {
     let (store, _audit) = test_db().await;
     seed_test_org(&store).await;
 
-    let group = create_scim_group(&store, TEST_ORG_ID, "ToBeCascaded", None)
+    let group = create_scim_group(&store, TEST_ORG_ID, "ToBeCascaded", None, &[])
         .await
         .expect("create group");
     let user = create_scim_user(
@@ -240,9 +250,14 @@ async fn test_scim_group_delete_cascades_members() {
     .await
     .expect("create user");
 
-    let _ = add_scim_group_member(&store, &group.id, TEST_ORG_ID, &user.id)
-        .await
-        .expect("add member");
+    add_scim_group_members(
+        &store,
+        &group.id,
+        TEST_ORG_ID,
+        std::slice::from_ref(&user.id),
+    )
+    .await
+    .expect("add member");
 
     // Delete the group
     let _ = delete_scim_group(&store, &group.id, TEST_ORG_ID)
@@ -267,7 +282,7 @@ async fn test_scim_filter_group_external_id_co_is_case_sensitive() {
     let (store, _audit) = test_db().await;
     seed_test_org(&store).await;
 
-    create_scim_group(&store, TEST_ORG_ID, "Eng", Some("GroupCase-ID-1"))
+    create_scim_group(&store, TEST_ORG_ID, "Eng", Some("GroupCase-ID-1"), &[])
         .await
         .expect("Failed to create group");
 
@@ -309,7 +324,7 @@ async fn test_scim_filter_group_display_name_co_remains_case_insensitive() {
     let (store, _audit) = test_db().await;
     seed_test_org(&store).await;
 
-    create_scim_group(&store, TEST_ORG_ID, "Engineering", None)
+    create_scim_group(&store, TEST_ORG_ID, "Engineering", None, &[])
         .await
         .expect("Failed to create group");
 
@@ -328,4 +343,206 @@ async fn test_scim_filter_group_display_name_co_remains_case_insensitive() {
     );
     assert_eq!(groups.len(), 1);
     assert_eq!(groups[0].display_name, "Engineering");
+}
+
+// ========================================================================
+// Atomicity and batch semantics of member writes
+// ========================================================================
+//
+// Member writes run in one transaction: a rejected value rolls the whole
+// operation back, duplicates within a batch collapse to one row, and the
+// org-scope check happens inside the transaction.
+
+#[tokio::test]
+async fn test_scim_create_group_with_members() {
+    let (store, _audit) = test_db().await;
+    seed_test_org(&store).await;
+
+    let user = create_scim_user(
+        &store,
+        Some(TEST_ORG_ID),
+        "founding-member@example.com",
+        None,
+        None,
+        true,
+    )
+    .await
+    .expect("create user");
+
+    // Duplicate values in the batch collapse to one membership row.
+    let group = create_scim_group(
+        &store,
+        TEST_ORG_ID,
+        "Founders",
+        None,
+        &[user.id.clone(), user.id.clone()],
+    )
+    .await
+    .expect("create group with members");
+
+    let members = get_scim_group_members(&store, &group.id, TEST_ORG_ID)
+        .await
+        .expect("get members")
+        .unwrap_or_default();
+    assert_eq!(members.len(), 1, "duplicate batch values must collapse");
+    assert_eq!(members[0].id, user.id);
+}
+
+#[tokio::test]
+async fn test_scim_create_group_with_nul_member_rolls_back() {
+    let (store, _audit) = test_db().await;
+    seed_test_org(&store).await;
+
+    let user = create_scim_user(
+        &store,
+        Some(TEST_ORG_ID),
+        "valid-member@example.com",
+        None,
+        None,
+        true,
+    )
+    .await
+    .expect("create user");
+
+    // The valid member is inserted before the NUL one fails — the rollback
+    // must take the group and the valid membership row with it.
+    let err = create_scim_group(
+        &store,
+        TEST_ORG_ID,
+        "Doomed",
+        None,
+        &[user.id.clone(), "bad\0user".to_string()],
+    )
+    .await
+    .expect_err("NUL member must fail the create");
+    assert!(
+        err.downcast_ref::<InvalidIndexValue>().is_some(),
+        "error must carry InvalidIndexValue: {err}"
+    );
+
+    let (groups, total) = list_scim_groups(&store, TEST_ORG_ID, None, 1, 100)
+        .await
+        .expect("list groups");
+    assert_eq!(total, 0, "no group may persist after the rollback");
+    assert!(groups.is_empty());
+}
+
+#[tokio::test]
+async fn test_scim_add_group_members_nul_rolls_back() {
+    let (store, _audit) = test_db().await;
+    seed_test_org(&store).await;
+
+    let group = create_scim_group(&store, TEST_ORG_ID, "Stable", None, &[])
+        .await
+        .expect("create group");
+    let existing = create_scim_user(
+        &store,
+        Some(TEST_ORG_ID),
+        "existing@example.com",
+        None,
+        None,
+        true,
+    )
+    .await
+    .expect("create existing user");
+    let incoming = create_scim_user(
+        &store,
+        Some(TEST_ORG_ID),
+        "incoming@example.com",
+        None,
+        None,
+        true,
+    )
+    .await
+    .expect("create incoming user");
+
+    add_scim_group_members(
+        &store,
+        &group.id,
+        TEST_ORG_ID,
+        std::slice::from_ref(&existing.id),
+    )
+    .await
+    .expect("seed existing member");
+
+    // The valid incoming member is inserted before the NUL one fails — the
+    // rollback must leave only the pre-existing member.
+    let err = add_scim_group_members(
+        &store,
+        &group.id,
+        TEST_ORG_ID,
+        &[incoming.id.clone(), "bad\0user".to_string()],
+    )
+    .await
+    .expect_err("NUL member must fail the batch");
+    assert!(
+        matches!(&err, GroupMembersError::Other(e) if e.downcast_ref::<InvalidIndexValue>().is_some()),
+        "error must carry InvalidIndexValue: {err}"
+    );
+
+    let members = get_scim_group_members(&store, &group.id, TEST_ORG_ID)
+        .await
+        .expect("get members")
+        .unwrap_or_default();
+    assert_eq!(members.len(), 1, "batch must roll back entirely");
+    assert_eq!(members[0].id, existing.id);
+}
+
+#[tokio::test]
+async fn test_scim_add_group_members_group_not_found() {
+    let (store, _audit) = test_db().await;
+    seed_test_org(&store).await;
+
+    let user = create_scim_user(
+        &store,
+        Some(TEST_ORG_ID),
+        "orphan-add@example.com",
+        None,
+        None,
+        true,
+    )
+    .await
+    .expect("create user");
+
+    // Nonexistent group.
+    let err = add_scim_group_members(
+        &store,
+        "nonexistent-group",
+        TEST_ORG_ID,
+        std::slice::from_ref(&user.id),
+    )
+    .await
+    .expect_err("nonexistent group must be rejected");
+    assert!(matches!(err, GroupMembersError::GroupNotFound));
+
+    // Group in a different org.
+    let group = create_scim_group(&store, TEST_ORG_ID, "Scoped", None, &[])
+        .await
+        .expect("create group");
+    let err = add_scim_group_members(
+        &store,
+        &group.id,
+        "some-other-org",
+        std::slice::from_ref(&user.id),
+    )
+    .await
+    .expect_err("cross-org group must be rejected");
+    assert!(matches!(err, GroupMembersError::GroupNotFound));
+
+    let members = get_scim_group_members(&store, &group.id, TEST_ORG_ID)
+        .await
+        .expect("get members")
+        .unwrap_or_default();
+    assert!(members.is_empty(), "cross-org add must not insert anything");
+}
+
+#[tokio::test]
+async fn test_scim_replace_group_members_group_not_found() {
+    let (store, _audit) = test_db().await;
+    seed_test_org(&store).await;
+
+    let err = replace_scim_group_members(&store, "nonexistent-group", TEST_ORG_ID, &[])
+        .await
+        .expect_err("nonexistent group must be rejected");
+    assert!(matches!(err, GroupMembersError::GroupNotFound));
 }

--- a/crates/vouch-server/src/handlers/scim/groups.rs
+++ b/crates/vouch-server/src/handlers/scim/groups.rs
@@ -16,7 +16,61 @@ use super::types::{
 };
 use crate::AppState;
 use crate::db;
-use crate::db::{ScimFilterError, ScimScope};
+use crate::db::{GroupMembersError, ScimFilterError, ScimScope};
+
+/// Maximum number of group members accepted in a single request (POST
+/// members array, PATCH add/replace values).
+///
+/// Member writes are atomic — one transaction per request — and Aurora DSQL
+/// caps rows mutated per transaction at 3,000 (error 54000, not
+/// configurable). Each member is 3 rows (1 document + 2 index entries), so
+/// 500 members is ~1,500 rows, a wide margin. Real provisioners batch ~100
+/// members per request. The delete side of PATCH replace scales with the
+/// *current* group size, not the request, so it is bounded by this cap only
+/// as long as groups grow through capped requests.
+pub(super) const MAX_MEMBERS_PER_REQUEST: usize = 500;
+
+/// Reject a members array larger than [`MAX_MEMBERS_PER_REQUEST`].
+fn members_over_cap(len: usize) -> Option<(StatusCode, Json<ScimError>)> {
+    if len <= MAX_MEMBERS_PER_REQUEST {
+        return None;
+    }
+    Some((
+        StatusCode::BAD_REQUEST,
+        Json(
+            ScimError::new(
+                400,
+                format!("members must not exceed {MAX_MEMBERS_PER_REQUEST} entries per request"),
+            )
+            .with_type("invalidValue"),
+        ),
+    ))
+}
+
+/// Map a failed group-member write to its SCIM error response.
+///
+/// `op` names the operation ("add"/"replace") in the log line and the
+/// 500 detail.
+fn group_members_error_response(op: &str, err: GroupMembersError) -> Response {
+    if let GroupMembersError::GroupNotFound = err {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(ScimError::new(404, "Group not found")),
+        )
+            .into_response();
+    }
+    if let GroupMembersError::Other(ref e) = err
+        && let Some(resp) = super::invalid_index_value_response(e)
+    {
+        return resp.into_response();
+    }
+    tracing::error!("Failed to {op} group members: {err}");
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ScimError::new(500, format!("Failed to {op} group members"))),
+    )
+        .into_response()
+}
 
 /// GET /scim/v2/Groups (RFC 7644 Section 3.4.2).
 ///
@@ -119,8 +173,9 @@ pub(crate) async fn list_groups(
 
 /// POST /scim/v2/Groups (RFC 7644 Section 3.3).
 ///
-/// Creates a new Group resource. Returns 201 Created on success,
-/// 409 Conflict if the group already exists.
+/// Creates a new Group resource and its initial members atomically:
+/// an invalid member value fails the whole request and nothing persists.
+/// Returns 201 Created on success.
 pub(crate) async fn create_group(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -137,6 +192,16 @@ pub(crate) async fn create_group(
         )
             .into_response();
     }
+    let member_ids: Vec<String> = group
+        .members
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .map(|m| m.value.clone())
+        .collect();
+    if let Some(resp) = members_over_cap(member_ids.len()) {
+        return resp.into_response();
+    }
 
     // Authenticate and check scope
     let auth = match authenticate_scim(&state, &headers).await {
@@ -147,12 +212,13 @@ pub(crate) async fn create_group(
         return (status, json).into_response();
     }
 
-    // Create group
+    // Create group with members atomically
     let db_group = match db::create_scim_group(
         &state.store,
         &auth.org_id,
         &group.display_name,
         group.external_id.as_deref(),
+        &member_ids,
     )
     .await
     {
@@ -162,33 +228,13 @@ pub(crate) async fn create_group(
                 return resp.into_response();
             }
             tracing::error!("Failed to create group: {e}");
-            let detail = if e.to_string().contains("UNIQUE") {
-                "Group already exists"
-            } else {
-                "Failed to create group"
-            };
             return (
-                StatusCode::CONFLICT,
-                Json(ScimError::new(409, detail).with_type("uniqueness")),
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ScimError::new(500, "Failed to create group")),
             )
                 .into_response();
         }
     };
-
-    // Add members if provided
-    if let Some(members) = &group.members {
-        for member in members {
-            if let Err(e) =
-                db::add_scim_group_member(&state.store, &db_group.id, &auth.org_id, &member.value)
-                    .await
-            {
-                if let Some(resp) = super::invalid_index_value_response(&e) {
-                    return resp.into_response();
-                }
-                tracing::warn!("Failed to add member {} to group: {e}", member.value);
-            }
-        }
-    }
 
     // Audit log
     if let Err(e) = db::insert_scim_audit(
@@ -338,6 +384,9 @@ pub(crate) async fn patch_group(
                                         v.get("value").and_then(|v| v.as_str()).map(String::from)
                                     })
                                     .collect();
+                                if let Some(resp) = members_over_cap(user_ids.len()) {
+                                    return resp.into_response();
+                                }
                                 if let Err(e) = db::replace_scim_group_members(
                                     &state.store,
                                     &id,
@@ -346,10 +395,7 @@ pub(crate) async fn patch_group(
                                 )
                                 .await
                                 {
-                                    if let Some(resp) = super::invalid_index_value_response(&e) {
-                                        return resp.into_response();
-                                    }
-                                    tracing::error!("Failed to replace group members: {e}");
+                                    return group_members_error_response("replace", e);
                                 }
                             }
                         }
@@ -370,23 +416,27 @@ pub(crate) async fn patch_group(
                     && path == "members"
                     && let Some(val) = &op.value
                 {
-                    // Add members
+                    // Add members atomically — a mid-list failure adds none
                     if let Some(arr) = val.as_array() {
-                        for member in arr {
-                            if let Some(user_id) = member.get("value").and_then(|v| v.as_str())
-                                && let Err(e) = db::add_scim_group_member(
-                                    &state.store,
-                                    &id,
-                                    &auth.org_id,
-                                    user_id,
-                                )
-                                .await
-                            {
-                                if let Some(resp) = super::invalid_index_value_response(&e) {
-                                    return resp.into_response();
-                                }
-                                tracing::warn!("Failed to add member: {e}");
-                            }
+                        let user_ids: Vec<String> = arr
+                            .iter()
+                            .filter_map(|v| {
+                                v.get("value").and_then(|v| v.as_str()).map(String::from)
+                            })
+                            .collect();
+                        if let Some(resp) = members_over_cap(user_ids.len()) {
+                            return resp.into_response();
+                        }
+                        if !user_ids.is_empty()
+                            && let Err(e) = db::add_scim_group_members(
+                                &state.store,
+                                &id,
+                                &auth.org_id,
+                                &user_ids,
+                            )
+                            .await
+                        {
+                            return group_members_error_response("add", e);
                         }
                     }
                 }
@@ -401,7 +451,12 @@ pub(crate) async fn patch_group(
                             db::remove_scim_group_member(&state.store, &id, &auth.org_id, &user_id)
                                 .await
                     {
-                        tracing::warn!("Failed to remove member: {e}");
+                        tracing::error!("Failed to remove group member: {e}");
+                        return (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            Json(ScimError::new(500, "Failed to remove group member")),
+                        )
+                            .into_response();
                     }
                 }
             }

--- a/crates/vouch-server/src/handlers/scim/tests.rs
+++ b/crates/vouch-server/src/handlers/scim/tests.rs
@@ -2461,12 +2461,15 @@ async fn test_scim_create_group_rejects_nul_display_name() {
 // A NUL in `members[*].value` (the `user_id` index) must fail the request
 // with a SCIM 400 `invalidValue` on every member write surface —
 // create-group members, PATCH replace members, and PATCH add member —
-// matching the displayName/externalId handling above.
+// matching the displayName/externalId handling above. Member writes are
+// atomic: a rejected value rolls back the whole operation, so nothing
+// persists alongside a 400.
 
 #[tokio::test]
 async fn test_scim_create_group_rejects_nul_member_user_id() {
     // POST /scim/v2/Groups with a NUL in members[0].value must be a 400,
-    // not a 201 CREATED with the invalid member dropped.
+    // not a 201 CREATED with the invalid member dropped — and the group
+    // itself must not persist, so a corrected retry gets 201, not 409.
     let (app, state) = test_app().await;
     let token = create_test_scim_token(&state.store, "test-nul-member-create", "test-org").await;
     let auth_header = format!("Bearer {token}");
@@ -2497,6 +2500,88 @@ async fn test_scim_create_group_rejects_nul_member_user_id() {
             .unwrap_or_default()
             .contains("user_id"),
         "detail must name the user_id field: {resp_body}"
+    );
+
+    // Rollback: the group must not exist after the 400.
+    let (status, body) = http_get(
+        &app,
+        "/scim/v2/Groups?filter=displayName%20eq%20%22NulMemberCreate%22",
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let list: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(
+        list["totalResults"], 0,
+        "group must not persist after a rejected create: {body}"
+    );
+
+    // A corrected retry succeeds instead of hitting a duplicate.
+    let retry = serde_json::json!({
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+        "displayName": "NulMemberCreate"
+    });
+    let (status, body) = http_post_json(
+        &app,
+        "/scim/v2/Groups",
+        &retry.to_string(),
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "corrected retry must succeed: {body}"
+    );
+}
+
+#[tokio::test]
+async fn test_scim_create_group_valid_and_nul_member_is_all_or_nothing() {
+    // A batch of [valid, NUL] must not keep the valid member either — the
+    // whole create rolls back.
+    let (app, state) = test_app().await;
+    let token = create_test_scim_token(&state.store, "test-nul-member-mixed", "test-org").await;
+    let auth_header = format!("Bearer {token}");
+
+    let (_, body) = http_post_json(
+        &app,
+        "/scim/v2/Users",
+        r#"{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],"userName":"mixed-batch@test-org.example.com"}"#,
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    let user: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let user_id = user["id"].as_str().expect("user id");
+
+    let body = serde_json::json!({
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+        "displayName": "MixedBatch",
+        "members": [{"value": user_id}, {"value": "bad\u{0}user"}]
+    });
+    let (status, resp_body) = http_post_json(
+        &app,
+        "/scim/v2/Groups",
+        &body.to_string(),
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "mixed batch must be rejected: {resp_body}"
+    );
+
+    let (status, body) = http_get(
+        &app,
+        "/scim/v2/Groups?filter=displayName%20eq%20%22MixedBatch%22",
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let list: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(
+        list["totalResults"], 0,
+        "neither the group nor the valid member may persist: {body}"
     );
 }
 
@@ -2553,16 +2638,42 @@ async fn test_scim_patch_group_replace_members_rejects_nul_user_id() {
 
 #[tokio::test]
 async fn test_scim_patch_group_add_member_rejects_nul_user_id() {
-    // PATCH add member with a NUL in value must be a 400, not 200 OK.
+    // PATCH add with a batch of [valid, NUL] must be a 400, not 200 OK —
+    // and none of the batch may land: the group keeps only the member it
+    // already had.
     let (app, state) = test_app().await;
     let token = create_test_scim_token(&state.store, "test-nul-member-add", "test-org").await;
     let auth_header = format!("Bearer {token}");
 
-    // Create a group to PATCH.
+    // Two users: one seeded into the group, one in the doomed batch.
+    let (_, body) = http_post_json(
+        &app,
+        "/scim/v2/Users",
+        r#"{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],"userName":"add-existing@test-org.example.com"}"#,
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    let existing: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let existing_id = existing["id"].as_str().expect("existing user id");
+
+    let (_, body) = http_post_json(
+        &app,
+        "/scim/v2/Users",
+        r#"{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],"userName":"add-incoming@test-org.example.com"}"#,
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    let incoming: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let incoming_id = incoming["id"].as_str().expect("incoming user id");
+
+    // Create a group with the existing member.
+    let create_body = format!(
+        r#"{{"schemas":["urn:ietf:params:scim:schemas:core:2.0:Group"],"displayName":"NulMemberAdd","members":[{{"value":"{existing_id}"}}]}}"#
+    );
     let (status, body) = http_post_json(
         &app,
         "/scim/v2/Groups",
-        r#"{"schemas":["urn:ietf:params:scim:schemas:core:2.0:Group"],"displayName":"NulMemberAdd"}"#,
+        &create_body,
         &[("Authorization", &auth_header)],
     )
     .await;
@@ -2572,7 +2683,8 @@ async fn test_scim_patch_group_add_member_rejects_nul_user_id() {
 
     let patch = serde_json::json!({
         "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-        "Operations": [{"op": "add", "path": "members", "value": [{"value": "bad\u{0}user"}]}]
+        "Operations": [{"op": "add", "path": "members",
+            "value": [{"value": incoming_id}, {"value": "bad\u{0}user"}]}]
     });
     let (status, resp_body) = http_request(
         &app,
@@ -2600,6 +2712,86 @@ async fn test_scim_patch_group_add_member_rejects_nul_user_id() {
             .contains("user_id"),
         "detail must name the user_id field: {resp_body}"
     );
+
+    // Rollback: the valid member of the rejected batch must not be added.
+    let (status, body) = http_get(
+        &app,
+        &format!("/scim/v2/Groups/{group_id}"),
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let group: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let members = group["members"].as_array().expect("members array");
+    assert_eq!(members.len(), 1, "batch must roll back entirely: {body}");
+    assert_eq!(
+        members
+            .first()
+            .and_then(|m| m["value"].as_str())
+            .unwrap_or_default(),
+        existing_id,
+        "only the pre-existing member may remain: {body}"
+    );
+}
+
+#[tokio::test]
+async fn test_scim_patch_group_add_existing_member_is_idempotent() {
+    // PATCH add of an already-present member returns 200 with one entry.
+    let (app, state) = test_app().await;
+    let token = create_test_scim_token(&state.store, "test-add-idempotent", "test-org").await;
+    let auth_header = format!("Bearer {token}");
+
+    let (_, body) = http_post_json(
+        &app,
+        "/scim/v2/Users",
+        r#"{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],"userName":"idempotent@test-org.example.com"}"#,
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    let user: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let user_id = user["id"].as_str().expect("user id");
+
+    let create_body = format!(
+        r#"{{"schemas":["urn:ietf:params:scim:schemas:core:2.0:Group"],"displayName":"IdempotentAdd","members":[{{"value":"{user_id}"}}]}}"#
+    );
+    let (status, body) = http_post_json(
+        &app,
+        "/scim/v2/Groups",
+        &create_body,
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "setup create failed: {body}");
+    let created: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let group_id = created["id"].as_str().expect("group id");
+
+    let patch = serde_json::json!({
+        "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+        "Operations": [{"op": "add", "path": "members", "value": [{"value": user_id}]}]
+    });
+    let (status, body) = http_request(
+        &app,
+        "PATCH",
+        &format!("/scim/v2/Groups/{group_id}"),
+        Some(patch.to_string()),
+        &[
+            ("Content-Type", "application/json"),
+            ("Authorization", &auth_header),
+        ],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "re-add must return 200: {body}");
+
+    let (status, body) = http_get(
+        &app,
+        &format!("/scim/v2/Groups/{group_id}"),
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let group: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let members = group["members"].as_array().expect("members array");
+    assert_eq!(members.len(), 1, "re-add must not duplicate: {body}");
 }
 
 #[tokio::test]
@@ -2685,5 +2877,145 @@ async fn test_scim_patch_group_replace_members() {
     assert!(
         !members.iter().any(|m| m["value"] == user_a_id),
         "previous member (user_a) must be removed after replace"
+    );
+}
+
+// ========================================================================
+// Group member request cap
+// ========================================================================
+//
+// Member writes are atomic (one transaction per request) and Aurora DSQL
+// caps rows mutated per transaction, so every member surface rejects
+// batches larger than MAX_MEMBERS_PER_REQUEST with a 400 before touching
+// the database.
+
+/// A members array one past the cap, as a JSON value.
+fn oversized_members() -> serde_json::Value {
+    let entries: Vec<serde_json::Value> = (0..=super::groups::MAX_MEMBERS_PER_REQUEST)
+        .map(|i| serde_json::json!({"value": format!("user-{i}")}))
+        .collect();
+    serde_json::Value::Array(entries)
+}
+
+#[tokio::test]
+async fn test_scim_create_group_rejects_oversized_members() {
+    let (app, state) = test_app().await;
+    let token = create_test_scim_token(&state.store, "test-cap-create", "test-org").await;
+    let auth_header = format!("Bearer {token}");
+
+    let body = serde_json::json!({
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+        "displayName": "TooBig",
+        "members": oversized_members()
+    });
+    let (status, resp_body) = http_post_json(
+        &app,
+        "/scim/v2/Groups",
+        &body.to_string(),
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "oversized members array must be a 400: {resp_body}"
+    );
+    let error: serde_json::Value = serde_json::from_str(&resp_body).expect("Valid JSON");
+    assert_eq!(error["scimType"], "invalidValue");
+
+    // Nothing may persist.
+    let (status, body) = http_get(
+        &app,
+        "/scim/v2/Groups?filter=displayName%20eq%20%22TooBig%22",
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let list: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(list["totalResults"], 0);
+}
+
+#[tokio::test]
+async fn test_scim_patch_group_rejects_oversized_member_batches() {
+    // Both PATCH add and PATCH replace reject an oversized batch.
+    let (app, state) = test_app().await;
+    let token = create_test_scim_token(&state.store, "test-cap-patch", "test-org").await;
+    let auth_header = format!("Bearer {token}");
+
+    let (status, body) = http_post_json(
+        &app,
+        "/scim/v2/Groups",
+        r#"{"schemas":["urn:ietf:params:scim:schemas:core:2.0:Group"],"displayName":"CapPatch"}"#,
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "setup create failed: {body}");
+    let created: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let group_id = created["id"].as_str().expect("group id");
+
+    for op in ["add", "replace"] {
+        let patch = serde_json::json!({
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+            "Operations": [{"op": op, "path": "members", "value": oversized_members()}]
+        });
+        let (status, resp_body) = http_request(
+            &app,
+            "PATCH",
+            &format!("/scim/v2/Groups/{group_id}"),
+            Some(patch.to_string()),
+            &[
+                ("Content-Type", "application/json"),
+                ("Authorization", &auth_header),
+            ],
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "oversized {op} batch must be a 400: {resp_body}"
+        );
+        let error: serde_json::Value = serde_json::from_str(&resp_body).expect("Valid JSON");
+        assert_eq!(error["scimType"], "invalidValue");
+    }
+
+    // The group is untouched.
+    let (status, body) = http_get(
+        &app,
+        &format!("/scim/v2/Groups/{group_id}"),
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let group: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert!(
+        group["members"].as_array().is_none_or(Vec::is_empty),
+        "no member of a rejected batch may land: {body}"
+    );
+}
+
+#[tokio::test]
+async fn test_scim_create_group_with_empty_members_array() {
+    // An explicit empty members array is a valid create.
+    let (app, state) = test_app().await;
+    let token = create_test_scim_token(&state.store, "test-empty-members", "test-org").await;
+    let auth_header = format!("Bearer {token}");
+
+    let body = serde_json::json!({
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+        "displayName": "EmptyMembers",
+        "members": []
+    });
+    let (status, resp_body) = http_post_json(
+        &app,
+        "/scim/v2/Groups",
+        &body.to_string(),
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "empty members array must create the group: {resp_body}"
     );
 }


### PR DESCRIPTION
## Problem

Two SCIM group member-write surfaces left partial state behind on failure:

- `POST /scim/v2/Groups` inserted the group document before adding members one at a time. A rejected member value (e.g. a NUL byte, #899) returned 400 with the group already created, so a corrected retry hit the 409 "Group already exists" branch.
- `PATCH` `add`/`members` called the db layer once per member, so a failure at member N left members 1..N-1 committed.

Separately, concurrent member writes could mint duplicate membership rows: in-transaction reads don't conflict under DSQL/Postgres snapshot isolation, so two adds (or replaces) of the same user could both see it missing and both insert it.

## Change

- `create_scim_group` now takes the member list and creates the group plus all membership rows in one transaction under `with_dsql_retry!`. Nothing persists on failure; a corrected retry gets 201.
- New batched `add_scim_group_members` replaces the per-member singular: one in-transaction `find_all` for dedup, all-or-nothing inserts. `replace_scim_group_members` moves its org-scope check inside the transaction (closing a TOCTOU with concurrent group deletion).
- Both member-inserting transactions version-bump the owning `ScimGroupDoc` via `compare_and_update`, so concurrent member mutations collide on the group row and `with_dsql_retry!` re-runs the loser against fresh state. Errors are a new `GroupMembersError` enum (`GroupNotFound` / `OccConflict` / `Other`), mirroring `CreateScimUserError`.
- Member batches are capped at 500 entries per request (POST members, PATCH add, PATCH replace) with a SCIM 400 before any DB work. Atomic writes put the whole batch in one transaction, and Aurora DSQL caps rows mutated per transaction at 3,000 (each member is 3 rows). Real provisioners batch ~100 members per request.
- Failed member writes now return errors instead of logging and returning 200/201. The PATCH `remove` branch had the same log-and-continue defect and is included.
- The 409 "uniqueness" branch on group create is gone: group documents cannot raise a unique violation (fresh UUIDv7 ids; the only UNIQUE constraint is on `(document_id, index_field, index_value)`), so that branch only ever mislabeled transient errors. They now return 500.

## Behavior changes

| Request | Before | After |
|---|---|---|
| POST group, invalid member value | 400, group persists (retry → 409) | 400, nothing persists |
| POST group, transient DB error | 409 `uniqueness` | 500 |
| PATCH add N members, member k invalid | 400, members 1..k-1 added | 400, none added |
| PATCH add/replace/remove, other DB error | 200, change silently missing | 500 |
| POST/PATCH with >500 members | attempted (fails on DSQL past ~1,000) | 400 `invalidValue` |
| Concurrent adds/replaces of same user | duplicate member rows possible | serialized via version bump |

Returning 500 from the middle of a multi-op PATCH is safe for provisioner retries because every op is idempotent: add dedups, replace is a full swap, remove is delete-if-present, displayName/externalId are assignments — replaying ops 1..k-1 converges.

Note: Vouch does not enforce `displayName` uniqueness anywhere; a duplicate group create returns 201 and produces two groups. That was already true — removing the 409 branch does not change it.

## Testing

- 5 new db-level tests: create rollback (NUL member → no group persists), batch dedup (`[u, u]` → one row), add rollback (`[valid, NUL]` → prior members untouched), `GroupNotFound` for nonexistent and cross-org groups, replace `GroupNotFound`.
- 5 new + 2 extended handler tests: rollback proof plus corrected-retry-gets-201, mixed valid+NUL all-or-nothing on create and PATCH add, idempotent re-add, oversized-batch 400 on all three surfaces, explicit empty members array. All 9 existing fixture call sites updated; the add-again-idempotent assertion is preserved.
- Gates: 169 SCIM tests, full unit suite (`make test`), integration suite (`make test-integration`), `make fmt`, `make lint` (clippy `-D warnings`) — all clean.
- Not directly tested (needs fault injection): the three 500 branches; the `OccConflict` retry path leans on the existing `compare_and_update` coverage in `db/tests/occ_modify.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SCIM provisioning semantics (atomic batches, new error codes, removed 409-on-create) and adds OCC on hot group-member paths; behavior is well-tested but affects IdP-facing group APIs.
> 
> **Overview**
> SCIM group membership is now **all-or-nothing** and **serialized** against concurrent writers.
> 
> **Database:** `create_scim_group` takes initial `member_user_ids` and commits the group plus every membership row in one transaction (with `with_dsql_retry!`). Singular `add_scim_group_member` becomes batched **`add_scim_group_members`**; add/replace run in a transaction with org checks inside the tx, duplicate IDs collapsed, and a **`compare_and_update`** bump on the group doc so concurrent adds/replaces/deletes collide instead of duplicating rows or leaving orphans. Failures surface as **`GroupMembersError`** (`GroupNotFound`, `OccConflict`, `Other`) instead of `Ok(false)`.
> 
> **HTTP:** POST create applies members atomically (no post-create loop). PATCH add/replace use the batch APIs; member arrays are capped at **500** per request (400 before DB). Failed member writes and PATCH remove DB errors return proper SCIM errors instead of log-and-continue; group create no longer maps transient DB errors to **409 uniqueness**.
> 
> **Tests:** New db/handler coverage for rollback on invalid members, batch dedup, caps, idempotent re-add, and corrected-retry-after-400 behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04434ab57948e8fdb69bd59672438f05a51bcc38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->