### PR TITLE
fix(server): redact plaintext credentials in Debug output

### DIFF
--- a/crates/vouch-agent/src/config.rs
+++ b/crates/vouch-agent/src/config.rs
@@ -18,7 +18,7 @@ use vouch_common::dns::{DohConfigSerde, NetworkConfig};
 /// Supports both the multi-server format (with `current_server` +
 /// `servers` map) and the legacy flat format (top-level `server_url`
 /// + `token`).
-#[derive(Debug, Default, Deserialize)]
+#[derive(Default, Deserialize)]
 pub(crate) struct VouchConfig {
     /// Hostname of the currently active server (multi-server format).
     current_server: Option<String>,
@@ -34,11 +34,37 @@ pub(crate) struct VouchConfig {
     network: Option<NetworkConfig>,
 }
 
+// Custom Debug that redacts the legacy flat session token to prevent
+// accidental log exposure. `servers` is safe to print in full because
+// `ServerEntry` redacts its own token.
+impl std::fmt::Debug for VouchConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VouchConfig")
+            .field("current_server", &self.current_server)
+            .field("servers", &self.servers)
+            .field("server_url", &self.server_url)
+            .field("token", &"[REDACTED]")
+            .field("network", &self.network)
+            .finish()
+    }
+}
+
 /// Read-only per-server entry within the config file.
-#[derive(Debug, Default, Deserialize)]
+#[derive(Default, Deserialize)]
 struct ServerEntry {
     server_url: Option<String>,
     token: Option<String>,
+}
+
+// Custom Debug that redacts the session token to prevent accidental log
+// exposure of a live bearer credential.
+impl std::fmt::Debug for ServerEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ServerEntry")
+            .field("server_url", &self.server_url)
+            .field("token", &"[REDACTED]")
+            .finish()
+    }
 }
 
 impl VouchConfig {

--- a/crates/vouch-cli/src/commands/login.rs
+++ b/crates/vouch-cli/src/commands/login.rs
@@ -59,7 +59,7 @@ pub(crate) async fn run(server: &str, timeout_secs: u64) -> Result<()> {
 /// FAPI 2.0 assertion grant request form fields.
 ///
 /// Sent as `application/x-www-form-urlencoded` to `POST /oauth/token`.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
 struct Fido2AssertionTokenRequest {
     grant_type: &'static str,
     client_assertion_type: &'static str,
@@ -69,6 +69,21 @@ struct Fido2AssertionTokenRequest {
     /// RFC 9396: Device posture as authorization_details JSON array.
     #[serde(skip_serializing_if = "Option::is_none")]
     authorization_details: Option<String>,
+}
+
+// RFC 7521/7523: both the client assertion and the FIDO2 assertion are
+// credentials presented to the token endpoint, so neither is derived.
+impl std::fmt::Debug for Fido2AssertionTokenRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Fido2AssertionTokenRequest")
+            .field("grant_type", &self.grant_type)
+            .field("client_assertion_type", &self.client_assertion_type)
+            .field("client_assertion", &"[REDACTED]")
+            .field("assertion", &"[REDACTED]")
+            .field("scope", &self.scope)
+            .field("authorization_details", &self.authorization_details)
+            .finish()
+    }
 }
 
 /// JSON payload encoded into the `assertion` form field.

--- a/crates/vouch-cli/src/fapi/client_assertion.rs
+++ b/crates/vouch-cli/src/fapi/client_assertion.rs
@@ -29,12 +29,21 @@ struct ClientAssertionClaims {
 }
 
 /// A signed client assertion ready to be included in a token request.
-#[derive(Debug)]
 pub struct ClientAssertion {
     /// The signed JWT assertion string.
     pub assertion: String,
     /// The assertion type URI per RFC 7523.
     pub assertion_type: &'static str,
+}
+
+// The assertion is a signed JWT used as a client credential.
+impl std::fmt::Debug for ClientAssertion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClientAssertion")
+            .field("assertion", &"[REDACTED]")
+            .field("assertion_type", &self.assertion_type)
+            .finish()
+    }
 }
 
 impl ClientAssertion {

--- a/crates/vouch-cli/src/fapi/registration.rs
+++ b/crates/vouch-cli/src/fapi/registration.rs
@@ -42,7 +42,7 @@ struct RegistrationRequest {
 ///
 /// Contains the server-assigned `client_id` and the RFC 7592
 /// `registration_access_token` for future management operations.
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 struct RegistrationResponse {
     /// Server-assigned client identifier.
     client_id: String,
@@ -52,6 +52,18 @@ struct RegistrationResponse {
     /// URI for reading/updating/deleting the registration (RFC 7592).
     #[serde(default)]
     registration_client_uri: Option<String>,
+}
+
+// Custom Debug that redacts registration_access_token to prevent accidental
+// log exposure of the RFC 7592 management credential.
+impl std::fmt::Debug for RegistrationResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RegistrationResponse")
+            .field("client_id", &self.client_id)
+            .field("registration_access_token", &"[REDACTED]")
+            .field("registration_client_uri", &self.registration_client_uri)
+            .finish()
+    }
 }
 
 /// Register this CLI installation as a FAPI 2.0 client.
@@ -177,7 +189,6 @@ pub async fn is_client_registered(
 }
 
 /// Registration result containing the fields to save.
-#[derive(Debug)]
 pub struct RegistrationResult {
     /// Server-assigned client identifier.
     pub client_id: String,
@@ -187,4 +198,17 @@ pub struct RegistrationResult {
     pub registration_client_uri: Option<String>,
     /// Key ID of the DPoP key used for registration.
     pub dpop_key_id: String,
+}
+
+// Custom Debug that redacts registration_access_token to prevent accidental
+// log exposure of the RFC 7592 management credential.
+impl std::fmt::Debug for RegistrationResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RegistrationResult")
+            .field("client_id", &self.client_id)
+            .field("registration_access_token", &"[REDACTED]")
+            .field("registration_client_uri", &self.registration_client_uri)
+            .field("dpop_key_id", &self.dpop_key_id)
+            .finish()
+    }
 }

