### PR TITLE
feat(cli): print remediation policy and idc status in aws discovery

### DIFF
--- a/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
+++ b/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
@@ -814,7 +814,10 @@ aws-err-target-role-trust-missing =
 
     Keep the aws:SourceIdentity condition and adjust its pattern to your organization's email domain — without it, anyone who can assume the management role could assume this role.
 
-    Also verify the management role { $management_role } has an IAM policy allowing sts:AssumeRole on this role.
+    Also verify the management role { $management_role } has an IAM policy allowing:
+
+    { $policy }
+
     If the trust statement is already present, the denial may instead come from a service control policy, a permissions boundary, an aws:SourceIdentity condition that does not match your identity, or a role that does not currently exist.
 
 sso-portal-err-token-expired = Identity Center access token is invalid or expired. Run '{ -cmd } login' to re-authenticate.
@@ -1147,6 +1150,7 @@ setup-aws-added-profile-block =
     To configure AWS role trust policy, see:
       https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_oidc.html
 setup-aws-discover-skipped = Skipped [{ $profile }] — already exists
+setup-aws-idc-existing-verified = Profile [{ $profile }] → assumable through AWS IAM Identity Center ({ $account } / { $permission_set })
 setup-aws-entitlements-invalid-skipped = Skipped entitlement — invalid role or account: { $role_arn }
 setup-aws-entitlements-name-taken = Skipped entitlement for { $role_arn } — profile name [{ $profile }] is already in use by a different profile. The entitlement was NOT configured; rename or remove the existing profile and re-run discovery.
 setup-aws-entitlements-partial = Warning: { $failed } of { $total } entitlement queries failed; entitlement results may be incomplete. Re-run discovery to retry.
@@ -1160,7 +1164,10 @@ setup-aws-entitlements-trust-remediation =
     { $statement }
 
     Keep the aws:SourceIdentity condition and adjust its pattern to your organization's email domain.
-    Also verify the management role { $management_role } has an IAM policy allowing sts:AssumeRole on this role.
+    Also verify the management role { $management_role } has an IAM policy allowing:
+
+    { $policy }
+
     AWS returns the same denial when the role does not currently exist (for example, infrastructure that is provisioned on demand).
 setup-aws-entitlements-rerun-hint = Re-run '{ -cmd } setup aws --discover' once access is granted to add the profile.
 setup-aws-sweep-assignment-stale = Profile [{ $profile }] — its Identity Center assignment ({ $account } / { $permission_set }) no longer exists. The profile was kept; remove it manually if unwanted.

--- a/crates/vouch-cli/src/commands/credential/aws.rs
+++ b/crates/vouch-cli/src/commands/credential/aws.rs
@@ -506,11 +506,13 @@ async fn assume_role_via_management_chain(
                 input.mgmt_role_arn,
                 &source_identity_pattern(input.session),
             );
+            let policy = management_role_policy_statement(input.role_arn);
             Err(err.context(tr_args!(
                 "aws-err-target-role-trust-missing",
                 role_arn = input.role_arn,
                 management_role = input.mgmt_role_arn,
-                statement = statement.as_str()
+                statement = statement.as_str(),
+                policy = policy.as_str()
             )))
         }
         Err(err) => Err(err.context(tr!("err-failed-assume-target-role-via-chaining"))),
@@ -557,6 +559,22 @@ pub(crate) fn chained_role_trust_statement(
         "Condition": {
             "StringLike": { "aws:SourceIdentity": source_identity }
         }
+    }))
+    .unwrap_or_default()
+}
+
+/// The identity-policy statement the management role needs so it can
+/// perform the chained hop into the target role.
+///
+/// The action triple matches the trust statement (and the agent-restricted
+/// session policy): the chained `AssumeRole` propagates the session's
+/// source identity, so `sts:SetSourceIdentity` and `sts:TagSession` are
+/// exercised alongside `sts:AssumeRole`.
+pub(crate) fn management_role_policy_statement(target_role_arn: &str) -> String {
+    serde_json::to_string_pretty(&serde_json::json!({
+        "Effect": "Allow",
+        "Action": ["sts:AssumeRole", "sts:SetSourceIdentity", "sts:TagSession"],
+        "Resource": target_role_arn
     }))
     .unwrap_or_default()
 }
@@ -1226,6 +1244,20 @@ mod tests {
         // This Bool condition key only exists for AssumeRoleWithWebIdentity
         // and would never match on the chained AssumeRole hop.
         assert!(!statement.contains("RoleAuthorizedByIdp"));
+    }
+
+    #[test]
+    fn test_management_role_policy_statement_exact_json() {
+        let statement = management_role_policy_statement("arn:aws:iam::999999999999:role/target");
+        let parsed: serde_json::Value = serde_json::from_str(&statement).unwrap();
+        assert_eq!(
+            parsed,
+            serde_json::json!({
+                "Effect": "Allow",
+                "Action": ["sts:AssumeRole", "sts:SetSourceIdentity", "sts:TagSession"],
+                "Resource": "arn:aws:iam::999999999999:role/target"
+            })
+        );
     }
 
     #[test]

