### PR TITLE
refactor(server): registration grant types derive from the token dispatch enum

### DIFF
--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -9,6 +9,7 @@ use crate::services::auth::{
 };
 use crate::services::oidc::ScopeSet;
 use crate::services::oidc::dpop::DpopError;
+use crate::services::oidc::grant_type::OAuthGrantType;
 use crate::services::oidc::token::validate_dpop_if_present;
 use aws_lc_rs::digest::{self, SHA256};
 use axum::{
@@ -222,15 +223,25 @@ pub(crate) async fn device_token(
     headers: HeaderMap,
     Json(req): Json<DeviceTokenRequest>,
 ) -> Result<Json<DeviceTokenResponse>, Response> {
-    // Validate grant type
-    if req.grant_type != "urn:ietf:params:oauth:grant-type:device_code" {
-        return Err(oauth_error(
-            StatusCode::BAD_REQUEST,
-            OAuthError {
-                error: "unsupported_grant_type".to_string(),
-                error_description: Some("Expected device_code grant type".to_string()),
-            },
-        ));
+    // Validate grant type through the owning enum; exhaustive so a new
+    // grant variant forces this dispatch to be revisited.
+    match req.grant_type.parse::<OAuthGrantType>() {
+        Ok(OAuthGrantType::DeviceCode) => {}
+        Ok(
+            OAuthGrantType::AuthorizationCode
+            | OAuthGrantType::ClientCredentials
+            | OAuthGrantType::TokenExchange
+            | OAuthGrantType::Fido2Assertion,
+        )
+        | Err(_) => {
+            return Err(oauth_error(
+                StatusCode::BAD_REQUEST,
+                OAuthError {
+                    error: "unsupported_grant_type".to_string(),
+                    error_description: Some("Expected device_code grant type".to_string()),
+                },
+            ));
+        }
     }
 
     // Validate device_code format before hashing and DB lookup.

--- a/crates/vouch-server/src/services/oidc/registration.rs
+++ b/crates/vouch-server/src/services/oidc/registration.rs
@@ -24,6 +24,7 @@ use crate::db::{
     OAuthEventType, RegistrationSource, TokenEndpointAuthMethod, UpdateClientRegistrationParams,
 };
 use crate::error::{OAuthErrorCode, ServiceError};
+use crate::services::oidc::grant_type::OAuthGrantType;
 use axum::http::StatusCode;
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -36,21 +37,20 @@ use subtle::ConstantTimeEq;
 // Allowed Grant and Response Types
 // ============================================================================
 
-/// Grant types that this server accepts for dynamic registration.
-/// Note: `refresh_token` is accepted in registration but the server never
-/// issues refresh tokens — clients that request it will simply never
+/// Grant types accepted in registration beyond what the token endpoint
+/// dispatches ([`OAuthGrantType`]). `refresh_token` is accepted so
+/// standard client libraries can register unmodified, but the server
+/// never issues refresh tokens — clients that request it simply never
 /// receive one in token responses.
-const ALLOWED_GRANT_TYPES: &[&str] = &[
-    "authorization_code",
-    "client_credentials",
-    "refresh_token",
-    "urn:ietf:params:oauth:grant-type:device_code",
-    "urn:ietf:params:oauth:grant-type:token-exchange",
-    "urn:ietf:params:oauth:grant-type:fido2-assertion",
-];
+const REGISTRATION_ONLY_GRANT_TYPES: &[&str] = &["refresh_token"];
 
-/// Response types that this server accepts for dynamic registration.
-const ALLOWED_RESPONSE_TYPES: &[&str] = &["code"];
+/// Every grant type this server accepts for dynamic registration: the
+/// token endpoint's dispatch set plus the registration-only extras.
+fn allowed_grant_types() -> Vec<&'static str> {
+    let mut allowed = OAuthGrantType::supported_wire_values();
+    allowed.extend_from_slice(REGISTRATION_ONLY_GRANT_TYPES);
+    allowed
+}
 
 /// Maximum number of redirect URIs per client.
 const MAX_REDIRECT_URIS: usize = 25;
@@ -910,8 +910,9 @@ fn validate_grant_and_response_types(
         .take()
         .unwrap_or_else(|| "client_secret_basic".to_string());
 
+    let allowed_grants = allowed_grant_types();
     for gt in &grant_types {
-        if !ALLOWED_GRANT_TYPES.contains(&gt.as_str()) {
+        if !allowed_grants.contains(&gt.as_str()) {
             return Err(ServiceError::oauth(
                 OAuthErrorCode::InvalidClientMetadata,
                 format!("Unsupported grant type: '{gt}'"),
@@ -919,7 +920,7 @@ fn validate_grant_and_response_types(
         }
     }
     for rt in &response_types {
-        if !ALLOWED_RESPONSE_TYPES.contains(&rt.as_str()) {
+        if !crate::services::oidc::SUPPORTED_RESPONSE_TYPES.contains(&rt.as_str()) {
             return Err(ServiceError::oauth(
                 OAuthErrorCode::InvalidClientMetadata,
                 format!("Unsupported response type: '{rt}'"),

--- a/crates/vouch-server/src/services/oidc/registration/tests.rs
+++ b/crates/vouch-server/src/services/oidc/registration/tests.rs
@@ -645,33 +645,39 @@ fn test_response_serialization_includes_secret_fields_when_present() {
 
 #[test]
 fn test_allowed_grant_types_includes_expected() {
+    let allowed = allowed_grant_types();
     assert!(
-        ALLOWED_GRANT_TYPES.contains(&"authorization_code"),
+        allowed.contains(&"authorization_code"),
         "authorization_code must be an allowed grant type"
     );
     assert!(
-        ALLOWED_GRANT_TYPES.contains(&"client_credentials"),
+        allowed.contains(&"client_credentials"),
         "client_credentials must be an allowed grant type"
     );
     assert!(
-        ALLOWED_GRANT_TYPES.contains(&"urn:ietf:params:oauth:grant-type:device_code"),
+        allowed.contains(&"urn:ietf:params:oauth:grant-type:device_code"),
         "device_code URN must be an allowed grant type"
     );
     assert!(
-        ALLOWED_GRANT_TYPES.contains(&"refresh_token"),
+        allowed.contains(&"refresh_token"),
         "refresh_token must be accepted in registration (though never issued)"
     );
 }
 
-/// Every grant the token endpoint dispatches must also be registrable.
-/// `ALLOWED_GRANT_TYPES` is a deliberate superset (it adds `refresh_token`),
-/// so this guards one direction: no dispatchable grant is unregistrable.
+/// The registration-only delta must stay disjoint from the token
+/// endpoint's dispatch set. Every dispatchable grant being registrable is
+/// guaranteed by construction (`allowed_grant_types` is the union); this
+/// guards the other direction — if a delta entry ever becomes
+/// dispatchable, it must be removed from the delta.
 #[test]
-fn every_dispatched_grant_is_registrable() {
-    for grant in crate::services::oidc::grant_type::OAuthGrantType::supported_wire_values() {
+fn registration_only_grants_are_not_dispatchable() {
+    for grant in REGISTRATION_ONLY_GRANT_TYPES {
         assert!(
-            ALLOWED_GRANT_TYPES.contains(&grant),
-            "token-endpoint grant {grant} must also be an allowed registration grant"
+            grant
+                .parse::<crate::services::oidc::grant_type::OAuthGrantType>()
+                .is_err(),
+            "{grant} is dispatched by the token endpoint; \
+             remove it from REGISTRATION_ONLY_GRANT_TYPES"
         );
     }
 }
@@ -679,8 +685,8 @@ fn every_dispatched_grant_is_registrable() {
 #[test]
 fn test_allowed_response_types_includes_code() {
     assert!(
-        ALLOWED_RESPONSE_TYPES.contains(&"code"),
-        "'code' must be in the allowed response types set"
+        crate::services::oidc::SUPPORTED_RESPONSE_TYPES.contains(&"code"),
+        "'code' must be in the supported response types set"
     );
 }
 
@@ -692,7 +698,7 @@ fn test_allowed_response_types_includes_code() {
 #[test]
 fn test_implicit_grant_not_allowed() {
     assert!(
-        !ALLOWED_GRANT_TYPES.contains(&"implicit"),
+        !allowed_grant_types().contains(&"implicit"),
         "The implicit grant type must not be allowed (deprecated by RFC 9700)"
     );
 }
@@ -701,7 +707,7 @@ fn test_implicit_grant_not_allowed() {
 #[test]
 fn test_token_response_type_not_allowed() {
     assert!(
-        !ALLOWED_RESPONSE_TYPES.contains(&"token"),
+        !crate::services::oidc::SUPPORTED_RESPONSE_TYPES.contains(&"token"),
         "'token' response type must not be allowed (implicit flow)"
     );
 }
@@ -710,7 +716,7 @@ fn test_token_response_type_not_allowed() {
 #[test]
 fn test_id_token_response_type_not_allowed() {
     assert!(
-        !ALLOWED_RESPONSE_TYPES.contains(&"id_token"),
+        !crate::services::oidc::SUPPORTED_RESPONSE_TYPES.contains(&"id_token"),
         "'id_token' response type must not be allowed (implicit flow)"
     );
 }


### PR DESCRIPTION
## Summary

Stacked on #1000 (uses its `SUPPORTED_RESPONSE_TYPES`); lands after it.

Dynamic registration kept `ALLOWED_GRANT_TYPES` — a **third** independent copy of the grant URNs that `grant_type.rs`'s module doc claims sole ownership of — plus its own `ALLOWED_RESPONSE_TYPES` beside the authorize validator's check.

## Changes

- `ALLOWED_GRANT_TYPES` deleted. Registration computes `allowed_grant_types()` = `OAuthGrantType::supported_wire_values()` ∪ `REGISTRATION_ONLY_GRANT_TYPES`. The deliberate delta is now a named one-entry const carrying its rationale (`refresh_token` accepted so standard client libraries register unmodified; the server never issues one).
- `ALLOWED_RESPONSE_TYPES` deleted in favor of the shared `SUPPORTED_RESPONSE_TYPES` from #1000.
- `handlers/device.rs` grant_type validation goes through the owning enum with an **exhaustive match, no `_` arm** — adding a grant variant forces this dispatch site to be revisited at compile time.

Accepted sets and wire behavior are unchanged.

## Proof by violation

The deleted consts' leftover references failed exactly as the visibility mechanism predicts:

```
error[E0425]: cannot find value `ALLOWED_GRANT_TYPES` in this scope
   --> crates/vouch-server/src/services/oidc/registration/tests.rs:649:9
```

## Tests

- `every_dispatched_grant_is_registrable` (one direction) is now true by construction and is replaced by the remaining meaningful invariant: `registration_only_grants_are_not_dispatchable` — if a delta entry ever becomes a token-endpoint grant, the test demands its removal from the delta.
- Constants tests retargeted to `allowed_grant_types()` / `SUPPORTED_RESPONSE_TYPES` (implicit/token/id_token still rejected).
- Gates: `make lint` clean, `make test` zero failures, `make test-integration` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of allowlist sources with unchanged accepted sets and error responses. Exhaustive match and tests reduce the chance of grant-type drift.
> 
> **Overview**
> Removes duplicate grant/response-type allowlists in dynamic registration so they share the token-endpoint enum and `SUPPORTED_RESPONSE_TYPES`.
> 
> Registration now allows `OAuthGrantType::supported_wire_values()` plus a named `refresh_token` delta (still never issued). Device-token grant checks parse `OAuthGrantType` with an exhaustive match so a new variant fails to compile until that site is updated.
> 
> Accepted sets and wire errors are unchanged. Tests now assert the registration-only delta is not dispatchable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b99899bc3f832fae4d561926ec8364468bbab03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->