### PR TITLE
fix(server): read full signed text when extracting SAML values

### DIFF
--- a/crates/vouch-server/src/services/idp/saml/c14n.rs
+++ b/crates/vouch-server/src/services/idp/saml/c14n.rs
@@ -366,6 +366,33 @@ fn node_qualified_name(node: roxmltree::Node<'_, '_>) -> String {
     }
 }
 
+/// Concatenate every text child of an element, skipping comments.
+///
+/// This is the only correct way to read a signed element's value. Signature
+/// digests cover the canonical form produced by [`exclusive_c14n`], which
+/// concatenates all text children and drops comments. `roxmltree`'s
+/// `Node::text()` returns only the *first* text child, so a comment placed
+/// mid-value (`<NameID>a@b.com<!---->.evil.tld</NameID>`) leaves the signed
+/// bytes byte-identical while `text()` yields only `a@b.com` — the signature
+/// verifies over one value and the application acts on another
+/// (CVE-2017-11427 class).
+///
+/// Returns `None` when the element has no text children.
+#[must_use]
+pub(crate) fn element_text(node: roxmltree::Node<'_, '_>) -> Option<String> {
+    let mut out = String::new();
+    let mut found = false;
+    for child in node.children() {
+        if child.is_text()
+            && let Some(text) = child.text()
+        {
+            out.push_str(text);
+            found = true;
+        }
+    }
+    found.then_some(out)
+}
+
 /// Escape text content per c14n spec.
 ///
 /// Replacements: `&` → `&amp;`, `<` → `&lt;`, `>` → `&gt;`, `\r` → `&#xD;`

--- a/crates/vouch-server/src/services/idp/saml/metadata.rs
+++ b/crates/vouch-server/src/services/idp/saml/metadata.rs
@@ -152,9 +152,8 @@ pub(crate) fn parse_idp_metadata(xml: &str) -> Result<IdpMetadata, MetadataError
                             if !x509_cert_node.has_tag_name((NS_DS, "X509Certificate")) {
                                 continue;
                             }
-                            let cert_text = x509_cert_node
-                                .text()
-                                .unwrap_or("")
+                            let cert_text = super::c14n::element_text(x509_cert_node)
+                                .unwrap_or_default()
                                 // Strip whitespace (certs often have line breaks in metadata).
                                 .split_whitespace()
                                 .collect::<String>();

--- a/crates/vouch-server/src/services/idp/saml/response.rs
+++ b/crates/vouch-server/src/services/idp/saml/response.rs
@@ -15,7 +15,7 @@ use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use jiff::Timestamp;
 
-use super::{SamlProvider, signature::SignatureError};
+use super::{SamlProvider, c14n, signature::SignatureError};
 
 // ============================================================================
 // SAML namespace constants
