### PR TITLE
fix(oidc): compare max_age at full precision

### DIFF
--- a/crates/vouch-server/src/handlers/oidc/authorize.rs
+++ b/crates/vouch-server/src/handlers/oidc/authorize.rs
@@ -1453,14 +1453,28 @@ async fn authorize_authenticated_user(
         ReauthPolicy::OnDemand => {
             validated.prompt() == Some(Prompt::Login)
                 || validated.max_age().is_some_and(|max_age| {
-                    let age_secs = jiff::Timestamp::now()
-                        .duration_since(auth_session.created_at)
-                        .as_secs()
-                        .max(0);
-                    let Ok(age) = u64::try_from(age_secs) else {
-                        return true;
-                    };
-                    age >= max_age
+                    // OIDC Core 3.1.2.1: "If the elapsed time is greater than
+                    // this value, the OP MUST attempt to actively
+                    // re-authenticate the End-User." The same paragraph adds:
+                    // "Note that max_age=0 is equivalent to prompt=login."
+                    //
+                    // Both hold only when elapsed time is compared at full
+                    // precision. Truncating to whole seconds first rounds a
+                    // fresh session's age down to zero, so `>` would let it
+                    // satisfy max_age=0 and break the prompt=login
+                    // equivalence, while `>=` re-authenticates at exactly
+                    // max_age, which the spec requires only beyond it.
+                    // Comparing durations directly is exact at every value:
+                    // elapsed is never precisely zero, so max_age=0 always
+                    // re-authenticates.
+                    //
+                    // A max_age too large for `i64` seconds is ~292 billion
+                    // years, far beyond any session, so saturating means "no
+                    // age limit" rather than an arbitrary rejection.
+                    let elapsed = jiff::Timestamp::now().duration_since(auth_session.created_at);
+                    let limit =
+                        jiff::SignedDuration::from_secs(i64::try_from(max_age).unwrap_or(i64::MAX));
+                    elapsed > limit
                 })
         }
     };

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9470.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9470.rs
@@ -228,6 +228,59 @@ async fn test_rfc9470_acr_values_too_long_rejected() {
 // ========================================================================
 
 #[tokio::test]
+async fn test_rfc9470_max_age_one_does_not_reauth_a_fresh_session() {
+    // OIDC Core 3.1.2.1 requires re-authentication only when the elapsed
+    // time is *greater than* max_age. A session created moments ago is well
+    // inside max_age=1, so the flow must proceed rather than bounce to
+    // /login.
+    //
+    // This pins the non-zero side of the boundary. It does not by itself
+    // distinguish the duration comparison from the previous truncating one —
+    // `floor(e) >= M` and `e >= M` agree for integer M, so those differ only
+    // at exactly `e == M`, which is not reachable in a test. The property
+    // that separates the implementations is max_age=0, covered by
+    // `test_rfc9470_max_age_zero_forces_reauth`: truncating and then testing
+    // `>` reports a fresh session's age as 0, so `0 > 0` skips the
+    // re-authentication that "max_age=0 is equivalent to prompt=login"
+    // requires.
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "maxage-one@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+
+    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    let challenge = sha256_base64url(verifier);
+
+    let response = http_get_full(
+        &app,
+        &format!(
+            "/oauth/authorize?response_type=code&client_id={}&redirect_uri={}&scope=openid\
+             &code_challenge={}&code_challenge_method=S256&max_age=1",
+            client.client_id,
+            urlencoding::encode("https://example.com/callback"),
+            challenge,
+        ),
+        &[("Cookie", &format!("__Host-vouch_session={session_token}"))],
+    )
+    .await;
+
+    let location = response
+        .headers
+        .get("Location")
+        .expect("Must have Location header")
+        .to_str()
+        .expect("Valid UTF-8");
+
+    assert!(
+        !location.starts_with("/login"),
+        "a session younger than max_age=1 must not be re-authenticated, got: {location}"
+    );
+}
+
+#[tokio::test]
 async fn test_rfc9470_max_age_zero_forces_reauth() {
     // RFC 9470 / OIDC Core Section 3.1.2.1: max_age=0 means the user must
     // re-authenticate regardless of how fresh the session is. The server


### PR DESCRIPTION
Replaces #985. Closes #974.

## What the spec says

OIDC Core §3.1.2.1:

> "If the elapsed time is greater than this value, the OP MUST attempt to actively re-authenticate the End-User."

and, in the same paragraph:

> "Note that max_age=0 is equivalent to prompt=login."

Both statements have to hold at once. Truncation is what made them conflict.

## Why the current code is not a violation, and why it still changes

`max_age` was evaluated by truncating elapsed time to whole seconds and testing `>=`. Since `floor(e) >= M` holds exactly when `e >= M` for integer `M`, that re-authenticates at precisely `max_age` rather than beyond it. The spec requires re-authentication *beyond* the limit but never forbids doing it earlier, so this is conformant — one second conservative at worst. **#985's premise that it is a spec violation is wrong.**

What it is, is a trap. Under truncation, `>` reports a fresh session's age as `0`, so `0 > 0` skips the re-authentication `max_age=0` demands. Anyone later "simplifying" the operator to match the spec's wording breaks the `prompt=login` equivalence — which is exactly what #985 did, and why it had to pad three tests with one-second sleeps to go green.

Comparing durations directly removes the conflict. Elapsed time is never precisely zero, so `max_age=0` always re-authenticates, and `>` is exact at every other value. The operator now matches the spec's wording *and* is safe.

A `max_age` too large for `i64` seconds is about 292 billion years, so saturating reads it as "no age limit" rather than an arbitrary rejection.

## Evidence

**The three existing `max_age=0` tests pass unmodified — no sleeps, no padding.** I verified they are the discriminator by simulating #985's approach (truncation kept, `>=` → `>`): exactly those three fail.

Adds `test_rfc9470_max_age_one_does_not_reauth_a_fresh_session` pinning the non-zero side. Its comment records honestly that it does **not** by itself separate the two implementations — for integer limits they differ only at exactly `elapsed == max_age`, which no test can reach. I wrote that test believing it discriminated, checked, and found it didn't; the comment now says so rather than overclaiming.

3005 unit tests pass, clippy clean. Only `authorize.rs` changed on the production side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 28b6a7da3c1ac83fd80cdf9e404b633efbd9355c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->