### PR TITLE
fix(server): transfer org-scoped applications when their creator is deleted

### DIFF
--- a/crates/vouch-server/src/db/tests/cascade_delete.rs
+++ b/crates/vouch-server/src/db/tests/cascade_delete.rs
@@ -497,3 +497,95 @@ async fn test_delete_user_skips_deactivated_org_admin_as_successor() {
         "a deactivated admin must not inherit the application"
     );
 }
+
+/// Two org admins deleted at the same time must not leave the organization's
+/// applications owned by a user that no longer exists.
+///
+/// Both deletions read the org's members to choose a successor, and a
+/// predicate read is what concurrent transactions do not conflict on: each
+/// would otherwise pick the other, and both rows would then be removed.
+/// Writing the org row makes the loser re-read and pick a survivor — or,
+/// when it is the last admin, unlink.
+///
+/// This asserts the invariant; it does not reproduce the skew. SQLite
+/// serializes writers, so the interleaving that produces it cannot occur
+/// here — the same reason
+/// `test_enroll_user_with_org_same_domain_converges_on_one_org` exercises
+/// its property sequentially. The guarantee under READ COMMITTED comes from
+/// the org-row write in `delete_user`, which is the pattern enrollment uses
+/// to claim its admin slot.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_concurrent_admin_deletes_never_strand_org_apps() {
+    let (store, _audit) = test_db().await;
+    seed_test_org(&store).await;
+    let store = std::sync::Arc::new(store);
+
+    let (admin_a, _) = upsert_user_with_org(
+        &store,
+        "race-admin-a@example.com",
+        None,
+        Some(TEST_ORG_ID),
+        true,
+    )
+    .await
+    .expect("create admin a");
+    let (admin_b, _) = upsert_user_with_org(
+        &store,
+        "race-admin-b@example.com",
+        None,
+        Some(TEST_ORG_ID),
+        true,
+    )
+    .await
+    .expect("create admin b");
+
+    let app_a = create_scoped_client(
+        &store,
+        &admin_a,
+        "App A",
+        AccessScope::Organization,
+        Some(TEST_ORG_ID),
+    )
+    .await;
+    let app_b = create_scoped_client(
+        &store,
+        &admin_b,
+        "App B",
+        AccessScope::Organization,
+        Some(TEST_ORG_ID),
+    )
+    .await;
+
+    let (r1, r2) = tokio::join!(
+        {
+            let s = std::sync::Arc::clone(&store);
+            let id = admin_a.clone();
+            async move { delete_user(&s, &id).await }
+        },
+        {
+            let s = std::sync::Arc::clone(&store);
+            let id = admin_b.clone();
+            async move { delete_user(&s, &id).await }
+        },
+    );
+    assert!(r1.expect("delete a"), "admin a must be deleted");
+    assert!(r2.expect("delete b"), "admin b must be deleted");
+
+    // Whatever order they ran in, no application may reference a deleted user.
+    for app_id in [&app_a, &app_b] {
+        let client = get_oauth_client_by_id(&store, app_id)
+            .await
+            .expect("lookup app")
+            .expect("app still exists");
+        if let Some(owner) = client.user_id.as_deref() {
+            let owner_exists = get_user_by_id(&store, owner)
+                .await
+                .expect("lookup owner")
+                .is_some();
+            assert!(
+                owner_exists,
+                "application {app_id} is owned by deleted user {owner}"
+            );
+        }
+    }
+}

--- a/crates/vouch-server/src/db/tests/cascade_delete.rs
+++ b/crates/vouch-server/src/db/tests/cascade_delete.rs
@@ -278,3 +278,222 @@ async fn test_oauth_client_cascade_delete() {
         "JWKS cache must be deleted with the client"
     );
 }
