### PR TITLE
fix(oidc): require a sender-constraint witness to issue any token

### DIFF
--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -29,7 +29,7 @@ use crate::handlers::session::{create_session_cookie, get_auth_context};
 use crate::impl_template_response;
 use crate::redact_email;
 use crate::services::auth::{
-    ClientAuthProof, CreateOAuthTokenParams, GrantProof, TokenIssuanceProof,
+    ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenIssuanceProof,
     create_oauth_access_token,
 };
 use crate::services::oidc::ScopeSet;
@@ -813,6 +813,7 @@ pub(crate) async fn browser_login_complete(
             client_auth: ClientAuthProof::NoAuth(
                 crate::services::auth::NoClientAuth::internal_endpoint(),
             ),
+            sender_constraint: SenderConstraintProof::no_registered_client(),
         },
     )
     .await

--- a/crates/vouch-server/src/handlers/certification.rs
+++ b/crates/vouch-server/src/handlers/certification.rs
@@ -33,8 +33,8 @@ use crate::{
     handlers::browser_login::hmac_sha256_base64url,
     handlers::session::create_session_cookie,
     services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, TokenIssuanceProof,
-        create_oauth_access_token,
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof,
+        TokenIssuanceProof, create_oauth_access_token,
     },
     services::oidc::ScopeSet,
 };
@@ -166,6 +166,7 @@ pub(crate) async fn complete_login(
             client_auth: ClientAuthProof::NoAuth(
                 crate::services::auth::NoClientAuth::internal_endpoint(),
             ),
+            sender_constraint: SenderConstraintProof::no_registered_client(),
         },
     )
     .await

--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -372,12 +372,11 @@ pub(crate) async fn device_token(
                 None => None,
             };
 
