### PR TITLE
feat(server): serve RFC 9116 security.txt

### DIFF
--- a/crates/vouch-server/src/config.rs
+++ b/crates/vouch-server/src/config.rs
@@ -331,6 +331,11 @@ pub struct Args {
     #[arg(long, env = "VOUCH_RESOURCE_TOS_URI")]
     pub resource_tos_uri: Option<String>,
 
+    /// Security contact email for `/.well-known/security.txt`
+    /// (RFC 9116 `Contact`). Defaults to "security@vouch.sh" when unset.
+    #[arg(long, env = "VOUCH_SECURITY_CONTACT")]
+    pub security_contact: Option<String>,
+
     /// CLI download URL for macOS.
     #[arg(long, env = "VOUCH_CLI_DOWNLOAD_MACOS")]
     pub cli_download_macos: Option<String>,
@@ -669,6 +674,9 @@ pub struct ServerConfig {
     /// (RFC 9728 §2 `resource_tos_uri`).
     /// Defaults to `"https://vouch.sh/terms/"`.
     pub resource_tos_uri: Option<String>,
+    /// Security contact email for `/.well-known/security.txt`
+    /// (RFC 9116 `Contact`). Defaults to `"security@vouch.sh"`.
+    pub security_contact: String,
     /// CLI download URL for macOS.
     pub cli_download_macos: Option<String>,
     /// CLI download URL for Linux.
@@ -917,6 +925,8 @@ impl ServerConfig {
             resource_tos_uri: args
                 .resource_tos_uri
                 .or_else(|| Some("https://vouch.sh/terms/".to_string())),
+            security_contact: vouch_common::env::non_empty(args.security_contact)
+                .unwrap_or_else(|| "security@vouch.sh".to_string()),
             cli_download_macos: args.cli_download_macos,
             cli_download_linux: args.cli_download_linux,
             cli_download_windows: args.cli_download_windows,

--- a/crates/vouch-server/src/handlers/legal.rs
+++ b/crates/vouch-server/src/handlers/legal.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//! Legal pages handler — redirects to vouch.sh.
+//! Legal and policy pages — vouch.sh redirects plus RFC 9116 security.txt.
 
-use axum::response::Redirect;
+use crate::AppState;
+use axum::extract::State;
+use axum::http::header;
+use axum::response::{IntoResponse, Redirect};
+use std::sync::Arc;
 
 /// Privacy policy page.
 /// GET /privacy → 301 to vouch.sh
@@ -13,4 +17,26 @@ pub(crate) async fn privacy_page() -> Redirect {
 /// GET /terms → 301 to vouch.sh
 pub(crate) async fn terms_page() -> Redirect {
     Redirect::permanent("https://vouch.sh/terms/")
+}
+
+/// Vulnerability disclosure contact (RFC 9116).
+/// GET /.well-known/security.txt
+///
+/// `Canonical` is built from the configured `base_url`, never the request
+/// `Host` header — the header is attacker-controlled behind the L4
+/// passthrough listener. `Expires` rolls 30 days ahead of each request so
+/// a long-lived deployment can never serve a stale value.
+pub(crate) async fn security_txt(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let config = state.config.load();
+    let now = jiff::Timestamp::now();
+    let expires = now
+        .checked_add(jiff::Span::new().hours(720))
+        .and_then(|ts| ts.round(jiff::Unit::Second))
+        .unwrap_or(now);
+    let base_url = config.base_url.trim_end_matches('/');
+    let body = format!(
+        "Contact: mailto:{}\r\nExpires: {expires}\r\nCanonical: {base_url}/.well-known/security.txt\r\n",
+        config.security_contact
+    );
+    ([(header::CONTENT_TYPE, "text/plain; charset=utf-8")], body)
 }

--- a/crates/vouch-server/src/infra/router.rs
+++ b/crates/vouch-server/src/infra/router.rs
@@ -772,6 +772,13 @@ fn build_ui_routes(config: &config::ServerConfig) -> anyhow::Result<Router<Arc<A
         // Legal pages (redirect to vouch.sh)
         .route("/privacy", get(handlers::legal::privacy_page))
         .route("/terms", get(handlers::legal::terms_page))
+        // Vulnerability disclosure contact (RFC 9116). Lives in the UI group
+        // because the API group's blanket no-store headers would contradict
+        // the document's own Expires field.
+        .route(
+            "/.well-known/security.txt",
+            get(handlers::legal::security_txt),
+        )
         // Integrations page
         .route(
             "/integrations",

--- a/crates/vouch-server/src/lib.rs
+++ b/crates/vouch-server/src/lib.rs
@@ -215,6 +215,7 @@ mod redirect_tests {
             resource_documentation: None,
             resource_policy_uri: None,
             resource_tos_uri: None,
+            security_contact: "security@vouch.sh".to_string(),
             cli_download_macos: None,
             cli_download_linux: None,
             cli_download_windows: None,

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
@@ -412,6 +412,7 @@ mod tests {
             resource_documentation: None,
             resource_policy_uri: None,
             resource_tos_uri: None,
+            security_contact: "security@vouch.sh".to_string(),
             cli_download_macos: None,
             cli_download_linux: None,
             cli_download_windows: None,

--- a/crates/vouch-server/src/test_utils.rs
+++ b/crates/vouch-server/src/test_utils.rs
@@ -76,6 +76,7 @@ pub fn test_config() -> ServerConfig {
         resource_documentation: Some("https://vouch.sh/docs/".to_string()),
         resource_policy_uri: Some("https://vouch.sh/privacy/".to_string()),
         resource_tos_uri: Some("https://vouch.sh/terms/".to_string()),
+        security_contact: "security@vouch.sh".to_string(),
         cli_download_macos: None,
         cli_download_linux: None,
         cli_download_windows: None,

--- a/crates/vouch-tests/tests/static_pages.rs
+++ b/crates/vouch-tests/tests/static_pages.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Tests for the lightweight static pages served by the auth server:
-//! - `/privacy`, `/terms` (`handlers/legal.rs`)
+//! - `/privacy`, `/terms`, `/.well-known/security.txt` (`handlers/legal.rs`)
 //! - `/install` (`handlers/install.rs`)
 //! - `/integrations` (`handlers/integrations.rs`)
 
@@ -55,6 +55,46 @@ mod legal {
             .to_str()
             .expect("location utf8");
         assert_eq!(location, "https://vouch.sh/terms/");
+    }
+}
+
+mod security_txt {
+    use super::*;
+
+    #[tokio::test]
+    async fn serves_rfc9116_document_unsigned() {
+        let harness = TestHarness::new().await;
+        // http_get_full sends no RFC 9421 signature; a 200 proves the route
+        // stays reachable without one.
+        let resp = http_get_full(&harness.router, "/.well-known/security.txt", &[]).await;
+
+        assert_eq!(resp.status, StatusCode::OK);
+        let content_type = resp
+            .headers
+            .get("content-type")
+            .expect("content-type header")
+            .to_str()
+            .expect("content-type utf8");
+        assert!(content_type.starts_with("text/plain"));
+        assert!(resp.body.contains("Contact: mailto:security@vouch.sh\r\n"));
+        assert!(
+            resp.body
+                .contains("Canonical: https://test.example.com/.well-known/security.txt\r\n")
+        );
+    }
+
+    #[tokio::test]
+    async fn expires_is_rfc3339_and_in_the_future() {
+        let harness = TestHarness::new().await;
+        let resp = http_get_full(&harness.router, "/.well-known/security.txt", &[]).await;
+
+        let expires_field = resp
+            .body
+            .lines()
+            .find_map(|line| line.strip_prefix("Expires: "))
+            .expect("Expires field present");
+        let expires: jiff::Timestamp = expires_field.trim().parse().expect("RFC 3339 timestamp");
+        assert!(expires > jiff::Timestamp::now());
     }
 }
 

--- a/docs/src/reference/environment-variables.md
+++ b/docs/src/reference/environment-variables.md
@@ -176,6 +176,15 @@ These optional variables configure descriptive metadata published in the OAuth 2
 > The same applies to the `/privacy` and `/terms` UI routes, which are fixed redirects to
 > `vouch.sh`. Override those at your reverse proxy if you need your own.
 
+## Vulnerability Disclosure (RFC 9116)
+
+The server publishes a security.txt document at `/.well-known/security.txt` with `Contact`,
+`Expires` (rolling, 30 days ahead), and `Canonical` (built from the base URL) fields.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `VOUCH_SECURITY_CONTACT` | No | `security@vouch.sh` | Contact email published in `security.txt`. Self-hosters should set this — the default routes vulnerability reports about your deployment to Vouch's security team. |
+
 ## CLI Download URLs
 
 These optional variables configure download links displayed in the server UI.

--- a/docs/src/reference/ports-and-endpoints.md
+++ b/docs/src/reference/ports-and-endpoints.md
@@ -57,6 +57,7 @@ Three things regularly surprise operators here:
 | `/.well-known/openid-configuration` | GET | None |
 | `/.well-known/oauth-authorization-server` | GET | None |
 | `/.well-known/oauth-protected-resource` | GET | None |
+| `/.well-known/security.txt` | GET | None |
 | `/oauth/jwks` | GET | None |
 | `/saml/metadata` | GET | None |
 


### PR DESCRIPTION
## Summary

Item 4 of #943. Instance hosts (e.g. `us.vouch.sh`) — the hosts researchers actually probe — served no vulnerability-disclosure contact; only the vouch.sh site did.

- New handler in `handlers/legal.rs` serves `GET /.well-known/security.txt` with `Contact`, `Expires` (rolling, 30 days ahead of each request so it can never go stale), and `Canonical` built from the configured `base_url` — never the request `Host` header, which is attacker-controlled behind the L4 passthrough listener.
- `Contact` comes from a new `VOUCH_SECURITY_CONTACT` variable defaulting to `security@vouch.sh`, so self-hosted deployments can point researchers at their own team.
- Route registered in the UI group: the API group's blanket no-store/`Expires: 0` headers would contradict the document's own `Expires` field.
- No signing-policy change: `/.well-known` is outside the RFC 9421 `/v1` scope (`requires_signature` already returns false, with an existing regression test), and a new test asserts the route answers unsigned. The issue's sig_policy checkbox was a no-op.
- Org issuer subdomains keep their restricted `ORG_HOST_ALLOWED_PATHS` and do not serve the file.
- Docs: rows added to `ports-and-endpoints.md` and `environment-variables.md`.

## Testing

- Two new integration tests in `vouch-tests/tests/static_pages.rs`: RFC 9116 fields + content type on an unsigned request; `Expires` parses as RFC 3339 and is in the future
- `cargo clippy --all-targets --all-features -- -D warnings` clean; all 2963 vouch-server lib tests pass; mdBook builds

Refs #943

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a small public metadata endpoint and optional config; no auth, token, or data-path changes.
> 
> **Overview**
> Instance hosts now expose an **RFC 9116** vulnerability disclosure document at `/.well-known/security.txt`, so researchers probing deployment URLs (not only vouch.sh) get a contact.
> 
> The handler returns `Contact` (from new **`VOUCH_SECURITY_CONTACT`**, default `security@vouch.sh`), a rolling **`Expires`** 30 days ahead on each request, and **`Canonical`** derived from configured **`base_url`**—not the request `Host` header. The route is registered on the **UI router** so API-wide `no-store` / `Expires: 0` headers do not fight the document’s own `Expires` field.
> 
> Integration tests cover plain-text response, default contact, canonical URL, and future `Expires`. Reference docs list the endpoint and env var.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d252afba204696d4e62e7be4342332fb325c68b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->