--- a/crates/vouch-cli/src/commands/setup/aws.rs
+++ b/crates/vouch-cli/src/commands/setup/aws.rs
@@ -520,9 +520,15 @@ async fn run_discover(
             };
 
             if aws_config.profile_exists(&profile_name) {
+                // This loop iterates the portal's assignment list, so an
+                // existing profile reached here is verified vendable — the
+                // portal authorizes GetRoleCredentials against the same
+                // assignments (no live probe needed, unlike role chaining).
                 tr_println!(
-                    "setup-aws-discover-skipped",
-                    profile = profile_name.as_str()
+                    "setup-aws-idc-existing-verified",
+                    profile = profile_name.as_str(),
+                    account = account.account_id.as_str(),
+                    permission_set = role.role_name.as_str()
                 );
                 skipped_count = skipped_count.saturating_add(1);
                 continue;
@@ -976,7 +982,7 @@ fn report_probe_outcome(
                 profile = profile_name,
                 role_arn = role_arn
             );
-            print_trust_remediation(input);
+            print_trust_remediation(input, role_arn);
             tr_println!("setup-aws-entitlements-rerun-hint");
             false
         }
@@ -986,7 +992,7 @@ fn report_probe_outcome(
                 profile = profile_name,
                 role_arn = role_arn
             );
-            print_trust_remediation(input);
+            print_trust_remediation(input, role_arn);
             false
         }
         // Throttling or network says nothing about trust — claim nothing.
@@ -1008,17 +1014,21 @@ fn report_probe_outcome(
 }
 
 /// Print the trust-statement remediation for a denied probe.
-fn print_trust_remediation(input: &DiscoveryContext<'_>) {
-    use crate::commands::credential::aws::{chained_role_trust_statement, source_identity_pattern};
+fn print_trust_remediation(input: &DiscoveryContext<'_>, target_role_arn: &str) {
+    use crate::commands::credential::aws::{
+        chained_role_trust_statement, management_role_policy_statement, source_identity_pattern,
+    };
 
     let statement = chained_role_trust_statement(
         input.management_role,
         &source_identity_pattern(input.role_session_name),
     );
+    let policy = management_role_policy_statement(target_role_arn);
     tr_println!(
         "setup-aws-entitlements-trust-remediation",
         management_role = input.management_role,
-        statement = statement.as_str()
+        statement = statement.as_str(),
+        policy = policy.as_str()
     );
 }
 


### PR DESCRIPTION
## Summary

Two improvements to `vouch setup aws --discover` output (follows #962; textually independent of it):

**Concrete remediation policy.** Both trust-remediation messages (discovery-time `setup-aws-entitlements-trust-remediation` and vend-time `aws-err-target-role-trust-missing`) previously ended with a vague "Also verify the management role … has an IAM policy allowing sts:AssumeRole on this role." Since the denied role ARN is known, they now print the exact identity-policy statement to attach:

```json
{
  "Effect": "Allow",
  "Action": ["sts:AssumeRole", "sts:SetSourceIdentity", "sts:TagSession"],
  "Resource": "arn:aws:iam::952961969614:role/vouch-demo"
}
```

The action triple matches the trust statement and the agent-restricted session policy — the chained hop propagates source identity, so `sts:AssumeRole` alone is not the whole requirement. New `management_role_policy_statement()` helper next to `chained_role_trust_statement()`, with an exact-JSON unit test.

**Positive status for Identity Center profiles.** An existing IdC profile previously printed `Skipped [name] — already exists`, which read as unverified next to the role profiles' "exists and is assumable" lines. The discovery loop iterates the portal's assignment list, and the portal authorizes `GetRoleCredentials` against those same assignments, so reaching an existing profile proves the portal will vend for it. It now prints:

```
Profile [vouch-vouch-prod-developer] → assumable through AWS IAM Identity Center (486135724840 / developer)
```

The neutral `setup-aws-discover-skipped` message remains at the inconclusive-probe site, where claiming nothing is deliberate. No live `GetRoleCredentials` probe is added: it would consult the same authorization source while minting full-session-duration credentials per profile.

## Testing

- `cargo test --package vouch-cli` — 752 passed (new exact-JSON test for the policy statement)
- `make lint` clean, `make fmt` run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CLI messaging, i18n strings, and a small JSON helper with a unit test—no credential exchange or IAM behavior changes.
> 
> **Overview**
> **Management-role remediation** now includes a copy-paste **identity policy** JSON block (not only the target role trust statement) when chained `AssumeRole` is denied at vend time (`aws-err-target-role-trust-missing`) and during setup discovery (`setup-aws-entitlements-trust-remediation`). A new `management_role_policy_statement()` mirrors the trust statement’s STS action triple (`AssumeRole`, `SetSourceIdentity`, `TagSession`) scoped to the known target role ARN.
> 
> **Identity Center discovery** no longer prints a neutral “Skipped — already exists” for profiles that already exist while walking portal assignments; it reports **`setup-aws-idc-existing-verified`** with account and permission set, on the rationale that the assignment list implies the portal will vend credentials. The generic skip message stays where entitlement probes are inconclusive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb86fb05ce9a89f6ddb924b37c3d078e83f89dbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

