### PR TITLE
feat(cli): verify assumability of discovered and existing aws profiles

### DIFF
--- a/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
+++ b/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
@@ -808,22 +808,14 @@ aws-err-region-partition-mismatch =
 aws-err-target-role-trust-missing =
     AWS denied assuming { $role_arn } through the management role.
 
-    If the role's trust policy does not yet trust { -product }, ask an
-    administrator to add this statement to the role's trust-policy
-    Statement array (required for roles assigned via account access
-    manager, which only trust the account-access service by default):
+    If the role's trust policy does not yet trust { -product }, ask an administrator to add this statement to the role's trust-policy Statement array (required for roles assigned via account access manager, which only trust the account-access service by default):
 
     { $statement }
 
-    Keep the aws:SourceIdentity condition and adjust its pattern to your
-    organization's email domain — without it, anyone who can assume the
-    management role could assume this role.
+    Keep the aws:SourceIdentity condition and adjust its pattern to your organization's email domain — without it, anyone who can assume the management role could assume this role.
 
-    Also verify the management role { $management_role } has an IAM policy
-    allowing sts:AssumeRole on this role. If the trust statement is already
-    present, the denial may instead come from a service control policy, a
-    permissions boundary, or an aws:SourceIdentity condition that does not
-    match your identity.
+    Also verify the management role { $management_role } has an IAM policy allowing sts:AssumeRole on this role.
+    If the trust statement is already present, the denial may instead come from a service control policy, a permissions boundary, an aws:SourceIdentity condition that does not match your identity, or a role that does not currently exist.
 
 sso-portal-err-token-expired = Identity Center access token is invalid or expired. Run '{ -cmd } login' to re-authenticate.
 
@@ -1158,6 +1150,23 @@ setup-aws-discover-skipped = Skipped [{ $profile }] — already exists
 setup-aws-entitlements-invalid-skipped = Skipped entitlement — invalid role or account: { $role_arn }
 setup-aws-entitlements-name-taken = Skipped entitlement for { $role_arn } — profile name [{ $profile }] is already in use by a different profile. The entitlement was NOT configured; rename or remove the existing profile and re-run discovery.
 setup-aws-entitlements-partial = Warning: { $failed } of { $total } entitlement queries failed; entitlement results may be incomplete. Re-run discovery to retry.
+setup-aws-entitlements-added-verified = Added profile [{ $profile }] → { $role_arn } (verified — the management role can assume it)
+setup-aws-entitlements-existing-verified = Profile [{ $profile }] → { $role_arn } already exists (verified — the management role can assume it)
+setup-aws-entitlements-not-assumable-skipped =
+    Entitled role { $role_arn } is NOT assumable — profile [{ $profile }] was not written: the management role was denied sts:AssumeRole on this role.
+setup-aws-entitlements-existing-trust-missing =
+    Profile [{ $profile }] → { $role_arn } already exists but is NOT currently assumable: the management role was denied sts:AssumeRole on this role. The profile was kept.
+setup-aws-entitlements-trust-remediation =
+    Ask an administrator to add this statement to the role's trust-policy Statement array:
+
+    { $statement }
+
+    Keep the aws:SourceIdentity condition and adjust its pattern to your organization's email domain.
+    Also verify the management role { $management_role } has an IAM policy allowing sts:AssumeRole on this role.
+    AWS returns the same denial when the role does not currently exist (for example, infrastructure that is provisioned on demand).
+setup-aws-entitlements-rerun-hint = Re-run '{ -cmd } setup aws --discover' once access is granted to add the profile.
+setup-aws-sweep-assignment-stale = Profile [{ $profile }] — its Identity Center assignment ({ $account } / { $permission_set }) no longer exists. The profile was kept; remove it manually if unwanted.
+setup-aws-sweep-summary = Checked { $checked } existing profiles; { $issues } not currently usable.
 setup-aws-discover-added = Added profile [{ $profile }] → { $role_arn }
 # Numeric arms ride as FluentValue::Number so locales can plural-form the
 # noun (e.g. "0 profil/1 profil/2 profile" rules).

--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -492,6 +492,7 @@ async fn assume_role_via_management_chain(
         // Plumbed but not yet fed: populating it requires a CreateTokenWithIAM
         // call on this path, which is deferred (#623).
         identity_context: None,
+        duration_seconds: 3600,
     })
     .await;
 