@@ -372,9 +372,9 @@ fn validate_issuer(
     let issuer = assertion
         .children()
         .find(|n| n.has_tag_name((NS_SAML, "Issuer")))
-        .and_then(|n| n.text())
-        .map(str::trim)
+        .and_then(c14n::element_text)
         .ok_or_else(|| ResponseError::Other("missing Issuer element in assertion".to_string()))?;
+    let issuer = issuer.trim();
 
     if issuer != expected_entity_id {
         return Err(ResponseError::IssuerMismatch {
@@ -415,7 +415,7 @@ fn validate_audience_restriction(
     let has_match = audience_restriction
         .children()
         .filter(|n| n.has_tag_name((NS_SAML, "Audience")))
-        .filter_map(|n| n.text())
+        .filter_map(c14n::element_text)
         .any(|text| text.trim() == sp_entity_id);
 
     if !has_match {
@@ -657,7 +657,11 @@ fn extract_name_id(assertion: roxmltree::Node<'_, '_>) -> Option<(String, Option
         .children()
         .find(|n| n.has_tag_name((NS_SAML, "Subject")))
         .and_then(|s| s.children().find(|n| n.has_tag_name((NS_SAML, "NameID"))))?;
-    let text = node.text().map(str::trim).filter(|s| !s.is_empty())?;
+    let text = c14n::element_text(node)?;
+    let text = text.trim();
+    if text.is_empty() {
+        return None;
+    }
     let format = node.attribute("Format").map(str::to_string);
     Some((text.to_string(), format))
 }
@@ -700,7 +704,7 @@ fn find_saml_attribute(assertion: roxmltree::Node<'_, '_>, attr_name: &str) -> O
             && let Some(value_node) = attribute
                 .children()
                 .find(|n| n.has_tag_name((NS_SAML, "AttributeValue")))
-            && let Some(text) = value_node.text()
+            && let Some(text) = c14n::element_text(value_node)
         {
             let trimmed = text.trim();
             if !trimmed.is_empty() {

--- a/crates/vouch-server/src/services/idp/saml/response/tests.rs
+++ b/crates/vouch-server/src/services/idp/saml/response/tests.rs
@@ -1228,6 +1228,122 @@ fn extract_name_id_reads_text_and_format() {
     assert_eq!(format, None);
 }
 
+/// An XML comment splits an element's text into multiple text nodes, but
+/// canonicalization concatenates them all and drops the comment — so the
+/// signature stays valid over the whole value. Every extractor must read the
+/// whole value too; reading only the first text node would let a holder of a
+/// legitimately signed assertion truncate it to another user's identity
+/// (CVE-2017-11427 class).
+#[test]
+fn comment_split_text_is_read_whole_not_truncated() {
+    let assertion_xml = r#"<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+        <saml:Issuer>https://idp.example.com<!---->.evil.tld</saml:Issuer>
+        <saml:Subject>
+            <saml:NameID>alice@example.com<!---->.evil.tld</saml:NameID>
+        </saml:Subject>
+        <saml:Conditions>
+            <saml:AudienceRestriction>
+                <saml:Audience>https://vouch.example.com<!---->.evil.tld</saml:Audience>
+            </saml:AudienceRestriction>
+        </saml:Conditions>
+        <saml:AttributeStatement>
+            <saml:Attribute Name="email">
+                <saml:AttributeValue>alice@example.com<!---->.evil.tld</saml:AttributeValue>
+            </saml:Attribute>
+        </saml:AttributeStatement>
+    </saml:Assertion>"#;
+    let doc = roxmltree::Document::parse(assertion_xml).expect("parse");
+    let assertion = doc.root_element();
+
+    let (name_id, _format) = super::extract_name_id(assertion).expect("name id present");
+    assert_eq!(
+        name_id, "alice@example.com.evil.tld",
+        "NameID must be the whole signed value, not the prefix before the comment"
+    );
+
+    let attr = super::find_saml_attribute(assertion, "email").expect("attribute present");
+    assert_eq!(
+        attr, "alice@example.com.evil.tld",
+        "AttributeValue must be the whole signed value"
+    );
+
+    // The audience is not the SP entity ID, so the restriction must not match.
+    assert!(
+        super::validate_audience_restriction(assertion, "https://vouch.example.com").is_err(),
+        "An Audience of https://vouch.example.com.evil.tld must not satisfy \
+         https://vouch.example.com"
+    );
+
+    // The issuer is not the configured entity ID, so it must not match.
+    assert!(
+        super::validate_issuer(assertion, "https://idp.example.com").is_err(),
+        "An Issuer of https://idp.example.com.evil.tld must not satisfy \
+         https://idp.example.com"
+    );
+
+    // A leading comment puts the text after a comment node rather than
+    // splitting it. The value is still fully signed, so it must still be read.
+    let leading = r#"<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+        <saml:Subject>
+            <saml:NameID><!---->alice@example.com</saml:NameID>
+        </saml:Subject>
+    </saml:Assertion>"#;
+    let doc = roxmltree::Document::parse(leading).expect("parse");
+    let (id, _) = super::extract_name_id(doc.root_element()).expect("name id present");
+    assert_eq!(id, "alice@example.com");
+}
+
+/// End-to-end: injecting a comment into the NameID of a *validly signed*
+/// assertion keeps the signature valid (canonicalization drops comments), so
+/// the attack has to be stopped by reading the whole value. The resulting
+/// identity must be the full attacker-controlled string, never the victim
+/// prefix.
+#[test]
+fn validate_saml_response_comment_injection_does_not_truncate_identity() {
+    use base64::Engine as _;
+    use base64::engine::general_purpose::STANDARD as B64;
+
+    let (key_pair, cert_der) = generate_test_key_and_cert();
+    let provider = test_provider(cert_der);
+    let (not_before, not_on_or_after) = valid_time_window();
+
+    let xml = build_signed_saml_response(
+        &key_pair,
+        "attacker@example.com.evil.tld",
+        "_response003",
+        "_assertion003",
+        "_request003",
+        "https://vouch.example.com/saml/acs",
+        "https://idp.example.com",
+        "https://vouch.example.com",
+        &not_before,
+        &not_on_or_after,
+        Some("_request003"),
+    );
+
+    // Split the signed NameID with a comment, aiming to truncate the identity
+    // down to the victim's address. The signature is untouched.
+    let injected_xml = xml.replace(
+        "attacker@example.com.evil.tld",
+        "attacker@example.com<!---->.evil.tld",
+    );
+    assert_ne!(xml, injected_xml, "Injection must actually change the XML");
+
+    let base64_response = B64.encode(injected_xml.as_bytes());
+    let assertion = validate_saml_response(&base64_response, "_request003", &provider)
+        .expect("comment injection leaves the signature valid, so validation succeeds");
+
+    assert_eq!(
+        assertion.email, "attacker@example.com.evil.tld",
+        "Identity must be the whole signed value; truncating to \
+         attacker@example.com would authenticate as a different user"
+    );
+    assert_eq!(
+        assertion.name_id.as_deref(),
+        Some("attacker@example.com.evil.tld")
+    );
+}
+
 /// Tamper-detection: modifying the email in the assertion after signing must
 /// cause digest mismatch during validation.
 #[test]

--- a/crates/vouch-server/src/services/idp/saml/signature.rs
+++ b/crates/vouch-server/src/services/idp/saml/signature.rs
@@ -201,11 +201,12 @@ pub(crate) fn verify_xml_signature(
     }
 
     // Step 5: Canonicalize the signed element (enveloped-signature: exclude Signature subtree)
-    let canonical_element = c14n_excluding_signature(signed_element, sig_node, &inclusive_prefixes);
+    let canonical_element =
+        c14n_excluding_signature(signed_element, sig_node, &inclusive_prefixes)?;
 
     // Step 6: Compute SHA-256 digest and compare with <ds:DigestValue>
     let digest_value_b64 = find_child_element(reference_node, NS_DS, "DigestValue")
-        .and_then(|n| n.text())
+        .and_then(c14n::element_text)
         .ok_or_else(|| SignatureError::Other("missing DigestValue".to_string()))?;
 
     let expected_digest = BASE64_STANDARD
@@ -230,7 +231,7 @@ pub(crate) fn verify_xml_signature(
 
     // Step 8: Extract <ds:SignatureValue>
     let sig_value_b64 = find_child_element(sig_node, NS_DS, "SignatureValue")
-        .and_then(|n| n.text())
+        .and_then(c14n::element_text)
         .ok_or_else(|| SignatureError::Other("missing SignatureValue".to_string()))?;
 
     let sig_bytes = BASE64_STANDARD
@@ -371,7 +372,7 @@ fn c14n_excluding_signature(
     signed_element: roxmltree::Node<'_, '_>,
     sig_node: roxmltree::Node<'_, '_>,
     inclusive_prefixes: &[&str],
-) -> String {
+) -> Result<String, SignatureError> {
     // Build canonical form by iterating children and excluding the Signature.
     // We need to produce the canonical opening tag of signed_element, then
     // recurse into children (skipping sig_node), then close.
@@ -383,20 +384,27 @@ fn c14n_excluding_signature(
     let mut xml_without_sig = String::with_capacity(4096);
     serialize_node_excl(&mut xml_without_sig, signed_element, sig_node.id());
 
-    let doc = match roxmltree::Document::parse(&xml_without_sig) {
-        Ok(d) => d,
-        Err(e) => {
-            tracing::warn!("Failed to reparse element for c14n (enveloped-sig): {e}");
-            // Fall back to full c14n (less secure but prevents crash)
-            return c14n::exclusive_c14n(signed_element, inclusive_prefixes);
-        }
-    };
+    // Both failure paths below must be hard errors. Returning some *other*
+    // canonical form (the element with its Signature still inside, or an empty
+    // string) would hash bytes the signer never saw, which is the shape every
+    // signature-bypass in this family takes. The digest comparison would reject
+    // it today, but only by luck of ordering — fail closed here instead.
+    let doc = roxmltree::Document::parse(&xml_without_sig).map_err(|e| {
+        SignatureError::Other(format!(
+            "failed to reparse element for enveloped-signature c14n: {e}"
+        ))
+    })?;
 
-    if let Some(root_elem) = doc.root().children().find(|n| n.is_element()) {
-        c14n::exclusive_c14n(root_elem, inclusive_prefixes)
-    } else {
-        String::new()
-    }
+    let root_elem = doc
+        .root()
+        .children()
+        .find(|n| n.is_element())
+        .ok_or_else(|| {
+            SignatureError::Other(
+                "reparsed element for enveloped-signature c14n has no root element".to_string(),
+            )
+        })?;
+    Ok(c14n::exclusive_c14n(root_elem, inclusive_prefixes))
 }
 
 /// Recursively serialize a node, skipping the node with the given ID.


### PR DESCRIPTION
## What this fixes

Exclusive canonicalization concatenates every text child of an element and drops comments, so an XML signature covers the element's whole text value. Extraction used `roxmltree`'s `Node::text()`, which returns only the **first** text child.

A comment placed mid-value therefore leaves the canonical bytes — and so the digest and the signature — completely unchanged, while the application reads only the prefix:

```xml
<saml:NameID>victim@example.com<!---->.attacker.tld</saml:NameID>
```

That assertion is a genuine, validly signed assertion for `victim@example.com.attacker.tld` (an address the attacker controls), but it is read as `victim@example.com`. This is the CVE-2017-11427 class.

The two views genuinely disagree by construction: `c14n_excluding_signature` serializes the signed element while dropping comments, re-parses that string, digests it, and discards it — while extraction reads the original tree with the comment intact.

### Impact

- `extract_name_id` — account identity and the durable subject used for identity binding.
- `find_saml_attribute` — the configured email attribute and domain attribute. Forging the domain alone places the attacker in the victim's org.

The `Audience` and `Issuer` checks were also reading truncated values, but are not independently exploitable: cross-SP replay is blocked by the signed `SubjectConfirmationData/@Recipient` check, and the issuer is already bound by certificate matching. They are fixed for consistency.

Accounts already bound to the issuer are protected by the existing durable-subject conflict check. Accounts that are **unbound** — SCIM-provisioned, or predating binding — are matched on email and then lazily bound to the attacker's subject.

## The fix

Adds `c14n::element_text`, which concatenates all text children to match exactly what the canonicalizer hashes, and uses it at every site that reads text from signed XML. It lives next to `exclusive_c14n` because it is that function's contract.

Also makes both failure paths in `c14n_excluding_signature` hard errors. They previously canonicalized the element with its `Signature` subtree still included, or returned an empty string — either of which hashes bytes the signer never produced. The digest comparison rejected those cases anyway, so this is behavior-preserving.

## Tests

- `comment_split_text_is_read_whole_not_truncated` — unit coverage of all four extractors, plus the leading-comment case (which previously returned `None`).
- `validate_saml_response_comment_injection_does_not_truncate_identity` — end-to-end: injects a comment into a validly signed assertion, confirms the signature still verifies, and asserts the identity is the full signed value.

Both were verified to fail against the unfixed code. The end-to-end test demonstrates the full attack: signature valid, identity silently truncated.

`make fmt`, `make lint`, and `make test` are clean (2958 tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Authentication-critical SAML parsing fix; wrong text extraction could allow identity truncation on validly signed assertions.
> 
> **Overview**
> Fixes a **CVE-2017-11427–class** gap where XML comments could split element text so signatures still verified over the canonical full value while the app read only the first text node (e.g. `victim@example.com` vs `victim@example.com.evil.tld`).
> 
> Adds **`c14n::element_text`** to concatenate all text children (matching exc-c14n) and switches SAML **response** extraction (`NameID`, attributes, `Issuer`, `Audience`), **signature** parsing (`DigestValue`, `SignatureValue`), and **metadata** cert text to use it instead of `Node::text()`.
> 
> **`c14n_excluding_signature`** now returns **`Result`** and fails closed on reparse / missing root instead of falling back to alternate canonical bytes.
> 
> New unit and end-to-end tests cover comment-split values and signed assertions with injected comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a946438df2dcc92e05bf5c70fc58757bcdb9cbfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->