### PR TITLE
fix(server): void device-auth approvals when their authenticator is deleted

### DIFF
--- a/crates/vouch-server/src/db/authenticators.rs
+++ b/crates/vouch-server/src/db/authenticators.rs
@@ -3,7 +3,7 @@
 
 use super::document_type::Document;
 use super::documents::authenticator::AuthenticatorDoc;
-use super::documents::device_auth::DeviceAuthRequestDoc;
+use super::documents::device_auth::{DeviceAuthRequestDoc, DeviceAuthStatus};
 use super::documents::session::SessionDoc;
 use super::store::{DocumentStore, StoreTransaction};
 use super::users::User;
@@ -200,18 +200,30 @@ pub async fn count_authenticators_for_user(store: &DocumentStore, user_id: &str)
     store.count::<AuthenticatorDoc>("user_id", user_id).await
 }
 
+/// Void any approval that referenced a now-deleted authenticator. The
+/// approval's evidence is gone, so an `authorized` request is denied
+/// rather than left redeemable (RFC 8628 §3.5 `access_denied`); consumed
+/// requests keep their attribution for replay revocation.
+fn detach_authenticator_from_device_auth(d: &mut DeviceAuthRequestDoc) {
+    d.authenticator_id = None;
+    if d.status == DeviceAuthStatus::Authorized {
+        d.status = DeviceAuthStatus::Denied;
+    }
+}
+
 /// Delete an authenticator by ID.
 ///
 /// Performs application-level cascade deletes:
-/// 1. Clear authenticator_id references in device_auth_requests
+/// 1. Void device_auth_request approvals that referenced this authenticator
 /// 2. Delete sessions using this authenticator
 /// 3. Delete the authenticator
 pub async fn delete_authenticator(store: &DocumentStore, authenticator_id: &str) -> Result<u64> {
-    // 1. Clear authenticator_id references in device_auth_requests
     store
-        .update_by_index::<DeviceAuthRequestDoc, _>("authenticator_id", authenticator_id, |d| {
-            d.authenticator_id = None;
-        })
+        .update_by_index::<DeviceAuthRequestDoc, _>(
+            "authenticator_id",
+            authenticator_id,
+            detach_authenticator_from_device_auth,
+        )
         .await?;
 
     // 2. Delete sessions using this authenticator
@@ -233,9 +245,11 @@ pub async fn delete_authenticator_in_tx(
     tx: &mut StoreTransaction<'_>,
     authenticator_id: &str,
 ) -> Result<()> {
-    tx.update_by_index::<DeviceAuthRequestDoc, _>("authenticator_id", authenticator_id, |d| {
-        d.authenticator_id = None;
-    })
+    tx.update_by_index::<DeviceAuthRequestDoc, _>(
+        "authenticator_id",
+        authenticator_id,
+        detach_authenticator_from_device_auth,
+    )
     .await?;
     tx.delete_by_index::<SessionDoc>("authenticator_id", authenticator_id)
         .await?;

--- a/crates/vouch-server/src/db/device_auth.rs
+++ b/crates/vouch-server/src/db/device_auth.rs
@@ -11,22 +11,78 @@ use jiff::Timestamp;
 // Re-export DeviceAuthStatus from documents module
 pub use super::documents::device_auth::DeviceAuthStatus;
 
+/// Approval evidence recorded when a pending request is authorized.
+///
+/// Only [`state_from_stored`] constructs one, and only from a row whose
+/// approval fields are all present — the device-code grant cannot reach
+/// token issuance holding a partial approval.
+#[derive(Debug, Clone)]
+pub struct DeviceAuthApproval {
+    pub user_id: String,
+    pub user_email: String,
+    /// Authenticator that approved the request.
+    pub authenticator_id: String,
+    /// Whether the approving browser session completed a WebAuthn ceremony.
+    /// The device-code grant issues its token with this as the
+    /// `hardware_verified` claim.
+    pub hardware_verified: bool,
+}
+
+/// Domain state of a device authorization request. The stored document
+/// keeps the status and the approval fields separate so rows stay readable
+/// across a rolling deploy; this enum is what consumers see, and it has no
+/// approval-less `Authorized`.
+#[derive(Debug)]
+pub enum DeviceAuthState {
+    Pending,
+    Authorized(DeviceAuthApproval),
+    Denied,
+    /// `user_id` is retained for replay revocation; `None` on rows written
+    /// before approval attribution was recorded.
+    Consumed {
+        user_id: Option<String>,
+    },
+}
+
+/// An `authorized` row whose approval fields are incomplete — the approving
+/// authenticator was deleted before redemption — has no approval left to
+/// redeem and reads as denied. RFC 8628 §3.5
+/// (<https://www.rfc-editor.org/rfc/rfc8628#section-3.5>):
+///
+/// > access_denied
+/// >    The authorization request was denied.
+fn state_from_stored(data: &DeviceAuthRequestDoc) -> DeviceAuthState {
+    match data.status {
+        DeviceAuthStatus::Pending => DeviceAuthState::Pending,
+        DeviceAuthStatus::Denied => DeviceAuthState::Denied,
+        DeviceAuthStatus::Authorized => {
+            match (&data.user_id, &data.user_email, &data.authenticator_id) {
+                (Some(user_id), Some(user_email), Some(authenticator_id)) => {
+                    DeviceAuthState::Authorized(DeviceAuthApproval {
+                        user_id: user_id.clone(),
+                        user_email: user_email.clone(),
+                        authenticator_id: authenticator_id.clone(),
+                        hardware_verified: data.hardware_verified,
+                    })
+                }
+                _ => DeviceAuthState::Denied,
+            }
+        }
+        DeviceAuthStatus::Consumed => DeviceAuthState::Consumed {
+            user_id: data.user_id.clone(),
+        },
+    }
+}
+
 /// Device authorization request record.
 #[derive(Debug)]
 pub struct DeviceAuthRequest {
     pub id: String,
     pub device_code_hash: String,
     pub user_code: String,
-    pub status: DeviceAuthStatus,
+    pub state: DeviceAuthState,
     /// OAuth client_id that initiated this device authorization.
     pub client_id: Option<String>,
-    pub user_id: Option<String>,
-    pub user_email: Option<String>,
-    pub authenticator_id: Option<String>,
-    /// Whether the approving browser session completed a WebAuthn ceremony.
-    /// The device-code grant issues its token with this as the
-    /// `hardware_verified` claim.
-    pub hardware_verified: bool,
     pub expires_at: Timestamp,
     pub interval_seconds: i32,
     pub last_poll_at: Option<Timestamp>,
@@ -35,16 +91,13 @@ pub struct DeviceAuthRequest {
 
 impl From<Document<DeviceAuthRequestDoc>> for DeviceAuthRequest {
     fn from(doc: Document<DeviceAuthRequestDoc>) -> Self {
+        let state = state_from_stored(&doc.data);
         Self {
             id: doc.id,
             device_code_hash: doc.data.device_code_hash,
             user_code: doc.data.user_code,
-            status: doc.data.status,
+            state,
             client_id: doc.data.client_id,
-            user_id: doc.data.user_id,
-            user_email: doc.data.user_email,
-            authenticator_id: doc.data.authenticator_id,
-            hardware_verified: doc.data.hardware_verified,
             expires_at: doc.data.expires_at,
             interval_seconds: doc.data.interval_seconds,
             last_poll_at: doc.data.last_poll_at,
@@ -249,6 +302,11 @@ pub async fn authorize_device_auth(
 /// Uses `compare_and_update` (OCC) for the same reason as
 /// [`authorize_device_auth`]: two concurrent denials (or a concurrent
 /// authorize + deny) cannot both win under READ COMMITTED.
+///
+/// Test-only: no production path denies explicitly — a request either gets
+/// approved, expires, or is voided when its approving authenticator is
+/// deleted (`delete_authenticator`).
+#[cfg(test)]
 pub async fn deny_device_auth(store: &DocumentStore, id: &str) -> Result<()> {
     if id.is_empty() {
         bail!("deny_device_auth called with empty id");
@@ -307,15 +365,18 @@ pub struct DeviceCodeClaim {
 
 /// Try to consume an authorized device code (RFC 8628 Section 3.5).
 ///
-/// On success returns a [`DeviceCodeClaim`] witness — proof that this caller
-/// won the optimistic-concurrency consume. All "lost" cases (not found,
-/// not currently `Authorized`, expired, or concurrent consumer won via
-/// version mismatch) map to [`ClaimError::AlreadyConsumed`] — deliberately
-/// indistinguishable, each rejected as an invalid_grant.
+/// On success returns the [`DeviceAuthApproval`] read in the same atomic
+/// step plus a [`DeviceCodeClaim`] witness — proof that this caller won the
+/// optimistic-concurrency consume. Token issuance takes its user
+/// attribution from this approval, never from an earlier (raceable) read.
+/// All "lost" cases (not found, no redeemable approval, expired, or
+/// concurrent consumer won via version mismatch) map to
+/// [`ClaimError::AlreadyConsumed`] — deliberately indistinguishable, each
+/// rejected as an invalid_grant.
 pub async fn try_consume_device_auth(
     store: &DocumentStore,
     device_code_hash: &str,
-) -> std::result::Result<DeviceCodeClaim, ClaimError> {
+) -> std::result::Result<(DeviceAuthApproval, DeviceCodeClaim), ClaimError> {
     let now = Timestamp::now();
 
     let doc = store
@@ -326,8 +387,10 @@ pub async fn try_consume_device_auth(
         return Err(ClaimError::AlreadyConsumed);
     };
 
-    // Only consume if currently Authorized and not expired.
-    if doc.data.status != DeviceAuthStatus::Authorized || doc.data.expires_at <= now {
+    let DeviceAuthState::Authorized(approval) = state_from_stored(&doc.data) else {
+        return Err(ClaimError::AlreadyConsumed);
+    };
+    if doc.data.expires_at <= now {
         return Err(ClaimError::AlreadyConsumed);
     }
 
@@ -341,7 +404,7 @@ pub async fn try_consume_device_auth(
         .await
         .map_err(|e| ClaimError::Database(e.to_string()))?;
     if won {
-        Ok(DeviceCodeClaim { _private: () })
+        Ok((approval, DeviceCodeClaim { _private: () }))
     } else {
         Err(ClaimError::AlreadyConsumed)
     }

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -96,10 +96,12 @@ pub use organizations::{
 pub use organizations::create_organization;
 
 // Re-export device auth types and functions
+#[cfg(test)]
+pub use device_auth::deny_device_auth;
 pub use device_auth::{
-    AuthorizeDeviceAuthParams, DeviceAuthRequest, DeviceAuthStatus, OidcState,
-    authorize_device_auth, create_device_auth_request, create_oidc_state,
-    delete_expired_device_auth_requests, delete_expired_oidc_states, deny_device_auth,
+    AuthorizeDeviceAuthParams, DeviceAuthApproval, DeviceAuthRequest, DeviceAuthState,
+    DeviceAuthStatus, OidcState, authorize_device_auth, create_device_auth_request,
+    create_oidc_state, delete_expired_device_auth_requests, delete_expired_oidc_states,
     get_device_auth_by_code_hash, get_device_auth_by_user_code, get_oidc_state,
     try_consume_device_auth, try_consume_oidc_state, update_device_auth_poll_time,
 };

--- a/crates/vouch-server/src/db/tests/concurrency.rs
+++ b/crates/vouch-server/src/db/tests/concurrency.rs
@@ -1046,15 +1046,19 @@ async fn test_delete_authenticator_clears_device_auth_reference() {
     .await
     .expect("authorize device auth");
 
-    // Verify the authenticator_id is set before the cascade.
+    // Verify the approval references the authenticator before the cascade.
     let before = get_device_auth_by_id(&store, &request_id)
         .await
         .expect("get device auth")
         .expect("must exist before cascade");
+    let approval = match before.state {
+        DeviceAuthState::Authorized(approval) => Some(approval),
+        _ => None,
+    }
+    .expect("expected authorized state before cascade");
     assert_eq!(
-        before.authenticator_id.as_deref(),
-        Some(auth_id.as_str()),
-        "authenticator_id must be set before cascade delete"
+        approval.authenticator_id, auth_id,
+        "approval must reference the authenticator before cascade delete"
     );
 
     // Delete the authenticator — this triggers the cascade.
@@ -1062,13 +1066,15 @@ async fn test_delete_authenticator_clears_device_auth_reference() {
         .await
         .expect("delete authenticator");
 
-    // The device_auth_request must now have authenticator_id cleared.
+    // The approval's evidence is gone, so the request must read as denied
+    // rather than stay redeemable (RFC 8628 §3.5 access_denied).
     let after = get_device_auth_by_id(&store, &request_id)
         .await
         .expect("get device auth")
         .expect("device auth request must still exist after cascade");
     assert!(
-        after.authenticator_id.is_none(),
-        "authenticator_id must be cleared by cascade delete"
+        matches!(after.state, DeviceAuthState::Denied),
+        "cascade delete must void the approval, got {:?}",
+        after.state
     );
 }

--- a/crates/vouch-server/src/db/tests/device_auth.rs
+++ b/crates/vouch-server/src/db/tests/device_auth.rs
@@ -42,8 +42,7 @@ async fn test_device_auth_request_lifecycle() {
         .expect("Device auth should exist");
 
     assert_eq!(request.user_code, user_code);
-    assert_eq!(request.status, DeviceAuthStatus::Pending);
-    assert!(request.user_id.is_none());
+    assert!(matches!(request.state, DeviceAuthState::Pending));
 
     // Get by user code
     let request = get_device_auth_by_user_code(&store, user_code)
@@ -111,7 +110,7 @@ async fn test_device_auth_authorization_flow() {
         .await
         .expect("Failed to get request")
         .expect("Should exist");
-    assert_eq!(request.status, DeviceAuthStatus::Pending);
+    assert!(matches!(request.state, DeviceAuthState::Pending));
 
     // Authorize the request
     authorize_device_auth(
@@ -132,10 +131,56 @@ async fn test_device_auth_authorization_flow() {
         .await
         .expect("Failed to get request")
         .expect("Should exist");
-    assert_eq!(request.status, DeviceAuthStatus::Authorized);
-    assert_eq!(request.user_id, Some(user_id.clone()));
-    assert_eq!(request.user_email, Some(user.email.clone()));
-    assert_eq!(request.authenticator_id, Some(auth_id));
+    let approval = match request.state {
+        DeviceAuthState::Authorized(approval) => Some(approval),
+        _ => None,
+    }
+    .expect("expected authorized state");
+    assert_eq!(approval.user_id, user_id);
+    assert_eq!(approval.user_email, user.email);
+    assert_eq!(approval.authenticator_id, auth_id);
+}
+
+/// Rows written before authenticator deletion voided approvals can carry
+/// `authorized` with a cleared `authenticator_id`; `state_from_stored`
+/// reads them as denied (RFC 8628 §3.5 access_denied), never as an
+/// approval with missing evidence.
+#[tokio::test]
+async fn test_authorized_row_with_cleared_authenticator_reads_denied() {
+    let (store, _audit) = test_db().await;
+
+    let doc = super::documents::device_auth::DeviceAuthRequestDoc {
+        device_code_hash: "legacy_cleared_hash".to_string(),
+        user_code: "LGCY-0001".to_string(),
+        status: DeviceAuthStatus::Authorized,
+        client_id: None,
+        user_id: Some("user_a".to_string()),
+        user_email: Some("a@example.com".to_string()),
+        authenticator_id: None,
+        hardware_verified: true,
+        expires_at: "2099-12-31T23:59:59Z".parse().unwrap(),
+        interval_seconds: 5,
+        last_poll_at: None,
+        consumed_at: None,
+    };
+    store.insert(&doc).await.expect("insert legacy-shaped row");
+
+    let request = get_device_auth_by_code_hash(&store, "legacy_cleared_hash")
+        .await
+        .expect("get")
+        .expect("exists");
+    assert!(
+        matches!(request.state, DeviceAuthState::Denied),
+        "incomplete approval must read as denied, got {:?}",
+        request.state
+    );
+
+    // And the code cannot be consumed.
+    let result = try_consume_device_auth(&store, "legacy_cleared_hash").await;
+    assert!(
+        result.is_err(),
+        "incomplete approval must not be redeemable"
+    );
 }
 
 #[tokio::test]
@@ -245,7 +290,7 @@ async fn test_try_consume_device_auth_authorized_succeeds() {
         .await
         .expect("get")
         .expect("should exist");
-    assert_eq!(request.status, DeviceAuthStatus::Consumed);
+    assert!(matches!(request.state, DeviceAuthState::Consumed { .. }));
     assert!(request.consumed_at.is_some(), "consumed_at should be set");
 }
 
@@ -467,8 +512,12 @@ async fn test_double_authorization_should_fail() {
         .await
         .expect("get")
         .expect("exists");
-    assert_eq!(req.status, DeviceAuthStatus::Authorized);
-    assert_eq!(req.user_id.as_deref(), Some("user_a"));
+    let approval = match req.state {
+        DeviceAuthState::Authorized(approval) => Some(approval),
+        _ => None,
+    }
+    .expect("expected authorized state");
+    assert_eq!(approval.user_id, "user_a");
 }
 
 #[tokio::test]
@@ -505,8 +554,7 @@ async fn test_authorize_after_deny_should_fail() {
         .await
         .expect("get")
         .expect("exists");
-    assert_eq!(req.status, DeviceAuthStatus::Denied);
-    assert!(req.user_id.is_none());
+    assert!(matches!(req.state, DeviceAuthState::Denied));
 }
 
 #[tokio::test]
@@ -544,8 +592,12 @@ async fn test_deny_after_authorize_should_fail() {
         .await
         .expect("get")
         .expect("exists");
-    assert_eq!(req.status, DeviceAuthStatus::Authorized);
-    assert_eq!(req.user_id.as_deref(), Some("user_a"));
+    let approval = match req.state {
+        DeviceAuthState::Authorized(approval) => Some(approval),
+        _ => None,
+    }
+    .expect("expected authorized state");
+    assert_eq!(approval.user_id, "user_a");
 }
 
 #[tokio::test]
@@ -574,5 +626,5 @@ async fn test_double_deny_should_fail() {
         .await
         .expect("get")
         .expect("exists");
-    assert_eq!(req.status, DeviceAuthStatus::Denied);
+    assert!(matches!(req.state, DeviceAuthState::Denied));
 }

--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -2,7 +2,7 @@
 //! Device Authorization Grant handlers (RFC 8628).
 
 use crate::AppState;
-use crate::db::{self, DeviceAuthStatus};
+use crate::db::{self, DeviceAuthState};
 use crate::services::auth::{
     ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenIssuanceProof,
     create_oauth_access_token,
@@ -285,19 +285,19 @@ pub(crate) async fn device_token(
         ));
     }
 
-    match request.status {
-        DeviceAuthStatus::Pending => Err(oauth_error(
+    match request.state {
+        DeviceAuthState::Pending => Err(oauth_error(
             StatusCode::BAD_REQUEST,
             OAuthError::authorization_pending(),
         )),
-        DeviceAuthStatus::Denied => Err(oauth_error(
+        DeviceAuthState::Denied => Err(oauth_error(
             StatusCode::BAD_REQUEST,
             OAuthError::access_denied(),
         )),
-        DeviceAuthStatus::Consumed => {
+        DeviceAuthState::Consumed { user_id } => {
             // RFC 8628 Section 3.5: Device code already used.
             // Replay detected — revoke all tokens for the affected user.
-            if let Some(ref user_id) = request.user_id {
+            if let Some(ref user_id) = user_id {
                 revoke_sessions_for_device_replay(&state, user_id).await;
             }
             Err(oauth_error(
@@ -305,7 +305,7 @@ pub(crate) async fn device_token(
                 OAuthError::invalid_grant(),
             ))
         }
-        DeviceAuthStatus::Authorized => {
+        DeviceAuthState::Authorized(stale_approval) => {
             // RFC 9449 / FAPI 2.0: Validate the DPoP proof if present.
             // This happens BEFORE consuming the device code so that a
             // `use_dpop_nonce` or `invalid_dpop_proof` response does not
@@ -402,8 +402,10 @@ pub(crate) async fn device_token(
                 .map(|c| c.thumbprint.clone());
 
             // RFC 8628 Section 3.5: Atomically consume the device
-            // code before issuing a token. The returned claim is the
-            // structural proof that this caller won the consume; it is
+            // code before issuing a token. The returned approval is the
+            // attribution read in the same atomic step — issuance never
+            // uses the raceable top-of-handler read — and the claim is
+            // the structural proof that this caller won the consume,
             // threaded into TokenIssuanceProof below.
             //
             // `AlreadyConsumed` is deliberately indistinguishable between a
@@ -411,17 +413,13 @@ pub(crate) async fn device_token(
             // concurrent caller just consumed (race loser) — see
             // `try_consume_device_auth`. Match the authorization code flow's
             // defensive "replay = full logout" posture and revoke all of the
-            // user's OAuth sessions in either case. We use `request.user_id`
-            // (read at the top of the handler, set when the device was
-            // authorized) rather than a fresh lookup, since it is already
-            // available and immune to read-snapshot timing under WAL.
-            let device_claim =
+            // user's OAuth sessions in either case, attributed via the
+            // approval read at the top of the handler.
+            let (approval, device_claim) =
                 match db::try_consume_device_auth(&state.store, &device_code_hash).await {
-                    Ok(claim) => claim,
+                    Ok(consumed) => consumed,
                     Err(db::claim::ClaimError::AlreadyConsumed) => {
-                        if let Some(ref user_id) = request.user_id {
-                            revoke_sessions_for_device_replay(&state, user_id).await;
-                        }
+                        revoke_sessions_for_device_replay(&state, &stale_approval.user_id).await;
                         return Err(oauth_error(
                             StatusCode::BAD_REQUEST,
                             OAuthError::invalid_grant(),
@@ -442,21 +440,12 @@ pub(crate) async fn device_token(
                         ));
                     }
                 };
-
-            // An authorized request always carries these fields; a missing one
-            // is an internal state inconsistency, not a client mistake.
-            let missing = |field: &str| {
-                tracing::error!("Authorized device auth request missing {field}");
-                oauth_error(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    OAuthError::server_error(),
-                )
-            };
-            let user_id = request.user_id.ok_or_else(|| missing("user_id"))?;
-            let user_email = request.user_email.ok_or_else(|| missing("user_email"))?;
-            let authenticator_id = request
-                .authenticator_id
-                .ok_or_else(|| missing("authenticator_id"))?;
+            let db::DeviceAuthApproval {
+                user_id,
+                user_email,
+                authenticator_id,
+                hardware_verified,
+            } = approval;
 
             // Use the registered client_id from the device auth request.
             let client_id = request
@@ -532,7 +521,7 @@ pub(crate) async fn device_token(
                     // Mirrors how the browser approved this request, so the
                     // claim the credential endpoints gate on reflects whether
                     // the authenticator was actually exercised.
-                    hardware_verification: if request.hardware_verified {
+                    hardware_verification: if hardware_verified {
                         crate::services::auth::HardwareVerification::Verified
                     } else {
                         crate::services::auth::HardwareVerification::NotVerified
@@ -889,6 +878,70 @@ mod tests {
         assert_eq!(
             error["error"], "access_denied",
             "Denied auth should return access_denied"
+        );
+    }
+
+    /// RFC 8628 §3.5 (https://www.rfc-editor.org/rfc/rfc8628#section-3.5):
+    ///
+    /// > access_denied
+    /// >    The authorization request was denied.
+    ///
+    /// Deleting the approving authenticator before the device redeems the
+    /// code voids the approval: the poll answers `access_denied`, not a 500,
+    /// and the device code is not burned on the way to the error.
+    #[tokio::test]
+    async fn test_rfc8628_poll_after_approving_authenticator_deleted() {
+        let (app, state) = test_app().await;
+
+        let device_code = "test_deleted_authenticator_code";
+        let expires_at = Timestamp::now()
+            .checked_add(Span::new().hours(1))
+            .expect("expiry");
+        let id = crate::db::create_device_auth_request(
+            &state.store,
+            &hash_device_code(device_code),
+            "GONE-CODE",
+            None,
+            expires_at,
+            0,
+        )
+        .await
+        .expect("create device auth");
+
+        let user = create_test_user(&state.store, "deleted-approver@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        crate::db::authorize_device_auth(
+            &state.store,
+            crate::db::AuthorizeDeviceAuthParams {
+                id: &id,
+                user_id: &user.id,
+                user_email: &user.email,
+                authenticator_id: &auth_id,
+                hardware_verified: true,
+            },
+        )
+        .await
+        .expect("authorize device");
+
+        crate::db::delete_authenticator(&state.store, &auth_id)
+            .await
+            .expect("delete authenticator");
+
+        let (status, body) = http_post_form(
+            &app,
+            "/oauth/token",
+            &format!(
+                "grant_type=urn:ietf:params:oauth:grant-type:device_code&device_code={device_code}"
+            ),
+            &[],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
+        let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+        assert_eq!(
+            error["error"], "access_denied",
+            "deleted approver must void the approval: {body}"
         );
     }
 

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -309,7 +309,7 @@ pub(crate) async fn device_verify_submit(
     }
 
     // Check if already used
-    if request.status != db::DeviceAuthStatus::Pending {
+    if !matches!(request.state, db::DeviceAuthState::Pending) {
         return DeviceVerifyTemplate {
             error: Some("This code has already been used.".to_string()),
             user_code: None,
@@ -884,7 +884,7 @@ pub(crate) async fn complete_enrollment_after_identity(
             .await
             .ok()
             .flatten()
-            .is_some_and(|r| r.status == db::DeviceAuthStatus::Pending);
+            .is_some_and(|r| matches!(r.state, db::DeviceAuthState::Pending));
         if !pending {
             tracing::error!("Device auth '{device_auth_id}' is missing or already settled");
             return ErrorTemplate {

--- a/crates/vouch-server/src/handlers/enroll/tests.rs
+++ b/crates/vouch-server/src/handlers/enroll/tests.rs
@@ -454,12 +454,10 @@ async fn test_cli_enroll_returning_user_requires_assertion_before_approval() {
         .await
         .expect("device auth lookup")
         .expect("device auth exists");
-    assert_eq!(
-        request.status,
-        crate::db::DeviceAuthStatus::Pending,
+    assert!(
+        matches!(request.state, crate::db::DeviceAuthState::Pending),
         "IdP sign-in alone must not release the waiting CLI"
     );
-    assert!(!request.hardware_verified);
 
     let approvals = state
         .audit


### PR DESCRIPTION
## Summary

Deleting an authenticator cleared `authenticator_id` on device-auth rows with **no status filter** (`db/authenticators.rs` cascade, added for #543), leaving `Authorized` rows with incomplete approval data. The poll handler then consumed the single-use device code **before** discovering the missing field, so the device received a 500 `server_error` and the flow was unrecoverable.

Reproduction (now a test): approve a device flow → delete the approving authenticator → poll `/oauth/token`:

```
assertion `left == right` failed: body: {"error":"server_error","error_description":"The authorization server encountered an unexpected condition"}
  left: 500
 right: 400
```

## Changes

- **`DeviceAuthState` domain enum** — `Pending | Authorized(DeviceAuthApproval) | Denied | Consumed { user_id }`. An approval-less `Authorized` is unrepresentable to consumers; the handler's `missing()` 500 path is deleted because the state it guarded can no longer be expressed. The stored document keeps its flat shape (status + nullable fields), so **nothing changes on the wire** and rows are readable in both directions across a rolling deploy.
- **One read mapping** (`state_from_stored`): an `authorized` row whose approval fields are incomplete reads as `Denied`. Per RFC 8628 §3.5 (https://www.rfc-editor.org/rfc/rfc8628#section-3.5):

  > access_denied
  >    The authorization request was denied.

- **`try_consume_device_auth` returns `(DeviceAuthApproval, DeviceCodeClaim)`** — token issuance takes its attribution from the same atomic compare-and-update that consumed the code, never from the earlier (raceable) top-of-handler read. This also closes a latent race where a deletion landing between the poll's read and the consume would have issued a token attributed to a deleted authenticator.
- **Cascade transitions explicitly**: `detach_authenticator_from_device_auth` (shared by `delete_authenticator` and `delete_authenticator_in_tx`) clears the reference and moves `Authorized → Denied`; consumed rows keep attribution for replay revocation.
- **`deny_device_auth` is now `#[cfg(test)]`** — it had no production caller (verified; its only non-db-test use is inside the device handler test module).

## Proof by violation

Reaching token issuance without a complete approval no longer compiles — the approval fields only exist inside `DeviceAuthApproval`, whose sole constructor is `state_from_stored`:

```
error[E0609]: no field `user_id` on type `DeviceAuthRequest`
   --> crates/vouch-server/src/handlers/device.rs:455:35
error[E0609]: no field `authenticator_id` on type `DeviceAuthRequest`
   --> crates/vouch-server/src/handlers/device.rs:458:18
```

## Tests

- `test_rfc8628_poll_after_approving_authenticator_deleted` — fails on main (500), passes here (`access_denied`), and proves the code is not burned on the way to the error.
- `test_authorized_row_with_cleared_authenticator_reads_denied` — pre-fix rows read as denied and cannot be consumed.
- The #543 cascade test now asserts the approval is voided (`Denied`), not merely that the field is cleared.
- Gates: `make lint` clean, `make test` zero failures, `make test-integration` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes OAuth device-code grant consumption and authenticator-delete cascade: incomplete approvals become non-redeemable and token user/authenticator attribution is taken from the atomic consume. A mapping or cascade bug could deny valid grants or issue tokens after the approving key is gone.
> 
> **Overview**
> Deleting an authenticator no longer leaves a device-code grant redeemable. Cascade now **voids** `Authorized` rows (`Authorized` → `Denied` and clears `authenticator_id`); consumed rows keep user attribution for replay revocation.
> 
> Consumers see a new `DeviceAuthState` enum with no approval-less `Authorized`. Incomplete stored approvals (including pre-fix rows) map to `Denied` and poll as RFC 8628 `access_denied` instead of burning the code and returning 500.
> 
> `try_consume_device_auth` now returns the `DeviceAuthApproval` from the same OCC consume as the claim, so token issuance is not attributed from a raceable earlier read. Stored document shape is unchanged for rolling deploys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2ad9de26eb39247e1ca365fdad382881411fc76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->