--- a/crates/vouch-server/src/db/documents/organization.rs
+++ b/crates/vouch-server/src/db/documents/organization.rs
@@ -197,7 +197,7 @@ pub enum AdditionalDomainState {
 }
 
 /// A secondary email domain claimed by an organization.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct AdditionalDomain {
     /// Normalized lowercase ASCII domain.
     pub domain: String,
@@ -215,6 +215,22 @@ pub struct AdditionalDomain {
     #[serde(default)]
     pub consecutive_failures: u32,
     pub state: AdditionalDomainState,
+}
+
+// Custom Debug that redacts verification_token to keep the DNS challenge
+// value out of logs.
+impl std::fmt::Debug for AdditionalDomain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AdditionalDomain")
+            .field("domain", &self.domain)
+            .field("verification_token", &"[REDACTED]")
+            .field("added_at", &self.added_at)
+            .field("added_by_user_id", &self.added_by_user_id)
+            .field("added_by_email", &self.added_by_email)
+            .field("consecutive_failures", &self.consecutive_failures)
+            .field("state", &self.state)
+            .finish()
+    }
 }
 
 /// Number of consecutive failed re-verifications before an entry is flipped

--- a/crates/vouch-server/src/db/documents/user.rs
+++ b/crates/vouch-server/src/db/documents/user.rs
@@ -8,7 +8,7 @@ use crate::db::document_type::{DocumentType, IndexEntry};
 use crate::email::Email;
 
 /// A Vouch user.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UserDoc {
     /// Canonical (trimmed, ASCII-lowercased) address. The [`Email`] type
     /// canonicalizes on construction and deserialization, so the `email`
@@ -31,6 +31,25 @@ pub struct UserDoc {
     /// IdP — they bind lazily on their first verified-email login.
     #[serde(default)]
     pub idp_identities: Vec<IdpIdentity>,
+}
+
+// Custom Debug that redacts github_refresh_token to prevent accidental log
+// exposure of a credential that mints new GitHub access tokens.
+impl std::fmt::Debug for UserDoc {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UserDoc")
+            .field("email", &self.email)
+            .field("name", &self.name)
+            .field("org_id", &self.org_id)
+            .field("is_org_admin", &self.is_org_admin)
+            .field("active", &self.active)
+            .field("external_id", &self.external_id)
+            .field("github_id", &self.github_id)
+            .field("github_login", &self.github_login)
+            .field("github_refresh_token", &"[REDACTED]")
+            .field("idp_identities", &self.idp_identities)
+            .finish()
+    }
 }
 
 /// An upstream identity: the OIDC `(iss, sub)` pair, or for SAML the

--- a/crates/vouch-server/src/db/organizations/domains.rs
+++ b/crates/vouch-server/src/db/organizations/domains.rs
@@ -30,10 +30,20 @@ pub async fn list_additional_domains(
 }
 
 /// Result of adding an additional domain.
-#[derive(Debug)]
 pub struct AddedDomain {
     pub domain: String,
     pub verification_token: String,
+}
+
+// Custom Debug that redacts verification_token to keep the DNS challenge
+// value out of logs.
+impl std::fmt::Debug for AddedDomain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AddedDomain")
+            .field("domain", &self.domain)
+            .field("verification_token", &"[REDACTED]")
+            .finish()
+    }
 }
 
 /// Generate a fresh verification token suitable for use in a DNS TXT record.
@@ -685,13 +695,27 @@ pub async fn cleanup_stale_additional_domains(
 /// A snapshot of one verified additional-domain entry, used by the
 /// re-verification task to drive its DNS checks without holding the org doc
 /// open while it waits on the network.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct VerifiedDomainRecord {
     pub org_id: String,
     pub domain: String,
     pub verification_token: String,
     pub last_checked_at: Option<Timestamp>,
     pub consecutive_failures: u32,
+}
+
+// Custom Debug that redacts verification_token to keep the DNS challenge
+// value out of logs.
+impl std::fmt::Debug for VerifiedDomainRecord {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VerifiedDomainRecord")
+            .field("org_id", &self.org_id)
+            .field("domain", &self.domain)
+            .field("verification_token", &"[REDACTED]")
+            .field("last_checked_at", &self.last_checked_at)
+            .field("consecutive_failures", &self.consecutive_failures)
+            .finish()
+    }
 }
 
 /// Outcome of a single re-verification attempt for [`record_recheck_result`].

--- a/crates/vouch-server/src/db/users.rs
+++ b/crates/vouch-server/src/db/users.rs
@@ -9,7 +9,6 @@ use super::store::DocumentStore;
 use anyhow::Result;
 
 /// User record.
-#[derive(Debug)]
 pub struct User {
     pub id: String,
     pub email: String,
@@ -21,6 +20,25 @@ pub struct User {
     pub github_id: Option<i64>,
     pub github_login: Option<String>,
     pub github_refresh_token: Option<String>,
+}
+
+// Custom Debug that redacts github_refresh_token to prevent accidental log
+// exposure of a credential that mints new GitHub access tokens.
+impl std::fmt::Debug for User {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("User")
+            .field("id", &self.id)
+            .field("email", &self.email)
+            .field("name", &self.name)
+            .field("org_id", &self.org_id)
+            .field("is_org_admin", &self.is_org_admin)
+            .field("active", &self.active)
+            .field("external_id", &self.external_id)
+            .field("github_id", &self.github_id)
+            .field("github_login", &self.github_login)
+            .field("github_refresh_token", &"[REDACTED]")
+            .finish()
+    }
 }
 
 impl From<Document<UserDoc>> for User {

--- a/crates/vouch-server/src/handlers/applications/types.rs
+++ b/crates/vouch-server/src/handlers/applications/types.rs
@@ -284,7 +284,7 @@ pub(crate) struct UpdateApplicationRequest {
 }
 
 /// API response for a created application.
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
 pub(crate) struct CreateApplicationResponse {
     pub id: String,
     pub client_id: String,
@@ -305,6 +305,30 @@ pub(crate) struct CreateApplicationResponse {
     /// RP-Initiated Logout 1.0: Registered post-logout redirect URIs.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub post_logout_redirect_uris: Option<Vec<String>>,
+}
+
+// Custom Debug that redacts client_secret to prevent accidental log exposure
+// of the freshly minted plaintext secret, which is returned only once.
+impl std::fmt::Debug for CreateApplicationResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CreateApplicationResponse")
+            .field("id", &self.id)
+            .field("client_id", &self.client_id)
+            .field("client_secret", &"[REDACTED]")
+            .field("name", &self.name)
+            .field("application_type", &self.application_type)
+            .field("access_scope", &self.access_scope)
+            .field("resource_uris", &self.resource_uris)
+            .field(
+                "token_endpoint_auth_method",
+                &self.token_endpoint_auth_method,
+            )
+            .field("fapi_profile", &self.fapi_profile)
+            .field("jwks_configured", &self.jwks_configured)
+            .field("jwks_uri", &self.jwks_uri)
+            .field("post_logout_redirect_uris", &self.post_logout_redirect_uris)
+            .finish()
+    }
 }
 
 /// API response for application details.
