### PR TITLE
fix(server): enforce per-profile client-assertion signing algorithms

### DIFF
--- a/crates/vouch-server/src/db/documents/oauth.rs
+++ b/crates/vouch-server/src/db/documents/oauth.rs
@@ -265,6 +265,17 @@ impl JwsAlgorithm {
     /// This is a `shall` (MUST-strength) requirement, and the three-algorithm list is
     /// restrictive: `RS256` is deliberately not among them.
     pub const FAPI_ALLOWED: [Self; 3] = [Self::Es256, Self::Ps256, Self::EdDsa];
+
+    /// Algorithms permitted for `private_key_jwt` (RFC 7523 §2.2) client-assertion
+    /// signing by clients not opted into FAPI 2.0 ([`FapiProfile::None`]):
+    /// [`Self::FAPI_ALLOWED`] plus `RS256`.
+    ///
+    /// [`FapiProfile::client_assertion_algorithms`] selects this per client, and
+    /// [`FapiProfile::client_assertion_algorithms_union`] — what discovery's
+    /// `token_endpoint_auth_signing_alg_values_supported` (`services/oidc/discovery.rs`)
+    /// actually advertises — is derived from it, not an independently maintained copy.
+    pub const CLIENT_ASSERTION_ALLOWED: [Self; 4] =
+        [Self::Es256, Self::Rs256, Self::Ps256, Self::EdDsa];
 }
 
 impl std::str::FromStr for JwsAlgorithm {
@@ -366,6 +377,12 @@ pub enum FapiProfile {
 }
 
 impl FapiProfile {
+    /// Every profile variant. [`Self::client_assertion_algorithms_union`] iterates
+    /// this, so a new variant added here without a matching arm in
+    /// [`Self::client_assertion_algorithms`] fails to compile (non-exhaustive match)
+    /// rather than silently inheriting another profile's allowlist.
+    pub const ALL: [Self; 2] = [Self::None, Self::Fapi2Security];
+
     /// Returns the canonical string representation used in the wire format.
     #[must_use]
     pub fn as_str(&self) -> &'static str {
@@ -373,6 +390,37 @@ impl FapiProfile {
             Self::None => "none",
             Self::Fapi2Security => "fapi2_security",
         }
+    }
+
+    /// Algorithms this profile permits for `private_key_jwt` (RFC 7523 §2.2)
+    /// client-assertion signing. Callers select this per client via
+    /// `client.fapi_profile.client_assertion_algorithms()`
+    /// (`services/oidc/jwt_bearer/client_auth.rs`).
+    #[must_use]
+    pub fn client_assertion_algorithms(&self) -> &'static [JwsAlgorithm] {
+        match self {
+            Self::None => &JwsAlgorithm::CLIENT_ASSERTION_ALLOWED,
+            Self::Fapi2Security => &JwsAlgorithm::FAPI_ALLOWED,
+        }
+    }
+
+    /// The union of every profile's [`Self::client_assertion_algorithms`], over
+    /// [`Self::ALL`]. Discovery's `token_endpoint_auth_signing_alg_values_supported`
+    /// (`services/oidc/discovery.rs`) is exactly this union, so it cannot advertise
+    /// an algorithm no profile enforces, or omit one some profile does — the
+    /// advertised and enforced sets are structurally tied, not asserted equal in a
+    /// docstring.
+    #[must_use]
+    pub fn client_assertion_algorithms_union() -> Vec<JwsAlgorithm> {
+        let mut union: Vec<JwsAlgorithm> = Vec::new();
+        for profile in Self::ALL {
+            for alg in profile.client_assertion_algorithms() {
+                if !union.contains(alg) {
+                    union.push(*alg);
+                }
+            }
+        }
+        union
     }
 }
 

