### PR TITLE
refactor(server): derive discovery metadata from enforcement sources

### DIFF
--- a/crates/vouch-server/src/db/documents/oauth.rs
+++ b/crates/vouch-server/src/db/documents/oauth.rs
@@ -331,6 +331,14 @@ impl ResponseMode {
             .collect::<Vec<_>>()
             .join(", ")
     }
+
+    /// Accepted wire values in table order, for discovery metadata
+    /// (`response_modes_supported`). Reads [`Self::ACCEPTED`], so the
+    /// discovery document cannot advertise a mode the parser rejects.
+    #[must_use]
+    pub fn supported_wire_values() -> Vec<&'static str> {
+        Self::ACCEPTED.iter().map(|(value, _)| *value).collect()
+    }
 }
 
 /// FAPI 2.0 compliance profile.

--- a/crates/vouch-server/src/db/par.rs
+++ b/crates/vouch-server/src/db/par.rs
@@ -117,8 +117,13 @@ pub struct CreateParParams<'a> {
 /// Returns an error if the CSPRNG fails.
 fn generate_request_uri() -> Result<String> {
     let encoded = URL_SAFE_NO_PAD.encode(crate::crypto::generate_random_bytes(32)?);
-    Ok(format!("urn:ietf:params:oauth:request_uri:{encoded}"))
+    Ok(format!("{REQUEST_URI_URN_PREFIX}{encoded}"))
 }
+
+/// RFC 9126 Section 2.2 `request_uri` URN prefix. Issued by
+/// [`generate_request_uri`] and matched by the authorize endpoint to
+/// route PAR lookups — one constant so the two cannot drift.
+pub(crate) const REQUEST_URI_URN_PREFIX: &str = "urn:ietf:params:oauth:request_uri:";
 
 /// Create a pushed authorization request.
 ///

--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -9,6 +9,7 @@ use crate::services::auth::{
 };
 use crate::services::oidc::ScopeSet;
 use crate::services::oidc::dpop::DpopError;
