### PR TITLE
chore: add Cursor Cloud agent environment bootstrap

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,13 @@
+{
+  // Cursor Cloud agent environment for Vouch. Uses the default Ubuntu image;
+  // `.cursor/install.sh` is the counterpart to `.claude/hooks/session-setup.sh`.
+  // Secrets (VOUCH_JWT_SECRET, VOUCH_IDPS, …) belong in the Cloud Agents dashboard.
+  "name": "vouch",
+  "install": "bash .cursor/install.sh",
+  "ports": [
+    {
+      "name": "vouch-server",
+      "port": 3000
+    }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -89,8 +89,30 @@ ensure_export() {
   fi
 }
 
-ensure_export AWS_LC_FIPS_SYS_CC clang
-ensure_export AWS_LC_FIPS_SYS_CXX clang++
+remove_export() {
+  key=$1
+  unset "${key}" || true
+  [ -f "${HOME}/.bashrc" ] && sed -i -E "/^export ${key}=/d" "${HOME}/.bashrc"
+}
+
+# aws-lc-fips-sys builds a CMake C/C++ project for the FIPS module, so its build
+# needs a C++ compiler that can link libstdc++ on this image. Stock Ubuntu's
+# default (g++) does; only fall back to clang when the default can't link but
+# clang++ can. Forcing clang++ unconditionally breaks images whose clang install
+# can't find libstdc++ ("/usr/bin/ld: cannot find -lstdc++"), which fails the
+# aws-lc-fips-sys build even though gcc would have compiled it. Leaving CC/CXX
+# unset lets cc-rs/cmake use the working system default.
+probe_cxx() { printf 'int main(){return 0;}\n' | "$1" -x c++ - -o /dev/null 2>/dev/null; }
+if probe_cxx c++ || probe_cxx g++; then
+  remove_export AWS_LC_FIPS_SYS_CC
+  remove_export AWS_LC_FIPS_SYS_CXX
+elif probe_cxx clang++; then
+  ensure_export AWS_LC_FIPS_SYS_CC clang
+  ensure_export AWS_LC_FIPS_SYS_CXX clang++
+else
+  echo "install: no C++ compiler can link libstdc++; aws-lc-fips-sys will not build" >&2
+  exit 1
+fi
 ensure_export CARGO_INCREMENTAL 0
 
 cargo_config="${HOME}/.cargo/config.toml"

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Cursor Cloud install: prepare the default Ubuntu image to build and gate this
+# repo. Counterpart to .claude/hooks/session-setup.sh — same packages and tools,
+# but this script must fail the Build if cargo/CSS prep fails (session-setup
+# always exits 0). Idempotent; runs from the project root.
+set -euo pipefail
+
+[ "$(uname)" = "Linux" ] || {
+  echo "Cursor Cloud install is Linux-only" >&2
+  exit 1
+}
+
+export PATH="${HOME}/.cargo/bin:${HOME}/.local/bin:${PATH}"
+if [ -f "${HOME}/.cargo/env" ]; then
+  # shellcheck source=/dev/null
+  . "${HOME}/.cargo/env"
+fi
+
+# session-setup.sh packages (aws-lc-rs FIPS, hidapi, prek shell linters), plus
+# curl/ca-certificates/python3-pip that a from-scratch Ubuntu may lack.
+pkgs=(
+  libudev-dev libssl-dev pkg-config cmake clang golang-go shellcheck shfmt
+  curl ca-certificates python3-pip
+)
+if ! dpkg -s "${pkgs[@]}" >/dev/null 2>&1; then
+  sudo apt-get update -qq || true
+  sudo apt-get install -y -qq "${pkgs[@]}"
+fi
+
+if ! command -v rustup >/dev/null 2>&1 && [ ! -x "${HOME}/.cargo/bin/rustup" ]; then
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |
+    sh -s -- -y --default-toolchain none
+fi
+if [ -f "${HOME}/.cargo/env" ]; then
+  # shellcheck source=/dev/null
+  . "${HOME}/.cargo/env"
+fi
+
+# Standalone Tailwind CSS v4 CLI. Pin matches Dockerfile / reusable-build.yml
+# (v4.3.3). Prefer GitHub; npm fallback like session-setup.sh.
+if ! command -v tailwindcss >/dev/null 2>&1; then
+  tw_ver=v4.3.3
+  case "$(uname -m)" in
+  x86_64)
+    tw_arch=x64
+    tw_sum=dc61b3ac6b8c9ca874c0cc4c57b2409791a64c5540404ca5f5367360babc313a
+    ;;
+  aarch64 | arm64)
+    tw_arch=arm64
+    tw_sum=55fd0b241214eff3de1e8ee4f22796662f2d2e7a49bcfca7477cfd0bac398195
+    ;;
+  *)
+    tw_arch=""
+    tw_sum=""
+    ;;
+  esac
+  if [ -n "${tw_arch}" ]; then
+    tw_tmp=$(mktemp)
+    if curl -fsSL --max-time 120 -o "${tw_tmp}" \
+      "https://github.com/tailwindlabs/tailwindcss/releases/download/${tw_ver}/tailwindcss-linux-${tw_arch}" &&
+      echo "${tw_sum}  ${tw_tmp}" | sha256sum -c -; then
+      sudo install -m 755 "${tw_tmp}" /usr/local/bin/tailwindcss
+    fi
+    rm -f "${tw_tmp}"
+  fi
+  if ! command -v tailwindcss >/dev/null 2>&1 && command -v npm >/dev/null 2>&1; then
+    npm install -g --silent @tailwindcss/cli
+    (cd "$(dirname "${PWD}")" && npm install --no-save --silent tailwindcss)
+  fi
+fi
+command -v tailwindcss >/dev/null 2>&1
+
+if ! command -v prek >/dev/null 2>&1 && [ ! -x "${HOME}/.local/bin/prek" ]; then
+  pip3 install --user --quiet --break-system-packages prek
+fi
+if [ -x "${HOME}/.local/bin/prek" ] && ! command -v prek >/dev/null 2>&1; then
+  sudo ln -sf "${HOME}/.local/bin/prek" /usr/local/bin/prek
+fi
+
+ensure_export() {
+  key=$1
+  val=$2
+  export "${key}=${val}"
+  touch "${HOME}/.bashrc"
+  if grep -qsE "^export ${key}=" "${HOME}/.bashrc"; then
+    sed -i -E "s|^export ${key}=.*|export ${key}=${val}|" "${HOME}/.bashrc"
+  else
+    printf '\nexport %s=%s\n' "${key}" "${val}" >>"${HOME}/.bashrc"
+  fi
+}
+
+ensure_export AWS_LC_FIPS_SYS_CC clang
+ensure_export AWS_LC_FIPS_SYS_CXX clang++
+ensure_export CARGO_INCREMENTAL 0
+
+cargo_config="${HOME}/.cargo/config.toml"
+mkdir -p "${HOME}/.cargo"
+if grep -qsE '^[[:space:]]*incremental[[:space:]]*=' "${cargo_config}"; then
+  sed -i -E 's/^([[:space:]]*incremental[[:space:]]*=[[:space:]]*).*/\1false/' \
+    "${cargo_config}"
+else
+  printf '\n[build]\nincremental = false\n' >>"${cargo_config}"
+fi
+
+rustup show
+cargo fetch --locked
+make css-build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,14 +6,16 @@ See `CLAUDE.md` for full project overview, architecture, code conventions, and c
 
 ### System dependencies
 