--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -1447,6 +1447,53 @@ mod tests {
         assert_eq!(none_json, r#""none""#);
     }
 
+    #[test]
+    fn test_fapi_profile_client_assertion_algorithms_per_variant() {
+        assert_eq!(
+            FapiProfile::None.client_assertion_algorithms(),
+            &JwsAlgorithm::CLIENT_ASSERTION_ALLOWED
+        );
+        assert_eq!(
+            FapiProfile::Fapi2Security.client_assertion_algorithms(),
+            &JwsAlgorithm::FAPI_ALLOWED
+        );
+    }
+
+    #[test]
+    fn test_client_assertion_algorithms_union_contains_every_profile_set() {
+        let union = FapiProfile::client_assertion_algorithms_union();
+        for profile in FapiProfile::ALL {
+            for alg in profile.client_assertion_algorithms() {
+                assert!(
+                    union.contains(alg),
+                    "{profile:?}'s allowed algorithm {alg} must be in the union"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_client_assertion_algorithms_union_matches_client_assertion_allowed() {
+        // Non-FAPI already permits every algorithm any profile permits (RS256
+        // plus the FAPI-allowed three), so today the union equals it exactly.
+        // This pins that fact rather than assuming it: adding a profile with an
+        // algorithm outside CLIENT_ASSERTION_ALLOWED would fail this test, not
+        // silently widen or narrow what discovery advertises.
+        let mut union: Vec<&str> = FapiProfile::client_assertion_algorithms_union()
+            .iter()
+            .map(JwsAlgorithm::as_str)
+            .collect();
+        union.sort_unstable();
+
+        let mut allowed: Vec<&str> = JwsAlgorithm::CLIENT_ASSERTION_ALLOWED
+            .iter()
+            .map(JwsAlgorithm::as_str)
+            .collect();
+        allowed.sort_unstable();
+
+        assert_eq!(union, allowed);
+    }
+
     // ========================================================================
     // Test Helpers
     // ========================================================================

--- a/crates/vouch-server/src/handlers/applications/validate.rs
+++ b/crates/vouch-server/src/handlers/applications/validate.rs
@@ -34,6 +34,7 @@ pub(super) enum AppValidationError {
     FapiMissingJwks,
     PrivateKeyJwtMissingJwks,
     FapiDowngradeUnsupported,
+    FapiJwksNoAllowedAlgorithm,
     JwksNotJson,
     JwksMissingKeys,
     InvalidJwksUri,
@@ -53,6 +54,7 @@ impl AppValidationError {
             Self::FapiRequiresConfidentialClient => "invalid_fapi_profile",
             Self::FapiMissingJwks | Self::PrivateKeyJwtMissingJwks => "missing_jwks",
             Self::FapiDowngradeUnsupported => "fapi_downgrade_unsupported",
+            Self::FapiJwksNoAllowedAlgorithm => "fapi_jwks_algorithm_unsupported",
             Self::JwksNotJson | Self::JwksMissingKeys => "invalid_jwks",
             Self::InvalidJwksUri => "invalid_jwks_uri",
         }
@@ -100,6 +102,13 @@ impl AppValidationError {
             Self::FapiDowngradeUnsupported => {
                 "A FAPI 2.0 application cannot be changed to a standard profile. \
                  Create a new standard application instead."
+                    .to_string()
+            }
+            Self::FapiJwksNoAllowedAlgorithm => {
+                "FAPI 2.0 requires a JWKS key usable with ES256, PS256, or EdDSA \
+                 (RFC 7523 client-assertion signing). None of the configured keys \
+                 are usable: every key declares an alg outside that set. Add a \
+                 compatible key, or remove the alg constraint from an existing one."
                     .to_string()
             }
             Self::JwksNotJson => "JWKS must be valid JSON".to_string(),
@@ -205,6 +214,17 @@ pub(super) fn validate_create_application<'a>(
 
     let jwks = jwks_trimmed.map(parse_jwks).transpose()?;
     validate_jwks_uri(jwks_uri)?;
+
+    // FAPI validation: an inline JWKS must have at least one key the
+    // FAPI_ALLOWED validator can actually select (see jwks_has_fapi_allowed_key).
+    // A jwks_uri can't be inspected synchronously, so this only guards the
+    // inline case; the same is true of validate_update_fapi.
+    if is_fapi
+        && let Some(ref parsed_jwks) = jwks
+        && !jwks_has_fapi_allowed_key(parsed_jwks)
+    {
+        return Err(AppValidationError::FapiJwksNoAllowedAlgorithm);
+    }
 
     Ok(ValidatedCreateApp {
         name,
@@ -354,6 +374,20 @@ pub(super) fn validate_update_fapi(
         && client.jwks_uri.is_none()
     {
         return Err(AppValidationError::FapiMissingJwks);
+    }
+
+    // FAPI validation: an inline JWKS (submitted or already on the client) must
+    // have at least one key usable with FAPI_ALLOWED. Reached whenever the
+    // request declares `fapi_profile=fapi2_security` — a fresh upgrade or an
+    // explicit re-confirmation — same scope as the FapiMissingJwks check above.
+    // A JWKS-only update that omits `fapi_profile` on an already-FAPI client
+    // takes the early return above and is not re-validated here, matching that
+    // check's existing scope; the client stays FAPI either way, so this is a
+    // known gap shared by both checks, not one this change introduces.
+    if let Some(jwks) = validated.jwks.as_ref().or(client.jwks.as_ref())
+        && !jwks_has_fapi_allowed_key(jwks)
+    {
+        return Err(AppValidationError::FapiJwksNoAllowedAlgorithm);
     }
 
     Ok(())
@@ -573,6 +607,39 @@ fn parse_jwks(jwks_json: &str) -> Result<serde_json::Value, AppValidationError> 
         return Err(AppValidationError::JwksMissingKeys);
     }
     Ok(val)
+}
+
+/// Returns `true` when `jwks` contains at least one key the FAPI 2.0
+/// client-assertion validator (`FapiProfile::client_assertion_algorithms`, which
+/// yields `JwsAlgorithm::FAPI_ALLOWED` for `FapiProfile::Fapi2Security`) could
+/// actually use: a key that declares no `alg` but has a `kty` the runtime
+/// matcher can select for ES256/PS256/EdDSA (`EC`/`RSA`/`OKP`), or a key whose
+/// declared `alg` is ES256, PS256, or EdDSA outright.
+///
+/// A key search skips a JWK whose declared `alg` differs from the assertion's
+/// header (`jwt_bearer/jwks.rs`), so a JWKS made only of `alg: RS256` keys would
+/// leave a FAPI client with no algorithm it is both allowed to use and has a
+/// matching key for — permanently unauthenticatable, the same "no way back"
+/// failure [`AppValidationError::FapiDowngradeUnsupported`] prevents on the
+/// standard-profile transition. The `kty` check on the no-`alg` branch closes
+/// the same bug class for an incompatible or missing `kty` (e.g. `oct`): the
+/// runtime matcher (`jwt_bearer/jwks.rs`) only ever selects `EC`/`RSA`/`OKP`
+/// for ES256/PS256/EdDSA, so a key with any other `kty` is unmatchable
+/// regardless of `alg`.
+fn jwks_has_fapi_allowed_key(jwks: &serde_json::Value) -> bool {
+    let Some(keys) = jwks.get("keys").and_then(|k| k.as_array()) else {
+        return false;
+    };
+    keys.iter().any(|key| {
+        let Some(alg) = key.get("alg").and_then(|a| a.as_str()) else {
+            return key
+                .get("kty")
+                .and_then(|v| v.as_str())
+                .is_some_and(|kty| matches!(kty, "EC" | "RSA" | "OKP"));
+        };
+        alg.parse::<JwsAlgorithm>()
+            .is_ok_and(|parsed| JwsAlgorithm::FAPI_ALLOWED.contains(&parsed))
+    })
 }
 
 fn validate_jwks_uri(jwks_uri: Option<&str>) -> Result<(), AppValidationError> {
@@ -915,6 +982,274 @@ mod tests {
         assert!(fields.jwks.is_some(), "request JWKS used");
         assert_eq!(fields.jwks_uri, Some("https://client.example/jwks.json"));
         assert!(fields.dpop_bound_access_tokens);
+    }
+
+    // ========================================================================
+    // FAPI upgrade requires a usable key (#1003 round 2) — a JWKS made only of
+    // alg-pinned keys outside FAPI_ALLOWED (ES256/PS256/EdDSA) leaves a FAPI
+    // client with no algorithm it can both present and match a key for: the
+    // client-assertion validator rejects RS256 for FAPI clients
+    // (jwt_bearer/client_auth.rs), and key selection skips a JWK whose
+    // declared alg differs from the assertion's (jwt_bearer/jwks.rs) — so an
+    // RS256-only key can never be selected for the algorithms FAPI does
+    // allow. This mirrors FapiDowngradeUnsupported: refuse the transition
+    // instead of persisting an application that can no longer authenticate.
+    // ========================================================================
+
+    fn rs256_only_jwks_json() -> String {
+        serde_json::json!({"keys": [{"kty": "RSA", "alg": "RS256", "n": "n", "e": "AQAB"}]})
+            .to_string()
+    }
+
+    // An RSA key with no `alg` constraint: RS256-shaped key material, but usable
+    // with PS256 because nothing pins it to RS256. Distinguishes "no key at all
+    // works" from "the alg happens to be spelled out and disallowed" — the guard
+    // must key off the declared alg, not the key type.
+    fn unpinned_rsa_jwks_json() -> String {
+        serde_json::json!({"keys": [{"kty": "RSA", "n": "n", "e": "AQAB"}]}).to_string()
+    }
+
+    fn eddsa_jwks_json() -> String {
+        serde_json::json!({"keys": [{"kty": "OKP", "crv": "Ed25519", "alg": "EdDSA", "x": "x"}]})
+            .to_string()
+    }
+
+    #[tokio::test]
+    async fn fapi_upgrade_rejected_when_jwks_has_no_allowed_algorithm_key() {
+        let state = test_app_state().await;
+        let user = create_test_user(&state.store, "fapi-upgrade-rs256@example.com").await;
+        let created = create_test_client(&state.store, &user.id, TestClientSpec::default()).await;
+        let client = crate::db::get_oauth_client_by_id(&state.store, &created.app_id)
+            .await
+            .expect("db lookup")
+            .expect("client exists");
+
+        let jwks = rs256_only_jwks_json();
+        let validated = validate_update_format(UpdateAppInput {
+            redirect_uris: None,
+            resource_uris: None,
+            post_logout_redirect_uris: None,
+            access_scope: None,
+            fapi_profile: Some("fapi2_security"),
+            jwks: Some(&jwks),
+            jwks_uri: None,
+        })
+        .expect("valid update input");
+
+        let err = validate_update_fapi(&validated, &client)
+            .expect_err("RS256-only JWKS must be rejected for a FAPI upgrade");
+        assert_eq!(err.code(), "fapi_jwks_algorithm_unsupported");
+    }
+
+    #[tokio::test]
+    async fn fapi_upgrade_accepted_when_jwks_has_an_allowed_algorithm_key() {
+        let state = test_app_state().await;
+        let user = create_test_user(&state.store, "fapi-upgrade-es256@example.com").await;
+        let created = create_test_client(&state.store, &user.id, TestClientSpec::default()).await;
+        let client = crate::db::get_oauth_client_by_id(&state.store, &created.app_id)
+            .await
+            .expect("db lookup")
+            .expect("client exists");
+
+        let jwks = fapi_jwks_json();
+        let validated = validate_update_format(UpdateAppInput {
+            redirect_uris: None,
+            resource_uris: None,
+            post_logout_redirect_uris: None,
+            access_scope: None,
+            fapi_profile: Some("fapi2_security"),
+            jwks: Some(&jwks),
+            jwks_uri: None,
+        })
+        .expect("valid update input");
+
+        validate_update_fapi(&validated, &client)
+            .expect("a JWKS with no alg constraint must pass the FAPI upgrade guard");
+    }
+
+    #[tokio::test]
+    async fn fapi_upgrade_accepted_when_jwks_has_unpinned_rsa_key() {
+        let state = test_app_state().await;
+        let user = create_test_user(&state.store, "fapi-upgrade-rsa-unpinned@example.com").await;
+        let created = create_test_client(&state.store, &user.id, TestClientSpec::default()).await;
+        let client = crate::db::get_oauth_client_by_id(&state.store, &created.app_id)
+            .await
+            .expect("db lookup")
+            .expect("client exists");
+
+        let jwks = unpinned_rsa_jwks_json();
+        let validated = validate_update_format(UpdateAppInput {
+            redirect_uris: None,
+            resource_uris: None,
+            post_logout_redirect_uris: None,
+            access_scope: None,
+            fapi_profile: Some("fapi2_security"),
+            jwks: Some(&jwks),
+            jwks_uri: None,
+        })
+        .expect("valid update input");
+
+        validate_update_fapi(&validated, &client)
+            .expect("an unpinned RSA key (usable with PS256) must pass the FAPI upgrade guard");
+    }
+
+    #[tokio::test]
+    async fn fapi_upgrade_accepted_when_jwks_has_eddsa_key() {
+        let state = test_app_state().await;
+        let user = create_test_user(&state.store, "fapi-upgrade-eddsa@example.com").await;
+        let created = create_test_client(&state.store, &user.id, TestClientSpec::default()).await;
+        let client = crate::db::get_oauth_client_by_id(&state.store, &created.app_id)
+            .await
+            .expect("db lookup")
+            .expect("client exists");
+
+        let jwks = eddsa_jwks_json();
+        let validated = validate_update_format(UpdateAppInput {
+            redirect_uris: None,
+            resource_uris: None,
+            post_logout_redirect_uris: None,
+            access_scope: None,
+            fapi_profile: Some("fapi2_security"),
+            jwks: Some(&jwks),
+            jwks_uri: None,
+        })
+        .expect("valid update input");
+
+        validate_update_fapi(&validated, &client)
+            .expect("an OKP/EdDSA key must pass the FAPI upgrade guard");
+    }
+
+    // The guard also fires on an explicit re-confirmation (fapi_profile
+    // resubmitted, not just a fresh non-FAPI -> FAPI transition): swapping the
+    // JWKS of an already-FAPI client to an RS256-only key would strand it
+    // exactly the same way. A JWKS-only update that omits `fapi_profile`
+    // entirely is a known, pre-existing gap shared with FapiMissingJwks (see
+    // the comment on the guard) — out of scope here.
+    #[tokio::test]
+    async fn fapi_reconfirm_rejected_when_new_jwks_has_no_allowed_algorithm_key() {
+        let state = test_app_state().await;
+        let client = fapi_test_client(&state, "fapi-reconfirm-rs256@example.com").await;
+
+        let jwks = rs256_only_jwks_json();
+        let validated = validate_update_format(UpdateAppInput {
+            redirect_uris: None,
+            resource_uris: None,
+            post_logout_redirect_uris: None,
+            access_scope: None,
+            fapi_profile: Some("fapi2_security"),
+            jwks: Some(&jwks),
+            jwks_uri: None,
+        })
+        .expect("valid update input");
+
+        let err = validate_update_fapi(&validated, &client)
+            .expect_err("RS256-only JWKS must be rejected on FAPI re-confirmation");
+        assert_eq!(err.code(), "fapi_jwks_algorithm_unsupported");
+    }
+
+    #[test]
+    fn fapi_create_rejected_when_jwks_has_no_allowed_algorithm_key() {
+        let redirect_uris = vec!["https://example.com/cb".to_string()];
+        let jwks = rs256_only_jwks_json();
+        let err = validate_create_application(CreateAppInput {
+            name: "Payments",
+            application_type: "web",
+            redirect_uris: &redirect_uris,
+            resource_uris: &[],
+            post_logout_redirect_uris: None,
+            access_scope: None,
+            fapi_profile: Some("fapi2_security"),
+            jwks: Some(&jwks),
+            jwks_uri: None,
+        })
+        .expect_err("RS256-only JWKS must be rejected at FAPI creation");
+        assert_eq!(err.code(), "fapi_jwks_algorithm_unsupported");
+    }
+
+    #[test]
+    fn fapi_create_accepted_when_jwks_has_unpinned_rsa_key() {
+        let redirect_uris = vec!["https://example.com/cb".to_string()];
+        let jwks = unpinned_rsa_jwks_json();
+        validate_create_application(CreateAppInput {
+            name: "Payments",
+            application_type: "web",
+            redirect_uris: &redirect_uris,
+            resource_uris: &[],
+            post_logout_redirect_uris: None,
+            access_scope: None,
+            fapi_profile: Some("fapi2_security"),
+            jwks: Some(&jwks),
+            jwks_uri: None,
+        })
+        .expect("an unpinned RSA key (usable with PS256) must pass FAPI creation");
+    }
+
+    #[test]
+    fn fapi_create_accepted_when_jwks_has_eddsa_key() {
+        let redirect_uris = vec!["https://example.com/cb".to_string()];
+        let jwks = eddsa_jwks_json();
+        validate_create_application(CreateAppInput {
+            name: "Payments",
+            application_type: "web",
+            redirect_uris: &redirect_uris,
+            resource_uris: &[],
+            post_logout_redirect_uris: None,
+            access_scope: None,
+            fapi_profile: Some("fapi2_security"),
+            jwks: Some(&jwks),
+            jwks_uri: None,
+        })
+        .expect("an OKP/EdDSA key must pass FAPI creation");
+    }
+
+    #[test]
+    fn jwks_has_fapi_allowed_key_covers_alg_and_kty_cases() {
+        let no_alg = serde_json::json!({"keys": [{"kty": "EC"}]});
+        assert!(jwks_has_fapi_allowed_key(&no_alg), "no alg field survives");
+
+        // The nuance that motivated this guard: an RSA key normally used for
+        // RS256 survives if it declares no alg constraint, because it can then
+        // be presented with PS256 instead.
+        let unpinned_rsa = serde_json::json!({"keys": [{"kty": "RSA"}]});
+        assert!(
+            jwks_has_fapi_allowed_key(&unpinned_rsa),
+            "an RSA key with no alg field survives (usable with PS256)"
+        );
+
+        let es256 = serde_json::json!({"keys": [{"kty": "EC", "alg": "ES256"}]});
+        assert!(jwks_has_fapi_allowed_key(&es256));
+
+        let ps256 = serde_json::json!({"keys": [{"kty": "RSA", "alg": "PS256"}]});
+        assert!(jwks_has_fapi_allowed_key(&ps256));
+
+        let eddsa = serde_json::json!({"keys": [{"kty": "OKP", "alg": "EdDSA"}]});
+        assert!(jwks_has_fapi_allowed_key(&eddsa));
+
+        let rs256_only = serde_json::json!({"keys": [{"kty": "RSA", "alg": "RS256"}]});
+        assert!(!jwks_has_fapi_allowed_key(&rs256_only));
+
+        // A kty the runtime matcher never selects for ES256/PS256/EdDSA (e.g. a
+        // symmetric "oct" key) must not survive just because it omits alg —
+        // it's unmatchable at runtime regardless.
+        let unmatchable_kty_no_alg = serde_json::json!({"keys": [{"kty": "oct"}]});
+        assert!(
+            !jwks_has_fapi_allowed_key(&unmatchable_kty_no_alg),
+            "a kty outside EC/RSA/OKP must not survive on a missing alg"
+        );
+
+        let mixed = serde_json::json!({
+            "keys": [{"kty": "RSA", "alg": "RS256"}, {"kty": "EC", "alg": "ES256"}]
+        });
+        assert!(
+            jwks_has_fapi_allowed_key(&mixed),
+            "one usable key is enough"
+        );
+
+        let empty = serde_json::json!({"keys": []});
+        assert!(!jwks_has_fapi_allowed_key(&empty));
+
+        let no_keys_field = serde_json::json!({});
+        assert!(!jwks_has_fapi_allowed_key(&no_keys_field));
     }
 
     // ========================================================================

--- a/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
@@ -856,8 +856,8 @@ async fn test_fapi2_non_fapi_client_secret_basic() {
 // ========================================================================
 
 #[tokio::test]
-async fn test_fapi2_discovery_excludes_rs256() {
-    // FAPI 2.0 Section 5.4.1: RS256 must NOT appear in any algorithm list.
+async fn test_fapi2_discovery_dpop_excludes_rs256() {
+    // FAPI 2.0 Section 5.4.1: RS256 must NOT appear in FAPI-only algorithm lists.
     let (app, _state) = test_app().await;
 
     let (status, body) = http_get(&app, "/.well-known/openid-configuration", &[]).await;
@@ -865,14 +865,18 @@ async fn test_fapi2_discovery_excludes_rs256() {
 
     let doc: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
 
-    // FAPI 2.0 Section 5.4.1 restricts RS256 from DPoP and token endpoint auth signing.
-    // request_object_signing_alg_values_supported intentionally includes RS256 to support
-    // OIDC Basic Profile conformance (oidcc-request-uri-signed-rs256). The JAR validator
-    // enforces PS256/ES256/EdDSA for FAPI clients at runtime via validate_fapi_algorithm().
-    let alg_fields = [
-        "token_endpoint_auth_signing_alg_values_supported",
-        "dpop_signing_alg_values_supported",
-    ];
+    // dpop_signing_alg_values_supported is FAPI-scoped only (every DPoP proof is
+    // validated against JwsAlgorithm::FAPI_ALLOWED, not per-client), so RS256 stays
+    // excluded there. request_object_signing_alg_values_supported and
+    // token_endpoint_auth_signing_alg_values_supported both intentionally include
+    // RS256 for non-FAPI clients: OIDC Discovery 1.0 Section 3
+    // (<https://openid.net/specs/openid-connect-discovery-1_0.html>) and RFC 8414
+    // Section 2 (<https://www.rfc-editor.org/rfc/rfc8414>) both describe
+    // token_endpoint_auth_signing_alg_values_supported with "Servers SHOULD support
+    // RS256." The JAR and jwt_bearer validators still enforce PS256/ES256/EdDSA per
+    // FAPI-profile client at runtime via validate_fapi_algorithm() /
+    // FapiProfile::client_assertion_algorithms().
+    let alg_fields = ["dpop_signing_alg_values_supported"];
 
     for field in &alg_fields {
         if let Some(arr) = doc[field].as_array() {

--- a/crates/vouch-server/src/handlers/oidc/tests/helpers.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/helpers.rs
@@ -176,6 +176,70 @@ pub(super) async fn create_test_jwt_client(
     (client, pkcs8_bytes)
 }
 
+/// Generate an RS256 signing key pair. Returns (key_pair, JWK public key).
+///
+/// Used for per-client-profile algorithm enforcement tests (#1003): shared
+/// across `rfc7523.rs` (token endpoint) and `rfc9126.rs` (PAR).
+pub(super) fn generate_rs256_signing_key() -> (aws_lc_rs::rsa::KeyPair, serde_json::Value) {
+    use aws_lc_rs::encoding::AsDer;
+    use aws_lc_rs::rsa::{KeyPair as RsaKeyPair, KeySize};
+    use aws_lc_rs::signature::KeyPair as _;
+
+    let key_pair = RsaKeyPair::generate(KeySize::Rsa2048).expect("RSA-2048 keygen");
+    let spki_der = key_pair.public_key().as_der().expect("SPKI DER");
+    let (n_bytes, e_bytes) = crate::crypto::kms_signer::parse_spki_rsa(spki_der.as_ref())
+        .expect("parse RSA SPKI components");
+
+    let jwk = serde_json::json!({
+        "kty": "RSA",
+        "n": URL_SAFE_NO_PAD.encode(&n_bytes),
+        "e": URL_SAFE_NO_PAD.encode(&e_bytes),
+        "use": "sig",
+        "alg": "RS256",
+        "kid": "test-key-1"
+    });
+
+    (key_pair, jwk)
+}
+
+/// Sign a client-assertion JWT with an RS256 key pair.
+pub(super) fn sign_client_assertion_rs256(
+    key_pair: &aws_lc_rs::rsa::KeyPair,
+    client_id: &str,
+    audience: &str,
+) -> String {
+    use aws_lc_rs::signature::RSA_PKCS1_SHA256;
+
+    let now = jiff::Timestamp::now().as_second();
+    let header = serde_json::json!({ "alg": "RS256", "typ": "JWT", "kid": "test-key-1" });
+    let claims = serde_json::json!({
+        "iss": client_id,
+        "sub": client_id,
+        "aud": audience,
+        "iat": now,
+        "exp": now + 60,
+        "jti": uuid::Uuid::now_v7().to_string()
+    });
+
+    let header_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&header).unwrap());
+    let claims_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&claims).unwrap());
+    let signing_input = format!("{header_b64}.{claims_b64}");
+
+    let rng = aws_lc_rs::rand::SystemRandom::new();
+    let mut sig_bytes = vec![0u8; key_pair.public_modulus_len()];
+    key_pair
+        .sign(
+            &RSA_PKCS1_SHA256,
+            &rng,
+            signing_input.as_bytes(),
+            &mut sig_bytes,
+        )
+        .expect("RS256 signing");
+    let sig_b64 = URL_SAFE_NO_PAD.encode(&sig_bytes);
+
+    format!("{signing_input}.{sig_b64}")
+}
+
 pub(super) use crate::test_utils::build_client_assertion;
 
 /// Build a JWT assertion for `private_key_jwt` client auth, deliberately

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7523.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7523.rs
@@ -773,6 +773,102 @@ async fn test_non_fapi_client_accepts_token_endpoint_audience() {
 }
 
 // ========================================================================
+// Per-client-profile algorithm enforcement (#1003)
+//
+// FAPI 2.0 Section 5.4.1 restricts private_key_jwt client-assertion signing to
+// PS256/ES256/EdDSA (JwsAlgorithm::FAPI_ALLOWED); RS256 is deliberately excluded.
+// Non-FAPI clients keep RS256 via JwsAlgorithm::CLIENT_ASSERTION_ALLOWED. Both
+// profiles accepting ES256 is already exercised by every other test in this file
+// (e.g. test_fapi_client_accepts_issuer_audience, test_rfc7523_private_key_jwt_client_auth_full_flow).
+// ========================================================================
+
+#[tokio::test]
+async fn test_fapi_client_rejects_rs256_assertion() {
+    // FAPI 2.0 Section 5.4.1: RS256 must be rejected for FAPI-profile clients,
+    // even though the assertion is otherwise well-formed and correctly signed.
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "fapi-rs256-reject@example.com").await;
+
+    let (key_pair, jwk) = generate_rs256_signing_key();
+    let jwks_value = serde_json::json!({ "keys": [jwk] });
+    let client = create_test_client(
+        &state.store,
+        &user.id,
+        TestClientSpec {
+            jwks: TestJwks::Custom(jwks_value),
+            token_endpoint_auth_method: Some(crate::db::TokenEndpointAuthMethod::PrivateKeyJwt),
+            fapi_profile: Some(db::FapiProfile::Fapi2Security),
+            dpop_bound_access_tokens: true,
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let base_url = &state.config().base_url;
+    let assertion = sign_client_assertion_rs256(&key_pair, &client.client_id, base_url);
+
+    let body = format!(
+        "grant_type=client_credentials\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={}",
+        assertion
+    );
+
+    let (status, resp_body) = http_post_form(&app, "/oauth/token", &body, &[]).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "FAPI client with RS256 assertion must be rejected: {resp_body}"
+    );
+    let error: serde_json::Value = serde_json::from_str(&resp_body).expect("Valid JSON");
+    assert_eq!(
+        error["error"], "invalid_client",
+        "FAPI client RS256 rejection must be invalid_client: {resp_body}"
+    );
+}
+
+#[tokio::test]
+async fn test_non_fapi_client_accepts_rs256_assertion() {
+    // RFC 7523 does not restrict client-assertion algorithms; non-FAPI clients
+    // keep RS256 via JwsAlgorithm::CLIENT_ASSERTION_ALLOWED.
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "nonfapi-rs256-accept@example.com").await;
+
+    let (key_pair, jwk) = generate_rs256_signing_key();
+    let jwks_value = serde_json::json!({ "keys": [jwk] });
+    let client = create_test_client(
+        &state.store,
+        &user.id,
+        TestClientSpec {
+            jwks: TestJwks::Custom(jwks_value),
+            token_endpoint_auth_method: Some(crate::db::TokenEndpointAuthMethod::PrivateKeyJwt),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let base_url = &state.config().base_url;
+    let token_endpoint_url = format!("{base_url}/oauth/token");
+    let assertion = sign_client_assertion_rs256(&key_pair, &client.client_id, &token_endpoint_url);
+
+    let body = format!(
+        "grant_type=client_credentials\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={}",
+        assertion
+    );
+
+    let (status, resp_body) = http_post_form(&app, "/oauth/token", &body, &[]).await;
+    // Client auth must succeed. The grant may fail (unauthorized_client) but
+    // invalid_client would mean client auth itself failed.
+    let error: serde_json::Value = serde_json::from_str(&resp_body).expect("Valid JSON");
+    assert_ne!(
+        error["error"], "invalid_client",
+        "Non-FAPI client with RS256 assertion must pass client auth (status={status}): {resp_body}"
+    );
+}
+
+// ========================================================================
 // RFC 7523 §3 — `jti` is OPTIONAL for non-FAPI clients
 //
 // Regression tests for PR #409: a committed JTI must not be treated as

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
@@ -2566,6 +2566,52 @@ async fn test_rfc9126_par_rejects_private_key_jwt_with_bad_aud() {
 }
 
 #[tokio::test]
+async fn test_rfc9126_par_rejects_fapi_client_rs256_assertion() {
+    // #1003: per-client-profile algorithm enforcement runs inside
+    // authenticate_client_jwt, the single client-assertion verifier shared by
+    // every private_key_jwt call site — not just the token endpoint. FAPI 2.0
+    // Section 5.4.1 restricts client assertions to PS256/ES256/EdDSA, so RS256
+    // must be rejected at PAR exactly as it is at /oauth/token
+    // (test_fapi_client_rejects_rs256_assertion in tests/rfc7523.rs).
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "par-fapi-rs256@example.com").await;
+    let (key_pair, jwk) = generate_rs256_signing_key();
+    let jwks_value = serde_json::json!({ "keys": [jwk] });
+    let client = create_test_client(
+        &state.store,
+        &user.id,
+        TestClientSpec {
+            jwks: TestJwks::Custom(jwks_value),
+            token_endpoint_auth_method: Some(crate::db::TokenEndpointAuthMethod::PrivateKeyJwt),
+            fapi_profile: Some(crate::db::FapiProfile::Fapi2Security),
+            dpop_bound_access_tokens: true,
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let assertion =
+        sign_client_assertion_rs256(&key_pair, &client.client_id, &state.config().base_url);
+
+    let body = format!(
+        "client_id={}\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={}",
+        client.client_id, assertion,
+    );
+
+    let (status, response_body) = http_post_form(&app, "/oauth/par", &body, &[]).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "FAPI client with RS256 assertion must be rejected at PAR: {response_body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&response_body).expect("Valid JSON");
+    assert_eq!(json["error"], "invalid_client");
+}
+
+#[tokio::test]
 async fn test_rfc9126_par_rejects_private_key_jwt_with_nbf_too_far_future() {
     // RFC 7523 / FAPI 2.0: client_assertion `nbf` must be within clock-skew
     // tolerance of "now". An `nbf` 70 seconds in the future exceeds the FAPI

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9449.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9449.rs
@@ -1742,8 +1742,17 @@ async fn test_dpop_signing_algs_match_supported_algorithms() {
     }
 }
 
+/// Discovery must advertise exactly `FapiProfile::client_assertion_algorithms_union()`
+/// — the same derivation `services/oidc/discovery.rs` calls, over the same
+/// `FapiProfile::ALL` that `client.fapi_profile.client_assertion_algorithms()`
+/// selects per client — so this list is structurally tied to what the jwt_bearer validator
+/// (`services/oidc/jwt_bearer/client_auth.rs`) actually enforces per profile, not
+/// separately asserted equal. Per-profile enforcement itself (FAPI clients
+/// restricted to `FAPI_ALLOWED`, non-FAPI clients keeping RS256) is proven live by
+/// `test_fapi_client_rejects_rs256_assertion` and
+/// `test_non_fapi_client_accepts_rs256_assertion` in `tests/rfc7523.rs` (#1003).
 #[tokio::test]
-async fn test_token_endpoint_auth_signing_algs_match_fapi_allowed() {
+async fn test_token_endpoint_auth_signing_algs_match_client_assertion_algorithms_union() {
     let (app, _state) = test_app().await;
     let (status, body) = http_get(&app, "/.well-known/openid-configuration", &[]).await;
 
@@ -1757,7 +1766,7 @@ async fn test_token_endpoint_auth_signing_algs_match_fapi_allowed() {
             .map(|v| v.as_str().expect("alg should be string").to_string())
             .collect();
 
-    let source: BTreeSet<String> = crate::db::JwsAlgorithm::FAPI_ALLOWED
+    let source: BTreeSet<String> = crate::db::FapiProfile::client_assertion_algorithms_union()
         .iter()
         .map(|alg| alg.as_str().to_string())
         .collect();
@@ -1765,7 +1774,7 @@ async fn test_token_endpoint_auth_signing_algs_match_fapi_allowed() {
     assert_eq!(
         discovered, source,
         "discovery token_endpoint_auth_signing_alg_values_supported must exactly match \
-         JwsAlgorithm::FAPI_ALLOWED"
+         FapiProfile::client_assertion_algorithms_union()"
     );
 
     for alg in &discovered {

--- a/crates/vouch-server/src/services/oidc/discovery.rs
+++ b/crates/vouch-server/src/services/oidc/discovery.rs
@@ -7,7 +7,7 @@
 //! - RFC 9396 OAuth 2.0 Rich Authorization Requests (authorization_details supported)
 
 use crate::AppState;
-use crate::db::{JwsAlgorithm, ResponseMode, TokenEndpointAuthMethod};
+use crate::db::{FapiProfile, JwsAlgorithm, ResponseMode, TokenEndpointAuthMethod};
 use crate::error::ServiceError;
 use crate::services::auth::ACR_AAL3;
 use crate::services::oidc::OAuthScope;
@@ -86,7 +86,10 @@ pub struct OidcDiscoveryDocument {
     pub resource_indicators_supported: Option<bool>,
     /// RFC 7523: Supported JWS algorithms for JWT client authentication.
     ///
-    /// See [`JwsAlgorithm::FAPI_ALLOWED`] for the FAPI 2.0 citation excluding RS256.
+    /// The union of every [`FapiProfile`]'s allowed set — see
+    /// [`FapiProfile::client_assertion_algorithms_union`]. FAPI 2.0 clients are
+    /// restricted to [`JwsAlgorithm::FAPI_ALLOWED`] at enforcement time; this field
+    /// additionally advertises `RS256` because non-FAPI clients may use it.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token_endpoint_auth_signing_alg_values_supported: Option<Vec<JwsAlgorithm>>,
     /// RFC 9126: URL of the Pushed Authorization Request endpoint.
@@ -247,8 +250,13 @@ pub fn build_discovery_document(state: &Arc<AppState>) -> OidcDiscoveryDocument 
         authorization_response_iss_parameter_supported: true,
         // RFC 8707: Advertise resource indicator support
         resource_indicators_supported: Some(true),
-        // RFC 7523: JWT client auth signing algorithms.
-        token_endpoint_auth_signing_alg_values_supported: Some(JwsAlgorithm::FAPI_ALLOWED.to_vec()),
+        // RFC 7523: JWT client auth signing algorithms — the union of every
+        // FapiProfile's allowed set (RS256 comes in via the non-FAPI profile).
+        // Structurally derived, not an independently maintained list: see
+        // FapiProfile::client_assertion_algorithms_union.
+        token_endpoint_auth_signing_alg_values_supported: Some(
+            FapiProfile::client_assertion_algorithms_union(),
+        ),
         // RFC 9126: Pushed Authorization Request endpoint
         pushed_authorization_request_endpoint: Some(format!("{base_url}/oauth/par")),
         require_pushed_authorization_requests: false,

--- a/crates/vouch-server/src/services/oidc/jar.rs
+++ b/crates/vouch-server/src/services/oidc/jar.rs
@@ -680,7 +680,7 @@ fn validate_temporal_claims(
 )]
 mod tests {
     use super::*;
-    use crate::services::oidc::jwt_bearer::SUPPORTED_ALGORITHMS;
+    use crate::db::JwsAlgorithm;
 
     // ========================================================================
     // Helper: Build a minimal JWT string from a raw header JSON object.
@@ -808,7 +808,12 @@ mod tests {
 
     #[test]
     fn test_jar_supported_algorithms_includes_ps256() {
-        assert!(SUPPORTED_ALGORITHMS.contains(&"PS256"));
+        assert!(JwsAlgorithm::CLIENT_ASSERTION_ALLOWED.contains(&JwsAlgorithm::Ps256));
+        let jwt = make_jwt_with_header(&serde_json::json!({"alg": "PS256", "typ": "JWT"}));
+        assert!(
+            parse_request_object_header(&jwt).is_ok(),
+            "PS256 must be structurally accepted"
+        );
     }
 
     // ========================================================================

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
@@ -7,7 +7,7 @@
 use super::jwks::{find_matching_key_with_refresh_client, resolve_client_jwks};
 use super::validate::{
     JwtAssertionClaims, JwtAssertionHeader, decode_claims_unverified, map_algorithm,
-    parse_assertion_header, validate_jwt_assertion,
+    parse_assertion_header, validate_client_assertion_algorithm, validate_jwt_assertion,
 };
 use crate::AppState;
 use crate::db::claim::ClaimError;
@@ -165,6 +165,19 @@ pub async fn authenticate_client_jwt(
             "Client {} attempted private_key_jwt but is configured for {}",
             client.client_id,
             client.token_endpoint_auth_method.as_str()
+        );
+        return Err(ClientAuthError::InvalidCredentials);
+    }
+
+    // 4b. FAPI 2.0 Section 5.4.1: restrict the assertion algorithm to the
+    // client's profile. See JwsAlgorithm::FAPI_ALLOWED. Checked before JWKS
+    // resolution so a disallowed algorithm never triggers a JWKS fetch.
+    let allowed_algorithms = client.fapi_profile.client_assertion_algorithms();
+    if let Err(e) = validate_client_assertion_algorithm(&header.alg, allowed_algorithms) {
+        tracing::warn!(
+            "Client {} used disallowed client-assertion algorithm '{}': {e}",
+            client.client_id,
+            header.alg
         );
         return Err(ClientAuthError::InvalidCredentials);
     }

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/mod.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/mod.rs
@@ -15,4 +15,3 @@ pub mod jwks;
 pub mod validate;
 
 pub use jwks::{find_matching_key_with_refresh_client, resolve_client_jwks};
-pub use validate::SUPPORTED_ALGORITHMS;

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/validate.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/validate.rs
@@ -4,17 +4,12 @@
 //! Provides shared validation logic used by both JWT client authentication
 //! (Section 2.2) and JWT authorization grants (Section 2.1).
 
+use crate::db::JwsAlgorithm;
 use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
-
-/// Supported algorithms for JWT assertions (asymmetric only).
-///
-/// HS* and "none" are unconditionally rejected to prevent symmetric key
-/// confusion attacks (RFC 7523 Section 3).
-pub const SUPPORTED_ALGORITHMS: &[&str] = &["ES256", "RS256", "PS256", "EdDSA"];
 
 /// Clock skew tolerance in seconds.
 ///
@@ -129,18 +124,64 @@ pub fn parse_assertion_header(assertion: &str) -> ServiceResult<JwtAssertionHead
         )
     })?;
 
-    // Validate algorithm
-    if !SUPPORTED_ALGORITHMS.contains(&header.alg.as_str()) {
+    // Structural algorithm check: only asymmetric algorithms are ever accepted.
+    // HS* and "none" are unconditionally rejected to prevent symmetric key
+    // confusion attacks (RFC 7523 Section 3). This does not consider the
+    // presenting client — the per-client-profile allowlist (e.g. excluding
+    // RS256 for FAPI clients) is applied later via
+    // `validate_client_assertion_algorithm`, once the client is resolved.
+    if header.alg.parse::<JwsAlgorithm>().is_err() {
+        let supported = JwsAlgorithm::CLIENT_ASSERTION_ALLOWED
+            .iter()
+            .map(JwsAlgorithm::as_str)
+            .collect::<Vec<_>>()
+            .join(", ");
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidClient,
             format!(
-                "Unsupported JWT assertion algorithm: {}. Supported: ES256, RS256, PS256, EdDSA",
+                "Unsupported JWT assertion algorithm: {}. Supported: {supported}",
                 header.alg
             ),
         ));
     }
 
     Ok(header)
+}
+
+/// Validate that a client assertion's algorithm is permitted for the presenting
+/// client's profile.
+///
+/// Distinct from the structural check in [`parse_assertion_header`] (which only
+/// rejects symmetric/`none` algorithms): this enforces the per-client allowlist,
+/// e.g. FAPI 2.0 clients restricted to [`JwsAlgorithm::FAPI_ALLOWED`]. Callers
+/// select `allowed` via `client.fapi_profile.client_assertion_algorithms()`
+/// (`crate::db::FapiProfile::client_assertion_algorithms`).
+///
+/// # Errors
+/// Returns `ServiceError::OAuth` with `invalid_client` if `alg` is not in `allowed`.
+pub fn validate_client_assertion_algorithm(
+    alg: &str,
+    allowed: &[JwsAlgorithm],
+) -> ServiceResult<()> {
+    let permitted = alg
+        .parse::<JwsAlgorithm>()
+        .is_ok_and(|parsed| allowed.contains(&parsed));
+    if !permitted {
+        let allowed_list = allowed
+            .iter()
+            .map(JwsAlgorithm::as_str)
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(ServiceError::oauth(
+            OAuthErrorCode::InvalidClient,
+            format!(
+                "Client assertion algorithm '{alg}' is not permitted for this client. \
+                 Allowed: {allowed_list}"
+            ),
+        ));
+    }
+
+    Ok(())
 }
 
 /// Validate a JWT assertion's signature and claims.
@@ -318,12 +359,17 @@ mod tests {
     }
 
     #[test]
-    fn test_supported_algorithms() {
-        assert!(SUPPORTED_ALGORITHMS.contains(&"ES256"));
-        assert!(SUPPORTED_ALGORITHMS.contains(&"RS256"));
-        assert!(SUPPORTED_ALGORITHMS.contains(&"EdDSA"));
-        assert!(!SUPPORTED_ALGORITHMS.contains(&"HS256"));
-        assert!(!SUPPORTED_ALGORITHMS.contains(&"none"));
+    fn test_structural_algorithm_gate_matches_client_assertion_allowed() {
+        // parse_assertion_header's structural gate accepts exactly the algorithms
+        // JwsAlgorithm can parse — the same four CLIENT_ASSERTION_ALLOWED names.
+        for alg in JwsAlgorithm::CLIENT_ASSERTION_ALLOWED {
+            assert!(
+                alg.as_str().parse::<JwsAlgorithm>().is_ok(),
+                "{alg} must be structurally accepted"
+            );
+        }
+        assert!("HS256".parse::<JwsAlgorithm>().is_err());
+        assert!("none".parse::<JwsAlgorithm>().is_err());
     }
 
     #[test]
@@ -984,5 +1030,45 @@ mod tests {
     fn test_map_algorithm_ps256() {
         let alg = map_algorithm("PS256").expect("PS256 should be mapped");
         assert_eq!(alg, jsonwebtoken::Algorithm::PS256);
+    }
+
+    // ====================================================================
+    // validate_client_assertion_algorithm tests (#1003)
+    // ====================================================================
+
+    #[test]
+    fn test_validate_client_assertion_algorithm_allows_listed() {
+        assert!(validate_client_assertion_algorithm("ES256", &JwsAlgorithm::FAPI_ALLOWED).is_ok());
+        assert!(validate_client_assertion_algorithm("PS256", &JwsAlgorithm::FAPI_ALLOWED).is_ok());
+        assert!(validate_client_assertion_algorithm("EdDSA", &JwsAlgorithm::FAPI_ALLOWED).is_ok());
+    }
+
+    #[test]
+    fn test_validate_client_assertion_algorithm_rejects_unlisted() {
+        let result = validate_client_assertion_algorithm("RS256", &JwsAlgorithm::FAPI_ALLOWED);
+        assert!(
+            result.is_err(),
+            "RS256 must be rejected against FAPI_ALLOWED"
+        );
+        let err = result.unwrap_err();
+        let desc = oauth_error_description(&err);
+        assert!(
+            desc.contains("Allowed: ES256, PS256, EdDSA"),
+            "error message must list the allowed set, got: {desc}"
+        );
+    }
+
+    #[test]
+    fn test_validate_client_assertion_algorithm_allows_rs256_in_wider_set() {
+        assert!(
+            validate_client_assertion_algorithm("RS256", &JwsAlgorithm::CLIENT_ASSERTION_ALLOWED)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_validate_client_assertion_algorithm_rejects_unparseable() {
+        let result = validate_client_assertion_algorithm("HS256", &JwsAlgorithm::FAPI_ALLOWED);
+        assert!(result.is_err(), "HS256 must be rejected outright");
     }
 }

--- a/docs/src/reference/environment-variables.md
+++ b/docs/src/reference/environment-variables.md
@@ -157,6 +157,16 @@ Vouch supports loading configuration from an S3 object for centralized managemen
 |----------|----------|---------|-------------|
 | `VOUCH_JWT_ASSERTION_MAX_LIFETIME` | No | `300` | Maximum lifetime (seconds) for `private_key_jwt` client-authentication JWT assertions (RFC 7523 §2.2 / §3). Assertions older than this are rejected. |
 
+The signing algorithm allowed for a client's assertion depends on its FAPI 2.0 profile, not
+just this lifetime bound. Applications with `fapi_profile = fapi2_security` may only sign
+assertions with ES256, PS256, or EdDSA (FAPI 2.0 Section 5.4.1); other applications may
+additionally use RS256. Discovery's `token_endpoint_auth_signing_alg_values_supported`
+advertises the full four-algorithm union — an application's own profile determines which of
+those it may actually use. Setting `fapi_profile = fapi2_security` on an application whose
+JWKS keys are all pinned to an algorithm outside that set (e.g. every key declares
+`"alg": "RS256"`) is refused with a `fapi_jwks_algorithm_unsupported` error, since the
+application would otherwise be unable to authenticate at all after the change.
+
 ## Protected Resource Metadata (RFC 9728)
 
 These optional variables configure descriptive metadata published in the OAuth 2.0 Protected Resource Metadata document at `/.well-known/oauth-protected-resource`.


### PR DESCRIPTION
## Summary

Fixes #1003: the token endpoint accepted RS256-signed client assertions from every client while discovery advertised only ES256/PS256/EdDSA, and the FAPI narrowing function never ran on the client-auth path.

- `authenticate_client_jwt` — the single path validating `private_key_jwt` client assertions for all token grants, PAR, revoke, and introspect — now enforces a per-profile allowlist: `fapi2_security` clients are limited to ES256/PS256/EdDSA; non-FAPI clients keep RS256.
- The sets are derived from `FapiProfile`: an exhaustive `client_assertion_algorithms()` match plus `FapiProfile::ALL`, with discovery's `token_endpoint_auth_signing_alg_values_supported` computed as `client_assertion_algorithms_union()` over all profiles. Adding a profile variant without deciding its algorithms fails to compile, and the advertised set is the same computation as the enforced sets rather than an independently maintained list.
- Creating or upgrading a client to `fapi2_security` is rejected with `fapi_jwks_algorithm_unsupported` when its JWKS contains no key usable under the FAPI algorithms (wrong `alg` pin or unmatchable `kty`), mirroring the existing `FapiDowngradeUnsupported` guard — otherwise the profile change would permanently lock the client out of authentication.
- Removed the stringly-typed `SUPPORTED_ALGORITHMS` duplicate list; the structural header gate parses `JwsAlgorithm` directly.
- Operator docs updated (`docs/src/reference/environment-variables.md`).

## Spec basis

FAPI 2.0 Security Profile, Section 5.4.1 "General requirements" (<https://openid.net/specs/fapi-security-profile-2_0-final.html>, fetched this session): "Authorization servers, clients, and resource servers when creating or processing JWTs shall adhere to [RFC8725]; use PS256, ES256, or EdDSA (using the Ed25519 variant) algorithms; and not use or accept the none algorithm." (shall; applies to the AS processing client-assertion JWTs). FAPI 2.0 contains no requirement about advertised metadata algorithm lists, so restricting enforcement per profile while advertising the union is a product decision, not a conformance question.

RFC 8414 Section 2 and OIDC Discovery 1.0 Section 3 (<https://www.rfc-editor.org/rfc/rfc8414>, fetched this session, confirmed against both sources): for `token_endpoint_auth_signing_alg_values_supported`, "Servers SHOULD support RS256." The previous FAPI-only advertisement under-met this SHOULD; advertising RS256 for non-FAPI clients now meets it.

## Testing

- `cargo test -p vouch-server --all-features` → 3070 passed, 0 failed; clippy `-D warnings` clean; `mdbook build` clean
- Drift guards were mutation-verified: deleting the enforcement call, reverting the discovery derivation, or collapsing the per-profile selection each fail a named test
- New regression tests: FAPI client + RS256 assertion rejected at `/oauth/token` and `/oauth/par` (401 `invalid_client`); non-FAPI client + RS256 accepted; JWKS guard matrix at create and update (RS256-pinned rejected; unpinned RSA, EC, OKP accepted; `oct` rejected)

A follow-up PR this session restructures `validate_update_fapi` to also validate JWKS-only edits on already-FAPI clients (pre-existing gap shared with the `FapiMissingJwks` check, currently documented inline). Conformance note: the next external FAPI conformance suite run should confirm the discovery metadata change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes JWT client-authentication algorithm enforcement and OIDC discovery metadata, which are security-critical OAuth/FAPI paths. FAPI clients that previously succeeded with RS256 will now get invalid_client.
> 
> **Overview**
> Enforces FAPI 2.0 §5.4.1 on `private_key_jwt` assertions: `fapi2_security` clients may only sign with ES256/PS256/EdDSA; non-FAPI clients still keep RS256. The check runs in `authenticate_client_jwt` (token, PAR, and other jwt-bearer call sites) before JWKS resolution.
> 
> Allowlists live on `FapiProfile` (`client_assertion_algorithms` / `client_assertion_algorithms_union`). Discovery’s `token_endpoint_auth_signing_alg_values_supported` is that union (now includes RS256), while DPoP stays FAPI-only. The old string `SUPPORTED_ALGORITHMS` list is gone; header parsing uses `JwsAlgorithm` directly.
> 
> Creating or upgrading to FAPI is rejected with `fapi_jwks_algorithm_unsupported` when an inline JWKS has no key usable under FAPI algorithms (RS256-pinned or unmatchable `kty`). JWKS-only updates that omit `fapi_profile` remain a known gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37b1bcfb9bdcbef259ddc6e82686e3cbbae79604. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->