### PR TITLE
fix(cli): simplify assumability probe messages

### DIFF
--- a/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
+++ b/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
@@ -1150,12 +1150,10 @@ setup-aws-discover-skipped = Skipped [{ $profile }] — already exists
 setup-aws-entitlements-invalid-skipped = Skipped entitlement — invalid role or account: { $role_arn }
 setup-aws-entitlements-name-taken = Skipped entitlement for { $role_arn } — profile name [{ $profile }] is already in use by a different profile. The entitlement was NOT configured; rename or remove the existing profile and re-run discovery.
 setup-aws-entitlements-partial = Warning: { $failed } of { $total } entitlement queries failed; entitlement results may be incomplete. Re-run discovery to retry.
-setup-aws-entitlements-added-verified = Added profile [{ $profile }] → { $role_arn } (verified — the management role can assume it)
-setup-aws-entitlements-existing-verified = Profile [{ $profile }] → { $role_arn } already exists (verified — the management role can assume it)
-setup-aws-entitlements-not-assumable-skipped =
-    Entitled role { $role_arn } is NOT assumable — profile [{ $profile }] was not written: the management role was denied sts:AssumeRole on this role.
-setup-aws-entitlements-existing-trust-missing =
-    Profile [{ $profile }] → { $role_arn } already exists but is NOT currently assumable: the management role was denied sts:AssumeRole on this role. The profile was kept.
+setup-aws-entitlements-added-verified = Added profile [{ $profile }] → { $role_arn } (assumable)
+setup-aws-entitlements-existing-verified = Profile [{ $profile }] → { $role_arn } exists and is assumable
+setup-aws-entitlements-not-assumable-skipped = Role { $role_arn } is not assumable — profile [{ $profile }] was not written
+setup-aws-entitlements-existing-trust-missing = Profile [{ $profile }] → { $role_arn } exists but is not assumable — the profile was kept
 setup-aws-entitlements-trust-remediation =
     Ask an administrator to add this statement to the role's trust-policy Statement array:
 


### PR DESCRIPTION
## Summary

Trims the four per-profile assumability probe outcome messages printed by `vouch setup aws --discover` (added in #961). Values-only change in `crates/vouch-cli/i18n/en-US/vouch-cli.ftl` — message IDs and variables are unchanged, so no Rust changes.

| Before | After |
|---|---|
| `Added profile [x] → arn (verified — the management role can assume it)` | `Added profile [x] → arn (assumable)` |
| `Profile [x] → arn already exists (verified — the management role can assume it)` | `Profile [x] → arn exists and is assumable` |
| `Entitled role arn is NOT assumable — profile [x] was not written: the management role was denied sts:AssumeRole on this role.` | `Role arn is not assumable — profile [x] was not written` |
| `Profile [x] → arn already exists but is NOT currently assumable: the management role was denied sts:AssumeRole on this role. The profile was kept.` | `Profile [x] → arn exists but is not assumable — the profile was kept` |

The `sts:AssumeRole` denial detail dropped from the negative lines is still covered by the trust-remediation block printed immediately after either one.

## Testing

- `cargo test --package vouch-cli` — 751 passed (includes the i18n completeness tests)
- `make fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing English copy only in the en-US catalog; no behavior, API, or security logic changes.
> 
> **Overview**
> Shortens the four **en-US** Fluent strings printed during `vouch setup aws --discover` when the CLI probes whether entitled roles are assumable. Message IDs and placeholders (`$profile`, `$role_arn`) are unchanged—**only** `vouch-cli.ftl` copy is updated.
> 
> Success lines drop the long “verified — the management role can assume it” wording in favor of **(assumable)** / **exists and is assumable**. Failure lines no longer repeat `sts:AssumeRole` denial detail on the per-profile line; they state simply that the role or profile is **not assumable** (profile kept or not written). The separate **`setup-aws-entitlements-trust-remediation`** block still carries trust-policy and management-role guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 096a9811612b38bc4a4a4dbc11a0af58d3f432db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->