### PR TITLE
ci: run cargo-deny bans check in CI, release gate, and make audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,7 @@ jobs:
           persist-credentials: false
       - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
-          command: check licenses advisories sources
+          command: check advisories bans licenses sources
 
   scan:
     name: Security Scan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
       - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
-          command: check licenses advisories sources
+          command: check advisories bans licenses sources
 
   build:
     name: Build and Push (${{ matrix.platform }})

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,8 @@ test-coverage: ## Generate test coverage report (requires cargo-llvm-cov)
 test-mutants: ## Run mutation testing (requires cargo-mutants)
 	$(CARGO) mutants --workspace --timeout 60 --output mutants.out
 
-audit: ## Check dependencies for security advisories and license issues
-	$(CARGO) deny check advisories licenses sources
+audit: ## Check dependencies for security advisories, bans, and license issues
+	$(CARGO) deny check advisories bans licenses sources
 
 ##@ Docker
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,7 @@
 # cargo-deny configuration
 # https://embarkstudios.github.io/cargo-deny/
 #
-# Run locally: cargo deny check licenses advisories sources
+# Run locally: cargo deny check advisories bans licenses sources
 
 [graph]
 all-features = true
@@ -56,7 +56,11 @@ expression = "Apache-2.0"
 license-files = []
 
 [bans]
-multiple-versions = "deny"
+# Duplicate versions are reported but not gate-breaking: dependency bumps that
+# transiently split a crate would otherwise fail required checks on unrelated
+# PRs in the merge queue. Wildcards stay hard-deny (the workspace pins exact
+# versions, so this should never fire).
+multiple-versions = "warn"
 wildcards = "deny"
 allow-wildcard-paths = true
 
@@ -107,8 +111,6 @@ skip = [
     { crate = "http-body:>=0.4,<0.5", reason = "aws-sdk still uses http-body 0.4 internally" },
     # itertools version split
     { crate = "itertools@0.13.0", reason = "some dependencies still on itertools 0.13" },
-    # pastey version split
-    { crate = "pastey@0.1.1", reason = "transitive dependency version split" },
     # rand 0.9 vs 0.10 (a pinned 0.9.4 skip went stale when 0.9.5 shipped)
     { crate = "rand:>=0.9,<0.10", reason = "some crates still on rand 0.9" },
     { crate = "rand_core:>=0.6,<0.7", reason = "rand 0.8 ecosystem" },
@@ -147,7 +149,7 @@ skip = [
 skip-tree = [
     # windows-sys bumps frequently; many crates lag behind. Rather than tracking
     # each transitive dep individually, skip the entire tree for older versions.
-    { crate = "windows-sys:>=0.59,<0.60", reason = "foundational Windows crate that bumps frequently; many deps lag behind" },
+    { crate = "windows-sys:<0.61", reason = "foundational Windows crate that bumps frequently; many deps lag behind" },
 ]
 
 [sources]


### PR DESCRIPTION
## Summary

Item 3 of #943. The `[bans]` table in `deny.toml` (`multiple-versions`, `wildcards`) was configured but never executed — CI, the release gate, and `make audit` all ran `check licenses advisories sources`. This adds `bans` to all three commands and the `deny.toml` header comment.

- `multiple-versions` downgrades to `warn`: duplicates surface in the job log without failing required checks, so a transient lockfile split from a dependency bump cannot block the merge queue. `wildcards` stays `deny` (the workspace pins exact versions, so it should never fire).
- The existing `windows-sys` skip-tree entry widens to `<0.61` (three versions currently in the lockfile) and the stale `pastey@0.1.1` skip is removed (cargo-deny flags it as unnecessary), keeping the warning output clean so new duplicates are visible.

## Testing

- `cargo deny check advisories bans licenses sources` → `advisories ok, bans ok, licenses ok, sources ok`, zero warnings
- `actionlint` and `zizmor` clean on both edited workflows

Refs #943

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and supply-chain tooling only; no application runtime or auth logic changes.
> 
> **Overview**
> **cargo-deny `[bans]` is now actually enforced** wherever dependency policy runs: CI license job, release `license-audit`, `make audit`, and the `deny.toml` header comment all use `cargo deny check advisories bans licenses sources` instead of omitting `bans`.
> 
> In **`deny.toml`**, duplicate crate versions are **`warn`** instead of **`deny`** so transient lockfile splits from bumps do not block the merge queue; **`wildcards`** stays **`deny`**. Housekeeping: drop the unnecessary **`pastey@0.1.1`** skip and widen the **`windows-sys`** skip-tree to **`<0.61`** so logs stay clean and new duplicates remain visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a54d98e1c8ff5e339652966ae0af8875dbc160e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->