@@ -523,7 +524,7 @@ async fn assume_role_via_management_chain(
 /// session is not email-shaped (the `sub` is capped at 64 chars, so a very
 /// long email could also land here with a truncated domain — the printed
 /// statement is remediation text, not applied policy).
-fn source_identity_pattern(session: &str) -> String {
+pub(crate) fn source_identity_pattern(session: &str) -> String {
     // At the 64-char RoleSessionName cap the domain may be cut mid-way; a
     // derived pattern like `*@exampl` would look plausible but be wrong.
     // Fail closed with the obviously-editable placeholder instead.
@@ -545,7 +546,10 @@ fn source_identity_pattern(session: &str) -> String {
 /// Deliberately excludes `sts:RoleAuthorizedByIdp` — that condition key is
 /// defined only for `AssumeRoleWithWebIdentity` and can never match on a
 /// plain `AssumeRole` hop.
-fn chained_role_trust_statement(management_role_arn: &str, source_identity: &str) -> String {
+pub(crate) fn chained_role_trust_statement(
+    management_role_arn: &str,
+    source_identity: &str,
+) -> String {
     serde_json::to_string_pretty(&serde_json::json!({
         "Effect": "Allow",
         "Principal": { "AWS": management_role_arn },
@@ -759,6 +763,10 @@ pub(crate) struct ManagementRoleSession {
     /// RS256 token pinned to the management role; doubles as the
     /// `CreateTokenWithIAM` jwt-bearer assertion.
     pub(crate) id_token: SecretString,
+    /// The token's `sub` claim — the `RoleSessionName` used on both chain
+    /// hops, so downstream probes appear in CloudTrail under the same
+    /// session identity as real vends.
+    pub(crate) role_session_name: String,
     /// The token's `email` claim — the Identity Store lookup key.
     /// `None` when the server did not include an email claim.
     pub(crate) user_email: Option<String>,
@@ -826,6 +834,7 @@ pub(crate) async fn assume_management_role(
     Ok(ManagementRoleSession {
         credentials,
         id_token,
+        role_session_name: session,
         user_email,
     })
 }

--- a/crates/vouch-cli/src/commands/setup/aws.rs
+++ b/crates/vouch-cli/src/commands/setup/aws.rs
@@ -1268,33 +1268,21 @@ mod tests {
     #[test]
     fn test_discover_credential_process_embeds_idc_application() {
         let vouch_path = std::path::Path::new("/usr/local/bin/vouch");
-        let app_arn = "arn:aws:sso::123456789012:application/ssoins-abc/apl-xyz";
-        let account_id = "111111111111";
-        let role_name = "ReadOnly";
 
-        let credential_process = format!(
-            "\"{}\" credential aws --idc-application {} --account {} --permission-set \"{}\"",
-            vouch_path.display(),
-            app_arn,
-            account_id,
-            role_name,
-        );
+        let credential_process = crate::integrations::aws::CredentialProcessLine::IdentityCenter {
+            application_arn: Some(
+                "arn:aws:sso::123456789012:application/ssoins-abc/apl-xyz".to_string(),
+            ),
+            account: "111111111111".to_string(),
+            permission_set: "ReadOnly".to_string(),
+        }
+        .render(vouch_path);
 
-        assert!(
-            credential_process.contains("--idc-application"),
-            "credential_process must include --idc-application: {credential_process}"
-        );
-        assert!(
-            credential_process.contains(app_arn),
-            "credential_process must embed the application ARN: {credential_process}"
-        );
-        assert!(
-            credential_process.contains(&format!("--account {account_id}")),
-            "credential_process must include --account: {credential_process}"
-        );
-        assert!(
-            credential_process.contains(&format!("--permission-set \"{role_name}\"")),
-            "credential_process must include --permission-set: {credential_process}"
+        assert_eq!(
+            credential_process,
+            "\"/usr/local/bin/vouch\" credential aws \
+             --idc-application arn:aws:sso::123456789012:application/ssoins-abc/apl-xyz \
+             --account 111111111111 --permission-set ReadOnly"
         );
     }
 

--- a/crates/vouch-cli/src/commands/setup/aws.rs
+++ b/crates/vouch-cli/src/commands/setup/aws.rs
@@ -10,6 +10,8 @@
 //! - Identity Center: `--management-role <arn> --identity-center-application <arn>
 //!   --region <region> [--discover]` — stores org + IdC, optionally enumerates.
 
+use std::collections::{BTreeMap, BTreeSet};
+
 use anyhow::{Context, Result};
 use inquire::{Confirm, InquireError, Select, Text};
 use vouch_cli::{tr, tr_args, tr_println};
@@ -491,8 +493,7 @@ async fn run_discover(
     let mut aws_config = load_or_create_aws_config()?;
     let mut created_count: u32 = 0;
     let mut skipped_count: u32 = 0;
-    let mut assignments: std::collections::BTreeSet<(String, String)> =
-        std::collections::BTreeSet::new();
+    let mut assignments: BTreeSet<(String, String)> = BTreeSet::new();
 
     for account in &accounts {
         let roles = list_account_roles(&http_client, &idc.region, &idc_token, &account.account_id)
@@ -575,7 +576,7 @@ async fn run_discover(
         Ok(probed) => probed,
         Err(err) => {
             tracing::debug!("entitlement discovery skipped: {err:#}");
-            std::collections::BTreeSet::new()
+            BTreeSet::new()
         }
     };
     validate_existing_profiles(&ctx, &aws_config, &assignments, &probed).await;
@@ -623,7 +624,7 @@ async fn discover_entitlements(
     aws_config: &mut AwsConfig,
     created: &mut u32,
     skipped: &mut u32,
-) -> Result<std::collections::BTreeSet<String>> {
+) -> Result<BTreeSet<String>> {
     use crate::integrations::aws::account_access::{self, AamPrincipal};
     use crate::integrations::aws::{identitystore, sso_admin};
     use vouch_common::aws::Partition;
@@ -634,19 +635,19 @@ async fn discover_entitlements(
             "entitlement discovery skipped: account access manager is not available \
              in the {region} region's partition"
         );
-        return Ok(std::collections::BTreeSet::new());
+        return Ok(BTreeSet::new());
     }
 
     let Some(email) = input.user_email else {
         tracing::debug!("entitlement discovery skipped: server token has no email claim");
-        return Ok(std::collections::BTreeSet::new());
+        return Ok(BTreeSet::new());
     };
 
     let instances = sso_admin::list_instances(input.http_client, region, &input.creds).await?;
     let Some(identity_store_id) = resolve_identity_store(&instances, &input.idc.application_arn)
     else {
         tracing::debug!("entitlement discovery skipped: could not resolve the identity store");
-        return Ok(std::collections::BTreeSet::new());
+        return Ok(BTreeSet::new());
     };
 
     let user_id = match identitystore::get_user_id(
@@ -661,7 +662,7 @@ async fn discover_entitlements(
         Ok(user_id) => user_id,
         Err(err) if crate::exit_code::aws_error_code_matches(&err, "ResourceNotFoundException") => {
             tracing::debug!("entitlement discovery skipped: no Identity Center user for {email}");
-            return Ok(std::collections::BTreeSet::new());
+            return Ok(BTreeSet::new());
         }
         Err(err) => return Err(err),
     };
@@ -679,7 +680,7 @@ async fn discover_entitlements(
         account_access::list_applications(input.http_client, region, &input.creds).await?;
     if applications.is_empty() {
         tracing::debug!("entitlement discovery: no account access manager application");
-        return Ok(std::collections::BTreeSet::new());
+        return Ok(BTreeSet::new());
     }
 
     let mut principals = vec![AamPrincipal::User(user_id)];
@@ -718,7 +719,7 @@ async fn discover_entitlements(
         }
     }
 
-    let mut entitled = std::collections::BTreeMap::new();
+    let mut entitled = BTreeMap::new();
     let mut failed: u32 = 0;
     let mut first_error: Option<anyhow::Error> = None;
     while let Some(joined) = join_set.join_next().await {
@@ -762,7 +763,7 @@ async fn discover_entitlements(
         if failed == 0 {
             tracing::debug!("entitlement discovery: no entitlements for {email}");
         }
-        return Ok(std::collections::BTreeSet::new());
+        return Ok(BTreeSet::new());
     }
 
     Ok(write_entitled_profiles(entitled.values(), input, aws_config, created, skipped).await)
@@ -786,7 +787,7 @@ async fn write_entitled_profiles<'a>(
     aws_config: &mut AwsConfig,
     created: &mut u32,
     skipped: &mut u32,
-) -> std::collections::BTreeSet<String> {
+) -> BTreeSet<String> {
     // Validate names and collisions first, collecting the roles to probe.
     let mut targets = Vec::new();
     for role in roles {
@@ -829,7 +830,7 @@ async fn write_entitled_profiles<'a>(
 
     // Probe concurrently, then report and write in input order. A confirmed
     // denial gates the write of a new profile.
-    let mut probed = std::collections::BTreeSet::new();
+    let mut probed = BTreeSet::new();
     for (target, probe) in probe_targets(input, targets).await {
         let usable = report_probe_outcome(input, &target, &probe);
         match target.disposition {
@@ -918,7 +919,7 @@ async fn probe_targets(
         });
     }
 
-    let mut results = std::collections::BTreeMap::new();
+    let mut results = BTreeMap::new();
     while let Some(joined) = join_set.join_next().await {
         // A panicked task leaves its slot empty and reports as inconclusive.
         if let Ok((index, result)) = joined {
@@ -1029,8 +1030,8 @@ fn print_trust_remediation(input: &DiscoveryContext<'_>) {
 async fn validate_existing_profiles(
     ctx: &DiscoveryContext<'_>,
     aws_config: &AwsConfig,
-    assignments: &std::collections::BTreeSet<(String, String)>,
-    probed: &std::collections::BTreeSet<String>,
+    assignments: &BTreeSet<(String, String)>,
+    probed: &BTreeSet<String>,
 ) {
     use crate::integrations::aws::CredentialProcessLine;
 

--- a/crates/vouch-cli/src/commands/setup/aws.rs
+++ b/crates/vouch-cli/src/commands/setup/aws.rs
@@ -377,29 +377,21 @@ fn store_org(
 
 /// Write a `vouch credential aws --role <arn>` profile into `~/.aws/config`.
 ///
-/// When `management_role` differs from `role_arn`, the generated
-/// `credential_process` includes `--via <management_role>` so the CLI can
-/// chain through the correct management role in multi-org configurations.
 /// The `credential_process` line for an STS role profile.
 ///
 /// Includes `--via` when chaining through a management role that differs
-/// from the target role.
+/// from the target role, so the CLI chains through the correct management
+/// role in multi-org configurations.
 fn sts_credential_process(
     vouch_path: &std::path::Path,
     role_arn: &str,
     management_role: &str,
 ) -> String {
-    if management_role != role_arn {
-        format!(
-            "\"{}\" credential aws --role {role_arn} --via {management_role}",
-            vouch_path.display()
-        )
-    } else {
-        format!(
-            "\"{}\" credential aws --role {role_arn}",
-            vouch_path.display()
-        )
+    crate::integrations::aws::CredentialProcessLine::Role {
+        role_arn: role_arn.to_string(),
+        via: (management_role != role_arn).then(|| management_role.to_string()),
     }
+    .render(vouch_path)
 }
 
 fn write_sts_profile(
@@ -499,6 +491,8 @@ async fn run_discover(
     let mut aws_config = load_or_create_aws_config()?;
     let mut created_count: u32 = 0;
     let mut skipped_count: u32 = 0;
+    let mut assignments: std::collections::BTreeSet<(String, String)> =
+        std::collections::BTreeSet::new();
 
     for account in &accounts {
         let roles = list_account_roles(&http_client, &idc.region, &idc_token, &account.account_id)
@@ -511,6 +505,7 @@ async fn run_discover(
             })?;
 
         for role in &roles {
+            assignments.insert((account.account_id.clone(), role.role_name.clone()));
             let safe_name = sanitize_profile_name(&account.account_name);
             let name_part = if safe_name.is_empty() {
                 account.account_id.clone()
@@ -534,13 +529,14 @@ async fn run_discover(
 
             aws_config.set_profile(&AwsProfile {
                 name: profile_name.clone(),
-                credential_process: Some(format!(
-                    "\"{}\" credential aws --idc-application {} --account {} --permission-set \"{}\"",
-                    vouch_path.display(),
-                    idc.application_arn,
-                    account.account_id,
-                    role.role_name,
-                )),
+                credential_process: Some(
+                    crate::integrations::aws::CredentialProcessLine::IdentityCenter {
+                        application_arn: Some(idc.application_arn.clone()),
+                        account: account.account_id.clone(),
+                        permission_set: role.role_name.clone(),
+                    }
+                    .render(&vouch_path),
+                ),
                 region: None,
                 output: Some("json".to_string()),
             });
@@ -557,25 +553,32 @@ async fn run_discover(
     // Entitlement pass — best-effort: failures are debug-logged only and
     // the permission-set results above still land.
     let user_email = mgmt_session.user_email;
-    let creds = std::sync::Arc::new(mgmt_session.credentials);
-    if let Err(err) = discover_entitlements(
-        EntitlementDiscovery {
-            http_client: &http_client,
-            idc,
-            management_role,
-            user_email: user_email.as_deref(),
-            creds,
-            vouch_path: &vouch_path,
-            profile_prefix,
-        },
+    let role_session_name = mgmt_session.role_session_name;
+    let ctx = DiscoveryContext {
+        http_client: &http_client,
+        idc,
+        management_role,
+        role_session_name: &role_session_name,
+        user_email: user_email.as_deref(),
+        creds: std::sync::Arc::new(mgmt_session.credentials),
+        vouch_path: &vouch_path,
+        profile_prefix,
+    };
+    let probed = match discover_entitlements(
+        &ctx,
         &mut aws_config,
         &mut created_count,
         &mut skipped_count,
     )
     .await
     {
-        tracing::debug!("entitlement discovery skipped: {err:#}");
-    }
+        Ok(probed) => probed,
+        Err(err) => {
+            tracing::debug!("entitlement discovery skipped: {err:#}");
+            std::collections::BTreeSet::new()
+        }
+    };
+    validate_existing_profiles(&ctx, &aws_config, &assignments, &probed).await;
 
     if created_count > 0 {
         aws_config.save()?;
@@ -590,11 +593,14 @@ async fn run_discover(
     Ok(())
 }
 
-/// Inputs to the account access manager entitlement pass.
-struct EntitlementDiscovery<'a> {
+/// Shared inputs for the entitlement pass and the existing-profile sweep.
+struct DiscoveryContext<'a> {
     http_client: &'a reqwest::Client,
     idc: &'a AwsIdentityCenter,
     management_role: &'a str,
+    /// The management session's `RoleSessionName` (the JWT `sub`), reused
+    /// for probe hops so CloudTrail shows one session identity per human.
+    role_session_name: &'a str,
     user_email: Option<&'a str>,
     creds: std::sync::Arc<crate::integrations::aws::sts::StsCredentials>,
     vouch_path: &'a std::path::Path,
@@ -609,12 +615,15 @@ struct EntitlementDiscovery<'a> {
 /// identity store) are debug-logged and return `Ok`; real failures propagate
 /// for the caller's debug log. Only findings are user-visible: added/skipped
 /// profile lines, dropped invalid entitlements, and partial-failure warnings.
+///
+/// Returns the role ARNs whose assumability was probed, so the
+/// existing-profile sweep does not probe them again.
 async fn discover_entitlements(
-    input: EntitlementDiscovery<'_>,
+    input: &DiscoveryContext<'_>,
     aws_config: &mut AwsConfig,
     created: &mut u32,
     skipped: &mut u32,
-) -> Result<()> {
+) -> Result<std::collections::BTreeSet<String>> {
     use crate::integrations::aws::account_access::{self, AamPrincipal};
     use crate::integrations::aws::{identitystore, sso_admin};
     use vouch_common::aws::Partition;
@@ -625,19 +634,19 @@ async fn discover_entitlements(
             "entitlement discovery skipped: account access manager is not available \
              in the {region} region's partition"
         );
-        return Ok(());
+        return Ok(std::collections::BTreeSet::new());
     }
 
     let Some(email) = input.user_email else {
         tracing::debug!("entitlement discovery skipped: server token has no email claim");
-        return Ok(());
+        return Ok(std::collections::BTreeSet::new());
     };
 
     let instances = sso_admin::list_instances(input.http_client, region, &input.creds).await?;
     let Some(identity_store_id) = resolve_identity_store(&instances, &input.idc.application_arn)
     else {
         tracing::debug!("entitlement discovery skipped: could not resolve the identity store");
-        return Ok(());
+        return Ok(std::collections::BTreeSet::new());
     };
 
     let user_id = match identitystore::get_user_id(
@@ -652,7 +661,7 @@ async fn discover_entitlements(
         Ok(user_id) => user_id,
         Err(err) if crate::exit_code::aws_error_code_matches(&err, "ResourceNotFoundException") => {
             tracing::debug!("entitlement discovery skipped: no Identity Center user for {email}");
-            return Ok(());
+            return Ok(std::collections::BTreeSet::new());
         }
         Err(err) => return Err(err),
     };
@@ -670,7 +679,7 @@ async fn discover_entitlements(
         account_access::list_applications(input.http_client, region, &input.creds).await?;
     if applications.is_empty() {
         tracing::debug!("entitlement discovery: no account access manager application");
-        return Ok(());
+        return Ok(std::collections::BTreeSet::new());
     }
 
     let mut principals = vec![AamPrincipal::User(user_id)];
@@ -753,22 +762,33 @@ async fn discover_entitlements(
         if failed == 0 {
             tracing::debug!("entitlement discovery: no entitlements for {email}");
         }
-        return Ok(());
+        return Ok(std::collections::BTreeSet::new());
     }
 
-    write_entitled_profiles(entitled.values(), &input, aws_config, created, skipped);
-    Ok(())
+    Ok(write_entitled_profiles(entitled.values(), input, aws_config, created, skipped).await)
 }
 
 /// Validate each entitled role and append its `--role`/`--via` profile,
 /// updating the shared discovery counters.
-fn write_entitled_profiles<'a>(
+///
+/// Every entitled role — candidate or already configured — is probed for
+/// assumability on every pass (the entitlement map does not imply the role
+/// trusts the management role, and a trust statement can be added or
+/// removed at any time). A new profile is written only when the probe does
+/// not confirm a denial, so `~/.aws/config` never gains a dead entry; an
+/// existing profile that fails the probe is reported but kept — removing
+/// operator config is not discovery's call.
+///
+/// Returns the role ARNs that were probed.
+async fn write_entitled_profiles<'a>(
     roles: impl Iterator<Item = &'a crate::integrations::aws::account_access::EntitledRole>,
-    input: &EntitlementDiscovery<'_>,
+    input: &DiscoveryContext<'_>,
     aws_config: &mut AwsConfig,
     created: &mut u32,
     skipped: &mut u32,
-) {
+) -> std::collections::BTreeSet<String> {
+    // Validate names and collisions first, collecting the roles to probe.
+    let mut targets = Vec::new();
     for role in roles {
         let Some(profile_name) = entitled_role_profile_name(role, input.profile_prefix) else {
             tr_println!(
@@ -781,13 +801,12 @@ fn write_entitled_profiles<'a>(
         if let Some(existing) = aws_config.get_profile(&profile_name) {
             match classify_name_collision(&existing, &role.role_arn) {
                 // A prior discovery run already configured this role —
-                // benign, idempotent re-run.
-                NameCollision::SameRole => {
-                    tr_println!(
-                        "setup-aws-discover-skipped",
-                        profile = profile_name.as_str()
-                    );
-                }
+                // re-validate that the assumption still works.
+                NameCollision::SameRole => targets.push(ProbeTarget {
+                    role_arn: role.role_arn.clone(),
+                    profile_name,
+                    disposition: Disposition::Existing,
+                }),
                 // Cross-mechanism collision: the existing profile vends
                 // something else, and the entitlement was NOT configured.
                 NameCollision::Foreign => {
@@ -796,27 +815,301 @@ fn write_entitled_profiles<'a>(
                         profile = profile_name.as_str(),
                         role_arn = role.role_arn.as_str()
                     );
+                    *skipped = skipped.saturating_add(1);
                 }
             }
-            *skipped = skipped.saturating_add(1);
             continue;
         }
-        aws_config.set_profile(&AwsProfile {
-            name: profile_name.clone(),
-            credential_process: Some(sts_credential_process(
-                input.vouch_path,
-                &role.role_arn,
-                input.management_role,
-            )),
-            region: None,
-            output: Some("json".to_string()),
+        targets.push(ProbeTarget {
+            role_arn: role.role_arn.clone(),
+            profile_name,
+            disposition: Disposition::Added,
         });
+    }
+
+    // Probe concurrently, then report and write in input order. A confirmed
+    // denial gates the write of a new profile.
+    let mut probed = std::collections::BTreeSet::new();
+    for (target, probe) in probe_targets(input, targets).await {
+        let usable = report_probe_outcome(input, &target, &probe);
+        match target.disposition {
+            Disposition::Added if usable => {
+                aws_config.set_profile(&AwsProfile {
+                    name: target.profile_name.clone(),
+                    credential_process: Some(sts_credential_process(
+                        input.vouch_path,
+                        &target.role_arn,
+                        input.management_role,
+                    )),
+                    region: None,
+                    output: Some("json".to_string()),
+                });
+                *created = created.saturating_add(1);
+            }
+            Disposition::Added | Disposition::Existing => {
+                *skipped = skipped.saturating_add(1);
+            }
+        }
+        probed.insert(target.role_arn);
+    }
+    probed
+}
+
+/// Whether the profile being reported was written this pass or already
+/// existed from a prior run — selects the status-line wording only.
+#[derive(Clone, Copy)]
+enum Disposition {
+    Added,
+    Existing,
+}
+
+/// A role profile awaiting an assumability probe.
+struct ProbeTarget {
+    role_arn: String,
+    profile_name: String,
+    disposition: Disposition,
+}
+
+/// Probe each target's chained `AssumeRole` hop — the same call vending
+/// performs, with the region resolved the same way vending resolves it —
+/// with bounded concurrency (the same fan-out shape as the entitlement
+/// queries above). Results return in input order so the printed report
+/// stays deterministic. One CloudTrail `AssumeRole` event per target; the
+/// 900-second minimum duration keeps the unused probe session as short as
+/// AWS allows.
+async fn probe_targets(
+    input: &DiscoveryContext<'_>,
+    targets: Vec<ProbeTarget>,
+) -> Vec<(
+    ProbeTarget,
+    Result<crate::integrations::aws::sts::StsCredentials>,
+)> {
+    use crate::integrations::aws::sts::{AssumeRoleRequest, assume_role};
+
+    let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(4));
+    let mut join_set = tokio::task::JoinSet::new();
+    for (index, target) in targets.iter().enumerate() {
+        let semaphore = std::sync::Arc::clone(&semaphore);
+        let http_client = input.http_client.clone();
+        let creds = std::sync::Arc::clone(&input.creds);
+        let role_session_name = input.role_session_name.to_string();
+        let role_arn = target.role_arn.clone();
+        join_set.spawn(async move {
+            let probe = async {
+                let _permit = semaphore
+                    .acquire_owned()
+                    .await
+                    .context("probe semaphore closed")?;
+                let region = crate::integrations::aws::resolve_region_with_fallback(&role_arn)?;
+                assume_role(AssumeRoleRequest {
+                    http_client: &http_client,
+                    role_arn: &role_arn,
+                    role_session_name: &role_session_name,
+                    region: &region,
+                    source_creds: &creds,
+                    session_policy_names: &[],
+                    session_policy: None,
+                    identity_context: None,
+                    duration_seconds: 900,
+                })
+                .await
+            };
+            (index, probe.await)
+        });
+    }
+
+    let mut results = std::collections::BTreeMap::new();
+    while let Some(joined) = join_set.join_next().await {
+        // A panicked task leaves its slot empty and reports as inconclusive.
+        if let Ok((index, result)) = joined {
+            results.insert(index, result);
+        }
+    }
+    targets
+        .into_iter()
+        .enumerate()
+        .map(|(index, target)| {
+            let result = results
+                .remove(&index)
+                .unwrap_or_else(|| Err(anyhow::anyhow!("probe task failed")));
+            (target, result)
+        })
+        .collect()
+}
+
+/// Print the probe outcome for one profile.
+///
+/// Returns whether the profile should exist: `false` only on a confirmed
+/// AWS access denial. Inconclusive probes (throttling, network, region
+/// resolution) claim nothing and return `true` — a transient fault must
+/// not drop profiles.
+fn report_probe_outcome(
+    input: &DiscoveryContext<'_>,
+    target: &ProbeTarget,
+    probe: &Result<crate::integrations::aws::sts::StsCredentials>,
+) -> bool {
+    let profile_name = target.profile_name.as_str();
+    let role_arn = target.role_arn.as_str();
+    // Denial detection: signature/clock-skew 403s classify as network
+    // errors, not denials — see `CliError::is_aws_access_denied`.
+    match (target.disposition, probe) {
+        (Disposition::Added, Ok(_)) => {
+            tr_println!(
+                "setup-aws-entitlements-added-verified",
+                profile = profile_name,
+                role_arn = role_arn
+            );
+            true
+        }
+        (Disposition::Existing, Ok(_)) => {
+            tr_println!(
+                "setup-aws-entitlements-existing-verified",
+                profile = profile_name,
+                role_arn = role_arn
+            );
+            true
+        }
+        (Disposition::Added, Err(err)) if crate::exit_code::aws_access_denied(err) => {
+            tr_println!(
+                "setup-aws-entitlements-not-assumable-skipped",
+                profile = profile_name,
+                role_arn = role_arn
+            );
+            print_trust_remediation(input);
+            tr_println!("setup-aws-entitlements-rerun-hint");
+            false
+        }
+        (Disposition::Existing, Err(err)) if crate::exit_code::aws_access_denied(err) => {
+            tr_println!(
+                "setup-aws-entitlements-existing-trust-missing",
+                profile = profile_name,
+                role_arn = role_arn
+            );
+            print_trust_remediation(input);
+            false
+        }
+        // Throttling or network says nothing about trust — claim nothing.
+        (Disposition::Added, Err(err)) => {
+            tracing::debug!("entitlement probe inconclusive for {role_arn}: {err:#}");
+            tr_println!(
+                "setup-aws-discover-added",
+                profile = profile_name,
+                role_arn = role_arn
+            );
+            true
+        }
+        (Disposition::Existing, Err(err)) => {
+            tracing::debug!("entitlement probe inconclusive for {role_arn}: {err:#}");
+            tr_println!("setup-aws-discover-skipped", profile = profile_name);
+            true
+        }
+    }
+}
+
+/// Print the trust-statement remediation for a denied probe.
+fn print_trust_remediation(input: &DiscoveryContext<'_>) {
+    use crate::commands::credential::aws::{chained_role_trust_statement, source_identity_pattern};
+
+    let statement = chained_role_trust_statement(
+        input.management_role,
+        &source_identity_pattern(input.role_session_name),
+    );
+    tr_println!(
+        "setup-aws-entitlements-trust-remediation",
+        management_role = input.management_role,
+        statement = statement.as_str()
+    );
+}
+
+/// Health-check every Vouch-managed profile that discovery did not already
+/// touch this run: role-carrying profiles are probed through the management
+/// session (the same hop vending uses); Identity Center profiles are
+/// checked against the assignments the portal returned. Report-only —
+/// nothing is written or removed.
+async fn validate_existing_profiles(
+    ctx: &DiscoveryContext<'_>,
+    aws_config: &AwsConfig,
+    assignments: &std::collections::BTreeSet<(String, String)>,
+    probed: &std::collections::BTreeSet<String>,
+) {
+    use crate::integrations::aws::CredentialProcessLine;
+
+    let mut checked: u32 = 0;
+    let mut issues: u32 = 0;
+    let mut seen = probed.clone();
+    let mut targets = Vec::new();
+    for profile in aws_config.find_all_vouch_profiles() {
+        let Some(line) = profile
+            .credential_process
+            .as_deref()
+            .and_then(CredentialProcessLine::parse)
+        else {
+            continue;
+        };
+        match line {
+            CredentialProcessLine::Role { role_arn, via } => {
+                if !seen.insert(role_arn.clone()) {
+                    continue;
+                }
+                // A profile pinned to a different org's management role
+                // cannot be probed with this run's session.
+                if via.is_some_and(|via| via != ctx.management_role) {
+                    tracing::debug!(
+                        "sweep skipped {}: chained via a different management role",
+                        profile.name
+                    );
+                    continue;
+                }
+                checked = checked.saturating_add(1);
+                if role_arn == ctx.management_role {
+                    // The session in hand is this role — trivially assumable.
+                    tr_println!(
+                        "setup-aws-entitlements-existing-verified",
+                        profile = profile.name.as_str(),
+                        role_arn = role_arn.as_str()
+                    );
+                    continue;
+                }
+                targets.push(ProbeTarget {
+                    role_arn,
+                    profile_name: profile.name,
+                    disposition: Disposition::Existing,
+                });
+            }
+            CredentialProcessLine::IdentityCenter {
+                application_arn,
+                account,
+                permission_set,
+            } => {
+                // An absent `--idc-application` resolves to the configured
+                // org at vend time — treat it as this org's profile.
+                if application_arn.is_some_and(|app| app != ctx.idc.application_arn) {
+                    continue;
+                }
+                checked = checked.saturating_add(1);
+                if !assignments.contains(&(account.clone(), permission_set.clone())) {
+                    issues = issues.saturating_add(1);
+                    tr_println!(
+                        "setup-aws-sweep-assignment-stale",
+                        profile = profile.name.as_str(),
+                        account = account.as_str(),
+                        permission_set = permission_set.as_str()
+                    );
+                }
+            }
+        }
+    }
+    for (target, probe) in probe_targets(ctx, targets).await {
+        if !report_probe_outcome(ctx, &target, &probe) {
+            issues = issues.saturating_add(1);
+        }
+    }
+    if checked > 0 {
         tr_println!(
-            "setup-aws-discover-added",
-            profile = profile_name.as_str(),
-            role_arn = role.role_arn.as_str()
+            "setup-aws-sweep-summary",
+            checked = checked,
+            issues = issues
         );
-        *created = created.saturating_add(1);
     }
 }
 
@@ -832,12 +1125,24 @@ enum NameCollision {
 }
 
 fn classify_name_collision(existing: &AwsProfile, role_arn: &str) -> NameCollision {
-    let same_role = existing
+    use crate::integrations::aws::CredentialProcessLine;
+
+    let same_role = match existing
         .credential_process
         .as_deref()
-        .and_then(crate::integrations::aws::extract_role_from_credential_process)
-        .as_deref()
-        == Some(role_arn);
+        .and_then(CredentialProcessLine::parse)
+    {
+        Some(CredentialProcessLine::Role {
+            role_arn: existing_role,
+            via: _,
+        }) => existing_role == role_arn,
+        Some(CredentialProcessLine::IdentityCenter {
+            application_arn: _,
+            account: _,
+            permission_set: _,
+        })
+        | None => false,
+    };
     if same_role {
         NameCollision::SameRole
     } else {

--- a/crates/vouch-cli/src/integrations/aws/config.rs
+++ b/crates/vouch-cli/src/integrations/aws/config.rs
@@ -101,16 +101,24 @@ impl AwsConfig {
     pub(crate) fn vouch_profiles_with_role(&self) -> Vec<VouchProfile> {
         let mut profiles = Vec::new();
         for profile in self.find_all_vouch_profiles() {
-            let Some(credential_process) = profile.credential_process.as_deref() else {
+            let Some(line) = profile
+                .credential_process
+                .as_deref()
+                .and_then(CredentialProcessLine::parse)
+            else {
                 continue;
             };
-            let Some(role_arn) = extract_role_from_credential_process(credential_process) else {
-                continue;
-            };
-            profiles.push(VouchProfile {
-                name: profile.name,
-                role_arn,
-            });
+            match line {
+                CredentialProcessLine::Role { role_arn, via: _ } => profiles.push(VouchProfile {
+                    name: profile.name,
+                    role_arn,
+                }),
+                CredentialProcessLine::IdentityCenter {
+                    application_arn: _,
+                    account: _,
+                    permission_set: _,
+                } => {}
+            }
         }
         profiles
     }
@@ -153,11 +161,22 @@ impl AwsConfig {
     #[must_use]
     pub(crate) fn find_vouch_profile_for_role(&self, role_arn: &str) -> Option<AwsProfile> {
         self.find_all_vouch_profiles().into_iter().find(|p| {
-            p.credential_process
+            match p
+                .credential_process
                 .as_deref()
-                .and_then(extract_role_from_credential_process)
-                .as_deref()
-                == Some(role_arn)
+                .and_then(CredentialProcessLine::parse)
+            {
+                Some(CredentialProcessLine::Role {
+                    role_arn: existing,
+                    via: _,
+                }) => existing == role_arn,
+                Some(CredentialProcessLine::IdentityCenter {
+                    application_arn: _,
+                    account: _,
+                    permission_set: _,
+                })
+                | None => false,
+            }
         })
     }
 
@@ -251,44 +270,136 @@ impl AwsConfig {
     }
 }
 
-/// Extract the AWS role ARN from a credential_process command.
+/// A vouch `credential_process` command line, as written to `~/.aws/config`.
 ///
-/// Looks for `--role <arn>` in the command string.
-#[must_use]
-pub(crate) fn extract_role_from_credential_process(credential_process: &str) -> Option<String> {
-    // Find --role and extract the next token
-    if let Some(role_start) = credential_process.find("--role") {
-        let after_flag = credential_process
-            .get(role_start.saturating_add(6)..)?
-            .trim_start();
-        // Role ARN is the next whitespace-delimited token
-        let role_arn = after_flag.split_whitespace().next()?;
-        if role_arn.starts_with("arn:aws") {
-            return Some(role_arn.to_string());
-        }
-    }
-    None
+/// This is the single source of truth for the wire format: profiles are
+/// generated with [`CredentialProcessLine::render`] and read back with
+/// [`CredentialProcessLine::parse`], so every consumer (status display,
+/// name-collision classification, the discovery sweep's org-boundary check)
+/// works on typed fields instead of substring extraction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CredentialProcessLine {
+    /// `--role <arn> [--via <management-role-arn>]` — an STS role profile,
+    /// vended directly or chained through a management role.
+    Role {
+        role_arn: String,
+        via: Option<String>,
+    },
+    /// `[--idc-application <arn>] --account <id> --permission-set <name>` —
+    /// an Identity Center permission-set profile. Discovery always writes
+    /// `--idc-application`; when absent, the credential command resolves
+    /// the configured org's Identity Center instead.
+    IdentityCenter {
+        application_arn: Option<String>,
+        account: String,
+        permission_set: String,
+    },
 }
 
-/// Extract an Identity Center target description from a credential_process command.
-///
-/// Looks for `--account <id> --permission-set <name>` and returns a pre-formatted
-/// `"IdC <account>/<permission-set>"` string for status display.
-#[must_use]
-pub(crate) fn extract_idc_target_from_credential_process(
-    credential_process: &str,
-) -> Option<String> {
-    fn extract_flag_value<'a>(s: &'a str, flag: &str) -> Option<&'a str> {
-        let start = s.find(flag)?;
-        let after = s.get(start.saturating_add(flag.len())..)?.trim_start();
-        // Value may be quoted; strip surrounding double-quotes if present.
-        let raw = after.split(|c: char| c.is_ascii_whitespace()).next()?;
-        Some(raw.trim_matches('"'))
+impl CredentialProcessLine {
+    /// Parse a `credential_process` command line.
+    ///
+    /// Tokenizes quote-aware (values may be double-quoted) and matches
+    /// flags as whole tokens, so `--account` can never match inside another
+    /// flag name and a trailing flag with no value is treated as absent.
+    /// Returns `None` for lines that are neither profile form — including a
+    /// `--role` whose value is not an ARN.
+    #[must_use]
+    pub(crate) fn parse(credential_process: &str) -> Option<Self> {
+        let mut role_arn = None;
+        let mut via = None;
+        let mut application_arn = None;
+        let mut account = None;
+        let mut permission_set = None;
+        let mut tokens = tokenize(credential_process).into_iter();
+        while let Some(token) = tokens.next() {
+            match token.as_str() {
+                "--role" => role_arn = tokens.next(),
+                "--via" => via = tokens.next(),
+                "--idc-application" => application_arn = tokens.next(),
+                "--account" => account = tokens.next(),
+                "--permission-set" => permission_set = tokens.next(),
+                _ => {}
+            }
+        }
+        // `arn:aws` also prefixes the GovCloud/China partitions
+        // (`arn:aws-us-gov:`, `arn:aws-cn:`).
+        if let Some(role_arn) = role_arn.filter(|arn| arn.starts_with("arn:aws")) {
+            return Some(Self::Role { role_arn, via });
+        }
+        if let (Some(account), Some(permission_set)) = (account, permission_set) {
+            return Some(Self::IdentityCenter {
+                application_arn,
+                account,
+                permission_set,
+            });
+        }
+        None
     }
 
-    let account = extract_flag_value(credential_process, "--account")?;
-    let ps = extract_flag_value(credential_process, "--permission-set")?;
-    Some(format!("IdC {account}/{ps}"))
+    /// Render the `credential_process` command line for this profile.
+    #[must_use]
+    pub(crate) fn render(&self, vouch_path: &std::path::Path) -> String {
+        match self {
+            Self::Role {
+                role_arn,
+                via: Some(via),
+            } => format!(
+                "\"{}\" credential aws --role {role_arn} --via {via}",
+                vouch_path.display()
+            ),
+            Self::Role {
+                role_arn,
+                via: None,
+            } => format!(
+                "\"{}\" credential aws --role {role_arn}",
+                vouch_path.display()
+            ),
+            // Permission-set names cannot contain whitespace or quotes
+            // (AWS allows only `[\w+=,.@-]`), so the value is unquoted;
+            // parse still accepts quoted values from older configs.
+            Self::IdentityCenter {
+                application_arn: Some(application_arn),
+                account,
+                permission_set,
+            } => format!(
+                "\"{}\" credential aws --idc-application {application_arn} \
+                 --account {account} --permission-set {permission_set}",
+                vouch_path.display()
+            ),
+            Self::IdentityCenter {
+                application_arn: None,
+                account,
+                permission_set,
+            } => format!(
+                "\"{}\" credential aws --account {account} --permission-set {permission_set}",
+                vouch_path.display()
+            ),
+        }
+    }
+}
+
+/// Split a command line into tokens, treating double-quoted spans as part
+/// of the enclosing token (quotes are dropped).
+fn tokenize(line: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+    for c in line.chars() {
+        match c {
+            '"' => in_quotes = !in_quotes,
+            c if c.is_ascii_whitespace() && !in_quotes => {
+                if !current.is_empty() {
+                    tokens.push(std::mem::take(&mut current));
+                }
+            }
+            c => current.push(c),
+        }
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    tokens
 }
 
 #[cfg(test)]
@@ -618,49 +729,143 @@ output = json
     }
 
     #[test]
-    fn test_extract_role_from_credential_process() {
+    fn test_parse_role_line() {
         assert_eq!(
-            extract_role_from_credential_process(
+            CredentialProcessLine::parse(
                 "/usr/local/bin/vouch credential aws --role arn:aws:iam::123456789012:role/MyRole"
             ),
-            Some("arn:aws:iam::123456789012:role/MyRole".to_string())
+            Some(CredentialProcessLine::Role {
+                role_arn: "arn:aws:iam::123456789012:role/MyRole".to_string(),
+                via: None,
+            })
         );
-    }
-
-    #[test]
-    fn test_extract_role_with_extra_spaces() {
+        // Extra whitespace between flag and value.
         assert_eq!(
-            extract_role_from_credential_process(
+            CredentialProcessLine::parse(
                 "vouch credential aws --role   arn:aws:iam::999888777666:role/DevRole"
             ),
-            Some("arn:aws:iam::999888777666:role/DevRole".to_string())
+            Some(CredentialProcessLine::Role {
+                role_arn: "arn:aws:iam::999888777666:role/DevRole".to_string(),
+                via: None,
+            })
         );
-    }
-
-    #[test]
-    fn test_extract_role_govcloud() {
+        // GovCloud partition ARNs share the `arn:aws` prefix.
         assert_eq!(
-            extract_role_from_credential_process(
+            CredentialProcessLine::parse(
                 "vouch credential aws --role arn:aws-us-gov:iam::123456789012:role/GovRole"
             ),
-            Some("arn:aws-us-gov:iam::123456789012:role/GovRole".to_string())
+            Some(CredentialProcessLine::Role {
+                role_arn: "arn:aws-us-gov:iam::123456789012:role/GovRole".to_string(),
+                via: None,
+            })
         );
     }
 
     #[test]
-    fn test_extract_role_no_role_flag() {
+    fn test_parse_chained_role_line() {
         assert_eq!(
-            extract_role_from_credential_process("vouch credential aws"),
-            None
+            CredentialProcessLine::parse(
+                "\"/usr/local/bin/vouch\" credential aws --role arn:aws:iam::1:role/R \
+                 --via arn:aws:iam::2:role/vouch/Hub"
+            ),
+            Some(CredentialProcessLine::Role {
+                role_arn: "arn:aws:iam::1:role/R".to_string(),
+                via: Some("arn:aws:iam::2:role/vouch/Hub".to_string()),
+            })
+        );
+        // A trailing flag with no value is treated as absent, not empty.
+        assert_eq!(
+            CredentialProcessLine::parse("vouch credential aws --role arn:aws:iam::1:role/R --via"),
+            Some(CredentialProcessLine::Role {
+                role_arn: "arn:aws:iam::1:role/R".to_string(),
+                via: None,
+            })
         );
     }
 
     #[test]
-    fn test_extract_role_invalid_arn() {
+    fn test_parse_identity_center_line() {
+        // Older discovery runs quoted the permission-set name; parse must
+        // keep accepting those lines even though render no longer quotes.
         assert_eq!(
-            extract_role_from_credential_process("vouch credential aws --role not-an-arn"),
+            CredentialProcessLine::parse(
+                r#""/usr/local/bin/vouch" credential aws --idc-application arn:aws:sso::1:application/ssoins-x/apl-y --account 111111111111 --permission-set "Admin""#
+            ),
+            Some(CredentialProcessLine::IdentityCenter {
+                application_arn: Some("arn:aws:sso::1:application/ssoins-x/apl-y".to_string()),
+                account: "111111111111".to_string(),
+                permission_set: "Admin".to_string(),
+            })
+        );
+        // `--idc-application` is optional: the credential command resolves
+        // the configured org's Identity Center when it is absent.
+        assert_eq!(
+            CredentialProcessLine::parse(
+                "vouch credential aws --account 111111111111 --permission-set Admin"
+            ),
+            Some(CredentialProcessLine::IdentityCenter {
+                application_arn: None,
+                account: "111111111111".to_string(),
+                permission_set: "Admin".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn test_parse_rejects_non_profile_lines() {
+        // No flags at all.
+        assert_eq!(CredentialProcessLine::parse("vouch credential aws"), None);
+        // A --role value that is not an ARN.
+        assert_eq!(
+            CredentialProcessLine::parse("vouch credential aws --role not-an-arn"),
             None
         );
+        // An Identity Center line needs both --account and --permission-set.
+        assert_eq!(
+            CredentialProcessLine::parse("vouch credential aws --account 111111111111"),
+            None
+        );
+    }
+
+    mod roundtrip {
+        use super::*;
+        use proptest::prelude::*;
+
+        proptest! {
+            /// Every rendered role line parses back to itself.
+            #[test]
+            fn role_line_roundtrips(
+                account in "[0-9]{12}",
+                role_name in "[A-Za-z0-9+=,.@_-]{1,64}",
+                chained in proptest::bool::ANY,
+            ) {
+                let line = CredentialProcessLine::Role {
+                    role_arn: format!("arn:aws:iam::{account}:role/vouch/{role_name}"),
+                    via: chained
+                        .then(|| format!("arn:aws:iam::{account}:role/vouch/Hub")),
+                };
+                let rendered = line.render(std::path::Path::new("/usr/local/bin/vouch"));
+                prop_assert_eq!(CredentialProcessLine::parse(&rendered), Some(line));
+            }
+
+            /// Every rendered Identity Center line parses back to itself.
+            #[test]
+            fn identity_center_line_roundtrips(
+                account in "[0-9]{12}",
+                permission_set in "[A-Za-z0-9+=,.@_-]{1,32}",
+                pinned_application in proptest::bool::ANY,
+            ) {
+                let line = CredentialProcessLine::IdentityCenter {
+                    application_arn: pinned_application.then(|| format!(
+                        "arn:aws:sso::{account}:application/ssoins-1/apl-1"
+                    )),
+                    account,
+                    permission_set,
+                };
+                let rendered = line.render(std::path::Path::new("/usr/local/bin/vouch"));
+                prop_assert_eq!(CredentialProcessLine::parse(&rendered), Some(line));
+            }
+        }
     }
 
     #[test]

--- a/crates/vouch-cli/src/integrations/aws/mod.rs
+++ b/crates/vouch-cli/src/integrations/aws/mod.rs
@@ -17,10 +17,7 @@ pub(crate) mod sso_portal;
 pub(crate) mod sts;
 
 // Re-export commonly used types
-pub(crate) use config::{
-    AwsConfig, AwsProfile, VouchProfile, extract_idc_target_from_credential_process,
-    extract_role_from_credential_process,
-};
+pub(crate) use config::{AwsConfig, AwsProfile, CredentialProcessLine, VouchProfile};
 
 use vouch_cli::{tr, tr_args};
 
@@ -139,23 +136,27 @@ fn named_vouch_profile(config: &AwsConfig, name: &str) -> anyhow::Result<VouchPr
         );
     };
 
-    if let Some(role_arn) = extract_role_from_credential_process(&credential_process) {
-        return Ok(VouchProfile {
+    match CredentialProcessLine::parse(&credential_process) {
+        Some(CredentialProcessLine::Role { role_arn, via: _ }) => Ok(VouchProfile {
             name: name.to_string(),
             role_arn,
-        });
-    }
-
-    if let Some(target) = extract_idc_target_from_credential_process(&credential_process) {
-        return Err(CliError::ConfigError(tr_args!(
+        }),
+        Some(CredentialProcessLine::IdentityCenter {
+            application_arn: _,
+            account,
+            permission_set,
+        }) => Err(CliError::ConfigError(tr_args!(
             "aws-err-profile-is-identity-center",
             profile = name,
-            target = target,
+            target = format!("IdC {account}/{permission_set}"),
         ))
-        .into());
+        .into()),
+        None => Err(CliError::ConfigError(tr_args!(
+            "aws-err-profile-missing-role",
+            profile = name
+        ))
+        .into()),
     }
-
-    Err(CliError::ConfigError(tr_args!("aws-err-profile-missing-role", profile = name)).into())
 }
 
 /// Find a region from an explicit flag, a named profile, then the environment.
@@ -430,10 +431,17 @@ fn check_aws_status(
         .find_all_vouch_profiles()
         .into_iter()
         .map(|p| {
-            let target = p.credential_process.as_ref().and_then(|cp| {
-                extract_role_from_credential_process(cp)
-                    .or_else(|| config::extract_idc_target_from_credential_process(cp))
-            });
+            let target =
+                p.credential_process
+                    .as_deref()
+                    .and_then(|cp| match CredentialProcessLine::parse(cp)? {
+                        CredentialProcessLine::Role { role_arn, via: _ } => Some(role_arn),
+                        CredentialProcessLine::IdentityCenter {
+                            application_arn: _,
+                            account,
+                            permission_set,
+                        } => Some(format!("IdC {account}/{permission_set}")),
+                    });
             ProfileSummary {
                 name: p.name,
                 target,

--- a/crates/vouch-cli/src/integrations/aws/sts.rs
+++ b/crates/vouch-cli/src/integrations/aws/sts.rs
@@ -180,6 +180,10 @@ pub(crate) struct AssumeRoleRequest<'a> {
     /// authorization). Only SigV4 `AssumeRole` accepts it —
     /// `AssumeRoleWithWebIdentity` does not (#623).
     pub identity_context: Option<&'a str>,
+    /// Session duration in seconds (AWS accepts 900–3600 for chained
+    /// sessions). Vending uses 3600; the entitlement assumability probe
+    /// uses 900 since its session is dropped unused.
+    pub duration_seconds: u32,
 }
 
 /// Call AWS STS `AssumeRole` using SigV4-signed form POST.
@@ -196,7 +200,7 @@ pub(crate) async fn assume_role(req: AssumeRoleRequest<'_>) -> Result<StsCredent
 
     // Bind owned values to variables first — sign_and_send_form_post takes &[(&str, &str)]
     // so all values must outlive the params slice. This pattern mirrors redshift.rs.
-    let duration_str = "3600".to_string();
+    let duration_str = req.duration_seconds.to_string();
 
     // Build managed policy ARNs with partition-appropriate prefixes.
     let policy_arns: Vec<String> = req


### PR DESCRIPTION
## Summary

`vouch setup aws --discover` previously wrote a `--role <arn> --via <management-role>` profile for every syntactically valid Account Access Manager entitlement — but an entitlement says nothing about whether the management role can actually assume the role (AAM only validates its own `account-access.amazonaws.com` trust statement, and the SSO portal API refuses to vend entitled roles — verified live with a 403 `ForbiddenException`). Profiles could be written that fail at first use.

Discovery now verifies assumability with the same chained `AssumeRole` hop vending performs:

- **Entitlement pass**: every entitled role — new candidate or already configured — is probed on every run. A confirmed AWS access denial gates the write of a new profile: it is not written, and the output prints the exact trust statement to add (principal = management role, `sts:AssumeRole`/`sts:SetSourceIdentity`/`sts:TagSession`, gated on `aws:SourceIdentity`) plus a re-run hint. Inconclusive probes (throttling, network) fail open and write — a transient fault must not drop profiles.
- **Full-config sweep**: after discovery, every profile in `~/.aws/config` whose `credential_process` invokes vouch is health-checked. Role profiles are probed via the management session (deduped by ARN, skipping roles already probed this run and profiles chained via a different org's management role; a profile targeting the management role itself is trivially verified). Permission-set profiles are cross-checked against the assignments the portal returned — a revoked assignment is flagged with no extra API call. Existing profiles that fail are reported but kept; removal stays the operator's call. A summary line reports checked/unusable counts.
- **Probe mechanics**: probes run through a bounded fan-out (semaphore of 4, results in input order), use the 900-second minimum session duration since the session is dropped unused, resolve the region exactly as vending does (`resolve_region_with_fallback`), and reuse the management session's `RoleSessionName` (the JWT `sub`) so probe and vend events correlate in CloudTrail under one identity. One `AssumeRole` CloudTrail event per role per discover run.

## credential_process is now a typed format

`CredentialProcessLine` (`integrations/aws/config.rs`) owns the wire format: `Role { role_arn, via }` and `IdentityCenter { application_arn, account, permission_set }`, with a quote-aware tokenizer, `parse()`, and `render()` as the only generator. The three substring extractors are deleted and all consumers (profile resolution, status display, collision classification, the sweep) migrated. `--idc-application` is optional in parse (absent = resolve the configured org, matching vend behavior); permission-set values are no longer quoted in render (AWS names are `[\w+=,.@-]`) while parse still accepts quoted lines from older configs; the vouch path keeps double quotes because the AWS SDK — not a shell — parses this line, and single quotes are not quoting characters in its Windows splitter. Proptest round-trips (`parse(render(x)) == x`) lock both variants.

## Other changes

- `AssumeRoleRequest` gained `duration_seconds` (vending unchanged at 3600).
- `ManagementRoleSession` exposes `role_session_name`; `chained_role_trust_statement` / `source_identity_pattern` are `pub(crate)` for reuse.
- The trust-remediation messages are rewrapped sentence-per-line (interpolated ARNs previously produced ragged hard-wrapped output) and now note that AWS returns the same denial when the role does not currently exist — relevant for on-demand-provisioned infrastructure.

## Verification

- `make fmt` / `make lint` (clippy `-D warnings`) clean; 4,776 workspace tests pass (~10 new: parse/render unit tests, two proptest round-trips); i18n completeness tests green.
- Reviewed by rust-code-reviewer with an adversarial verification pass: five findings raised and confirmed fixed (probe region parity, bounded concurrency, CloudTrail session identity, match flattening, parser test coverage); the extractor migration was verified complete by grepping for stray callers.
- Live against a production org: entitled role with the trust statement probes `(verified)` and vends; a chained role without it produces the trust-missing block and `~/.aws/config` gains no dead profile; the full sweep checked 12 real profiles and correctly flagged the one targeting a currently-unprovisioned role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds live STS probes during discovery (extra API calls and CloudTrail noise) and changes when profiles are written, but behavior is scoped to setup/discover and uses the same assume path as credential vending.
> 
> **Overview**
> **`vouch setup aws --discover`** no longer writes Account Access Manager entitlement profiles blindly. Each entitled role gets a **chained `AssumeRole` probe** (same hop as vending, 900s session, bounded concurrency, management session `RoleSessionName` for CloudTrail). Confirmed access denials **block new profiles** and print trust-policy remediation; inconclusive errors still allow writes. Existing same-role profiles are re-probed and reported as verified or not assumable (kept on disk).
> 
> After discovery, a **report-only sweep** health-checks other vouch-managed profiles: STS roles are probed (deduped, org-boundary aware); Identity Center profiles are compared to portal assignments for stale entries, with a checked/issues summary.
> 
> **`CredentialProcessLine`** replaces ad-hoc string parsing for `credential_process` (role vs Identity Center) with shared `parse`/`render`, used across setup, profile resolution, status, and collision checks.
> 
> **Supporting changes:** `AssumeRoleRequest.duration_seconds` (vend 3600, probes 900), `ManagementRoleSession.role_session_name`, and expanded i18n for verified/skipped/sweep/trust messages plus clearer trust-denial copy (including non-existent roles).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea7d81013ebaed322ee4581dc697cb6216f7e783. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->