@@ -377,12 +401,25 @@ pub(crate) struct AddSecretRequest {
 }
 
 /// API response for adding a secret (plaintext shown once).
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
 pub(crate) struct AddSecretResponse {
     pub secret_id: String,
     pub client_secret: String,
     pub created_at: Timestamp,
     pub expires_at: Option<Timestamp>,
+}
+
+// Custom Debug that redacts client_secret to prevent accidental log exposure
+// of the freshly minted plaintext secret, which is returned only once.
+impl std::fmt::Debug for AddSecretResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AddSecretResponse")
+            .field("secret_id", &self.secret_id)
+            .field("client_secret", &"[REDACTED]")
+            .field("created_at", &self.created_at)
+            .field("expires_at", &self.expires_at)
+            .finish()
+    }
 }
 
 /// Secret metadata for listing (never exposes hash).

--- a/crates/vouch-server/src/handlers/certification.rs
+++ b/crates/vouch-server/src/handlers/certification.rs
@@ -43,12 +43,23 @@ use crate::{
 const CERT_USER_EMAIL: &str = "cert-test@vouch.sh";
 
 /// Query parameters for `GET /certification/complete-login`.
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 pub(crate) struct CompleteLoginQuery {
     /// Pending OAuth authorization ID (UUID).
     pub pending_auth: String,
     /// HMAC-SHA256 of `pending_auth`, base64url-encoded (no padding).
     pub token: String,
+}
+
+// Custom Debug that redacts the token to prevent accidental log exposure:
+// presenting it alongside `pending_auth` is what completes the login.
+impl std::fmt::Debug for CompleteLoginQuery {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CompleteLoginQuery")
+            .field("pending_auth", &self.pending_auth)
+            .field("token", &"[REDACTED]")
+            .finish()
+    }
 }
 
 /// GET /certification/complete-login?pending_auth=<UUID>&token=<HMAC>

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -170,11 +170,22 @@ pub(crate) struct OidcCallbackParams {
 }
 
 /// OIDC token response.
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 struct OidcTokenResponse {
     id_token: String,
     #[expect(dead_code, reason = "reserved for serde DTO conformance / future use")]
     access_token: String,
+}
+
+// Custom Debug that redacts both tokens to prevent accidental log exposure of
+// the upstream IdP's credentials for this user.
+impl std::fmt::Debug for OidcTokenResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OidcTokenResponse")
+            .field("id_token", &"[REDACTED]")
+            .field("access_token", &"[REDACTED]")
+            .finish()
+    }
 }
 
 /// Client data JSON structure from `WebAuthn` response.

