### PR TITLE
fix(server): serialize cross-org domain claims on a shared row

### DIFF
--- a/crates/vouch-server/src/db/documents/organization.rs
+++ b/crates/vouch-server/src/db/documents/organization.rs
@@ -64,6 +64,38 @@ pub struct SubdomainClaimDoc {
     pub released_at: Option<Timestamp>,
 }
 
+/// Cross-org uniqueness slot for a verified email domain.
+///
+/// Two organizations must never both claim the same email domain: domain →
+/// org lookup resolves `ORDER BY created_at DESC LIMIT 1`, so a duplicate
+/// silently routes enrollment to whichever org document was created later,
+/// and the SCIM domain gate passes for both.
+///
+/// The `document_indexes` UNIQUE constraint is per-document, so it cannot
+/// express that. Two orgs verifying the same domain write to two different
+/// primary keys and never conflict. Hashing the domain into a shared
+/// document ID is what forces them to collide — the same construction as
+/// `deterministic_org_id` and [`SubdomainClaimDoc`].
+///
+/// Unlike a subdomain label, a released domain carries no reuse cooldown, so
+/// the row is deleted on release rather than tombstoned.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DomainClaimDoc {
+    /// The claimed domain (normalized lowercase).
+    pub domain: String,
+    /// The organization holding the claim.
+    pub org_id: String,
+}
+
+impl DocumentType for DomainClaimDoc {
+    const DOC_TYPE: &'static str = "domain_claim";
+
+    fn index_entries(&self) -> Vec<IndexEntry> {
+        // Looked up exclusively by deterministic document ID.
+        Vec::new()
+    }
+}
+
 impl DocumentType for SubdomainClaimDoc {
     const DOC_TYPE: &'static str = "subdomain_claim";
 

--- a/crates/vouch-server/src/db/enrollment.rs
+++ b/crates/vouch-server/src/db/enrollment.rs
@@ -4,7 +4,7 @@
 //! This module provides enrollment operations that ensure consistency
 //! when creating organizations and users during the OIDC enrollment flow.
 
-use super::documents::organization::OrganizationDoc;
+use super::documents::organization::{DomainClaimDoc, OrganizationDoc};
 use super::documents::user::{IdpIdentity, UpstreamLogin, UserDoc, idp_identity_index_value};
 use super::store::DocumentStore;
 use crate::error::ServiceError;
@@ -124,8 +124,41 @@ async fn get_or_create_org(store: &DocumentStore, domain: &str) -> Result<String
         additional_domains: Vec::new(),
         subdomain: None,
     };
