### PR TITLE
docs: remove weasel words and tighten operator guide prose

### DIFF
--- a/docs/src/admin/scim.md
+++ b/docs/src/admin/scim.md
@@ -1,6 +1,6 @@
 # SCIM Provisioning
 
-Vouch supports SCIM 2.0 (RFC 7643/7644) for user provisioning and de-provisioning from external identity providers. SCIM is a **launch requirement** for enterprise deployments.
+Vouch supports SCIM 2.0 (RFC 7643/7644) for user provisioning and de-provisioning from external identity providers.
 
 ## Setup
 
@@ -123,13 +123,13 @@ When a user is de-provisioned via SCIM (e.g., employee leaves the organization):
 | User record deleted | Immediate | User cannot re-enroll or authenticate |
 | Audit event logged | Immediate | De-provisioning recorded with SCIM token info |
 
-**Key principle**: De-provisioning is immediate and complete. When someone leaves via SCIM, they lose all Vouch access instantly — no waiting for session expiration.
+Nothing waits for session expiry: access ends when the IdP sends the delete.
 
 ## SCIM Endpoint Authentication
 
 SCIM endpoints require bearer token authentication:
 
-**Endpoint**: `POST /scim/v2/Users`, `DELETE /scim/v2/Users/:id`, etc.
+**Endpoint**: every `/scim/v2/*` route — `Users` and `Groups`, with `GET`, `POST`, `PATCH`, and `DELETE`.
 
 **Authentication**:
 - Bearer token in the `Authorization` header
@@ -156,8 +156,8 @@ User creation validates domain ownership inside a transaction keyed on the
 organization record, so heavy concurrent provisioning (an IdP bulk-syncing
 many users at once) or simultaneous domain changes can occasionally collide.
 When the server exhausts its internal retries it responds with
-`503 Service Unavailable` and a `Retry-After` header rather than an error:
-this is transient backpressure, not a fault. Okta and Entra retry such
+`503 Service Unavailable` and a `Retry-After` header: this is transient
+backpressure, not a fault. Okta and Entra retry such
 responses automatically; no operator action is needed unless 503s persist,
 which indicates sustained contention on the organization (for example, a
 domain-management script running during a bulk sync).

--- a/docs/src/advanced/airgap-installation.md
+++ b/docs/src/advanced/airgap-installation.md
@@ -90,38 +90,36 @@ docker images | grep vouch
 
 ## Step 4: Secure Key Generation
 
-**This is a critical security operation. Follow your organization's key ceremony procedures.**
-
-Vouch requires several cryptographic keys for different purposes. All key generation should be performed on a trusted, air-gapped workstation. See the [Key Ceremony](airgap-key-ceremony.md) chapter for detailed instructions on generating each key.
+Generate every key on a trusted, air-gapped workstation, following your organization's key ceremony procedures. See the [Key Ceremony](airgap-key-ceremony.md) chapter for per-key instructions.
 
 ### Key Overview
 
 | Key | Type | Format | Required | Purpose |
 |-----|------|--------|----------|---------|
-| JWT Secret | Symmetric | UTF-8 (32+ chars) | **Yes** | Sign OAuth tokens and sessions |
+| JWT Secret | Symmetric | UTF-8 (32+ chars) | **Yes** | Signs internal state tokens (authorization codes, WebAuthn state, CSRF) |
 | SSH CA Key | Ed25519 | Base64-encoded OpenSSH PEM | Optional | Sign SSH certificates |
 | OIDC Signing Key | P-256 ECDSA | Base64-encoded PKCS#8 PEM | Optional* | Sign OIDC ID tokens |
 | TLS Certificate | RSA/EC | Base64-encoded PEM | Optional | HTTPS encryption |
 | TLS Private Key | RSA/EC | Base64-encoded PEM | Optional | HTTPS encryption |
 
-*Auto-generates ephemeral key if not provided (not recommended for production).
+*When unset, the server generates an ephemeral key at startup; issued tokens then fail verification after a restart.
 
-> **Note:** All PEM-formatted keys and certificates must be base64-encoded when passed via environment variables. This ensures proper handling of newlines and special characters.
+> Base64-encode all PEM keys and certificates passed via environment variables — multi-line PEM content does not survive as an environment-variable value.
 
 ## Step 5: Database Setup
 
-Vouch uses SQLite by default, which is suitable for single-node deployments. The database is created automatically on first startup.
+Vouch defaults to SQLite, which backs a single node. The database is created automatically on first startup.
 
 ```bash
 # SQLite (default, single-node)
 export VOUCH_DATABASE_URL="sqlite:/data/vouch.db?mode=rwc"
 
-# Create data directory with appropriate permissions
+# Create the data directory, readable only by the service user
 mkdir -p /data
 chmod 700 /data
 ```
 