+
+// ========================================================================
+// Org-scoped application ownership transfer on user deletion
+// ========================================================================
+
+/// Build an OAuth client owned by `user_id` with the given access scope.
+async fn create_scoped_client(
+    store: &DocumentStore,
+    user_id: &str,
+    name: &str,
+    access_scope: AccessScope,
+    org_id: Option<&str>,
+) -> String {
+    let (client, _) = create_oauth_client(
+        store,
+        &CreateOAuthClientParams {
+            user_id: Some(user_id),
+            name,
+            description: None,
+            application_type: OAuthClientType::Web,
+            redirect_uris: &[],
+            access_scope,
+            org_id,
+            resource_uris: &[],
+            token_endpoint_auth_method: None,
+            jwks: None,
+            jwks_uri: None,
+            fapi_profile: None,
+            dpop_bound_access_tokens: None,
+            grant_types: None,
+            response_types: None,
+            software_id: None,
+            software_version: None,
+            registration_source: RegistrationSource::Manual,
+            registration_access_token_hash: None,
+            registration_metadata: None,
+            id_token_signed_response_alg: JwsAlgorithm::Rs256,
+            tls_client_auth_subject_dn: None,
+            tls_client_auth_san_dns: None,
+            tls_client_auth_san_uri: None,
+            tls_client_auth_san_ip: None,
+            tls_client_auth_san_email: None,
+            tls_client_certificate_bound_access_tokens: None,
+            authorization_signed_response_alg: None,
+            introspection_signed_response_alg: None,
+            request_object_signing_alg: None,
+            require_signed_request_object: None,
+            userinfo_signed_response_alg: None,
+            request_uris: None,
+            post_logout_redirect_uris: None,
+        },
+    )
+    .await
+    .expect("Failed to create client");
+    client.id
+}
+
+/// Deleting an org-scoped application's creator transfers the application to
+/// an active org admin. Management is creator-only, so leaving `user_id`
+/// empty would strand the application with no one able to manage it.
+#[tokio::test]
+async fn test_delete_user_transfers_org_scoped_apps_to_org_admin() {
+    let (store, _audit) = test_db().await;
+    seed_test_org(&store).await;
+
+    let (creator_id, _) = upsert_user_with_org(
+        &store,
+        "org-app-creator@example.com",
+        None,
+        Some(TEST_ORG_ID),
+        false,
+    )
+    .await
+    .expect("create creator");
+    let (admin_id, _) = upsert_user_with_org(
+        &store,
+        "org-app-admin@example.com",
+        None,
+        Some(TEST_ORG_ID),
+        true,
+    )
+    .await
+    .expect("create admin");
+
+    let org_app = create_scoped_client(
+        &store,
+        &creator_id,
+        "Org App",
+        AccessScope::Organization,
+        Some(TEST_ORG_ID),
+    )
+    .await;
+    let personal_app = create_scoped_client(
+        &store,
+        &creator_id,
+        "Personal App",
+        AccessScope::Personal,
+        Some(TEST_ORG_ID),
+    )
+    .await;
+
+    assert!(
+        delete_user(&store, &creator_id).await.expect("delete_user"),
+        "creator must be deleted"
+    );
+
+    let org_client = get_oauth_client_by_id(&store, &org_app)
+        .await
+        .expect("lookup org app")
+        .expect("org app still exists");
+    assert_eq!(
+        org_client.user_id.as_deref(),
+        Some(admin_id.as_str()),
+        "org-scoped app must transfer to the org admin so it stays manageable"
+    );
+
+    let personal_client = get_oauth_client_by_id(&store, &personal_app)
+        .await
+        .expect("lookup personal app")
+        .expect("personal app still exists");
+    assert_eq!(
+        personal_client.user_id, None,
+        "personal app has no other legitimate owner and stays unlinked"
+    );
+}
+
+/// With no other active org admin to inherit it, an org-scoped application
+/// is unlinked as before — there is no one to transfer it to.
+#[tokio::test]
+async fn test_delete_user_unlinks_org_app_when_no_admin_remains() {
+    let (store, _audit) = test_db().await;
+    seed_test_org(&store).await;
+
+    let (creator_id, _) = upsert_user_with_org(
+        &store,
+        "sole-admin@example.com",
+        None,
+        Some(TEST_ORG_ID),
+        true,
+    )
+    .await
+    .expect("create creator");
+
+    let org_app = create_scoped_client(
+        &store,
+        &creator_id,
+        "Sole Org App",
+        AccessScope::Organization,
+        Some(TEST_ORG_ID),
+    )
+    .await;
+
+    assert!(
+        delete_user(&store, &creator_id).await.expect("delete_user"),
+        "creator must be deleted"
+    );
+
+    let org_client = get_oauth_client_by_id(&store, &org_app)
+        .await
+        .expect("lookup org app")
+        .expect("org app still exists");
+    assert_eq!(
+        org_client.user_id, None,
+        "with no successor admin the app is unlinked"
+    );
+}
+
+/// A deactivated org admin must not inherit applications — they cannot
+/// authenticate, so the transfer would strand the app just as surely.
+#[tokio::test]
+async fn test_delete_user_skips_deactivated_org_admin_as_successor() {
+    let (store, _audit) = test_db().await;
+    seed_test_org(&store).await;
+
+    let (creator_id, _) = upsert_user_with_org(
+        &store,
+        "transfer-creator@example.com",
+        None,
+        Some(TEST_ORG_ID),
+        false,
+    )
+    .await
+    .expect("create creator");
+    let (inactive_admin_id, _) = upsert_user_with_org(
+        &store,
+        "inactive-admin@example.com",
+        None,
+        Some(TEST_ORG_ID),
+        true,
+    )
+    .await
+    .expect("create inactive admin");
+    update_user_active_status(&store, &inactive_admin_id, false)
+        .await
+        .expect("deactivate admin");
+
+    let org_app = create_scoped_client(
+        &store,
+        &creator_id,
+        "Org App",
+        AccessScope::Organization,
+        Some(TEST_ORG_ID),
+    )
+    .await;
+
+    assert!(
+        delete_user(&store, &creator_id).await.expect("delete_user"),
+        "creator must be deleted"
+    );
+
+    let org_client = get_oauth_client_by_id(&store, &org_app)
+        .await
+        .expect("lookup org app")
+        .expect("org app still exists");
+    assert_eq!(
+        org_client.user_id, None,
+        "a deactivated admin must not inherit the application"
+    );
+}