-    match store.insert_with_id(&id, &doc).await {
-        Ok(result) => Ok(result.id),
+
+    // Take the domain's claim slot alongside the org row. Two orgs cannot
+    // share a *primary* domain — the org ID is a hash of it, so they collide
+    // on the primary key — but a primary domain and another org's additional
+    // domain can still race: the index read above sees nothing while that
+    // other org is mid-verification, and the two writes touch different rows.
+    // The shared slot is what makes them conflict.
+    let claim_id = crate::db::organizations::deterministic_domain_claim_id(domain);
+    let mut tx = store.begin().await?;
+    let slot_taken = match tx.get::<DomainClaimDoc>(&claim_id).await? {
+        None => {
+            let slot = DomainClaimDoc {
+                domain: domain.to_string(),
+                org_id: id.clone(),
+            };
+            tx.insert_with_id(&claim_id, &slot).await.is_ok()
+        }
+        // Held by another org that verified this domain first; fall through
+        // to the existing-org lookup below rather than creating a duplicate.
+        Some(existing) => existing.data.org_id == id,
+    };
+    if !slot_taken {
+        // Dropping the transaction rolls it back.
+        drop(tx);
+        return store
+            .find_one::<OrganizationDoc>("domain", domain)
+            .await?
+            .map(|org| org.id)
+            .context("domain claimed by an organization that could not be found");
+    }
+    match tx.insert_with_id(&id, &doc).await {
+        Ok(result) => {
+            tx.commit().await?;
+            Ok(result.id)
+        }
         Err(e) if super::pool::is_unique_violation(&e) => {
             // Concurrent enrollee inserted first — re-fetch.
             let org = match store.get::<OrganizationDoc>(&id).await? {

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -74,7 +74,7 @@ pub use authenticators::{
 
 // Re-export organization types and functions
 pub use documents::organization::{
-    AdditionalDomain, OrgSigningKeyDoc, SigningKeyState, SubdomainClaimDoc,
+    AdditionalDomain, DomainClaimDoc, OrgSigningKeyDoc, SigningKeyState, SubdomainClaimDoc,
     UNVERIFY_FAILURE_THRESHOLD,
 };
 pub use organizations::{

--- a/crates/vouch-server/src/db/organizations/domains.rs
+++ b/crates/vouch-server/src/db/organizations/domains.rs
@@ -11,7 +11,7 @@ use super::ORG_SCAN_PAGE_SIZE;
 use super::issuer::{release_ineligible_subdomain, subdomain_to_release};
 use super::validation::{DomainValidationError, normalize_domain};
 use crate::db::documents::organization::{
-    AdditionalDomain, AdditionalDomainState, OrganizationDoc,
+    AdditionalDomain, AdditionalDomainState, DomainClaimDoc, OrganizationDoc,
 };
 use crate::db::store::DocumentStore;
 use anyhow::Result;
@@ -19,6 +19,21 @@ use jiff::Timestamp;
 
 /// Maximum additional (non-primary) email domains per organization.
 pub const MAX_ADDITIONAL_DOMAINS: usize = 10;
+
+/// Deterministic document ID for a domain's cross-org claim slot.
+///
+/// Same construction as `deterministic_org_id` and
+/// `deterministic_subdomain_claim_id`: the shared primary key is what makes
+/// concurrent claims from different organizations collide, since each would
+/// otherwise version-bump only its own org document and never conflict.
+pub(crate) fn deterministic_domain_claim_id(domain: &str) -> String {
+    use aws_lc_rs::digest::{self, SHA256};
+
+    let mut ctx = digest::Context::new(&SHA256);
+    ctx.update(b"domain_claim\0");
+    ctx.update(domain.as_bytes());
+    hex::encode(ctx.finish().as_ref())
+}
 
 /// List additional domains for an organization.
 pub async fn list_additional_domains(
@@ -359,6 +374,32 @@ pub async fn mark_additional_domain_verified(
             return Err(MarkVerifiedError::ClaimedByOtherOrg);
         }
 
+        // Take the claim slot. The read above settles conflicts against
+        // already-committed domains, but two organizations verifying the same
+        // domain concurrently both see nothing and then version-bump their own
+        // org document, which never conflicts. A shared primary key is what
+        // makes them collide.
+        let claim_id = deterministic_domain_claim_id(&normalized);
+        match tx.get::<DomainClaimDoc>(&claim_id).await? {
+            None => {
+                let slot = DomainClaimDoc {
+                    domain: normalized.clone(),
+                    org_id: org_id.to_string(),
+                };
+                if let Err(e) = tx.insert_with_id(&claim_id, &slot).await {
+                    if crate::db::pool::is_unique_violation(&e) {
+                        return Err(MarkVerifiedError::ClaimedByOtherOrg);
+                    }
+                    return Err(MarkVerifiedError::Other(e));
+                }
+            }
+            Some(existing) if existing.data.org_id != org_id => {
+                return Err(MarkVerifiedError::ClaimedByOtherOrg);
+            }
+            // Already ours: re-verification of a domain this org still holds.
+            Some(_) => {}
+        }
+
         // Reset re-verification state so a freshly re-verified entry is treated
         // identically to a brand-new verification by the background task.
         entry.state = AdditionalDomainState::Verified {
@@ -427,6 +468,11 @@ pub async fn remove_additional_domain(
         let version = org_doc.version;
         let mut data = org_doc.data;
 
+        // A verified entry holds a claim slot; a pending one never took one.
+        let held_claim = data.additional_domains.iter().any(|ad| {
+            ad.domain == normalized && matches!(ad.state, AdditionalDomainState::Verified { .. })
+        });
+
         let original_len = data.additional_domains.len();
         data.additional_domains.retain(|ad| ad.domain != normalized);
         if data.additional_domains.len() == original_len {
@@ -439,14 +485,27 @@ pub async fn remove_additional_domain(
         // the claim slot and the mirror must move together, but the common
         // no-subdomain path stays a plain CAS (a read-then-write transaction
         // can deadlock concurrent writers on SQLite's deferred locking).
-        let released = if let Some(label) = subdomain_to_release(&data) {
+        // A transaction is opened only when something besides the org
+        // document must move with it: a released subdomain, or a claim slot.
+        // Releasing the slot has to be atomic with the removal — dropping it
+        // while the removal fails would let another org claim a domain this
+        // one still holds, and the reverse strands the domain permanently,
+        // since a second removal attempt returns early with nothing to remove.
+        let subdomain = subdomain_to_release(&data);
+        let released = if subdomain.is_some() || held_claim {
             let mut tx = store.begin().await?;
-            release_ineligible_subdomain(&mut tx, org_id, &mut data, &label).await?;
+            if let Some(label) = subdomain.as_deref() {
+                release_ineligible_subdomain(&mut tx, org_id, &mut data, label).await?;
+            }
+            if held_claim {
+                tx.delete(&deterministic_domain_claim_id(&normalized))
+                    .await?;
+            }
             if !tx.compare_and_update(org_id, version, &data).await? {
                 return Err(OrgCasError::OccConflict);
             }
             tx.commit().await?;
-            Some(label)
+            subdomain
         } else {
             if !store.compare_and_update(org_id, version, &data).await? {
                 return Err(OrgCasError::OccConflict);
@@ -875,15 +934,24 @@ pub async fn record_recheck_result(
             None
         };
 
-        if let Some(label) = to_release {
+        // Losing verification also releases the domain's claim slot, or the
+        // domain stays unclaimable by anyone — including this org, which can
+        // no longer re-verify it.
+        if to_release.is_some() || flipped {
             let mut tx = store.begin().await?;
-            release_ineligible_subdomain(&mut tx, org_id, &mut data, &label).await?;
+            if let Some(label) = to_release.as_deref() {
+                release_ineligible_subdomain(&mut tx, org_id, &mut data, label).await?;
+            }
+            if flipped {
+                tx.delete(&deterministic_domain_claim_id(&normalized))
+                    .await?;
+            }
             if !tx.compare_and_update(org_id, version, &data).await? {
                 return Err(OrgCasError::OccConflict);
             }
             tx.commit().await?;
             if let RecheckEffect::FlippedToUnverified { released_subdomain } = &mut effect {
-                *released_subdomain = Some(label);
+                *released_subdomain = to_release;
             }
         } else if !store.compare_and_update(org_id, version, &data).await? {
             return Err(OrgCasError::OccConflict);
@@ -1157,6 +1225,115 @@ mod tests {
             err.to_string().contains("pending verification"),
             "expected cross-page pending conflict to be detected, got: {err}"
         );
+    }
+
+    /// The slot, not the conflict read, is what settles a concurrent claim.
+    ///
+    /// The slot is seeded for org A *without* updating org A's document, which
+    /// is the state a real interleaving produces: org A's write has landed but
+    /// the index the conflict read consults has not caught up. The read
+    /// therefore finds nothing and only the slot can reject org B — so this
+    /// fails when the slot is removed. A sequential two-call test does not:
+    /// by the second call org A's domain is already indexed, and the
+    /// pre-existing read rejects it without the slot doing any work.
+    #[tokio::test]
+    async fn claim_slot_rejects_a_second_org_when_the_index_read_cannot() {
+        let store = fresh_store().await;
+        let org_a = create_organization(&store, "a-corp.com", None, None)
+            .await
+            .unwrap();
+        let org_b = create_organization(&store, "b-corp.com", None, None)
+            .await
+            .unwrap();
+
+        add_additional_domain(
+            &store,
+            &org_b.id,
+            "contested.com",
+            "user-b",
+            "u@example.com",
+        )
+        .await
+        .unwrap();
+
+        // Org A holds the slot; nothing in any org document says so yet.
+        store
+            .insert_with_id(
+                &deterministic_domain_claim_id("contested.com"),
+                &DomainClaimDoc {
+                    domain: "contested.com".to_string(),
+                    org_id: org_a.id.clone(),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            store
+                .find_one::<OrganizationDoc>("domain", "contested.com")
+                .await
+                .unwrap()
+                .is_none(),
+            "precondition: the conflict read must not see the claim"
+        );
+
+        let result = mark_additional_domain_verified(&store, &org_b.id, "contested.com").await;
+        assert!(
+            matches!(result, Err(MarkVerifiedError::ClaimedByOtherOrg)),
+            "the slot must reject the second org, got: {result:?}"
+        );
+    }
+
+    /// Releasing a domain frees its slot, or the domain becomes permanently
+    /// unclaimable — including by the organization that released it.
+    #[tokio::test]
+    async fn removing_a_verified_domain_frees_it_for_another_org() {
+        let store = fresh_store().await;
+        let org_a = create_organization(&store, "a-corp.com", None, None)
+            .await
+            .unwrap();
+        let org_b = create_organization(&store, "b-corp.com", None, None)
+            .await
+            .unwrap();
+
+        add_additional_domain(&store, &org_a.id, "shared.com", "user-a", "u@example.com")
+            .await
+            .unwrap();
+        mark_additional_domain_verified(&store, &org_a.id, "shared.com")
+            .await
+            .unwrap();
+
+        remove_additional_domain(&store, &org_a.id, "shared.com")
+            .await
+            .unwrap()
+            .expect("domain was attached");
+
+        add_additional_domain(&store, &org_b.id, "shared.com", "user-b", "u@example.com")
+            .await
+            .unwrap();
+        mark_additional_domain_verified(&store, &org_b.id, "shared.com")
+            .await
+            .expect("released domain must be claimable again");
+    }
+
+    /// Re-verifying a domain this org already holds is not a conflict with
+    /// itself: the recheck path calls straight back into verification.
+    #[tokio::test]
+    async fn reverifying_own_domain_is_not_a_conflict() {
+        let store = fresh_store().await;
+        let org = create_organization(&store, "acme.com", None, None)
+            .await
+            .unwrap();
+        add_additional_domain(&store, &org.id, "acme.co.uk", "user-1", "u@example.com")
+            .await
+            .unwrap();
+
+        mark_additional_domain_verified(&store, &org.id, "acme.co.uk")
+            .await
+            .unwrap();
+        mark_additional_domain_verified(&store, &org.id, "acme.co.uk")
+            .await
+            .expect("re-verifying our own domain must succeed");
     }
 
     #[tokio::test]

--- a/crates/vouch-server/src/db/organizations/mod.rs
+++ b/crates/vouch-server/src/db/organizations/mod.rs
@@ -9,6 +9,7 @@ use anyhow::Result;
 mod validation;
 use jiff::Timestamp;
 mod domains;
+pub(crate) use domains::deterministic_domain_claim_id;
 pub use domains::{
     AddDomainError, AddedDomain, DomainRemovalSummary, MAX_ADDITIONAL_DOMAINS, MarkVerifiedError,
     RecheckEffect, RecheckOutcome, StaleDomainRemoval, VerifiedDomainRecord, add_additional_domain,


### PR DESCRIPTION
Closes #965.

## The race

`mark_additional_domain_verified` reads the `domain` index for a conflict, then version-bumps **its own** organization document. Two organizations verifying the same domain concurrently both see nothing and both write successfully — different primary keys never collide, so nothing serializes them. `add_additional_domain` has the same shape, and its comment accepts that race explicitly on the grounds that *"Only one will win at verification time"*. That was the assumption being relied on.

A duplicate is not cosmetic. `find_one` resolves `ORDER BY created_at DESC LIMIT 1`, so domain → org routing silently follows whichever organization document was created later — enrollment binds users to the wrong org, invisibly to both admins — and the SCIM domain gate passes for both.

SQLite mostly hides this (serialized writes; the loser retries and sees the conflict). PostgreSQL at READ COMMITTED and DSQL at REPEATABLE READ both let it through.

## Why not a database constraint

This was the first thing I checked, and it is closed off on both routes:

- A **partial** unique index scoped to `index_field = 'domain'` — Aurora DSQL rejects `WHERE` on `CREATE INDEX`.
- A **non-partial** unique index on `(index_field, index_value)` — would forbid any two documents sharing a value for the same field, breaking `org_id`, `user_id`, and every other legitimately-shared index.

The `document_indexes` UNIQUE constraint is per-document *by design*. "Unique for this one field only" is inexpressible in the schema.

## The fix

The domain gets a row of its own, keyed by `sha256("domain_claim\0" + domain)`. Concurrent claimants collide on that shared primary key instead of writing past each other.

This is the third use of an established pattern, not a new design: `deterministic_org_id` does it for primary domains (its doc comment explains precisely this reasoning), and `SubdomainClaimDoc` for subdomain labels. Unlike a subdomain, a released domain has no reuse cooldown, so the row is deleted rather than tombstoned.

**Both windows are closed.** Verification takes the slot, and so does organization creation — two orgs cannot share a *primary* domain, since the org ID is a hash of it, but a primary domain still races against another org's additional domain.

**Release is exhaustive**, or a domain becomes unclaimable by anyone including its previous holder. Removal and the unverify flip both drop the row atomically with the document update. Stale-domain cleanup needs no release: it only removes pending entries, which never took a slot, and unverified ones, whose slot the flip already dropped.

## On the test

The first version I wrote **passed with the fix removed** — two sequential calls are caught by the pre-existing index read, so it tested nothing. The committed test seeds the slot *without* the document mirror, which is the state an interleaving actually produces: the index read finds nothing, so only the slot can reject the second organization. Verified to fail with `Ok(())` when the slot logic is removed.

3022 unit tests and all 27 integration suites pass.

## Known limitation

Domain ownership is now dual-written — the organization document and the slot — so each state transition has to move both, which is why there are four touch points rather than one. The cleaner end state is to make the slot the single source of truth for domain → org, dropping the mirror entirely; that touches `verified_domains()`, the index, enrollment lookup, and the SCIM gate, so it is a refactor rather than a fix. Worth doing if this area is revisited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches tenant isolation: domain → org routing for enrollment and SCIM. Dual-writes the claim slot with org documents; a failed release could strand a domain or allow a duplicate claim.
> 
> **Overview**
> Closes a race where two orgs could both verify the same email domain: the conflict check only reads the `domain` index, then each org version-bumps **its own** document, so concurrent writes never collide. Duplicates silently mis-route enrollment (`ORDER BY created_at DESC`) and pass the SCIM domain gate.
> 
> Adds a `DomainClaimDoc` keyed by `sha256("domain_claim\0" + domain)` (same pattern as org IDs and subdomain claims). Verification and org creation take the slot in the same transaction as the org write. Removal and the unverified flip delete the row atomically with the org update so the domain is claimable again and never stranded. Re-verify of a domain this org already holds is not treated as a conflict.
> 
> Tests seed the slot without an indexed org document so the slot—not the existing index read—is what rejects the second claimant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c9c157a4b997388c1473ae30486ecdd8c34a407. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->