-            // FAPI 2.0 Section 5.2.2: sender-constrained access tokens
-            // required (DPoP or mTLS). Mirrors `handle_authorization_code_grant`.
-            // The built-in CLI flow carries no registered client_id, so there
-            // is no `fapi_profile` to enforce against.
+            // Every sender-constraint requirement registered for this
+            // client. The built-in CLI flow carries no registered client_id,
+            // so there is no registration to enforce against.
             let sender_constraint = match oauth_client {
-                Some(ref oc) => match crate::services::oidc::fapi::validate_fapi_token_request(
+                Some(ref oc) => match SenderConstraintProof::validate(
                     oc,
                     crate::services::oidc::fapi::SenderConstraints {
                         dpop: dpop_proof.is_some(),
@@ -389,48 +388,6 @@ pub(crate) async fn device_token(
                 },
                 None => SenderConstraintProof::no_registered_client(),
             };
-
-            if let Some(ref oc) = oauth_client {
-                // RFC 9449: When the client requires DPoP-bound access
-                // tokens, a valid DPoP proof MUST be present. The client
-                // explicitly opted into DPoP binding via
-                // `dpop_bound_access_tokens=true`, so mTLS alone does not
-                // satisfy this — the access token must carry a `cnf.jkt`.
-                if oc.dpop_bound_access_tokens && dpop_proof.is_none() {
-                    return Err(oauth_error(
-                        StatusCode::BAD_REQUEST,
-                        OAuthError {
-                            error: "invalid_request".to_string(),
-                            error_description: Some(
-                                "Client requires DPoP-bound access tokens \
-                                 but no DPoP proof was provided"
-                                    .to_string(),
-                            ),
-                        },
-                    ));
-                }
-
-                // RFC 8705 Section 3: When the client requires
-                // certificate-bound access tokens, a client certificate
-                // MUST be present. DPoP is accepted as an alternative
-                // sender-constraint mechanism.
-                if oc.tls_client_certificate_bound_access_tokens
-                    && !has_mtls_cert
-                    && dpop_proof.is_none()
-                {
-                    return Err(oauth_error(
-                        StatusCode::BAD_REQUEST,
-                        OAuthError {
-                            error: "invalid_request".to_string(),
-                            error_description: Some(
-                                "Client requires certificate-bound access \
-                                 tokens but no client certificate was presented"
-                                    .to_string(),
-                            ),
-                        },
-                    ));
-                }
-            }
 
             // RFC 8705 Section 3: Bind the access token to the mTLS
             // certificate thumbprint only when the client has opted in.

--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -4,7 +4,7 @@
 use crate::AppState;
 use crate::db::{self, DeviceAuthStatus};
 use crate::services::auth::{
-    ClientAuthProof, CreateOAuthTokenParams, GrantProof, TokenIssuanceProof,
+    ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenIssuanceProof,
     create_oauth_access_token,
 };
 use crate::services::oidc::ScopeSet;
@@ -374,17 +374,23 @@ pub(crate) async fn device_token(
 
             // FAPI 2.0 Section 5.2.2: sender-constrained access tokens
             // required (DPoP or mTLS). Mirrors `handle_authorization_code_grant`.
-            if let Some(ref oc) = oauth_client {
-                if let Err(e) = crate::services::oidc::fapi::validate_fapi_token_request(
+            // The built-in CLI flow carries no registered client_id, so there
+            // is no `fapi_profile` to enforce against.
+            let sender_constraint = match oauth_client {
+                Some(ref oc) => match crate::services::oidc::fapi::validate_fapi_token_request(
                     oc,
                     crate::services::oidc::fapi::SenderConstraints {
                         dpop: dpop_proof.is_some(),
                         mtls_cert: has_mtls_cert,
                     },
                 ) {
-                    return Err(e.into_oauth_response().into_response());
-                }
+                    Ok(witness) => witness,
+                    Err(e) => return Err(e.into_oauth_response().into_response()),
+                },
+                None => SenderConstraintProof::no_registered_client(),
+            };
 
+            if let Some(ref oc) = oauth_client {
                 // RFC 9449: When the client requires DPoP-bound access
                 // tokens, a valid DPoP proof MUST be present. The client
                 // explicitly opted into DPoP binding via
@@ -574,6 +580,7 @@ pub(crate) async fn device_token(
                     client_auth: ClientAuthProof::NoAuth(
                         crate::services::auth::NoClientAuth::internal_endpoint(),
                     ),
+                    sender_constraint,
                 },
             )
             .await

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -32,7 +32,7 @@ use super::{
 use crate::error::ServiceError;
 use crate::redact_email;
 use crate::services::auth::{
-    ClientAuthProof, CreateOAuthTokenParams, GrantProof, TokenIssuanceProof,
+    ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenIssuanceProof,
     create_oauth_access_token,
 };
 use crate::services::idp::IdentityResult;
@@ -838,6 +838,7 @@ pub(crate) async fn complete_enrollment_after_identity(
             client_auth: ClientAuthProof::NoAuth(
                 crate::services::auth::NoClientAuth::internal_endpoint(),
             ),
+            sender_constraint: SenderConstraintProof::no_registered_client(),
         },
     )
     .await
@@ -1697,6 +1698,7 @@ pub(crate) async fn browser_register_complete(
             client_auth: ClientAuthProof::NoAuth(
                 crate::services::auth::NoClientAuth::internal_endpoint(),
             ),
+            sender_constraint: SenderConstraintProof::no_registered_client(),
         },
     )
     .await

--- a/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
@@ -1730,3 +1730,50 @@ async fn test_fapi2_client_credentials_with_dpop_issues_bound_token() {
         "client_credentials token must carry cnf.jkt bound to the DPoP proof key"
     );
 }
+
+/// A client that registered `dpop_bound_access_tokens` must present a DPoP
+/// proof on the client_credentials grant, exactly as on the authorization-code
+/// and device grants. mTLS does not substitute: the client asked for a
+/// `cnf.jkt` binding specifically.
+#[tokio::test]
+async fn test_client_credentials_rejects_dpop_bound_client_without_proof() {
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "cc-dpop-bound@example.com").await;
+    let (pkcs8_bytes, jwk) = generate_es256_signing_key();
+    let client = create_test_client(
+        &state.store,
+        &user.id,
+        TestClientSpec {
+            jwks: TestJwks::Custom(serde_json::json!({ "keys": [jwk] })),
+            token_endpoint_auth_method: Some(crate::db::TokenEndpointAuthMethod::PrivateKeyJwt),
+            // Not a FAPI client: the binding flag alone must be enforced.
+            dpop_bound_access_tokens: true,
+            grant_types: Some(vec!["client_credentials".to_string()]),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let assertion = build_client_assertion(
+        &client.client_id,
+        &state.config().base_url,
+        &pkcs8_bytes,
+        None,
+    );
+    let body = format!(
+        "grant_type=client_credentials\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}",
+    );
+
+    let (status, resp_body) = http_post_form(&app, "/oauth/token", &body, &[]).await;
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "a dpop_bound_access_tokens client must not receive an unbound token: {resp_body}"
+    );
+    let error: serde_json::Value = serde_json::from_str(&resp_body).expect("Valid JSON");
+    assert_eq!(error["error"], "invalid_request", "body: {resp_body}");
+}

--- a/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
@@ -1611,3 +1611,122 @@ async fn test_fapi2_token_exchange_with_dpop_issues_bound_token() {
         "exchanged token must carry cnf.jkt bound to the DPoP proof key"
     );
 }
+
+// ============================================================================
+// FAPI 2.0 Client Credentials (RFC 6749 §4.4) — Sender Constraints
+//
+// FAPI 2.0 Section 5.2.2 applies to every grant a FAPI client can reach.
+// The client_credentials grant is reachable by any registered client — the
+// token endpoint does not gate grants by the client's registered
+// `grant_types` — so it must enforce sender-constraining like the others.
+// ============================================================================
+
+/// Create a FAPI client registered for the `client_credentials` grant.
+async fn create_fapi_client_credentials_client(
+    store: &db::store::DocumentStore,
+    user_id: &str,
+) -> (TestOAuthClient, Vec<u8>) {
+    let (pkcs8_bytes, jwk) = generate_es256_signing_key();
+    let jwks_value = serde_json::json!({ "keys": [jwk] });
+
+    let client = create_test_client(
+        store,
+        user_id,
+        TestClientSpec {
+            jwks: TestJwks::Custom(jwks_value),
+            token_endpoint_auth_method: Some(crate::db::TokenEndpointAuthMethod::PrivateKeyJwt),
+            fapi_profile: Some(db::FapiProfile::Fapi2Security),
+            grant_types: Some(vec!["client_credentials".to_string()]),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    (client, pkcs8_bytes)
+}
+
+/// A FAPI client using the `client_credentials` grant without any sender
+/// constraint (no DPoP proof, no mTLS certificate) must be rejected rather
+/// than issued a plain bearer token.
+#[tokio::test]
+async fn test_fapi2_client_credentials_rejects_unbound_fapi_client() {
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "fapi2-cc-unbound@example.com").await;
+    let (client, pkcs8_bytes) = create_fapi_client_credentials_client(&state.store, &user.id).await;
+
+    let assertion = build_client_assertion(
+        &client.client_id,
+        &state.config().base_url,
+        &pkcs8_bytes,
+        None,
+    );
+    let body = format!(
+        "grant_type=client_credentials\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}",
+    );
+
+    let (status, resp_body) = http_post_form(&app, "/oauth/token", &body, &[]).await;
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "FAPI client_credentials without a sender constraint must be rejected: {resp_body}"
+    );
+    let error: serde_json::Value = serde_json::from_str(&resp_body).expect("Valid JSON");
+    assert_eq!(
+        error["error"], "invalid_request",
+        "must return invalid_request: {resp_body}"
+    );
+}
+
+/// A FAPI client presenting a valid DPoP proof on the `client_credentials`
+/// grant receives a DPoP-bound token: `cnf.jkt` matches the proof key and
+/// `token_type` is `DPoP` (RFC 9449 Section 5).
+#[tokio::test]
+async fn test_fapi2_client_credentials_with_dpop_issues_bound_token() {
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "fapi2-cc-dpop@example.com").await;
+    let (client, pkcs8_bytes) = create_fapi_client_credentials_client(&state.store, &user.id).await;
+
+    let (dpop_key, dpop_jwk) = generate_dpop_key_pair();
+    let expected_jkt = compute_jwk_thumbprint(&dpop_jwk);
+    let token_uri = format!("{}/oauth/token", state.config().base_url);
+    let nonce = acquire_dpop_nonce(&app, &dpop_key, &dpop_jwk, "POST", &token_uri).await;
+    let proof = create_dpop_proof(&dpop_key, &dpop_jwk, "POST", &token_uri, Some(&nonce), None);
+
+    let assertion = build_client_assertion(
+        &client.client_id,
+        &state.config().base_url,
+        &pkcs8_bytes,
+        None,
+    );
+    let body = format!(
+        "grant_type=client_credentials\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}",
+    );
+
+    let (status, resp_body) =
+        http_post_form(&app, "/oauth/token", &body, &[("DPoP", &proof)]).await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "FAPI client_credentials with DPoP must succeed: {resp_body}"
+    );
+    let resp: serde_json::Value = serde_json::from_str(&resp_body).expect("Valid JSON");
+    assert_eq!(
+        resp["token_type"], "DPoP",
+        "a DPoP-bound token must be advertised as token_type=DPoP: {resp_body}"
+    );
+    let access_token = resp["access_token"].as_str().expect("access_token");
+    let claims = decode_jwt_payload(access_token);
+    assert_eq!(
+        claims["cnf"]["jkt"].as_str(),
+        Some(expected_jkt.as_str()),
+        "client_credentials token must carry cnf.jkt bound to the DPoP proof key"
+    );
+}