--- a/crates/vouch-server/src/db/users.rs
+++ b/crates/vouch-server/src/db/users.rs
@@ -145,6 +145,33 @@ pub async fn get_users_by_ids(
         .collect())
 }
 
+/// Pick the org admin that inherits a departing user's org-scoped
+/// applications.
+///
+/// Returns the lowest-sorting active org admin in `org_id`, excluding
+/// `departing_user_id`. Sorting by ID makes the choice deterministic, so
+/// concurrent deletions in the same organization agree on a successor.
+/// Returns `None` when the user has no org or the org has no other active
+/// admin — in that case the caller unlinks rather than transfers.
+async fn org_admin_successor(
+    tx: &mut super::store::StoreTransaction<'_>,
+    org_id: Option<&str>,
+    departing_user_id: &str,
+) -> Result<Option<String>> {
+    let Some(org_id) = org_id else {
+        return Ok(None);
+    };
+
+    let members = tx.find_all::<UserDoc>("org_id", org_id).await?;
+    let mut admin_ids: Vec<String> = members
+        .into_iter()
+        .filter(|m| m.data.is_org_admin && m.data.active && m.id != departing_user_id)
+        .map(|m| m.id)
+        .collect();
+    admin_ids.sort();
+    Ok(admin_ids.into_iter().next())
+}
+
 /// Delete a user and all associated data atomically.
 ///
 /// Wraps all cascade deletes in a single transaction so that a partial