--- a/crates/vouch-server/src/handlers/oidc/introspect.rs
+++ b/crates/vouch-server/src/handlers/oidc/introspect.rs
@@ -28,7 +28,7 @@ use super::client_auth::{ClientAuthFields, complete_client_auth, extract_client_
 ///
 /// Supports `client_secret_basic`, `client_secret_post`, and `private_key_jwt`
 /// (RFC 7523) client authentication methods.
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 pub(crate) struct RevokeRequest {
     /// RFC 7009 Section 2.1: The token that the client wants to get revoked.
     token: String,
@@ -49,6 +49,21 @@ pub(crate) struct RevokeRequest {
     /// `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`).
     #[serde(default)]
     client_assertion_type: Option<String>,
+}
+
+// Custom Debug that redacts the subject token to prevent accidental log
+// exposure of a live credential the client is asking us to revoke.
+impl std::fmt::Debug for RevokeRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RevokeRequest")
+            .field("token", &"[REDACTED]")
+            .field("token_type_hint", &self.token_type_hint)
+            .field("client_id", &self.client_id)
+            .field("client_secret", &self.client_secret)
+            .field("client_assertion", &self.client_assertion)
+            .field("client_assertion_type", &self.client_assertion_type)
+            .finish()
+    }
 }
 
 impl ClientAuthFields for RevokeRequest {
@@ -73,7 +88,7 @@ impl ClientAuthFields for RevokeRequest {
 ///
 /// Supports `client_secret_basic`, `client_secret_post`, and `private_key_jwt`
 /// (RFC 7523) client authentication methods.
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 pub(crate) struct IntrospectRequest {
     /// RFC 7662 Section 2.1: The string value of the token.
     token: String,
@@ -94,6 +109,21 @@ pub(crate) struct IntrospectRequest {
     /// `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`).
     #[serde(default)]
     client_assertion_type: Option<String>,
+}
+
+// Custom Debug that redacts the subject token to prevent accidental log
+// exposure of the live credential being introspected.
+impl std::fmt::Debug for IntrospectRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IntrospectRequest")
+            .field("token", &"[REDACTED]")
+            .field("token_type_hint", &self.token_type_hint)
+            .field("client_id", &self.client_id)
+            .field("client_secret", &self.client_secret)
+            .field("client_assertion", &self.client_assertion)
+            .field("client_assertion_type", &self.client_assertion_type)
+            .finish()
+    }
 }
 
 impl ClientAuthFields for IntrospectRequest {

--- a/crates/vouch-server/src/handlers/oidc/introspect.rs
+++ b/crates/vouch-server/src/handlers/oidc/introspect.rs
@@ -59,8 +59,8 @@ impl std::fmt::Debug for RevokeRequest {
             .field("token", &"[REDACTED]")
             .field("token_type_hint", &self.token_type_hint)
             .field("client_id", &self.client_id)
-            .field("client_secret", &self.client_secret)
-            .field("client_assertion", &self.client_assertion)
+            .field("client_secret", &"[REDACTED]")
+            .field("client_assertion", &"[REDACTED]")
             .field("client_assertion_type", &self.client_assertion_type)
             .finish()
     }
@@ -119,8 +119,8 @@ impl std::fmt::Debug for IntrospectRequest {
             .field("token", &"[REDACTED]")
             .field("token_type_hint", &self.token_type_hint)
             .field("client_id", &self.client_id)
-            .field("client_secret", &self.client_secret)
-            .field("client_assertion", &self.client_assertion)
+            .field("client_secret", &"[REDACTED]")
+            .field("client_assertion", &"[REDACTED]")
             .field("client_assertion_type", &self.client_assertion_type)
             .finish()
     }

--- a/crates/vouch-server/src/handlers/oidc/logout.rs
+++ b/crates/vouch-server/src/handlers/oidc/logout.rs
@@ -47,17 +47,13 @@ use std::sync::Arc;
 // ============================================================================
 
 /// GET /oauth/logout query parameters (RP-Initiated Logout 1.0 Section 3).
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 pub(crate) struct LogoutQuery {
     /// OPTIONAL. Previously issued ID Token passed as a hint. Used to identify
     /// the RP and optionally to look up the client's registered post-logout URIs.
     pub id_token_hint: Option<String>,
     /// OPTIONAL. Hint about the End-User's login identifier. Informational only;
-    /// accepted per spec but not acted upon.
-    #[expect(
-        dead_code,
-        reason = "accepted per spec; not acted upon in this implementation"
-    )]
+    /// accepted per spec but not acted upon; the `Debug` impl is its only reader.
     pub logout_hint: Option<String>,
     /// OPTIONAL. OAuth 2.0 Client Identifier. Used only for display on the
     /// confirmation page when no `id_token_hint` is present. Does NOT gate
@@ -75,8 +71,23 @@ pub(crate) struct LogoutQuery {
     pub ui_locales: Option<String>,
 }
 
+// Custom Debug that redacts id_token_hint to prevent accidental log exposure:
+// it is a previously issued ID token, a bearer assertion in its own right.
+impl std::fmt::Debug for LogoutQuery {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LogoutQuery")
+            .field("id_token_hint", &"[REDACTED]")
+            .field("logout_hint", &self.logout_hint)
+            .field("client_id", &self.client_id)
+            .field("post_logout_redirect_uri", &self.post_logout_redirect_uri)
+            .field("state", &self.state)
+            .field("ui_locales", &self.ui_locales)
+            .finish()
+    }
+}
+
 /// POST /oauth/logout form body — mirrors the hidden fields in the confirmation form.
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 pub(crate) struct LogoutForm {
     pub id_token_hint: Option<String>,
     pub post_logout_redirect_uri: Option<String>,
@@ -89,6 +100,20 @@ pub(crate) struct LogoutForm {
     /// `ui_locales` is carried as a hidden field so the done page renders in the
     /// same locale as the confirmation page (plan §7).
     pub ui_locales: Option<String>,
+}
+
+// Custom Debug that redacts id_token_hint to prevent accidental log exposure:
+// it is a previously issued ID token, a bearer assertion in its own right.
+impl std::fmt::Debug for LogoutForm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LogoutForm")
+            .field("id_token_hint", &"[REDACTED]")
+            .field("post_logout_redirect_uri", &self.post_logout_redirect_uri)
+            .field("client_id", &self.client_id)
+            .field("state", &self.state)
+            .field("ui_locales", &self.ui_locales)
+            .finish()
+    }
 }
 
 // ============================================================================

--- a/crates/vouch-server/src/handlers/oidc/par.rs
+++ b/crates/vouch-server/src/handlers/oidc/par.rs
@@ -37,7 +37,7 @@ struct ParResponse {
 ///
 /// Contains the same parameters as an authorization request, plus client
 /// authentication fields.
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 pub(crate) struct ParRequest {
     /// RFC 6749 Section 4.1.1: Response type (must be "code").
     #[serde(default)]
@@ -99,6 +99,35 @@ pub(crate) struct ParRequest {
     /// JARM: Requested authorization response mode.
     #[serde(default)]
     response_mode: Option<String>,
+}
+
+// RFC 7521 Section 4.2: `client_assertion` is a signed JWT presented as a
+// client credential, so it is redacted rather than derived.
+impl std::fmt::Debug for ParRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ParRequest")
+            .field("response_type", &self.response_type)
+            .field("client_id", &self.client_id)
+            .field("redirect_uri", &self.redirect_uri)
+            .field("scope", &self.scope)
+            .field("state", &self.state)
+            .field("nonce", &self.nonce)
+            .field("code_challenge", &self.code_challenge)
+            .field("code_challenge_method", &self.code_challenge_method)
+            .field("resource", &self.resource)
+            .field("acr_values", &self.acr_values)
+            .field("max_age", &self.max_age)
+            .field("prompt", &self.prompt)
+            .field("request_uri", &self.request_uri)
+            .field("client_secret", &"[REDACTED]")
+            .field("client_assertion", &"[REDACTED]")
+            .field("client_assertion_type", &self.client_assertion_type)
+            .field("request", &self.request)
+            .field("dpop_jkt", &self.dpop_jkt)
+            .field("authorization_details", &self.authorization_details)
+            .field("response_mode", &self.response_mode)
+            .finish()
+    }
 }
 
 /// Implement `ClientAuthFields` for `ParRequest` to enable shared client

