### PR TITLE
fix(server): require SubjectConfirmationData.InResponseTo unconditionally

### DIFF
--- a/crates/vouch-server/src/services/idp/saml/response.rs
+++ b/crates/vouch-server/src/services/idp/saml/response.rs
@@ -8,6 +8,10 @@
 //!
 //! - XSW mitigations: extracts identity only from the verified signed element
 //! - Multiple assertions are rejected
+//! - Only solicited responses are accepted: the ACS handler requires a stored
+//!   request ID before calling in, so SAML Profiles 4.1.5 ("An unsolicited
+//!   <Response> MUST NOT contain an InResponseTo attribute") is satisfied by
+//!   construction — there is no unsolicited path to guard
 //! - Clock skew tolerance is capped at 120 seconds
 //! - Replay prevention: callers must consume the state record after this returns Ok
 
@@ -299,21 +303,12 @@ pub(crate) fn validate_saml_response(
     // Step 11: Validate SubjectConfirmation Method is bearer (Core 2.4.1.2)
     // Step 12: Validate SubjectConfirmationData (Profiles 4.1.4.3)
     //
-    // When only the Assertion is signed (Response is unsigned), the
-    // `Response.InResponseTo` attribute is not covered by any signature and
-    // can be modified without invalidating the assertion signature. In that
-    // case, require `SubjectConfirmationData.InResponseTo` — which lives
-    // inside the signed Assertion — as the signed binding to the expected
-    // request ID. This prevents an attacker with MITM capability from
-    // modifying the unsigned `Response.InResponseTo` to impersonate a victim.
-    let response_signed = signed_element.has_tag_name((NS_SAMLP, "Response"));
-    validate_subject_confirmation(
-        assertion,
-        expected_request_id,
-        &provider.acs_url,
-        now,
-        !response_signed,
-    )?;
+    // The bearer `SubjectConfirmationData.InResponseTo` is the binding to the
+    // request, and it is required regardless of which element is signed. It
+    // lives inside the assertion, which the POST binding requires to be
+    // signed (4.1.4.5); `Response.InResponseTo` sits outside and can be
+    // modified without invalidating that signature, so it is never relied on.
+    validate_subject_confirmation(assertion, expected_request_id, &provider.acs_url, now)?;
 
     // Step 10: Extract email
     let email = extract_email(assertion, provider.email_attribute.as_deref())?;
@@ -487,7 +482,6 @@ fn validate_subject_confirmation(
     expected_request_id: &str,
     acs_url: &str,
     now: Timestamp,
-    require_irt: bool,
 ) -> Result<(), ResponseError> {
     // SAML Profiles 4.1.4.3: Subject MUST be present for Web Browser SSO.
     let subject = assertion
@@ -520,13 +514,8 @@ fn validate_subject_confirmation(
     // single-confirmation failures still report a specific cause.
     let mut first_error: Option<ResponseError> = None;
     for confirmation in confirmations {
-        match validate_single_subject_confirmation(
-            confirmation,
-            expected_request_id,
-            acs_url,
-            now,
-            require_irt,
-        ) {
+        match validate_single_subject_confirmation(confirmation, expected_request_id, acs_url, now)
+        {
             Ok(()) => return Ok(()),
             Err(e) => {
                 first_error.get_or_insert(e);
@@ -546,17 +535,27 @@ fn validate_subject_confirmation(
 /// SAML Profiles Section 4.1.4.3: SubjectConfirmationData Recipient,
 /// InResponseTo, and NotOnOrAfter MUST be validated.
 ///
-/// When `require_irt` is true (Response is not signed, assertion-only
-/// signature), `SubjectConfirmationData.InResponseTo` MUST be present and
-/// match the expected request ID. The unsigned `Response.InResponseTo`
-/// attribute can be modified without invalidating the assertion signature,
-/// so it must not be the sole binding to the expected request ID.
+/// `SubjectConfirmationData.InResponseTo` MUST be present and match the
+/// expected request ID. SAML Profiles 4.1.4.3 lists this under "Regardless
+/// of the SAML binding used, the service provider MUST do the following":
+///
+///   "Verify that the InResponseTo attribute in the bearer
+///    <SubjectConfirmationData> equals the ID of its original
+///    <AuthnRequest> message, unless the response is unsolicited (see
+///    Section 4.1.5), in which case the attribute MUST NOT be present"
+///
+/// The requirement does not depend on which element carries the signature.
+/// Only the POST binding is accepted here, and 4.1.4.5 requires that "the
+/// enclosed assertion(s) MUST be signed" for it, so this attribute is
+/// always inside signed content and the check can always be made. The
+/// `Response.InResponseTo` attribute sits outside the assertion and is
+/// modifiable without invalidating its signature, so it is never the
+/// binding relied upon.
 fn validate_single_subject_confirmation(
     confirmation: roxmltree::Node<'_, '_>,
     expected_request_id: &str,
     acs_url: &str,
     now: Timestamp,
-    require_irt: bool,
 ) -> Result<(), ResponseError> {
     // SAML Core 2.4.1.2: Verify Method is bearer
     let method = confirmation.attribute("Method").unwrap_or("");
@@ -586,25 +585,18 @@ fn validate_single_subject_confirmation(
         });
     }
 
-    // Check InResponseTo matches request ID.
-    //
-    // When the Response is not signed (assertion-only signature), the
-    // unsigned Response.InResponseTo cannot be trusted as the binding to
-    // the expected request ID. Require SubjectConfirmationData.InResponseTo,
-    // which is inside the signed Assertion and therefore covered by the
-    // signature.
-    let in_response_to = conf_data.attribute("InResponseTo");
-
-    if require_irt && in_response_to.is_none() {
+    // SAML Profiles 4.1.4.3: the InResponseTo attribute in the bearer
+    // SubjectConfirmationData MUST equal the original AuthnRequest ID. This
+    // is the only binding to the request that lives inside signed content;
+    // absence of it is a failure, not a case to skip.
+    let Some(in_response_to) = conf_data.attribute("InResponseTo") else {
         return Err(ResponseError::MissingSubjectConfirmationInResponseTo);
-    }
+    };
 
-    if let Some(irt) = in_response_to
-        && irt != expected_request_id
-    {
+    if in_response_to != expected_request_id {
         return Err(ResponseError::InResponseToMismatch {
             expected: expected_request_id.to_string(),
-            actual: irt.to_string(),
+            actual: in_response_to.to_string(),
         });
     }
 

--- a/crates/vouch-server/src/services/idp/saml/response/tests.rs
+++ b/crates/vouch-server/src/services/idp/saml/response/tests.rs
@@ -546,7 +546,6 @@ fn subject_confirmation_bearer_method_passes() {
             "_req123",
             "https://vouch.example.com/saml/acs",
             now,
-            false
         )
         .is_ok()
     );
@@ -569,7 +568,6 @@ fn subject_confirmation_non_bearer_method_returns_error() {
         "_req123",
         "https://vouch.example.com/saml/acs",
         now,
-        false,
     )
     .unwrap_err();
     assert!(
@@ -595,7 +593,6 @@ fn subject_confirmation_missing_method_returns_error() {
         "_req123",
         "https://vouch.example.com/saml/acs",
         now,
-        false,
     )
     .unwrap_err();
     assert!(
@@ -645,7 +642,7 @@ fn subject_confirmation_multiple_one_valid_bearer_passes() {
     let xml = assertion_with_subject_confirmations(&confirmations);
     let doc = roxmltree::Document::parse(&xml).unwrap();
     let assertion = doc.root().children().find(|n| n.is_element()).unwrap();
-    let result = validate_subject_confirmation(assertion, "_req123", acs, now, false);
+    let result = validate_subject_confirmation(assertion, "_req123", acs, now);
     assert!(
         result.is_ok(),
         "Expected Ok when at least one SubjectConfirmation is valid, got: {result:?}"
@@ -676,7 +673,7 @@ fn subject_confirmation_multiple_all_invalid_recipient_returns_error() {
     let xml = assertion_with_subject_confirmations(&confirmations);
     let doc = roxmltree::Document::parse(&xml).unwrap();
     let assertion = doc.root().children().find(|n| n.is_element()).unwrap();
-    let err = validate_subject_confirmation(assertion, "_req123", acs, now, false).unwrap_err();
+    let err = validate_subject_confirmation(assertion, "_req123", acs, now).unwrap_err();
     assert!(
         matches!(err, ResponseError::DestinationMismatch { .. }),
         "Expected DestinationMismatch when all Recipients are wrong, got: {err}"
@@ -706,7 +703,7 @@ fn subject_confirmation_mixed_methods_one_valid_bearer_passes() {
     let xml = assertion_with_subject_confirmations(&confirmations);
     let doc = roxmltree::Document::parse(&xml).unwrap();
     let assertion = doc.root().children().find(|n| n.is_element()).unwrap();
-    let result = validate_subject_confirmation(assertion, "_req123", acs, now, false);
+    let result = validate_subject_confirmation(assertion, "_req123", acs, now);
     assert!(
         result.is_ok(),
         "Expected Ok when a bearer SubjectConfirmation is present alongside a non-bearer one, got: {result:?}"
@@ -741,7 +738,7 @@ fn subject_confirmation_multiple_first_expired_second_valid_passes() {
     let xml = assertion_with_subject_confirmations(&confirmations);
     let doc = roxmltree::Document::parse(&xml).unwrap();
     let assertion = doc.root().children().find(|n| n.is_element()).unwrap();
-    let result = validate_subject_confirmation(assertion, "_req123", acs, now, false);
+    let result = validate_subject_confirmation(assertion, "_req123", acs, now);
     assert!(
         result.is_ok(),
         "Expected Ok when a later SubjectConfirmation is valid despite an expired first one, got: {result:?}"
@@ -1424,7 +1421,6 @@ fn subject_confirmation_missing_subject_returns_error() {
         "_req123",
         "https://vouch.example.com/saml/acs",
         now,
-        false,
     )
     .unwrap_err();
     assert!(
@@ -1449,7 +1445,6 @@ fn subject_confirmation_empty_children_returns_error() {
         "_req123",
         "https://vouch.example.com/saml/acs",
         now,
-        false,
     )
     .unwrap_err();
     assert!(
@@ -1622,7 +1617,6 @@ fn subject_confirmation_require_irt_missing_irt_returns_error() {
         "_req123",
         "https://vouch.example.com/saml/acs",
         now,
-        true,
     )
     .unwrap_err();
     assert!(
@@ -1658,7 +1652,6 @@ fn subject_confirmation_require_irt_present_matching_passes() {
             "_req123",
             "https://vouch.example.com/saml/acs",
             now,
-            true,
         )
         .is_ok()
     );
@@ -1690,7 +1683,6 @@ fn subject_confirmation_require_irt_mismatch_fails() {
         "_req123",
         "https://vouch.example.com/saml/acs",
         now,
-        true,
     )
     .unwrap_err();
     assert!(
@@ -1699,10 +1691,11 @@ fn subject_confirmation_require_irt_mismatch_fails() {
     );
 }
 
-/// When `require_irt` is false and SubjectConfirmationData.InResponseTo is
-/// absent, validation MUST pass (existing behavior for Response-signed case).
+/// SAML Profiles 4.1.4.3 requires the bearer SubjectConfirmationData to
+/// carry InResponseTo for a solicited response, "Regardless of the SAML
+/// binding used". An assertion without it is rejected whatever is signed.
 #[test]
-fn subject_confirmation_no_require_irt_missing_irt_passes() {
+fn subject_confirmation_missing_irt_is_rejected() {
     let now = Timestamp::now();
     let future = now
         .checked_add(jiff::Span::new().hours(1))
@@ -1720,15 +1713,16 @@ fn subject_confirmation_no_require_irt_missing_irt_passes() {
     );
     let doc = roxmltree::Document::parse(&xml).unwrap();
     let assertion = doc.root().children().find(|n| n.is_element()).unwrap();
+    let err = validate_subject_confirmation(
+        assertion,
+        "_req123",
+        "https://vouch.example.com/saml/acs",
+        now,
+    )
+    .unwrap_err();
     assert!(
-        validate_subject_confirmation(
-            assertion,
-            "_req123",
-            "https://vouch.example.com/saml/acs",
-            now,
-            false,
-        )
-        .is_ok()
+        matches!(err, ResponseError::MissingSubjectConfirmationInResponseTo),
+        "Expected MissingSubjectConfirmationInResponseTo, got: {err}"
     );
 }
 
@@ -1945,11 +1939,14 @@ fn xsw_inresponseto_assertion_matches_but_response_differs_fails() {
 
 // --- Response-signed complement tests ---
 
-/// COMPLEMENT CASE: When the Response itself is signed,
-/// Response.InResponseTo is covered by the signature and can be trusted.
-/// SubjectConfirmationData.InResponseTo is NOT required in this case.
+/// Signing the Response does not excuse a missing
+/// SubjectConfirmationData.InResponseTo. SAML Profiles 4.1.4.3 lists the
+/// check under "Regardless of the SAML binding used, the service provider
+/// MUST do the following", with no exemption based on which element carries
+/// the signature — and 4.1.4.5 requires the assertion to be signed for the
+/// POST binding anyway, so the attribute is always inside signed content.
 #[test]
-fn response_signed_missing_scd_irt_passes() {
+fn response_signed_missing_scd_irt_is_still_rejected() {
     use base64::Engine as _;
     use base64::engine::general_purpose::STANDARD as B64;
 
@@ -1973,9 +1970,12 @@ fn response_signed_missing_scd_irt_passes() {
     );
 
     let base64_response = B64.encode(xml.as_bytes());
-    let result = validate_saml_response(&base64_response, "_request_irt_6", &provider);
-    let assertion = result.expect("Expected Ok for Response-signed with SCD.InResponseTo absent");
-    assert_eq!(assertion.email, "alice@example.com");
+    let err = validate_saml_response(&base64_response, "_request_irt_6", &provider)
+        .expect_err("a solicited response must carry SubjectConfirmationData.InResponseTo");
+    assert!(
+        matches!(err, ResponseError::MissingSubjectConfirmationInResponseTo),
+        "Expected MissingSubjectConfirmationInResponseTo, got: {err}"
+    );
 }
 
 /// When the Response is signed and SCD.InResponseTo is present and matches,


### PR DESCRIPTION
## The gap

#978 made the `SubjectConfirmationData/@InResponseTo` check conditional on the Response being unsigned. A Response-signed IdP that omits the attribute therefore passes validation with no binding to the original request inside signed content.

SAML Profiles §4.1.4.3 lists the check under **"Regardless of the SAML binding used, the service provider MUST do the following"**:

> "Verify that the InResponseTo attribute in the bearer `<SubjectConfirmationData>` equals the ID of its original `<AuthnRequest>` message, unless the response is unsolicited (see Section 4.1.5), in which case the attribute MUST NOT be present"

The requirement does not depend on which element carries the signature.

There is also no compatibility argument for keeping it conditional. Only the POST binding is accepted here, and §4.1.4.5 states:

> "If the HTTP POST binding is used to deliver the `<Response>`, the enclosed assertion(s) MUST be signed."

So the attribute is always inside signed content and the check can always be performed. `Response.InResponseTo` sits outside the assertion and can be modified without invalidating its signature, so it is never the binding relied upon — which was #978's correct insight, just applied too narrowly.

Removing the condition removes the `require_irt` flag threaded through three functions along with it.

## Tests

Two tests asserted the gap and now assert rejection:

- `subject_confirmation_missing_irt_is_rejected` (was `..._no_require_irt_missing_irt_passes`)
- `response_signed_missing_scd_irt_is_still_rejected` (was `response_signed_missing_scd_irt_passes`) — end-to-end through `validate_saml_response`

165 SAML tests, 3004 unit tests, and all 27 integration suites pass.

## On §4.1.5

The converse requirement — "An unsolicited `<Response>` MUST NOT contain an InResponseTo attribute" — needs no guard. The ACS handler requires a stored request ID before calling `validate_saml_response`, so there is no unsolicited path to reach. Recorded in the module docs so it is not later mistaken for a missing check and "fixed" with dead code.

## Provenance

Found by reading the spec rather than reasoning about it. I reviewed #978 and recommended its conditional form as "strictly more compatible" without opening SAML Profiles; the text says otherwise. This is the class of mistake #990 is meant to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Tightens SAML SSO request-binding checks used for authentication. Stricter validation can reject previously accepted Response-signed IdP assertions that omit SCD InResponseTo.
> 
> **Overview**
> SAML ACS validation now **always** requires bearer `SubjectConfirmationData.InResponseTo` to match the original AuthnRequest ID, even when the Response itself is signed.
> 
> Previously the check was skipped for Response-signed messages, so an IdP that omitted the attribute had no request binding inside signed assertion content. The `require_irt` flag is removed; `Response.InResponseTo` is still not treated as the trusted binding.
> 
> Tests that previously allowed a missing SCD `InResponseTo` now expect `MissingSubjectConfirmationInResponseTo`. Module docs note that unsolicited responses (Profiles 4.1.5) never reach this path because ACS requires a stored request ID.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bdc742ceffe9b8357eaf13cfa7c4f23b4fba91c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->