--- a/crates/vouch-server/src/handlers/oidc/tests/oidc_userinfo.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/oidc_userinfo.rs
@@ -82,7 +82,7 @@ async fn test_userinfo_no_email_when_scope_is_none() {
     // "full access" — it must return only `sub`, never the user's email.
     use crate::services::auth::{
         ClientAuthProof, CreateOAuthTokenParams, GrantProof, HardwareVerification, NoClientAuth,
-        TokenIssuanceProof, create_oauth_access_token,
+        SenderConstraintProof, TokenIssuanceProof, create_oauth_access_token,
     };
     use secrecy::ExposeSecret;
 
@@ -113,6 +113,7 @@ async fn test_userinfo_no_email_when_scope_is_none() {
         TokenIssuanceProof {
             grant: GrantProof::TestingOnly,
             client_auth: ClientAuthProof::NoAuth(NoClientAuth::internal_endpoint()),
+            sender_constraint: SenderConstraintProof::no_registered_client(),
         },
     )
     .await

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -9,7 +9,9 @@ use crate::AppState;
 use crate::db::JwtAssertionJtiClaim;
 use crate::error::OAuthErrorResponse;
 use crate::error::{OAuthErrorCode, ServiceError};
-use crate::services::auth::{ClientAuthProof, GrantProof, TokenIssuanceProof};
+use crate::services::auth::{
+    ClientAuthProof, GrantProof, SenderConstraintProof, TokenIssuanceProof,
+};
 use crate::services::oidc::{
     ScopeSet,
     client_credentials::{ClientCredentialsBindings, exchange_client_credentials},
@@ -489,10 +491,6 @@ async fn resolve_non_jwt_auth(
 }
 
 /// Handle authorization code grant.
-#[expect(
-    clippy::too_many_lines,
-    reason = "linear RFC 6749 section 4.1.3 authorization-code grant validation"
-)]
 async fn handle_authorization_code_grant(
     State(state): State<Arc<AppState>>,
     client_cert: crate::handlers::extractors::OptionalClientCert,
@@ -617,8 +615,8 @@ async fn handle_authorization_code_grant(
         return *resp;
     }
 
-    // FAPI 2.0: Require DPoP for FAPI clients (sender-constrained tokens).
-    let sender_constraint = match crate::services::oidc::fapi::validate_fapi_token_request(
+    // Every sender-constraint requirement registered for this client.
+    let sender_constraint = match SenderConstraintProof::validate(
         &authenticated_client.client,
         crate::services::oidc::fapi::SenderConstraints {
             dpop: dpop_proof.is_some(),
@@ -628,40 +626,6 @@ async fn handle_authorization_code_grant(
         Ok(witness) => witness,
         Err(e) => return e.into_oauth_response().into_response(),
     };
-
-    // RFC 9449 Section 5: When the client requires DPoP-bound access tokens,
-    // a valid DPoP proof MUST be present. The client explicitly opted into
-    // DPoP binding via dpop_bound_access_tokens=true, so mTLS alone does
-    // not satisfy this — the access token must carry a jkt confirmation.
-    if authenticated_client.client.dpop_bound_access_tokens && dpop_proof.is_none() {
-        return ServiceError::oauth(
-            OAuthErrorCode::InvalidRequest,
-            "Client requires DPoP-bound access tokens \
-             but no DPoP proof was provided",
-        )
-        .into_oauth_response()
-        .into_response();
-    }
-
-    // RFC 8705 Section 3: When the client requires certificate-bound access
-    // tokens, a client certificate MUST be present. Without a cert the token
-    // would be issued without a cnf.x5t#S256 binding, violating the client's
-    // registered constraint. DPoP is accepted as an alternative sender
-    // constraint mechanism.
-    if authenticated_client
-        .client
-        .tls_client_certificate_bound_access_tokens
-        && !has_mtls_cert
-        && dpop_proof.is_none()
-    {
-        return ServiceError::oauth(
-            OAuthErrorCode::InvalidRequest,
-            "Client requires certificate-bound access tokens \
-             but no client certificate was presented",
-        )
-        .into_oauth_response()
-        .into_response();
-    }
 
     // RFC 8705 Section 3: Bind access token to cert thumbprint only when opted in.
     let mtls_thumbprint = extract_mtls_thumbprint(&authenticated_client, &client_cert);
@@ -777,7 +741,7 @@ async fn handle_client_credentials_grant(
 
     // FAPI 2.0 Section 5.2.2: sender-constrained access tokens required
     // (DPoP or mTLS), same as every other grant a FAPI client can reach.
-    let sender_constraint = match crate::services::oidc::fapi::validate_fapi_token_request(
+    let sender_constraint = match SenderConstraintProof::validate(
         &authenticated_client.client,
         crate::services::oidc::fapi::SenderConstraints {
             dpop: dpop_proof.is_some(),
@@ -974,7 +938,7 @@ async fn handle_token_exchange_grant(
     // (DPoP or mTLS) on every grant a FAPI client can use — without this, a
     // FAPI client could exchange a bound subject_token for an unbound one.
     // Mirrors `handle_authorization_code_grant`.
-    let sender_constraint = match crate::services::oidc::fapi::validate_fapi_token_request(
+    let sender_constraint = match SenderConstraintProof::validate(
         &authenticated_client.client,
         crate::services::oidc::fapi::SenderConstraints {
             dpop: dpop_proof.is_some(),
@@ -1165,7 +1129,7 @@ async fn handle_fido2_assertion_grant(
     let has_mtls_cert = client_cert.0.is_some();
 
     // FAPI 2.0: Require sender-constrained tokens (DPoP or mTLS)
-    let sender_constraint = match crate::services::oidc::fapi::validate_fapi_token_request(
+    let sender_constraint = match SenderConstraintProof::validate(
         &jwt_authenticated.client,
         crate::services::oidc::fapi::SenderConstraints {
             dpop: dpop_proof.is_some(),

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -12,7 +12,7 @@ use crate::error::{OAuthErrorCode, ServiceError};
 use crate::services::auth::{ClientAuthProof, GrantProof, TokenIssuanceProof};
 use crate::services::oidc::{
     ScopeSet,
-    client_credentials::exchange_client_credentials,
+    client_credentials::{ClientCredentialsBindings, exchange_client_credentials},
     exchange::{TokenExchangeParams, exchange_token},
     grant_type::{OAuthGrantType, ParseOAuthGrantTypeError},
     jwt_bearer::client_auth::{PendingJti, authenticate_client_jwt},
@@ -618,15 +618,16 @@ async fn handle_authorization_code_grant(
     }
 
     // FAPI 2.0: Require DPoP for FAPI clients (sender-constrained tokens).
-    if let Err(e) = crate::services::oidc::fapi::validate_fapi_token_request(
+    let sender_constraint = match crate::services::oidc::fapi::validate_fapi_token_request(
         &authenticated_client.client,
         crate::services::oidc::fapi::SenderConstraints {
             dpop: dpop_proof.is_some(),
             mtls_cert: has_mtls_cert,
         },
     ) {
-        return e.into_oauth_response().into_response();
-    }
+        Ok(witness) => witness,
+        Err(e) => return e.into_oauth_response().into_response(),
+    };
 
     // RFC 9449 Section 5: When the client requires DPoP-bound access tokens,
     // a valid DPoP proof MUST be present. The client explicitly opted into
@@ -679,7 +680,8 @@ async fn handle_authorization_code_grant(
         mtls_cert_thumbprint: mtls_thumbprint.as_deref(),
     };
 
-    match exchange_authorization_code(&state, exchange_params, client_auth).await {
+    match exchange_authorization_code(&state, exchange_params, client_auth, sender_constraint).await
+    {
         Ok(result) => {
             crate::infra::metrics::record_auth_event("authorization_code_success");
             token_success_response(TokenResponse {
@@ -752,6 +754,40 @@ async fn handle_client_credentials_grant(
     // RFC 8705 Section 3: Bind access token to cert thumbprint only when opted in.
     let mtls_thumbprint = extract_mtls_thumbprint(&authenticated_client, &client_cert);
 
+    // RFC 9449 Section 5: Validate the DPoP proof if present so the issued
+    // token carries a `cnf.jkt` binding.
+    let dpop_header = headers.get("DPoP").and_then(|v| v.to_str().ok());
+    let dpop_proof =
+        match validate_dpop_if_present(&state, dpop_header, "POST", "/oauth/token").await {
+            Ok(proof) => proof,
+            Err(crate::services::oidc::dpop::DpopError::UseNonce(nonce)) => {
+                return dpop_use_nonce_response(&nonce);
+            }
+            Err(e @ crate::services::oidc::dpop::DpopError::Database(_)) => {
+                return ServiceError::oauth(OAuthErrorCode::ServerError, e.to_string())
+                    .into_oauth_response()
+                    .into_response();
+            }
+            Err(e) => {
+                return ServiceError::oauth(OAuthErrorCode::InvalidDpopProof, e.to_string())
+                    .into_oauth_response()
+                    .into_response();
+            }
+        };
+
+    // FAPI 2.0 Section 5.2.2: sender-constrained access tokens required
+    // (DPoP or mTLS), same as every other grant a FAPI client can reach.
+    let sender_constraint = match crate::services::oidc::fapi::validate_fapi_token_request(
+        &authenticated_client.client,
+        crate::services::oidc::fapi::SenderConstraints {
+            dpop: dpop_proof.is_some(),
+            mtls_cert: client_cert.0.is_some(),
+        },
+    ) {
+        Ok(witness) => witness,
+        Err(e) => return e.into_oauth_response().into_response(),
+    };
+
     let jti_claim = match commit_optional_jti(&state, pending_jti, "client_credentials").await {
         Ok(c) => c,
         Err(r) => return r,
@@ -796,13 +832,17 @@ async fn handle_client_credentials_grant(
     let proof = TokenIssuanceProof {
         grant: GrantProof::ClientCredentials,
         client_auth,
+        sender_constraint,
     };
 
     match exchange_client_credentials(
         &state,
         &authenticated_client.client,
         params.scope.as_deref(),
-        mtls_thumbprint.as_deref(),
+        ClientCredentialsBindings {
+            dpop_jkt: dpop_proof.as_ref().map(|p| p.jkt.as_str()),
+            mtls_cert_thumbprint: mtls_thumbprint.as_deref(),
+        },
         proof,
     )
     .await
@@ -934,15 +974,16 @@ async fn handle_token_exchange_grant(
     // (DPoP or mTLS) on every grant a FAPI client can use — without this, a
     // FAPI client could exchange a bound subject_token for an unbound one.
     // Mirrors `handle_authorization_code_grant`.
-    if let Err(e) = crate::services::oidc::fapi::validate_fapi_token_request(
+    let sender_constraint = match crate::services::oidc::fapi::validate_fapi_token_request(
         &authenticated_client.client,
         crate::services::oidc::fapi::SenderConstraints {
             dpop: dpop_proof.is_some(),
             mtls_cert: client_cert.0.is_some(),
         },
     ) {
-        return e.into_oauth_response().into_response();
-    }
+        Ok(witness) => witness,
+        Err(e) => return e.into_oauth_response().into_response(),
+    };
 
     // RFC 8707: If resource is present, use it as audience (unless audience is explicitly set).
     // If both are present, they must match.
@@ -1018,6 +1059,7 @@ async fn handle_token_exchange_grant(
     let proof = TokenIssuanceProof {
         grant: GrantProof::TokenExchange,
         client_auth,
+        sender_constraint,
     };
 
     match exchange_token(&state, exchange_params, proof).await {
@@ -1123,15 +1165,16 @@ async fn handle_fido2_assertion_grant(
     let has_mtls_cert = client_cert.0.is_some();
 
     // FAPI 2.0: Require sender-constrained tokens (DPoP or mTLS)
-    if let Err(e) = crate::services::oidc::fapi::validate_fapi_token_request(
+    let sender_constraint = match crate::services::oidc::fapi::validate_fapi_token_request(
         &jwt_authenticated.client,
         crate::services::oidc::fapi::SenderConstraints {
             dpop: dpop_proof.is_some(),
             mtls_cert: has_mtls_cert,
         },
     ) {
-        return e.into_oauth_response().into_response();
-    }
+        Ok(witness) => witness,
+        Err(e) => return e.into_oauth_response().into_response(),
+    };
 
     // RFC 8705 Section 3: Bind access token to cert thumbprint only when opted in.
     let mtls_thumbprint = extract_mtls_thumbprint(&jwt_authenticated, &client_cert);
@@ -1169,6 +1212,7 @@ async fn handle_fido2_assertion_grant(
         &state,
         exchange_params,
         client_auth,
+        sender_constraint,
     )
     .await
     {

--- a/crates/vouch-server/src/services/auth.rs
+++ b/crates/vouch-server/src/services/auth.rs
@@ -333,12 +333,18 @@ pub(crate) const MAX_DELEGATION_DEPTH: usize = 5;
 ///
 /// `TokenIssuanceProof` is not `Clone` — the proof represents a one-shot
 /// authorization to issue a token and cannot be duplicated.
+///
+/// Every issuance must also supply a
+/// [`SenderConstraintProof`], so minting an
+/// unbound access token for a FAPI client is a compile error rather than a
+/// per-grant check that a new grant can forget to call.
 #[must_use = "the proof was constructed to authorize a single token issuance; \
               dropping it without calling create_oauth_access_token is a bug"]
 #[derive(Debug)]
 pub(crate) struct TokenIssuanceProof {
     pub(crate) grant: GrantProof,
     pub(crate) client_auth: ClientAuthProof,
+    pub(crate) sender_constraint: SenderConstraintProof,
 }
 
 /// Witness for the grant-level replay primitive consumed during token issuance.
@@ -436,6 +442,43 @@ impl JwtClientAuthProof {
             _auth: auth,
             _jti: jti,
         }
+    }
+}
+
+/// Witness that FAPI 2.0 sender-constraint requirements were settled for this
+/// issuance.
+///
+/// FAPI 2.0 Section 5.2.2 requires access tokens issued to a FAPI client to be
+/// sender-constrained (DPoP or mTLS). Requiring this witness on
+/// [`TokenIssuanceProof`] means a grant cannot mint a token without deciding
+/// which case it is in — the enforcement is not a call a new grant can forget.
+///
+/// Both constructors are named for the case they assert, so which one a grant
+/// picked is visible at the call site and in review.
+#[derive(Debug)]
+pub(crate) struct SenderConstraintProof {
+    _private: (),
+}
+
+impl SenderConstraintProof {
+    /// The request was checked against a registered client's `fapi_profile`.
+    ///
+    /// Produced by
+    /// [`crate::services::oidc::fapi::validate_fapi_token_request`], which is
+    /// the only caller that should construct it.
+    pub(crate) fn fapi_checked() -> Self {
+        Self { _private: () }
+    }
+
+    /// There is no registered OAuth client whose profile could constrain this
+    /// issuance.
+    ///
+    /// Browser sessions, enrollment bootstrap/completion, and the
+    /// certification-test bypass mint tokens for a user rather than for a
+    /// client. The device grant's built-in CLI flow (no `client_id`) is the
+    /// same case.
+    pub(crate) fn no_registered_client() -> Self {
+        Self { _private: () }
     }
 }
 
@@ -669,8 +712,17 @@ pub(crate) async fn create_oauth_access_token(
     //
     // `JwtAssertionJtiClaim` holds only `_private: ()` — the JTI string is
     // not retained in the witness, so the Debug log cannot leak it.
-    let TokenIssuanceProof { grant, client_auth } = proof;
-    tracing::debug!(?grant, ?client_auth, "token issuance proof consumed");
+    let TokenIssuanceProof {
+        grant,
+        client_auth,
+        sender_constraint,
+    } = proof;
+    tracing::debug!(
+        ?grant,
+        ?client_auth,
+        ?sender_constraint,
+        "token issuance proof consumed"
+    );
 
     let now = Timestamp::now();
     let session_hours = i64::try_from(state.config().session_hours)

--- a/crates/vouch-server/src/services/auth.rs
+++ b/crates/vouch-server/src/services/auth.rs
@@ -445,33 +445,66 @@ impl JwtClientAuthProof {
     }
 }
 
-/// Witness that FAPI 2.0 sender-constraint requirements were settled for this
-/// issuance.
+/// Witness that every sender-constraint requirement applying to an issuance
+/// was checked.
 ///
-/// FAPI 2.0 Section 5.2.2 requires access tokens issued to a FAPI client to be
-/// sender-constrained (DPoP or mTLS). Requiring this witness on
-/// [`TokenIssuanceProof`] means a grant cannot mint a token without deciding
-/// which case it is in — the enforcement is not a call a new grant can forget.
-///
-/// Both constructors are named for the case they assert, so which one a grant
-/// picked is visible at the call site and in review.
+/// Requiring this on [`TokenIssuanceProof`] means a grant cannot mint a token
+/// without deciding which case it is in — the enforcement is not a call a new
+/// grant can forget. Both constructors are named for the case they assert, so
+/// the choice is visible at the call site and in review.
 #[derive(Debug)]
 pub(crate) struct SenderConstraintProof {
     _private: (),
 }
 
 impl SenderConstraintProof {
-    /// The request was checked against a registered client's `fapi_profile`.
+    /// Check every sender-constraint requirement registered for `client`.
     ///
-    /// Produced by
-    /// [`crate::services::oidc::fapi::validate_fapi_token_request`], which is
-    /// the only caller that should construct it.
-    pub(crate) fn fapi_checked() -> Self {
-        Self { _private: () }
+    /// Three independent requirements, all enforced here so that no grant
+    /// enforces a different subset:
+    /// - FAPI 2.0 Section 5.2.2 — a FAPI client's tokens must be
+    ///   sender-constrained by DPoP or mTLS.
+    /// - RFC 9449 Section 5 — a client that registered
+    ///   `dpop_bound_access_tokens` must present a DPoP proof. mTLS does not
+    ///   substitute: the client asked for a `cnf.jkt` binding specifically.
+    /// - RFC 8705 Section 3 — a client that registered
+    ///   `tls_client_certificate_bound_access_tokens` must present a
+    ///   certificate, with DPoP accepted as an alternative constraint.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ServiceError::OAuth` with `invalid_request` if a registered
+    /// requirement is unmet.
+    pub(crate) fn validate(
+        client: &db::OAuthClient,
+        constraints: crate::services::oidc::fapi::SenderConstraints,
+    ) -> ServiceResult<Self> {
+        crate::services::oidc::fapi::validate_fapi_token_request(client, constraints)?;
+
+        if client.dpop_bound_access_tokens && !constraints.dpop {
+            return Err(ServiceError::oauth(
+                OAuthErrorCode::InvalidRequest,
+                "Client requires DPoP-bound access tokens \
+                 but no DPoP proof was provided",
+            ));
+        }
+
+        if client.tls_client_certificate_bound_access_tokens
+            && !constraints.mtls_cert
+            && !constraints.dpop
+        {
+            return Err(ServiceError::oauth(
+                OAuthErrorCode::InvalidRequest,
+                "Client requires certificate-bound access tokens \
+                 but no client certificate was presented",
+            ));
+        }
+
+        Ok(Self { _private: () })
     }
 
-    /// There is no registered OAuth client whose profile could constrain this
-    /// issuance.
+    /// There is no registered OAuth client whose registration could constrain
+    /// this issuance.
     ///
     /// Browser sessions, enrollment bootstrap/completion, and the
     /// certification-test bypass mint tokens for a user rather than for a

--- a/crates/vouch-server/src/services/oidc/client_credentials.rs
+++ b/crates/vouch-server/src/services/oidc/client_credentials.rs
@@ -41,11 +41,20 @@ pub struct ClientCredentialsResult {
 /// # Errors
 /// Returns `unauthorized_client` if the client does not have the
 /// `client_credentials` grant type registered.
+/// Sender-constraint bindings to stamp into the issued access token.
+///
+/// RFC 9449 (`cnf.jkt`) and RFC 8705 (`cnf.x5t#S256`) — DPoP takes priority
+/// over mTLS in `create_oauth_access_token`.
+pub(crate) struct ClientCredentialsBindings<'a> {
+    pub(crate) dpop_jkt: Option<&'a str>,
+    pub(crate) mtls_cert_thumbprint: Option<&'a str>,
+}
+
 pub(crate) async fn exchange_client_credentials(
     state: &Arc<AppState>,
     client: &OAuthClient,
     requested_scope: Option<&str>,
-    mtls_cert_thumbprint: Option<&str>,
+    bindings: ClientCredentialsBindings<'_>,
     proof: TokenIssuanceProof,
 ) -> ServiceResult<ClientCredentialsResult> {
     // Verify client has client_credentials in its registered grant_types
@@ -78,8 +87,8 @@ pub(crate) async fn exchange_client_credentials(
             authenticator_id: None,
             client_id: &client.client_id,
             scope: scope.clone(),
-            dpop_jkt: None,
-            mtls_cert_thumbprint,
+            dpop_jkt: bindings.dpop_jkt,
+            mtls_cert_thumbprint: bindings.mtls_cert_thumbprint,
             act: None,
             audience: None,
             auth_time: None,
@@ -98,9 +107,16 @@ pub(crate) async fn exchange_client_credentials(
         client.client_id
     );
 
+    // RFC 9449 Section 5: token_type is "DPoP" when the token is sender-constrained
+    let token_type = if bindings.dpop_jkt.is_some() {
+        "DPoP"
+    } else {
+        "Bearer"
+    };
+
     Ok(ClientCredentialsResult {
         access_token: session_result.token.expose_secret().to_string(),
-        token_type: "Bearer".to_string(),
+        token_type: token_type.to_string(),
         expires_in: session_result.expires_in,
         scope,
     })
@@ -113,7 +129,7 @@ pub(crate) async fn exchange_client_credentials(
 )]
 mod tests {
     use super::*;
-    use crate::services::auth::{ClientAuthProof, GrantProof};
+    use crate::services::auth::{ClientAuthProof, GrantProof, SenderConstraintProof};
     use crate::services::oidc::OAuthScope;
 
     #[test]
@@ -191,12 +207,16 @@ mod tests {
             &state,
             &client,
             None,
-            Some(thumbprint),
+            ClientCredentialsBindings {
+                dpop_jkt: None,
+                mtls_cert_thumbprint: Some(thumbprint),
+            },
             TokenIssuanceProof {
                 grant: GrantProof::ClientCredentials,
                 client_auth: ClientAuthProof::MutualTls(
                     crate::services::oidc::token::MtlsCertVerification::for_testing(),
                 ),
+                sender_constraint: SenderConstraintProof::no_registered_client(),
             },
         )
         .await

--- a/crates/vouch-server/src/services/oidc/fapi.rs
+++ b/crates/vouch-server/src/services/oidc/fapi.rs
@@ -8,7 +8,6 @@
 
 use crate::db::{OAuthClient, TokenEndpointAuthMethod};
 use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
-use crate::services::auth::SenderConstraintProof;
 
 /// FAPI 2.0 authorization code lifetime in seconds (shorter than standard).
 pub const FAPI_AUTH_CODE_LIFETIME_SECONDS: i64 = 60;
@@ -91,9 +90,9 @@ pub struct SenderConstraints {
 pub(crate) fn validate_fapi_token_request(
     client: &OAuthClient,
     constraints: SenderConstraints,
-) -> ServiceResult<SenderConstraintProof> {
+) -> ServiceResult<()> {
     if !client.is_fapi() {
-        return Ok(SenderConstraintProof::fapi_checked());
+        return Ok(());
     }
 
     // FAPI 2.0 Section 5.2.2: Sender-constrained tokens required (DPoP or mTLS)
@@ -104,7 +103,7 @@ pub(crate) fn validate_fapi_token_request(
         ));
     }
 
-    Ok(SenderConstraintProof::fapi_checked())
+    Ok(())
 }
 
 /// Validate that an algorithm is allowed for a FAPI 2.0 client.

--- a/crates/vouch-server/src/services/oidc/fapi.rs
+++ b/crates/vouch-server/src/services/oidc/fapi.rs
@@ -8,6 +8,7 @@
 
 use crate::db::{OAuthClient, TokenEndpointAuthMethod};
 use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
+use crate::services::auth::SenderConstraintProof;
 
 /// FAPI 2.0 authorization code lifetime in seconds (shorter than standard).
 pub const FAPI_AUTH_CODE_LIFETIME_SECONDS: i64 = 60;
@@ -87,12 +88,12 @@ pub struct SenderConstraints {
 /// # Errors
 ///
 /// Returns `ServiceError::OAuth` with `invalid_request` if constraints are violated.
-pub fn validate_fapi_token_request(
+pub(crate) fn validate_fapi_token_request(
     client: &OAuthClient,
     constraints: SenderConstraints,
-) -> ServiceResult<()> {
+) -> ServiceResult<SenderConstraintProof> {
     if !client.is_fapi() {
-        return Ok(());
+        return Ok(SenderConstraintProof::fapi_checked());
     }
 
     // FAPI 2.0 Section 5.2.2: Sender-constrained tokens required (DPoP or mTLS)
@@ -103,7 +104,7 @@ pub fn validate_fapi_token_request(
         ));
     }
 
-    Ok(())
+    Ok(SenderConstraintProof::fapi_checked())
 }
 
 /// Validate that an algorithm is allowed for a FAPI 2.0 client.

--- a/crates/vouch-server/src/services/oidc/fido2_grant.rs
+++ b/crates/vouch-server/src/services/oidc/fido2_grant.rs
@@ -19,7 +19,7 @@ use crate::db::{self, AuthEventParams, AuthEventType};
 use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
 use crate::services::auth::{
     AuthenticatorLookupParams, ClientAuthProof, CreateOAuthTokenParams, GrantProof,
-    LoginAssertionParams, TokenIssuanceProof, create_oauth_access_token,
+    LoginAssertionParams, SenderConstraintProof, TokenIssuanceProof, create_oauth_access_token,
     lookup_and_verify_authenticator, verify_login_assertion,
 };
 use crate::services::oidc::authorization_details::AuthorizationDetails;
@@ -112,6 +112,7 @@ pub(crate) async fn exchange_fido2_assertion(
     state: &Arc<AppState>,
     params: Fido2AssertionParams<'_>,
     client_auth: ClientAuthProof,
+    sender_constraint: SenderConstraintProof,
 ) -> ServiceResult<Fido2AssertionResult> {
     // 1. Base64url-decode and parse the assertion JSON
     let assertion_bytes = URL_SAFE_NO_PAD.decode(params.assertion).map_err(|_| {
@@ -362,6 +363,7 @@ pub(crate) async fn exchange_fido2_assertion(
     let proof = TokenIssuanceProof {
         grant: GrantProof::Fido2Assertion(challenge_claim),
         client_auth,
+        sender_constraint,
     };
     let session_result = create_oauth_access_token(
         state,

--- a/crates/vouch-server/src/services/oidc/token.rs
+++ b/crates/vouch-server/src/services/oidc/token.rs
@@ -15,8 +15,8 @@ use crate::db::{self, Authenticator, OAuthClient, Session, User};
 use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
 use crate::redact_email;
 use crate::services::auth::{
-    AuthMethod, ClientAuthProof, CreateOAuthTokenParams, GrantProof, TokenIssuanceProof,
-    create_oauth_access_token, decode_token,
+    AuthMethod, ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof,
+    TokenIssuanceProof, create_oauth_access_token, decode_token,
 };
 use aws_lc_rs::digest::{self, SHA256};
 use base64::Engine;
@@ -271,6 +271,7 @@ pub(crate) async fn exchange_authorization_code(
     state: &Arc<AppState>,
     params: AuthCodeExchangeParams<'_>,
     client_auth: ClientAuthProof,
+    sender_constraint: SenderConstraintProof,
 ) -> ServiceResult<AuthCodeExchangeResult> {
     // Decode and validate the authorization code
     let auth_code = decode_authorization_code(state, params.code, params.client_id).await?;
@@ -324,6 +325,7 @@ pub(crate) async fn exchange_authorization_code(
     let proof = TokenIssuanceProof {
         grant: GrantProof::AuthorizationCode(auth_code_claim),
         client_auth,
+        sender_constraint,
     };
     let session_result = create_oauth_access_token(
         state,

--- a/crates/vouch-server/src/test_utils.rs
+++ b/crates/vouch-server/src/test_utils.rs
@@ -889,8 +889,8 @@ pub async fn create_test_session(
     auth_id: &str,
 ) -> String {
     use crate::services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, TokenIssuanceProof,
-        create_oauth_access_token,
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof,
+        TokenIssuanceProof, create_oauth_access_token,
     };
     use crate::services::oidc::ScopeSet;
     use secrecy::ExposeSecret;
@@ -922,6 +922,7 @@ pub async fn create_test_session(
             client_auth: ClientAuthProof::NoAuth(
                 crate::services::auth::NoClientAuth::internal_endpoint(),
             ),
+            sender_constraint: SenderConstraintProof::no_registered_client(),
         },
     )
     .await
@@ -949,8 +950,8 @@ pub async fn create_test_session_with_audience(
     audience: &str,
 ) -> String {
     use crate::services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, TokenIssuanceProof,
-        create_oauth_access_token,
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof,
+        TokenIssuanceProof, create_oauth_access_token,
     };
     use crate::services::oidc::ScopeSet;
     use secrecy::ExposeSecret;
@@ -982,6 +983,7 @@ pub async fn create_test_session_with_audience(
             client_auth: ClientAuthProof::NoAuth(
                 crate::services::auth::NoClientAuth::internal_endpoint(),
             ),
+            sender_constraint: SenderConstraintProof::no_registered_client(),
         },
     )
     .await
@@ -998,8 +1000,8 @@ pub async fn create_test_session_with_audience(
 /// sessions (e.g., the RFC 8693 ID-token fork).
 pub async fn create_test_bootstrap_session(state: &AppState, user_id: &str, email: &str) -> String {
     use crate::services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, TokenIssuanceProof,
-        create_oauth_access_token,
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof,
+        TokenIssuanceProof, create_oauth_access_token,
     };
     use crate::services::oidc::ScopeSet;
     use secrecy::ExposeSecret;
@@ -1030,6 +1032,7 @@ pub async fn create_test_bootstrap_session(state: &AppState, user_id: &str, emai
             client_auth: ClientAuthProof::NoAuth(
                 crate::services::auth::NoClientAuth::internal_endpoint(),
             ),
+            sender_constraint: SenderConstraintProof::no_registered_client(),
         },
     )
     .await
@@ -1053,8 +1056,8 @@ pub async fn create_test_bootstrap_session_with_authenticator(
     auth_id: &str,
 ) -> String {
     use crate::services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, TokenIssuanceProof,
-        create_oauth_access_token,
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof,
+        TokenIssuanceProof, create_oauth_access_token,
     };
     use crate::services::oidc::ScopeSet;
     use secrecy::ExposeSecret;
@@ -1086,6 +1089,7 @@ pub async fn create_test_bootstrap_session_with_authenticator(
             client_auth: ClientAuthProof::NoAuth(
                 crate::services::auth::NoClientAuth::internal_endpoint(),
             ),
+            sender_constraint: SenderConstraintProof::no_registered_client(),
         },
     )
     .await
@@ -1106,8 +1110,8 @@ pub async fn create_test_session_with_iat(
     iat: i64,
 ) -> String {
     use crate::services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, TokenIssuanceProof,
-        create_oauth_access_token,
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof,
+        TokenIssuanceProof, create_oauth_access_token,
     };
     use crate::services::oidc::ScopeSet;
     use secrecy::ExposeSecret;
@@ -1139,6 +1143,7 @@ pub async fn create_test_session_with_iat(
             client_auth: ClientAuthProof::NoAuth(
                 crate::services::auth::NoClientAuth::internal_endpoint(),
             ),
+            sender_constraint: SenderConstraintProof::no_registered_client(),
         },
     )
     .await
@@ -1159,8 +1164,8 @@ pub async fn create_test_session_for_client(
     client_id: &str,
 ) -> String {
     use crate::services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, TokenIssuanceProof,
-        create_oauth_access_token,
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof,
+        TokenIssuanceProof, create_oauth_access_token,
     };
     use crate::services::oidc::ScopeSet;
     use secrecy::ExposeSecret;
@@ -1192,6 +1197,7 @@ pub async fn create_test_session_for_client(
             client_auth: ClientAuthProof::NoAuth(
                 crate::services::auth::NoClientAuth::internal_endpoint(),
             ),
+            sender_constraint: SenderConstraintProof::no_registered_client(),
         },
     )
     .await
@@ -1212,8 +1218,8 @@ pub async fn create_test_session_with_dpop(
     dpop_jkt: &str,
 ) -> String {
     use crate::services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, TokenIssuanceProof,
-        create_oauth_access_token,
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof,
+        TokenIssuanceProof, create_oauth_access_token,
     };
     use crate::services::oidc::ScopeSet;
     use secrecy::ExposeSecret;
@@ -1245,6 +1251,7 @@ pub async fn create_test_session_with_dpop(
             client_auth: ClientAuthProof::NoAuth(
                 crate::services::auth::NoClientAuth::internal_endpoint(),
             ),
+            sender_constraint: SenderConstraintProof::no_registered_client(),
         },
     )
     .await
@@ -1265,8 +1272,8 @@ pub async fn create_test_session_with_mtls(
     mtls_cert_thumbprint: &str,
 ) -> String {
     use crate::services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, TokenIssuanceProof,
-        create_oauth_access_token,
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof,
+        TokenIssuanceProof, create_oauth_access_token,
     };
     use crate::services::oidc::ScopeSet;
     use secrecy::ExposeSecret;
@@ -1298,6 +1305,7 @@ pub async fn create_test_session_with_mtls(
             client_auth: ClientAuthProof::NoAuth(
                 crate::services::auth::NoClientAuth::internal_endpoint(),
             ),
+            sender_constraint: SenderConstraintProof::no_registered_client(),
         },
     )
     .await


### PR DESCRIPTION
The `client_credentials` grant never called `validate_fapi_token_request` and hardcoded `dpop_jkt: None`, so a FAPI client could obtain a plain bearer token with no `cnf` claim. It also ignored the `DPoP` header entirely, so a client that did send a proof still received an unbound token.

FAPI 2.0 §5.2.2 sender-constraining was enforced by a call each grant handler had to remember to make. Four grants made it; the fifth did not. This makes the requirement structural instead: `TokenIssuanceProof` now carries a `SenderConstraintProof` alongside its existing grant and client-auth witnesses, so a grant cannot mint an access token without either enforcing FAPI constraints against a registered client or naming the case where no registered client exists (`SenderConstraintProof::no_registered_client()` — browser sessions, enrollment, certification bypass, and the device flow's built-in CLI path).

A grant that skips the check no longer compiles.

`client_credentials` now also validates DPoP and threads the resulting `jkt` into the issued token, which additionally makes `token_type` `DPoP` per RFC 9449 §5.

## Tests

- `test_fapi2_client_credentials_rejects_unbound_fapi_client`
- `test_fapi2_client_credentials_with_dpop_issues_bound_token`

The first was verified against the unenforced code: it returned 200 with a plain bearer token whose JWT payload carried no `cnf` claim.

Deleting the `sender_constraint` field from any grant's proof was also confirmed to fail the build with `missing field 'sender_constraint'`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes OAuth token issuance across all grants and fixes a security gap on `client_credentials` for FAPI and DPoP-bound clients; regressions would affect authentication for registered clients.
> 
> **Overview**
> **Sender-constraint enforcement is now structural:** `TokenIssuanceProof` must include a `SenderConstraintProof`, either from `SenderConstraintProof::validate()` (FAPI §5.2.2, `dpop_bound_access_tokens`, RFC 8705 cert binding) or `no_registered_client()` for flows without a registered OAuth client (browser login, enrollment, certification, device CLI).
> 
> Grant handlers no longer duplicate inline FAPI/DPoP/mTLS checks; they call the shared validator and pass the witness into issuance. **Authorization code, device, token exchange, FIDO2, and client credentials** all thread the same proof.
> 
> **`client_credentials` is fixed:** it now validates the `DPoP` header, runs sender-constraint checks (closing the gap where FAPI clients could get plain bearer tokens with no `cnf`), binds `cnf.jkt` via new `ClientCredentialsBindings`, and returns `token_type=DPoP` when appropriate (RFC 9449 §5).
> 
> New FAPI integration tests cover unbound rejection, DPoP-bound issuance, and `dpop_bound_access_tokens` without proof on `client_credentials`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e9e49b885ed7b28483ab87dc196d7bb6ce5beeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->