-The build requires `libssl-dev`, `libudev-dev`, `cmake`, `golang-go`, `clang`, and `pkg-config` on Linux. The `aws-lc-rs` FIPS build also needs these environment variables set:
+The build requires `libssl-dev`, `libudev-dev`, `cmake`, `golang-go`, `clang`, and `pkg-config` on Linux. The `aws-lc-rs` FIPS build (`aws-lc-fips-sys`) compiles a CMake C/C++ project, so it needs a C++ toolchain that can link `libstdc++`. The system default (`g++`) builds it on stock Ubuntu. Only on images where the default can't link but `clang` can, point the FIPS build at clang:
 
 ```
 export AWS_LC_FIPS_SYS_CC=clang
 export AWS_LC_FIPS_SYS_CXX=clang++
 ```
 
-Cursor Cloud agents use `.cursor/environment.json` on the default Ubuntu image. Its `install` script (`.cursor/install.sh`) is the counterpart to `.claude/hooks/session-setup.sh`: it installs those packages, rustup, the TailwindCSS CLI, and `prek` when missing, persists `AWS_LC_FIPS_SYS_CC`/`CXX`, and then runs `rustup show`, `cargo fetch --locked`, and `make css-build`. Do not start `vouch-server` from `start`/`terminals` — it needs `VOUCH_IDPS` and other secrets from the Cloud Agents dashboard.
+Do not force clang unconditionally: on images whose clang install can't find `libstdc++` (`/usr/bin/ld: cannot find -lstdc++`) this breaks a build that `g++` would have completed.
+
+Cursor Cloud agents use `.cursor/environment.json` on the default Ubuntu image. Its `install` script (`.cursor/install.sh`) is the counterpart to `.claude/hooks/session-setup.sh`: it installs those packages, rustup, the TailwindCSS CLI, and `prek` when missing, selects a C/C++ toolchain that can build `aws-lc-fips-sys` (preferring the system default and falling back to clang only when needed), and then runs `rustup show`, `cargo fetch --locked`, and `make css-build`. Do not start `vouch-server` from `start`/`terminals` — it needs `VOUCH_IDPS` and other secrets from the Cloud Agents dashboard.
 
 On Claude Code sessions, `.claude/hooks/session-setup.sh` runs at session start and installs the same tools when missing (each step skips silently if the network policy blocks its download).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,17 +13,17 @@ export AWS_LC_FIPS_SYS_CC=clang
 export AWS_LC_FIPS_SYS_CXX=clang++
 ```
 
-These are already configured in `~/.bashrc` on the Cloud VM.
+Cursor Cloud agents use `.cursor/environment.json` on the default Ubuntu image. Its `install` script (`.cursor/install.sh`) is the counterpart to `.claude/hooks/session-setup.sh`: it installs those packages, rustup, the TailwindCSS CLI, and `prek` when missing, persists `AWS_LC_FIPS_SYS_CC`/`CXX`, and then runs `rustup show`, `cargo fetch --locked`, and `make css-build`. Do not start `vouch-server` from `start`/`terminals` — it needs `VOUCH_IDPS` and other secrets from the Cloud Agents dashboard.
 
-On Claude Code sessions, `.claude/hooks/session-setup.sh` runs at session start and installs the system packages, rustup, the TailwindCSS CLI, and `prek` when missing (each step skips silently if the network policy blocks its download).
+On Claude Code sessions, `.claude/hooks/session-setup.sh` runs at session start and installs the same tools when missing (each step skips silently if the network policy blocks its download).
 
 ### TailwindCSS
 
 The server UI requires the **standalone** TailwindCSS v4 CLI binary (not npm). It is installed at `/usr/local/bin/tailwindcss`. Run `make css-build` before starting the server or building the project. (On Claude Code remote containers, where GitHub release downloads may be blocked, the session hook falls back to installing the same CLI from the npm registry — this does not add a node toolchain to the project.)
 
-### Disk space (Claude Code remote containers)
+### Disk space (cloud agents)
 
-Writable disk is a fixed per-session allowance, and a full `--all-features` build of this workspace is large. The session hook disables incremental compilation in these containers (`~/.cargo/config.toml`), which roughly halves `target/` (~14 GB vs ~30 GB per full build cycle). On "no space left on device", delete `target/` subdirectories you no longer need — deletes still succeed while writes fail.
+Writable disk is a fixed per-session allowance, and a full `--all-features` build of this workspace is large. Both the Cursor Cloud `install` script and the Claude session hook set `incremental = false` in `~/.cargo/config.toml`. That roughly halves `target/` (~14 GB vs ~30 GB per full build cycle). On "no space left on device", delete `target/` subdirectories you no longer need — deletes still succeed while writes fail.
 
 ### Running the server locally
 


### PR DESCRIPTION
## Summary
- Add `.cursor/environment.json` so Cursor Cloud agents bootstrap from the default Ubuntu image (no custom Dockerfile).
- Add `.cursor/install.sh` as the idempotent counterpart to `.claude/hooks/session-setup.sh`: system packages, rustup, Tailwind CSS CLI, `prek`, FIPS compiler env, then `rustup show`, `cargo fetch --locked`, and `make css-build`.
- Document the Cursor Cloud path in `AGENTS.md`. Secrets stay in the Cloud Agents dashboard; `vouch-server` is not auto-started.

## Test plan
- [ ] Confirm `.cursor/environment.json` matches the [environment schema](https://www.cursor.com/schemas/environment.schema.json) (comments allowed; no unknown fields).
- [ ] Start a Cursor Cloud agent from this branch and verify `install` completes (apt packages, rustup toolchain from `rust-toolchain.toml`, Tailwind CLI, `prek`, `make css-build`).
- [ ] `make css-build` and `cargo fetch --locked` succeed in the cloud environment.
- [ ] Confirm `vouch-server` is not started automatically.


Made with [Cursor](https://cursor.com)