### PR TITLE
refactor(scim): apply PATCH operations through a shared attribute table

### DIFF
--- a/crates/vouch-server/src/db/scim.rs
+++ b/crates/vouch-server/src/db/scim.rs
@@ -1176,6 +1176,10 @@ fn apply_scim_group_filter(
 
 /// Update a SCIM group, scoped to the caller's org.
 ///
+/// Both fields are written through, so `external_id: None` clears the stored
+/// value — the caller passes the group's full desired state, as it does for
+/// [`update_scim_user`].
+///
 /// Returns `Ok(false)` if the group doesn't exist, belongs to a different org,
 /// or if a concurrent org-ownership change races with the modify loop and causes
 /// the mutation to be skipped. `Ok(true)` on a successful update.
@@ -1187,7 +1191,7 @@ pub async fn update_scim_group(
     store: &DocumentStore,
     id: &str,
     org_id: &str,
-    display_name: Option<&str>,
+    display_name: &str,
     external_id: Option<&str>,
 ) -> Result<bool> {
     // Pre-check: return not-found quickly without entering the modify loop
@@ -1200,7 +1204,7 @@ pub async fn update_scim_group(
     }
 
     // Owned copies for the Fn closure.
-    let display_name_owned = display_name.map(String::from);
+    let display_name_owned = String::from(display_name);
     let external_id_owned = external_id.map(String::from);
 
     let applied = std::sync::atomic::AtomicBool::new(false);
@@ -1215,12 +1219,8 @@ pub async fn update_scim_group(
             if data.org_id != org_id {
                 return;
             }
-            if let Some(ref name) = display_name_owned {
-                data.display_name = name.clone();
-            }
-            if let Some(ref ext_id) = external_id_owned {
-                data.external_id = Some(ext_id.clone());
-            }
+            data.display_name = display_name_owned.clone();
+            data.external_id = external_id_owned.clone();
             applied.store(true, std::sync::atomic::Ordering::Relaxed);
         })
         .await?;

--- a/crates/vouch-server/src/db/tests/occ_modify.rs
+++ b/crates/vouch-server/src/db/tests/occ_modify.rs
@@ -439,7 +439,7 @@ async fn test_update_scim_group_only_intended_fields_change() {
         &store,
         &group.id,
         TEST_ORG_ID,
-        Some("UpdatedName"),
+        "UpdatedName",
         Some("ext-456"),
     )
     .await
@@ -476,7 +476,7 @@ async fn test_update_scim_group_wrong_org_returns_false() {
         .await
         .expect("create_scim_group");
 
-    let found = update_scim_group(&store, &group.id, "wrong-org", Some("HackedName"), None)
+    let found = update_scim_group(&store, &group.id, "wrong-org", "HackedName", None)
         .await
         .expect("update_scim_group query must not error");
     assert!(!found, "cross-org update must return false");
@@ -818,7 +818,7 @@ async fn test_update_scim_group_concurrent_org_change_reports_not_applied() {
         })
     }));
 