@@ -156,12 +183,18 @@ pub async fn get_users_by_ids(
 /// 3. Delete authenticators (and their related device_auth refs)
 /// 4. Delete SSH issued certificate records
 /// 5. Delete token exchanges
-/// 6. Unlink OAuth clients (set user_id to None)
+/// 6. Transfer org-scoped OAuth clients to an org admin; unlink the rest
 /// 7. Delete the user
 ///
 /// Note: SSH revocation records (`SshRevokedCertDoc`) are intentionally
 /// NOT deleted — they must outlive the user so SSH servers can still
 /// check the KRL. They expire naturally via `expires_at`.
+///
+/// # Returns
+///
+/// `Ok(true)` when the user existed and was deleted, `Ok(false)` when no
+/// user with `user_id` was found — callers surface the latter as a 404 and
+/// must not record a deletion audit event.
 pub async fn delete_user(store: &DocumentStore, user_id: &str) -> Result<bool> {
     use super::documents::authenticator::AuthenticatorDoc;
     use super::documents::credential::{EnrollmentSessionDoc, SshIssuedCertDoc};
@@ -185,9 +218,10 @@ pub async fn delete_user(store: &DocumentStore, user_id: &str) -> Result<bool> {
         // dead code: `tx.delete` returns `Ok(())` regardless of whether
         // anything was removed. Mirrors `delete_scim_group` /
         // `delete_custom_policy`.
-        let Some(_) = tx.get::<UserDoc>(user_id).await? else {
+        let Some(user_doc) = tx.get::<UserDoc>(user_id).await? else {
             return Ok(false);
         };
+        let org_id = user_doc.data.org_id.clone();
 
         // 1. Delete sessions
         tx.delete_by_index::<SessionDoc>("user_id", user_id).await?;
@@ -214,9 +248,25 @@ pub async fn delete_user(store: &DocumentStore, user_id: &str) -> Result<bool> {
         tx.delete_by_index::<TokenExchangeDoc>("subject_user_id", user_id)
             .await?;
 
-        // 6. Unlink OAuth clients (set user_id to None)
+        // 6. Reassign org-scoped OAuth clients; unlink the rest.
+        //
+        // Application management is creator-only: every check compares the
+        // caller against `Some(client.user_id)`. Clearing `user_id` therefore
+        // strands an organization's applications permanently — no one can
+        // rotate their secrets, update redirect URIs, or delete them. An
+        // org-scoped application belongs to the organization rather than to
+        // the individual, so it transfers to an active org admin, keeping it
+        // both manageable and discoverable in that admin's normal list.
+        // Personal and public applications have no other legitimate owner
+        // and are unlinked.
+        let successor = org_admin_successor(&mut tx, org_id.as_deref(), user_id).await?;
         tx.update_by_index::<OAuthClientDoc, _>("user_id", user_id, |d| {
-            d.user_id = None;
+            d.user_id = match (d.access_scope, successor.as_deref()) {
+                (super::documents::oauth::AccessScope::Organization, Some(admin_id)) => {
+                    Some(admin_id.to_string())
+                }
+                _ => None,
+            };
         })
         .await?;
 

--- a/crates/vouch-server/src/db/users.rs
+++ b/crates/vouch-server/src/db/users.rs
@@ -145,6 +145,26 @@ pub async fn get_users_by_ids(
         .collect())
 }
 
+/// Failure modes of [`delete_user`].
+#[derive(Debug, thiserror::Error)]
+pub enum DeleteUserError {
+    /// Another transaction changed the organization row while this delete was
+    /// choosing a successor for the user's org-scoped applications.
+    #[error("organization changed during delete")]
+    OccConflict,
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+impl super::pool::RetryableError for DeleteUserError {
+    fn is_retryable(&self) -> bool {
+        match self {
+            Self::OccConflict => true,
+            Self::Other(e) => super::pool::is_retryable_db_error(e),
+        }
+    }
+}
+
 /// Pick the org admin that inherits a departing user's org-scoped
 /// applications.
 ///
@@ -195,7 +215,7 @@ async fn org_admin_successor(
 /// `Ok(true)` when the user existed and was deleted, `Ok(false)` when no
 /// user with `user_id` was found — callers surface the latter as a 404 and
 /// must not record a deletion audit event.
-pub async fn delete_user(store: &DocumentStore, user_id: &str) -> Result<bool> {
+pub async fn delete_user(store: &DocumentStore, user_id: &str) -> Result<bool, DeleteUserError> {
     use super::documents::authenticator::AuthenticatorDoc;
     use super::documents::credential::{EnrollmentSessionDoc, SshIssuedCertDoc};
     use super::documents::oauth::OAuthClientDoc;
@@ -269,6 +289,36 @@ pub async fn delete_user(store: &DocumentStore, user_id: &str) -> Result<bool> {
             };
         })
         .await?;
+
+        // Serialize deletions within an organization on the org row.
+        //
+        // Choosing a successor reads the org's members, and a predicate read
+        // is exactly what concurrent transactions do not conflict on under
+        // READ COMMITTED. Two admins deleted at once would each pick the
+        // other — both reads predate both deletions — and the applications
+        // would land on a user row that no longer exists. Writing the org
+        // row makes those transactions collide: the loser retries, re-reads
+        // members without the winner, and picks someone who still exists.
+        // Enrollment claims its admin slot against the same row for the same
+        // reason.
+        //
+        // Every delete of a member of an org takes this write, not only the
+        // ones that transfer: the user being deleted may itself be the
+        // successor a concurrent delete just chose. Deleting a user is a rare
+        // administrative action, so serializing per organization costs
+        // little.
+        if let Some(ref org_id) = org_id
+            && let Some(org_doc) = tx
+                .get::<super::documents::organization::OrganizationDoc>(org_id)
+                .await?
+        {
+            let won = tx
+                .compare_and_update(org_id, org_doc.version, &org_doc.data)
+                .await?;
+            if !won {
+                return Err(DeleteUserError::OccConflict);
+            }
+        }
 
         // 7. Delete the user
         tx.delete(user_id).await?;

--- a/crates/vouch-server/src/handlers/admin/members.rs
+++ b/crates/vouch-server/src/handlers/admin/members.rs
@@ -506,7 +506,12 @@ pub(crate) async fn remove_member(
         )
     })?;
 
-    let deleted = db::delete_user(&state.store, &target_id).await?;
+    let deleted = db::delete_user(&state.store, &target_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete user: {e}");
+            ServiceError::Internal("Failed to delete user".to_string())
+        })?;
     if !deleted {
         return Err(member_gone());
     }


### PR DESCRIPTION
Deleting a user cleared `user_id` on every application they created. Application management is creator-only — each check compares the caller against `Some(client.user_id)` — so an organization's applications became permanently unmanageable: nobody could rotate their secrets, update redirect URIs, or delete them.

Org-scoped applications now transfer to the lowest-sorting active org admin, chosen deterministically so concurrent deletions agree on a successor. Personal and public applications have no other legitimate owner and are unlinked as before. A transferred application appears in the new owner's normal list, so it is reachable without knowing its UUID.

The creator-only authorization model is unchanged.

Also documents `delete_user`'s `Ok(false)` return, which was never stated and is how the meaning drifted.

## Tests

- `test_delete_user_transfers_org_scoped_apps_to_org_admin`
- `test_delete_user_unlinks_org_app_when_no_admin_remains`
- `test_delete_user_skips_deactivated_org_admin_as_successor`

The first fails against the previous behavior with `left: None, right: Some(admin_id)`.

Closes #913. Supersedes #926, which fixed the same lockout by granting org admins application management — a model that was explicitly rejected when the access-scope design was settled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth ownership on user deletion and adds org-row OCC serialization; incorrect successor logic could mis-assign org apps, but scope is limited to rare admin deletes with strong test coverage.
> 
> **Overview**
> **User deletion** no longer clears `user_id` on every OAuth application the user owned. Because app management is creator-only, that behavior left **org-scoped** apps permanently unmanageable.
> 
> `delete_user` now **reassigns** org-scoped clients to the lowest-ID **active** org admin (deterministic successor via `org_admin_successor`). Personal and other scopes still get `user_id` set to `None`. If there is no eligible admin (sole admin deleted, or only inactive admins), org apps are unlinked as before.
> 
> To avoid concurrent admin deletes each picking the other as successor and leaving apps owned by deleted users, the delete transaction **CAS-updates the organization row**; a lost race returns retryable `DeleteUserError::OccConflict`. The function’s error type is now `Result<bool, DeleteUserError>`, and admin **remove member** maps failures to a 500.
> 
> Adds cascade-delete tests for transfer, unlink, inactive-admin skip, and concurrent dual-admin delete invariants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71c5c3559b8d1131e3fbdbed31bf4334be070564. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->