-For high-availability deployments, a local PostgreSQL instance is supported:
+For multi-node deployments, use PostgreSQL on the internal network:
 
 ```bash
 # PostgreSQL (multi-node, must be reachable on the internal network)
@@ -279,7 +277,7 @@ enclave than anywhere else:
 
 ## Step 7: Deploy Services
 
-There are several options for deploying the Vouch server.
+Deploy the server with systemd, Docker Compose, or Helm.
 
 ### Option A: Systemd Service (RPM Install)
 

--- a/docs/src/advanced/airgap-key-ceremony.md
+++ b/docs/src/advanced/airgap-key-ceremony.md
@@ -1,10 +1,10 @@
 # Key Ceremony
 
-This chapter details the cryptographic key generation procedures required for an air-gapped Vouch deployment. All key generation should be performed on a trusted, air-gapped workstation following your organization's key ceremony procedures.
+This chapter covers generating the keys an air-gapped Vouch deployment needs. Generate every key on a trusted, air-gapped workstation, following your organization's key ceremony procedures.
 
 ## JWT Secret Generation (Required)
 
-The JWT secret is used to sign all OAuth tokens and session cookies. It must be at least 32 characters.
+The JWT secret signs internal state tokens — authorization codes, WebAuthn challenge state, and CSRF tokens. It must be at least 32 characters.
 
 ```bash
 # Generate cryptographically secure 64-character secret
@@ -23,7 +23,7 @@ head -c 48 /dev/urandom | base64
 
 ## SSH CA Key Generation (Ed25519)
 
