### PR TITLE
ci: achieve SLSA Build Level 3 via reusable build workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,605 +31,55 @@ jobs:
         with:
           command: check advisories bans licenses sources
 
-  build:
-    name: Build and Push (${{ matrix.platform }})
-    needs: license-audit
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-latest
-            artifact: digests-amd64
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-            artifact: digests-arm64
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-      attestations: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Set SOURCE_DATE_EPOCH for reproducible builds
-        run: |
-          SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
-          echo "SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}" >> "$GITHUB_ENV"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: Log in to Container Registry
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: Build and push by digest
-        id: build
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          platforms: ${{ matrix.platform }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: |
-            type=gha,scope=${{ matrix.platform }}
-            type=gha,scope=ci-scan
-          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-          provenance: true
-          sbom: true
-          build-args: |
-            SOURCE_DATE_EPOCH=${{ env.SOURCE_DATE_EPOCH }}
-
-      - name: Export digest
-        env:
-          DIGEST: ${{ steps.build.outputs.digest }}
-        run: |
-          mkdir -p /tmp/digests
-          touch "/tmp/digests/${DIGEST#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ${{ matrix.artifact }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge:
-    name: Merge Manifests
+  version:
+    name: Compute Version
     runs-on: ubuntu-latest
-    needs: build
+    permissions: {}
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Get version
+        id: version
+        env:
+          REF_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          VERSION="${REF_TAG#v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+  # Build and attest run inside the reusable workflow so the Sigstore
+  # certificate records reusable-build.yml as the signer identity (SLSA
+  # Build Level 3). The permissions here are the ceiling for the called
+  # workflow's jobs; each job inside declares its own subset.
+  build:
+    name: Build
+    needs: [license-audit, version]
     permissions:
       contents: read
       packages: write
       id-token: write
       attestations: write
       artifact-metadata: write
-    outputs:
-      digest: ${{ steps.inspect.outputs.digest }}
-
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          path: /tmp/digests
-          pattern: digests-*
-          merge-multiple: true
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: Log in to Container Registry
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha,prefix=
-            type=raw,value=latest,enable=${{ github.ref == format('refs/tags/{0}', github.event.inputs.tag || github.ref_name) }}
-
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
-        env:
-          REGISTRY_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-        run: |
-          # shellcheck disable=SC2046  # intentional word splitting: -t flags and image@digest args
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf "${REGISTRY_IMAGE}@sha256:%s " *)
-
-      - name: Inspect image
-        id: inspect
-        env:
-          REGISTRY_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          META_VERSION: ${{ steps.meta.outputs.version }}
-        run: |
-          digest=$(docker buildx imagetools inspect "${REGISTRY_IMAGE}:${META_VERSION}" --format '{{json .Manifest.Digest}}' | tr -d '"')
-          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
-
-      - name: Generate artifact attestation
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.inspect.outputs.digest }}
-          push-to-registry: true
-
-  build-cli:
-    name: Build CLI (${{ matrix.name }})
-    needs: license-audit
-    runs-on: ${{ matrix.runner }}
-    permissions:
-      contents: read
-      id-token: write
-      attestations: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: linux-amd64
-            runner: ubuntu-latest
-            target: x86_64-unknown-linux-musl
-            bins: "vouch vouch-agent"
-            archive-ext: tar.gz
-          - name: linux-arm64
-            runner: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-musl
-            bins: "vouch vouch-agent"
-            archive-ext: tar.gz
-          - name: macos-arm64
-            runner: macos-latest
-            target: aarch64-apple-darwin
-            bins: "vouch vouch-agent"
-            archive-ext: tar.gz
-          - name: windows-amd64
-            runner: windows-latest
-            target: x86_64-pc-windows-msvc
-            bins: "vouch"
-            archive-ext: zip
-            rustflags: "-C target-feature=+crt-static"
-          - name: windows-arm64
-            runner: windows-latest
-            target: aarch64-pc-windows-msvc
-            bins: "vouch"
-            archive-ext: zip
-            rustflags: "-C target-feature=+crt-static"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Set SOURCE_DATE_EPOCH for reproducible builds
-        shell: bash
-        run: |
-          SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
-          echo "SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}" >> "$GITHUB_ENV"
-
-      - name: Install GNU tar (macOS)
-        if: runner.os == 'macOS'
-        run: brew list gnu-tar &>/dev/null || brew install gnu-tar
-
-      - name: Setup Rust toolchain
-        if: runner.os != 'Linux'
-        shell: bash
-        env:
-          TARGET: ${{ matrix.target }}
-        run: |
-          rustup show
-          rustup target add "${TARGET}"
-
-      - name: Setup Rust cache
-        if: runner.os != 'Linux'
-        # Restore-only (save-if:false) and non-Linux; a tag build reads only
-        # main/tag-scoped caches, so there is no cross-ref poisoning vector.
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.1 # zizmor: ignore[cache-poisoning]
-        with:
-          prefix-key: "v2"
-          shared-key: "release-${{ matrix.target }}"
-          save-if: "false"
-
-      - name: Set RUSTFLAGS
-        if: matrix.rustflags
-        shell: bash
-        env:
-          RUSTFLAGS_VALUE: ${{ matrix.rustflags }}
-        run: echo "RUSTFLAGS=${RUSTFLAGS_VALUE}" >> "$GITHUB_ENV"
-
-      - name: Cache cargo binaries
-        if: runner.os != 'Linux'
-        id: cache-cargo-bin
-        # Caches a version-pinned cargo-cyclonedx binary (non-Linux only); the
-        # key pins the exact version and a tag build reads only main/tag caches.
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 # zizmor: ignore[cache-poisoning]
-        with:
-          path: |
-            ~/.cargo/bin/cargo-cyclonedx
-            ~/.cargo/bin/cargo-cyclonedx.exe
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-bin-cyclonedx-v0.5.6
-
-      - name: Install cargo-cyclonedx
-        if: runner.os != 'Linux' && steps.cache-cargo-bin.outputs.cache-hit != 'true'
-        shell: bash
-        run: cargo install cargo-cyclonedx --version 0.5.6
-
-      - name: Set up Docker Buildx
-        if: runner.os == 'Linux'
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: Build CLI and Agent (Linux)
-        if: runner.os == 'Linux'
-        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
-        with:
-          targets: cli
-        env:
-          TARGET: ${{ matrix.target }}
-          SOURCE_DATE_EPOCH: ${{ env.SOURCE_DATE_EPOCH }}
-          GENERATE_SBOM: "true"
-
-      - name: Build CLI and Agent
-        if: runner.os != 'Linux' && matrix.bins == 'vouch vouch-agent'
-        env:
-          TARGET: ${{ matrix.target }}
-        run: cargo build --release --target "${TARGET}" -p vouch-cli -p vouch-agent
-
-      - name: Build CLI only
-        if: matrix.bins == 'vouch'
-        shell: bash
-        env:
-          TARGET: ${{ matrix.target }}
-        run: cargo build --release --target "${TARGET}" -p vouch-cli
-
-      - name: Generate SBOM
-        if: runner.os != 'Linux'
-        shell: bash
-        env:
-          TARGET: ${{ matrix.target }}
-        run: cargo cyclonedx --target "${TARGET}" --format json
-
-      - name: Get version
-        id: version
-        shell: bash
-        env:
-          REF_TAG: ${{ github.event.inputs.tag || github.ref_name }}
-        run: |
-          VERSION="${REF_TAG#v}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-
-      - name: Import Apple Developer Certificate
-        if: runner.os == 'macOS'
-        env:
-          APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
-        run: |
-          echo "$APPLE_CERTIFICATE_P12_BASE64" | base64 --decode > certificate.p12
-          security create-keychain -p "$MACOS_KEYCHAIN_PASSWORD" build.keychain
-          security default-keychain -s build.keychain
-          security unlock-keychain -p "$MACOS_KEYCHAIN_PASSWORD" build.keychain
-          security import certificate.p12 -k build.keychain \
-            -P "$APPLE_CERTIFICATE_PASSWORD" \
-            -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: \
-            -s -k "$MACOS_KEYCHAIN_PASSWORD" build.keychain
-          rm certificate.p12
-
-      - name: Code sign macOS binaries
-        if: runner.os == 'macOS'
-        env:
-          APPLE_CERTIFICATE_NAME: ${{ secrets.APPLE_CERTIFICATE_NAME }}
-          TARGET: ${{ matrix.target }}
-          BINS: ${{ matrix.bins }}
-        run: |
-          for bin in ${BINS}; do
-            echo "Signing ${bin}..."
-            /usr/bin/codesign --force \
-              --sign "$APPLE_CERTIFICATE_NAME" \
-              --options runtime \
-              --timestamp \
-              "target/${TARGET}/release/${bin}"
-            /usr/bin/codesign --verify "target/${TARGET}/release/${bin}"
-          done
-
-      - name: Notarize macOS binaries
-        if: runner.os == 'macOS'
-        env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          TARGET: ${{ matrix.target }}
-          VERSION: ${{ steps.version.outputs.version }}
-          BINS: ${{ matrix.bins }}
-        run: |
-          xcrun notarytool store-credentials "notarytool-profile" \
-            --apple-id "$APPLE_ID" \
-            --team-id "$APPLE_TEAM_ID" \
-            --password "$APPLE_ID_PASSWORD"
-
-          NOTARIZE_ZIP="vouch-notarize-${VERSION}.zip"
-          mkdir -p notarize-staging
-          for bin in ${BINS}; do
-            cp "target/${TARGET}/release/${bin}" notarize-staging/
-          done
-          ditto -c -k --keepParent notarize-staging "$NOTARIZE_ZIP"
-
-          xcrun notarytool submit "$NOTARIZE_ZIP" \
-            --keychain-profile "notarytool-profile" \
-            --wait
-
-          rm -rf notarize-staging "$NOTARIZE_ZIP"
-
-      - name: Code sign Windows binaries
-        if: runner.os == 'Windows'
-        uses: skeeto/aas-sign@0008af00d4dd2ff2e482ba5ede70831d78f9da59 # v1.1.0
-        with:
-          version: v1.1.0
-          endpoint: ${{ secrets.TRUSTED_SIGNING_ENDPOINT }}
-          account: ${{ secrets.TRUSTED_SIGNING_ACCOUNT }}
-          profile: ${{ secrets.CERTIFICATE_PROFILE }}
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          files: |
-            target/${{ matrix.target }}/release/vouch.exe
-
-      - name: Create archive (tar.gz)
-        if: matrix.archive-ext == 'tar.gz'
-        shell: bash
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-          TARGET: ${{ matrix.target }}
-          BINS: ${{ matrix.bins }}
-        run: |
-          STAGING="vouch-v${VERSION}-${TARGET}"
-
-          # Use GNU tar (gtar on macOS, tar on Linux)
-          if command -v gtar &> /dev/null; then
-            TAR_CMD="gtar"
-          else
-            TAR_CMD="tar"
-          fi
-
-          mkdir -p "${STAGING}"
-          for bin in ${BINS}; do
-            cp "target/${TARGET}/release/${bin}" "${STAGING}/"
-          done
-
-          # Create deterministic archive for reproducible builds
-          $TAR_CMD --sort=name \
-              --mtime="@${SOURCE_DATE_EPOCH}" \
-              --owner=0 --group=0 --numeric-owner \
-              -czf "${STAGING}.tar.gz" "${STAGING}"
-          shasum -a 256 "${STAGING}.tar.gz" > "${STAGING}.tar.gz.sha256"
-
-      - name: Create archive (zip)
-        if: matrix.archive-ext == 'zip'
-        shell: bash
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-          TARGET: ${{ matrix.target }}
-        run: |
-          ARCHIVE="vouch-v${VERSION}-${TARGET}.zip"
-
-          # Stage signed binary in CWD so it lands at the zip root (no versioned
-          # subdir). Users get vouch.exe directly on extract; winget can use a
-          # constant RelativeFilePath: vouch.exe across versions.
-          cp "target/${TARGET}/release/vouch.exe" vouch.exe
-          7z a "${ARCHIVE}" vouch.exe
-          rm vouch.exe
-
-          sha256sum "${ARCHIVE}" > "${ARCHIVE}.sha256"
-
-      - name: Collect SBOM artifacts
-        id: sbom
-        shell: bash
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-          TARGET: ${{ matrix.target }}
-        run: |
-          MAIN_SBOM=""
-          # Find and copy CycloneDX SBOMs with target-specific names
-          for sbom in $(find . -maxdepth 3 -name "*_cdx.json" -o -name "*.cdx.json" 2>/dev/null | grep -v "^./target/"); do
-            base=$(basename "${sbom}")
-            dest="vouch-v${VERSION}-${TARGET}-${base}"
-            cp "${sbom}" "${dest}"
-            # Use vouch-cli SBOM as the main one for attestation (always present)
-            if [[ "${base}" == *"vouch-cli"* ]] || [[ "${base}" == *"vouch_cli"* ]]; then
-              MAIN_SBOM="${dest}"
-            fi
-          done
-          # Fallback to first SBOM found if no vouch-cli specific one
-          if [[ -z "${MAIN_SBOM}" ]]; then
-            for cdx in "vouch-v${VERSION}-${TARGET}"-*cdx.json; do
-              [[ -e "${cdx}" ]] && { MAIN_SBOM="${cdx}"; break; }
-            done
-          fi
-          echo "main_sbom=${MAIN_SBOM}" >> "$GITHUB_OUTPUT"
-
-      - name: Upload binary artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: binaries-${{ matrix.name }}
-          path: |
-            vouch-v*.tar.gz
-            vouch-v*.zip
-            vouch-v*.sha256
-            vouch-v*cdx.json
-          if-no-files-found: error
-          retention-days: 5
-
-      - name: Attest build provenance (CLI archive)
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
-        with:
-          subject-path: vouch-v${{ steps.version.outputs.version }}-${{ matrix.target }}.${{ matrix.archive-ext }}
-
-      - name: Attest SBOM (CLI archive)
-        if: steps.sbom.outputs.main_sbom != ''
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
-        with:
-          subject-path: vouch-v${{ steps.version.outputs.version }}-${{ matrix.target }}.${{ matrix.archive-ext }}
-          sbom-path: ${{ steps.sbom.outputs.main_sbom }}
-
-      - name: Cleanup macOS keychain
-        if: runner.os == 'macOS' && always()
-        run: |
-          security delete-keychain build.keychain 2>/dev/null || true
-
-  build-server:
-    name: Build Server (${{ matrix.name }})
-    needs: license-audit
-    runs-on: ${{ matrix.runner }}
-    permissions:
-      contents: read
-      id-token: write
-      attestations: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: linux-amd64-server
-            runner: ubuntu-latest
-            target: x86_64-unknown-linux-musl
-          - name: linux-arm64-server
-            runner: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-musl
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Set SOURCE_DATE_EPOCH for reproducible builds
-        run: |
-          SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
-          echo "SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}" >> "$GITHUB_ENV"
-
-      - name: Get version
-        id: version
-        env:
-          REF_TAG: ${{ github.event.inputs.tag || github.ref_name }}
-        run: |
-          VERSION="${REF_TAG#v}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-
-      - name: Build CSS
-        run: |
-          ARCH=$(uname -m)
-          case "$ARCH" in
-            x86_64)
-              BINARY="tailwindcss-linux-x64"
-              CHECKSUM="dc61b3ac6b8c9ca874c0cc4c57b2409791a64c5540404ca5f5367360babc313a"
-              ;;
-            aarch64)
-              BINARY="tailwindcss-linux-arm64"
-              CHECKSUM="55fd0b241214eff3de1e8ee4f22796662f2d2e7a49bcfca7477cfd0bac398195"
-              ;;
-          esac
-          curl -sLO "https://github.com/tailwindlabs/tailwindcss/releases/download/v4.3.3/${BINARY}"
-          echo "${CHECKSUM}  ${BINARY}" | sha256sum -c -
-          chmod +x "${BINARY}"
-          cd crates/vouch-server && "../../${BINARY}" -i styles/input.css -o static/css/output.css --minify
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: Build server and generate SBOM (musl)
-        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
-        with:
-          targets: server
-        env:
-          TARGET: ${{ matrix.target }}
-          SOURCE_DATE_EPOCH: ${{ env.SOURCE_DATE_EPOCH }}
-          GENERATE_SBOM: "true"
-
-      - name: Create server archive
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-          TARGET: ${{ matrix.target }}
-        run: |
-          SERVER_STAGING="vouch-server-v${VERSION}-${TARGET}"
-
-          mkdir -p "${SERVER_STAGING}"
-          cp "target/${TARGET}/release/vouch-server" "${SERVER_STAGING}/"
-
-          tar --sort=name \
-              --mtime="@${SOURCE_DATE_EPOCH}" \
-              --owner=0 --group=0 --numeric-owner \
-              -czf "${SERVER_STAGING}.tar.gz" "${SERVER_STAGING}"
-          shasum -a 256 "${SERVER_STAGING}.tar.gz" > "${SERVER_STAGING}.tar.gz.sha256"
-
-      - name: Collect SBOM artifacts
-        id: sbom
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-          TARGET: ${{ matrix.target }}
-        run: |
-          MAIN_SBOM=""
-          for sbom in $(find . -maxdepth 3 -name "*_cdx.json" -o -name "*.cdx.json" 2>/dev/null | grep -v "^./target/"); do
-            base=$(basename "${sbom}")
-            dest="vouch-v${VERSION}-${TARGET}-${base}"
-            cp "${sbom}" "${dest}"
-            if [[ "${base}" == *"vouch-server"* ]] || [[ "${base}" == *"vouch_server"* ]]; then
-              MAIN_SBOM="${dest}"
-            fi
-          done
-          if [[ -z "${MAIN_SBOM}" ]]; then
-            for cdx in "vouch-v${VERSION}-${TARGET}"-*cdx.json; do
-              [[ -e "${cdx}" ]] && { MAIN_SBOM="${cdx}"; break; }
-            done
-          fi
-          echo "main_sbom=${MAIN_SBOM}" >> "$GITHUB_OUTPUT"
-
-      - name: Upload binary artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: binaries-${{ matrix.name }}
-          path: |
-            vouch-server-v*.tar.gz
-            vouch-server-v*.sha256
-            vouch-v*cdx.json
-          if-no-files-found: error
-          retention-days: 5
-
-      - name: Attest build provenance (server archive)
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
-        with:
-          subject-path: vouch-server-v${{ steps.version.outputs.version }}-${{ matrix.target }}.tar.gz
-
-      - name: Attest SBOM (server archive)
-        if: steps.sbom.outputs.main_sbom != ''
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
-        with:
-          subject-path: vouch-server-v${{ steps.version.outputs.version }}-${{ matrix.target }}.tar.gz
-          sbom-path: ${{ steps.sbom.outputs.main_sbom }}
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+    secrets:
+      APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
+      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+      APPLE_CERTIFICATE_NAME: ${{ secrets.APPLE_CERTIFICATE_NAME }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      TRUSTED_SIGNING_ENDPOINT: ${{ secrets.TRUSTED_SIGNING_ENDPOINT }}
+      TRUSTED_SIGNING_ACCOUNT: ${{ secrets.TRUSTED_SIGNING_ACCOUNT }}
+      CERTIFICATE_PROFILE: ${{ secrets.CERTIFICATE_PROFILE }}
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
 
   linux-packages:
     name: Linux Packages (${{ matrix.arch }})
     runs-on: ubuntu-latest
-    needs: [build-cli, build-server]
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -768,7 +218,7 @@ jobs:
   verify-reproducibility:
     name: Verify Reproducible Build (Linux)
     runs-on: ubuntu-latest
-    needs: build-cli
+    needs: build
     permissions:
       contents: read
 
@@ -936,7 +386,7 @@ jobs:
   conformance:
     name: Trigger Conformance Tests
     runs-on: ubuntu-latest
-    needs: merge
+    needs: build
     permissions:
       contents: read
     steps:
@@ -959,81 +409,10 @@ jobs:
             -f "client_payload[version]=${VERSION}" \
             -f "client_payload[image]=${IMAGE}"
 
-  helm:
-    name: Package Helm Chart
-    runs-on: ubuntu-latest
-    needs: merge
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-      attestations: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Set up Helm
-        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
-
-      - name: Log in to Container Registry
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get version
-        id: version
-        env:
-          REF_TAG: ${{ github.event.inputs.tag || github.ref_name }}
-        run: |
-          VERSION="${REF_TAG#v}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-
-      - name: Update Chart.yaml version
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          sed -i "s/^version:.*/version: ${VERSION}/" charts/vouch-server/Chart.yaml
-          sed -i "s/^appVersion:.*/appVersion: \"${VERSION}\"/" charts/vouch-server/Chart.yaml
-
-      - name: Update image repository in values.yaml
-        env:
-          REGISTRY_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-        run: |
-          sed -i "s|repository:.*|repository: ${REGISTRY_IMAGE}|" charts/vouch-server/values.yaml
-
-      - name: Package Helm chart
-        run: |
-          helm package charts/vouch-server --destination .helm-packages
-
-      - name: Generate Helm chart attestation
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
-        with:
-          subject-path: .helm-packages/*.tgz
-
-      - name: Upload Helm chart artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: helm-chart
-          path: .helm-packages/*.tgz
-          if-no-files-found: error
-          retention-days: 5
-          include-hidden-files: true
-
-      - name: Push Helm chart to OCI registry
-        env:
-          OCI_REGISTRY: oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts
-        run: |
-          helm push .helm-packages/*.tgz "${OCI_REGISTRY}"
-
   release-artifacts:
     name: Publish Release Artifacts
     runs-on: ubuntu-latest
-    needs: [build-cli, build-server, linux-packages, merge, helm]
+    needs: [build, linux-packages]
     permissions:
       contents: write
 
@@ -1397,7 +776,7 @@ jobs:
   release-notes:
     name: Generate Release Notes
     runs-on: ubuntu-latest
-    needs: [merge, helm, publish-release, homebrew, publish-packages]
+    needs: [build, publish-release, homebrew, publish-packages]
     permissions:
       contents: write
 
@@ -1519,7 +898,9 @@ jobs:
             #### Verify provenance
 
             ```bash
-            gh attestation verify vouch-${{ steps.version.outputs.tag }}-aarch64-apple-darwin.tar.gz --owner vouch-sh
+            gh attestation verify vouch-${{ steps.version.outputs.tag }}-aarch64-apple-darwin.tar.gz \
+              --owner vouch-sh \
+              --signer-workflow vouch-sh/vouch/.github/workflows/reusable-build.yml
             ```
 
             ### Using Helm (OCI)
@@ -1551,8 +932,16 @@ jobs:
             ```bash
             # Container image
             gh attestation verify oci://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.tag }} \
-              --owner ${{ github.repository_owner }}
+              --owner ${{ github.repository_owner }} \
+              --signer-workflow vouch-sh/vouch/.github/workflows/reusable-build.yml
 
             # Binary archives
-            gh attestation verify vouch-${{ steps.version.outputs.tag }}-aarch64-apple-darwin.tar.gz --owner vouch-sh
+            gh attestation verify vouch-${{ steps.version.outputs.tag }}-aarch64-apple-darwin.tar.gz \
+              --owner vouch-sh \
+              --signer-workflow vouch-sh/vouch/.github/workflows/reusable-build.yml
+
+            # Helm chart
+            gh attestation verify vouch-server-${{ steps.version.outputs.version }}.tgz \
+              --owner vouch-sh \
+              --signer-workflow vouch-sh/vouch/.github/workflows/reusable-build.yml
             ```

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -1,0 +1,685 @@
+# Builds and attests every release artifact (container image, CLI archives,
+# server archives, Helm chart, SBOMs). Build and attest run inside this
+# reusable workflow so the Sigstore certificate records it as the signer
+# identity, which is what makes the provenance SLSA Build Level 3. Verify:
+#   gh attestation verify <artifact> --owner vouch-sh \
+#     --signer-workflow vouch-sh/vouch/.github/workflows/reusable-build.yml
+name: Reusable Build
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Release version without the v prefix (e.g. 0.1.0)'
+        required: true
+        type: string
+    secrets:
+      APPLE_CERTIFICATE_P12_BASE64:
+        required: true
+      APPLE_CERTIFICATE_PASSWORD:
+        required: true
+      MACOS_KEYCHAIN_PASSWORD:
+        required: true
+      APPLE_CERTIFICATE_NAME:
+        required: true
+      APPLE_ID:
+        required: true
+      APPLE_ID_PASSWORD:
+        required: true
+      APPLE_TEAM_ID:
+        required: true
+      TRUSTED_SIGNING_ENDPOINT:
+        required: true
+      TRUSTED_SIGNING_ACCOUNT:
+        required: true
+      CERTIFICATE_PROFILE:
+        required: true
+      AZURE_CLIENT_ID:
+        required: true
+      AZURE_TENANT_ID:
+        required: true
+
+permissions: {}
+
+# The caller's workflow-level env does not propagate into a called workflow;
+# these mirror the values in release.yml.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: Build and Push (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            artifact: digests-amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            artifact: digests-arm64
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set SOURCE_DATE_EPOCH for reproducible builds
+        run: |
+          SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
+          echo "SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}" >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: |
+            type=gha,scope=${{ matrix.platform }}
+            type=gha,scope=ci-scan
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          provenance: true
+          sbom: true
+          build-args: |
+            SOURCE_DATE_EPOCH=${{ env.SOURCE_DATE_EPOCH }}
+
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.artifact }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge Manifests
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=
+            type=raw,value=latest,enable=${{ github.ref == format('refs/tags/{0}', github.event.inputs.tag || github.ref_name) }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        env:
+          REGISTRY_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        run: |
+          # shellcheck disable=SC2046  # intentional word splitting: -t flags and image@digest args
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf "${REGISTRY_IMAGE}@sha256:%s " *)
+
+      - name: Inspect image
+        id: inspect
+        env:
+          REGISTRY_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          META_VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          digest=$(docker buildx imagetools inspect "${REGISTRY_IMAGE}:${META_VERSION}" --format '{{json .Manifest.Digest}}' | tr -d '"')
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate artifact attestation
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.inspect.outputs.digest }}
+          push-to-registry: true
+
+  build-cli:
+    name: Build CLI (${{ matrix.name }})
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-amd64
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            bins: "vouch vouch-agent"
+            archive-ext: tar.gz
+          - name: linux-arm64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+            bins: "vouch vouch-agent"
+            archive-ext: tar.gz
+          - name: macos-arm64
+            runner: macos-latest
+            target: aarch64-apple-darwin
+            bins: "vouch vouch-agent"
+            archive-ext: tar.gz
+          - name: windows-amd64
+            runner: windows-latest
+            target: x86_64-pc-windows-msvc
+            bins: "vouch"
+            archive-ext: zip
+            rustflags: "-C target-feature=+crt-static"
+          - name: windows-arm64
+            runner: windows-latest
+            target: aarch64-pc-windows-msvc
+            bins: "vouch"
+            archive-ext: zip
+            rustflags: "-C target-feature=+crt-static"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set SOURCE_DATE_EPOCH for reproducible builds
+        shell: bash
+        run: |
+          SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
+          echo "SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}" >> "$GITHUB_ENV"
+
+      - name: Install GNU tar (macOS)
+        if: runner.os == 'macOS'
+        run: brew list gnu-tar &>/dev/null || brew install gnu-tar
+
+      - name: Setup Rust toolchain
+        if: runner.os != 'Linux'
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          rustup show
+          rustup target add "${TARGET}"
+
+      - name: Setup Rust cache
+        if: runner.os != 'Linux'
+        # Restore-only (save-if:false) and non-Linux; a tag build reads only
+        # main/tag-scoped caches, so there is no cross-ref poisoning vector.
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.1 # zizmor: ignore[cache-poisoning]
+        with:
+          prefix-key: "v2"
+          shared-key: "release-${{ matrix.target }}"
+          save-if: "false"
+
+      - name: Set RUSTFLAGS
+        if: matrix.rustflags
+        shell: bash
+        env:
+          RUSTFLAGS_VALUE: ${{ matrix.rustflags }}
+        run: echo "RUSTFLAGS=${RUSTFLAGS_VALUE}" >> "$GITHUB_ENV"
+
+      - name: Cache cargo binaries
+        if: runner.os != 'Linux'
+        id: cache-cargo-bin
+        # Caches a version-pinned cargo-cyclonedx binary (non-Linux only); the
+        # key pins the exact version and a tag build reads only main/tag caches.
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 # zizmor: ignore[cache-poisoning]
+        with:
+          path: |
+            ~/.cargo/bin/cargo-cyclonedx
+            ~/.cargo/bin/cargo-cyclonedx.exe
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-bin-cyclonedx-v0.5.6
+
+      - name: Install cargo-cyclonedx
+        if: runner.os != 'Linux' && steps.cache-cargo-bin.outputs.cache-hit != 'true'
+        shell: bash
+        run: cargo install cargo-cyclonedx --version 0.5.6
+
+      - name: Set up Docker Buildx
+        if: runner.os == 'Linux'
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Build CLI and Agent (Linux)
+        if: runner.os == 'Linux'
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
+        with:
+          targets: cli
+        env:
+          TARGET: ${{ matrix.target }}
+          SOURCE_DATE_EPOCH: ${{ env.SOURCE_DATE_EPOCH }}
+          GENERATE_SBOM: "true"
+
+      - name: Build CLI and Agent
+        if: runner.os != 'Linux' && matrix.bins == 'vouch vouch-agent'
+        env:
+          TARGET: ${{ matrix.target }}
+        run: cargo build --release --target "${TARGET}" -p vouch-cli -p vouch-agent
+
+      - name: Build CLI only
+        if: matrix.bins == 'vouch'
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: cargo build --release --target "${TARGET}" -p vouch-cli
+
+      - name: Generate SBOM
+        if: runner.os != 'Linux'
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: cargo cyclonedx --target "${TARGET}" --format json
+
+      - name: Import Apple Developer Certificate
+        if: runner.os == 'macOS'
+        env:
+          APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+        run: |
+          echo "$APPLE_CERTIFICATE_P12_BASE64" | base64 --decode > certificate.p12
+          security create-keychain -p "$MACOS_KEYCHAIN_PASSWORD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$MACOS_KEYCHAIN_PASSWORD" build.keychain
+          security import certificate.p12 -k build.keychain \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$MACOS_KEYCHAIN_PASSWORD" build.keychain
+          rm certificate.p12
+
+      - name: Code sign macOS binaries
+        if: runner.os == 'macOS'
+        env:
+          APPLE_CERTIFICATE_NAME: ${{ secrets.APPLE_CERTIFICATE_NAME }}
+          TARGET: ${{ matrix.target }}
+          BINS: ${{ matrix.bins }}
+        run: |
+          for bin in ${BINS}; do
+            echo "Signing ${bin}..."
+            /usr/bin/codesign --force \
+              --sign "$APPLE_CERTIFICATE_NAME" \
+              --options runtime \
+              --timestamp \
+              "target/${TARGET}/release/${bin}"
+            /usr/bin/codesign --verify "target/${TARGET}/release/${bin}"
+          done
+
+      - name: Notarize macOS binaries
+        if: runner.os == 'macOS'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          TARGET: ${{ matrix.target }}
+          VERSION: ${{ inputs.version }}
+          BINS: ${{ matrix.bins }}
+        run: |
+          xcrun notarytool store-credentials "notarytool-profile" \
+            --apple-id "$APPLE_ID" \
+            --team-id "$APPLE_TEAM_ID" \
+            --password "$APPLE_ID_PASSWORD"
+
+          NOTARIZE_ZIP="vouch-notarize-${VERSION}.zip"
+          mkdir -p notarize-staging
+          for bin in ${BINS}; do
+            cp "target/${TARGET}/release/${bin}" notarize-staging/
+          done
+          ditto -c -k --keepParent notarize-staging "$NOTARIZE_ZIP"
+
+          xcrun notarytool submit "$NOTARIZE_ZIP" \
+            --keychain-profile "notarytool-profile" \
+            --wait
+
+          rm -rf notarize-staging "$NOTARIZE_ZIP"
+
+      - name: Code sign Windows binaries
+        if: runner.os == 'Windows'
+        uses: skeeto/aas-sign@0008af00d4dd2ff2e482ba5ede70831d78f9da59 # v1.1.0
+        with:
+          version: v1.1.0
+          endpoint: ${{ secrets.TRUSTED_SIGNING_ENDPOINT }}
+          account: ${{ secrets.TRUSTED_SIGNING_ACCOUNT }}
+          profile: ${{ secrets.CERTIFICATE_PROFILE }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          files: |
+            target/${{ matrix.target }}/release/vouch.exe
+
+      - name: Create archive (tar.gz)
+        if: matrix.archive-ext == 'tar.gz'
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          TARGET: ${{ matrix.target }}
+          BINS: ${{ matrix.bins }}
+        run: |
+          STAGING="vouch-v${VERSION}-${TARGET}"
+
+          # Use GNU tar (gtar on macOS, tar on Linux)
+          if command -v gtar &> /dev/null; then
+            TAR_CMD="gtar"
+          else
+            TAR_CMD="tar"
+          fi
+
+          mkdir -p "${STAGING}"
+          for bin in ${BINS}; do
+            cp "target/${TARGET}/release/${bin}" "${STAGING}/"
+          done
+
+          # Create deterministic archive for reproducible builds
+          $TAR_CMD --sort=name \
+              --mtime="@${SOURCE_DATE_EPOCH}" \
+              --owner=0 --group=0 --numeric-owner \
+              -czf "${STAGING}.tar.gz" "${STAGING}"
+          shasum -a 256 "${STAGING}.tar.gz" > "${STAGING}.tar.gz.sha256"
+
+      - name: Create archive (zip)
+        if: matrix.archive-ext == 'zip'
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          ARCHIVE="vouch-v${VERSION}-${TARGET}.zip"
+
+          # Stage signed binary in CWD so it lands at the zip root (no versioned
+          # subdir). Users get vouch.exe directly on extract; winget can use a
+          # constant RelativeFilePath: vouch.exe across versions.
+          cp "target/${TARGET}/release/vouch.exe" vouch.exe
+          7z a "${ARCHIVE}" vouch.exe
+          rm vouch.exe
+
+          sha256sum "${ARCHIVE}" > "${ARCHIVE}.sha256"
+
+      - name: Collect SBOM artifacts
+        id: sbom
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          MAIN_SBOM=""
+          # Find and copy CycloneDX SBOMs with target-specific names
+          for sbom in $(find . -maxdepth 3 -name "*_cdx.json" -o -name "*.cdx.json" 2>/dev/null | grep -v "^./target/"); do
+            base=$(basename "${sbom}")
+            dest="vouch-v${VERSION}-${TARGET}-${base}"
+            cp "${sbom}" "${dest}"
+            # Use vouch-cli SBOM as the main one for attestation (always present)
+            if [[ "${base}" == *"vouch-cli"* ]] || [[ "${base}" == *"vouch_cli"* ]]; then
+              MAIN_SBOM="${dest}"
+            fi
+          done
+          # Fallback to first SBOM found if no vouch-cli specific one
+          if [[ -z "${MAIN_SBOM}" ]]; then
+            for cdx in "vouch-v${VERSION}-${TARGET}"-*cdx.json; do
+              [[ -e "${cdx}" ]] && { MAIN_SBOM="${cdx}"; break; }
+            done
+          fi
+          echo "main_sbom=${MAIN_SBOM}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload binary artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: binaries-${{ matrix.name }}
+          path: |
+            vouch-v*.tar.gz
+            vouch-v*.zip
+            vouch-v*.sha256
+            vouch-v*cdx.json
+          if-no-files-found: error
+          retention-days: 5
+
+      - name: Attest build provenance (CLI archive)
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: vouch-v${{ inputs.version }}-${{ matrix.target }}.${{ matrix.archive-ext }}
+
+      - name: Attest SBOM (CLI archive)
+        if: steps.sbom.outputs.main_sbom != ''
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: vouch-v${{ inputs.version }}-${{ matrix.target }}.${{ matrix.archive-ext }}
+          sbom-path: ${{ steps.sbom.outputs.main_sbom }}
+
+      - name: Cleanup macOS keychain
+        if: runner.os == 'macOS' && always()
+        run: |
+          security delete-keychain build.keychain 2>/dev/null || true
+
+  build-server:
+    name: Build Server (${{ matrix.name }})
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-amd64-server
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - name: linux-arm64-server
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set SOURCE_DATE_EPOCH for reproducible builds
+        run: |
+          SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
+          echo "SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}" >> "$GITHUB_ENV"
+
+      - name: Build CSS
+        run: |
+          ARCH=$(uname -m)
+          case "$ARCH" in
+            x86_64)
+              BINARY="tailwindcss-linux-x64"
+              CHECKSUM="dc61b3ac6b8c9ca874c0cc4c57b2409791a64c5540404ca5f5367360babc313a"
+              ;;
+            aarch64)
+              BINARY="tailwindcss-linux-arm64"
+              CHECKSUM="55fd0b241214eff3de1e8ee4f22796662f2d2e7a49bcfca7477cfd0bac398195"
+              ;;
+          esac
+          curl -sLO "https://github.com/tailwindlabs/tailwindcss/releases/download/v4.3.3/${BINARY}"
+          echo "${CHECKSUM}  ${BINARY}" | sha256sum -c -
+          chmod +x "${BINARY}"
+          cd crates/vouch-server && "../../${BINARY}" -i styles/input.css -o static/css/output.css --minify
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Build server and generate SBOM (musl)
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
+        with:
+          targets: server
+        env:
+          TARGET: ${{ matrix.target }}
+          SOURCE_DATE_EPOCH: ${{ env.SOURCE_DATE_EPOCH }}
+          GENERATE_SBOM: "true"
+
+      - name: Create server archive
+        env:
+          VERSION: ${{ inputs.version }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          SERVER_STAGING="vouch-server-v${VERSION}-${TARGET}"
+
+          mkdir -p "${SERVER_STAGING}"
+          cp "target/${TARGET}/release/vouch-server" "${SERVER_STAGING}/"
+
+          tar --sort=name \
+              --mtime="@${SOURCE_DATE_EPOCH}" \
+              --owner=0 --group=0 --numeric-owner \
+              -czf "${SERVER_STAGING}.tar.gz" "${SERVER_STAGING}"
+          shasum -a 256 "${SERVER_STAGING}.tar.gz" > "${SERVER_STAGING}.tar.gz.sha256"
+
+      - name: Collect SBOM artifacts
+        id: sbom
+        env:
+          VERSION: ${{ inputs.version }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          MAIN_SBOM=""
+          for sbom in $(find . -maxdepth 3 -name "*_cdx.json" -o -name "*.cdx.json" 2>/dev/null | grep -v "^./target/"); do
+            base=$(basename "${sbom}")
+            dest="vouch-v${VERSION}-${TARGET}-${base}"
+            cp "${sbom}" "${dest}"
+            if [[ "${base}" == *"vouch-server"* ]] || [[ "${base}" == *"vouch_server"* ]]; then
+              MAIN_SBOM="${dest}"
+            fi
+          done
+          if [[ -z "${MAIN_SBOM}" ]]; then
+            for cdx in "vouch-v${VERSION}-${TARGET}"-*cdx.json; do
+              [[ -e "${cdx}" ]] && { MAIN_SBOM="${cdx}"; break; }
+            done
+          fi
+          echo "main_sbom=${MAIN_SBOM}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload binary artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: binaries-${{ matrix.name }}
+          path: |
+            vouch-server-v*.tar.gz
+            vouch-server-v*.sha256
+            vouch-v*cdx.json
+          if-no-files-found: error
+          retention-days: 5
+
+      - name: Attest build provenance (server archive)
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: vouch-server-v${{ inputs.version }}-${{ matrix.target }}.tar.gz
+
+      - name: Attest SBOM (server archive)
+        if: steps.sbom.outputs.main_sbom != ''
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: vouch-server-v${{ inputs.version }}-${{ matrix.target }}.tar.gz
+          sbom-path: ${{ steps.sbom.outputs.main_sbom }}
+
+  helm:
+    name: Package Helm Chart
+    runs-on: ubuntu-latest
+    needs: merge
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update Chart.yaml version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          sed -i "s/^version:.*/version: ${VERSION}/" charts/vouch-server/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"${VERSION}\"/" charts/vouch-server/Chart.yaml
+
+      - name: Update image repository in values.yaml
+        env:
+          REGISTRY_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        run: |
+          sed -i "s|repository:.*|repository: ${REGISTRY_IMAGE}|" charts/vouch-server/values.yaml
+
+      - name: Package Helm chart
+        run: |
+          helm package charts/vouch-server --destination .helm-packages
+
+      - name: Generate Helm chart attestation
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: .helm-packages/*.tgz
+
+      - name: Upload Helm chart artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: helm-chart
+          path: .helm-packages/*.tgz
+          if-no-files-found: error
+          retention-days: 5
+          include-hidden-files: true
+
+      - name: Push Helm chart to OCI registry
+        env:
+          OCI_REGISTRY: oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts
+        run: |
+          helm push .helm-packages/*.tgz "${OCI_REGISTRY}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -358,6 +358,16 @@ sha256sum out/target/*/release/vouch-server
 
 For container images, the release workflow also sets `provenance: true` and `sbom: true` on the Docker build, generating SLSA provenance attestations that can be verified with `cosign` or `gh attestation verify`.
 
+All release artifacts are built and attested inside a reusable workflow (`.github/workflows/reusable-build.yml`), so their provenance meets SLSA Build Level 3: the Sigstore certificate records the reusable workflow as the signer identity, which verifiers can pin:
+
+```bash
+gh attestation verify vouch-v<version>-<target>.tar.gz \
+  --owner vouch-sh \
+  --signer-workflow vouch-sh/vouch/.github/workflows/reusable-build.yml
+```
+
+This applies to releases built after the reusable workflow was introduced; older releases carry attestations without the reusable-workflow signer identity and fail `--signer-workflow` verification.
+
 ### Local Reproducibility
 
 For local builds to match CI output, ensure:


### PR DESCRIPTION
## Summary

Moves the build+attest jobs from `release.yml` into a new reusable workflow `.github/workflows/reusable-build.yml` (`on: workflow_call`), so GitHub Artifact Attestations record the reusable workflow as the signer identity — GitHub's supported mechanism for SLSA v1 Build Level 3 provenance. Both build and attest steps run inside the called workflow, per [GitHub's L3 guide](https://docs.github.com/actions/security-guides/using-artifact-attestations-and-reusable-workflows-to-achieve-slsa-v1-build-level-3).

Refs #944 (dry run and public docs updates remain after merge).

## What moved into `reusable-build.yml`

- `build` (container per-platform matrix) and `merge` (manifest list + image attestation)
- `build-cli` (5-target matrix incl. macOS/Windows code signing)
- `build-server` (2-target musl matrix)
- `helm` (chart package + attestation + OCI push), keeping its internal `needs: merge`

All six `actions/attest` call sites (image, CLI archives, server archives, chart, two SBOM predicates) now run inside the reusable workflow. Moved blocks are verbatim except: dropped `needs: license-audit` (gating moved to the caller wrapper), per-job "Get version" steps replaced by the `version` input, and the never-consumed `merge.outputs.digest` removed. `REGISTRY`/`IMAGE_NAME` env is re-declared in the called workflow (caller env does not propagate).

## `release.yml` becomes the orchestrator

- New `version` job computes the version once; a `build` wrapper job calls the reusable workflow with the union permissions ceiling (`contents: read`, `packages: write`, `id-token: write`, `attestations: write`, `artifact-metadata: write`) and passes all 12 signing secrets explicitly (no `secrets: inherit`).
- Downstream jobs rewired to `needs: build`; artifact names and archive filenames are unchanged, so artifact handoff needs no changes.
- Workflow name stays `Release`: `ami.yml`'s `workflow_run` trigger and the Azure Trusted Signing federated credential subject (`repo:vouch-sh/vouch:workflow:Release:ref_type:tag`) both depend on it.
- Release-notes verification instructions and CONTRIBUTING.md now include `--signer-workflow vouch-sh/vouch/.github/workflows/reusable-build.yml`, plus a Helm chart verify example.

## OIDC federation verified

The repo's OIDC sub customization is `include_claim_keys: [repo, workflow, ref_type]` — all caller-scoped claims for reusable workflows (`job_workflow_ref`, the only claim the move changes, is not included). Confirmed against the Azure app's federated credential via `az ad app federated-credential list`; Windows signing keeps working without Azure changes.

## Verification

- Scripted move with occurrence-count assertions; independent `diff` of every moved block against `HEAD` shows only the intended edits
- `actionlint` and `zizmor` clean on both files (existing inline suppressions moved with their steps); all `prek` hooks pass
- No release job names are required status checks in the main ruleset
- After merge: dry-run with an rc tag (cancel before `publish-release`), verify `gh attestation verify --signer-workflow` on every artifact class per #944's acceptance criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Behavioral changes (deliberate)

The `build` wrapper is atomic: a caller job cannot `needs` a single job inside a called workflow. Two accepted consequences (discussed and kept as-is):

- `conformance` previously fired once `merge` completed; it now waits for all build legs and is blocked by any leg failure until the failed leg is re-run green. Same for `verify-reproducibility` (previously gated only on `build-cli`).
- Splitting the invocation per component (or moving the dispatch into the reusable workflow) was considered and rejected to keep one invocation and one unambiguous signer identity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large CI refactor touches every release artifact path and attestation signer identity; miswired secrets or job dependencies could break releases or change verify behavior for new tags.
> 
> **Overview**
> **Moves release build and attestation into** `.github/workflows/reusable-build.yml` **so Sigstore provenance pins the reusable workflow as signer identity (SLSA Build Level 3).** Container multi-arch build/merge, CLI/server matrix builds (including signing), Helm packaging, and all `actions/attest` steps now run inside that called workflow; version is passed via a `version` input instead of per-job tag parsing.
> 
> **`release.yml` is slimmed to orchestration:** a `version` job, a `build` wrapper that calls the reusable workflow with explicit signing secrets and the needed permission ceiling, and downstream jobs (`linux-packages`, reproducibility, conformance, release artifacts/notes) updated to `needs: build` while keeping artifact names unchanged.
> 
> **Docs:** release-note attestation examples and **CONTRIBUTING** now document `gh attestation verify` with `--signer-workflow vouch-sh/vouch/.github/workflows/reusable-build.yml` (plus Helm chart verify).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51e7ada16ffc1405c5a8694ccb52233d23080733. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
