### PR TITLE
docs(server): correct FAPI 2.0 section citations to the sections that carry them

### DIFF
--- a/crates/vouch-server/src/handlers/oidc/par.rs
+++ b/crates/vouch-server/src/handlers/oidc/par.rs
@@ -223,7 +223,7 @@ pub(crate) async fn par(
     let jwt_auth = any_auth.jwt_auth;
     let secret_verification = any_auth.secret_verification;
 
-    // RFC 8705 §2 / FAPI 2.0 §5.2.2: mTLS dispatch. When the client is
+    // RFC 8705 §2 / FAPI 2.0 §5.3.2.1: mTLS dispatch. When the client is
     // registered with `tls_client_auth` or `self_signed_tls_client_auth`
     // and no body-level credential has authenticated it, verify the TLS
     // client certificate. Must run before FAPI auth-method validation so
@@ -262,7 +262,7 @@ pub(crate) async fn par(
 
     // FAPI 2.0: Validate client authentication method.
     //
-    // FAPI 2.0 Section 5.2.2 requires `private_key_jwt`. Client secrets and
+    // FAPI 2.0 Section 5.3.2.1 requires `private_key_jwt`. Client secrets and
     // public-client ("none") authentication are rejected for FAPI clients.
     // The method is derived from the verification witnesses — what this
     // request actually authenticated with — not the registered

--- a/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
@@ -496,7 +496,7 @@ async fn test_fapi2_dpop_code_binding_missing_dpop_at_token() {
 
 #[tokio::test]
 async fn test_fapi2_authorize_rejects_without_par() {
-    // FAPI 2.0 Section 5.2.2: FAPI clients MUST use PAR.
+    // FAPI 2.0 Section 5.3.2.2: FAPI clients MUST use PAR.
     // A direct GET /oauth/authorize without request_uri must return an error page.
     let (app, state) = test_app().await;
 
@@ -531,7 +531,7 @@ async fn test_fapi2_authorize_rejects_without_par() {
 
 #[tokio::test]
 async fn test_fapi2_par_accepts_private_key_jwt() {
-    // FAPI 2.0 Section 5.2.2: FAPI clients must use private_key_jwt.
+    // FAPI 2.0 Section 5.3.2.1: FAPI clients must use private_key_jwt.
     // Verify that a FAPI client using the correct private_key_jwt authentication
     // is accepted at the PAR endpoint.
     //
@@ -586,7 +586,7 @@ async fn test_fapi2_par_accepts_private_key_jwt() {
     );
 }
 
-/// FAPI 2.0 Section 5.2.2: the auth-method gate must judge the method the
+/// FAPI 2.0 Section 5.3.2.1: the auth-method gate must judge the method the
 /// request ACTUALLY authenticated with, not the registered one. A stale
 /// client secret on a client registered as private_key_jwt must be
 /// rejected at PAR (#706).
@@ -649,7 +649,7 @@ async fn test_fapi2_par_rejects_client_id_only_for_private_key_jwt_client() {
 
 #[tokio::test]
 async fn test_fapi2_token_rejects_without_dpop() {
-    // FAPI 2.0 Section 5.2.2: Sender-constrained tokens are required.
+    // FAPI 2.0 Section 5.3.2.1: Sender-constrained tokens are required.
     // A FAPI client that authenticates with private_key_jwt but omits the
     // DPoP header must be rejected.
     let (app, state) = test_app().await;
@@ -857,7 +857,7 @@ async fn test_fapi2_non_fapi_client_secret_basic() {
 
 #[tokio::test]
 async fn test_fapi2_discovery_excludes_rs256() {
-    // FAPI 2.0 Section 5.2.2: RS256 must NOT appear in any algorithm list.
+    // FAPI 2.0 Section 5.4.1: RS256 must NOT appear in any algorithm list.
     let (app, _state) = test_app().await;
 
     let (status, body) = http_get(&app, "/.well-known/openid-configuration", &[]).await;
@@ -865,7 +865,7 @@ async fn test_fapi2_discovery_excludes_rs256() {
 
     let doc: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
 
-    // FAPI 2.0 Section 5.2.2 restricts RS256 from DPoP and token endpoint auth signing.
+    // FAPI 2.0 Section 5.4.1 restricts RS256 from DPoP and token endpoint auth signing.
     // request_object_signing_alg_values_supported intentionally includes RS256 to support
     // OIDC Basic Profile conformance (oidcc-request-uri-signed-rs256). The JAR validator
     // enforces PS256/ES256/EdDSA for FAPI clients at runtime via validate_fapi_algorithm().
@@ -887,7 +887,7 @@ async fn test_fapi2_discovery_excludes_rs256() {
 
 #[tokio::test]
 async fn test_fapi2_discovery_includes_fapi_algorithms() {
-    // FAPI 2.0 Section 5.2.2: PS256, ES256, EdDSA must be in signing algorithm lists.
+    // FAPI 2.0 Section 5.4.1: PS256, ES256, EdDSA must be in signing algorithm lists.
     let (app, _state) = test_app().await;
 
     let (status, body) = http_get(&app, "/.well-known/openid-configuration", &[]).await;
@@ -1123,7 +1123,7 @@ async fn test_discovery_tls_client_auth_in_auth_methods_with_tls() {
 // ============================================================================
 // FAPI 2.0 Device Authorization Grant (RFC 8628) — Sender Constraints
 //
-// FAPI 2.0 Section 5.2.2 requires sender-constrained access tokens. The
+// FAPI 2.0 Section 5.3.2.1 requires sender-constrained access tokens. The
 // device code grant must enforce this for FAPI clients, consistent with the
 // authorization code and FIDO2 assertion grants.
 // ============================================================================
@@ -1181,7 +1181,7 @@ fn device_token_body(device_code: &str) -> String {
     )
 }
 
-/// FAPI 2.0 Section 5.2.2: A FAPI client completing device flow without a
+/// FAPI 2.0 Section 5.3.2.1: A FAPI client completing device flow without a
 /// sender constraint (DPoP or mTLS) must be rejected with `invalid_request`.
 /// The device code must NOT be consumed so the client can retry with a proof.
 #[tokio::test]
@@ -1528,7 +1528,7 @@ async fn test_fapi2_device_flow_unknown_client_id_rejected() {
 // ============================================================================
 // FAPI 2.0 Token Exchange (RFC 8693) — Sender Constraints
 //
-// FAPI 2.0 Section 5.2.2 applies to every grant a FAPI client can use.
+// FAPI 2.0 Section 5.3.2.1 applies to every grant a FAPI client can use.
 // Without enforcement here, a FAPI client could exchange a DPoP-bound
 // subject_token for an unbound access token, undoing the sender constraint
 // in one hop.
@@ -1625,7 +1625,7 @@ async fn test_fapi2_token_exchange_with_dpop_issues_bound_token() {
 // ============================================================================
 // FAPI 2.0 Client Credentials (RFC 6749 §4.4) — Sender Constraints
 //
-// FAPI 2.0 Section 5.2.2 applies to every grant a FAPI client can reach.
+// FAPI 2.0 Section 5.3.2.1 applies to every grant a FAPI client can reach.
 // The client_credentials grant is reachable by any registered client — the
 // token endpoint does not gate grants by the client's registered
 // `grant_types` — so it must enforce sender-constraining like the others.

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7523.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7523.rs
@@ -1689,7 +1689,7 @@ async fn test_rfc7523_token_private_key_jwt_plus_dpop_invalid_client_bad_jwt() {
     assert_eq!(json["error"], "invalid_client");
 }
 
-/// FAPI 2.0 §5.2.2: FAPI clients require sender-constrained access tokens.
+/// FAPI 2.0 §5.3.2.1: FAPI clients require sender-constrained access tokens.
 /// `private_key_jwt` alone is client authentication — not sender-constraint.
 /// Without DPoP and without mTLS, the token endpoint must reject with
 /// `invalid_request` "FAPI 2.0 requires sender-constrained access tokens

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9101.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9101.rs
@@ -157,8 +157,9 @@ async fn test_rfc9101_discovery_includes_request_object_signing_alg_values_suppo
     assert!(alg_strs.contains(&"PS256"), "Must support PS256");
     assert!(alg_strs.contains(&"EdDSA"), "Must support EdDSA");
     // RS256 is advertised for non-FAPI clients (OIDC Basic Profile conformance).
-    // FAPI 2.0 Section 5.2.2 restricts DPoP/token-endpoint signing, not JAR signing.
-    // The JAR validator enforces PS256/ES256/EdDSA for FAPI clients at runtime.
+    // Vouch deliberately advertises RS256 for JAR request objects while the JAR
+    // validator enforces the FAPI 2.0 Section 5.4.1 set (PS256/ES256/EdDSA) for
+    // FAPI clients at runtime.
     assert!(
         alg_strs.contains(&"RS256"),
         "RS256 must be advertised for OIDC Basic Profile conformance (oidcc-request-uri-signed-rs256)"

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
@@ -1626,7 +1626,7 @@ async fn test_rfc9126_par_jti_replay_returns_invalid_client() {
 }
 
 // ========================================================================
-// RFC 8705 §2 / FAPI 2.0 §5.2.2 — mTLS Client Authentication at PAR
+// RFC 8705 §2 / FAPI 2.0 §5.3.2.1 — mTLS Client Authentication at PAR
 //
 // PAR must apply the same mTLS dispatch as the token endpoint: a client
 // registered with tls_client_auth must present a valid TLS client

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -742,7 +742,7 @@ async fn handle_client_credentials_grant(
             }
         };
 
-    // FAPI 2.0 Section 5.2.2: sender-constrained access tokens required
+    // FAPI 2.0 Section 5.3.2.1: sender-constrained access tokens required
     // (DPoP or mTLS), same as every other grant a FAPI client can reach.
     let sender_constraint = match SenderConstraintProof::validate(
         &authenticated_client.client,
@@ -937,7 +937,7 @@ async fn handle_token_exchange_grant(
     // RFC 8705 Section 3: Bind access token to cert thumbprint only when opted in.
     let mtls_thumbprint = extract_mtls_thumbprint(&authenticated_client, &client_cert);
 
-    // FAPI 2.0 Section 5.2.2: sender-constrained access tokens required
+    // FAPI 2.0 Section 5.3.2.1: sender-constrained access tokens required
     // (DPoP or mTLS) on every grant a FAPI client can use — without this, a
     // FAPI client could exchange a bound subject_token for an unbound one.
     // Mirrors `handle_authorization_code_grant`.

--- a/crates/vouch-server/src/services/auth.rs
+++ b/crates/vouch-server/src/services/auth.rs
@@ -462,7 +462,7 @@ impl SenderConstraintProof {
     ///
     /// Three independent requirements, all enforced here so that no grant
     /// enforces a different subset:
-    /// - FAPI 2.0 Section 5.2.2 — a FAPI client's tokens must be
+    /// - FAPI 2.0 Section 5.3.2.1 — a FAPI client's tokens must be
     ///   sender-constrained by DPoP or mTLS.
     /// - RFC 9449 Section 5 — a client that registered
     ///   `dpop_bound_access_tokens` must present a DPoP proof. mTLS does not

--- a/crates/vouch-server/src/services/oidc/fapi.rs
+++ b/crates/vouch-server/src/services/oidc/fapi.rs
@@ -29,7 +29,7 @@ pub const STANDARD_CLOCK_SKEW_SECONDS: i64 = 10;
 
 /// Validate FAPI 2.0 constraints on an authorization request.
 ///
-/// FAPI 2.0 Section 5.2.2 requires Pushed Authorization Requests (PAR).
+/// FAPI 2.0 Section 5.3.2.2 requires Pushed Authorization Requests (PAR).
 /// The `request_uri` must be present, obtained from a prior PAR endpoint call.
 ///
 /// Non-FAPI clients pass validation unconditionally.
@@ -50,7 +50,7 @@ pub fn validate_fapi_authorization_request(
         return Ok(());
     }
 
-    // FAPI 2.0 Section 5.2.2: PAR is required
+    // FAPI 2.0 Section 5.3.2.2: PAR is required
     if !has_par {
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidRequest,
@@ -63,7 +63,7 @@ pub fn validate_fapi_authorization_request(
 
 /// Sender-constraint mechanisms present on a token request.
 ///
-/// FAPI 2.0 Section 5.2.2 requires at least one of these for FAPI clients.
+/// FAPI 2.0 Section 5.3.2.1 requires at least one of these for FAPI clients.
 #[derive(Debug, Clone, Copy)]
 pub struct SenderConstraints {
     /// A valid DPoP proof was provided in the request.
@@ -74,7 +74,7 @@ pub struct SenderConstraints {
 
 /// Validate FAPI 2.0 constraints on a token request.
 ///
-/// FAPI 2.0 Section 5.2.2 requires sender-constrained access tokens,
+/// FAPI 2.0 Section 5.3.2.1 requires sender-constrained access tokens,
 /// so FAPI clients must present at least one mechanism in `constraints`.
 ///
 /// Non-FAPI clients pass validation unconditionally.
@@ -90,7 +90,7 @@ pub(crate) fn validate_fapi_token_request(
         return Ok(());
     }
 
-    // FAPI 2.0 Section 5.2.2: Sender-constrained tokens required (DPoP or mTLS)
+    // FAPI 2.0 Section 5.3.2.1: Sender-constrained tokens required (DPoP or mTLS)
     if !constraints.dpop && !constraints.mtls_cert {
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidRequest,
@@ -141,7 +141,7 @@ pub fn validate_fapi_algorithm(client: &OAuthClient, algorithm: &str) -> Service
 
 /// Validate that the client authentication method is allowed for FAPI 2.0.
 ///
-/// FAPI 2.0 Section 5.2.2 requires `private_key_jwt` (mTLS support is deferred).
+/// FAPI 2.0 Section 5.3.2.1 requires `private_key_jwt` (mTLS support is deferred).
 ///
 /// Non-FAPI clients pass validation unconditionally.
 ///

--- a/crates/vouch-server/src/services/oidc/jarm.rs
+++ b/crates/vouch-server/src/services/oidc/jarm.rs
@@ -46,7 +46,7 @@ struct JarmErrorClaims {
 ///
 /// Uses `client.authorization_signed_response_alg` if explicitly set;
 /// defaults to ES256 which is FAPI 2.0 compliant (PS256, ES256, EdDSA
-/// per FAPI 2.0 Section 5.2.2.1). RS256 is only used when a client
+/// per FAPI 2.0 Section 5.4.1). RS256 is only used when a client
 /// explicitly registers with `authorization_signed_response_alg=RS256`.
 fn select_alg(_state: &AppState, client: &OAuthClient) -> &'static str {
     match client.authorization_signed_response_alg {


### PR DESCRIPTION
## Summary

Stacked on #1008 (whose spec fetch surfaced this); lands after it.

Comments across the FAPI enforcement code cited "FAPI 2.0 Section 5.2.2" for three unrelated requirements. §5.2.2 is "Requirements for endpoints not used by web browsers" — TLS cipher suites — and carries none of them. All corrections verified against https://openid.net/specs/fapi-security-profile-2_0-final.html, fetched this session (twice by the implementing agent for #1008, once independently for this sweep):

| Claim in comments | Wrong citation | Actual section | Verbatim anchor |
|---|---|---|---|
| Signing-algorithm restriction (no RS256) | §5.2.2 | **§5.4.1** | "…shall adhere to [RFC8725]; use PS256, ES256, or EdDSA (using the Ed25519 variant) algorithms; and not use or accept the none algorithm." |
| PAR required | §5.2.2 | **§5.3.2.2** | "shall support client-authenticated pushed authorization requests according to [RFC9126]" |
| Sender-constrained tokens; private_key_jwt / mTLS client auth | §5.2.2 | **§5.3.2.1** | "shall only issue sender-constrained access tokens"; "shall authenticate clients using one of the following methods: MTLS … or private_key_jwt" |

26 comment lines across 9 files (`services/oidc/{fapi,jarm}`, `services/auth.rs`, `handlers/oidc/{par,token}`, and five per-RFC test files). Two are rewords rather than number swaps:

- `jarm.rs` cited a nonexistent "§5.2.2.1".
- `handlers/oidc/tests/rfc9101.rs` claimed the spec "restricts DPoP/token-endpoint signing, not JAR signing" — §5.4.1 states no JAR exemption, so the comment now describes Vouch's RS256 JAR advertisement as the deliberate product decision it is (OIDC Basic Profile conformance), not a spec carve-out.

The correct §5.2.2 citations in `infra/tls.rs` (actual TLS requirements) are untouched, as are SCIM's RFC 7644 §3.5.2.2 references (different spec).

Comment-only: zero code or test-behavior changes. Gates: fmt clean, clippy zero warnings, full `--all-features` suite green (pre-push hook re-ran both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only documentation fix with no runtime, auth, or test-behavior changes.
> 
> **Overview**
> Corrects FAPI 2.0 spec citations that wrongly pointed at **§5.2.2** (TLS cipher suites) for unrelated requirements.
> 
> Comments now cite **§5.3.2.1** (sender-constrained tokens / `private_key_jwt` and mTLS), **§5.3.2.2** (PAR required), and **§5.4.1** (signing algorithms). A JAR discovery comment no longer claims a spec carve-out for RS256; it describes Vouch’s deliberate advertisement for OIDC Basic Profile, with FAPI clients still gated at runtime. No logic or test assertions change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5ca6e2512877d33fc89df9fd4aa95b03901181f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->