+use crate::services::oidc::grant_type::OAuthGrantType;
 use crate::services::oidc::token::validate_dpop_if_present;
 use aws_lc_rs::digest::{self, SHA256};
 use axum::{
@@ -222,15 +223,25 @@ pub(crate) async fn device_token(
     headers: HeaderMap,
     Json(req): Json<DeviceTokenRequest>,
 ) -> Result<Json<DeviceTokenResponse>, Response> {
-    // Validate grant type
-    if req.grant_type != "urn:ietf:params:oauth:grant-type:device_code" {
-        return Err(oauth_error(
-            StatusCode::BAD_REQUEST,
-            OAuthError {
-                error: "unsupported_grant_type".to_string(),
-                error_description: Some("Expected device_code grant type".to_string()),
-            },
-        ));
+    // Validate grant type through the owning enum; exhaustive so a new
+    // grant variant forces this dispatch to be revisited.
+    match req.grant_type.parse::<OAuthGrantType>() {
+        Ok(OAuthGrantType::DeviceCode) => {}
+        Ok(
+            OAuthGrantType::AuthorizationCode
+            | OAuthGrantType::ClientCredentials
+            | OAuthGrantType::TokenExchange
+            | OAuthGrantType::Fido2Assertion,
+        )
+        | Err(_) => {
+            return Err(oauth_error(
+                StatusCode::BAD_REQUEST,
+                OAuthError {
+                    error: "unsupported_grant_type".to_string(),
+                    error_description: Some("Expected device_code grant type".to_string()),
+                },
+            ));
+        }
     }
 
     // Validate device_code format before hashing and DB lookup.

--- a/crates/vouch-server/src/handlers/oidc/authorize.rs
+++ b/crates/vouch-server/src/handlers/oidc/authorize.rs
@@ -458,7 +458,7 @@ async fn authorize_inner(state: Arc<AppState>, params: AuthorizeQuery, jar: Cook
             .into_response();
         }
 
-        if request_uri.starts_with("urn:ietf:params:oauth:request_uri:") {
+        if request_uri.starts_with(crate::db::par::REQUEST_URI_URN_PREFIX) {
             // RFC 9126: PAR URN — must be reasonably sized.
             if request_uri.len() > 256 {
                 return AuthorizeDeniedTemplate {

--- a/crates/vouch-server/src/handlers/oidc/tests/oidc_discovery.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/oidc_discovery.rs
@@ -422,3 +422,197 @@ async fn test_oidc_discovery_hardware_claims_not_in_claims_supported() {
         "claims_supported must not include hardware_aaguid (removed for OIDC conformance)"
     );
 }
+
+// ── Advertised-vs-enforced drift guards ─────────────────────────────────
+// Same shape as test_oidc_discovery_grant_types_match_token_parser: each
+// advertised list must equal its enforcement source, and every advertised
+// value must round-trip through the code that enforces it.
+
+#[tokio::test]
+async fn test_oidc_discovery_response_modes_match_parser() {
+    let (app, _state) = test_app().await;
+    let (status, body) = http_get(&app, "/.well-known/openid-configuration", &[]).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let discovery: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let discovered: BTreeSet<String> = discovery["response_modes_supported"]
+        .as_array()
+        .expect("response_modes_supported is an array")
+        .iter()
+        .map(|v| v.as_str().expect("mode is a string").to_string())
+        .collect();
+
+    let source: BTreeSet<String> = crate::db::ResponseMode::supported_wire_values()
+        .into_iter()
+        .map(String::from)
+        .collect();
+
+    assert_eq!(
+        discovered, source,
+        "discovery response_modes_supported must exactly match ResponseMode::ACCEPTED"
+    );
+    for mode in &discovered {
+        assert!(
+            crate::db::ResponseMode::parse(mode).is_some(),
+            "discovery advertises a response_mode the parser rejects: {mode}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_oidc_discovery_response_types_match_validator() {
+    let (app, _state) = test_app().await;
+    let (status, body) = http_get(&app, "/.well-known/openid-configuration", &[]).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let discovery: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let discovered: BTreeSet<String> = discovery["response_types_supported"]
+        .as_array()
+        .expect("response_types_supported is an array")
+        .iter()
+        .map(|v| v.as_str().expect("type is a string").to_string())
+        .collect();
+
+    let source: BTreeSet<String> = crate::services::oidc::SUPPORTED_RESPONSE_TYPES
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+
+    assert_eq!(
+        discovered, source,
+        "discovery response_types_supported must exactly match the authorize validator"
+    );
+}
+
+#[tokio::test]
+async fn test_oidc_discovery_code_challenge_methods_match_parser() {
+    let (app, _state) = test_app().await;
+    let (status, body) = http_get(&app, "/.well-known/openid-configuration", &[]).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let discovery: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let discovered: BTreeSet<String> = discovery["code_challenge_methods_supported"]
+        .as_array()
+        .expect("code_challenge_methods_supported is an array")
+        .iter()
+        .map(|v| v.as_str().expect("method is a string").to_string())
+        .collect();
+
+    let source: BTreeSet<String> =
+        crate::services::oidc::authorization::CodeChallengeMethod::SUPPORTED
+            .iter()
+            .map(|m| m.as_str().to_string())
+            .collect();
+
+    assert_eq!(
+        discovered, source,
+        "discovery code_challenge_methods_supported must exactly match the PKCE parser"
+    );
+    for method in &discovered {
+        assert!(
+            crate::services::oidc::authorization::CodeChallengeMethod::parse(method).is_some(),
+            "discovery advertises a code_challenge_method the parser rejects: {method}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_oidc_discovery_scopes_match_parser() {
+    let (app, _state) = test_app().await;
+    let (status, body) = http_get(&app, "/.well-known/openid-configuration", &[]).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let discovery: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let discovered: BTreeSet<String> = discovery["scopes_supported"]
+        .as_array()
+        .expect("scopes_supported is an array")
+        .iter()
+        .map(|v| v.as_str().expect("scope is a string").to_string())
+        .collect();
+
+    let source: BTreeSet<String> = crate::services::oidc::OAuthScope::all()
+        .iter()
+        .map(|s| s.as_str().to_string())
+        .collect();
+
+    assert_eq!(
+        discovered, source,
+        "discovery scopes_supported must exactly match OAuthScope::all()"
+    );
+    for scope in &discovered {
+        assert!(
+            crate::services::oidc::OAuthScope::parse(scope).is_some(),
+            "discovery advertises a scope the parser rejects: {scope}"
+        );
+    }
+}
+
+/// `claims_supported` mirrors [`crate::services::oidc::token::IdTokenClaims`]:
+/// a fully populated token must emit exactly the advertised claims plus the
+/// deliberately unadvertised ones (`cnf`, and the custom hardware claims —
+/// see `test_oidc_discovery_hardware_claims_not_in_claims_supported`).
+#[tokio::test]
+async fn test_oidc_discovery_claims_match_id_token_struct() {
+    let (app, _state) = test_app().await;
+    let (status, body) = http_get(&app, "/.well-known/openid-configuration", &[]).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let discovery: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let advertised: BTreeSet<String> = discovery["claims_supported"]
+        .as_array()
+        .expect("claims_supported is an array")
+        .iter()
+        .map(|v| v.as_str().expect("claim is a string").to_string())
+        .collect();
+
+    let source: BTreeSet<String> = crate::services::oidc::token::ADVERTISED_ID_TOKEN_CLAIMS
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+    assert_eq!(
+        advertised, source,
+        "discovery claims_supported must exactly match ADVERTISED_ID_TOKEN_CLAIMS"
+    );
+
+    let claims = crate::services::oidc::token::IdTokenClaims {
+        iss: "https://issuer.example".to_string(),
+        sub: "user".to_string(),
+        aud: "client".to_string(),
+        exp: 1,
+        iat: 1,
+        auth_time: Some(1),
+        nonce: Some("nonce".to_string()),
+        email: Some("user@example.com".to_string()),
+        email_verified: Some(true),
+        hardware_verified: Some(true),
+        hardware_aaguid: Some("aaguid".to_string()),
+        cnf: Some(crate::services::oidc::claims::CnfClaim {
+            jkt: Some("thumbprint".to_string()),
+            x5t_s256: None,
+        }),
+        amr: Some(vec![crate::services::auth::AuthMethod::HardwareKey]),
+        acr: Some("acr".to_string()),
+        at_hash: Some("hash".to_string()),
+    };
+    let serialized = serde_json::to_value(&claims).expect("serialize IdTokenClaims");
+    let emitted: BTreeSet<String> = serialized
+        .as_object()
+        .expect("IdTokenClaims serializes to an object")
+        .keys()
+        .cloned()
+        .collect();
+
+    let expected: BTreeSet<String> = source
+        .into_iter()
+        .chain(
+            ["cnf", "hardware_verified", "hardware_aaguid"]
+                .iter()
+                .map(ToString::to_string),
+        )
+        .collect();
+    assert_eq!(
+        emitted, expected,
+        "IdTokenClaims fields drifted from claims_supported: \
+         update ADVERTISED_ID_TOKEN_CLAIMS (or the unadvertised set here)"
+    );
+}

--- a/crates/vouch-server/src/services/oidc/authorization.rs
+++ b/crates/vouch-server/src/services/oidc/authorization.rs
@@ -30,16 +30,19 @@ pub enum CodeChallengeMethod {
 }
 
 impl CodeChallengeMethod {
+    /// Every accepted `code_challenge_method`, in the order advertised in
+    /// discovery metadata (`code_challenge_methods_supported`).
+    /// [`parse`](Self::parse) reads this table, so an advertised method
+    /// cannot be unparseable.
+    pub const SUPPORTED: &'static [Self] = &[Self::S256];
+
     /// Parse a code challenge method from a string value.
     ///
     /// Only `S256` is accepted per RFC 9700. Returns `None` for `plain`
     /// and all other unsupported methods.
     #[must_use]
     pub fn parse(s: &str) -> Option<Self> {
-        match s {
-            "S256" => Some(Self::S256),
-            _ => None,
-        }
+        Self::SUPPORTED.iter().copied().find(|m| m.as_str() == s)
     }
 
     /// Return the string representation used in OAuth parameters.
@@ -456,7 +459,7 @@ pub fn validate_authorize_request(
     params: AuthorizeRequestParams,
 ) -> ServiceResult<ValidatedAuthRequest> {
     // RFC 6749 Section 4.1.1: response_type must be "code"
-    if params.response_type != "code" {
+    if !super::SUPPORTED_RESPONSE_TYPES.contains(&params.response_type.as_str()) {
         return Err(ServiceError::oauth(
             OAuthErrorCode::UnsupportedResponseType,
             "Only 'code' response type is supported",

--- a/crates/vouch-server/src/services/oidc/discovery.rs
+++ b/crates/vouch-server/src/services/oidc/discovery.rs
@@ -7,10 +7,11 @@
 //! - RFC 9396 OAuth 2.0 Rich Authorization Requests (authorization_details supported)
 
 use crate::AppState;
-use crate::db::{JwsAlgorithm, TokenEndpointAuthMethod};
+use crate::db::{JwsAlgorithm, ResponseMode, TokenEndpointAuthMethod};
 use crate::error::ServiceError;
 use crate::services::auth::ACR_AAL3;
 use crate::services::oidc::OAuthScope;
+use crate::services::oidc::authorization::CodeChallengeMethod;
 use crate::services::oidc::grant_type::OAuthGrantType;
 use serde::Serialize;
 use std::sync::Arc;
@@ -211,13 +212,14 @@ pub fn build_discovery_document(state: &Arc<AppState>) -> OidcDiscoveryDocument 
             .iter()
             .map(|s| s.as_str().to_string())
             .collect(),
-        response_types_supported: vec!["code".to_string()],
-        response_modes_supported: vec![
-            "query".to_string(),
-            "form_post".to_string(),
-            "jwt".to_string(),
-            "query.jwt".to_string(),
-        ],
+        response_types_supported: super::SUPPORTED_RESPONSE_TYPES
+            .iter()
+            .map(ToString::to_string)
+            .collect(),
+        response_modes_supported: ResponseMode::supported_wire_values()
+            .into_iter()
+            .map(String::from)
+            .collect(),
         grant_types_supported: OAuthGrantType::supported_wire_values()
             .into_iter()
             .map(String::from)
@@ -231,22 +233,15 @@ pub fn build_discovery_document(state: &Arc<AppState>) -> OidcDiscoveryDocument 
         token_endpoint_auth_methods_supported: auth_methods.clone(),
         revocation_endpoint_auth_methods_supported: auth_methods.clone(),
         introspection_endpoint_auth_methods_supported: auth_methods,
-        claims_supported: vec![
-            "sub".to_string(),
-            "iss".to_string(),
-            "aud".to_string(),
-            "exp".to_string(),
-            "iat".to_string(),
-            "auth_time".to_string(),
-            "nonce".to_string(),
-            "at_hash".to_string(),
-            "email".to_string(),
-            "email_verified".to_string(),
-            "amr".to_string(),
-            "acr".to_string(),
-        ],
+        claims_supported: super::token::ADVERTISED_ID_TOKEN_CLAIMS
+            .iter()
+            .map(ToString::to_string)
+            .collect(),
         claims_parameter_supported: false,
-        code_challenge_methods_supported: vec!["S256".to_string()],
+        code_challenge_methods_supported: CodeChallengeMethod::SUPPORTED
+            .iter()
+            .map(|m| m.as_str().to_string())
+            .collect(),
         // RS256 excluded per FAPI 2.0 Section 5.2.2.
         dpop_signing_alg_values_supported: Some(vec![
             JwsAlgorithm::Es256,

--- a/crates/vouch-server/src/services/oidc/mod.rs
+++ b/crates/vouch-server/src/services/oidc/mod.rs
@@ -52,6 +52,13 @@
 //! - [`org_keys`] - Per-organization issuer signing keys and operator rotation
 //! - [`mtls`] - mTLS client authentication (crate-local)
 
+/// Every accepted `response_type`. The authorize-endpoint validator,
+/// registration validation, and discovery's `response_types_supported`
+/// all read this list, so an advertised type cannot be unacceptable and
+/// vice versa. Vouch issues only authorization codes (RFC 6749 §4.1.1);
+/// implicit and hybrid response types are not supported.
+pub(crate) const SUPPORTED_RESPONSE_TYPES: &[&str] = &["code"];
+
 pub mod authorization;
 pub mod authorization_details;
 pub mod claims;

--- a/crates/vouch-server/src/services/oidc/registration.rs
+++ b/crates/vouch-server/src/services/oidc/registration.rs
@@ -24,6 +24,7 @@ use crate::db::{
     OAuthEventType, RegistrationSource, TokenEndpointAuthMethod, UpdateClientRegistrationParams,
 };
 use crate::error::{OAuthErrorCode, ServiceError};
+use crate::services::oidc::grant_type::OAuthGrantType;
 use axum::http::StatusCode;
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -36,21 +37,20 @@ use subtle::ConstantTimeEq;
 // Allowed Grant and Response Types
 // ============================================================================
 
-/// Grant types that this server accepts for dynamic registration.
-/// Note: `refresh_token` is accepted in registration but the server never
-/// issues refresh tokens — clients that request it will simply never
+/// Grant types accepted in registration beyond what the token endpoint
+/// dispatches ([`OAuthGrantType`]). `refresh_token` is accepted so
+/// standard client libraries can register unmodified, but the server
+/// never issues refresh tokens — clients that request it simply never
 /// receive one in token responses.
-const ALLOWED_GRANT_TYPES: &[&str] = &[
-    "authorization_code",
-    "client_credentials",
-    "refresh_token",
-    "urn:ietf:params:oauth:grant-type:device_code",
-    "urn:ietf:params:oauth:grant-type:token-exchange",
-    "urn:ietf:params:oauth:grant-type:fido2-assertion",
-];
+const REGISTRATION_ONLY_GRANT_TYPES: &[&str] = &["refresh_token"];
 
-/// Response types that this server accepts for dynamic registration.
-const ALLOWED_RESPONSE_TYPES: &[&str] = &["code"];
+/// Every grant type this server accepts for dynamic registration: the
+/// token endpoint's dispatch set plus the registration-only extras.
+fn allowed_grant_types() -> Vec<&'static str> {
+    let mut allowed = OAuthGrantType::supported_wire_values();
+    allowed.extend_from_slice(REGISTRATION_ONLY_GRANT_TYPES);
+    allowed
+}
 
 /// Maximum number of redirect URIs per client.
 const MAX_REDIRECT_URIS: usize = 25;
@@ -910,8 +910,9 @@ fn validate_grant_and_response_types(
         .take()
         .unwrap_or_else(|| "client_secret_basic".to_string());
 
+    let allowed_grants = allowed_grant_types();
     for gt in &grant_types {
-        if !ALLOWED_GRANT_TYPES.contains(&gt.as_str()) {
+        if !allowed_grants.contains(&gt.as_str()) {
             return Err(ServiceError::oauth(
                 OAuthErrorCode::InvalidClientMetadata,
                 format!("Unsupported grant type: '{gt}'"),
@@ -919,7 +920,7 @@ fn validate_grant_and_response_types(
         }
     }
     for rt in &response_types {
-        if !ALLOWED_RESPONSE_TYPES.contains(&rt.as_str()) {
+        if !crate::services::oidc::SUPPORTED_RESPONSE_TYPES.contains(&rt.as_str()) {
             return Err(ServiceError::oauth(
                 OAuthErrorCode::InvalidClientMetadata,
                 format!("Unsupported response type: '{rt}'"),

--- a/crates/vouch-server/src/services/oidc/registration/tests.rs
+++ b/crates/vouch-server/src/services/oidc/registration/tests.rs
@@ -645,33 +645,39 @@ fn test_response_serialization_includes_secret_fields_when_present() {
 
 #[test]
 fn test_allowed_grant_types_includes_expected() {
+    let allowed = allowed_grant_types();
     assert!(
-        ALLOWED_GRANT_TYPES.contains(&"authorization_code"),
+        allowed.contains(&"authorization_code"),
         "authorization_code must be an allowed grant type"
     );
     assert!(
-        ALLOWED_GRANT_TYPES.contains(&"client_credentials"),
+        allowed.contains(&"client_credentials"),
         "client_credentials must be an allowed grant type"
     );
     assert!(
-        ALLOWED_GRANT_TYPES.contains(&"urn:ietf:params:oauth:grant-type:device_code"),
+        allowed.contains(&"urn:ietf:params:oauth:grant-type:device_code"),
         "device_code URN must be an allowed grant type"
     );
     assert!(
-        ALLOWED_GRANT_TYPES.contains(&"refresh_token"),
+        allowed.contains(&"refresh_token"),
         "refresh_token must be accepted in registration (though never issued)"
     );
 }
 
-/// Every grant the token endpoint dispatches must also be registrable.
-/// `ALLOWED_GRANT_TYPES` is a deliberate superset (it adds `refresh_token`),
-/// so this guards one direction: no dispatchable grant is unregistrable.
+/// The registration-only delta must stay disjoint from the token
+/// endpoint's dispatch set. Every dispatchable grant being registrable is
+/// guaranteed by construction (`allowed_grant_types` is the union); this
+/// guards the other direction — if a delta entry ever becomes
+/// dispatchable, it must be removed from the delta.
 #[test]
-fn every_dispatched_grant_is_registrable() {
-    for grant in crate::services::oidc::grant_type::OAuthGrantType::supported_wire_values() {
+fn registration_only_grants_are_not_dispatchable() {
+    for grant in REGISTRATION_ONLY_GRANT_TYPES {
         assert!(
-            ALLOWED_GRANT_TYPES.contains(&grant),
-            "token-endpoint grant {grant} must also be an allowed registration grant"
+            grant
+                .parse::<crate::services::oidc::grant_type::OAuthGrantType>()
+                .is_err(),
+            "{grant} is dispatched by the token endpoint; \
+             remove it from REGISTRATION_ONLY_GRANT_TYPES"
         );
     }
 }
@@ -679,8 +685,8 @@ fn every_dispatched_grant_is_registrable() {
 #[test]
 fn test_allowed_response_types_includes_code() {
     assert!(
-        ALLOWED_RESPONSE_TYPES.contains(&"code"),
-        "'code' must be in the allowed response types set"
+        crate::services::oidc::SUPPORTED_RESPONSE_TYPES.contains(&"code"),
+        "'code' must be in the supported response types set"
     );
 }
 
@@ -692,7 +698,7 @@ fn test_allowed_response_types_includes_code() {
 #[test]
 fn test_implicit_grant_not_allowed() {
     assert!(
-        !ALLOWED_GRANT_TYPES.contains(&"implicit"),
+        !allowed_grant_types().contains(&"implicit"),
         "The implicit grant type must not be allowed (deprecated by RFC 9700)"
     );
 }
@@ -701,7 +707,7 @@ fn test_implicit_grant_not_allowed() {
 #[test]
 fn test_token_response_type_not_allowed() {
     assert!(
-        !ALLOWED_RESPONSE_TYPES.contains(&"token"),
+        !crate::services::oidc::SUPPORTED_RESPONSE_TYPES.contains(&"token"),
         "'token' response type must not be allowed (implicit flow)"
     );
 }
@@ -710,7 +716,7 @@ fn test_token_response_type_not_allowed() {
 #[test]
 fn test_id_token_response_type_not_allowed() {
     assert!(
-        !ALLOWED_RESPONSE_TYPES.contains(&"id_token"),
+        !crate::services::oidc::SUPPORTED_RESPONSE_TYPES.contains(&"id_token"),
         "'id_token' response type must not be allowed (implicit flow)"
     );
 }

--- a/crates/vouch-server/src/services/oidc/token.rs
+++ b/crates/vouch-server/src/services/oidc/token.rs
@@ -271,6 +271,26 @@ pub struct IdTokenClaims {
     pub at_hash: Option<String>,
 }
 
+/// The [`IdTokenClaims`] fields advertised in discovery's
+/// `claims_supported`, kept next to the struct they mirror. The custom
+/// claims (`hardware_verified`, `hardware_aaguid`) and `cnf` are emitted
+/// but deliberately not advertised. A drift test serializes a fully
+/// populated [`IdTokenClaims`] and checks its keys against this list.
+pub(crate) const ADVERTISED_ID_TOKEN_CLAIMS: &[&str] = &[
+    "sub",
+    "iss",
+    "aud",
+    "exp",
+    "iat",
+    "auth_time",
+    "nonce",
+    "at_hash",
+    "email",
+    "email_verified",
+    "amr",
+    "acr",
+];
+
 /// Exchange an authorization code for tokens.
 ///
 /// # Arguments


### PR DESCRIPTION
## Summary

`services/oidc/discovery.rs` hand-wrote four of its list fields as literals independent of the code that enforces them. `ResponseMode::ACCEPTED`'s own docstring records how exactly this drift class shipped a bug before (the error message omitted `form_post` while the parser accepted it) — and discovery was a third independent literal of that same set.

## Changes

Every advertised list now derives from the single source its enforcing code reads:

| Discovery field | Enforcement source |
|---|---|
| `response_modes_supported` | `ResponseMode::ACCEPTED` (new `supported_wire_values()`) |
| `code_challenge_methods_supported` | new `CodeChallengeMethod::SUPPORTED` table, which `parse()` also reads |
| `response_types_supported` | new `SUPPORTED_RESPONSE_TYPES`, which `validate_authorize_request` now checks against |
| `claims_supported` | new `ADVERTISED_ID_TOKEN_CLAIMS`, beside the `IdTokenClaims` struct it mirrors |

Also: the PAR `request_uri` URN prefix (`db/par.rs` `format!` literal vs `authorize.rs` `starts_with` literal) becomes one shared `REQUEST_URI_URN_PREFIX` const. The existing RFC 9126 test keeps its independent literal, deliberately — a test reading the const would pass a typo'd const; pinning the wire string guards both production sites through the shared source.

`grant_types_supported` and `scopes_supported` already derived correctly and are untouched.

## No behavior change

Wire output is byte-identical: each derivation preserves the previous hand-written order. `claims_supported` had no enforcement source to derive from, so the const is the honest fix — true derivation would need serde reflection; the drift test below makes struct changes fail loudly instead.

## Tests

Five new drift guards in `handlers/oidc/tests/oidc_discovery.rs`, cloned from the existing `test_oidc_discovery_grant_types_match_token_parser` shape: set-equality against the enforcement source plus per-value parser round-trip for response modes, response types, code challenge methods, and scopes. The claims test serializes a fully populated `IdTokenClaims` and asserts its keys are exactly the advertised list plus the deliberately unadvertised `cnf`/`hardware_verified`/`hardware_aaguid` — adding a claim to the struct without updating the advertised list (or vice versa) fails.

Gates: `make lint` clean, `make test` zero failures, `make test-integration` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OIDC discovery, authorize validation, client registration, and device-grant parsing. Intended as a no-behavior refactor, but a mismatch in those shared lists would advertise or accept the wrong protocol surface.
> 
> **Overview**
> Stops hand-writing OIDC discovery lists independently of the code that enforces them. `response_modes_supported`, `response_types_supported`, `code_challenge_methods_supported`, and `claims_supported` now read the same tables used by parsers/validators (`ResponseMode::ACCEPTED`, `SUPPORTED_RESPONSE_TYPES`, `CodeChallengeMethod::SUPPORTED`, `ADVERTISED_ID_TOKEN_CLAIMS`). Wire order is preserved; advertised claims still omit `cnf` and the hardware claims.
> 
> Registration grant/response types are built from those same sources plus a registration-only `refresh_token` delta. Device-code grant checks parse through `OAuthGrantType` exhaustively. PAR issuance and authorize routing share `REQUEST_URI_URN_PREFIX`.
> 
> Adds discovery drift tests that require advertised values to match enforcement sources (and ID token struct keys for claims).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebbf4e87a1aeea2a83667a1636945df6b84cbd96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->