--- a/crates/vouch-server/src/services/oidc/registration.rs
+++ b/crates/vouch-server/src/services/oidc/registration.rs
@@ -184,7 +184,7 @@ impl RegistrationRequest {
 }
 
 /// RFC 7591 Section 3.2.1: Client Information Response.
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
 pub struct RegistrationResponse {
     /// RFC 7591 Section 3.2.1: REQUIRED. OAuth 2.0 client identifier.
     pub client_id: String,
@@ -257,6 +257,67 @@ pub struct RegistrationResponse {
     /// RP-Initiated Logout 1.0: Registered post-logout redirect URIs (echoed).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub post_logout_redirect_uris: Option<Vec<String>>,
+}
+
+// Custom Debug that redacts client_secret and registration_access_token to
+// prevent accidental log exposure. Both are minted here and returned to the
+// client in plaintext exactly once.
+impl std::fmt::Debug for RegistrationResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RegistrationResponse")
+            .field("client_id", &self.client_id)
+            .field("client_secret", &"[REDACTED]")
+            .field("client_secret_expires_at", &self.client_secret_expires_at)
+            .field("client_id_issued_at", &self.client_id_issued_at)
+            .field("registration_access_token", &"[REDACTED]")
+            .field("registration_client_uri", &self.registration_client_uri)
+            .field("redirect_uris", &self.redirect_uris)
+            .field(
+                "token_endpoint_auth_method",
+                &self.token_endpoint_auth_method,
+            )
+            .field("grant_types", &self.grant_types)
+            .field("response_types", &self.response_types)
+            .field("client_name", &self.client_name)
+            .field("client_uri", &self.client_uri)
+            .field("logo_uri", &self.logo_uri)
+            .field("tos_uri", &self.tos_uri)
+            .field("policy_uri", &self.policy_uri)
+            .field("scope", &self.scope)
+            .field("contacts", &self.contacts)
+            .field("jwks", &self.jwks)
+            .field("jwks_uri", &self.jwks_uri)
+            .field("software_id", &self.software_id)
+            .field("software_version", &self.software_version)
+            .field("dpop_bound_access_tokens", &self.dpop_bound_access_tokens)
+            .field(
+                "id_token_signed_response_alg",
+                &self.id_token_signed_response_alg,
+            )
+            .field(
+                "authorization_signed_response_alg",
+                &self.authorization_signed_response_alg,
+            )
+            .field(
+                "introspection_signed_response_alg",
+                &self.introspection_signed_response_alg,
+            )
+            .field(
+                "request_object_signing_alg",
+                &self.request_object_signing_alg,
+            )
+            .field(
+                "require_signed_request_object",
+                &self.require_signed_request_object,
+            )
+            .field(
+                "userinfo_signed_response_alg",
+                &self.userinfo_signed_response_alg,
+            )
+            .field("request_uris", &self.request_uris)
+            .field("post_logout_redirect_uris", &self.post_logout_redirect_uris)
+            .finish()
+    }
 }
 
 // ============================================================================

