### PR TITLE
refactor(server): compile-enforced secret redaction via SecretString

### DIFF
--- a/crates/vouch-common/src/api.rs
+++ b/crates/vouch-common/src/api.rs
@@ -148,7 +148,8 @@ pub struct DeviceTokenRequest {
 #[derive(Serialize, Deserialize)]
 pub struct DeviceTokenResponse {
     /// JWT access token.
-    pub access_token: String,
+    #[serde(serialize_with = "serialize_secret_string")]
+    pub access_token: secrecy::SecretString,
     /// Token type ("Bearer" or "DPoP" for sender-constrained tokens).
     pub token_type: String,
     /// Seconds until token expires.
@@ -446,7 +447,8 @@ pub struct SshCaPublicKeyResponse {
 #[derive(Serialize, Deserialize)]
 pub struct CloudTokenResponse {
     /// OIDC ID token for use with cloud provider identity federation.
-    pub id_token: String,
+    #[serde(serialize_with = "serialize_secret_string")]
+    pub id_token: secrecy::SecretString,
     /// Token validity period in seconds.
     pub expires_in: u64,
 }
@@ -515,6 +517,28 @@ where
     serializer.serialize_str(secret.expose_secret())
 }
 
+/// Serialize an `Option<SecretString>` by exposing its value.
+///
+/// The `Option` counterpart of [`serialize_secret_string`], with the same
+/// deliberate-exposure contract. `None` serializes as an explicit `null` —
+/// matching `Option<String>` — so wire formats are unchanged on fields that
+/// don't use `skip_serializing_if`.
+///
+/// Use with `#[serde(serialize_with = "vouch_common::serialize_opt_secret_string")]`.
+pub fn serialize_opt_secret_string<S>(
+    secret: &Option<secrecy::SecretString>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    use secrecy::ExposeSecret;
+    match secret {
+        Some(value) => serializer.serialize_some(value.expose_secret()),
+        None => serializer.serialize_none(),
+    }
+}
+
 impl std::fmt::Debug for GitHubTokenResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GitHubTokenResponse")
@@ -564,7 +588,7 @@ mod tests {
     #[test]
     fn test_cloud_token_response_debug_redacts_id_token() {
         let response = CloudTokenResponse {
-            id_token: "eyJhbGciOiJSUzI1NiJ9.secret-token".to_string(),
+            id_token: "eyJhbGciOiJSUzI1NiJ9.secret-token".into(),
             expires_in: 28_800,
         };
         let debug = format!("{response:?}");

--- a/crates/vouch-common/src/lib.rs
+++ b/crates/vouch-common/src/lib.rs
@@ -42,7 +42,7 @@ pub use api::{
     ListKeysResponse, OAuthError, RegisterCompleteRequest, RegisterCompleteResponse,
     RegisterStartRequest, RegisterStartResponse, RenameKeyRequest, RenameKeyResponse,
     SessionStatus, SshCaPublicKeyResponse, SshCertificateRequest, SshCertificateResponse,
-    serialize_secret_string,
+    serialize_opt_secret_string, serialize_secret_string,
 };
 pub use cookie::{SessionCookie, clear_cookie, cookie_path, write_cookie};
 pub use error::ApiError;

--- a/crates/vouch-server/src/db/documents/organization.rs
+++ b/crates/vouch-server/src/db/documents/organization.rs
@@ -2,7 +2,7 @@
 //! Organization document type.
 
 use jiff::Timestamp;
-use secrecy::{ExposeSecret, SecretString};
+use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
 
 use crate::db::document_type::{DocumentType, IndexEntry};
@@ -105,15 +105,6 @@ impl DocumentType for SubdomainClaimDoc {
     }
 }
 
-/// Serialize a [`SecretString`] field by exposing it. Only for fields whose
-/// document is sealed at rest by the store.
-fn serialize_secret_string<S: serde::Serializer>(
-    value: &SecretString,
-    serializer: S,
-) -> Result<S::Ok, S::Error> {
-    serializer.serialize_str(value.expose_secret())
-}
-
 /// State of a per-org issuer signing key (Auth0-style rotation).
 ///
 /// A key set always holds a `Current` signer and a `Next` successor: the
@@ -171,7 +162,7 @@ pub struct OrgSigningKeyDoc {
     /// it out of `Debug` output and zeroizes the buffer on drop; at rest the
     /// document store seals the whole document (keys are only ever created
     /// when `DocumentStore::is_encrypted`).
-    #[serde(serialize_with = "serialize_secret_string")]
+    #[serde(serialize_with = "vouch_common::serialize_secret_string")]
     pub private_pkcs8_der_b64: SecretString,
     /// Rotation state; also selects the document's deterministic ID. Defaults
     /// to `Current` so existing rows without this field deserialize correctly.
@@ -234,7 +225,9 @@ pub struct AdditionalDomain {
     /// Normalized lowercase ASCII domain.
     pub domain: String,
     /// Random hex token the admin must publish as `_vouch-verification.<domain>` TXT.
-    pub verification_token: String,
+    /// Serialized by exposure: the org document is sealed at rest by the store.
+    #[serde(serialize_with = "vouch_common::serialize_secret_string")]
+    pub verification_token: SecretString,
     pub added_at: Timestamp,
     pub added_by_user_id: String,
     /// Email of the admin who added this entry, denormalized at write time

--- a/crates/vouch-server/src/db/documents/user.rs
+++ b/crates/vouch-server/src/db/documents/user.rs
@@ -8,7 +8,7 @@ use crate::db::document_type::{DocumentType, IndexEntry};
 use crate::email::Email;
 
 /// A Vouch user.
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct UserDoc {
     /// Canonical (trimmed, ASCII-lowercased) address. The [`Email`] type
     /// canonicalizes on construction and deserialization, so the `email`
@@ -23,7 +23,8 @@ pub struct UserDoc {
     pub external_id: Option<String>,
     pub github_id: Option<i64>,
     pub github_login: Option<String>,
-    pub github_refresh_token: Option<String>,
+    #[serde(serialize_with = "vouch_common::serialize_opt_secret_string")]
+    pub github_refresh_token: Option<secrecy::SecretString>,
     /// Upstream IdP identities bound to this account, at most one per
     /// issuer (enforced by `enroll_user_with_org`, not the schema).
     /// Empty for accounts that predate identity binding and for
@@ -231,6 +232,44 @@ mod tests {
         let doc: Result<UserDoc, _> = serde_json::from_str(json);
         let doc = doc.expect("legacy user JSON must deserialize");
         assert!(doc.idp_identities.is_empty());
+    }
+
+    #[test]
+    fn github_refresh_token_round_trips_as_plain_json_string() {
+        // The SecretString field must serialize exactly like the
+        // Option<String> it replaced (explicit serializer, None -> null),
+        // and stored documents must read back with the value intact.
+        use secrecy::ExposeSecret;
+
+        let mut doc = UserDoc {
+            email: Email::new("rt@example.com"),
+            name: None,
+            org_id: None,
+            is_org_admin: false,
+            active: true,
+            external_id: None,
+            github_id: None,
+            github_login: None,
+            github_refresh_token: Some("ghr_secret-value".into()),
+            idp_identities: Vec::new(),
+        };
+        let json = serde_json::to_value(&doc).expect("serialize UserDoc");
+        assert_eq!(json["github_refresh_token"], "ghr_secret-value");
+
+        let read: UserDoc = serde_json::from_value(json).expect("deserialize UserDoc");
+        assert_eq!(
+            read.github_refresh_token
+                .as_ref()
+                .map(|s| s.expose_secret()),
+            Some("ghr_secret-value")
+        );
+
+        doc.github_refresh_token = None;
+        let json = serde_json::to_value(&doc).expect("serialize UserDoc");
+        assert!(
+            json["github_refresh_token"].is_null() && json.get("github_refresh_token").is_some(),
+            "None must serialize as an explicit null: {json}"
+        );
     }
 
     #[test]

--- a/crates/vouch-server/src/db/documents/user.rs
+++ b/crates/vouch-server/src/db/documents/user.rs
@@ -254,7 +254,10 @@ mod tests {
             idp_identities: Vec::new(),
         };
         let json = serde_json::to_value(&doc).expect("serialize UserDoc");
-        assert_eq!(json["github_refresh_token"], "ghr_secret-value");
+        assert_eq!(
+            json.get("github_refresh_token"),
+            Some(&serde_json::Value::from("ghr_secret-value"))
+        );
 
         let read: UserDoc = serde_json::from_value(json).expect("deserialize UserDoc");
         assert_eq!(
@@ -267,7 +270,7 @@ mod tests {
         doc.github_refresh_token = None;
         let json = serde_json::to_value(&doc).expect("serialize UserDoc");
         assert!(
-            json["github_refresh_token"].is_null() && json.get("github_refresh_token").is_some(),
+            json.get("github_refresh_token") == Some(&serde_json::Value::Null),
             "None must serialize as an explicit null: {json}"
         );
     }

--- a/crates/vouch-server/src/db/organizations/domains.rs
+++ b/crates/vouch-server/src/db/organizations/domains.rs
@@ -47,7 +47,7 @@ pub async fn list_additional_domains(
 /// Result of adding an additional domain.
 pub struct AddedDomain {
     pub domain: String,
-    pub verification_token: String,
+    pub verification_token: secrecy::SecretString,
 }
 
 // Custom Debug that redacts verification_token to keep the DNS challenge
@@ -278,7 +278,7 @@ pub async fn add_additional_domain(
 
         data.additional_domains.push(AdditionalDomain {
             domain: normalized.clone(),
-            verification_token: token.clone(),
+            verification_token: token.clone().into(),
             added_at: now,
             added_by_user_id: added_by_user_id.to_string(),
             added_by_email: added_by_email.to_string(),
@@ -293,7 +293,7 @@ pub async fn add_additional_domain(
 
         Ok(AddedDomain {
             domain: normalized.clone(),
-            verification_token: token,
+            verification_token: token.into(),
         })
     })
 }
@@ -307,7 +307,7 @@ pub async fn get_verification_token(
     store: &DocumentStore,
     org_id: &str,
     domain: &str,
-) -> Result<Option<String>> {
+) -> Result<Option<secrecy::SecretString>> {
     let normalized = normalize_domain(domain)?;
     let Some(doc) = store.get::<OrganizationDoc>(org_id).await? else {
         return Ok(None);
@@ -758,7 +758,7 @@ pub async fn cleanup_stale_additional_domains(
 pub struct VerifiedDomainRecord {
     pub org_id: String,
     pub domain: String,
-    pub verification_token: String,
+    pub verification_token: secrecy::SecretString,
     pub last_checked_at: Option<Timestamp>,
     pub consecutive_failures: u32,
 }
@@ -1020,6 +1020,8 @@ async fn find_conflicting_claim_in_other_org(
     reason = "test code: panic on assertion failure is acceptable"
 )]
 mod tests {
+    use secrecy::ExposeSecret;
+
     use super::super::{create_organization, fresh_store};
     use super::*;
 
@@ -1039,7 +1041,7 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(added.domain, "acme.co.uk");
-        assert!(!added.verification_token.is_empty());
+        assert!(!added.verification_token.expose_secret().is_empty());
 
         let list = list_additional_domains(&store, &org.id).await.unwrap();
         assert_eq!(list.len(), 1);
@@ -1593,7 +1595,7 @@ mod tests {
             .unwrap();
         doc.data.additional_domains.push(AdditionalDomain {
             domain: "squatted.example.com".to_string(),
-            verification_token: "tok".to_string(),
+            verification_token: "tok".into(),
             added_at: stale_added,
             added_by_user_id: "u1".to_string(),
             added_by_email: "u1@example.com".to_string(),
@@ -1676,7 +1678,7 @@ mod tests {
             .unwrap();
         doc.data.additional_domains.push(AdditionalDomain {
             domain: "drifted.example.com".to_string(),
-            verification_token: "tok".to_string(),
+            verification_token: "tok".into(),
             added_at: old_verified_at,
             added_by_user_id: "u1".to_string(),
             added_by_email: "u1@example.com".to_string(),
@@ -1758,7 +1760,7 @@ mod tests {
             .unwrap();
         doc.data.additional_domains.push(AdditionalDomain {
             domain: "flips-late.example.com".to_string(),
-            verification_token: "tok".to_string(),
+            verification_token: "tok".into(),
             added_at: stale_added,
             added_by_user_id: "u1".to_string(),
             added_by_email: "u1@example.com".to_string(),
@@ -1834,7 +1836,7 @@ mod tests {
                     // now Verified" — i.e., the admin verified it during
                     // the race window.
                     domain: "racy.example.com".to_string(),
-                    verification_token: "tok".to_string(),
+                    verification_token: "tok".into(),
                     added_at,
                     added_by_user_id: "u1".to_string(),
                     added_by_email: "u1@example.com".to_string(),
@@ -1848,7 +1850,7 @@ mod tests {
                     // A genuinely stale Pending entry that should still be
                     // removed even when other candidates are spared.
                     domain: "squat.example.com".to_string(),
-                    verification_token: "tok2".to_string(),
+                    verification_token: "tok2".into(),
                     added_at,
                     added_by_user_id: "u1".to_string(),
                     added_by_email: "u1@example.com".to_string(),

--- a/crates/vouch-server/src/db/users.rs
+++ b/crates/vouch-server/src/db/users.rs
@@ -19,7 +19,7 @@ pub struct User {
     pub external_id: Option<String>,
     pub github_id: Option<i64>,
     pub github_login: Option<String>,
-    pub github_refresh_token: Option<String>,
+    pub github_refresh_token: Option<secrecy::SecretString>,
 }
 
 // Custom Debug that redacts github_refresh_token to prevent accidental log
@@ -417,7 +417,7 @@ pub async fn update_user_github_identity(
             data.github_id = Some(github_id);
             data.github_login = Some(github_login.to_string());
             if let Some(token) = github_refresh_token {
-                data.github_refresh_token = Some(token.to_string());
+                data.github_refresh_token = Some(secrecy::SecretString::from(token));
             }
         })
         .await?;
@@ -432,7 +432,7 @@ pub async fn update_user_github_identity(
 pub async fn get_user_github_refresh_token(
     store: &DocumentStore,
     user_id: &str,
-) -> Result<Option<String>> {
+) -> Result<Option<secrecy::SecretString>> {
     let doc = store.get::<UserDoc>(user_id).await?;
     Ok(doc.and_then(|d| d.data.github_refresh_token))
 }

--- a/crates/vouch-server/src/handlers/admin/domains.rs
+++ b/crates/vouch-server/src/handlers/admin/domains.rs
@@ -21,6 +21,7 @@ use axum::http::{HeaderMap, Method};
 use axum::response::{IntoResponse, Redirect, Response};
 use axum_extra::extract::cookie::CookieJar;
 use jiff::Timestamp;
+use secrecy::ExposeSecret;
 use serde::Deserialize;
 use std::sync::Arc;
 
@@ -107,15 +108,17 @@ fn build_rows(org: &db::Organization) -> Vec<DomainRow> {
     });
     for ad in &org.additional_domains {
         use crate::db::documents::organization::AdditionalDomainState;
+        // Deliberate render-boundary exposure: showing the TXT challenge
+        // value so the admin can publish it is this page's purpose.
         let (status, verification_token) = match &ad.state {
             AdditionalDomainState::Verified { .. } => (DomainRowStatus::Verified, None),
             AdditionalDomainState::Unverified { .. } => (
                 DomainRowStatus::Unverified,
-                Some(ad.verification_token.clone()),
+                Some(ad.verification_token.expose_secret().to_string()),
             ),
             AdditionalDomainState::Pending => (
                 DomainRowStatus::Pending,
-                Some(ad.verification_token.clone()),
+                Some(ad.verification_token.expose_secret().to_string()),
             ),
         };
         rows.push(DomainRow {
@@ -341,7 +344,7 @@ pub(crate) async fn admin_verify_domain(
         }
     };
 
-    let txt_ok = match dns::verify_txt_record(&normalized, &token).await {
+    let txt_ok = match dns::verify_txt_record(&normalized, token.expose_secret()).await {
         Ok(b) => b,
         Err(e) => {
             tracing::warn!(

--- a/crates/vouch-server/src/handlers/admin/scim_tokens.rs
+++ b/crates/vouch-server/src/handlers/admin/scim_tokens.rs
@@ -14,7 +14,7 @@ use axum::http::{HeaderMap, Method, StatusCode};
 use axum::response::{IntoResponse, Redirect, Response};
 use axum_extra::extract::cookie::CookieJar;
 use jiff::Timestamp;
-use secrecy::ExposeSecret;
+use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use std::sync::Arc;
 
@@ -68,7 +68,8 @@ pub(crate) struct CreateScimTokenRequest {
 #[derive(serde::Serialize)]
 pub(crate) struct CreateScimTokenResponse {
     pub id: String,
-    pub token: String,
+    #[serde(serialize_with = "vouch_common::serialize_secret_string")]
+    pub token: SecretString,
     pub description: Option<String>,
     pub expires_at: Option<Timestamp>,
     pub audit_read: bool,
@@ -175,7 +176,7 @@ pub(crate) async fn create_scim_token(
 
     Ok(Json(CreateScimTokenResponse {
         id: token_id,
-        token: generated.plaintext.expose_secret().to_string(),
+        token: generated.plaintext.clone(),
         description: req.description,
         expires_at,
         audit_read: req.audit_read,
@@ -475,6 +476,8 @@ pub(crate) async fn admin_create_scim_token(
         auth,
         tokens,
         flash_message: None,
+        // Deliberate render-boundary exposure: this page shows the token
+        // once, at creation, which is its purpose (Askama needs Display).
         new_token: Some(generated.plaintext.expose_secret().to_string()),
     }
     .into_response())

--- a/crates/vouch-server/src/handlers/applications/api.rs
+++ b/crates/vouch-server/src/handlers/applications/api.rs
@@ -172,7 +172,7 @@ pub(crate) async fn create_application_api(
             return Err(e);
         }
 
-        Some(secret)
+        Some(secrecy::SecretString::from(secret))
     } else {
         None
     };
@@ -504,7 +504,7 @@ pub(crate) async fn add_secret_api(
         StatusCode::CREATED,
         Json(AddSecretResponse {
             secret_id: record.id,
-            client_secret: secret,
+            client_secret: secret.into(),
             created_at: record.created_at,
             expires_at: record.expires_at,
         }),

--- a/crates/vouch-server/src/handlers/applications/types.rs
+++ b/crates/vouch-server/src/handlers/applications/types.rs
@@ -288,7 +288,8 @@ pub(crate) struct UpdateApplicationRequest {
 pub(crate) struct CreateApplicationResponse {
     pub id: String,
     pub client_id: String,
-    pub client_secret: Option<String>,
+    #[serde(serialize_with = "vouch_common::serialize_opt_secret_string")]
+    pub client_secret: Option<secrecy::SecretString>,
     pub name: String,
     pub application_type: String,
     pub access_scope: String,
@@ -404,7 +405,8 @@ pub(crate) struct AddSecretRequest {
 #[derive(Serialize)]
 pub(crate) struct AddSecretResponse {
     pub secret_id: String,
-    pub client_secret: String,
+    #[serde(serialize_with = "vouch_common::serialize_secret_string")]
+    pub client_secret: secrecy::SecretString,
     pub created_at: Timestamp,
     pub expires_at: Option<Timestamp>,
 }

--- a/crates/vouch-server/src/handlers/certification.rs
+++ b/crates/vouch-server/src/handlers/certification.rs
@@ -79,15 +79,16 @@ pub(crate) async fn complete_login(
     Query(query): Query<CompleteLoginQuery>,
 ) -> Response {
     // ── 1. Token validation ───────────────────────────────────────────────
-    let secret = match state.config().certification_test_token.as_ref() {
-        Some(s) => s.expose_secret().to_string(),
+    let config = state.config();
+    let secret = match config.certification_test_token.as_ref() {
+        Some(s) => s,
         None => {
             tracing::error!("Certification endpoint called but token not configured");
             return StatusCode::NOT_FOUND.into_response();
         }
     };
 
-    let expected = hmac_sha256_base64url(&secret, &query.pending_auth);
+    let expected = hmac_sha256_base64url(secret.expose_secret(), &query.pending_auth);
 
     let token_valid: bool = expected
         .as_bytes()
@@ -237,11 +238,12 @@ pub(crate) async fn deny_login(
     Query(query): Query<CompleteLoginQuery>,
 ) -> Response {
     // Validate HMAC token.
-    let secret = match state.config().certification_test_token.as_ref() {
-        Some(s) => s.expose_secret().to_string(),
+    let config = state.config();
+    let secret = match config.certification_test_token.as_ref() {
+        Some(s) => s,
         None => return StatusCode::NOT_FOUND.into_response(),
     };
-    let expected = hmac_sha256_base64url(&secret, &query.pending_auth);
+    let expected = hmac_sha256_base64url(secret.expose_secret(), &query.pending_auth);
     let token_valid: bool = expected
         .as_bytes()
         .ct_eq(query.token.expose_secret().as_bytes())

--- a/crates/vouch-server/src/handlers/certification.rs
+++ b/crates/vouch-server/src/handlers/certification.rs
@@ -21,7 +21,7 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Redirect, Response},
 };
-use secrecy::ExposeSecret;
+use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use subtle::ConstantTimeEq;
 
@@ -48,7 +48,7 @@ pub(crate) struct CompleteLoginQuery {
     /// Pending OAuth authorization ID (UUID).
     pub pending_auth: String,
     /// HMAC-SHA256 of `pending_auth`, base64url-encoded (no padding).
-    pub token: String,
+    pub token: SecretString,
 }
 
 // Custom Debug that redacts the token to prevent accidental log exposure:
@@ -89,7 +89,10 @@ pub(crate) async fn complete_login(
 
     let expected = hmac_sha256_base64url(&secret, &query.pending_auth);
 
-    let token_valid: bool = expected.as_bytes().ct_eq(query.token.as_bytes()).into();
+    let token_valid: bool = expected
+        .as_bytes()
+        .ct_eq(query.token.expose_secret().as_bytes())
+        .into();
     if !token_valid {
         tracing::warn!(
             pending_auth = %query.pending_auth,
@@ -239,7 +242,10 @@ pub(crate) async fn deny_login(
         None => return StatusCode::NOT_FOUND.into_response(),
     };
     let expected = hmac_sha256_base64url(&secret, &query.pending_auth);
-    let token_valid: bool = expected.as_bytes().ct_eq(query.token.as_bytes()).into();
+    let token_valid: bool = expected
+        .as_bytes()
+        .ct_eq(query.token.expose_secret().as_bytes())
+        .into();
     if !token_valid {
         return StatusCode::FORBIDDEN.into_response();
     }

--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -20,7 +20,6 @@ use axum::{
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use jiff::{Span, Timestamp};
-use secrecy::ExposeSecret;
 use std::sync::Arc;
 use vouch_common::{
     DeviceCodeRequest, DeviceCodeResponse, DeviceTokenRequest, DeviceTokenResponse, OAuthError,
@@ -603,7 +602,10 @@ pub(crate) async fn device_token(
             let token_type = if dpop_jkt.is_some() { "DPoP" } else { "Bearer" };
 
             Ok(Json(DeviceTokenResponse {
-                access_token: token.expose_secret().to_string(),
+                // Clone the SecretString rather than rebuilding it via
+                // expose_secret(): the intermediate String would never be
+                // zeroized.
+                access_token: token.clone(),
                 token_type: token_type.to_string(),
                 expires_in,
                 email: user_email,

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -172,9 +172,9 @@ pub(crate) struct OidcCallbackParams {
 /// OIDC token response.
 #[derive(Deserialize)]
 struct OidcTokenResponse {
-    id_token: String,
+    id_token: secrecy::SecretString,
     #[expect(dead_code, reason = "reserved for serde DTO conformance / future use")]
-    access_token: String,
+    access_token: secrecy::SecretString,
 }
 
 // Custom Debug that redacts both tokens to prevent accidental log exposure of
@@ -598,7 +598,7 @@ pub(crate) async fn oidc_callback(
     let identity = match crate::services::idp::oidc::verify_id_token(
         &state.http_client,
         &oidc_provider.provider,
-        &tokens.id_token,
+        tokens.id_token.expose_secret(),
         client_id,
         &stored_state.nonce,
     )

--- a/crates/vouch-server/src/handlers/oidc/introspect.rs
+++ b/crates/vouch-server/src/handlers/oidc/introspect.rs
@@ -18,7 +18,7 @@ use axum::{
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
-use secrecy::SecretString;
+use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use std::sync::Arc;
 
@@ -31,7 +31,7 @@ use super::client_auth::{ClientAuthFields, complete_client_auth, extract_client_
 #[derive(Deserialize)]
 pub(crate) struct RevokeRequest {
     /// RFC 7009 Section 2.1: The token that the client wants to get revoked.
-    token: String,
+    token: SecretString,
     /// RFC 7009 Section 2.1: A hint about the type of the token.
     #[serde(default)]
     token_type_hint: Option<String>,
@@ -44,7 +44,7 @@ pub(crate) struct RevokeRequest {
     client_secret: Option<SecretString>,
     /// RFC 7521 Section 4.2: JWT assertion for `private_key_jwt` authentication.
     #[serde(default)]
-    client_assertion: Option<String>,
+    client_assertion: Option<SecretString>,
     /// RFC 7521 Section 4.2: Assertion type (must be
     /// `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`).
     #[serde(default)]
@@ -76,7 +76,7 @@ impl ClientAuthFields for RevokeRequest {
     }
 
     fn client_assertion(&self) -> Option<&str> {
-        self.client_assertion.as_deref()
+        self.client_assertion.as_ref().map(|s| s.expose_secret())
     }
 
     fn client_assertion_type(&self) -> Option<&str> {
@@ -91,7 +91,7 @@ impl ClientAuthFields for RevokeRequest {
 #[derive(Deserialize)]
 pub(crate) struct IntrospectRequest {
     /// RFC 7662 Section 2.1: The string value of the token.
-    token: String,
+    token: SecretString,
     /// RFC 7662 Section 2.1: A hint about the type of the token.
     #[serde(default)]
     token_type_hint: Option<String>,
@@ -104,7 +104,7 @@ pub(crate) struct IntrospectRequest {
     client_secret: Option<SecretString>,
     /// RFC 7521 Section 4.2: JWT assertion for `private_key_jwt` authentication.
     #[serde(default)]
-    client_assertion: Option<String>,
+    client_assertion: Option<SecretString>,
     /// RFC 7521 Section 4.2: Assertion type (must be
     /// `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`).
     #[serde(default)]
@@ -136,7 +136,7 @@ impl ClientAuthFields for IntrospectRequest {
     }
 
     fn client_assertion(&self) -> Option<&str> {
-        self.client_assertion.as_deref()
+        self.client_assertion.as_ref().map(|s| s.expose_secret())
     }
 
     fn client_assertion_type(&self) -> Option<&str> {
@@ -173,7 +173,7 @@ pub(crate) async fn revoke(
 
     let _result = svc_revoke(
         &state,
-        &params.token,
+        params.token.expose_secret(),
         params.token_type_hint.as_deref(),
         client_info,
         &caller_client_id,
@@ -236,7 +236,7 @@ pub(crate) async fn introspect(
 
     let result = match svc_introspect(
         &state,
-        &params.token,
+        params.token.expose_secret(),
         params.token_type_hint.as_deref(),
         Some(client_id.as_str()),
     )

--- a/crates/vouch-server/src/handlers/oidc/logout.rs
+++ b/crates/vouch-server/src/handlers/oidc/logout.rs
@@ -39,6 +39,7 @@ use axum::{
 };
 use axum_extra::extract::cookie::CookieJar;
 use jsonwebtoken::Validation;
+use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use std::sync::Arc;
 
@@ -51,7 +52,7 @@ use std::sync::Arc;
 pub(crate) struct LogoutQuery {
     /// OPTIONAL. Previously issued ID Token passed as a hint. Used to identify
     /// the RP and optionally to look up the client's registered post-logout URIs.
-    pub id_token_hint: Option<String>,
+    pub id_token_hint: Option<SecretString>,
     /// OPTIONAL. Hint about the End-User's login identifier. Informational only;
     /// accepted per spec but not acted upon; the `Debug` impl is its only reader.
     pub logout_hint: Option<String>,
@@ -89,7 +90,7 @@ impl std::fmt::Debug for LogoutQuery {
 /// POST /oauth/logout form body — mirrors the hidden fields in the confirmation form.
 #[derive(Deserialize)]
 pub(crate) struct LogoutForm {
-    pub id_token_hint: Option<String>,
+    pub id_token_hint: Option<SecretString>,
     pub post_logout_redirect_uri: Option<String>,
     pub client_id: Option<String>,
     /// `state` is carried as a hidden form field through the confirmation page.
@@ -266,8 +267,8 @@ pub(crate) async fn logout(
     // (spec says the server SHOULD show the confirmation page regardless).
     let hint_claims = query
         .id_token_hint
-        .as_deref()
-        .and_then(|hint| verify_id_token_hint(&state, hint));
+        .as_ref()
+        .and_then(|hint| verify_id_token_hint(&state, hint.expose_secret()));
 
     // When both a verified hint and a bare client_id are present, they MUST agree.
     // Spec §3: "If client_id is given, it MUST match the aud of id_token_hint."
@@ -297,8 +298,14 @@ pub(crate) async fn logout(
     // The confirmation form propagates the hint, redirect URI, state, and
     // ui_locales as hidden fields so the POST handler can re-validate them.
     let template = LogoutConfirmTemplate {
+        // Deliberate render-boundary exposure: the hint rides through the
+        // confirmation page as a hidden form field, so the template needs
+        // the plaintext.
         id_token_hint: if hint_claims.is_some() {
-            query.id_token_hint.clone()
+            query
+                .id_token_hint
+                .as_ref()
+                .map(|s| s.expose_secret().to_string())
         } else {
             None
         },
@@ -324,8 +331,8 @@ pub(crate) async fn logout_post(
 ) -> Response {
     let hint_claims = form
         .id_token_hint
-        .as_deref()
-        .and_then(|hint| verify_id_token_hint(&state, hint));
+        .as_ref()
+        .and_then(|hint| verify_id_token_hint(&state, hint.expose_secret()));
 
     // Enforce client_id == hint.aud on the POST leg as well.
     let hint_claims = filter_hint_by_client_id(hint_claims, form.client_id.as_deref());

--- a/crates/vouch-server/src/handlers/oidc/par.rs
+++ b/crates/vouch-server/src/handlers/oidc/par.rs
@@ -19,7 +19,7 @@ use axum::{
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
-use secrecy::SecretString;
+use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use subtle::ConstantTimeEq;
@@ -83,7 +83,7 @@ pub(crate) struct ParRequest {
     client_secret: Option<SecretString>,
     /// RFC 7521 Section 4.2: Client assertion for JWT client authentication.
     #[serde(default)]
-    client_assertion: Option<String>,
+    client_assertion: Option<SecretString>,
     /// RFC 7521 Section 4.2: Client assertion type.
     #[serde(default)]
     client_assertion_type: Option<String>,
@@ -142,7 +142,7 @@ impl ClientAuthFields for ParRequest {
     }
 
     fn client_assertion(&self) -> Option<&str> {
-        self.client_assertion.as_deref()
+        self.client_assertion.as_ref().map(|s| s.expose_secret())
     }
 
     fn client_assertion_type(&self) -> Option<&str> {

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc6749_token.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc6749_token.rs
@@ -544,3 +544,39 @@ async fn test_token_db_error_on_client_lookup_returns_internal_server_error() {
         "DB error must not be reported as invalid_client: {body}"
     );
 }
+
+#[test]
+fn test_token_response_wire_shape_with_and_without_id_token() {
+    // RFC 6749 Section 5.1 responses without an ID token (client
+    // credentials, refresh) serialize `id_token: null`, and the token
+    // values serialize as plain strings. Pins the wire shape across the
+    // SecretString field migration: the explicit serializers must produce
+    // exactly what the bare `String`/`Option<String>` fields did.
+    let with = crate::handlers::oidc::token::TokenResponse {
+        access_token: "at-secret".into(),
+        token_type: "Bearer".to_string(),
+        expires_in: 3600,
+        id_token: Some("idt-secret".into()),
+        scope: None,
+        email: None,
+        authorization_details: None,
+    };
+    let json = serde_json::to_value(&with).expect("serialize TokenResponse");
+    assert_eq!(json["access_token"], "at-secret");
+    assert_eq!(json["id_token"], "idt-secret");
+
+    let without = crate::handlers::oidc::token::TokenResponse {
+        access_token: "at-secret".into(),
+        token_type: "Bearer".to_string(),
+        expires_in: 3600,
+        id_token: None,
+        scope: None,
+        email: None,
+        authorization_details: None,
+    };
+    let json = serde_json::to_value(&without).expect("serialize TokenResponse");
+    assert!(
+        json["id_token"].is_null() && json.get("id_token").is_some(),
+        "id_token must serialize as an explicit null when absent: {json}"
+    );
+}

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc6749_token.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc6749_token.rs
@@ -580,3 +580,50 @@ fn test_token_response_wire_shape_with_and_without_id_token() {
         "id_token must serialize as an explicit null when absent: {json}"
     );
 }
+
+#[test]
+fn test_token_request_debug_never_prints_credential_material() {
+    // Every credential-bearing field must be absent from `{:?}` output —
+    // the manual Debug impl prints [REDACTED] and the SecretString fields
+    // self-redact even if a future impl prints them directly.
+    let request = crate::handlers::oidc::token::TokenRequest {
+        grant_type: "authorization_code".to_string(),
+        code: Some("visible-code".to_string()),
+        redirect_uri: None,
+        client_id: Some("client-1".to_string()),
+        client_secret: Some("secret-cs".into()),
+        code_verifier: Some("secret-cv".to_string()),
+        device_code: None,
+        subject_token: Some("secret-st".into()),
+        subject_token_type: None,
+        actor_token: Some("secret-at".into()),
+        actor_token_type: None,
+        audience: None,
+        scope: None,
+        requested_token_type: None,
+        resource: None,
+        client_assertion: Some("secret-ca".into()),
+        client_assertion_type: None,
+        assertion: Some("secret-a".into()),
+        authorization_details: None,
+    };
+    let debug = format!("{request:?}");
+    for secret in [
+        "secret-cs",
+        "secret-cv",
+        "secret-st",
+        "secret-at",
+        "secret-ca",
+        "secret-a",
+    ] {
+        assert!(
+            !debug.contains(secret),
+            "{secret} leaked into Debug: {debug}"
+        );
+    }
+    assert!(debug.contains("[REDACTED]"), "{debug}");
+    assert!(
+        debug.contains("client-1"),
+        "non-secrets stay visible: {debug}"
+    );
+}

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -26,7 +26,7 @@ use axum::{
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
-use secrecy::SecretString;
+use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -93,13 +93,13 @@ pub(crate) struct TokenRequest {
     pub device_code: Option<String>,
     /// RFC 8693 Section 2.1: The subject token to exchange.
     #[serde(default)]
-    pub subject_token: Option<String>,
+    pub subject_token: Option<SecretString>,
     /// RFC 8693 Section 2.1: Type identifier for the subject token.
     #[serde(default)]
     pub subject_token_type: Option<String>,
     /// RFC 8693 Section 2.1: Optional actor token (for delegation).
     #[serde(default)]
-    pub actor_token: Option<String>,
+    pub actor_token: Option<SecretString>,
     /// RFC 8693 Section 2.1: Type identifier for the actor token.
     #[serde(default)]
     pub actor_token_type: Option<String>,
@@ -117,13 +117,13 @@ pub(crate) struct TokenRequest {
     pub resource: Option<String>,
     /// RFC 7521 Section 4.2: Client assertion for JWT client authentication.
     #[serde(default)]
-    pub client_assertion: Option<String>,
+    pub client_assertion: Option<SecretString>,
     /// RFC 7521 Section 4.2: Client assertion type.
     #[serde(default)]
     pub client_assertion_type: Option<String>,
     /// RFC 7521 Section 4.1: The assertion for JWT bearer grants.
     #[serde(default)]
-    pub assertion: Option<String>,
+    pub assertion: Option<SecretString>,
     /// RFC 9396: Rich authorization details (JSON array).
     #[serde(default)]
     pub authorization_details: Option<String>,
@@ -270,7 +270,7 @@ pub(crate) async fn token(
         );
     }
     if let Some(ref v) = params.client_assertion
-        && v.len() > MAX_ASSERTION_LEN
+        && v.expose_secret().len() > MAX_ASSERTION_LEN
     {
         return token_error_response(
             "invalid_request",
@@ -278,7 +278,7 @@ pub(crate) async fn token(
         );
     }
     if let Some(ref v) = params.assertion
-        && v.len() > MAX_ASSERTION_LEN
+        && v.expose_secret().len() > MAX_ASSERTION_LEN
     {
         return token_error_response(
             "invalid_request",
@@ -969,9 +969,12 @@ async fn handle_token_exchange_grant(
     };
 
     let exchange_params = TokenExchangeParams {
-        subject_token: params.subject_token.as_deref().unwrap_or_default(),
+        subject_token: params
+            .subject_token
+            .as_ref()
+            .map_or("", |s| s.expose_secret()),
         subject_token_type: params.subject_token_type.as_deref().unwrap_or_default(),
-        actor_token: params.actor_token.as_deref(),
+        actor_token: params.actor_token.as_ref().map(|s| s.expose_secret()),
         actor_token_type: params.actor_token_type.as_deref(),
         audience: effective_audience,
         scope: params.scope.as_deref(),
@@ -1057,7 +1060,7 @@ impl ClientAuthFields for TokenRequest {
     }
 
     fn client_assertion(&self) -> Option<&str> {
-        self.client_assertion.as_deref()
+        self.client_assertion.as_ref().map(|s| s.expose_secret())
     }
 
     fn client_assertion_type(&self) -> Option<&str> {
@@ -1148,7 +1151,7 @@ async fn handle_fido2_assertion_grant(
 
     // Exchange the FIDO2 assertion for an access token
     let exchange_params = crate::services::oidc::fido2_grant::Fido2AssertionParams {
-        assertion: &assertion,
+        assertion: assertion.expose_secret(),
         client: &crate::services::oidc::token::AuthenticatedClient {
             client: jwt_authenticated.client,
             is_public: false,

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -34,13 +34,15 @@ use std::sync::Arc;
 #[derive(Serialize)]
 pub(super) struct TokenResponse {
     /// The access token issued by the authorization server.
-    pub access_token: String,
+    #[serde(serialize_with = "vouch_common::serialize_secret_string")]
+    pub access_token: SecretString,
     /// The type of the token issued ("Bearer" or "DPoP").
     pub token_type: String,
     /// The lifetime in seconds of the access token.
     pub expires_in: u64,
     /// OIDC Core Section 3.1.3.3: The ID Token.
-    pub id_token: Option<String>,
+    #[serde(serialize_with = "vouch_common::serialize_opt_secret_string")]
+    pub id_token: Option<SecretString>,
     /// RFC 6749 Section 3.3: The scope of the access token.
     pub scope: Option<ScopeSet>,
     /// User email (included in FIDO2 assertion grant responses).
@@ -175,7 +177,8 @@ impl TokenRequest {
 #[derive(Serialize)]
 pub(super) struct TokenExchangeResponse {
     /// The security token issued by the authorization server.
-    pub access_token: String,
+    #[serde(serialize_with = "vouch_common::serialize_secret_string")]
+    pub access_token: SecretString,
     /// RFC 8693 Section 2.2.1: The type of the issued security token.
     pub issued_token_type: String,
     /// The type of the token issued (e.g., "Bearer").

--- a/crates/vouch-server/src/infra/cleanup.rs
+++ b/crates/vouch-server/src/infra/cleanup.rs
@@ -15,6 +15,7 @@ use crate::db::store::DocumentStore;
 use crate::infra::dns;
 use aws_lc_rs::rand as aws_rand;
 use jiff::{Span, Timestamp};
+use secrecy::ExposeSecret;
 use tokio::task::JoinHandle;
 
 /// Minimum gap between consecutive DNS re-checks for the same domain.
@@ -393,19 +394,20 @@ async fn recheck_additional_domains(
 /// Re-verify a single domain and persist the result. Errors are logged and
 /// swallowed so one bad record never aborts the surrounding pass.
 async fn recheck_one(store: &DocumentStore, audit: &AuditStore, rec: db::VerifiedDomainRecord) {
-    let outcome = match dns::verify_txt_record(&rec.domain, &rec.verification_token).await {
-        Ok(true) => db::RecheckOutcome::Success,
-        Ok(false) => db::RecheckOutcome::Failure,
-        Err(e) => {
-            tracing::warn!(
-                error = %e,
-                domain = %rec.domain,
-                org_id = %rec.org_id,
-                "DNS re-verification lookup failed; treating as failure"
-            );
-            db::RecheckOutcome::Failure
-        }
-    };
+    let outcome =
+        match dns::verify_txt_record(&rec.domain, rec.verification_token.expose_secret()).await {
+            Ok(true) => db::RecheckOutcome::Success,
+            Ok(false) => db::RecheckOutcome::Failure,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    domain = %rec.domain,
+                    org_id = %rec.org_id,
+                    "DNS re-verification lookup failed; treating as failure"
+                );
+                db::RecheckOutcome::Failure
+            }
+        };
 
     match db::record_recheck_result(store, &rec.org_id, &rec.domain, outcome).await {
         Ok(db::RecheckEffect::FlippedToUnverified { released_subdomain }) => {
@@ -521,7 +523,7 @@ mod tests {
             .unwrap();
         doc.data.additional_domains.push(AdditionalDomain {
             domain: "squatted.example.com".to_string(),
-            verification_token: "tok".to_string(),
+            verification_token: "tok".into(),
             added_at: stale_added,
             added_by_user_id: "u1".to_string(),
             added_by_email: "u1@acme.com".to_string(),
@@ -591,7 +593,7 @@ mod tests {
         let rec = db::VerifiedDomainRecord {
             org_id: org.id.clone(),
             domain: "widgets.io".to_string(),
-            verification_token: "tok".to_string(),
+            verification_token: "tok".into(),
             last_checked_at: None,
             consecutive_failures: 0,
         };

--- a/crates/vouch-server/src/infra/s3_config.rs
+++ b/crates/vouch-server/src/infra/s3_config.rs
@@ -55,8 +55,10 @@ pub struct S3ConfigSource {
 pub struct S3TlsConfig {
     /// Base64-encoded PEM certificate.
     pub cert: Option<String>,
-    /// Base64-encoded PEM private key.
-    pub key: Option<String>,
+    /// Base64-encoded PEM private key. Serialized by exposure: this type
+    /// round-trips the operator-provisioned S3 config object.
+    #[serde(serialize_with = "vouch_common::serialize_opt_secret_string")]
+    pub key: Option<SecretString>,
 }
 
 // Custom Debug that redacts private key to prevent accidental log exposure.
@@ -157,7 +159,8 @@ pub enum S3IdpEntry {
         id: String,
         issuer: String,
         client_id: String,
-        client_secret: String,
+        #[serde(serialize_with = "vouch_common::serialize_secret_string")]
+        client_secret: SecretString,
     },
     Saml {
         id: String,
@@ -250,13 +253,13 @@ pub struct S3GithubConfig {
     /// GitHub App name (slug).
     pub app_name: Option<String>,
     /// Base64-encoded PEM RSA private key.
-    pub app_key: Option<String>,
+    pub app_key: Option<SecretString>,
     /// Webhook secret.
-    pub webhook_secret: Option<String>,
+    pub webhook_secret: Option<SecretString>,
     /// OAuth client ID.
     pub client_id: Option<String>,
     /// OAuth client secret.
-    pub client_secret: Option<String>,
+    pub client_secret: Option<SecretString>,
 }
 
 // Custom Debug that redacts secrets to prevent accidental log exposure.
@@ -297,7 +300,7 @@ pub struct S3Config {
     /// Example: { "us-east-1": "postgres://vouch@abc123.dsql.us-east-1.on.aws/postgres" }
     pub dsql_endpoints: Option<HashMap<String, String>>,
     /// JWT signing secret.
-    pub jwt_secret: Option<String>,
+    pub jwt_secret: Option<SecretString>,
     /// Session duration in hours.
     pub session_hours: Option<u64>,
 
@@ -342,20 +345,20 @@ pub struct S3Config {
 
     // SSH CA key (base64-encoded PEM Ed25519 private key)
     /// SSH CA private key.
-    pub ssh_ca_key: Option<String>,
+    pub ssh_ca_key: Option<SecretString>,
 
     /// AWS KMS key ID for SSH CA signing (multi-region `mrk-` prefix).
     pub ssh_ca_kms_key_id: Option<String>,
 
     // OIDC signing key (base64-encoded PEM EC P-256 private key)
     /// OIDC signing key.
-    pub oidc_signing_key: Option<String>,
+    pub oidc_signing_key: Option<SecretString>,
 
     /// AWS KMS key ID for OIDC signing (multi-region `mrk-` prefix).
     pub oidc_signing_kms_key_id: Option<String>,
 
     /// OIDC RSA signing key (base64-encoded PEM RSA-3072 private key).
-    pub oidc_rsa_signing_key: Option<String>,
+    pub oidc_rsa_signing_key: Option<SecretString>,
 
     /// AWS KMS key ID for OIDC RSA signing (RSA_3072).
     pub oidc_rsa_signing_kms_key_id: Option<String>,
@@ -695,21 +698,15 @@ async fn apply_config_update(
 
     // Track if TLS config changed
     let old_tls_cert = new_config.tls_cert.clone();
-    let old_tls_key = new_config
-        .tls_key
-        .as_ref()
-        .map(|s| s.expose_secret().to_string());
+    let old_tls_key = new_config.tls_key.clone();
 
     // Merge S3 config (runtime update — oidc block check is skipped for runtime updates)
     new_config.merge_s3_config(&s3_config, true)?;
 
     // Check if TLS config changed
     let tls_changed = new_config.tls_cert != old_tls_cert
-        || new_config
-            .tls_key
-            .as_ref()
-            .map(|s| s.expose_secret().to_string())
-            != old_tls_key;
+        || new_config.tls_key.as_ref().map(|s| s.expose_secret())
+            != old_tls_key.as_ref().map(|s| s.expose_secret());
 
     // Reload TLS if configured and changed
     if tls_changed && let (Some(cert), Some(key)) = (&new_config.tls_cert, &new_config.tls_key) {
@@ -759,7 +756,7 @@ impl ServerConfig {
                     self.tls_cert = Some(v.clone());
                 }
                 if let Some(v) = &tls.key {
-                    self.tls_key = Some(SecretString::from(v.clone()));
+                    self.tls_key = Some(v.clone());
                 }
             }
             // All other fields are ignored at runtime
@@ -811,7 +808,7 @@ impl ServerConfig {
             self.base_url = crate::config::BaseUrl::new(v);
         }
         if let Some(v) = &s3.jwt_secret {
-            self.jwt_secret = SecretString::from(v.clone());
+            self.jwt_secret = v.clone();
         }
         if let Some(v) = s3.session_hours {
             self.session_hours = v;
@@ -834,7 +831,7 @@ impl ServerConfig {
                 self.tls_cert = Some(v.clone());
             }
             if let Some(v) = &tls.key {
-                self.tls_key = Some(SecretString::from(v.clone()));
+                self.tls_key = Some(v.clone());
             }
         }
 
@@ -883,22 +880,22 @@ impl ServerConfig {
                 self.github_app_name = Some(v.clone());
             }
             if let Some(v) = &github.app_key {
-                self.github_app_key = Some(SecretString::from(v.clone()));
+                self.github_app_key = Some(v.clone());
             }
             if let Some(v) = &github.webhook_secret {
-                self.github_webhook_secret = Some(SecretString::from(v.clone()));
+                self.github_webhook_secret = Some(v.clone());
             }
             if let Some(v) = &github.client_id {
                 self.github_app_client_id = Some(v.clone());
             }
             if let Some(v) = &github.client_secret {
-                self.github_app_client_secret = Some(SecretString::from(v.clone()));
+                self.github_app_client_secret = Some(v.clone());
             }
         }
 
         // SSH CA key
         if let Some(v) = &s3.ssh_ca_key {
-            self.ssh_ca_key = Some(SecretString::from(v.clone()));
+            self.ssh_ca_key = Some(v.clone());
         }
         if let Some(v) = &s3.ssh_ca_kms_key_id {
             self.ssh_ca_kms_key_id = Some(v.clone());
@@ -906,7 +903,7 @@ impl ServerConfig {
 
         // OIDC signing key
         if let Some(v) = &s3.oidc_signing_key {
-            self.oidc_signing_key = Some(SecretString::from(v.clone()));
+            self.oidc_signing_key = Some(v.clone());
         }
         if let Some(v) = &s3.oidc_signing_kms_key_id {
             self.oidc_signing_kms_key_id = Some(v.clone());
@@ -914,7 +911,7 @@ impl ServerConfig {
 
         // OIDC RSA signing key
         if let Some(v) = &s3.oidc_rsa_signing_key {
-            self.oidc_rsa_signing_key = Some(SecretString::from(v.clone()));
+            self.oidc_rsa_signing_key = Some(v.clone());
         }
         if let Some(v) = &s3.oidc_rsa_signing_kms_key_id {
             self.oidc_rsa_signing_kms_key_id = Some(v.clone());
@@ -1063,7 +1060,7 @@ mod tests {
         let s3 = S3Config {
             tls: Some(S3TlsConfig {
                 cert: Some("base64cert".to_string()),
-                key: Some("base64key".to_string()),
+                key: Some("base64key".into()),
             }),
             ..Default::default()
         };
@@ -1118,10 +1115,10 @@ mod tests {
             github: Some(S3GithubConfig {
                 app_id: Some(12345),
                 app_name: Some("my-app".to_string()),
-                app_key: Some("base64key".to_string()),
-                webhook_secret: Some("secret".to_string()),
+                app_key: Some("base64key".into()),
+                webhook_secret: Some("secret".into()),
                 client_id: Some("client-id".to_string()),
-                client_secret: Some("client-secret".to_string()),
+                client_secret: Some("client-secret".into()),
             }),
             ..Default::default()
         };
@@ -1144,7 +1141,7 @@ mod tests {
             session_hours: Some(24),
             tls: Some(S3TlsConfig {
                 cert: Some("new_cert".to_string()),
-                key: Some("new_key".to_string()),
+                key: Some("new_key".into()),
             }),
             ..Default::default()
         };
@@ -1170,7 +1167,7 @@ mod tests {
             session_hours: Some(24),
             tls: Some(S3TlsConfig {
                 cert: Some("new_cert".to_string()),
-                key: Some("new_key".to_string()),
+                key: Some("new_key".into()),
             }),
             ..Default::default()
         };
@@ -1372,8 +1369,11 @@ mod tests {
         let config: S3Config = serde_json::from_str(json).expect("Failed to parse");
 
         assert_eq!(
-            config.oidc_rsa_signing_key,
-            Some("base64encodedpemkey".to_string())
+            config
+                .oidc_rsa_signing_key
+                .as_ref()
+                .map(|s| s.expose_secret()),
+            Some("base64encodedpemkey")
         );
         assert_eq!(
             config.oidc_rsa_signing_kms_key_id,
@@ -1388,7 +1388,7 @@ mod tests {
         assert!(config.oidc_rsa_signing_kms_key_id.is_none());
 
         let s3 = S3Config {
-            oidc_rsa_signing_key: Some("base64encodedpemkey".to_string()),
+            oidc_rsa_signing_key: Some("base64encodedpemkey".into()),
             oidc_rsa_signing_kms_key_id: Some("mrk-rsa-key-123".to_string()),
             ..Default::default()
         };
@@ -1408,7 +1408,7 @@ mod tests {
         let mut config = crate::test_utils::test_config();
 
         let s3 = S3Config {
-            oidc_rsa_signing_key: Some("base64encodedpemkey".to_string()),
+            oidc_rsa_signing_key: Some("base64encodedpemkey".into()),
             oidc_rsa_signing_kms_key_id: Some("mrk-rsa-key-123".to_string()),
             ..Default::default()
         };
@@ -1582,7 +1582,7 @@ mod tests {
             id: "google".to_string(),
             issuer: "https://accounts.google.com".to_string(),
             client_id: "client-abc".to_string(),
-            client_secret: "secret-xyz".to_string(),
+            client_secret: "secret-xyz".into(),
         };
         match entry.into_idp_config() {
             IdpConfig::Oidc(oidc) => {
@@ -1629,7 +1629,7 @@ mod tests {
             id: "google".to_string(),
             issuer: "https://accounts.google.com".to_string(),
             client_id: "client-abc".to_string(),
-            client_secret: "should-not-leak".to_string(),
+            client_secret: "should-not-leak".into(),
         };
         let debug = format!("{entry:?}");
         assert!(debug.contains("[REDACTED]"), "must redact secret: {debug}");
@@ -1655,7 +1655,7 @@ mod tests {
             rp_id: Some("hijacked.example.com".to_string()),
             tls: Some(S3TlsConfig {
                 cert: Some("new-cert-base64".to_string()),
-                key: Some("new-key-base64".to_string()),
+                key: Some("new-key-base64".into()),
             }),
             ..Default::default()
         };
@@ -1739,7 +1739,7 @@ p3HeUzp466+syZz4uujFaFZUPW4t8nZUSdXHuxxzhLovxtFNGqAybYFZ\n\
         let s3 = S3Config {
             tls: Some(S3TlsConfig {
                 cert: Some(TEST_CERT_PEM.to_string()),
-                key: Some(TEST_KEY_PEM.to_string()),
+                key: Some(TEST_KEY_PEM.into()),
             }),
             ..Default::default()
         };
@@ -1768,7 +1768,7 @@ p3HeUzp466+syZz4uujFaFZUPW4t8nZUSdXHuxxzhLovxtFNGqAybYFZ\n\
         let s3 = S3Config {
             tls: Some(S3TlsConfig {
                 cert: Some("garbage-not-a-cert".to_string()),
-                key: Some("garbage-not-a-key".to_string()),
+                key: Some("garbage-not-a-key".into()),
             }),
             ..Default::default()
         };

--- a/crates/vouch-server/src/infra/startup.rs
+++ b/crates/vouch-server/src/infra/startup.rs
@@ -491,14 +491,12 @@ async fn build_app_state(
         );
         Some(key)
     } else {
-        // Clone the PEM content (or None) before crossing the spawn_blocking boundary.
-        // RSA-3072 generation takes ~200ms; offload to avoid blocking the tokio runtime.
-        let pem_owned = config
-            .oidc_rsa_signing_key
-            .as_ref()
-            .map(|s| s.expose_secret().to_string());
+        // Clone the SecretString (not a bare String) before crossing the
+        // spawn_blocking boundary so the PEM stays zeroizing. RSA-3072
+        // generation takes ~200ms; offload to avoid blocking the runtime.
+        let pem_owned = config.oidc_rsa_signing_key.clone();
         let key = tokio::task::spawn_blocking(move || {
-            OidcRsaSigningKey::load_or_generate(pem_owned.as_deref())
+            OidcRsaSigningKey::load_or_generate(pem_owned.as_ref().map(|s| s.expose_secret()))
         })
         .await
         .map_err(|e| anyhow::anyhow!("RSA key generation task panicked: {e}"))??;

--- a/crates/vouch-server/src/services/integrations/aws.rs
+++ b/crates/vouch-server/src/services/integrations/aws.rs
@@ -134,7 +134,7 @@ pub(crate) type AwsResult<T> = Result<T, AwsError>;
 /// Result of issuing an AWS OIDC token.
 pub(crate) struct AwsTokenResult {
     /// The signed OIDC ID token.
-    pub id_token: String,
+    pub id_token: secrecy::SecretString,
     /// Token validity in seconds.
     pub expires_in: u64,
 }
@@ -258,7 +258,7 @@ pub(crate) async fn issue_aws_token(
     }
 
     Ok(AwsTokenResult {
-        id_token,
+        id_token: id_token.into(),
         expires_in,
     })
 }
@@ -272,13 +272,14 @@ pub(crate) async fn issue_aws_token(
 mod tests {
     use super::*;
     use crate::crypto::keys::OidcRsaSigningKey;
+    use secrecy::ExposeSecret;
 
     /// The signed OIDC ID token is a bearer credential for AWS STS and
     /// must never appear in `{:?}` output.
     #[test]
     fn test_aws_token_result_debug_redacts_id_token() {
         let result = AwsTokenResult {
-            id_token: "eyJhbGciOiJSUzI1NiJ9.secret-token".to_string(),
+            id_token: "eyJhbGciOiJSUzI1NiJ9.secret-token".into(),
             expires_in: 28_800,
         };
         let debug = format!("{result:?}");
@@ -362,10 +363,10 @@ mod tests {
         .await
         .expect("issue_aws_token should succeed");
 
-        let header = decode_jwt_header(&result.id_token);
+        let header = decode_jwt_header(result.id_token.expose_secret());
         assert_eq!(header["alg"], "RS256", "AWS token must use RS256");
 
-        let claims = decode_jwt_payload(&result.id_token);
+        let claims = decode_jwt_payload(result.id_token.expose_secret());
         assert_eq!(claims["iss"], BASE_URL, "iss must match the issuer URL");
         assert_eq!(claims["aud"], BASE_URL, "aud must be the issuer URL");
         assert_eq!(claims["sub"], USER_EMAIL, "sub must be the user email");
@@ -386,7 +387,7 @@ mod tests {
         .await
         .expect("issue_aws_token should succeed");
 
-        let claims = decode_jwt_payload(&result.id_token);
+        let claims = decode_jwt_payload(result.id_token.expose_secret());
         let tags = &claims["https://aws.amazon.com/tags"];
         assert!(tags.is_object(), "aws tags claim must be present");
 
@@ -424,7 +425,7 @@ mod tests {
         .await
         .expect("issue_aws_token should succeed");
 
-        let claims = decode_jwt_payload(&result.id_token);
+        let claims = decode_jwt_payload(result.id_token.expose_secret());
         let tags = &claims["https://aws.amazon.com/tags"];
         let principal_tags = &tags["principal_tags"];
 
@@ -459,7 +460,7 @@ mod tests {
         .await
         .expect("issue_aws_token should succeed");
 
-        let claims = decode_jwt_payload(&result.id_token);
+        let claims = decode_jwt_payload(result.id_token.expose_secret());
         let tags = &claims["https://aws.amazon.com/tags"];
         let principal_tags = &tags["principal_tags"];
 
@@ -499,7 +500,7 @@ mod tests {
         .await
         .expect("issue_aws_token should succeed");
 
-        let claims = decode_jwt_payload(&result.id_token);
+        let claims = decode_jwt_payload(result.id_token.expose_secret());
         let tags = &claims["https://aws.amazon.com/tags"];
         let principal_tags = &tags["principal_tags"];
 
@@ -532,7 +533,7 @@ mod tests {
         .await
         .expect("issue_aws_token should succeed");
 
-        let claims = decode_jwt_payload(&result.id_token);
+        let claims = decode_jwt_payload(result.id_token.expose_secret());
         let tags = &claims["https://aws.amazon.com/tags"];
         let principal_tags = &tags["principal_tags"];
         let transitive_keys: Vec<&str> = tags["transitive_tag_keys"]
@@ -586,7 +587,7 @@ mod tests {
         .await
         .expect("issue_aws_token should succeed");
 
-        let claims = decode_jwt_payload(&result.id_token);
+        let claims = decode_jwt_payload(result.id_token.expose_secret());
         assert_eq!(claims["iss"], org_issuer, "iss must be the org issuer");
         assert_eq!(claims["aud"], org_issuer, "aud must equal the org issuer");
     }
@@ -628,7 +629,7 @@ mod tests {
         .await
         .expect("issue_aws_token should succeed");
 
-        let claims = decode_jwt_payload(&result.id_token);
+        let claims = decode_jwt_payload(result.id_token.expose_secret());
         assert_eq!(
             claims["https://aws.amazon.com/roles"],
             serde_json::json!([role]),
@@ -651,7 +652,7 @@ mod tests {
         .await
         .expect("issue_aws_token should succeed");
 
-        let claims = decode_jwt_payload(&result.id_token);
+        let claims = decode_jwt_payload(result.id_token.expose_secret());
         assert!(
             claims.get("https://aws.amazon.com/roles").is_none(),
             "roles claim must be absent when no pin is requested"
@@ -672,7 +673,7 @@ mod tests {
         .await
         .expect("issue_aws_token should succeed");
 
-        let claims = decode_jwt_payload(&result.id_token);
+        let claims = decode_jwt_payload(result.id_token.expose_secret());
         assert_eq!(
             claims["hardware_aaguid"], TEST_AAGUID,
             "hardware_aaguid claim must reflect the supplied snapshot"

--- a/crates/vouch-server/src/services/integrations/github/app.rs
+++ b/crates/vouch-server/src/services/integrations/github/app.rs
@@ -131,7 +131,7 @@ pub struct GitHubRepository {
 /// Response from GitHub's installation token endpoint.
 #[derive(Deserialize)]
 struct InstallationTokenResponse {
-    token: String,
+    token: SecretString,
     expires_at: String,
     permissions: HashMap<String, String>,
     repositories: Option<Vec<GitHubRepository>>,
@@ -367,7 +367,7 @@ impl GitHubApp {
             .context("Failed to parse installation token response")?;
 
         Ok(GitHubInstallationToken {
-            token: SecretString::from(token_response.token),
+            token: token_response.token,
             expires_at: token_response.expires_at,
             permissions: token_response.permissions,
             repositories: token_response.repositories,
@@ -590,13 +590,13 @@ pub(crate) async fn get_github_user(
 #[derive(Deserialize)]
 pub(crate) struct GitHubOAuthTokenResponse {
     /// Access token for API calls.
-    pub access_token: String,
+    pub access_token: SecretString,
     /// Token type (usually "bearer").
     pub token_type: String,
     /// Granted scopes (space-separated).
     pub scope: Option<String>,
     /// Refresh token for getting new access tokens.
-    pub refresh_token: Option<String>,
+    pub refresh_token: Option<SecretString>,
     /// Access token expiration in seconds (8 hours for GitHub Apps).
     pub expires_in: Option<u64>,
     /// Refresh token expiration in seconds (6 months for GitHub Apps).

--- a/crates/vouch-server/src/services/integrations/github/installations.rs
+++ b/crates/vouch-server/src/services/integrations/github/installations.rs
@@ -9,6 +9,8 @@
 
 use std::collections::{HashMap, HashSet};
 
+use secrecy::ExposeSecret;
+
 use super::{
     GitHubError, GitHubInstallationId, GitHubResult, GitHubService,
     list_user_accessible_installations,
@@ -218,7 +220,7 @@ impl GitHubService<'_> {
 
         // Verify user actually has access to this installation
         let user_installations =
-            list_user_accessible_installations(app.http_client(), &access_token)
+            list_user_accessible_installations(app.http_client(), access_token.expose_secret())
                 .await
                 .map_err(|e| GitHubError::GitHubApi(e.to_string()))?;
 
@@ -326,14 +328,18 @@ impl GitHubService<'_> {
             .collect();
 
         // Fetch installations the user can access
-        let installations =
-            match list_user_accessible_installations(app.http_client(), &access_token).await {
-                Ok(installations) => installations,
-                Err(e) => {
-                    tracing::warn!("Failed to fetch user installations: {}", e);
-                    return Ok(vec![]);
-                }
-            };
+        let installations = match list_user_accessible_installations(
+            app.http_client(),
+            access_token.expose_secret(),
+        )
+        .await
+        {
+            Ok(installations) => installations,
+            Err(e) => {
+                tracing::warn!("Failed to fetch user installations: {}", e);
+                return Ok(vec![]);
+            }
+        };
 
         // Filter to unlinked installations only
         let unlinked = installations

--- a/crates/vouch-server/src/services/integrations/github/oauth.rs
+++ b/crates/vouch-server/src/services/integrations/github/oauth.rs
@@ -7,6 +7,8 @@
 //! - Store GitHub identity and refresh token
 //! - Refresh access tokens using stored refresh tokens
 
+use secrecy::{ExposeSecret, SecretString};
+
 use super::{
     GitHubError, GitHubResult, GitHubService, exchange_oauth_code, get_github_user,
     refresh_oauth_token,
@@ -55,9 +57,12 @@ impl GitHubService<'_> {
         .map_err(|e| GitHubError::GitHubApi(format!("{e:#}")))?;
 
         // Get GitHub user info
-        let github_user = get_github_user(app.http_client(), &token_response.access_token)
-            .await
-            .map_err(|e| GitHubError::GitHubApi(format!("{e:#}")))?;
+        let github_user = get_github_user(
+            app.http_client(),
+            token_response.access_token.expose_secret(),
+        )
+        .await
+        .map_err(|e| GitHubError::GitHubApi(format!("{e:#}")))?;
 
         // Update user's GitHub identity
         db::update_user_github_identity(
@@ -65,7 +70,10 @@ impl GitHubService<'_> {
             params.user_id,
             github_user.id.cast_signed(),
             &github_user.login,
-            token_response.refresh_token.as_deref(),
+            token_response
+                .refresh_token
+                .as_ref()
+                .map(|s| s.expose_secret()),
         )
         .await
         .map_err(GitHubError::Database)?;
@@ -86,7 +94,7 @@ impl GitHubService<'_> {
     pub(crate) async fn get_user_access_token(
         &self,
         user_id: &str,
-    ) -> GitHubResult<Option<String>> {
+    ) -> GitHubResult<Option<SecretString>> {
         // Get the user's refresh token
         let refresh_token = match db::get_user_github_refresh_token(self.store, user_id)
             .await
@@ -101,10 +109,14 @@ impl GitHubService<'_> {
         let client_secret = self.oauth_client_secret()?;
 
         // Refresh the token
-        let token_response =
-            refresh_oauth_token(app.http_client(), client_id, client_secret, &refresh_token)
-                .await
-                .map_err(|e| GitHubError::GitHubApi(format!("{e:#}")))?;
+        let token_response = refresh_oauth_token(
+            app.http_client(),
+            client_id,
+            client_secret,
+            refresh_token.expose_secret(),
+        )
+        .await
+        .map_err(|e| GitHubError::GitHubApi(format!("{e:#}")))?;
 
         // Persist the rotated refresh token. GitHub rotates refresh tokens:
         // the old token is invalidated by the refresh above, so losing the
@@ -127,7 +139,7 @@ impl GitHubService<'_> {
                 user_id,
                 github_id,
                 github_login,
-                Some(new_refresh_token),
+                Some(new_refresh_token.expose_secret()),
             )
             .await
             .map_err(GitHubError::Database)?;

--- a/crates/vouch-server/src/services/oidc/client_credentials.rs
+++ b/crates/vouch-server/src/services/oidc/client_credentials.rs
@@ -15,13 +15,12 @@ use crate::services::auth::{
     CreateOAuthTokenParams, TokenIssuanceProof, create_oauth_access_token,
 };
 use crate::services::oidc::ScopeSet;
-use secrecy::ExposeSecret;
 use std::sync::Arc;
 
 /// Result of a client credentials grant exchange.
 pub struct ClientCredentialsResult {
     /// The issued access token.
-    pub access_token: String,
+    pub access_token: secrecy::SecretString,
     /// Token type ("Bearer").
     pub token_type: String,
     /// Expiration in seconds.
@@ -115,7 +114,7 @@ pub(crate) async fn exchange_client_credentials(
     };
 
     Ok(ClientCredentialsResult {
-        access_token: session_result.token.expose_secret().to_string(),
+        access_token: session_result.token.clone(),
         token_type: token_type.to_string(),
         expires_in: session_result.expires_in,
         scope,
@@ -131,6 +130,7 @@ mod tests {
     use super::*;
     use crate::services::auth::{ClientAuthProof, GrantProof, SenderConstraintProof};
     use crate::services::oidc::OAuthScope;
+    use secrecy::ExposeSecret;
 
     #[test]
     fn test_scope_filters_openid_and_email() {
@@ -225,7 +225,7 @@ mod tests {
         // Decode the access token JWT and verify the cnf claim
         let config = state.config();
         let decoded = crate::services::auth::decode_token(
-            &result.access_token,
+            result.access_token.expose_secret(),
             &state.oidc_key,
             &config.base_url,
         )

--- a/crates/vouch-server/src/services/oidc/exchange.rs
+++ b/crates/vouch-server/src/services/oidc/exchange.rs
@@ -71,7 +71,7 @@ pub struct TokenExchangeParams<'a> {
 /// Result of a token exchange (RFC 8693 Section 2.2).
 pub struct TokenExchangeResult {
     /// The security token issued by the authorization server.
-    pub access_token: String,
+    pub access_token: secrecy::SecretString,
     /// RFC 8693 Section 2.2.1: The type of the issued security token.
     pub issued_token_type: String,
     /// RFC 6749 Section 7.1: The type of the token issued (e.g., "Bearer").
@@ -499,7 +499,7 @@ pub(crate) async fn exchange_token(
     };
 
     Ok(TokenExchangeResult {
-        access_token: session_result.token.expose_secret().to_string(),
+        access_token: session_result.token.clone(),
         issued_token_type: token_types::ACCESS_TOKEN.to_string(),
         token_type: token_type.to_string(),
         expires_in,
@@ -638,7 +638,7 @@ async fn issue_id_token(
     );
 
     Ok(TokenExchangeResult {
-        access_token: id_token,
+        access_token: id_token.into(),
         issued_token_type: token_types::ID_TOKEN.to_string(),
         token_type: "Bearer".to_string(),
         expires_in,
@@ -768,7 +768,7 @@ mod tests {
     #[test]
     fn test_token_exchange_result_debug_redacts_access_token() {
         let result = TokenExchangeResult {
-            access_token: "eyJhbGciOiJFUzI1NiJ9.exchange-secret-token".to_string(),
+            access_token: "eyJhbGciOiJFUzI1NiJ9.exchange-secret-token".into(),
             issued_token_type: token_types::ACCESS_TOKEN.to_string(),
             token_type: "Bearer".to_string(),
             expires_in: 3600,

--- a/crates/vouch-server/src/services/oidc/fido2_grant.rs
+++ b/crates/vouch-server/src/services/oidc/fido2_grant.rs
@@ -27,7 +27,6 @@ use crate::services::oidc::token::AuthenticatedClient;
 use crate::services::oidc::{ScopeSet, ValidatedDpopProof};
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use uuid::Uuid;
@@ -82,7 +81,7 @@ pub struct Fido2AssertionParams<'a> {
 /// Result of a successful FIDO2 assertion grant exchange.
 pub struct Fido2AssertionResult {
     /// The OAuth access token.
-    pub access_token: String,
+    pub access_token: secrecy::SecretString,
     /// Token type ("DPoP" or "Bearer").
     pub token_type: String,
     /// Expires in seconds.
@@ -410,7 +409,7 @@ pub(crate) async fn exchange_fido2_assertion(
     };
 
     Ok(Fido2AssertionResult {
-        access_token: session_result.token.expose_secret().to_string(),
+        access_token: session_result.token.clone(),
         token_type: token_type.to_string(),
         expires_in: session_result.expires_in,
         scope: Some(scope),

--- a/crates/vouch-server/src/services/oidc/registration.rs
+++ b/crates/vouch-server/src/services/oidc/registration.rs
@@ -27,6 +27,7 @@ use crate::error::{OAuthErrorCode, ServiceError};
 use axum::http::StatusCode;
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use subtle::ConstantTimeEq;
@@ -189,8 +190,11 @@ pub struct RegistrationResponse {
     /// RFC 7591 Section 3.2.1: REQUIRED. OAuth 2.0 client identifier.
     pub client_id: String,
     /// RFC 7591 Section 3.2.1: OAuth 2.0 client secret (for confidential clients).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub client_secret: Option<String>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "vouch_common::serialize_opt_secret_string"
+    )]
+    pub client_secret: Option<SecretString>,
     /// RFC 7591 Section 3.2.1: 0 = does not expire. REQUIRED when client_secret issued.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub client_secret_expires_at: Option<i64>,
@@ -198,8 +202,11 @@ pub struct RegistrationResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub client_id_issued_at: Option<i64>,
     /// RFC 7592: Registration access token for future management.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub registration_access_token: Option<String>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "vouch_common::serialize_opt_secret_string"
+    )]
+    pub registration_access_token: Option<SecretString>,
     /// RFC 7592: Client configuration endpoint URI.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub registration_client_uri: Option<String>,
@@ -646,7 +653,7 @@ pub async fn register_client(
         )
         .await?;
 
-        Some(secret)
+        Some(SecretString::from(secret))
     } else {
         None
     };
@@ -687,7 +694,7 @@ pub async fn register_client(
             None
         },
         client_id_issued_at: Some(client_id_issued_at),
-        registration_access_token: Some(reg_token),
+        registration_access_token: Some(reg_token.into()),
         registration_client_uri: Some(format!("{base_url}/oauth/register/{}", client.client_id)),
         redirect_uris: if redirect_uris.is_empty() {
             None
@@ -1319,7 +1326,7 @@ pub async fn update_client_configuration(
 
     let base_url = &state.config().base_url;
     let mut response = build_client_response(updated, base_url);
-    response.registration_access_token = Some(new_reg_token);
+    response.registration_access_token = Some(new_reg_token.into());
 
     Ok(response)
 }

--- a/crates/vouch-server/src/services/oidc/registration/tests.rs
+++ b/crates/vouch-server/src/services/oidc/registration/tests.rs
@@ -534,7 +534,7 @@ fn test_response_serialization_omits_none_fields() {
         client_secret: None,
         client_secret_expires_at: None,
         client_id_issued_at: Some(1_700_000_000),
-        registration_access_token: Some("vouch_reg_abc123".to_string()),
+        registration_access_token: Some("vouch_reg_abc123".into()),
         registration_client_uri: Some(
             "https://example.com/oauth/register/test-client-id".to_string(),
         ),
@@ -600,7 +600,7 @@ fn test_response_serialization_omits_none_fields() {
 fn test_response_serialization_includes_secret_fields_when_present() {
     let response = RegistrationResponse {
         client_id: "test-client".to_string(),
-        client_secret: Some("s3cr3t".to_string()),
+        client_secret: Some("s3cr3t".into()),
         client_secret_expires_at: Some(0),
         client_id_issued_at: Some(1_700_000_000),
         registration_access_token: None,

--- a/crates/vouch-server/src/services/oidc/token.rs
+++ b/crates/vouch-server/src/services/oidc/token.rs
@@ -85,13 +85,13 @@ pub struct ClientCredentials {
 /// Result of exchanging an authorization code.
 pub struct AuthCodeExchangeResult {
     /// The access token.
-    pub access_token: String,
+    pub access_token: SecretString,
     /// Token type ("Bearer" or "DPoP").
     pub token_type: String,
     /// Expiration in seconds.
     pub expires_in: u64,
     /// The ID token (JWT).
-    pub id_token: String,
+    pub id_token: SecretString,
     /// Granted scope.
     pub scope: ScopeSet,
     /// RFC 9396: Rich authorization details.
@@ -428,10 +428,10 @@ pub(crate) async fn exchange_authorization_code(
     }
 
     Ok(AuthCodeExchangeResult {
-        access_token: access_token.expose_secret().to_string(),
+        access_token,
         token_type: token_type.to_string(),
         expires_in,
-        id_token,
+        id_token: id_token.into(),
         scope: auth_code.scope,
         authorization_details: grants.authorization_details,
     })
@@ -1932,10 +1932,10 @@ mod tests {
     #[test]
     fn test_auth_code_exchange_result_debug_redacts_tokens() {
         let result = AuthCodeExchangeResult {
-            access_token: "eyJhbGciOiJFUzI1NiJ9.access-secret-token".to_string(),
+            access_token: "eyJhbGciOiJFUzI1NiJ9.access-secret-token".into(),
             token_type: "Bearer".to_string(),
             expires_in: 3600,
-            id_token: "eyJhbGciOiJFUzI1NiJ9.id-secret-token".to_string(),
+            id_token: "eyJhbGciOiJFUzI1NiJ9.id-secret-token".into(),
             scope: ScopeSet::parse("openid"),
             authorization_details: None,
         };

--- a/crates/vouch-server/tests/secrets_redacted_in_debug.rs
+++ b/crates/vouch-server/tests/secrets_redacted_in_debug.rs
@@ -3,11 +3,16 @@
 //!
 //! A derived `Debug` prints every field verbatim, so any `{:?}` of such a
 //! struct — a `tracing` field, an `anyhow` context, a test failure message —
-//! writes the live credential into the log. The convention in this workspace
-//! is a hand-written `impl Debug` that prints `[REDACTED]` for the secret
-//! fields and leaves the rest visible (see `AuthCodeExchangeResult` in
-//! `services/oidc/token.rs`), rather than `SecretString`, so the response
-//! types keep their plain `String` fields for serde.
+//! writes the live credential into the log.
+//!
+//! In `vouch-server` and `vouch-common` the guarantee is now carried by the
+//! field type: credential fields are `secrecy::SecretString` (self-redacting
+//! `Debug`, no `Serialize` impl — serialization points opt in explicitly via
+//! `vouch_common::serialize_secret_string`), with the hand-written
+//! `[REDACTED]` Debug impls kept on top. This scan remains because
+//! `vouch-cli` and `vouch-agent` still hold bare-`String` secrets protected
+//! only by manual impls; once they migrate, this file is deleted with them
+//! (issue #989).
 //!
 //! Detection is by field name and type: a field whose name ends in `_token`,
 //! `_secret`, or `_token_hint` (or is exactly `token`/`secret`) and whose


### PR DESCRIPTION
## What

Migrates every plaintext-credential field in `vouch-server` and `vouch-common` from bare `String` to `secrecy::SecretString`. Part of #989 (second item): the redaction guarantee moves from hand-maintained Debug impls plus a source-scanning test into the field type itself.

Why this is compile-enforced: secrecy's `SecretString` derives `Deserialize` but deliberately has no `Serialize` impl, so every serialization point must opt in via `#[serde(serialize_with = "vouch_common::serialize_secret_string")]` (or the new `serialize_opt_secret_string` for `Option` fields, which preserves explicit-`null` semantics). A future secret field that forgets the attribute fails to compile instead of silently leaking; Debug output self-redacts; values zeroize on drop.

Per review decision, the hand-written `[REDACTED]` Debug impls **stay** — they print the literal string, so they compile unchanged and remain as belt-and-braces on top of the type.

## Scope (8 commits, reviewable independently)

1. vouch-common foundation: `DeviceTokenResponse`, `CloudTokenResponse`, the `serialize_opt_secret_string` helper; `AwsTokenResult` wraps at mint.
2. OAuth token pipeline: `AuthCodeExchangeResult`, `TokenExchangeResult`, `ClientCredentialsResult`, `Fido2AssertionResult`, `TokenResponse`, `TokenExchangeResponse`.
3. Request side: `TokenRequest` (subject/actor tokens, assertions), revoke/introspect, PAR, logout `id_token_hint`, certification HMAC token, enroll IdP token response. `ClientAuthFields` keeps its `Option<&str>` signature.
4. GitHub cluster: OAuth/installation token responses and `github_refresh_token` on `UserDoc`/`User` end-to-end through the refresh rotation. `UserDoc` drops an unused `PartialEq, Eq` derive.
5. Domain verification TXT tokens; deletes the server-local `serialize_secret_string` copy in favor of vouch-common's.
6. S3 runtime config secrets; the TLS-change comparison compares exposed `&str` views instead of rebuilding owned Strings.
7. One-time-display responses: SCIM token, application secrets, RFC 7591 `client_secret` / `registration_access_token` (`skip_serializing_if` composes with the explicit serializer).
8. Sweep: the last production `expose_secret().to_string()` rebuilds are gone; the scanner's module doc now describes the actual convention.

Nine production `SecretString → String` rebuilds (a gap the KB flags: the intermediate `String` is never zeroized) became moves or borrows. The survivors are three commented render-boundary exposures where plaintext display is the feature: the admin domains TXT value, the SCIM one-time token page, and the logout confirmation hidden field.

Deliberately unchanged, with reasons in code: `UserInfoForm.access_token` and clap `Args` (boundary DTOs with no Debug, consumed immediately), Askama template fields (need `Display`), `S3DocumentKeyConfig.encrypted_private_key` (KMS ciphertext, not plaintext).

## Wire compatibility

Byte-identical JSON everywhere: the explicit serializers produce exactly what the bare fields did, including `id_token: null` (no `skip_serializing_if`) and RFC 7591 key absence (with it). Pinned by new tests (TokenResponse wire shape, UserDoc round-trip incl. explicit null, TokenRequest Debug no-plaintext) and the existing registration serialization tests, which now exercise the SecretString path. Stored documents (`UserDoc`, `AdditionalDomain`, `OrgSigningKeyDoc`) round-trip unchanged.

## Scanner status

`tests/secrets_redacted_in_debug.rs` stays in this PR and stays green — server/common fields are now non-matches by type. It still covers `vouch-cli`/`vouch-agent`, which hold bare-String secrets; a follow-up PR migrates those crates and deletes the scanner with them. Deleting it now would silently drop their coverage.

## Verification

`make fmt`, `make lint` (zero warnings under the no-panic wall), `make test` (51 test binaries), `make test-integration` (27 binaries) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth/token, stored GitHub refresh tokens, domain TXT secrets, and S3 config credentials. Intended to be wire-identical, but a serializer or clone/expose mistake could leak secrets or change JSON.
> 
> **Overview**
> Moves plaintext credential fields in `vouch-server` and `vouch-common` from `String` to `secrecy::SecretString`, so Debug self-redacts, values zeroize on drop, and serialization must opt in (a missing `serialize_with` fails to compile). Adds `serialize_opt_secret_string` so `Option` fields still emit explicit `null` when they did before.
> 
> Covers token mint/response types (device, OIDC, exchange, client credentials, FIDO2, AWS), inbound request secrets (token/revoke/introspect/PAR/logout/certification/enroll), GitHub OAuth/install tokens and `UserDoc.github_refresh_token`, domain verification tokens, S3 config secrets, and one-time-display API responses (SCIM, app secrets, RFC 7591 registration). Replaces `expose_secret().to_string()` rebuilds with clones/borrows except three documented UI render boundaries.
> 
> JSON is meant to stay byte-identical; new tests pin TokenResponse wire shape, UserDoc round-trip, and TokenRequest Debug. The secrets scanner stays for `vouch-cli`/`vouch-agent`. Manual `[REDACTED]` Debug impls are kept.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 635d821a8c2953b09a3def8502754060d45710a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->