-The SSH CA signs user SSH certificates. If not provided, SSH certificate issuance will be disabled.
+The SSH CA signs user SSH certificates. Provision the key deliberately: if none is provided, the server generates one at `./ssh_ca_key` on first start (see the auto-generation warning in [Key Management](../configuration/keys.md#ssh-ca-key)). Set `VOUCH_SSH_CA_KEY_PATH=""` to disable the SSH CA.
 
 ```bash
 # Generate Ed25519 SSH CA key pair (no passphrase for automated use)
@@ -56,7 +56,7 @@ export VOUCH_SSH_CA_KEY_PATH="/secrets/ssh_ca_key"
 
 ## OIDC Signing Key Generation (P-256 ECDSA)
 
-The OIDC signing key signs ID tokens using ES256 algorithm. If not provided, an ephemeral key is generated on each server restart (not recommended for production as it invalidates all existing tokens).
+The OIDC signing key signs ID tokens using the ES256 algorithm. If unset, the server generates an ephemeral key at each start, and every previously issued token fails verification.
 
 ```bash
 # Generate P-256 EC private key in PKCS#8 format
@@ -103,7 +103,7 @@ export VOUCH_OIDC_RSA_SIGNING_KEY="$(base64 -i oidc_rsa_key.pem | tr -d '\n')"
 
 ## TLS Certificate Generation
 
-For production, use certificates signed by your internal CA. For testing, self-signed certificates can be used.
+For production, use certificates signed by your internal CA. For testing, use a self-signed certificate.
 
 ```bash
 # Generate EC private key and self-signed certificate

--- a/docs/src/advanced/airgap-yubikey.md
+++ b/docs/src/advanced/airgap-yubikey.md
@@ -1,14 +1,18 @@
 # YubiKey Provisioning
 
-In an air-gapped environment, YubiKey provisioning is done entirely on the internal network through the Vouch server's web UI. This chapter covers the provisioning workflow, hardware requirements, and spare key strategy.
+In an air-gapped environment, YubiKey provisioning happens entirely on the internal network through the Vouch server's web UI. This chapter covers the provisioning workflow, hardware requirements, and spare key strategy.
 
 ## Provisioning Workflow
 
-1. **Administrator** creates a user account via the Vouch server web interface
-2. **User** navigates to `https://auth.internal` on their workstation browser
+1. **User** opens `https://auth.internal/enroll/start` in a browser on their workstation
+2. **User** authenticates with the internal identity provider
 3. **User** inserts their YubiKey and completes the WebAuthn registration flow
 4. **User** sets a PIN on their YubiKey if one is not already configured (minimum 8 characters)
 5. The credential is registered and the user can begin authenticating
+
+There is no admin pre-creation step: enrollment is user-initiated, and the first enrollee from a
+domain becomes that organization's administrator — see
+[Organizations and Administrators](../admin/organizations.md).
 
 ## YubiKey Requirements
 
@@ -18,7 +22,7 @@ In an air-gapped environment, YubiKey provisioning is done entirely on the inter
 
 ## Spare Key Strategy
 
-Each user should register at least two YubiKeys (primary and backup). If a YubiKey is lost or damaged:
+Register at least two YubiKeys per user (primary and backup). If a YubiKey is lost or damaged:
 
 1. User reports lost key to administrator
 2. Administrator revokes the lost key's credential via the web UI

--- a/docs/src/advanced/airgap.md
+++ b/docs/src/advanced/airgap.md
@@ -35,7 +35,7 @@ In an air-gapped environment:
 - Internal identity provider (no Google Workspace)
 - Time sync from isolated NTP or GPS
 
-Vouch's built-in SSH CA and local-first architecture make it well-suited for these constraints.
+Vouch fits these constraints: the SSH CA is built in, and all state lives in a local database, so nothing depends on an external service.
 
 ## Architecture
 

--- a/docs/src/configuration/database.md
+++ b/docs/src/configuration/database.md
@@ -1,6 +1,6 @@
 # Database Setup
 
-Vouch supports three database backends. Choose based on your deployment requirements.
+Vouch supports three database backends.
 
 ## SQLite (Default)
 
@@ -82,4 +82,4 @@ Database migrations are embedded in the server binary and run automatically on s
 | PostgreSQL | `pg_dump` | Daily |
 | Aurora DSQL | AWS automated backups | Continuous |
 
-Always back up before upgrading the Vouch server, as migrations may modify the schema.
+Back up before upgrading the Vouch server: migrations modify the schema, and restoring a backup is the only rollback.

--- a/docs/src/configuration/keys.md
+++ b/docs/src/configuration/keys.md
@@ -1,6 +1,6 @@
 # Key Management
 
-Vouch uses several cryptographic keys. This page covers their lifecycle and rotation.
+Vouch uses seven kinds of cryptographic keys. This page covers their lifecycle and rotation.
 
 ## Key Inventory
 
@@ -56,7 +56,7 @@ looking for the `-----BEGIN` header. The file at `VOUCH_SSH_CA_KEY_PATH` must be
 > certificates, while `/health` stays green. Prefer `VOUCH_SSH_CA_KEY` or
 > `VOUCH_SSH_CA_KMS_KEY_ID` for anything beyond a single-node install — neither auto-generates.
 
-When using KMS, the server calls `kms:Sign` with Ed25519. The KMS key must be an asymmetric signing key with `ECC_EDWARDS_CURVE_25519` key spec. Multi-region keys (`mrk-` prefix) are recommended for high availability.
+When using KMS, the server calls `kms:Sign` with Ed25519. The KMS key must be an asymmetric signing key with `ECC_EDWARDS_CURVE_25519` key spec. Use a multi-region key (`mrk-` prefix) for high availability.
 
 ### Rotation
 
@@ -68,7 +68,7 @@ SSH CA key rotation requires coordinated updates:
 4. Restart the server
 5. After all existing certificates expire (max 8 hours), remove the old public key from hosts
 
-> **Important**: During rotation, hosts should trust both old and new CA public keys to avoid disruption.
+> **Important**: During rotation, keep both the old and new CA public keys in `TrustedUserCAKeys` until step 5 — removing the old key early invalidates certificates that have not yet expired.
 
 ### Public Key Distribution
 
@@ -105,7 +105,7 @@ VOUCH_OIDC_SIGNING_KMS_KEY_ID=mrk-abcd1234efgh5678
 
 If neither is set, an ephemeral key is generated on startup. This means tokens cannot be verified after a server restart unless the same key is provided.
 
-When using KMS, the server calls `kms:Sign` with P-256 ECDSA (`ECC_NIST_P256` key spec). Multi-region keys (`mrk-` prefix) are recommended.
+When using KMS, the server calls `kms:Sign` with P-256 ECDSA (`ECC_NIST_P256` key spec). Use a multi-region key (`mrk-` prefix) for high availability.
 
 ### Generation
 
@@ -144,7 +144,7 @@ Access tokens are always signed with ES256 (the OIDC Signing Key above).
 openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:3072 -out oidc_rsa_key.pem
 ```
 
-A minimum key size of 3072 bits is enforced. Keys smaller than 3072 bits are rejected at startup.
+The server rejects keys smaller than 3072 bits at startup.
 
 ### Configuration
 
@@ -163,7 +163,7 @@ When using KMS, the key must be:
 - Key usage: `SIGN_VERIFY`
 - Signing algorithm: `RSASSA_PKCS1_V1_5_SHA_256`
 
-Multi-region keys (`mrk-` prefix) are recommended.
+Use a multi-region key (`mrk-` prefix) for high availability.
 
 ### Rotation
 
@@ -189,7 +189,7 @@ VOUCH_JWT_SECRET="$(openssl rand -base64 48)"
 VOUCH_JWT_HMAC_KMS_KEY_ID=mrk-5678abcd1234efgh
 ```
 
-When using KMS, the server uses `kms:GenerateMac` and `kms:VerifyMac` with HMAC-SHA256. The KMS key must be a `HMAC_256` key type. Multi-region keys (`mrk-` prefix) are recommended.
+When using KMS, the server uses `kms:GenerateMac` and `kms:VerifyMac` with HMAC-SHA256. The KMS key must be a `HMAC_256` key type. Use a multi-region key (`mrk-` prefix) for high availability.
 
 ### Generation (local secret)
 

--- a/docs/src/configuration/sources.md
+++ b/docs/src/configuration/sources.md
@@ -32,7 +32,7 @@ For production deployments, Vouch supports loading configuration from an S3 obje
 - **Centralized management** — Single source of truth for multi-instance deployments
 - **Dynamic updates** — Configuration changes without server restart (for supported fields)
 - **TLS hot-reload** — Automatic certificate rotation without downtime
-- **Secrets management** — Leverage S3 encryption and IAM for credential protection
+- **Secrets management** — S3 encryption and IAM protect the document's secrets
 
 **Enabling S3 Configuration:**
 
@@ -108,7 +108,7 @@ As an alternative to managing local key material, Vouch supports AWS KMS for sig
 | `VOUCH_OIDC_RSA_SIGNING_KMS_KEY_ID` | RSA-3072 (`RSA_3072`) | `VOUCH_OIDC_RSA_SIGNING_KEY` |
 | `VOUCH_JWT_HMAC_KMS_KEY_ID` | HMAC-256 (`HMAC_256`) | `VOUCH_JWT_SECRET` |
 
-Multi-region keys (`mrk-` prefix) are recommended for high availability. KMS key IDs can also be set in the S3 config (`ssh_ca_kms_key_id`, `oidc_signing_kms_key_id`, `jwt_hmac_kms_key_id`).
+Use multi-region keys (`mrk-` prefix) for high availability. KMS key IDs can also be set in the S3 config (`ssh_ca_kms_key_id`, `oidc_signing_kms_key_id`, `jwt_hmac_kms_key_id`).
 
 See [Key Management](keys.md) for generation and rotation details.
 
@@ -121,7 +121,7 @@ See [Key Management](keys.md) for generation and rotation details.
 
 Non-hot-reloadable fields include: `jwt_secret`, `database_url`, `listen_addr`, `rp_id`, `rp_name`, `session_hours`, `cors_origins`, `allowed_domains`, `dpop.*`, OIDC settings, SAML settings, GitHub App settings, SSH CA key, OIDC signing keys, and all KMS key IDs.
 
-Changes to non-hot-reloadable fields in S3 are silently ignored. A server restart is required to apply them.
+Changes to non-hot-reloadable fields in S3 are silently ignored; restart the server to apply them.
 
 ## TLS Certificate Hot-Reload
 

--- a/docs/src/configuration/tls.md
+++ b/docs/src/configuration/tls.md
@@ -23,7 +23,7 @@ export VOUCH_TLS_CERT="$(base64 -i cert.pem | tr -d '\n')"
 export VOUCH_TLS_KEY="$(base64 -i key.pem | tr -d '\n')"
 ```
 
-Both `VOUCH_TLS_CERT` and `VOUCH_TLS_KEY` must be set together. If only one is provided, the server will fail to start.
+Both `VOUCH_TLS_CERT` and `VOUCH_TLS_KEY` must be set together. If only one is set, the server fails to start.
 
 ### TLS Properties
 

--- a/docs/src/getting-started/overview.md
+++ b/docs/src/getting-started/overview.md
@@ -4,12 +4,12 @@ This section covers deploying the Vouch server for your organization. The server
 
 ## Deployment Checklist
 
-Before deploying, ensure you have:
+Before deploying, you need:
 
 - [ ] **Domain name** — A domain for your Vouch server (e.g., `auth.example.com`)
 - [ ] **TLS certificate** — Valid certificate for your domain (or use Let's Encrypt)
 - [ ] **Database** — SQLite (single node) or PostgreSQL (multi-node)
-- [ ] **Identity provider** — Google Workspace
+- [ ] **Identity provider** — At least one upstream OIDC or SAML IdP (Google Workspace, Entra ID, Okta, or any compliant provider)
 - [ ] **JWT secret** — Cryptographically random string, minimum 32 characters (or use AWS KMS HMAC)
 - [ ] **SSH CA key** (optional) — Ed25519 key pair for signing SSH certificates (or use AWS KMS)
 - [ ] **OIDC signing key** (optional) — P-256 EC key for signing ID tokens (or use AWS KMS)
@@ -46,11 +46,11 @@ Before deploying, ensure you have:
 
 ## Deployment Methods
 
-| Method | Best For | Guide |
-|--------|----------|-------|
-| [Systemd](../install/systemd.md) | Bare metal, VMs, single-node | Production |
-| [Docker](../install/docker.md) | Container-based deployments | Production |
-| [Kubernetes](../install/kubernetes.md) | Multi-node, high availability | Production |
+| Method | Best for |
+|--------|----------|
+| [Systemd](../install/systemd.md) | Bare metal, VMs, single-node |
+| [Docker](../install/docker.md) | Container-based deployments |
+| [Kubernetes](../install/kubernetes.md) | Multi-node, high availability |
 
 ## Configuration
 
@@ -64,7 +64,7 @@ VOUCH_JWT_SECRET=<64-char-secret>    # Session signing secret
 VOUCH_DATABASE_URL=sqlite:vouch.db?mode=rwc  # Database
 ```
 
-For production, you'll also want:
+For production, also set:
 
 ```bash
 VOUCH_TLS_CERT=<base64-encoded-pem>  # TLS certificate
@@ -77,7 +77,7 @@ VOUCH_IDP_GOOGLE_CLIENT_ID=...
 VOUCH_IDP_GOOGLE_CLIENT_SECRET=...
 ```
 
-For AWS deployments, you can use KMS for all signing operations instead of managing local keys. See the [Configuration Reference](../configuration/sources.md) for KMS options.
+AWS deployments can use KMS for all signing operations instead of managing local keys. See the [Configuration Reference](../configuration/sources.md) for KMS options.
 
 ## Sizing
 
@@ -87,12 +87,12 @@ For AWS deployments, you can use KMS for all signing operations instead of manag
 | Memory | 256 MB | 512 MB |
 | Disk | 1 GB (SQLite) | 10 GB (PostgreSQL) |
 
-The server is single-process, async (tokio). Per-session memory overhead is minimal (~2 KB for token metadata). The primary bottleneck is database I/O during token issuance and session validation.
+The server is single-process, async (tokio). Per-session memory overhead is ~2 KB of token metadata. The primary bottleneck is database I/O during token issuance and session validation.
 
 **Database guidance:**
-- **SQLite** — suitable for single-node deployments under ~500 users
-- **PostgreSQL** — recommended for multi-node or >500 users
-- **Aurora DSQL** — for AWS deployments requiring managed infrastructure
+- **SQLite** — single-node deployments under ~500 users
+- **PostgreSQL** — multi-node deployments, or more than 500 users
+- **Aurora DSQL** — AWS deployments using managed database infrastructure
 
 ## Next Steps
 

--- a/docs/src/idp/entra-id.md
+++ b/docs/src/idp/entra-id.md
@@ -93,7 +93,7 @@ VOUCH_ALLOWED_DOMAINS=example.com
 ## Step 5: Test
 
 1. Run `vouch enroll` on a workstation
-2. The browser should redirect to the Microsoft sign-in page
+2. The browser redirects to the Microsoft sign-in page
 3. After signing in, complete the WebAuthn registration with your YubiKey
 
 ## Why personal Microsoft accounts aren't supported
@@ -110,7 +110,7 @@ As a consequence, the `https://login.microsoftonline.com/common/v2.0` issuer is 
 
 **`InvalidIssuer` at the callback**
 
-Make sure the configured issuer ends in `/v2.0`. The v1 endpoints use a different token format and are not compatible with standard OIDC discovery.
+The configured issuer must end in `/v2.0`. The v1 endpoints use a different token format and are not compatible with standard OIDC discovery.
 
 **`Email address is not verified by the identity provider` after sign-in**
 

--- a/docs/src/idp/generic-oidc.md
+++ b/docs/src/idp/generic-oidc.md
@@ -70,26 +70,26 @@ If not set, users from any email domain can enroll (provided they authenticate w
 
 ## Tested Providers
 
-The following providers have been tested with Vouch:
+These providers are tested with Vouch:
 
-| Provider | Status | Notes |
-|----------|--------|-------|
-| Google Workspace | Tested | See [dedicated guide](google-workspace.md) |
-| Microsoft Entra ID | Tested | See [dedicated guide](entra-id.md) |
-| Okta | Tested | Use the Org Authorization Server or a custom one |
-| Keycloak | Tested | Requires a configured realm with client credentials |
-| Auth0 | Tested | Use the tenant issuer URL with trailing slash |
+| Provider | Notes |
+|----------|-------|
+| Google Workspace | See [dedicated guide](google-workspace.md) |
+| Microsoft Entra ID | See [dedicated guide](entra-id.md) |
+| Okta | Use the Org Authorization Server or a custom one |
+| Keycloak | Requires a configured realm with client credentials |
+| Auth0 | Use the tenant issuer URL with trailing slash |
 
 ## Troubleshooting
 
 **"Failed to fetch upstream OIDC discovery document"**
 - Verify the issuer URL is correct and reachable from the server
-- Check that the URL uses HTTPS (HTTP is only allowed for `localhost`)
+- Verify the URL uses HTTPS (HTTP is only allowed for `localhost`)
 - Confirm the discovery endpoint returns valid JSON
 
 **"Issuer mismatch"**
 - The `issuer` field in the discovery document must exactly match the configured `VOUCH_IDP_<SLUG>_ISSUER` value (trailing slashes matter). Entra `/organizations/v2.0` is special-cased automatically — its discovery document returns a `{tenantid}` template that vouch handles transparently. The `/common/v2.0` endpoint is not supported; see [Microsoft Entra ID](./entra-id.md#why-personal-microsoft-accounts-arent-supported).
 
 **Token errors after authentication**
-- Ensure the client secret is correct and not expired
+- Verify the client secret is correct and not expired
 - Verify the redirect URI registered with the IdP exactly matches `https://<your-vouch-domain>/oauth/callback`

--- a/docs/src/idp/google-workspace.md
+++ b/docs/src/idp/google-workspace.md
@@ -71,7 +71,7 @@ VOUCH_ALLOWED_DOMAINS=example.com,subsidiary.com
 ## Step 4: Test
 
 1. Run `vouch enroll` on a workstation
-2. The browser should redirect to Google sign-in
+2. The browser redirects to Google sign-in
 3. After signing in, complete the WebAuthn registration with your YubiKey
 
 ## Claims Mapping
@@ -88,7 +88,7 @@ VOUCH_ALLOWED_DOMAINS=example.com,subsidiary.com
 - Verify the redirect URI exactly matches `https://<your-vouch-domain>/oauth/callback`
 
 **"This app is not verified"**
-- Ensure the OAuth consent screen is set to **Internal** for Google Workspace
+- Set the OAuth consent screen to **Internal** for Google Workspace
 
 **Users from wrong domain can enroll**
 - Set `VOUCH_ALLOWED_DOMAINS` to restrict enrollment to specific email domains

--- a/docs/src/idp/overview.md
+++ b/docs/src/idp/overview.md
@@ -84,7 +84,7 @@ VOUCH_IDP_CORP_SAML_EMAIL_ATTRIBUTE=http://schemas.xmlsoap.org/ws/2005/05/identi
 VOUCH_IDP_CORP_SAML_DOMAIN_ATTRIBUTE=department
 ```
 
-Notes on slug-to-env-var conversion: hyphens in the slug become underscores in env-var names. `corp-saml` becomes `VOUCH_IDP_CORP_SAML_TYPE`, etc.
+Hyphens in the slug become underscores in env-var names: `corp-saml` becomes `VOUCH_IDP_CORP_SAML_*`.
 
 ### S3 configuration
 

--- a/docs/src/idp/saml.md
+++ b/docs/src/idp/saml.md
@@ -119,7 +119,7 @@ VOUCH_ALLOWED_DOMAINS=example.com
 ### Okta
 
 - Metadata URL: found in the Okta SAML app's **Sign On** tab under **Metadata URL**
-- Email attribute: typically `email` or configure in the Okta attribute statements
+- Email attribute: `email`, set in the Okta attribute statements
 - Set the Single Sign-On URL to `https://auth.example.com/saml/acs` and Audience URI to your SP entity ID
 
 ### Google Workspace
@@ -132,12 +132,12 @@ VOUCH_ALLOWED_DOMAINS=example.com
 
 **"Failed to fetch SAML IdP metadata"**
 - Verify the metadata URL is correct and reachable from the server
-- Check that the URL returns valid XML (not an HTML login page)
-- Ensure the server can make outbound HTTPS requests
+- Verify the URL returns valid XML (not an HTML login page)
+- Confirm the server can make outbound HTTPS requests
 
 **Signature verification errors**
 - Confirm the IdP's signing certificate in the metadata is current and not expired
-- Ensure the server clock is synchronized (NTP). SAML assertions have time-based validity windows.
+- Confirm the server clock is NTP-synchronized. SAML assertions have time-based validity windows.
 
 **Email not extracted from assertion**
 - Check the SAML assertion attributes using debug logging (`RUST_LOG=vouch_server=debug`)

--- a/docs/src/install/kubernetes.md
+++ b/docs/src/install/kubernetes.md
@@ -70,7 +70,7 @@ env:
 # - VOUCH_IDP_GOOGLE_CLIENT_SECRET
 existingSecret: ""
 
-# Or create a new secret (not recommended for production)
+# Or create a new secret (puts secret values in this file; use existingSecret in production)
 secrets: {}
   # VOUCH_JWT_SECRET: ""
 

--- a/docs/src/install/systemd.md
+++ b/docs/src/install/systemd.md
@@ -18,7 +18,7 @@ The package installs:
 - Binary at `/usr/bin/vouch-server`
 - Systemd unit at `/etc/systemd/system/vouch-server.service`
 - Default config at `/etc/vouch/vouch.env`
-- Data directory at `/data` (with appropriate permissions)
+- Data directory at `/data` (owned by the `vouch` user, mode `700`)
 
 ## Configure
 

--- a/docs/src/operations/backup-recovery.md
+++ b/docs/src/operations/backup-recovery.md
@@ -108,12 +108,12 @@ If the JWT secret changes (lost or compromised):
 
 1. Stop the server
 2. Restore from backup
-3. Users who enrolled after the backup will need to re-enroll
+3. Users who enrolled after the backup must re-enroll
 4. Start the server
 
 ## Disaster Recovery Testing
 
-Periodically test your recovery procedures:
+Test the recovery procedures before you need them:
 
 1. Restore a database backup to a test environment
 2. Start a test server with production keys

--- a/docs/src/operations/high-availability.md
+++ b/docs/src/operations/high-availability.md
@@ -94,7 +94,7 @@ Set your orchestrator's termination grace period above 30 seconds so it does not
 drain — Kubernetes defaults to 30, which leaves no margin.
 
 The background cleanup and S3 polling tasks are aborted rather than drained; an interrupted cleanup
-pass simply resumes on the next instance's next tick.
+pass resumes on the next instance's next tick.
 
 ## Regional and multi-region notes
 

--- a/docs/src/operations/security-hardening.md
+++ b/docs/src/operations/security-hardening.md
@@ -93,8 +93,8 @@ Applied to every response, with no configuration:
 | `Cache-Control` | `no-cache` (API routes additionally get `no-store, must-revalidate`) |
 | `Strict-Transport-Security` | `max-age=63072000; includeSubDomains; preload` — **only when TLS is configured** |
 
-Note that HSTS is emitted only when Vouch itself terminates TLS. If you terminate at a proxy, the
-proxy must add HSTS.
+HSTS is emitted only when Vouch itself terminates TLS. If you terminate at a proxy, the proxy must
+add HSTS.
 
 ### Content Security Policy
 

--- a/docs/src/operations/troubleshooting.md
+++ b/docs/src/operations/troubleshooting.md
@@ -55,7 +55,7 @@ key, region, and that the instance role has `s3:GetObject` and `s3:HeadObject`.
 
 **`Failed to start mTLS listener`**
 The mTLS listener starts automatically whenever TLS is configured, and a bind failure on its port
-is fatal. Usually the port is already in use; change it with `VOUCH_MTLS_PORT`.
+is fatal. The most common cause is another process on the port; change it with `VOUCH_MTLS_PORT`.
 
 **The server starts but binds the wrong port.**
 Not an error. When TLS is configured, `VOUCH_LISTEN_ADDR` is ignored and the server binds 443 and
@@ -92,8 +92,8 @@ redirect. On Linux, binding below 1024 needs `CAP_NET_BIND_SERVICE`.
 **"Failed to fetch upstream OIDC discovery document"**
 
 1. Verify the configured `VOUCH_IDP_<SLUG>_ISSUER` is correct and reachable: `curl -s $VOUCH_IDP_<SLUG>_ISSUER/.well-known/openid-configuration | jq .issuer`
-2. Check that the issuer URL uses HTTPS (HTTP is only allowed for `localhost`)
-3. Ensure the server can make outbound HTTPS requests (check firewall/proxy)
+2. Verify the issuer URL uses HTTPS (HTTP is only allowed for `localhost`)
+3. Confirm the server can make outbound HTTPS requests (firewall, proxy)
 
 **"Issuer mismatch" during OIDC discovery**
 - The `issuer` field in the discovery document must exactly match `VOUCH_IDP_<SLUG>_ISSUER` (trailing slashes matter)
@@ -103,13 +103,13 @@ redirect. On Linux, binding below 1024 needs `CAP_NET_BIND_SERVICE`.
 
 **"Failed to fetch SAML IdP metadata"**
 - Verify the configured `VOUCH_IDP_<SLUG>_METADATA_URL` is correct and reachable
-- Check that the URL returns XML, not an HTML login page
-- Ensure the server can make outbound HTTPS requests
+- Verify the URL returns XML, not an HTML login page
+- Confirm the server can make outbound HTTPS requests
 
 **SAML signature verification errors**
 - Confirm the IdP's signing certificate in the metadata is current and not expired
-- Ensure the server clock is synchronized via NTP — SAML assertions have time-based validity windows (typically 5 minutes of skew tolerance)
-- Check the IdP assertion signing algorithm matches what the server expects
+- Confirm the server clock is NTP-synchronized — SAML assertions have time-based validity windows (5 minutes of skew tolerance is common)
+- Verify the IdP assertion signing algorithm matches what the server expects
 
 **"Duplicate IdP slug"**
 - Every entry in `VOUCH_IDPS` / `idps[].id` must be unique. Rename one of them.

--- a/docs/src/operations/updates.md
+++ b/docs/src/operations/updates.md
@@ -6,7 +6,7 @@
 
 1. **Read the release notes** for breaking changes
 2. **Back up the database** before upgrading
-3. **Test in staging** if possible
+3. **Test in staging** before production
 
 ### Server Update
 
@@ -45,20 +45,21 @@ sudo dnf upgrade vouch    # RHEL/Fedora
 
 ### Rollback
 
-If an update causes issues:
+To roll back:
 
 1. Stop the server
-2. Restore the database from pre-upgrade backup
+2. Restore the database from the pre-upgrade backup
 3. Install the previous version
 4. Start the server
 
-> **Note**: Database migrations may not be reversible. Always back up before upgrading.
+> Database migrations have no rollback step — restoring the pre-upgrade backup is the rollback.
+> Back up before upgrading.
 
 ## Version Compatibility
 
 - The server is backward-compatible with older CLI versions
 - Upgrade the server first, then clients
-- Major version bumps may require simultaneous client updates (documented in release notes)
+- Release notes call out major versions that require simultaneous client updates
 
 ## Release Channels
 

--- a/docs/src/reference/environment-variables.md
+++ b/docs/src/reference/environment-variables.md
@@ -86,7 +86,7 @@ OIDC IdPs auto-discover authorization, token, and JWKS endpoints from `{issuer}/
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `VOUCH_OIDC_SIGNING_KEY` | No | _(auto-generate)_ | OIDC signing key content (base64-encoded PEM format, P-256 ECDSA). Used for signing access tokens and ID tokens with ES256 algorithm. If not set, an ephemeral key is generated on each server restart (not recommended for production). |
+| `VOUCH_OIDC_SIGNING_KEY` | No | _(auto-generate)_ | OIDC signing key content (base64-encoded PEM format, P-256 ECDSA). Used for signing access tokens and ID tokens with ES256 algorithm. If not set, an ephemeral key is generated on each server restart, and issued tokens fail verification after a restart or across instances. |
 | `VOUCH_OIDC_RSA_SIGNING_KEY` | No | _(auto-generate)_ | OIDC RSA signing key content (base64-encoded PEM format, RSA-3072). Used for signing ID tokens with RS256 algorithm per OIDC Core Section 3.1.3.7 and all AWS credential tokens (`/v1/credentials/aws/token`, serving both STS `AssumeRoleWithWebIdentity` and IAM Identity Center `CreateTokenWithIAM`). Minimum 3072-bit key enforced. If not set, an ephemeral key is generated on each server restart — AWS token verification then breaks after restarts and across multiple instances, so any deployment using the AWS integration must set this (or the KMS variant). |
 
 ## AWS KMS
@@ -168,7 +168,7 @@ These optional variables configure descriptive metadata published in the OAuth 2
 | `VOUCH_RESOURCE_POLICY_URI` | No | `https://vouch.sh/privacy/` | URL of the resource's data-use policy. |
 | `VOUCH_RESOURCE_TOS_URI` | No | `https://vouch.sh/terms/` | URL of the resource's terms of service. |
 
-> **Self-hosters should override the last three.** Their defaults point at Vouch's own site, so a
+> **Override the last three on a self-hosted deployment.** Their defaults point at Vouch's own site, so a
 > deployment that leaves them alone publishes Vouch's documentation, privacy policy, and terms as
 > its own in a document clients read to learn who operates the resource. Point them at your
 > organization's pages.
@@ -183,7 +183,7 @@ The server publishes a security.txt document at `/.well-known/security.txt` with
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `VOUCH_SECURITY_CONTACT` | No | `security@vouch.sh` | Contact email published in `security.txt`. Self-hosters should set this — the default routes vulnerability reports about your deployment to Vouch's security team. |
+| `VOUCH_SECURITY_CONTACT` | No | `security@vouch.sh` | Contact email published in `security.txt`. Set this on a self-hosted deployment — the default routes vulnerability reports about your deployment to Vouch's security team. |
 
 ## CLI Download URLs
 

--- a/docs/src/reference/s3-config-schema.md
+++ b/docs/src/reference/s3-config-schema.md
@@ -159,7 +159,7 @@ All certificate and key fields in the S3 configuration must be **base64-encoded 
 base64 -i cert.pem | tr -d '\n'
 ```
 
-This ensures proper handling of newlines and special characters within JSON values.
+Base64 encoding keeps multi-line PEM content in a single JSON string value.
 
 ## Hot-Reloadable vs Startup-Only Fields
 


### PR DESCRIPTION
## Summary

Sweep of the operator mdBook (`docs/`) for direct, Amazon-style prose. 24 of 38 pages changed; prose only, no structural reorganization.

- **Hedges replaced with stated consequences** — "not recommended for production" now says what breaks ("issued tokens fail verification after a restart"); "migrations may not be reversible" now says "migrations have no rollback step — restoring the pre-upgrade backup is the rollback".
- **Passive recommendations turned into imperatives** — five instances of "Multi-region keys are recommended" are now "Use a multi-region key (`mrk-` prefix) for high availability"; "key generation should be performed on" is now "Generate every key on".
- **Vague qualifiers replaced with facts** — "with appropriate permissions" → "owned by the `vouch` user, mode `700`"; "memory overhead is minimal" → "~2 KB of token metadata"; "several cryptographic keys" → "seven kinds".
- **Filler removed** — "Note that", "Leverage", "simply", "There are several options for…", prose "etc.", "The browser should redirect" → "redirects", "Ensure" → "Verify"/"Confirm" in troubleshooting checklists.
- **Content-free table columns dropped** — the deployment-methods "Guide" column (every row said "Production") and the tested-providers "Status" column (every row said "Tested").

## Factual corrections

Four statements had drifted from the authoritative pages:

1. `getting-started/overview.md` — the checklist named Google Workspace as *the* identity provider; any OIDC/SAML IdP works.
2. `advanced/airgap-key-ceremony.md` and the airgap-installation key table — said the JWT secret "signs all OAuth tokens and session cookies"; it signs internal state tokens (authorization codes, WebAuthn state, CSRF), per `configuration/keys.md` and the env-var reference.
3. `advanced/airgap-key-ceremony.md` — said a missing SSH CA key disables SSH issuance; the server auto-generates one at `./ssh_ca_key`, the behavior `keys.md` warns about. Now links that warning.
4. `advanced/airgap-yubikey.md` — the workflow began with an administrator creating a user account, which `admin/organizations.md` lists as something admins cannot do. Rewritten as the user-initiated `/enroll/start` flow.

## Verification

- `make docs-build` passes
- Weasel-pattern sweep (`rg` over `docs/src`) returns no remaining hits
- Diff is confined to `docs/src/*.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown documentation changes only; no runtime, auth, or deployment logic is modified.
> 
> **Overview**
> **Documentation-only** sweep of `docs/src` (~24 pages): no code or structural changes.
> 
> The edits **tighten operator-facing prose** — passive recommendations become imperatives (for example KMS multi-region keys), vague qualifiers become concrete facts (`/data` owned by `vouch`, mode `700`), and hedges like “not recommended for production” are replaced with **what actually breaks** (ephemeral OIDC keys, migration rollback via backup only). Filler (“Note that”, “Leverage”, “should redirect”) is trimmed; SCIM and troubleshooting checklists use direct **Verify/Confirm** wording. Deployment and tested-provider tables lose columns that added no information (every row “Production” / “Tested”).
> 
> **Factual corrections** align the guide with current behavior: deployment checklist IdP is any OIDC/SAML provider (not only Google Workspace); **JWT secret** is documented as signing internal state tokens, not OAuth sessions; **SSH CA** documents auto-generation at `./ssh_ca_key` instead of “disabled if missing”; **air-gap YubiKey** flow is user-initiated `/enroll/start` without admin pre-creation, with a link to organizations docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1de7595b46cb31d28b8b6e94c5bf84a104294fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->