### PR TITLE
refactor(server): single-source the DPoP signing algorithm allow-list

### DIFF
--- a/crates/vouch-server/src/db/documents/oauth.rs
+++ b/crates/vouch-server/src/db/documents/oauth.rs
@@ -251,6 +251,20 @@ impl JwsAlgorithm {
             Self::EdDsa => "EdDSA",
         }
     }
+
+    /// Algorithms permitted for FAPI 2.0-scoped signing (DPoP proofs, token endpoint
+    /// client authentication, and other FAPI-profiled JWTs).
+    ///
+    /// FAPI 2.0 Security Profile, Section 5.4.1 "General requirements"
+    /// (<https://openid.net/specs/fapi-security-profile-2_0-final.html>) reads:
+    ///
+    /// > Authorization servers, clients, and resource servers when creating or processing
+    /// > JWTs shall adhere to \[RFC8725\]; use `PS256`, `ES256`, or `EdDSA` (using the
+    /// > `Ed25519` variant) algorithms; and not use or accept the `none` algorithm.
+    ///
+    /// This is a `shall` (MUST-strength) requirement, and the three-algorithm list is
+    /// restrictive: `RS256` is deliberately not among them.
+    pub const FAPI_ALLOWED: [Self; 3] = [Self::Es256, Self::Ps256, Self::EdDsa];
 }
 
 impl std::str::FromStr for JwsAlgorithm {

--- a/crates/vouch-server/src/handlers/oidc/par.rs
+++ b/crates/vouch-server/src/handlers/oidc/par.rs
@@ -223,7 +223,7 @@ pub(crate) async fn par(
     let jwt_auth = any_auth.jwt_auth;
     let secret_verification = any_auth.secret_verification;
 
-    // RFC 8705 §2 / FAPI 2.0 §5.2.2: mTLS dispatch. When the client is
+    // RFC 8705 §2 / FAPI 2.0 §5.3.2.1: mTLS dispatch. When the client is
     // registered with `tls_client_auth` or `self_signed_tls_client_auth`
     // and no body-level credential has authenticated it, verify the TLS
     // client certificate. Must run before FAPI auth-method validation so
@@ -262,7 +262,7 @@ pub(crate) async fn par(
 
     // FAPI 2.0: Validate client authentication method.
     //
-    // FAPI 2.0 Section 5.2.2 requires `private_key_jwt`. Client secrets and
+    // FAPI 2.0 Section 5.3.2.1 requires `private_key_jwt`. Client secrets and
     // public-client ("none") authentication are rejected for FAPI clients.
     // The method is derived from the verification witnesses — what this
     // request actually authenticated with — not the registered

--- a/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
@@ -496,7 +496,7 @@ async fn test_fapi2_dpop_code_binding_missing_dpop_at_token() {
 
 #[tokio::test]
 async fn test_fapi2_authorize_rejects_without_par() {
-    // FAPI 2.0 Section 5.2.2: FAPI clients MUST use PAR.
+    // FAPI 2.0 Section 5.3.2.2: FAPI clients MUST use PAR.
     // A direct GET /oauth/authorize without request_uri must return an error page.
     let (app, state) = test_app().await;
 
@@ -531,7 +531,7 @@ async fn test_fapi2_authorize_rejects_without_par() {
 
 #[tokio::test]
 async fn test_fapi2_par_accepts_private_key_jwt() {
-    // FAPI 2.0 Section 5.2.2: FAPI clients must use private_key_jwt.
+    // FAPI 2.0 Section 5.3.2.1: FAPI clients must use private_key_jwt.
     // Verify that a FAPI client using the correct private_key_jwt authentication
     // is accepted at the PAR endpoint.
     //
@@ -586,7 +586,7 @@ async fn test_fapi2_par_accepts_private_key_jwt() {
     );
 }
 
-/// FAPI 2.0 Section 5.2.2: the auth-method gate must judge the method the
+/// FAPI 2.0 Section 5.3.2.1: the auth-method gate must judge the method the
 /// request ACTUALLY authenticated with, not the registered one. A stale
 /// client secret on a client registered as private_key_jwt must be
 /// rejected at PAR (#706).
@@ -649,7 +649,7 @@ async fn test_fapi2_par_rejects_client_id_only_for_private_key_jwt_client() {
 
 #[tokio::test]
 async fn test_fapi2_token_rejects_without_dpop() {
-    // FAPI 2.0 Section 5.2.2: Sender-constrained tokens are required.
+    // FAPI 2.0 Section 5.3.2.1: Sender-constrained tokens are required.
     // A FAPI client that authenticates with private_key_jwt but omits the
     // DPoP header must be rejected.
     let (app, state) = test_app().await;
@@ -857,7 +857,7 @@ async fn test_fapi2_non_fapi_client_secret_basic() {
 
 #[tokio::test]
 async fn test_fapi2_discovery_excludes_rs256() {
-    // FAPI 2.0 Section 5.2.2: RS256 must NOT appear in any algorithm list.
+    // FAPI 2.0 Section 5.4.1: RS256 must NOT appear in any algorithm list.
     let (app, _state) = test_app().await;
 
     let (status, body) = http_get(&app, "/.well-known/openid-configuration", &[]).await;
@@ -865,7 +865,7 @@ async fn test_fapi2_discovery_excludes_rs256() {
 
     let doc: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
 
-    // FAPI 2.0 Section 5.2.2 restricts RS256 from DPoP and token endpoint auth signing.
+    // FAPI 2.0 Section 5.4.1 restricts RS256 from DPoP and token endpoint auth signing.
     // request_object_signing_alg_values_supported intentionally includes RS256 to support
     // OIDC Basic Profile conformance (oidcc-request-uri-signed-rs256). The JAR validator
     // enforces PS256/ES256/EdDSA for FAPI clients at runtime via validate_fapi_algorithm().
@@ -887,7 +887,7 @@ async fn test_fapi2_discovery_excludes_rs256() {
 
 #[tokio::test]
 async fn test_fapi2_discovery_includes_fapi_algorithms() {
-    // FAPI 2.0 Section 5.2.2: PS256, ES256, EdDSA must be in signing algorithm lists.
+    // FAPI 2.0 Section 5.4.1: PS256, ES256, EdDSA must be in signing algorithm lists.
     let (app, _state) = test_app().await;
 
     let (status, body) = http_get(&app, "/.well-known/openid-configuration", &[]).await;
@@ -1123,7 +1123,7 @@ async fn test_discovery_tls_client_auth_in_auth_methods_with_tls() {
 // ============================================================================
 // FAPI 2.0 Device Authorization Grant (RFC 8628) — Sender Constraints
 //
-// FAPI 2.0 Section 5.2.2 requires sender-constrained access tokens. The
+// FAPI 2.0 Section 5.3.2.1 requires sender-constrained access tokens. The
 // device code grant must enforce this for FAPI clients, consistent with the
 // authorization code and FIDO2 assertion grants.
 // ============================================================================
@@ -1181,7 +1181,7 @@ fn device_token_body(device_code: &str) -> String {
     )
 }
 
-/// FAPI 2.0 Section 5.2.2: A FAPI client completing device flow without a
+/// FAPI 2.0 Section 5.3.2.1: A FAPI client completing device flow without a
 /// sender constraint (DPoP or mTLS) must be rejected with `invalid_request`.
 /// The device code must NOT be consumed so the client can retry with a proof.
 #[tokio::test]
@@ -1528,7 +1528,7 @@ async fn test_fapi2_device_flow_unknown_client_id_rejected() {
 // ============================================================================
 // FAPI 2.0 Token Exchange (RFC 8693) — Sender Constraints
 //
-// FAPI 2.0 Section 5.2.2 applies to every grant a FAPI client can use.
+// FAPI 2.0 Section 5.3.2.1 applies to every grant a FAPI client can use.
 // Without enforcement here, a FAPI client could exchange a DPoP-bound
 // subject_token for an unbound access token, undoing the sender constraint
 // in one hop.
@@ -1625,7 +1625,7 @@ async fn test_fapi2_token_exchange_with_dpop_issues_bound_token() {
 // ============================================================================
 // FAPI 2.0 Client Credentials (RFC 6749 §4.4) — Sender Constraints
 //
-// FAPI 2.0 Section 5.2.2 applies to every grant a FAPI client can reach.
+// FAPI 2.0 Section 5.3.2.1 applies to every grant a FAPI client can reach.
 // The client_credentials grant is reachable by any registered client — the
 // token endpoint does not gate grants by the client's registered
 // `grant_types` — so it must enforce sender-constraining like the others.

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7523.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7523.rs
@@ -1689,7 +1689,7 @@ async fn test_rfc7523_token_private_key_jwt_plus_dpop_invalid_client_bad_jwt() {
     assert_eq!(json["error"], "invalid_client");
 }
 
-/// FAPI 2.0 §5.2.2: FAPI clients require sender-constrained access tokens.
+/// FAPI 2.0 §5.3.2.1: FAPI clients require sender-constrained access tokens.
 /// `private_key_jwt` alone is client authentication — not sender-constraint.
 /// Without DPoP and without mTLS, the token endpoint must reject with
 /// `invalid_request` "FAPI 2.0 requires sender-constrained access tokens

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9101.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9101.rs
@@ -157,8 +157,9 @@ async fn test_rfc9101_discovery_includes_request_object_signing_alg_values_suppo
     assert!(alg_strs.contains(&"PS256"), "Must support PS256");
     assert!(alg_strs.contains(&"EdDSA"), "Must support EdDSA");
     // RS256 is advertised for non-FAPI clients (OIDC Basic Profile conformance).
-    // FAPI 2.0 Section 5.2.2 restricts DPoP/token-endpoint signing, not JAR signing.
-    // The JAR validator enforces PS256/ES256/EdDSA for FAPI clients at runtime.
+    // Vouch deliberately advertises RS256 for JAR request objects while the JAR
+    // validator enforces the FAPI 2.0 Section 5.4.1 set (PS256/ES256/EdDSA) for
+    // FAPI clients at runtime.
     assert!(
         alg_strs.contains(&"RS256"),
         "RS256 must be advertised for OIDC Basic Profile conformance (oidcc-request-uri-signed-rs256)"

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
@@ -1626,7 +1626,7 @@ async fn test_rfc9126_par_jti_replay_returns_invalid_client() {
 }
 
 // ========================================================================
-// RFC 8705 §2 / FAPI 2.0 §5.2.2 — mTLS Client Authentication at PAR
+// RFC 8705 §2 / FAPI 2.0 §5.3.2.1 — mTLS Client Authentication at PAR
 //
 // PAR must apply the same mTLS dispatch as the token endpoint: a client
 // registered with tls_client_auth must present a valid TLS client

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9449.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9449.rs
@@ -2,6 +2,7 @@
 //! RFC 9449 — DPoP (Demonstration of Proof of Possession) tests.
 
 use super::helpers::*;
+use std::collections::BTreeSet;
 
 // ========================================================================
 // DPoP Integration Tests (RFC 9449)
@@ -687,6 +688,94 @@ async fn test_rfc9449_dpop_symmetric_algorithm_rejected() {
     assert!(
         status == StatusCode::UNAUTHORIZED || status == StatusCode::BAD_REQUEST,
         "Symmetric algorithm DPoP proof should be rejected, got: {status}"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc9449_dpop_rs256_algorithm_rejected() {
+    // RS256 is a valid JwsAlgorithm but is not in JwsAlgorithm::FAPI_ALLOWED, so
+    // DPoP proofs declaring it must be rejected. This proof carries a REAL RSA
+    // keypair and a REAL RS256 signature over the signing input: if the
+    // SUPPORTED_ALGORITHMS gate were ever removed, this exact proof would pass
+    // signature verification and the request would succeed — so the test fails
+    // for the algorithm rejection specifically, not for an incidental
+    // malformed-JWK or bad-signature side effect (unlike the HS256 sibling
+    // below, which short-circuits at JWK deserialization since HS256 has no
+    // asymmetric JWK shape to embed).
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "dpop-rs256@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+
+    let (access_token, _) = issue_oauth_access_token(&app, &state, &user, &auth_id, &client).await;
+
+    use aws_lc_rs::encoding::AsDer;
+    use aws_lc_rs::rsa::{KeyPair as RsaKeyPair, KeySize};
+    use aws_lc_rs::signature::{KeyPair as _, RSA_PKCS1_SHA256};
+
+    let key_pair = RsaKeyPair::generate(KeySize::Rsa2048).expect("RSA-2048 keygen");
+    let spki_der = key_pair.public_key().as_der().expect("SPKI DER");
+    let (n_bytes, e_bytes) = crate::crypto::kms_signer::parse_spki_rsa(spki_der.as_ref())
+        .expect("parse RSA SPKI components");
+
+    let jwk = serde_json::json!({
+        "kty": "RSA",
+        "n": URL_SAFE_NO_PAD.encode(&n_bytes),
+        "e": URL_SAFE_NO_PAD.encode(&e_bytes)
+    });
+    let header = serde_json::json!({
+        "typ": "dpop+jwt",
+        "alg": "RS256",
+        "jwk": jwk
+    });
+    let claims = serde_json::json!({
+        "jti": uuid::Uuid::now_v7().to_string(),
+        "htm": "GET",
+        "htu": format!("{}/oauth/userinfo", state.config().base_url),
+        "iat": jiff::Timestamp::now().as_second()
+    });
+
+    let header_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&header).unwrap());
+    let claims_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&claims).unwrap());
+    let signing_input = format!("{header_b64}.{claims_b64}");
+
+    let rng = aws_lc_rs::rand::SystemRandom::new();
+    let mut sig_bytes = vec![0u8; key_pair.public_modulus_len()];
+    key_pair
+        .sign(
+            &RSA_PKCS1_SHA256,
+            &rng,
+            signing_input.as_bytes(),
+            &mut sig_bytes,
+        )
+        .expect("RS256 signing");
+    let sig_b64 = URL_SAFE_NO_PAD.encode(&sig_bytes);
+    let real_proof = format!("{signing_input}.{sig_b64}");
+
+    let (status, body) = http_get(
+        &app,
+        "/oauth/userinfo",
+        &[
+            ("Authorization", &format!("DPoP {access_token}")),
+            ("DPoP", &real_proof),
+        ],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "RS256 DPoP proof must be rejected by the algorithm allowlist: {body}"
+    );
+    let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(error["error"], "invalid_dpop_proof");
+    assert!(
+        error["error_description"]
+            .as_str()
+            .unwrap_or("")
+            .contains("unsupported DPoP algorithm"),
+        "rejection must be the algorithm-allowlist error, not a different DPoP failure: {body}"
     );
 }
 
@@ -1614,4 +1703,75 @@ async fn test_rfc9449_userinfo_dpop_bound_token_in_post_body_rejected() {
         StatusCode::UNAUTHORIZED,
         "DPoP-bound token via POST body must return 401: {body}"
     );
+}
+
+// ========================================================================
+// Advertised-vs-enforced drift guards — same shape as
+// test_oidc_discovery_grant_types_match_token_parser in oidc_discovery.rs.
+// ========================================================================
+
+#[tokio::test]
+async fn test_dpop_signing_algs_match_supported_algorithms() {
+    let (app, _state) = test_app().await;
+    let (status, body) = http_get(&app, "/.well-known/openid-configuration", &[]).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let discovery: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let discovered: BTreeSet<String> = discovery["dpop_signing_alg_values_supported"]
+        .as_array()
+        .expect("dpop_signing_alg_values_supported is an array")
+        .iter()
+        .map(|v| v.as_str().expect("alg should be string").to_string())
+        .collect();
+
+    let supported: BTreeSet<String> = crate::services::oidc::dpop::SUPPORTED_ALGORITHMS
+        .iter()
+        .map(|alg| alg.as_str().to_string())
+        .collect();
+
+    assert_eq!(
+        discovered, supported,
+        "discovery dpop_signing_alg_values_supported must exactly match dpop::SUPPORTED_ALGORITHMS"
+    );
+
+    for alg in &discovered {
+        assert!(
+            alg.parse::<crate::db::JwsAlgorithm>().is_ok(),
+            "discovery advertises a DPoP algorithm JwsAlgorithm cannot parse: {alg}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_token_endpoint_auth_signing_algs_match_fapi_allowed() {
+    let (app, _state) = test_app().await;
+    let (status, body) = http_get(&app, "/.well-known/openid-configuration", &[]).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let discovery: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let discovered: BTreeSet<String> =
+        discovery["token_endpoint_auth_signing_alg_values_supported"]
+            .as_array()
+            .expect("token_endpoint_auth_signing_alg_values_supported is an array")
+            .iter()
+            .map(|v| v.as_str().expect("alg should be string").to_string())
+            .collect();
+
+    let source: BTreeSet<String> = crate::db::JwsAlgorithm::FAPI_ALLOWED
+        .iter()
+        .map(|alg| alg.as_str().to_string())
+        .collect();
+
+    assert_eq!(
+        discovered, source,
+        "discovery token_endpoint_auth_signing_alg_values_supported must exactly match \
+         JwsAlgorithm::FAPI_ALLOWED"
+    );
+
+    for alg in &discovered {
+        assert!(
+            alg.parse::<crate::db::JwsAlgorithm>().is_ok(),
+            "discovery advertises a token endpoint auth algorithm JwsAlgorithm cannot parse: {alg}"
+        );
+    }
 }

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9728.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9728.rs
@@ -18,6 +18,7 @@ use crate::infra::resource_metadata::WELL_KNOWN_SUFFIX;
 use crate::services::oidc::protected_resource::{PROTECTED_RESOURCE_PREFIXES, SIGNED_METADATA_TYP};
 use aws_lc_rs::signature::{ECDSA_P256_SHA256_FIXED, UnparsedPublicKey};
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use std::collections::BTreeSet;
 
 // Shared RFC 7235 `WWW-Authenticate` mini-parser. The full grammar is
 // not needed — we only extract parameter values so tests can verify
@@ -183,7 +184,7 @@ async fn test_rfc9728_required_fields_present() {
     assert!(dpop_strs.contains(&"EdDSA"));
     assert!(
         !dpop_strs.contains(&"RS256"),
-        "FAPI 2.0 §5.2.2 excludes RS256 from DPoP"
+        "FAPI 2.0 §5.4.1 excludes RS256 from DPoP"
     );
 
     // signed_metadata MUST be present (we always sign).
@@ -276,6 +277,60 @@ async fn test_rfc9728_resource_signing_algs_match_available_keys() {
         .expect("resource_signing_alg_values_supported must be array");
     let alg_strs: Vec<&str> = algs.iter().filter_map(|v| v.as_str()).collect();
     assert_eq!(alg_strs, vec!["ES256"]);
+}
+
+/// Drift guard: the protected-resource metadata's `dpop_signing_alg_values_supported`
+/// must exactly match `JwsAlgorithm::FAPI_ALLOWED`, the same source the AS discovery
+/// document derives its `dpop_signing_alg_values_supported` from. Checks both
+/// representations of the field — the plain JSON and the `signed_metadata` JWT
+/// payload, which RFC 9728 §3.3 requires to mirror the outer JSON — since they
+/// are built independently and could drift from each other. Same shape as
+/// `test_dpop_signing_algs_match_supported_algorithms` in `tests/rfc9449.rs`.
+#[tokio::test]
+async fn test_rfc9728_dpop_signing_algs_match_fapi_allowed() {
+    let (app, _state) = test_app().await;
+
+    let (status, body) = http_get(&app, WELL_KNOWN_SUFFIX, &[]).await;
+    assert_eq!(status, StatusCode::OK);
+    let outer: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+
+    let source: BTreeSet<String> = crate::db::JwsAlgorithm::FAPI_ALLOWED
+        .iter()
+        .map(|alg| alg.as_str().to_string())
+        .collect();
+
+    let extract_algs = |doc: &serde_json::Value| -> BTreeSet<String> {
+        doc["dpop_signing_alg_values_supported"]
+            .as_array()
+            .expect("dpop_signing_alg_values_supported must be array")
+            .iter()
+            .map(|v| v.as_str().expect("alg should be string").to_string())
+            .collect()
+    };
+
+    let outer_algs = extract_algs(&outer);
+    assert_eq!(
+        outer_algs, source,
+        "protected-resource dpop_signing_alg_values_supported must exactly match \
+         JwsAlgorithm::FAPI_ALLOWED"
+    );
+
+    let jwt = outer["signed_metadata"]
+        .as_str()
+        .expect("signed_metadata must be string");
+    let signed_algs = extract_algs(&decode_jwt_payload(jwt));
+    assert_eq!(
+        signed_algs, source,
+        "signed_metadata.dpop_signing_alg_values_supported must exactly match \
+         JwsAlgorithm::FAPI_ALLOWED"
+    );
+
+    for alg in &source {
+        assert!(
+            alg.parse::<crate::db::JwsAlgorithm>().is_ok(),
+            "FAPI_ALLOWED wire string does not round-trip through JwsAlgorithm parsing: {alg}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -742,7 +742,7 @@ async fn handle_client_credentials_grant(
             }
         };
 
-    // FAPI 2.0 Section 5.2.2: sender-constrained access tokens required
+    // FAPI 2.0 Section 5.3.2.1: sender-constrained access tokens required
     // (DPoP or mTLS), same as every other grant a FAPI client can reach.
     let sender_constraint = match SenderConstraintProof::validate(
         &authenticated_client.client,
@@ -937,7 +937,7 @@ async fn handle_token_exchange_grant(
     // RFC 8705 Section 3: Bind access token to cert thumbprint only when opted in.
     let mtls_thumbprint = extract_mtls_thumbprint(&authenticated_client, &client_cert);
 
-    // FAPI 2.0 Section 5.2.2: sender-constrained access tokens required
+    // FAPI 2.0 Section 5.3.2.1: sender-constrained access tokens required
     // (DPoP or mTLS) on every grant a FAPI client can use — without this, a
     // FAPI client could exchange a bound subject_token for an unbound one.
     // Mirrors `handle_authorization_code_grant`.

--- a/crates/vouch-server/src/services/auth.rs
+++ b/crates/vouch-server/src/services/auth.rs
@@ -462,7 +462,7 @@ impl SenderConstraintProof {
     ///
     /// Three independent requirements, all enforced here so that no grant
     /// enforces a different subset:
-    /// - FAPI 2.0 Section 5.2.2 — a FAPI client's tokens must be
+    /// - FAPI 2.0 Section 5.3.2.1 — a FAPI client's tokens must be
     ///   sender-constrained by DPoP or mTLS.
     /// - RFC 9449 Section 5 — a client that registered
     ///   `dpop_bound_access_tokens` must present a DPoP proof. mTLS does not

--- a/crates/vouch-server/src/services/oidc/discovery.rs
+++ b/crates/vouch-server/src/services/oidc/discovery.rs
@@ -71,7 +71,7 @@ pub struct OidcDiscoveryDocument {
     pub code_challenge_methods_supported: Vec<String>,
     /// RFC 9449 Section 5.1: Supported DPoP JWS signing algorithms.
     ///
-    /// RS256 is excluded per FAPI 2.0 Section 5.2.2.
+    /// See [`JwsAlgorithm::FAPI_ALLOWED`] for the FAPI 2.0 citation excluding RS256.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dpop_signing_alg_values_supported: Option<Vec<JwsAlgorithm>>,
     /// OIDC Discovery 1.0 Section 3: OPTIONAL. Supported ACR values.
@@ -86,8 +86,7 @@ pub struct OidcDiscoveryDocument {
     pub resource_indicators_supported: Option<bool>,
     /// RFC 7523: Supported JWS algorithms for JWT client authentication.
     ///
-    /// Includes PS256 and EdDSA per FAPI 2.0 requirements; RS256 is excluded
-    /// per FAPI 2.0 Section 5.2.2.
+    /// See [`JwsAlgorithm::FAPI_ALLOWED`] for the FAPI 2.0 citation excluding RS256.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token_endpoint_auth_signing_alg_values_supported: Option<Vec<JwsAlgorithm>>,
     /// RFC 9126: URL of the Pushed Authorization Request endpoint.
@@ -99,9 +98,9 @@ pub struct OidcDiscoveryDocument {
     pub request_parameter_supported: bool,
     /// RFC 9101: Supported JWS algorithms for Request Object signing.
     ///
-    /// RS256 is included because FAPI 2.0 Section 5.2.2 restricts DPoP and token endpoint
-    /// auth signing, not JAR signing. The validation layer enforces PS256/ES256/EdDSA for
-    /// FAPI-profile clients; RS256 JARs from non-FAPI clients are accepted and advertised.
+    /// RS256 is included because [`JwsAlgorithm::FAPI_ALLOWED`] restricts DPoP and token
+    /// endpoint auth signing, not JAR signing. The validation layer enforces PS256/ES256/EdDSA
+    /// for FAPI-profile clients; RS256 JARs from non-FAPI clients are accepted and advertised.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_object_signing_alg_values_supported: Option<Vec<JwsAlgorithm>>,
     /// JARM: Supported JWS algorithms for authorization response signing.
@@ -242,24 +241,14 @@ pub fn build_discovery_document(state: &Arc<AppState>) -> OidcDiscoveryDocument 
             .iter()
             .map(|m| m.as_str().to_string())
             .collect(),
-        // RS256 excluded per FAPI 2.0 Section 5.2.2.
-        dpop_signing_alg_values_supported: Some(vec![
-            JwsAlgorithm::Es256,
-            JwsAlgorithm::Ps256,
-            JwsAlgorithm::EdDsa,
-        ]),
+        dpop_signing_alg_values_supported: Some(JwsAlgorithm::FAPI_ALLOWED.to_vec()),
         acr_values_supported: Some(vec![ACR_AAL3.to_string()]),
         // RFC 9207: Advertise that we include `iss` in authorization responses
         authorization_response_iss_parameter_supported: true,
         // RFC 8707: Advertise resource indicator support
         resource_indicators_supported: Some(true),
         // RFC 7523: JWT client auth signing algorithms.
-        // PS256 and EdDSA added per FAPI 2.0; RS256 excluded per FAPI 2.0 Section 5.2.2.
-        token_endpoint_auth_signing_alg_values_supported: Some(vec![
-            JwsAlgorithm::Es256,
-            JwsAlgorithm::Ps256,
-            JwsAlgorithm::EdDsa,
-        ]),
+        token_endpoint_auth_signing_alg_values_supported: Some(JwsAlgorithm::FAPI_ALLOWED.to_vec()),
         // RFC 9126: Pushed Authorization Request endpoint
         pushed_authorization_request_endpoint: Some(format!("{base_url}/oauth/par")),
         require_pushed_authorization_requests: false,

--- a/crates/vouch-server/src/services/oidc/dpop.rs
+++ b/crates/vouch-server/src/services/oidc/dpop.rs
@@ -16,15 +16,15 @@ use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use subtle::ConstantTimeEq;
 
-use crate::db::{self, store::DocumentStore};
+use crate::db::{self, JwsAlgorithm, store::DocumentStore};
 
 /// Nonce validity in seconds (5 minutes).
 const NONCE_VALIDITY_SECONDS: i64 = 300;
 
 /// Supported DPoP signing algorithms (asymmetric only per RFC 9449).
 ///
-/// RS256 is excluded per FAPI 2.0 Section 5.2.2.
-pub const SUPPORTED_ALGORITHMS: &[&str] = &["ES256", "PS256", "EdDSA"];
+/// See [`JwsAlgorithm::FAPI_ALLOWED`] for the FAPI 2.0 citation excluding RS256.
+pub const SUPPORTED_ALGORITHMS: &[JwsAlgorithm] = &JwsAlgorithm::FAPI_ALLOWED;
 
 /// DPoP JWT header.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -265,10 +265,13 @@ pub fn compute_access_token_hash(access_token: &str) -> String {
 
 /// Parse a DPoP proof JWT header (without signature verification or claims parsing).
 ///
-/// Extracts only the header to obtain the JWK and algorithm. Used internally
-/// by `parse_and_verify_dpop_proof` to build the decoding key before
+/// Extracts the header to obtain the JWK and algorithm, parsing the `alg`
+/// wire string into a [`JwsAlgorithm`] exactly once. The typed value is
+/// threaded onward to `build_decoding_key` and the `jsonwebtoken::Algorithm`
+/// mapping in `parse_and_verify_dpop_proof`. Used internally by
+/// `parse_and_verify_dpop_proof` to build the decoding key before
 /// performing combined signature verification + claims extraction.
-fn parse_dpop_header(proof: &str) -> Result<DpopHeader, DpopError> {
+fn parse_dpop_header(proof: &str) -> Result<(DpopHeader, JwsAlgorithm), DpopError> {
     let header_part = proof
         .split('.')
         .next()
@@ -312,11 +315,15 @@ fn parse_dpop_header(proof: &str) -> Result<DpopHeader, DpopError> {
         )));
     }
 
-    if !SUPPORTED_ALGORITHMS.contains(&header.alg.as_str()) {
+    let alg: JwsAlgorithm = header
+        .alg
+        .parse()
+        .map_err(|_| DpopError::UnsupportedAlgorithm(header.alg.clone()))?;
+    if !SUPPORTED_ALGORITHMS.contains(&alg) {
         return Err(DpopError::UnsupportedAlgorithm(header.alg.clone()));
     }
 
-    Ok(header)
+    Ok((header, alg))
 }
 
 /// Parse and verify a DPoP proof in a single pass.
@@ -328,17 +335,19 @@ fn parse_dpop_header(proof: &str) -> Result<DpopHeader, DpopError> {
 ///
 /// Returns the parsed header and verified claims.
 fn parse_and_verify_dpop_proof(proof: &str) -> Result<(DpopHeader, DpopClaims), DpopError> {
-    let header = parse_dpop_header(proof)?;
+    let (header, alg) = parse_dpop_header(proof)?;
 
     // Build decoding key from JWK
-    let decoding_key = build_decoding_key(&header.jwk, &header.alg)?;
+    let decoding_key = build_decoding_key(&header.jwk, alg)?;
 
-    // Map algorithm string to jsonwebtoken Algorithm
-    let algorithm = match header.alg.as_str() {
-        "ES256" => jsonwebtoken::Algorithm::ES256,
-        "PS256" => jsonwebtoken::Algorithm::PS256,
-        "EdDSA" => jsonwebtoken::Algorithm::EdDSA,
-        alg => return Err(DpopError::UnsupportedAlgorithm(alg.to_string())),
+    // Map the typed algorithm to jsonwebtoken's Algorithm enum.
+    let algorithm = match alg {
+        JwsAlgorithm::Es256 => jsonwebtoken::Algorithm::ES256,
+        JwsAlgorithm::Ps256 => jsonwebtoken::Algorithm::PS256,
+        JwsAlgorithm::EdDsa => jsonwebtoken::Algorithm::EdDSA,
+        JwsAlgorithm::Rs256 => {
+            return Err(DpopError::UnsupportedAlgorithm(header.alg.clone()));
+        }
     };
 
     // Build validation settings
@@ -466,39 +475,57 @@ pub fn normalize_uri(uri: &str) -> String {
 }
 
 /// Build a `DecodingKey` from a DPoP JWK.
-fn build_decoding_key(jwk: &DpopJwk, alg: &str) -> Result<jsonwebtoken::DecodingKey, DpopError> {
-    match (jwk, alg) {
-        (DpopJwk::Ec(ec), "ES256") => {
-            if ec.kty != "EC" || ec.crv != "P-256" {
-                return Err(DpopError::InvalidFormat(
-                    "ES256 requires EC key with P-256 curve".to_string(),
-                ));
+fn build_decoding_key(
+    jwk: &DpopJwk,
+    alg: JwsAlgorithm,
+) -> Result<jsonwebtoken::DecodingKey, DpopError> {
+    match alg {
+        JwsAlgorithm::Es256 => match jwk {
+            DpopJwk::Ec(ec) => {
+                if ec.kty != "EC" || ec.crv != "P-256" {
+                    return Err(DpopError::InvalidFormat(
+                        "ES256 requires EC key with P-256 curve".to_string(),
+                    ));
+                }
+                // jsonwebtoken expects base64url-encoded strings
+                jsonwebtoken::DecodingKey::from_ec_components(&ec.x, &ec.y)
+                    .map_err(|e| DpopError::InvalidFormat(format!("Invalid EC key: {e}")))
             }
-            // jsonwebtoken expects base64url-encoded strings
-            jsonwebtoken::DecodingKey::from_ec_components(&ec.x, &ec.y)
-                .map_err(|e| DpopError::InvalidFormat(format!("Invalid EC key: {e}")))
-        }
-        (DpopJwk::Rsa(rsa), "PS256") => {
-            if rsa.kty != "RSA" {
-                return Err(DpopError::InvalidFormat(
-                    "PS256 requires RSA key".to_string(),
-                ));
+            DpopJwk::Rsa(_) | DpopJwk::Okp(_) => {
+                Err(DpopError::UnsupportedAlgorithm(alg.as_str().to_string()))
             }
-            // jsonwebtoken expects base64url-encoded strings
-            jsonwebtoken::DecodingKey::from_rsa_components(&rsa.n, &rsa.e)
-                .map_err(|e| DpopError::InvalidFormat(format!("Invalid RSA key: {e}")))
-        }
-        (DpopJwk::Okp(okp), "EdDSA") => {
-            if okp.kty != "OKP" || okp.crv != "Ed25519" {
-                return Err(DpopError::InvalidFormat(
-                    "EdDSA requires OKP key with Ed25519 curve".to_string(),
-                ));
+        },
+        JwsAlgorithm::Ps256 => match jwk {
+            DpopJwk::Rsa(rsa) => {
+                if rsa.kty != "RSA" {
+                    return Err(DpopError::InvalidFormat(
+                        "PS256 requires RSA key".to_string(),
+                    ));
+                }
+                // jsonwebtoken expects base64url-encoded strings
+                jsonwebtoken::DecodingKey::from_rsa_components(&rsa.n, &rsa.e)
+                    .map_err(|e| DpopError::InvalidFormat(format!("Invalid RSA key: {e}")))
             }
-            // jsonwebtoken expects base64url-encoded string
-            jsonwebtoken::DecodingKey::from_ed_components(&okp.x)
-                .map_err(|e| DpopError::InvalidFormat(format!("Invalid Ed25519 key: {e}")))
-        }
-        _ => Err(DpopError::UnsupportedAlgorithm(alg.to_string())),
+            DpopJwk::Ec(_) | DpopJwk::Okp(_) => {
+                Err(DpopError::UnsupportedAlgorithm(alg.as_str().to_string()))
+            }
+        },
+        JwsAlgorithm::EdDsa => match jwk {
+            DpopJwk::Okp(okp) => {
+                if okp.kty != "OKP" || okp.crv != "Ed25519" {
+                    return Err(DpopError::InvalidFormat(
+                        "EdDSA requires OKP key with Ed25519 curve".to_string(),
+                    ));
+                }
+                // jsonwebtoken expects base64url-encoded string
+                jsonwebtoken::DecodingKey::from_ed_components(&okp.x)
+                    .map_err(|e| DpopError::InvalidFormat(format!("Invalid Ed25519 key: {e}")))
+            }
+            DpopJwk::Ec(_) | DpopJwk::Rsa(_) => {
+                Err(DpopError::UnsupportedAlgorithm(alg.as_str().to_string()))
+            }
+        },
+        JwsAlgorithm::Rs256 => Err(DpopError::UnsupportedAlgorithm(alg.as_str().to_string())),
     }
 }
 

--- a/crates/vouch-server/src/services/oidc/fapi.rs
+++ b/crates/vouch-server/src/services/oidc/fapi.rs
@@ -29,7 +29,7 @@ pub const STANDARD_CLOCK_SKEW_SECONDS: i64 = 10;
 
 /// Validate FAPI 2.0 constraints on an authorization request.
 ///
-/// FAPI 2.0 Section 5.2.2 requires Pushed Authorization Requests (PAR).
+/// FAPI 2.0 Section 5.3.2.2 requires Pushed Authorization Requests (PAR).
 /// The `request_uri` must be present, obtained from a prior PAR endpoint call.
 ///
 /// Non-FAPI clients pass validation unconditionally.
@@ -50,7 +50,7 @@ pub fn validate_fapi_authorization_request(
         return Ok(());
     }
 
-    // FAPI 2.0 Section 5.2.2: PAR is required
+    // FAPI 2.0 Section 5.3.2.2: PAR is required
     if !has_par {
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidRequest,
@@ -63,7 +63,7 @@ pub fn validate_fapi_authorization_request(
 
 /// Sender-constraint mechanisms present on a token request.
 ///
-/// FAPI 2.0 Section 5.2.2 requires at least one of these for FAPI clients.
+/// FAPI 2.0 Section 5.3.2.1 requires at least one of these for FAPI clients.
 #[derive(Debug, Clone, Copy)]
 pub struct SenderConstraints {
     /// A valid DPoP proof was provided in the request.
@@ -74,7 +74,7 @@ pub struct SenderConstraints {
 
 /// Validate FAPI 2.0 constraints on a token request.
 ///
-/// FAPI 2.0 Section 5.2.2 requires sender-constrained access tokens,
+/// FAPI 2.0 Section 5.3.2.1 requires sender-constrained access tokens,
 /// so FAPI clients must present at least one mechanism in `constraints`.
 ///
 /// Non-FAPI clients pass validation unconditionally.
@@ -90,7 +90,7 @@ pub(crate) fn validate_fapi_token_request(
         return Ok(());
     }
 
-    // FAPI 2.0 Section 5.2.2: Sender-constrained tokens required (DPoP or mTLS)
+    // FAPI 2.0 Section 5.3.2.1: Sender-constrained tokens required (DPoP or mTLS)
     if !constraints.dpop && !constraints.mtls_cert {
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidRequest,
@@ -141,7 +141,7 @@ pub fn validate_fapi_algorithm(client: &OAuthClient, algorithm: &str) -> Service
 
 /// Validate that the client authentication method is allowed for FAPI 2.0.
 ///
-/// FAPI 2.0 Section 5.2.2 requires `private_key_jwt` (mTLS support is deferred).
+/// FAPI 2.0 Section 5.3.2.1 requires `private_key_jwt` (mTLS support is deferred).
 ///
 /// Non-FAPI clients pass validation unconditionally.
 ///

--- a/crates/vouch-server/src/services/oidc/fapi.rs
+++ b/crates/vouch-server/src/services/oidc/fapi.rs
@@ -6,7 +6,7 @@
 //!
 //! Reference: <https://openid.net/specs/fapi-security-profile-2_0-final.html>
 
-use crate::db::{OAuthClient, TokenEndpointAuthMethod};
+use crate::db::{JwsAlgorithm, OAuthClient, TokenEndpointAuthMethod};
 use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
 
 /// FAPI 2.0 authorization code lifetime in seconds (shorter than standard).
@@ -17,11 +17,6 @@ pub const FAPI_AUTH_CODE_LIFETIME_SECONDS: i64 = 60;
 /// 60 seconds is sufficient for the client to exchange the code after redirect.
 /// Matches the FAPI 2.0 recommendation — no reason for standard clients to be laxer.
 pub const STANDARD_AUTH_CODE_LIFETIME_SECONDS: i64 = 60;
-
-/// Algorithms allowed for FAPI 2.0 clients.
-///
-/// RS256 is explicitly excluded per FAPI 2.0 Section 5.2.2 due to known weaknesses.
-pub const FAPI_ALLOWED_ALGORITHMS: &[&str] = &["PS256", "ES256", "EdDSA"];
 
 /// FAPI 2.0 clock skew tolerance for acceptance (tighter than standard).
 pub const FAPI_CLOCK_SKEW_ACCEPT_SECONDS: i64 = 10;
@@ -108,8 +103,7 @@ pub(crate) fn validate_fapi_token_request(
 
 /// Validate that an algorithm is allowed for a FAPI 2.0 client.
 ///
-/// FAPI 2.0 Section 5.2.2 prohibits RS256 due to known weaknesses.
-/// Only PS256, ES256, and EdDSA are permitted.
+/// See [`JwsAlgorithm::FAPI_ALLOWED`] for the FAPI 2.0 citation excluding RS256.
 ///
 /// Non-FAPI clients pass validation unconditionally.
 ///
@@ -127,13 +121,18 @@ pub fn validate_fapi_algorithm(client: &OAuthClient, algorithm: &str) -> Service
         return Ok(());
     }
 
-    if !FAPI_ALLOWED_ALGORITHMS.contains(&algorithm) {
+    let allowed = algorithm
+        .parse::<JwsAlgorithm>()
+        .is_ok_and(|alg| JwsAlgorithm::FAPI_ALLOWED.contains(&alg));
+    if !allowed {
+        let allowed_list = JwsAlgorithm::FAPI_ALLOWED
+            .iter()
+            .map(JwsAlgorithm::as_str)
+            .collect::<Vec<_>>()
+            .join(", ");
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidRequest,
-            format!(
-                "FAPI 2.0 does not allow algorithm '{}'. Allowed: PS256, ES256, EdDSA",
-                algorithm
-            ),
+            format!("FAPI 2.0 does not allow algorithm '{algorithm}'. Allowed: {allowed_list}"),
         ));
     }
 
@@ -379,7 +378,15 @@ mod tests {
     #[test]
     fn test_validate_fapi_algorithm_rejects_rs256() {
         let client = fapi_client();
-        assert!(validate_fapi_algorithm(&client, "RS256").is_err());
+        let result = validate_fapi_algorithm(&client, "RS256");
+        assert!(result.is_err(), "RS256 must be rejected");
+        if let Err(err) = result {
+            let message = err.oauth_description();
+            assert!(
+                message.contains("Allowed: ES256, PS256, EdDSA"),
+                "error message must pin the FAPI_ALLOWED wire order, got: {message}"
+            );
+        }
     }
 
     #[test]
@@ -550,13 +557,13 @@ mod tests {
 
     #[test]
     fn test_fapi_allowed_algorithms_excludes_rs256() {
-        assert!(!FAPI_ALLOWED_ALGORITHMS.contains(&"RS256"));
+        assert!(!JwsAlgorithm::FAPI_ALLOWED.contains(&JwsAlgorithm::Rs256));
     }
 
     #[test]
     fn test_fapi_allowed_algorithms_includes_required() {
-        assert!(FAPI_ALLOWED_ALGORITHMS.contains(&"PS256"));
-        assert!(FAPI_ALLOWED_ALGORITHMS.contains(&"ES256"));
-        assert!(FAPI_ALLOWED_ALGORITHMS.contains(&"EdDSA"));
+        assert!(JwsAlgorithm::FAPI_ALLOWED.contains(&JwsAlgorithm::Ps256));
+        assert!(JwsAlgorithm::FAPI_ALLOWED.contains(&JwsAlgorithm::Es256));
+        assert!(JwsAlgorithm::FAPI_ALLOWED.contains(&JwsAlgorithm::EdDsa));
     }
 }

--- a/crates/vouch-server/src/services/oidc/jar.rs
+++ b/crates/vouch-server/src/services/oidc/jar.rs
@@ -343,7 +343,7 @@ pub async fn validate_request_object(
     }
 
     // 2b. FAPI 2.0: Validate algorithm is in the FAPI allowlist.
-    // RS256 is excluded per FAPI 2.0 Section 5.2.2 — use PS256, ES256, or EdDSA.
+    // RS256 is excluded per FAPI 2.0 Section 5.4.1 — use PS256, ES256, or EdDSA.
     if let Err(e) =
         crate::services::oidc::fapi::validate_fapi_algorithm(client, &assertion_header.alg)
     {

--- a/crates/vouch-server/src/services/oidc/jarm.rs
+++ b/crates/vouch-server/src/services/oidc/jarm.rs
@@ -46,7 +46,7 @@ struct JarmErrorClaims {
 ///
 /// Uses `client.authorization_signed_response_alg` if explicitly set;
 /// defaults to ES256 which is FAPI 2.0 compliant (PS256, ES256, EdDSA
-/// per FAPI 2.0 Section 5.2.2.1). RS256 is only used when a client
+/// per FAPI 2.0 Section 5.4.1). RS256 is only used when a client
 /// explicitly registers with `authorization_signed_response_alg=RS256`.
 fn select_alg(_state: &AppState, client: &OAuthClient) -> &'static str {
     match client.authorization_signed_response_alg {

--- a/crates/vouch-server/src/services/oidc/protected_resource.rs
+++ b/crates/vouch-server/src/services/oidc/protected_resource.rs
@@ -191,8 +191,9 @@ pub struct ProtectedResourceMetadata {
     pub authorization_details_types_supported: Option<Vec<String>>,
 
     /// RFC 9728 §2 + RFC 9449 §5.1: OPTIONAL. JWS algorithms accepted
-    /// in DPoP proofs at this resource. RS256 is deliberately absent
-    /// (FAPI 2.0 §5.2.2 excludes it).
+    /// in DPoP proofs at this resource. See
+    /// [`JwsAlgorithm::FAPI_ALLOWED`] for the FAPI 2.0 citation
+    /// excluding RS256.
     pub dpop_signing_alg_values_supported: Vec<JwsAlgorithm>,
 
     /// RFC 9728 §2 + RFC 9449: OPTIONAL. `true` means every access
@@ -307,12 +308,7 @@ pub async fn build_protected_resource_metadata(
         .map(|s| s.as_str().to_string())
         .collect();
 
-    let dpop_signing_alg_values_supported = vec![
-        // RS256 excluded per FAPI 2.0 §5.2.2 (matches discovery.rs).
-        JwsAlgorithm::Es256,
-        JwsAlgorithm::Ps256,
-        JwsAlgorithm::EdDsa,
-    ];
+    let dpop_signing_alg_values_supported = JwsAlgorithm::FAPI_ALLOWED.to_vec();
 
     // Build the metadata first with an empty `signed_metadata`; sign
     // a copy of the claims; then populate `signed_metadata`. The


### PR DESCRIPTION
## Summary

The FAPI-profiled signing-algorithm set {ES256, PS256, EdDSA} was spelled **seven** times in two types (the issue enumerated six; implementation found a seventh in `protected_resource.rs`): `dpop.rs`'s string list, `fapi.rs`'s string list, hand-written vectors in `discovery.rs` (both algorithm fields) and `protected_resource.rs`, plus two catch-all matches inside `dpop.rs` whose `_` arms meant a new algorithm compiled cleanly and failed at runtime.

`JwsAlgorithm::FAPI_ALLOWED` (`db/documents/oauth.rs`) is now the only spelling. Every former site derives from it; `dpop.rs` parses the proof header's `alg` into the enum exactly once and threads the typed value through exhaustive matches (no `_` arms).

## Spec citation corrected

The codebase justified this set with "per FAPI 2.0 Section 5.2.2" — fetched three independent times during this work (developer twice, reviewer once), **§5.2.2 is TLS cipher suites for non-browser endpoints**. The algorithm requirement is §5.4.1 (https://openid.net/specs/fapi-security-profile-2_0-final.html):

> Authorization servers, clients, and resource servers when creating or processing JWTs shall adhere to [RFC8725]; use PS256, ES256, or EdDSA (using the Ed25519 variant) algorithms; and not use or accept the none algorithm.

Strength: **shall**. The three-algorithm set was always correct; only the citation was wrong. In-scope citations are corrected here; the remaining ~20 unrelated "§5.2.2" mis-citations (PAR → §5.3.2.2, sender-constrained/private_key_jwt → §5.3.2.1) land as a separate docs-only sweep PR.

## One disclosed wire change

`validate_fapi_algorithm`'s `error_description` now reads `Allowed: ES256, PS256, EdDSA` (previously hardcoded `Allowed: PS256, ES256, EdDSA`, while discovery advertised ES256-first — the two old orders were mutually inconsistent; the derivation makes discovery order win). Reaches the wire via JAR `invalid_request_object` descriptions. Everything else is byte-identical: discovery and protected-resource JSON preserve exact prior order and content.

**Scope guard**: `jwt_bearer/validate.rs` (client-assertion algorithms, still accepts RS256) is deliberately untouched — that is #1003, a behavior decision. The new drift guard pins the *advertisement* to the const, not to that validator.

## Proof by violation

Adding a temporary `JwsAlgorithm` variant produces exactly 3 `E0004 non-exhaustive patterns` errors at the sites that now enforce the set (`as_str`, the `jsonwebtoken::Algorithm` mapping, `build_decoding_key`), then was reverted (grep-verified). Mutation testing went further: allowing RS256 in `FAPI_ALLOWED` alone does **not** re-admit RS256 proofs — the two exhaustive `Rs256` arms are independent defense-in-depth layers; only removing all three enforcement points flips the RS256 test red, and it fails precisely at the tightened error-description assertion.

## Tests

- Drift guards (set-equality vs the enforcement source + per-value round-trip): `dpop_signing_alg_values_supported` and `token_endpoint_auth_signing_alg_values_supported` in discovery (rfc9449 tests), and the protected-resource field on **both** representations — plain JSON and the `signed_metadata` JWT payload (rfc9728 test), which RFC 9728 requires to mirror each other but which are built independently.
- `test_rfc9449_dpop_rs256_algorithm_rejected` rewritten with a real RSA-2048 keypair and real `RSA_PKCS1_SHA256` signature, asserting the specific allow-list rejection — if the gate were removed, the genuinely-signed proof would verify and the test would flip red (the old garbage-JWK version kept passing for the wrong reason).
- The `Allowed:` message is now pinned by an assertion, locking the disclosed wire change.
- Known accepted limits: the drift guards compare as sets (array order is statically guaranteed by the literal const + `to_vec()` + serde `Vec` serialization); the two `Rs256` match arms are exercised only via the compiler's exhaustiveness check plus the mutation experiment above.

## Gates

`make fmt` clean · `make lint` (clippy `-D warnings`, all targets/features) zero warnings · `cargo test -p vouch-server --all-features` 3051 lib + 9 integration targets, 0 failures · `make test-integration` clean. All counts independently re-verified by a second and third agent during review.

Closes #1002

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches DPoP proof verification and FAPI algorithm enforcement, which are security-sensitive, but the allowed set is unchanged except for a JAR error-description order.
> 
> **Overview**
> Makes `{ES256, PS256, EdDSA}` a single const (`JwsAlgorithm::FAPI_ALLOWED`) used by DPoP, FAPI validation, OIDC discovery, and protected-resource metadata. Duplicate string lists and handwritten vectors are removed.
> 
> DPoP now parses `alg` once into `JwsAlgorithm` and matches exhaustively (including explicit `Rs256` rejection) instead of string/`_` arms. `validate_fapi_algorithm` derives its allow-list and error text from the same const, so JAR `error_description` now lists `Allowed: ES256, PS256, EdDSA`.
> 
> Comments cite FAPI §5.4.1 for algorithms (and §5.3.2.x for PAR/sender-constraint). Tests add discovery/resource drift guards and a real RS256-signed DPoP proof that must fail on the allow-list. Client-assertion RS256 (`jwt_bearer`) is left as-is.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 155da70d8548c6371a443344127e477f2536a409. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->