### PR TITLE
ci: use v-stripped image tag in release-notes examples

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -924,14 +924,14 @@ jobs:
             ### Container Image
 
             ```bash
-            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.tag }}
+            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
             ```
 
             ### Verify Attestations
 
             ```bash
             # Container image
-            gh attestation verify oci://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.tag }} \
+            gh attestation verify oci://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }} \
               --owner ${{ github.repository_owner }} \
               --signer-workflow vouch-sh/vouch/.github/workflows/reusable-build.yml
 


### PR DESCRIPTION
The `docker pull` and container `gh attestation verify` examples in the generated release notes render the v-prefixed git tag (`:v2026.8.4`), but `docker/metadata-action`'s `type=semver,pattern={{version}}` strips the `v` when tagging the image — so both published commands fail with `MANIFEST_UNKNOWN` when copy-pasted. The pipeline's own image references (e.g. the reproducibility check) already use the bare `version` output.

Changes `steps.version.outputs.tag` → `steps.version.outputs.version` on the two container-image lines of the release-notes template. Archive and Helm examples are untouched — those filenames genuinely use the v-prefixed tag and bare version respectively.

Verified against v2026.8.4: `gh attestation verify oci://ghcr.io/vouch-sh/vouch:2026.8.4 --owner vouch-sh --signer-workflow vouch-sh/vouch/.github/workflows/reusable-build.yml` passes; the `:v2026.8.4` form is `MANIFEST_UNKNOWN`.

Refs #944

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change in the release workflow template; no build, publish, or runtime behavior changes.
> 
> **Overview**
> Fixes **copy-paste release notes** for the container image so they match how images are actually tagged on GHCR.
> 
> The generated **Container Image** `docker pull` and **Verify Attestations** `gh attestation verify oci://…` examples now use `steps.version.outputs.version` (e.g. `2026.8.4`) instead of `steps.version.outputs.tag` (e.g. `v2026.8.4`). That aligns with `docker/metadata-action` semver tagging, which drops the `v` prefix—so the old examples could fail with `MANIFEST_UNKNOWN`. Archive and Helm snippets are unchanged; they still use v-prefixed tag or bare version where those assets are named that way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7332dbf21f83165737e70b437771e9d812513566. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->