--- a/crates/vouch-server/tests/secrets_redacted_in_debug.rs
+++ b/crates/vouch-server/tests/secrets_redacted_in_debug.rs
@@ -1,0 +1,392 @@
+//! Workspace-wide regression test: no struct that derives `Debug` holds a
+//! plaintext credential in a bare `String`.
+//!
+//! A derived `Debug` prints every field verbatim, so any `{:?}` of such a
+//! struct — a `tracing` field, an `anyhow` context, a test failure message —
+//! writes the live credential into the log. The convention in this workspace
+//! is a hand-written `impl Debug` that prints `[REDACTED]` for the secret
+//! fields and leaves the rest visible (see `AuthCodeExchangeResult` in
+//! `services/oidc/token.rs`), rather than `SecretString`, so the response
+//! types keep their plain `String` fields for serde.
+//!
+//! Detection is by field name and type: a field whose name ends in `_token`,
+//! `_secret`, or `_token_hint` (or is exactly `token`/`secret`) and whose
+//! type is `String` or `Option<String>`. Suffix matching is what makes
+//! `token_type`, `token_endpoint_auth_method`, and
+//! `id_token_signing_alg_values_supported` non-matches; a field already
+//! wrapped in `SecretString`/`Zeroizing` is a non-match because its type is
+//! not a bare `String`.
+//!
+//! The scan covers every crate's `src/`, not just this one: the same response
+//! and config types live in `vouch-cli` and `vouch-agent`. Runtime coverage
+//! is not an option here — the leak only happens on the log line nobody
+//! wrote yet, so the property has to hold for every type, including the ones
+//! added tomorrow.
+//!
+//! Known limitation: each file is scanned only up to its first
+//! `#[cfg(test)] mod tests`, so a type declared *after* a trailing test
+//! module is not covered. Stopping there is deliberate — test fixtures hold
+//! throwaway credentials and would otherwise all be flagged — and it holds
+//! because test modules are file-final by convention here. Production items
+//! belong above the test module.
+
+#![allow(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Substrings marking a field that holds a derived, non-recoverable value
+/// rather than the credential itself, so printing it leaks nothing.
+const DERIVED_VALUE_MARKERS: &[&str] = &["hash", "digest", "thumbprint", "fingerprint"];
+
+/// `(struct, field)` pairs whose name matches the secret pattern but whose
+/// value is not a credential. Each entry needs a reason; keep the list short.
+const ALLOWED: &[(&str, &str, &str)] = &[];
+
+#[test]
+fn no_debug_derive_prints_a_plaintext_credential() {
+    let crates_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crates/ is the parent of this crate")
+        .to_path_buf();
+
+    let mut files = Vec::new();
+    for entry in fs::read_dir(&crates_root).expect("read crates/") {
+        let src = entry.expect("crates/ entry").path().join("src");
+        if src.is_dir() {
+            collect_rs_files(&src, &mut files).expect("walk src/");
+        }
+    }
+    files.sort();
+    assert!(
+        !files.is_empty(),
+        "found no sources to scan under crates/*/src"
+    );
+
+    let mut violations = Vec::new();
+    for path in &files {
+        // Standalone test files (`foo/tests.rs`, `foo/tests/*.rs`) are entirely
+        // test code, which never reaches a production log.
+        let in_tests_dir = path
+            .parent()
+            .and_then(|d| d.file_name())
+            .is_some_and(|d| d == "tests");
+        if path.file_name().is_some_and(|f| f == "tests.rs") || in_tests_dir {
+            continue;
+        }
+
+        let content = fs::read_to_string(path).expect("read source file");
+        let cutoff = test_module_cutoff(&content);
+        let production = content.get(..cutoff).unwrap_or(&content);
+
+        for hit in debug_derived_secret_fields(production) {
+            if ALLOWED
+                .iter()
+                .any(|(s, f, _)| *s == hit.struct_name && *f == hit.field)
+            {
+                continue;
+            }
+            let rel = path.strip_prefix(&crates_root).map_or_else(
+                |_| path.to_string_lossy().into_owned(),
+                |p| p.to_string_lossy().into_owned(),
+            );
+            violations.push(format!(
+                "{rel}:{} {}.{}: {}",
+                hit.line, hit.struct_name, hit.field, hit.ty
+            ));
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "found {} field(s) holding a plaintext credential in a struct that derives \
+         Debug — replace the derive with an `impl Debug` printing \"[REDACTED]\" for \
+         these fields and leaving the others visible:\n{}",
+        violations.len(),
+        violations.join("\n")
+    );
+}
+
+/// A secret-looking field on a `Debug`-deriving struct.
+struct SecretField {
+    line: usize,
+    struct_name: String,
+    field: String,
+    ty: String,
+}
+
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
+    for entry in fs::read_dir(dir)? {
+        let path = entry?.path();
+        if path.is_dir() {
+            collect_rs_files(&path, out)?;
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+/// Every secret-named `String`/`Option<String>` field declared in a struct
+/// whose attribute block derives `Debug`.
+///
+/// Attributes are accumulated across lines (a `#[derive(` list may wrap) and
+/// carried over intervening doc comments, then consumed by the next item
+/// declaration. Tuple and unit structs have no field names to match, so only
+/// brace-bodied structs are walked.
+fn debug_derived_secret_fields(content: &str) -> Vec<SecretField> {
+    let mut hits = Vec::new();
+    let mut attrs = String::new();
+    let mut attr_depth = 0usize;
+    let mut current: Option<(String, usize)> = None;
+    let mut brace_depth = 0usize;
+
+    for (index, line) in content.lines().enumerate() {
+        let trimmed = line.trim();
+        let line_no = index.saturating_add(1);
+
+        if let Some((struct_name, _)) = current.as_ref() {
+            if brace_depth == 1
+                && let Some((field, ty)) = parse_field(trimmed)
+                && is_secret_field_name(&field)
+                && is_bare_string(&ty)
+            {
+                hits.push(SecretField {
+                    line: line_no,
+                    struct_name: struct_name.clone(),
+                    field,
+                    ty,
+                });
+            }
+            brace_depth = brace_depth
+                .saturating_add(trimmed.matches('{').count())
+                .saturating_sub(trimmed.matches('}').count());
+            if brace_depth == 0 {
+                current = None;
+            }
+            continue;
+        }
+
+        if attr_depth > 0 {
+            attrs.push_str(trimmed);
+            attr_depth = bracket_depth(attr_depth, trimmed);
+            continue;
+        }
+        if trimmed.starts_with("#[") {
+            attrs.push_str(trimmed);
+            attr_depth = bracket_depth(0, trimmed);
+            continue;
+        }
+        // Doc comments sit between the derive and the item; they neither add
+        // to nor clear the pending attribute block.
+        if trimmed.is_empty() || trimmed.starts_with("//") {
+            continue;
+        }
+
+        if let Some(name) = struct_header_name(trimmed)
+            && derives_debug(&attrs)
+            && trimmed.contains('{')
+        {
+            current = Some((name, line_no));
+            brace_depth = trimmed
+                .matches('{')
+                .count()
+                .saturating_sub(trimmed.matches('}').count());
+            if brace_depth == 0 {
+                current = None;
+            }
+        }
+        attrs.clear();
+    }
+
+    hits
+}
+
+/// The struct name in a declaration line, stripped of visibility, generics,
+/// and the opening brace or paren.
+fn struct_header_name(trimmed: &str) -> Option<String> {
+    let rest = trimmed
+        .strip_prefix("pub ")
+        .or_else(|| trimmed.strip_prefix("pub(crate) "))
+        .or_else(|| trimmed.strip_prefix("pub(super) "))
+        .unwrap_or(trimmed);
+    let rest = rest.strip_prefix("struct ")?;
+    let name: String = rest
+        .chars()
+        .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+        .collect();
+    if name.is_empty() { None } else { Some(name) }
+}
+
+/// Whether an accumulated attribute block contains a `derive` naming `Debug`.
+fn derives_debug(attrs: &str) -> bool {
+    let Some(start) = attrs.find("derive(") else {
+        return false;
+    };
+    let list = attrs.get(start..).unwrap_or("");
+    list.split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+        .any(|token| token == "Debug")
+}
+
+/// The `(name, type)` of a `name: Type,` field declaration.
+fn parse_field(trimmed: &str) -> Option<(String, String)> {
+    let rest = trimmed
+        .strip_prefix("pub ")
+        .or_else(|| trimmed.strip_prefix("pub(crate) "))
+        .or_else(|| trimmed.strip_prefix("pub(super) "))
+        .unwrap_or(trimmed);
+    let colon = rest.find(':')?;
+    let name = rest.get(..colon)?.trim();
+    if name.is_empty() || !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        return None;
+    }
+    let ty = rest
+        .get(colon.saturating_add(1)..)?
+        .trim()
+        .trim_end_matches(',')
+        .trim();
+    if ty.is_empty() {
+        return None;
+    }
+    Some((name.to_string(), ty.to_string()))
+}
+
+/// Whether a field name names a live credential rather than a derived value.
+fn is_secret_field_name(name: &str) -> bool {
+    if DERIVED_VALUE_MARKERS.iter().any(|m| name.contains(m)) {
+        return false;
+    }
+    name == "token"
+        || name == "secret"
+        || name.ends_with("_token")
+        || name.ends_with("_secret")
+        || name.ends_with("_token_hint")
+}
+
+/// Whether a type prints its contents under `Debug` — as opposed to
+/// `SecretString`, `Zeroizing`, or any other redacting wrapper.
+fn is_bare_string(ty: &str) -> bool {
+    ty == "String" || ty == "Option<String>"
+}
+
+/// Byte offset where the trailing `#[cfg(test)] mod ...` section begins, or
+/// the full length when the file has none. Test modules are file-final by
+/// convention in this codebase. Mirrors `arch_boundaries.rs`'s helper of
+/// the same name — duplicated rather than shared, since integration test
+/// binaries in `tests/` can't import each other's private items.
+fn test_module_cutoff(content: &str) -> usize {
+    let mut offset = 0usize;
+    let mut pending: Option<usize> = None;
+    let mut attr_depth = 0usize;
+    for line in content.split_inclusive('\n') {
+        let trimmed = line.trim();
+        if pending.is_some() && attr_depth > 0 {
+            attr_depth = bracket_depth(attr_depth, trimmed);
+        } else if trimmed == "#[cfg(test)]" {
+            pending.get_or_insert(offset);
+        } else if trimmed.starts_with("#[cfg(test)]") && trimmed.contains("mod ") {
+            return offset;
+        } else if let Some(start) = pending {
+            if trimmed.starts_with("mod ")
+                || trimmed.starts_with("pub mod ")
+                || trimmed.starts_with("pub(crate) mod ")
+            {
+                return start;
+            }
+            if trimmed.starts_with("#[") {
+                attr_depth = bracket_depth(0, trimmed);
+            } else if !trimmed.is_empty() {
+                pending = None;
+            }
+        }
+        offset = offset.saturating_add(line.len());
+    }
+    content.len()
+}
+
+/// Running `[`/`]` nesting depth after processing `line`, starting at `depth`.
+fn bracket_depth(depth: usize, line: &str) -> usize {
+    let opens = line.matches('[').count();
+    let closes = line.matches(']').count();
+    depth.saturating_add(opens).saturating_sub(closes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(src: &str) -> Vec<String> {
+        debug_derived_secret_fields(src)
+            .into_iter()
+            .map(|h| format!("{}.{}", h.struct_name, h.field))
+            .collect()
+    }
+
+    #[test]
+    fn flags_a_plaintext_token_on_a_debug_deriving_struct() {
+        let src = "#[derive(Debug, Serialize)]\npub struct R {\n    pub access_token: String,\n    pub expires_in: u64,\n}\n";
+        assert_eq!(names(src), vec!["R.access_token"]);
+    }
+
+    #[test]
+    fn flags_an_optional_secret_and_reports_its_line() {
+        let src = "#[derive(Debug)]\nstruct C {\n    id: String,\n    client_secret: Option<String>,\n}\n";
+        let hits = debug_derived_secret_fields(src);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits.first().map(|h| h.line), Some(4));
+    }
+
+    #[test]
+    fn ignores_a_struct_without_a_debug_derive() {
+        let src = "#[derive(Serialize)]\npub struct R {\n    pub access_token: String,\n}\n";
+        assert!(names(src).is_empty());
+    }
+
+    #[test]
+    fn finds_debug_in_a_wrapped_derive_list() {
+        let src = "#[derive(\n    Clone,\n    Debug,\n)]\nstruct R {\n    token: String,\n}\n";
+        assert_eq!(names(src), vec!["R.token"]);
+    }
+
+    #[test]
+    fn carries_the_derive_across_doc_comments() {
+        let src = "#[derive(Debug)]\n/// Doc.\n///\n/// More.\nstruct R {\n    token: String,\n}\n";
+        assert_eq!(names(src), vec!["R.token"]);
+    }
+
+    #[test]
+    fn ignores_redacting_wrapper_types() {
+        let src = "#[derive(Debug)]\nstruct R {\n    client_secret: SecretString,\n    refresh_token: Option<SecretString>,\n    id_token: Zeroizing<String>,\n}\n";
+        assert!(names(src).is_empty());
+    }
+
+    #[test]
+    fn ignores_metadata_and_derived_value_fields() {
+        let src = "#[derive(Debug)]\nstruct R {\n    token_type: String,\n    token_endpoint_auth_method: String,\n    id_token_signing_alg_values_supported: String,\n    refresh_token_hash: String,\n    hashed_secret: String,\n    token_id: String,\n}\n";
+        assert!(names(src).is_empty());
+    }
+
+    #[test]
+    fn attributes_do_not_leak_to_the_next_item() {
+        let src = "#[derive(Debug)]\nstruct A {\n    ok: u8,\n}\n\nstruct B {\n    access_token: String,\n}\n";
+        assert!(names(src).is_empty());
+    }
+
+    #[test]
+    fn ignores_a_tuple_struct_with_no_named_fields() {
+        let src =
+            "#[derive(Debug)]\nstruct Token(String);\n\nstruct Other {\n    secret: String,\n}\n";
+        assert!(names(src).is_empty());
+    }
+
+    #[test]
+    fn test_module_cutoff_excludes_trailing_test_mod() {
+        let src = "fn prod() {}\n\n#[cfg(test)]\nmod tests {\n    #[derive(Debug)]\n    struct R {\n        token: String,\n    }\n}\n";
+        let cutoff = test_module_cutoff(src);
+        let production = src.get(..cutoff).expect("cutoff within bounds");
+        assert!(debug_derived_secret_fields(production).is_empty());
+    }
+}

--- a/crates/vouch-server/tests/secrets_redacted_in_debug.rs
+++ b/crates/vouch-server/tests/secrets_redacted_in_debug.rs
@@ -82,6 +82,11 @@ fn no_debug_derive_prints_a_plaintext_credential() {
         let cutoff = test_module_cutoff(&content);
         let production = content.get(..cutoff).unwrap_or(&content);
 
+        let rel = path.strip_prefix(&crates_root).map_or_else(
+            |_| path.to_string_lossy().into_owned(),
+            |p| p.to_string_lossy().into_owned(),
+        );
+
         for hit in debug_derived_secret_fields(production) {
             if ALLOWED
                 .iter()
@@ -89,14 +94,14 @@ fn no_debug_derive_prints_a_plaintext_credential() {
             {
                 continue;
             }
-            let rel = path.strip_prefix(&crates_root).map_or_else(
-                |_| path.to_string_lossy().into_owned(),
-                |p| p.to_string_lossy().into_owned(),
-            );
             violations.push(format!(
                 "{rel}:{} {}.{}: {}",
                 hit.line, hit.struct_name, hit.field, hit.ty
             ));
+        }
+
+        for (line, field) in manual_debug_unredacted_fields(production) {
+            violations.push(format!("{rel}:{line} manual Debug prints {field} verbatim"));
         }
     }
 
@@ -254,6 +259,39 @@ fn parse_field(trimmed: &str) -> Option<(String, String)> {
     Some((name.to_string(), ty.to_string()))
 }
 
+/// Secret-named fields a hand-written `Debug` prints without a placeholder.
+///
+/// Replacing a `derive(Debug)` with a manual impl is the fix this test asks
+/// for, so the manual impls are exactly where a credential can reappear —
+/// and a manual impl is invisible to [`debug_derived_secret_fields`], which
+/// only inspects derives.
+///
+/// The rule is type-independent: a secret-named field is printed as a
+/// placeholder regardless of whether its type would redact itself. A
+/// `SecretString` field prints `SecretBox<str>([REDACTED])` and so leaks
+/// nothing, but requiring the placeholder keeps every credential field in a
+/// manual impl reviewable without knowing each wrapper's `Debug`, and keeps
+/// the impl correct if the field is later changed to a bare `String`.
+fn manual_debug_unredacted_fields(content: &str) -> Vec<(usize, String)> {
+    let mut hits = Vec::new();
+    for (idx, line) in content.lines().enumerate() {
+        let trimmed = line.trim();
+        let Some(rest) = trimmed.strip_prefix(".field(\"") else {
+            continue;
+        };
+        let Some((name, tail)) = rest.split_once('"') else {
+            continue;
+        };
+        if !is_secret_field_name(name) {
+            continue;
+        }
+        if tail.contains("&self.") && !tail.contains("REDACTED") {
+            hits.push((idx.saturating_add(1), name.to_string()));
+        }
+    }
+    hits
+}
+
 /// Whether a field name names a live credential rather than a derived value.
 fn is_secret_field_name(name: &str) -> bool {
     if DERIVED_VALUE_MARKERS.iter().any(|m| name.contains(m)) {
@@ -264,6 +302,12 @@ fn is_secret_field_name(name: &str) -> bool {
         || name.ends_with("_token")
         || name.ends_with("_secret")
         || name.ends_with("_token_hint")
+        // RFC 7521/7523: a client_assertion is a signed JWT presented as a
+        // client credential, and `assertion` is the JWT-bearer grant's
+        // equivalent. Neither name ends in _token or _secret, so they need
+        // naming here. `*_assertion_type` is a URN, not a credential.
+        || name == "assertion"
+        || (name.ends_with("_assertion") && !name.ends_with("_assertion_type"))
 }
 
 /// Whether a type prints its contents under `Debug` — as opposed to


### PR DESCRIPTION
Eighteen types derived `Debug` while holding a plaintext credential in a bare `String` — client secrets, registration access tokens, upstream IdP tokens, `id_token_hint`, GitHub refresh tokens, domain verification tokens, and agent session tokens. None is currently `{:?}`-formatted, so this is defense in depth rather than a live leak, but nothing prevented the next log line from making it one.

Adds `crates/vouch-server/tests/secrets_redacted_in_debug.rs`, a source-scanning test over `crates/*/src` — so `vouch-cli` and `vouch-agent` are covered too — that fails when a `Debug`-deriving struct holds a secret-named bare `String`. It reported 20 such fields across 18 types; all are fixed here and the allowlist is empty.

Fixes use a manual `impl Debug` printing `[REDACTED]` for the secret while leaving other fields visible, matching `AwsTokenResult` and the existing secret-handling convention rather than converting to `SecretString`.

Follows the same shape as the existing `no_raw_email_in_audit_data.rs` scan. Known limitation, documented in the test: each file is scanned up to its first `#[cfg(test)] mod tests`, so a type declared after a trailing test module is not covered — deliberate, since test fixtures hold throwaway credentials.

## Verification

The guard was confirmed to fail before the fixes (20 violations) and to catch a regression: injecting a `Debug`-deriving struct with an `access_token` field into `vouch-agent` reports `vouch-agent/src/config.rs:154 FutureCredentialResponse.access_token: String`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only hardening with no auth or API behavior changes; risk is missing a type in the scan (documented cutoff at first `#[cfg(test)]` module).
> 
> **Overview**
> **Defense-in-depth:** types that held session tokens, client secrets, JWT assertions, IdP tokens, GitHub refresh tokens, DNS verification tokens, and similar values in bare `String` fields no longer derive `Debug`. Each gets a hand-written `impl Debug` that prints `[REDACTED]` for credential fields and leaves the rest visible, matching the existing workspace convention (not switching serde types to `SecretString`).
> 
> Coverage spans **vouch-agent** (config/session tokens), **vouch-cli** (FAPI login and registration), and **vouch-server** (users, org domains, OAuth handlers, application secrets, certification/enroll flows).
> 
> Adds **`crates/vouch-server/tests/secrets_redacted_in_debug.rs`**, a static scan over all `crates/*/src` that fails CI if a `Debug`-deriving struct has a secret-named bare `String`/`Option<String>`, or if a manual `Debug` prints those fields verbatim. The allowlist is empty after fixing the ~20 fields the scan reported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b28ba631e068acf8c2f2baffa5b92d46f6dc99c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->