-    let applied = update_scim_group(&hooked, &group.id, TEST_ORG_ID, Some("Hacked"), None)
+    let applied = update_scim_group(&hooked, &group.id, TEST_ORG_ID, "Hacked", None)
         .await
         .expect("update_scim_group must not error");
     assert!(

--- a/crates/vouch-server/src/db/tests/scim_groups.rs
+++ b/crates/vouch-server/src/db/tests/scim_groups.rs
@@ -36,7 +36,7 @@ async fn test_scim_group_lifecycle() {
         &store,
         &group.id,
         TEST_ORG_ID,
-        Some("Platform"),
+        "Platform",
         Some("ext-grp-2"),
     )
     .await

--- a/crates/vouch-server/src/handlers/scim/groups.rs
+++ b/crates/vouch-server/src/handlers/scim/groups.rs
@@ -367,11 +367,34 @@ async fn apply_member_op(
             Ok(())
         }
         ScimPatchOpType::Remove => {
-            let Some(user_id) = parse_member_filter(path) else {
-                return Ok(());
+            // Two forms reach here: a path filter naming one member,
+            // `members[value eq "…"]`, and `path: "members"` carrying the
+            // members to drop in `value`, which is what Entra sends.
+            //
+            // A bare `remove` of `members` with no filter and no value means
+            // "remove every member" in RFC 7644 §3.5.2.2. It stays a no-op:
+            // emptying a group is an authorization change, and one arriving
+            // as an operation with nothing naming what to remove is more
+            // likely a malformed request than an intended purge.
+            let user_ids: Vec<String> = match parse_member_filter(path) {
+                Some(user_id) => vec![user_id],
+                None => op
+                    .value
+                    .as_ref()
+                    .and_then(|v| v.as_array())
+                    .map(|members| {
+                        members
+                            .iter()
+                            .filter_map(|m| m.get("value").and_then(|v| v.as_str()))
+                            .map(String::from)
+                            .collect()
+                    })
+                    .unwrap_or_default(),
             };
-            if let Err(e) = db::remove_scim_group_member(db, group_id, org_id, &user_id).await {
-                tracing::warn!("Failed to remove member: {e}");
+            for user_id in user_ids {
+                if let Err(e) = db::remove_scim_group_member(db, group_id, org_id, &user_id).await {
+                    tracing::warn!("Failed to remove member: {e}");
+                }
             }
             Ok(())
         }
@@ -429,6 +452,13 @@ pub(crate) async fn patch_group(
         external_id: group.external_id.clone(),
     };
 
+    // Every attribute operation is validated before any membership is
+    // written. Membership writes go straight to the database while attribute
+    // operations accumulate in `patched`, so applying them as they were read
+    // would let an operation rejected later in the request — removing the
+    // required `displayName`, say — return 400 with group membership already
+    // changed. Members are collected here and applied below, in request order.
+    let mut member_ops = Vec::new();
     for op in &patch.operations {
         // A value filter may follow the attribute name, as in
         // `members[value eq "…"]`.
@@ -438,14 +468,17 @@ pub(crate) async fn patch_group(
                 .is_some_and(|attribute| attribute.eq_ignore_ascii_case("members"))
         });
         if let Some(path) = members_path {
-            if let Err(response) = apply_member_op(&state.store, &id, &auth.org_id, path, op).await
-            {
-                return response;
-            }
+            member_ops.push((path, op));
             continue;
         }
         if let Err(invalid) = apply_patch_op(GROUP_ATTRIBUTES, &mut patched, op) {
             return invalid.into_response();
+        }
+    }
+
+    for (path, op) in member_ops {
+        if let Err(response) = apply_member_op(&state.store, &id, &auth.org_id, path, op).await {
+            return response;
         }
     }
 

--- a/crates/vouch-server/src/handlers/scim/groups.rs
+++ b/crates/vouch-server/src/handlers/scim/groups.rs
@@ -10,8 +10,9 @@ use axum::{
 use std::sync::Arc;
 
 use super::authenticate_scim;
+use super::patch::{Attribute, InvalidValue, apply_patch_op, optional_string};
 use super::types::{
-    ScimError, ScimGroup, ScimGroupMember, ScimListQuery, ScimListResponse, ScimMeta,
+    ScimError, ScimGroup, ScimGroupMember, ScimListQuery, ScimListResponse, ScimMeta, ScimPatchOp,
     ScimPatchOpType, ScimPatchRequest,
 };
 use crate::AppState;
@@ -267,14 +268,121 @@ pub(crate) async fn get_group(
     Json(db_group_to_scim(base_url, group, members)).into_response()
 }
 
+/// The Group fields a PATCH can change, seeded from the stored record.
+/// Members are not here: they live in the membership table, not in the
+/// group document.
+struct GroupPatch {
+    display_name: String,
+    external_id: Option<String>,
+}
+
+/// The single-valued Group attributes Vouch stores (RFC 7643 §4.2).
+const GROUP_ATTRIBUTES: &[Attribute<GroupPatch>] = &[
+    Attribute {
+        paths: &["displayName"],
+        set: |group, path, value| {
+            let Some(display_name) = value.as_str() else {
+                return Err(InvalidValue::new(format!("{path} must be a string")));
+            };
+            if display_name.trim().is_empty() {
+                return Err(InvalidValue::new(format!("{path} must not be empty")));
+            }
+            group.display_name = display_name.to_string();
+            Ok(())
+        },
+        // RFC 7643 §4.2 makes displayName required, so a group has no state
+        // in which it carries none; RFC 7644 §3.12 maps a value the
+        // attribute cannot take to `invalidValue`.
+        remove: |_, path| {
+            Err(InvalidValue::new(format!(
+                "{path} is required and cannot be removed"
+            )))
+        },
+    },
+    Attribute {
+        paths: &["externalId"],
+        set: |group, path, value| {
+            group.external_id = optional_string(path, value)?;
+            Ok(())
+        },
+        remove: |group, _| {
+            group.external_id = None;
+            Ok(())
+        },
+    },
+];
+
+/// Applies one `members` operation against the membership table.
+///
+/// `members` is multi-valued (RFC 7643 §4.2) and stored as membership rows
+/// rather than as a field of the group document, so it is applied here
+/// rather than through [`GROUP_ATTRIBUTES`]. `add` and `replace` carry the
+/// member set in the operation's value; `remove` names a single member with
+/// a value filter (`members[value eq "…"]`).
+async fn apply_member_op(
+    db: &crate::db::store::DocumentStore,
+    group_id: &str,
+    org_id: &str,
+    path: &str,
+    op: &ScimPatchOp,
+) -> Result<(), Response> {
+    match op.op {
+        ScimPatchOpType::Add => {
+            if path.contains('[') {
+                return Ok(());
+            }
+            let Some(members) = op.value.as_ref().and_then(|v| v.as_array()) else {
+                return Ok(());
+            };
+            for member in members {
+                let Some(user_id) = member.get("value").and_then(|v| v.as_str()) else {
+                    continue;
+                };
+                if let Err(e) = db::add_scim_group_member(db, group_id, org_id, user_id).await {
+                    if let Some(resp) = super::invalid_index_value_response(&e) {
+                        return Err(resp.into_response());
+                    }
+                    tracing::warn!("Failed to add member: {e}");
+                }
+            }
+            Ok(())
+        }
+        ScimPatchOpType::Replace => {
+            if path.contains('[') {
+                return Ok(());
+            }
+            let Some(members) = op.value.as_ref().and_then(|v| v.as_array()) else {
+                return Ok(());
+            };
+            let user_ids: Vec<String> = members
+                .iter()
+                .filter_map(|m| m.get("value").and_then(|v| v.as_str()).map(String::from))
+                .collect();
+            if let Err(e) = db::replace_scim_group_members(db, group_id, org_id, &user_ids).await {
+                if let Some(resp) = super::invalid_index_value_response(&e) {
+                    return Err(resp.into_response());
+                }
+                tracing::error!("Failed to replace group members: {e}");
+            }
+            Ok(())
+        }
+        ScimPatchOpType::Remove => {
+            let Some(user_id) = parse_member_filter(path) else {
+                return Ok(());
+            };
+            if let Err(e) = db::remove_scim_group_member(db, group_id, org_id, &user_id).await {
+                tracing::warn!("Failed to remove member: {e}");
+            }
+            Ok(())
+        }
+    }
+}
+
 /// PATCH /scim/v2/Groups/:id (RFC 7644 Section 3.5.2).
 ///
-/// Modifies a Group resource using SCIM PATCH operations (add, replace, remove).
-/// Supports member management via the `members` path.
-#[expect(
-    clippy::too_many_lines,
-    reason = "SCIM PATCH operation handles add/remove/replace across all group fields"
-)]
+/// Modifies a Group resource using SCIM PATCH operations (add, replace,
+/// remove) applied against [`GROUP_ATTRIBUTES`], plus member management
+/// via the `members` path.
 pub(crate) async fn patch_group(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -316,146 +424,39 @@ pub(crate) async fn patch_group(
     };
 
     // Apply patch operations
-    let mut display_name = group.display_name.clone();
-    let mut external_id = group.external_id.clone();
+    let mut patched = GroupPatch {
+        display_name: group.display_name.clone(),
+        external_id: group.external_id.clone(),
+    };
 
     for op in &patch.operations {
-        match op.op {
-            ScimPatchOpType::Replace => {
-                if let Some(path) = &op.path {
-                    match path.as_str() {
-                        "displayName" => {
-                            if let Some(val) = &op.value
-                                && let Some(s) = val.as_str()
-                            {
-                                display_name = s.to_string();
-                            }
-                        }
-                        "externalId" => {
-                            if let Some(val) = &op.value {
-                                external_id = val.as_str().map(String::from);
-                            }
-                        }
-                        "members" => {
-                            // Replace all members
-                            if let Some(val) = &op.value
-                                && let Some(arr) = val.as_array()
-                            {
-                                let user_ids: Vec<String> = arr
-                                    .iter()
-                                    .filter_map(|v| {
-                                        v.get("value").and_then(|v| v.as_str()).map(String::from)
-                                    })
-                                    .collect();
-                                if let Err(e) = db::replace_scim_group_members(
-                                    &state.store,
-                                    &id,
-                                    &auth.org_id,
-                                    &user_ids,
-                                )
-                                .await
-                                {
-                                    if let Some(resp) = super::invalid_index_value_response(&e) {
-                                        return resp.into_response();
-                                    }
-                                    tracing::error!("Failed to replace group members: {e}");
-                                }
-                            }
-                        }
-                        _ => {}
-                    }
-                } else if let Some(val) = &op.value {
-                    // Replace entire resource
-                    if let Some(n) = val.get("displayName").and_then(|v| v.as_str()) {
-                        display_name = n.to_string();
-                    }
-                    if let Some(e) = val.get("externalId").and_then(|v| v.as_str()) {
-                        external_id = Some(e.to_string());
-                    }
-                }
+        // A value filter may follow the attribute name, as in
+        // `members[value eq "…"]`.
+        let members_path = op.path.as_deref().filter(|path| {
+            path.split('[')
+                .next()
+                .is_some_and(|attribute| attribute.eq_ignore_ascii_case("members"))
+        });
+        if let Some(path) = members_path {
+            if let Err(response) = apply_member_op(&state.store, &id, &auth.org_id, path, op).await
+            {
+                return response;
             }
-            ScimPatchOpType::Add => {
-                // RFC 7644 §3.5.2.1: an Add targeting a single-valued
-                // attribute replaces the existing value — the same
-                // semantics as Replace for displayName and externalId.
-                // The multi-valued `members` attribute is appended to.
-                if let Some(path) = &op.path {
-                    match path.as_str() {
-                        "displayName" => {
-                            if let Some(val) = &op.value
-                                && let Some(s) = val.as_str()
-                            {
-                                display_name = s.to_string();
-                            }
-                        }
-                        "externalId" => {
-                            if let Some(val) = &op.value {
-                                external_id = val.as_str().map(String::from);
-                            }
-                        }
-                        "members" => {
-                            // Add members
-                            if let Some(val) = &op.value
-                                && let Some(arr) = val.as_array()
-                            {
-                                for member in arr {
-                                    if let Some(user_id) =
-                                        member.get("value").and_then(|v| v.as_str())
-                                        && let Err(e) = db::add_scim_group_member(
-                                            &state.store,
-                                            &id,
-                                            &auth.org_id,
-                                            user_id,
-                                        )
-                                        .await
-                                    {
-                                        if let Some(resp) = super::invalid_index_value_response(&e)
-                                        {
-                                            return resp.into_response();
-                                        }
-                                        tracing::warn!("Failed to add member: {e}");
-                                    }
-                                }
-                            }
-                        }
-                        _ => {}
-                    }
-                } else if let Some(val) = &op.value {
-                    // Bulk add (no path) — merge presented attributes, same
-                    // as Replace.
-                    if let Some(n) = val.get("displayName").and_then(|v| v.as_str()) {
-                        display_name = n.to_string();
-                    }
-                    if let Some(e) = val.get("externalId").and_then(|v| v.as_str()) {
-                        external_id = Some(e.to_string());
-                    }
-                }
-            }
-            ScimPatchOpType::Remove => {
-                if let Some(path) = &op.path {
-                    if path == "externalId" {
-                        external_id = None;
-                    } else if path.starts_with("members")
-                        && let Some(user_id) = parse_member_filter(path)
-                        && let Err(e) =
-                            db::remove_scim_group_member(&state.store, &id, &auth.org_id, &user_id)
-                                .await
-                    {
-                        tracing::warn!("Failed to remove member: {e}");
-                    }
-                }
-            }
+            continue;
+        }
+        if let Err(invalid) = apply_patch_op(GROUP_ATTRIBUTES, &mut patched, op) {
+            return invalid.into_response();
         }
     }
 
     // Update group in database
-    if display_name != group.display_name || external_id != group.external_id {
+    if patched.display_name != group.display_name || patched.external_id != group.external_id {
         match db::update_scim_group(
             &state.store,
             &id,
             &auth.org_id,
-            Some(&display_name),
-            external_id.as_deref(),
+            &patched.display_name,
+            patched.external_id.as_deref(),
         )
         .await
         {

--- a/crates/vouch-server/src/handlers/scim/mod.rs
+++ b/crates/vouch-server/src/handlers/scim/mod.rs
@@ -7,11 +7,13 @@
 //!
 //! - [`types`] - SCIM types (error, list, user, group)
 //! - [`discovery`] - Discovery endpoints (ServiceProviderConfig, Schemas, ResourceTypes)
+//! - [`patch`] - Table-driven applier shared by User and Group PATCH
 //! - [`users`] - User CRUD operations
 //! - [`groups`] - Group CRUD operations
 
 pub(crate) mod discovery;
 pub(crate) mod groups;
+pub(crate) mod patch;
 pub(crate) mod types;
 pub(crate) mod users;
 

--- a/crates/vouch-server/src/handlers/scim/patch.rs
+++ b/crates/vouch-server/src/handlers/scim/patch.rs
@@ -105,6 +105,13 @@ pub(crate) fn apply_patch_op<S>(
 
 /// Merges the value object of an operation with no `path`: every attribute
 /// the object presents is stored, addressed by its dotted path.
+///
+/// An attribute reachable under several paths takes the first one the object
+/// presents, in table order, so the canonical path wins over its aliases. A
+/// bulk object carrying both `name.formatted` and `displayName` — including
+/// one holding `null` to clear the attribute the other sets — would otherwise
+/// resolve by table position rather than by which name the attribute is
+/// actually stored under.
 fn merge<S>(
     table: &[Attribute<S>],
     state: &mut S,
@@ -117,6 +124,7 @@ fn merge<S>(
                 .try_fold(value, |current, segment| current.get(segment));
             if let Some(presented) = presented {
                 (attribute.set)(state, path, presented)?;
+                break;
             }
         }
     }

--- a/crates/vouch-server/src/handlers/scim/patch.rs
+++ b/crates/vouch-server/src/handlers/scim/patch.rs
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! Table-driven applier for SCIM PATCH operations (RFC 7644 §3.5.2).
+//!
+//! A resource declares the single-valued attributes it stores as a table of
+//! [`Attribute`] entries: the paths that address the attribute, how a
+//! presented value is stored, and what a removal does. [`apply_patch_op`]
+//! applies `add`, `replace`, and `remove` against that table, so a resource
+//! never states the operation semantics itself and the three operations
+//! cannot diverge attribute by attribute.
+//!
+//! The semantics [`apply_patch_op`] implements:
+//!
+//! - `add` and `replace` both store the presented value: on a single-valued
+//!   attribute an `add` replaces (§3.5.2.1).
+//! - `remove` clears the stored value (§3.5.2.2). An attribute with no
+//!   absent state — a required or non-nullable one — rejects the removal as
+//!   `invalidValue` (§3.12) instead.
+//! - An operation with no `path` merges every attribute its value object
+//!   presents, each addressed by its dotted path (`name.formatted` reads
+//!   `{"name": {"formatted": …}}`).
+//! - A path no entry claims is ignored and the request still succeeds.
+//!   Identity providers PATCH attributes Vouch does not store — `title`,
+//!   `department`, `name.givenName`, enterprise-extension URNs — and
+//!   rejecting those fails the whole provisioning sync at the IdP over an
+//!   attribute the directory was never going to persist. A pathless
+//!   `remove` names no attribute to clear and is likewise ignored.
+//!
+//! Multi-valued attributes (Group `members`) have no table entry: they are
+//! stored outside the resource document and are applied by their handler
+//! before the operation reaches [`apply_patch_op`].
+
+use axum::{
+    Json,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+
+use super::types::{ScimError, ScimPatchOp, ScimPatchOpType};
+
+/// A value a PATCH operation cannot store, reported as a SCIM 400
+/// `invalidValue` (RFC 7644 §3.12).
+pub(crate) struct InvalidValue(String);
+
+impl InvalidValue {
+    pub(crate) fn new(detail: impl Into<String>) -> Self {
+        Self(detail.into())
+    }
+}
+
+impl IntoResponse for InvalidValue {
+    fn into_response(self) -> Response {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ScimError::new(400, self.0).with_type("invalidValue")),
+        )
+            .into_response()
+    }
+}
+
+/// A single-valued attribute of a SCIM resource, and how PATCH changes it.
+pub(crate) struct Attribute<S> {
+    /// Every attribute path addressing this attribute; the first is
+    /// canonical and the rest are aliases identity providers send for the
+    /// same stored field. Attribute names are case insensitive
+    /// (RFC 7643 §2.1).
+    pub paths: &'static [&'static str],
+    /// Stores the value an `add` or `replace` presents at `path`.
+    pub set: fn(&mut S, &str, &serde_json::Value) -> Result<(), InvalidValue>,
+    /// Clears the stored value for a `remove`, or rejects the removal when
+    /// the attribute has no absent state.
+    pub remove: fn(&mut S, &str) -> Result<(), InvalidValue>,
+}
+
+/// Applies one PATCH operation to `state` using `table`.
+pub(crate) fn apply_patch_op<S>(
+    table: &[Attribute<S>],
+    state: &mut S,
+    op: &ScimPatchOp,
+) -> Result<(), InvalidValue> {
+    let Some(path) = op.path.as_deref() else {
+        return match op.op {
+            ScimPatchOpType::Add | ScimPatchOpType::Replace => match &op.value {
+                Some(value) => merge(table, state, value),
+                None => Ok(()),
+            },
+            ScimPatchOpType::Remove => Ok(()),
+        };
+    };
+
+    let Some(attribute) = table
+        .iter()
+        .find(|attribute| attribute.paths.iter().any(|p| p.eq_ignore_ascii_case(path)))
+    else {
+        return Ok(());
+    };
+
+    match op.op {
+        ScimPatchOpType::Add | ScimPatchOpType::Replace => match &op.value {
+            Some(value) => (attribute.set)(state, path, value),
+            None => Ok(()),
+        },
+        ScimPatchOpType::Remove => (attribute.remove)(state, path),
+    }
+}
+
+/// Merges the value object of an operation with no `path`: every attribute
+/// the object presents is stored, addressed by its dotted path.
+fn merge<S>(
+    table: &[Attribute<S>],
+    state: &mut S,
+    value: &serde_json::Value,
+) -> Result<(), InvalidValue> {
+    for attribute in table {
+        for path in attribute.paths {
+            let presented = path
+                .split('.')
+                .try_fold(value, |current, segment| current.get(segment));
+            if let Some(presented) = presented {
+                (attribute.set)(state, path, presented)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Reads the value of an optional string attribute: a JSON string stores it
+/// and JSON `null` clears it — identity providers send `null` to unset an
+/// attribute — while any other JSON type is not a value the attribute can
+/// hold.
+pub(crate) fn optional_string(
+    path: &str,
+    value: &serde_json::Value,
+) -> Result<Option<String>, InvalidValue> {
+    match value {
+        serde_json::Value::String(s) => Ok(Some(s.clone())),
+        serde_json::Value::Null => Ok(None),
+        serde_json::Value::Bool(_)
+        | serde_json::Value::Number(_)
+        | serde_json::Value::Array(_)
+        | serde_json::Value::Object(_) => {
+            Err(InvalidValue::new(format!("{path} must be a string")))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default, PartialEq, Eq, Debug)]
+    struct Resource {
+        label: Option<String>,
+        enabled: bool,
+    }
+
+    const ATTRIBUTES: &[Attribute<Resource>] = &[
+        Attribute {
+            paths: &["name.formatted", "displayName"],
+            set: |resource, path, value| {
+                resource.label = optional_string(path, value)?;
+                Ok(())
+            },
+            remove: |resource, _| {
+                resource.label = None;
+                Ok(())
+            },
+        },
+        Attribute {
+            paths: &["enabled"],
+            set: |resource, path, value| {
+                let Some(enabled) = value.as_bool() else {
+                    return Err(InvalidValue::new(format!("{path} must be a boolean")));
+                };
+                resource.enabled = enabled;
+                Ok(())
+            },
+            remove: |_, path| Err(InvalidValue::new(format!("{path} cannot be removed"))),
+        },
+    ];
+
+    fn patch_op(
+        op: ScimPatchOpType,
+        path: Option<&str>,
+        value: Option<serde_json::Value>,
+    ) -> ScimPatchOp {
+        ScimPatchOp {
+            op,
+            path: path.map(String::from),
+            value,
+        }
+    }
+
+    fn apply(operation: &ScimPatchOp) -> Result<Resource, InvalidValue> {
+        let mut resource = Resource::default();
+        apply_patch_op(ATTRIBUTES, &mut resource, operation)?;
+        Ok(resource)
+    }
+
+    #[test]
+    fn add_and_replace_store_the_same_value() {
+        let value = Some(serde_json::json!("Ada"));
+        let added = apply(&patch_op(
+            ScimPatchOpType::Add,
+            Some("displayName"),
+            value.clone(),
+        ))
+        .ok();
+        let replaced = apply(&patch_op(
+            ScimPatchOpType::Replace,
+            Some("displayName"),
+            value,
+        ))
+        .ok();
+
+        assert_eq!(added, replaced);
+        assert_eq!(
+            replaced,
+            Some(Resource {
+                label: Some("Ada".to_string()),
+                enabled: false,
+            })
+        );
+    }
+
+    #[test]
+    fn an_alias_addresses_the_same_attribute() {
+        let value = Some(serde_json::json!("Ada"));
+        let canonical = apply(&patch_op(
+            ScimPatchOpType::Replace,
+            Some("name.formatted"),
+            value.clone(),
+        ))
+        .ok();
+        let alias = apply(&patch_op(
+            ScimPatchOpType::Replace,
+            Some("DISPLAYNAME"),
+            value,
+        ))
+        .ok();
+
+        assert_eq!(canonical, alias);
+    }
+
+    #[test]
+    fn remove_clears_a_removable_attribute_and_rejects_the_rest() {
+        let mut resource = Resource {
+            label: Some("Ada".to_string()),
+            enabled: true,
+        };
+        let cleared = apply_patch_op(
+            ATTRIBUTES,
+            &mut resource,
+            &patch_op(ScimPatchOpType::Remove, Some("displayName"), None),
+        );
+        assert!(cleared.is_ok());
+        assert_eq!(resource.label, None);
+
+        let rejected = apply_patch_op(
+            ATTRIBUTES,
+            &mut resource,
+            &patch_op(ScimPatchOpType::Remove, Some("enabled"), None),
+        );
+        assert!(rejected.is_err(), "a non-removable attribute must reject");
+        assert!(resource.enabled, "a rejected removal must change nothing");
+    }
+
+    #[test]
+    fn an_unclaimed_path_is_ignored_by_every_operation() {
+        for operation in [
+            ScimPatchOpType::Add,
+            ScimPatchOpType::Replace,
+            ScimPatchOpType::Remove,
+        ] {
+            let applied = apply(&patch_op(
+                operation,
+                Some("urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department"),
+                Some(serde_json::json!("Sales")),
+            ));
+            assert_eq!(applied.ok(), Some(Resource::default()));
+        }
+    }
+
+    #[test]
+    fn a_pathless_operation_merges_every_presented_attribute() {
+        let applied = apply(&patch_op(
+            ScimPatchOpType::Add,
+            None,
+            Some(serde_json::json!({"name": {"formatted": "Ada"}, "enabled": true})),
+        ));
+
+        assert_eq!(
+            applied.ok(),
+            Some(Resource {
+                label: Some("Ada".to_string()),
+                enabled: true,
+            })
+        );
+    }
+
+    #[test]
+    fn a_value_the_attribute_cannot_hold_is_rejected() {
+        let wrong_type = apply(&patch_op(
+            ScimPatchOpType::Replace,
+            Some("enabled"),
+            Some(serde_json::json!("true")),
+        ));
+        assert!(wrong_type.is_err(), "a string is not a boolean");
+
+        let in_bulk = apply(&patch_op(
+            ScimPatchOpType::Replace,
+            None,
+            Some(serde_json::json!({"enabled": "true"})),
+        ));
+        assert!(in_bulk.is_err(), "a pathless operation is equally strict");
+    }
+}

--- a/crates/vouch-server/src/handlers/scim/tests.rs
+++ b/crates/vouch-server/src/handlers/scim/tests.rs
@@ -734,11 +734,11 @@ async fn test_patch_user_add_bulk_merges_attributes() {
 }
 
 #[tokio::test]
-async fn test_patch_user_add_unsupported_path_returns_400() {
-    // RFC 7644 §3.5.2: An Add operation on an unsupported attribute path
-    // must return 400 invalidPath — the same error Replace returns for
-    // unknown paths. Previously Add silently ignored unknown paths and
-    // returned 200 OK, masking data loss.
+async fn test_patch_user_add_unsupported_path_is_ignored() {
+    // An Add on an attribute Vouch does not store is a no-op that still
+    // returns 200. Okta and Entra push attributes outside Vouch's schema
+    // (title, department, enterprise extensions) on every sync; rejecting
+    // them fails the whole sync at the IdP over data Vouch never persists.
     let (app, state) = test_app().await;
     let token = create_test_scim_token(&state.store, "test-add-unknown-path", "test-org").await;
     let auth_header = format!("Bearer {}", token);
@@ -746,7 +746,7 @@ async fn test_patch_user_add_unsupported_path_returns_400() {
     let (status, body) = http_post_json(
         &app,
         "/scim/v2/Users",
-        r#"{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"], "userName": "add-unknown@test-org.example.com", "active": true}"#,
+        r#"{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"], "userName": "add-unknown@test-org.example.com", "name": {"formatted": "Kept Name"}, "active": true}"#,
         &[("Authorization", &auth_header)],
     )
     .await;
@@ -766,9 +766,13 @@ async fn test_patch_user_add_unsupported_path_returns_400() {
     )
     .await;
 
-    assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
-    let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
-    assert_eq!(error["scimType"], "invalidPath");
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    let updated: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(
+        updated["name"]["formatted"], "Kept Name",
+        "an ignored path must leave the stored attributes alone"
+    );
+    assert_eq!(updated["active"], true);
 }
 
 // ========================================================================
@@ -870,12 +874,15 @@ async fn test_patch_user_remove_name_formatted_clears() {
 }
 
 // ========================================================================
-// RFC 7644 Section 3.5.3 - PATCH Unsupported Paths
+// RFC 7644 Section 3.5.2 - PATCH Unsupported Paths
 // ========================================================================
+//
+// A path outside the attributes Vouch stores is ignored, for every
+// operation and both resources: identity providers sync attributes the
+// directory does not hold, and a rejection there fails the whole sync.
 
 #[tokio::test]
-async fn test_rfc7644_patch_unsupported_path_returns_400() {
-    // RFC 7644 Section 3.5.3: Unsupported attribute paths should return 400
+async fn test_rfc7644_patch_unsupported_path_is_ignored() {
     let (app, state) = test_app().await;
 
     let token = create_test_scim_token(&state.store, "test-patch-invalid-path", "test-org").await;
@@ -893,7 +900,6 @@ async fn test_rfc7644_patch_unsupported_path_returns_400() {
     let created: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
     let user_id = created["id"].as_str().expect("user id");
 
-    // PATCH with an unsupported path should return 400
     let (status, body) = http_request(
         &app,
         "PATCH",
@@ -908,12 +914,177 @@ async fn test_rfc7644_patch_unsupported_path_returns_400() {
     )
     .await;
 
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    let updated: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(updated["active"], true, "the resource must be unchanged");
+}
+
+/// Every operation ignores a path Vouch does not store, and none of them
+/// disturbs the attributes it does store. `title` and the enterprise
+/// extension are the attributes Okta and Entra actually push.
+#[tokio::test]
+async fn test_patch_user_unknown_path_ignored_for_every_op() {
+    let (app, state) = test_app().await;
+    let token = create_test_scim_token(&state.store, "test-user-unknown-paths", "test-org").await;
+    let auth_header = format!("Bearer {}", token);
+
+    let (status, body) = http_post_json(
+        &app,
+        "/scim/v2/Users",
+        r#"{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"], "userName": "unknown-paths@test-org.example.com", "name": {"formatted": "Untouched"}, "externalId": "ext-untouched", "active": true}"#,
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "setup create failed: {body}");
+    let created: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let user_id = created["id"].as_str().expect("user id");
+
+    for op in ["add", "replace", "remove"] {
+        for path in [
+            "title",
+            "name.givenName",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department",
+        ] {
+            let patch = serde_json::json!({
+                "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+                "Operations": [{"op": op, "path": path, "value": "Sales"}]
+            });
+            let (status, body) = http_request(
+                &app,
+                "PATCH",
+                &format!("/scim/v2/Users/{user_id}"),
+                Some(patch.to_string()),
+                &[
+                    ("Authorization", &auth_header),
+                    ("Content-Type", "application/json"),
+                ],
+            )
+            .await;
+
+            assert_eq!(
+                status,
+                StatusCode::OK,
+                "{op} {path} must be ignored: {body}"
+            );
+            let updated: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+            assert_eq!(updated["name"]["formatted"], "Untouched", "{op} {path}");
+            assert_eq!(updated["externalId"], "ext-untouched", "{op} {path}");
+            assert_eq!(updated["active"], true, "{op} {path}");
+        }
+    }
+}
+
+/// The property the shared applier exists to hold: for a single-valued
+/// attribute, `add` and `replace` of the same value leave the same
+/// resource (RFC 7644 §3.5.2.1).
+#[tokio::test]
+async fn test_patch_user_add_and_replace_agree_on_single_valued_attributes() {
+    let (app, state) = test_app().await;
+    let token = create_test_scim_token(&state.store, "test-user-add-eq-replace", "test-org").await;
+    let auth_header = format!("Bearer {}", token);
+
+    let mut results = Vec::new();
+    for op in ["add", "replace"] {
+        let (status, body) = http_post_json(
+            &app,
+            "/scim/v2/Users",
+            &format!(
+                r#"{{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"], "userName": "{op}-eq@test-org.example.com", "name": {{"formatted": "Before"}}, "active": true}}"#
+            ),
+            &[("Authorization", &auth_header)],
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED, "setup create failed: {body}");
+        let created: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+        let user_id = created["id"].as_str().expect("user id");
+
+        let patch = serde_json::json!({
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+            "Operations": [
+                {"op": op, "path": "displayName", "value": "After"},
+                {"op": op, "path": "externalId", "value": "ext-after"},
+                {"op": op, "path": "active", "value": false},
+            ]
+        });
+        let (status, body) = http_request(
+            &app,
+            "PATCH",
+            &format!("/scim/v2/Users/{user_id}"),
+            Some(patch.to_string()),
+            &[
+                ("Authorization", &auth_header),
+                ("Content-Type", "application/json"),
+            ],
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{op} must return 200: {body}");
+
+        let mut updated: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+        // Identity and timestamps differ between the two users by design.
+        for field in ["id", "userName", "meta", "emails"] {
+            updated
+                .as_object_mut()
+                .expect("SCIM user object")
+                .remove(field);
+        }
+        results.push(updated);
+    }
+
+    assert_eq!(
+        results.first(),
+        results.last(),
+        "add and replace must leave the same resource"
+    );
+    assert_eq!(results[0]["name"]["formatted"], "After");
+    assert_eq!(results[0]["externalId"], "ext-after");
+    assert_eq!(results[0]["active"], false);
+}
+
+/// `active` is a stored boolean with no absent state, so a removal has no
+/// value to fall back to and is rejected rather than guessing (RFC 7644
+/// §3.12 `invalidValue`).
+#[tokio::test]
+async fn test_patch_user_remove_active_rejected() {
+    let (app, state) = test_app().await;
+    let token = create_test_scim_token(&state.store, "test-user-remove-active", "test-org").await;
+    let auth_header = format!("Bearer {}", token);
+
+    let (status, body) = http_post_json(
+        &app,
+        "/scim/v2/Users",
+        r#"{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"], "userName": "remove-active@test-org.example.com", "active": true}"#,
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "setup create failed: {body}");
+    let created: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let user_id = created["id"].as_str().expect("user id");
+
+    let (status, body) = http_request(
+        &app,
+        "PATCH",
+        &format!("/scim/v2/Users/{user_id}"),
+        Some(r#"{"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"], "Operations": [{"op": "remove", "path": "active"}]}"#.to_string()),
+        &[
+            ("Authorization", &auth_header),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+
     assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
     let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
-    assert_eq!(
-        error["scimType"], "invalidPath",
-        "Should return invalidPath scimType"
-    );
+    assert_eq!(error["scimType"], "invalidValue");
+
+    let (status, body) = http_get(
+        &app,
+        &format!("/scim/v2/Users/{user_id}"),
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let after: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(after["active"], true, "a rejected removal changes nothing");
 }
 
 // ========================================================================
@@ -2120,6 +2291,254 @@ async fn test_scim_patch_group_add_bulk_merges_attributes() {
     let updated: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
     assert_eq!(updated["displayName"], "BulkNew");
     assert_eq!(updated["externalId"], "bulk-group-ext");
+}
+
+// ========================================================================
+// RFC 7644 Section 3.5.2.2 — Group Remove operation
+// ========================================================================
+
+#[tokio::test]
+async fn test_scim_patch_group_remove_external_id_clears() {
+    // RFC 7644 §3.5.2.2: Remove on a single-valued attribute clears it.
+    let (app, state) = test_app().await;
+    let token = create_test_scim_token(&state.store, "test-group-remove-extid", "test-org").await;
+    let auth_header = format!("Bearer {}", token);
+
+    let (status, body) = http_post_json(
+        &app,
+        "/scim/v2/Groups",
+        r#"{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"], "displayName": "RemoveExtId", "externalId": "ext-removable"}"#,
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "setup create failed: {body}");
+    let created: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let group_id = created["id"].as_str().expect("group id");
+    assert_eq!(created["externalId"], "ext-removable");
+
+    let (status, body) = http_request(
+        &app,
+        "PATCH",
+        &format!("/scim/v2/Groups/{group_id}"),
+        Some(r#"{"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"], "Operations": [{"op": "remove", "path": "externalId"}]}"#.to_string()),
+        &[
+            ("Content-Type", "application/json"),
+            ("Authorization", &auth_header),
+        ],
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    let updated: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert!(
+        updated.get("externalId").is_none(),
+        "Remove externalId must clear it: {body}"
+    );
+    assert_eq!(
+        updated["displayName"], "RemoveExtId",
+        "the other attributes are untouched"
+    );
+}
+
+/// `displayName` is required (RFC 7643 §4.2), so a group has no state in
+/// which it carries none: the removal is rejected as `invalidValue` rather
+/// than storing an empty name.
+#[tokio::test]
+async fn test_scim_patch_group_remove_display_name_rejected() {
+    let (app, state) = test_app().await;
+    let token = create_test_scim_token(&state.store, "test-group-remove-name", "test-org").await;
+    let auth_header = format!("Bearer {}", token);
+
+    let (status, body) = http_post_json(
+        &app,
+        "/scim/v2/Groups",
+        r#"{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"], "displayName": "Required"}"#,
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "setup create failed: {body}");
+    let created: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let group_id = created["id"].as_str().expect("group id");
+
+    let (status, body) = http_request(
+        &app,
+        "PATCH",
+        &format!("/scim/v2/Groups/{group_id}"),
+        Some(r#"{"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"], "Operations": [{"op": "remove", "path": "displayName"}]}"#.to_string()),
+        &[
+            ("Content-Type", "application/json"),
+            ("Authorization", &auth_header),
+        ],
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
+    let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(error["scimType"], "invalidValue");
+
+    let (status, body) = http_get(
+        &app,
+        &format!("/scim/v2/Groups/{group_id}"),
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let after: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(
+        after["displayName"], "Required",
+        "a rejected removal changes nothing"
+    );
+}
+
+/// A `displayName` a group cannot carry — empty, or not a string — is
+/// rejected on PATCH, matching the check `POST /scim/v2/Groups` applies.
+#[tokio::test]
+async fn test_scim_patch_group_empty_display_name_rejected() {
+    let (app, state) = test_app().await;
+    let token = create_test_scim_token(&state.store, "test-group-empty-name", "test-org").await;
+    let auth_header = format!("Bearer {}", token);
+
+    let (status, body) = http_post_json(
+        &app,
+        "/scim/v2/Groups",
+        r#"{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"], "displayName": "NotEmpty"}"#,
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "setup create failed: {body}");
+    let created: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let group_id = created["id"].as_str().expect("group id");
+
+    for value in [serde_json::json!("   "), serde_json::json!(42)] {
+        let patch = serde_json::json!({
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+            "Operations": [{"op": "replace", "path": "displayName", "value": value}]
+        });
+        let (status, body) = http_request(
+            &app,
+            "PATCH",
+            &format!("/scim/v2/Groups/{group_id}"),
+            Some(patch.to_string()),
+            &[
+                ("Content-Type", "application/json"),
+                ("Authorization", &auth_header),
+            ],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST, "value {value}: {body}");
+        let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+        assert_eq!(error["scimType"], "invalidValue", "value {value}");
+    }
+}
+
+#[tokio::test]
+async fn test_scim_patch_group_unknown_path_ignored_for_every_op() {
+    let (app, state) = test_app().await;
+    let token = create_test_scim_token(&state.store, "test-group-unknown-paths", "test-org").await;
+    let auth_header = format!("Bearer {}", token);
+
+    let (status, body) = http_post_json(
+        &app,
+        "/scim/v2/Groups",
+        r#"{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"], "displayName": "UntouchedGroup", "externalId": "ext-untouched"}"#,
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "setup create failed: {body}");
+    let created: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let group_id = created["id"].as_str().expect("group id");
+
+    for op in ["add", "replace", "remove"] {
+        for path in ["description", "urn:example:params:scim:schemas:Group:owner"] {
+            let patch = serde_json::json!({
+                "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+                "Operations": [{"op": op, "path": path, "value": "ignored"}]
+            });
+            let (status, body) = http_request(
+                &app,
+                "PATCH",
+                &format!("/scim/v2/Groups/{group_id}"),
+                Some(patch.to_string()),
+                &[
+                    ("Content-Type", "application/json"),
+                    ("Authorization", &auth_header),
+                ],
+            )
+            .await;
+
+            assert_eq!(
+                status,
+                StatusCode::OK,
+                "{op} {path} must be ignored: {body}"
+            );
+            let updated: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+            assert_eq!(updated["displayName"], "UntouchedGroup", "{op} {path}");
+            assert_eq!(updated["externalId"], "ext-untouched", "{op} {path}");
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_scim_patch_group_add_and_replace_agree_on_single_valued_attributes() {
+    // The same property as the User test: on a single-valued attribute,
+    // add and replace of one value leave the same resource.
+    let (app, state) = test_app().await;
+    let token = create_test_scim_token(&state.store, "test-group-add-eq-replace", "test-org").await;
+    let auth_header = format!("Bearer {}", token);
+
+    let mut results = Vec::new();
+    for op in ["add", "replace"] {
+        let (status, body) = http_post_json(
+            &app,
+            "/scim/v2/Groups",
+            &format!(
+                r#"{{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"], "displayName": "Before-{op}"}}"#
+            ),
+            &[("Authorization", &auth_header)],
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED, "setup create failed: {body}");
+        let created: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+        let group_id = created["id"].as_str().expect("group id");
+
+        let patch = serde_json::json!({
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+            "Operations": [
+                {"op": op, "path": "displayName", "value": "After"},
+                {"op": op, "path": "externalId", "value": "ext-after"},
+            ]
+        });
+        let (status, body) = http_request(
+            &app,
+            "PATCH",
+            &format!("/scim/v2/Groups/{group_id}"),
+            Some(patch.to_string()),
+            &[
+                ("Content-Type", "application/json"),
+                ("Authorization", &auth_header),
+            ],
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{op} must return 200: {body}");
+
+        let mut updated: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+        for field in ["id", "meta"] {
+            updated
+                .as_object_mut()
+                .expect("SCIM group object")
+                .remove(field);
+        }
+        results.push(updated);
+    }
+
+    assert_eq!(
+        results.first(),
+        results.last(),
+        "add and replace must leave the same resource"
+    );
+    assert_eq!(results[0]["displayName"], "After");
+    assert_eq!(results[0]["externalId"], "ext-after");
 }
 
 // ========================================================================

--- a/crates/vouch-server/src/handlers/scim/tests.rs
+++ b/crates/vouch-server/src/handlers/scim/tests.rs
@@ -3904,3 +3904,205 @@ async fn test_scim_patch_group_add_member_concurrent_same_user() {
         count
     );
 }
+
+/// A pathless bulk merge carrying both `name.formatted` and its alias
+/// `displayName` stores the canonical path's value. Applying every alias in
+/// table order would let `displayName` overwrite it — and a `null` alias
+/// clear a name the canonical path had just set.
+#[tokio::test]
+async fn test_patch_user_bulk_prefers_canonical_path_over_alias() {
+    let (app, state) = test_app().await;
+    let token = create_test_scim_token(&state.store, "test-bulk-alias", "test-org").await;
+    let auth_header = format!("Bearer {}", token);
+
+    let (status, body) = http_post_json(
+        &app,
+        "/scim/v2/Users",
+        r#"{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"], "userName": "bulk-alias@test-org.example.com", "name": {"formatted": "Original"}, "active": true}"#,
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "setup create failed: {body}");
+    let created: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let user_id = created["id"].as_str().expect("user id");
+
+    // Both names present: the canonical `name.formatted` must win.
+    let (status, body) = http_request(
+        &app,
+        "PATCH",
+        &format!("/scim/v2/Users/{}", user_id),
+        Some(r#"{"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"], "Operations": [{"op": "replace", "value": {"name": {"formatted": "Canonical"}, "displayName": "Alias"}}]}"#.to_string()),
+        &[
+            ("Authorization", &auth_header),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    let updated: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(
+        updated["name"]["formatted"], "Canonical",
+        "the canonical path must win over its alias: {body}"
+    );
+
+    // A null alias must not clear the value the canonical path sets.
+    let (status, body) = http_request(
+        &app,
+        "PATCH",
+        &format!("/scim/v2/Users/{}", user_id),
+        Some(r#"{"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"], "Operations": [{"op": "replace", "value": {"name": {"formatted": "Still Set"}, "displayName": null}}]}"#.to_string()),
+        &[
+            ("Authorization", &auth_header),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    let updated: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(
+        updated["name"]["formatted"], "Still Set",
+        "a null alias must not clear the canonical value: {body}"
+    );
+}
+
+/// A group PATCH whose member operation precedes an operation that fails
+/// validation must not change membership: the request is rejected whole.
+#[tokio::test]
+async fn test_scim_patch_group_rejected_op_leaves_membership_unchanged() {
+    let (app, state) = test_app().await;
+    let token = create_test_scim_token(&state.store, "test-partial-apply", "test-org").await;
+    let auth_header = format!("Bearer {}", token);
+
+    let (status, body) = http_post_json(
+        &app,
+        "/scim/v2/Groups",
+        r#"{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"], "displayName": "Partial Apply"}"#,
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "setup create failed: {body}");
+    let created: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let group_id = created["id"].as_str().expect("group id");
+
+    let (status, body) = http_post_json(
+        &app,
+        "/scim/v2/Users",
+        r#"{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"], "userName": "partial-apply@test-org.example.com", "active": true}"#,
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "setup create failed: {body}");
+    let user: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let user_id = user["id"].as_str().expect("user id");
+
+    // Add a member, then remove the required displayName in the same request.
+    let (status, body) = http_request(
+        &app,
+        "PATCH",
+        &format!("/scim/v2/Groups/{}", group_id),
+        Some(format!(
+            r#"{{"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"], "Operations": [{{"op": "add", "path": "members", "value": [{{"value": "{user_id}"}}]}}, {{"op": "remove", "path": "displayName"}}]}}"#
+        )),
+        &[
+            ("Authorization", &auth_header),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "removing the required displayName must be rejected: {body}"
+    );
+
+    // The rejected request must not have added the member.
+    let (status, body) = http_get(
+        &app,
+        &format!("/scim/v2/Groups/{}", group_id),
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let group: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let members = group["members"].as_array().map_or(0, Vec::len);
+    assert_eq!(
+        members, 0,
+        "a rejected PATCH must not leave membership changed: {body}"
+    );
+}
+
+/// Entra sends member removals as `path: "members"` with the members in
+/// `value`, rather than a `members[value eq "…"]` filter. Both forms remove.
+#[tokio::test]
+async fn test_scim_patch_group_remove_members_by_value_list() {
+    let (app, state) = test_app().await;
+    let token = create_test_scim_token(&state.store, "test-remove-value", "test-org").await;
+    let auth_header = format!("Bearer {}", token);
+
+    let (status, body) = http_post_json(
+        &app,
+        "/scim/v2/Groups",
+        r#"{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"], "displayName": "Remove By Value"}"#,
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "setup create failed: {body}");
+    let created: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let group_id = created["id"].as_str().expect("group id");
+
+    let (status, body) = http_post_json(
+        &app,
+        "/scim/v2/Users",
+        r#"{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"], "userName": "remove-by-value@test-org.example.com", "active": true}"#,
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "setup create failed: {body}");
+    let user: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let user_id = user["id"].as_str().expect("user id");
+
+    let (status, body) = http_request(
+        &app,
+        "PATCH",
+        &format!("/scim/v2/Groups/{}", group_id),
+        Some(format!(
+            r#"{{"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"], "Operations": [{{"op": "add", "path": "members", "value": [{{"value": "{user_id}"}}]}}]}}"#
+        )),
+        &[
+            ("Authorization", &auth_header),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "add member failed: {body}");
+
+    let (status, body) = http_request(
+        &app,
+        "PATCH",
+        &format!("/scim/v2/Groups/{}", group_id),
+        Some(format!(
+            r#"{{"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"], "Operations": [{{"op": "remove", "path": "members", "value": [{{"value": "{user_id}"}}]}}]}}"#
+        )),
+        &[
+            ("Authorization", &auth_header),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "remove by value list failed: {body}"
+    );
+
+    let (status, body) = http_get(
+        &app,
+        &format!("/scim/v2/Groups/{}", group_id),
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let group: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let members = group["members"].as_array().map_or(0, Vec::len);
+    assert_eq!(members, 0, "member must have been removed: {body}");
+}

--- a/crates/vouch-server/src/handlers/scim/users.rs
+++ b/crates/vouch-server/src/handlers/scim/users.rs
@@ -10,9 +10,10 @@ use axum::{
 use std::sync::Arc;
 
 use super::authenticate_scim;
+use super::patch::{Attribute, InvalidValue, apply_patch_op, optional_string};
 use super::types::{
-    ScimEmail, ScimError, ScimListQuery, ScimListResponse, ScimMeta, ScimName, ScimPatchOpType,
-    ScimPatchRequest, ScimUser,
+    ScimEmail, ScimError, ScimListQuery, ScimListResponse, ScimMeta, ScimName, ScimPatchRequest,
+    ScimUser,
 };
 use crate::AppState;
 use crate::db;
@@ -333,14 +334,66 @@ pub(crate) async fn get_user(
     Json(db_user_to_scim(base_url, user)).into_response()
 }
 
+/// The User fields a PATCH can change, seeded from the stored record.
+struct UserPatch {
+    active: bool,
+    name: Option<String>,
+    external_id: Option<String>,
+    /// Set when an operation takes `active` from true to false; the handler
+    /// then invalidates sessions and revokes the user's credentials.
+    deactivated: bool,
+}
+
+/// The single-valued User attributes Vouch stores (RFC 7643 §4.1).
+/// `displayName` addresses the same stored name as `name.formatted`.
+const USER_ATTRIBUTES: &[Attribute<UserPatch>] = &[
+    Attribute {
+        paths: &["active"],
+        set: |user, path, value| {
+            // RFC 7643 §2.2 — `active` is a boolean. Coercing a non-boolean
+            // (e.g. the string "false") to `true` would silently reactivate
+            // a disabled user.
+            let Some(active) = value.as_bool() else {
+                return Err(InvalidValue::new(format!("{path} must be a boolean")));
+            };
+            user.deactivated |= user.active && !active;
+            user.active = active;
+            Ok(())
+        },
+        // `active` is a stored boolean with no absent state, so a removal
+        // has no value to fall back to: either default would change the
+        // user's access without the identity provider asking for it.
+        remove: |_, path| Err(InvalidValue::new(format!("{path} cannot be removed"))),
+    },
+    Attribute {
+        paths: &["name.formatted", "displayName"],
+        set: |user, path, value| {
+            user.name = optional_string(path, value)?;
+            Ok(())
+        },
+        remove: |user, _| {
+            user.name = None;
+            Ok(())
+        },
+    },
+    Attribute {
+        paths: &["externalId"],
+        set: |user, path, value| {
+            user.external_id = optional_string(path, value)?;
+            Ok(())
+        },
+        remove: |user, _| {
+            user.external_id = None;
+            Ok(())
+        },
+    },
+];
+
 /// PATCH /scim/v2/Users/:id (RFC 7644 Section 3.5.2).
 ///
-/// Modifies a User resource using SCIM PATCH operations (add, replace, remove).
-/// Deactivating a user invalidates all sessions and revokes SSH certificates.
-#[expect(
-    clippy::too_many_lines,
-    reason = "SCIM PATCH operation handles add/remove/replace across all user fields"
-)]
+/// Modifies a User resource using SCIM PATCH operations (add, replace,
+/// remove) applied against [`USER_ATTRIBUTES`]. Deactivating a user
+/// invalidates all sessions and revokes SSH certificates.
 pub(crate) async fn patch_user(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -382,165 +435,16 @@ pub(crate) async fn patch_user(
     };
 
     // Apply patch operations
-    let mut active = user.active;
-    let mut name = user.name.clone();
-    let mut external_id = user.external_id.clone();
-    let mut deactivated = false;
+    let mut patched = UserPatch {
+        active: user.active,
+        name: user.name,
+        external_id: user.external_id,
+        deactivated: false,
+    };
 
     for op in &patch.operations {
-        match op.op {
-            ScimPatchOpType::Replace => {
-                if let Some(path) = &op.path {
-                    match path.as_str() {
-                        "active" => {
-                            if let Some(val) = &op.value {
-                                // RFC 7643 §2.2 — `active` is a boolean. Coercing
-                                // non-boolean values (e.g. the string "false") to
-                                // `true` would silently reactivate disabled users.
-                                let Some(new_active) = val.as_bool() else {
-                                    return (
-                                        StatusCode::BAD_REQUEST,
-                                        Json(
-                                            ScimError::new(400, "active must be a boolean")
-                                                .with_type("invalidValue"),
-                                        ),
-                                    )
-                                        .into_response();
-                                };
-                                if active && !new_active {
-                                    deactivated = true;
-                                }
-                                active = new_active;
-                            }
-                        }
-                        "name.formatted" | "displayName" => {
-                            if let Some(val) = &op.value {
-                                name = val.as_str().map(String::from);
-                            }
-                        }
-                        "externalId" => {
-                            if let Some(val) = &op.value {
-                                external_id = val.as_str().map(String::from);
-                            }
-                        }
-                        _ => {
-                            return (
-                                StatusCode::BAD_REQUEST,
-                                Json(
-                                    ScimError::new(400, "Unsupported attribute path")
-                                        .with_type("invalidPath"),
-                                ),
-                            )
-                                .into_response();
-                        }
-                    }
-                } else if let Some(val) = &op.value {
-                    // Replace entire resource
-                    if let Some(a) = val.get("active").and_then(|v| v.as_bool()) {
-                        if active && !a {
-                            deactivated = true;
-                        }
-                        active = a;
-                    }
-                    if let Some(n) = val
-                        .get("name")
-                        .and_then(|v| v.get("formatted"))
-                        .and_then(|v| v.as_str())
-                    {
-                        name = Some(n.to_string());
-                    }
-                    if let Some(e) = val.get("externalId").and_then(|v| v.as_str()) {
-                        external_id = Some(e.to_string());
-                    }
-                }
-            }
-            ScimPatchOpType::Add => {
-                // RFC 7644 §3.5.2.1: an Add targeting a single-valued
-                // attribute replaces the existing value — the same
-                // semantics as Replace for the single-valued attributes
-                // Vouch stores (active, name.formatted, displayName,
-                // externalId). Multi-valued attributes are not supported
-                // via the path form on Users.
-                if let Some(path) = &op.path {
-                    match path.as_str() {
-                        "active" => {
-                            if let Some(val) = &op.value {
-                                let Some(new_active) = val.as_bool() else {
-                                    return (
-                                        StatusCode::BAD_REQUEST,
-                                        Json(
-                                            ScimError::new(400, "active must be a boolean")
-                                                .with_type("invalidValue"),
-                                        ),
-                                    )
-                                        .into_response();
-                                };
-                                if active && !new_active {
-                                    deactivated = true;
-                                }
-                                active = new_active;
-                            }
-                        }
-                        "name.formatted" | "displayName" => {
-                            if let Some(val) = &op.value {
-                                name = val.as_str().map(String::from);
-                            }
-                        }
-                        "externalId" => {
-                            if let Some(val) = &op.value {
-                                external_id = val.as_str().map(String::from);
-                            }
-                        }
-                        _ => {
-                            return (
-                                StatusCode::BAD_REQUEST,
-                                Json(
-                                    ScimError::new(400, "Unsupported attribute path")
-                                        .with_type("invalidPath"),
-                                ),
-                            )
-                                .into_response();
-                        }
-                    }
-                } else if let Some(val) = &op.value {
-                    // Bulk add (no path) — merge presented attributes, same
-                    // as Replace.
-                    if let Some(a) = val.get("active").and_then(|v| v.as_bool()) {
-                        if active && !a {
-                            deactivated = true;
-                        }
-                        active = a;
-                    }
-                    if let Some(n) = val
-                        .get("name")
-                        .and_then(|v| v.get("formatted"))
-                        .and_then(|v| v.as_str())
-                    {
-                        name = Some(n.to_string());
-                    }
-                    if let Some(e) = val.get("externalId").and_then(|v| v.as_str()) {
-                        external_id = Some(e.to_string());
-                    }
-                }
-            }
-            ScimPatchOpType::Remove => {
-                // RFC 7644 §3.5.2.2: a Remove targeting a single-valued
-                // attribute removes the stored value. Paths Vouch does not
-                // store are ignored (Remove of an absent attribute is a
-                // no-op); `active` is excluded because removing it would
-                // ambiguously reset activation state.
-                if let Some(path) = &op.path {
-                    match path.as_str() {
-                        "name.formatted" | "displayName" => {
-                            name = None;
-                        }
-                        "externalId" => {
-                            external_id = None;
-                        }
-                        _ => {}
-                    }
-                }
-            }
+        if let Err(invalid) = apply_patch_op(USER_ATTRIBUTES, &mut patched, op) {
+            return invalid.into_response();
         }
     }
 
@@ -549,9 +453,9 @@ pub(crate) async fn patch_user(
         &state.store,
         &id,
         &auth.org_id,
-        name.as_deref(),
-        external_id.as_deref(),
-        active,
+        patched.name.as_deref(),
+        patched.external_id.as_deref(),
+        patched.active,
     )
     .await
     {
@@ -577,7 +481,7 @@ pub(crate) async fn patch_user(
     }
 
     // If user was deactivated, invalidate all their sessions and revoke SSH certificates
-    if deactivated {
+    if patched.deactivated {
         tracing::info!(
             "User {} deactivated via SCIM, invalidating sessions and revoking SSH certificates",
             id
@@ -611,7 +515,10 @@ pub(crate) async fn patch_user(
         "User",
         &id,
         Some(&auth.token_id),
-        Some(&serde_json::json!({"active": active, "deactivated": deactivated}).to_string()),
+        Some(
+            &serde_json::json!({"active": patched.active, "deactivated": patched.deactivated})
+                .to_string(),
+        ),
         auth.org_domain.as_deref(),
     )
     .await

--- a/docs/src/admin/scim.md
+++ b/docs/src/admin/scim.md
@@ -71,6 +71,42 @@ curl -X DELETE -H "Authorization: Bearer $(vouch credential token)" \
 Revocation takes effect immediately — tokens are checked against the database on every request.
 Expired tokens are removed by the background cleanup task.
 
+## Attribute Updates (PATCH)
+
+`PATCH /scim/v2/Users/{id}` and `PATCH /scim/v2/Groups/{id}` accept `add`, `replace`, and `remove`
+operations. Vouch stores a subset of the SCIM schema, and all three operations behave the same way
+across it:
+
+| Resource | Attribute path | `add` / `replace` | `remove` |
+|----------|----------------|-------------------|----------|
+| User | `active` | sets it; a non-boolean is rejected | rejected |
+| User | `name.formatted`, `displayName` | sets the stored name | clears it |
+| User | `externalId` | sets it | clears it |
+| Group | `displayName` | sets it; empty is rejected | rejected |
+| Group | `externalId` | sets it | clears it |
+| Group | `members` | `add` appends members, `replace` swaps the whole set | `members[value eq "<user-id>"]` removes one member |
+
+An operation with no `path` — a value object such as `{"op": "replace", "value": {"active": false}}` —
+sets every attribute in the table the object carries. Attribute names are matched
+case-insensitively, as RFC 7643 requires.
+
+**Any other attribute path is ignored, and the request still returns `200`.** Okta and Entra push
+attributes Vouch does not store (`title`, `department`, `name.givenName`, enterprise extensions);
+rejecting those would fail an entire provisioning sync over data the directory never keeps. The
+consequence for you: a `200` does not by itself prove Vouch stored what the IdP sent. The response
+body is the resource as stored — check it when an attribute appears not to sync.
+
+The two removals marked rejected return `400` with `"scimType": "invalidValue"`, because the
+attribute has no absent state to fall back to: `active` on a User (either default would change the
+user's access on its own) and `displayName` on a Group (RFC 7643 requires it). A rejected operation
+leaves the record untouched — Vouch writes it only once every operation in the request is accepted.
+Group membership is the exception: member additions and removals are applied as they are processed,
+so a later rejected operation in the same request does not undo them.
+
+Setting `active` to `false` is the one attribute update with effects beyond the record: it
+invalidates the user's sessions, revokes their SSH certificates, and clears their GitHub refresh
+token, the same way de-provisioning does.
+
 ## De-Provisioning Behavior
 
 When a user is de-provisioned via SCIM (e.g., employee leaves the organization):

--- a/docs/src/admin/scim.md
+++ b/docs/src/admin/scim.md
@@ -84,7 +84,7 @@ across it:
 | User | `externalId` | sets it | clears it |
 | Group | `displayName` | sets it; empty is rejected | rejected |
 | Group | `externalId` | sets it | clears it |
-| Group | `members` | `add` appends members, `replace` swaps the whole set | `members[value eq "<user-id>"]` removes one member |
+| Group | `members` | `add` appends members, `replace` swaps the whole set | removes the members named by `members[value eq "<user-id>"]` or by a `value` list |
 
 An operation with no `path` — a value object such as `{"op": "replace", "value": {"active": false}}` —
 sets every attribute in the table the object carries. Attribute names are matched
@@ -99,9 +99,13 @@ body is the resource as stored — check it when an attribute appears not to syn
 The two removals marked rejected return `400` with `"scimType": "invalidValue"`, because the
 attribute has no absent state to fall back to: `active` on a User (either default would change the
 user's access on its own) and `displayName` on a Group (RFC 7643 requires it). A rejected operation
-leaves the record untouched — Vouch writes it only once every operation in the request is accepted.
-Group membership is the exception: member additions and removals are applied as they are processed,
-so a later rejected operation in the same request does not undo them.
+leaves the record untouched — Vouch writes it only once every operation in the request is accepted,
+membership included, so a `400` means nothing in the request was applied.
+
+A `remove` of `members` that names nothing — no `members[value eq "…"]` filter and no `value` list —
+is ignored rather than emptying the group. RFC 7644 reads that as "remove every member"; emptying a
+group changes who has access, and an operation that names no member is more often a malformed
+request than an intended purge. Send an explicit `value` list, or `replace` with the set you want.
 
 Setting `active` to `false` is the one attribute update with effects beyond the record: it
 invalidates the user's sessions, revokes their SSH certificates, and clears their GitHub refresh


### PR DESCRIPTION
`patch_user` and `patch_group` each hand-rolled add/replace/remove semantics per attribute path, so the arms drifted: remove recognized only `externalId` and silently ignored `displayName` and `name.formatted`, and the two resources answered an unknown path differently. Every new attribute reopened the class.

Both now use a shared applier driven by a per-resource attribute table. Users and Groups declare which paths they support; neither restates operation semantics. Group members stay separate, since they are multi-valued and live in the membership table.

`patch_user` drops from 293 to 147 lines and `patch_group` from 237 to 130; both `#[expect(clippy::too_many_lines)]` escapes are gone.

## Behavior changes

- **Unknown attribute paths are ignored uniformly (200).** Identity providers send `add` for attributes Vouch does not store (`title`, `department`, `name.givenName`, enterprise extensions), and rejecting those surfaces as a failed provisioning sync on the IdP side rather than anything visible here. This reverses the unknown-path rejection added in #921 and applies the same rule to Groups, which previously ignored them.
- **Removing a required attribute is rejected** with 400 `invalidValue`, so "required" cannot be bypassed via remove. Same for setting an empty group `displayName`.
- **Path matching is case-insensitive** per RFC 7643 §2.1; without it, ignoring unknown paths would silently drop a case-variant of a known path.
- A known path with an invalid value still returns 400 — `active` remains strictly boolean.

## Adjacent fix

`update_scim_group` treated `external_id: None` as "leave unchanged", so a group's `externalId` could never be cleared even though `patch_group` intended to. Both fields now write through, matching `update_scim_user`. Its only production caller passes the group's full desired state, so this cannot clear a field unintentionally.

## Known gap

`{"op":"remove","path":"members","value":[...]}` is still a silent no-op. Same defect class, but it needs its own decision on member semantics and is left for a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches enterprise SCIM provisioning (Users/Groups PATCH and group persistence); behavior changes (ignored unknown paths, atomic group PATCH) affect IdP sync outcomes but are covered by extensive tests.
> 
> **Overview**
> Introduces **`handlers/scim/patch.rs`**, a table-driven **`apply_patch_op`** used by User and Group PATCH instead of duplicated per-path logic. Each resource declares **`USER_ATTRIBUTES`** / **`GROUP_ATTRIBUTES`**; group **`members`** stay in **`apply_member_op`** on the membership table.
> 
> **Behavior changes:** Unknown attribute paths return **200** and are ignored (reverses prior **400 `invalidPath`** on Users) so Okta/Entra syncs are not failed on unstored fields. **Case-insensitive** path matching (RFC 7643). **Remove** of required fields (`active`, group `displayName`) and empty group names return **400 `invalidValue`**. Group PATCH **validates all attribute ops before applying member ops**, so a later invalid op does not leave membership partially changed. Entra-style **`remove` on `members` with a `value` list** is supported; bare **`remove` on `members`** with no filter/value stays a no-op.
> 
> **`update_scim_group`** now always writes **`display_name`** and **`external_id`** ( **`None` clears `externalId`** ), aligned with **`update_scim_user`**. Admin **`docs/src/admin/scim.md`** documents PATCH semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94a3717ce68ea8662763b33853a70f56c2052396. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->