### PR TITLE
fix(server): guard FAPI JWKS algorithm usability at dynamic registration

### DIFF
--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -144,10 +144,10 @@ pub use oauth::{
     create_oauth_client_secret, delete_expired_jwt_assertion_jtis, delete_oauth_client,
     get_oauth_client_by_client_id, get_oauth_client_by_id, get_oauth_client_secret_by_id,
     get_oauth_client_secrets, get_oauth_clients_for_user, get_oauth_secret_by_hash,
-    get_oauth_usage_stats, is_valid_post_logout_redirect_uri_str, record_oauth_event,
-    revoke_all_oauth_client_secrets, revoke_oauth_client_secret, store_jwt_assertion_jti,
-    update_oauth_client, update_oauth_client_last_used, update_oauth_client_registration,
-    validate_oauth_client_credentials,
+    get_oauth_usage_stats, is_valid_post_logout_redirect_uri_str, jwks_has_fapi_allowed_key,
+    record_oauth_event, revoke_all_oauth_client_secrets, revoke_oauth_client_secret,
+    store_jwt_assertion_jti, update_oauth_client, update_oauth_client_last_used,
+    update_oauth_client_registration, validate_oauth_client_credentials,
 };
 
 // Re-export test-only OAuth client helpers

--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -229,6 +229,58 @@ pub fn is_valid_post_logout_redirect_uri_str(uri: &str) -> bool {
     }
 }
 
+// ============================================================================
+// FAPI 2.0 JWKS algorithm-usability check (shared between the admin
+// application API and RFC 7591/7592 dynamic client registration, so the rule
+// lives in exactly one place)
+// ============================================================================
+
+/// Returns `true` when `jwks` contains at least one key the FAPI 2.0
+/// client-assertion validator (`FapiProfile::client_assertion_algorithms`, which
+/// yields `JwsAlgorithm::FAPI_ALLOWED` for `FapiProfile::Fapi2Security`) could
+/// actually use: a key whose `use` (if present) is `sig`, and that either
+/// declares no `alg` but has a `kty` the runtime matcher can select for
+/// ES256/PS256/EdDSA (`EC`/`RSA`/`OKP`), or declares `alg` as ES256, PS256, or
+/// EdDSA outright.
+///
+/// A key search skips a JWK whose declared `alg` differs from the assertion's
+/// header, or whose `use` is present and not `sig`
+/// (`services/oidc/jwt_bearer/jwks.rs`). So a JWKS made only of `alg: RS256`
+/// keys would leave a FAPI client with no algorithm it is both allowed to use
+/// and has a matching key for, and a JWKS made only of `use: "enc"` keys would
+/// leave it with no key the search selects at all — both permanently
+/// unauthenticatable. The `kty` check on the no-`alg` branch closes the same
+/// bug class for an incompatible or missing `kty` (e.g. `oct`): the runtime
+/// matcher only ever selects `EC`/`RSA`/`OKP` for ES256/PS256/EdDSA, so a key
+/// with any other `kty` is unmatchable regardless of `alg`.
+///
+/// Used at every point a FAPI 2.0 client's JWKS is accepted or replaced:
+/// application creation and update (`handlers/applications/validate.rs`) and
+/// RFC 7591/7592 dynamic client registration (`services/oidc/registration.rs`).
+#[must_use]
+pub fn jwks_has_fapi_allowed_key(jwks: &serde_json::Value) -> bool {
+    let Some(keys) = jwks.get("keys").and_then(|k| k.as_array()) else {
+        return false;
+    };
+    keys.iter().any(|key| {
+        let use_is_sig = key
+            .get("use")
+            .and_then(|u| u.as_str())
+            .is_none_or(|u| u == "sig");
+        if !use_is_sig {
+            return false;
+        }
+        let Some(alg) = key.get("alg").and_then(|a| a.as_str()) else {
+            return key
+                .get("kty")
+                .and_then(|v| v.as_str())
+                .is_some_and(|kty| matches!(kty, "EC" | "RSA" | "OKP"));
+        };
+        alg.parse::<JwsAlgorithm>()
+            .is_ok_and(|parsed| JwsAlgorithm::FAPI_ALLOWED.contains(&parsed))
+    })
+}
+
 /// Parameters for creating a new OAuth client application.
 pub struct CreateOAuthClientParams<'a> {
     pub user_id: Option<&'a str>,

--- a/crates/vouch-server/src/handlers/applications/validate.rs
+++ b/crates/vouch-server/src/handlers/applications/validate.rs
@@ -12,7 +12,7 @@ use axum::http::StatusCode;
 
 use crate::db::{
     AccessScope, CreateOAuthClientParams, FapiProfile, JwsAlgorithm, OAuthClient, OAuthClientType,
-    RegistrationSource, TokenEndpointAuthMethod,
+    RegistrationSource, TokenEndpointAuthMethod, jwks_has_fapi_allowed_key,
 };
 use crate::error::ServiceError;
 use crate::services::oidc::ResourceUri;
@@ -107,8 +107,10 @@ impl AppValidationError {
             Self::FapiJwksNoAllowedAlgorithm => {
                 "FAPI 2.0 requires a JWKS key usable with ES256, PS256, or EdDSA \
                  (RFC 7523 client-assertion signing). None of the configured keys \
-                 are usable: every key declares an alg outside that set. Add a \
-                 compatible key, or remove the alg constraint from an existing one."
+                 are usable: each either declares an alg outside that set, has a \
+                 kty the signing-key matcher can't select for those algorithms, or \
+                 is marked for a non-signing use. Add a compatible key, or adjust \
+                 an existing one's alg/kty/use."
                     .to_string()
             }
             Self::JwksNotJson => "JWKS must be valid JSON".to_string(),
@@ -402,9 +404,19 @@ pub(super) fn validate_update_fapi(
         return Err(AppValidationError::FapiMissingJwks);
     }
 
-    // FAPI validation: an inline JWKS (submitted or already on the client)
-    // must have at least one key usable with FAPI_ALLOWED.
-    if let Some(jwks) = validated.jwks.as_ref().or(client.jwks.as_ref())
+    // Only for private_key_jwt: its JWKS carries client-assertion signing
+    // keys, so an inline JWKS (submitted or already on the client) must have
+    // at least one key usable with FAPI_ALLOWED. tls_client_auth/
+    // self_signed_tls_client_auth JWKS conveys certificates via x5c instead
+    // (RFC 8705 §2.2.2), so this check does not apply to them. The effective
+    // auth method — not just the stored one — matters here: an explicit
+    // `fapi_profile` in this request forces private_key_jwt regardless of
+    // what the client currently uses (`compute_fapi_update_fields`), so this
+    // mirrors that same computation rather than re-deriving a second one.
+    let effective_is_private_key_jwt = validated.is_fapi
+        || client.token_endpoint_auth_method == TokenEndpointAuthMethod::PrivateKeyJwt;
+    if effective_is_private_key_jwt
+        && let Some(jwks) = validated.jwks.as_ref().or(client.jwks.as_ref())
         && !jwks_has_fapi_allowed_key(jwks)
     {
         return Err(AppValidationError::FapiJwksNoAllowedAlgorithm);
@@ -619,39 +631,6 @@ fn parse_jwks(jwks_json: &str) -> Result<serde_json::Value, AppValidationError> 
         return Err(AppValidationError::JwksMissingKeys);
     }
     Ok(val)
-}
-
-/// Returns `true` when `jwks` contains at least one key the FAPI 2.0
-/// client-assertion validator (`FapiProfile::client_assertion_algorithms`, which
-/// yields `JwsAlgorithm::FAPI_ALLOWED` for `FapiProfile::Fapi2Security`) could
-/// actually use: a key that declares no `alg` but has a `kty` the runtime
-/// matcher can select for ES256/PS256/EdDSA (`EC`/`RSA`/`OKP`), or a key whose
-/// declared `alg` is ES256, PS256, or EdDSA outright.
-///
-/// A key search skips a JWK whose declared `alg` differs from the assertion's
-/// header (`jwt_bearer/jwks.rs`), so a JWKS made only of `alg: RS256` keys would
-/// leave a FAPI client with no algorithm it is both allowed to use and has a
-/// matching key for — permanently unauthenticatable, the same "no way back"
-/// failure [`AppValidationError::FapiDowngradeUnsupported`] prevents on the
-/// standard-profile transition. The `kty` check on the no-`alg` branch closes
-/// the same bug class for an incompatible or missing `kty` (e.g. `oct`): the
-/// runtime matcher (`jwt_bearer/jwks.rs`) only ever selects `EC`/`RSA`/`OKP`
-/// for ES256/PS256/EdDSA, so a key with any other `kty` is unmatchable
-/// regardless of `alg`.
-fn jwks_has_fapi_allowed_key(jwks: &serde_json::Value) -> bool {
-    let Some(keys) = jwks.get("keys").and_then(|k| k.as_array()) else {
-        return false;
-    };
-    keys.iter().any(|key| {
-        let Some(alg) = key.get("alg").and_then(|a| a.as_str()) else {
-            return key
-                .get("kty")
-                .and_then(|v| v.as_str())
-                .is_some_and(|kty| matches!(kty, "EC" | "RSA" | "OKP"));
-        };
-        alg.parse::<JwsAlgorithm>()
-            .is_ok_and(|parsed| JwsAlgorithm::FAPI_ALLOWED.contains(&parsed))
-    })
 }
 
 fn validate_jwks_uri(jwks_uri: Option<&str>) -> Result<(), AppValidationError> {
@@ -1263,6 +1242,52 @@ mod tests {
             .expect("a redirect_uris-only update must not be affected by the FAPI JWKS checks");
     }
 
+    // The algorithm-usability check is private_key_jwt-only: a FAPI
+    // self_signed_tls_client_auth client's JWKS conveys certificates via
+    // x5c, not client-assertion signing keys, so an alg-pinned RS256 x5c
+    // entry must not block an otherwise-unrelated admin edit.
+    #[tokio::test]
+    async fn fapi_metadata_only_update_accepted_for_mtls_client_with_rs256_alg_pinned_x5c_jwks() {
+        let state = test_app_state().await;
+        let user = create_test_user(&state.store, "fapi-mtls-admin-edit@example.com").await;
+        let created = create_test_client(
+            &state.store,
+            &user.id,
+            TestClientSpec {
+                token_endpoint_auth_method: Some(TokenEndpointAuthMethod::SelfSignedTlsClientAuth),
+                jwks: TestJwks::Custom(
+                    serde_json::json!({"keys": [{"kty": "RSA", "alg": "RS256", "x5c": ["ZmFrZS1jZXJ0"]}]}),
+                ),
+                dpop_bound_access_tokens: true,
+                fapi_profile: Some(FapiProfile::Fapi2Security),
+                with_secret: false,
+                ..Default::default()
+            },
+        )
+        .await;
+        let client = crate::db::get_oauth_client_by_id(&state.store, &created.app_id)
+            .await
+            .expect("db lookup")
+            .expect("client exists");
+
+        let redirect_uris = vec!["https://example.com/callback".to_string()];
+        let validated = validate_update_format(UpdateAppInput {
+            redirect_uris: Some(&redirect_uris),
+            resource_uris: None,
+            post_logout_redirect_uris: None,
+            access_scope: None,
+            fapi_profile: None,
+            jwks: None,
+            jwks_uri: None,
+        })
+        .expect("valid update input");
+
+        validate_update_fapi(&validated, &client).expect(
+            "a metadata-only update to a FAPI mTLS client must not be blocked by the \
+             private_key_jwt-only algorithm guard",
+        );
+    }
+
     // Reverse edge: a request that omits `fapi_profile` AND `jwks` still
     // validates the STORED jwks, because the client remains FAPI regardless.
     // Simulates a client whose stored JWKS predates this guard (e.g. created
@@ -1414,6 +1439,24 @@ mod tests {
         assert!(
             jwks_has_fapi_allowed_key(&mixed),
             "one usable key is enough"
+        );
+
+        // The runtime matcher also filters on `use`: an otherwise-usable key
+        // marked for encryption is never selected for signature verification.
+        let enc_only = serde_json::json!({
+            "keys": [{"kty": "EC", "alg": "ES256", "use": "enc"}]
+        });
+        assert!(
+            !jwks_has_fapi_allowed_key(&enc_only),
+            "a use: enc key must not survive even with an allowed alg"
+        );
+
+        let explicit_sig = serde_json::json!({
+            "keys": [{"kty": "EC", "alg": "ES256", "use": "sig"}]
+        });
+        assert!(
+            jwks_has_fapi_allowed_key(&explicit_sig),
+            "an explicit use: sig key survives"
         );
 
         let empty = serde_json::json!({"keys": []});

--- a/crates/vouch-server/src/handlers/applications/validate.rs
+++ b/crates/vouch-server/src/handlers/applications/validate.rs
@@ -328,6 +328,24 @@ pub(super) fn validate_update_format<'a>(
     })
 }
 
+/// The FAPI profile the client will have once this update is applied: the
+/// requested profile when `fapi_profile` was provided, otherwise the client's
+/// current profile (an absent field preserves it — see [`ValidatedUpdateApp`]).
+///
+/// Shared by [`validate_update_fapi`] (to decide whether the FAPI-specific
+/// checks apply) and [`compute_fapi_update_fields`] (to build the persisted
+/// `fapi_profile`), so the two cannot disagree about what "the client will be
+/// FAPI after this update" means.
+fn effective_fapi_profile(validated: &ValidatedUpdateApp<'_>, client: &OAuthClient) -> FapiProfile {
+    if validated.is_fapi {
+        FapiProfile::Fapi2Security
+    } else if validated.fapi_profile_provided {
+        FapiProfile::None
+    } else {
+        client.fapi_profile
+    }
+}
+
 /// Validate semantic rules for an update against the existing client record.
 ///
 /// Call after authentication and the ownership check.  This covers rules that
@@ -347,15 +365,23 @@ pub(super) fn validate_update_fapi(
         return Err(AppValidationError::MissingRedirectUris);
     }
 
-    if !validated.is_fapi {
-        // A FAPI client authenticates with private_key_jwt and therefore has
-        // no client secret. Moving it to a standard profile would switch it to
-        // client_secret_basic without minting one, so every subsequent token
-        // request would fail with invalid_client and the application would be
-        // unusable with no way back. Refuse the transition instead.
-        if validated.fapi_profile_provided && client.is_fapi() {
-            return Err(AppValidationError::FapiDowngradeUnsupported);
-        }
+    // A FAPI client authenticates with private_key_jwt and therefore has no
+    // client secret. Moving it to a standard profile would switch it to
+    // client_secret_basic without minting one, so every subsequent token
+    // request would fail with invalid_client and the application would be
+    // unusable with no way back. Refuse the explicit transition outright —
+    // this check is about the request declaring a downgrade, not about the
+    // effective post-merge profile below.
+    if !validated.is_fapi && validated.fapi_profile_provided && client.is_fapi() {
+        return Err(AppValidationError::FapiDowngradeUnsupported);
+    }
+
+    // Everything below applies whenever the client is FAPI *after* this
+    // update — whether the request just declared it, or it stays FAPI
+    // because `fapi_profile` was omitted. A JWKS-only edit to an
+    // already-FAPI client must be validated exactly like a fresh upgrade:
+    // its new JWKS can strand the client the same way.
+    if effective_fapi_profile(validated, client) == FapiProfile::None {
         return Ok(());
     }
 
@@ -376,14 +402,8 @@ pub(super) fn validate_update_fapi(
         return Err(AppValidationError::FapiMissingJwks);
     }
 
-    // FAPI validation: an inline JWKS (submitted or already on the client) must
-    // have at least one key usable with FAPI_ALLOWED. Reached whenever the
-    // request declares `fapi_profile=fapi2_security` — a fresh upgrade or an
-    // explicit re-confirmation — same scope as the FapiMissingJwks check above.
-    // A JWKS-only update that omits `fapi_profile` on an already-FAPI client
-    // takes the early return above and is not re-validated here, matching that
-    // check's existing scope; the client stays FAPI either way, so this is a
-    // known gap shared by both checks, not one this change introduces.
+    // FAPI validation: an inline JWKS (submitted or already on the client)
+    // must have at least one key usable with FAPI_ALLOWED.
     if let Some(jwks) = validated.jwks.as_ref().or(client.jwks.as_ref())
         && !jwks_has_fapi_allowed_key(jwks)
     {
@@ -502,15 +522,7 @@ pub(super) fn compute_fapi_update_fields<'a>(
     client: &'a OAuthClient,
 ) -> Result<FapiUpdateFields<'a>, AppValidationError> {
     let is_fapi = validated.is_fapi;
-
-    let fapi_profile = if is_fapi {
-        FapiProfile::Fapi2Security
-    } else if validated.fapi_profile_provided {
-        // Explicitly set to non-FAPI
-        FapiProfile::None
-    } else {
-        client.fapi_profile
-    };
+    let fapi_profile = effective_fapi_profile(validated, client);
 
     // A FAPI→standard transition never reaches here: `validate_update_fapi`
     // rejects it, because the client has no secret to fall back to.
@@ -858,6 +870,36 @@ mod tests {
             .expect("client exists")
     }
 
+    /// A FAPI client whose stored JWKS predates the algorithm-usability
+    /// guard: its only key is pinned to `alg: RS256`, unusable under
+    /// `FAPI_ALLOWED`.
+    async fn stale_jwks_fapi_client(
+        state: &crate::AppState,
+        email: &str,
+    ) -> crate::db::OAuthClient {
+        let user = create_test_user(&state.store, email).await;
+        let jwks = serde_json::json!({
+            "keys": [{"kty": "RSA", "alg": "RS256", "n": "n", "e": "AQAB"}]
+        });
+        let created = create_test_client(
+            &state.store,
+            &user.id,
+            TestClientSpec {
+                token_endpoint_auth_method: Some(TokenEndpointAuthMethod::PrivateKeyJwt),
+                jwks: TestJwks::Custom(jwks),
+                dpop_bound_access_tokens: true,
+                fapi_profile: Some(FapiProfile::Fapi2Security),
+                with_secret: false,
+                ..Default::default()
+            },
+        )
+        .await;
+        crate::db::get_oauth_client_by_id(&state.store, &created.app_id)
+            .await
+            .expect("db lookup")
+            .expect("client exists")
+    }
+
     // A non-FAPI client that authenticates with `private_key_jwt` and carries
     // JWKS — the shape produced by authenticated dynamic registration (RFC
     // 7591) when the caller supplies `token_endpoint_auth_method=private_key_jwt`
@@ -1122,9 +1164,7 @@ mod tests {
     // The guard also fires on an explicit re-confirmation (fapi_profile
     // resubmitted, not just a fresh non-FAPI -> FAPI transition): swapping the
     // JWKS of an already-FAPI client to an RS256-only key would strand it
-    // exactly the same way. A JWKS-only update that omits `fapi_profile`
-    // entirely is a known, pre-existing gap shared with FapiMissingJwks (see
-    // the comment on the guard) — out of scope here.
+    // exactly the same way.
     #[tokio::test]
     async fn fapi_reconfirm_rejected_when_new_jwks_has_no_allowed_algorithm_key() {
         let state = test_app_state().await;
@@ -1145,6 +1185,137 @@ mod tests {
         let err = validate_update_fapi(&validated, &client)
             .expect_err("RS256-only JWKS must be rejected on FAPI re-confirmation");
         assert_eq!(err.code(), "fapi_jwks_algorithm_unsupported");
+    }
+
+    // A JWKS-only update that omits `fapi_profile` must still be validated:
+    // the field's absence preserves the client's existing profile, so a
+    // client that stays FAPI must have its new JWKS checked for a usable
+    // algorithm exactly as it would be on an explicit upgrade.
+    #[tokio::test]
+    async fn fapi_jwks_only_update_rejected_when_new_jwks_has_no_allowed_algorithm_key() {
+        let state = test_app_state().await;
+        let client = fapi_test_client(&state, "fapi-jwks-only-rs256@example.com").await;
+
+        let jwks = rs256_only_jwks_json();
+        let validated = validate_update_format(UpdateAppInput {
+            redirect_uris: None,
+            resource_uris: None,
+            post_logout_redirect_uris: None,
+            access_scope: None,
+            fapi_profile: None,
+            jwks: Some(&jwks),
+            jwks_uri: None,
+        })
+        .expect("valid update input");
+
+        let err = validate_update_fapi(&validated, &client).expect_err(
+            "RS256-only JWKS must be rejected on a JWKS-only update to an already-FAPI client",
+        );
+        assert_eq!(err.code(), "fapi_jwks_algorithm_unsupported");
+    }
+
+    #[tokio::test]
+    async fn fapi_jwks_only_update_accepted_when_new_jwks_has_an_allowed_algorithm_key() {
+        let state = test_app_state().await;
+        let client = fapi_test_client(&state, "fapi-jwks-only-eddsa@example.com").await;
+
+        let jwks = eddsa_jwks_json();
+        let validated = validate_update_format(UpdateAppInput {
+            redirect_uris: None,
+            resource_uris: None,
+            post_logout_redirect_uris: None,
+            access_scope: None,
+            fapi_profile: None,
+            jwks: Some(&jwks),
+            jwks_uri: None,
+        })
+        .expect("valid update input");
+
+        validate_update_fapi(&validated, &client).expect(
+            "a JWKS-only update with an allowed-algorithm key must pass on an already-FAPI client",
+        );
+    }
+
+    // No false positive: an ordinary update that never touches the JWKS must
+    // still pass for an already-FAPI client with a valid existing JWKS — the
+    // effective-profile check must not re-reject a client that was already fine.
+    #[tokio::test]
+    async fn fapi_metadata_only_update_unaffected_by_effective_profile_check() {
+        let state = test_app_state().await;
+        let client = fapi_test_client(&state, "fapi-metadata-only@example.com").await;
+
+        let redirect_uris = vec![
+            "https://example.com/callback".to_string(),
+            "https://example.com/callback2".to_string(),
+        ];
+        let validated = validate_update_format(UpdateAppInput {
+            redirect_uris: Some(&redirect_uris),
+            resource_uris: None,
+            post_logout_redirect_uris: None,
+            access_scope: None,
+            fapi_profile: None,
+            jwks: None,
+            jwks_uri: None,
+        })
+        .expect("valid update input");
+
+        validate_update_fapi(&validated, &client)
+            .expect("a redirect_uris-only update must not be affected by the FAPI JWKS checks");
+    }
+
+    // Reverse edge: a request that omits `fapi_profile` AND `jwks` still
+    // validates the STORED jwks, because the client remains FAPI regardless.
+    // Simulates a client whose stored JWKS predates this guard (e.g. created
+    // before it existed) — any subsequent update must surface the problem
+    // rather than silently continue to accept an unusable key.
+    #[tokio::test]
+    async fn fapi_metadata_only_update_rejected_when_stored_jwks_has_no_allowed_algorithm_key() {
+        let state = test_app_state().await;
+        let client = stale_jwks_fapi_client(&state, "fapi-stale-jwks@example.com").await;
+
+        let validated = update_input(None);
+        let err = validate_update_fapi(&validated, &client)
+            .expect_err("a metadata-only update must surface a pre-existing unusable stored JWKS");
+        assert_eq!(err.code(), "fapi_jwks_algorithm_unsupported");
+    }
+
+    // Same reverse edge, but with `fapi_profile` explicitly re-confirmed and
+    // JWKS left unspecified — the check must still fall back to the stored
+    // JWKS rather than treating "no jwks in this request" as "nothing to
+    // check".
+    #[tokio::test]
+    async fn fapi_reconfirm_rejected_when_stored_jwks_has_no_allowed_algorithm_key() {
+        let state = test_app_state().await;
+        let client = stale_jwks_fapi_client(&state, "fapi-reconfirm-stale-jwks@example.com").await;
+
+        let validated = update_input(Some("fapi2_security"));
+        let err = validate_update_fapi(&validated, &client).expect_err(
+            "an explicit re-confirmation with no new jwks must still check the stored JWKS",
+        );
+        assert_eq!(err.code(), "fapi_jwks_algorithm_unsupported");
+    }
+
+    // No new restriction for non-FAPI clients: RS256 stays allowed, and a
+    // JWKS-only update never triggers the FAPI-only checks.
+    #[tokio::test]
+    async fn fapi_jwks_only_update_accepted_for_non_fapi_client() {
+        let state = test_app_state().await;
+        let client = non_fapi_pkjwt_client(&state, "nonfapi-jwks-only-rs256@example.com").await;
+
+        let jwks = rs256_only_jwks_json();
+        let validated = validate_update_format(UpdateAppInput {
+            redirect_uris: None,
+            resource_uris: None,
+            post_logout_redirect_uris: None,
+            access_scope: None,
+            fapi_profile: None,
+            jwks: Some(&jwks),
+            jwks_uri: None,
+        })
+        .expect("valid update input");
+
+        validate_update_fapi(&validated, &client)
+            .expect("RS256 must remain unrestricted for a non-FAPI client's JWKS-only update");
     }
 
     #[test]

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7591.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7591.rs
@@ -1034,6 +1034,171 @@ async fn test_rfc7591_rejects_fapi_without_private_key_jwt() {
 }
 
 // ========================================================================
+// FAPI 2.0 JWKS algorithm usability — a client that registers as FAPI 2.0
+// with a JWKS containing no key usable under ES256/PS256/EdDSA would be
+// unable to authenticate at the token endpoint from the moment it's created.
+// See db::jwks_has_fapi_allowed_key.
+// ========================================================================
+
+#[tokio::test]
+async fn test_rfc7591_rejects_fapi_registration_with_rs256_only_jwks() {
+    let (app, state) = test_app().await;
+    let auth = bearer_token_unique(&state, "fapi-rs256-only").await;
+
+    let body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "dpop_bound_access_tokens": true,
+        "token_endpoint_auth_method": "private_key_jwt",
+        "jwks": {
+            "keys": [{"kty": "RSA", "alg": "RS256", "n": "n", "e": "AQAB"}]
+        }
+    });
+
+    let (status, body) = http_post_json(
+        &app,
+        "/oauth/register",
+        &body.to_string(),
+        &[("Authorization", &auth)],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "RS256-only JWKS must be rejected for a FAPI 2.0 registration: {body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(json["error"], "invalid_client_metadata");
+}
+
+#[tokio::test]
+async fn test_rfc7591_accepts_fapi_registration_with_unpinned_rsa_jwks() {
+    // An RSA key with no `alg` constraint is usable with PS256, so it must
+    // not be rejected the same way an alg: RS256 key is.
+    let (app, state) = test_app().await;
+    let auth = bearer_token_unique(&state, "fapi-rsa-unpinned").await;
+
+    let body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "dpop_bound_access_tokens": true,
+        "token_endpoint_auth_method": "private_key_jwt",
+        "jwks": {
+            "keys": [{"kty": "RSA", "n": "n", "e": "AQAB"}]
+        }
+    });
+
+    let (status, body) = http_post_json(
+        &app,
+        "/oauth/register",
+        &body.to_string(),
+        &[("Authorization", &auth)],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "an unpinned RSA key must pass FAPI 2.0 registration: {body}"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc7591_accepts_fapi_mtls_registration_with_rs256_alg_pinned_x5c_jwks() {
+    // RFC 8705 §2.2.2: a self_signed_tls_client_auth JWKS conveys the
+    // client's certificate via x5c; alg/kty are "not utilized in this
+    // context". The FAPI client-assertion algorithm guard must not apply to
+    // this auth method — it exists for private_key_jwt's signing keys.
+    let (app, state) = test_app().await;
+    let auth = bearer_token_unique(&state, "fapi-mtls-rs256-alg").await;
+
+    let cert_der = make_test_cert_der("fapi-mtls-client");
+    let x5c_b64 = base64::engine::general_purpose::STANDARD.encode(&cert_der);
+
+    let body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "dpop_bound_access_tokens": true,
+        "token_endpoint_auth_method": "self_signed_tls_client_auth",
+        "jwks": {
+            "keys": [{"kty": "RSA", "alg": "RS256", "x5c": [x5c_b64]}]
+        }
+    });
+
+    let (status, body) = http_post_json(
+        &app,
+        "/oauth/register",
+        &body.to_string(),
+        &[("Authorization", &auth)],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "mTLS FAPI registration with an alg-pinned x5c JWKS must succeed: {body}"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc7591_accepts_non_fapi_registration_with_rs256_only_jwks() {
+    // RFC 7523 does not restrict client-assertion algorithms; non-FAPI
+    // clients keep RS256. Symmetric with the existing PUT-side test
+    // (test_rfc7592_put_accepts_rs256_only_jwks_for_non_fapi_client).
+    let (app, state) = test_app().await;
+    let auth = bearer_token_unique(&state, "nonfapi-rs256-only").await;
+
+    let body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "token_endpoint_auth_method": "private_key_jwt",
+        "jwks": {
+            "keys": [{"kty": "RSA", "alg": "RS256", "n": "n", "e": "AQAB"}]
+        }
+    });
+
+    let (status, body) = http_post_json(
+        &app,
+        "/oauth/register",
+        &body.to_string(),
+        &[("Authorization", &auth)],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "RS256 must remain unrestricted for a non-FAPI registration: {body}"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc7591_accepts_fapi_registration_with_jwks_uri_only() {
+    // A remote jwks_uri can't be inspected synchronously, so the algorithm
+    // guard only applies to an inline jwks — documented scope limit, not a gap.
+    let (app, state) = test_app().await;
+    let auth = bearer_token_unique(&state, "fapi-jwks-uri-only").await;
+
+    let body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "dpop_bound_access_tokens": true,
+        "token_endpoint_auth_method": "private_key_jwt",
+        "jwks_uri": "https://example.com/.well-known/jwks.json"
+    });
+
+    let (status, body) = http_post_json(
+        &app,
+        "/oauth/register",
+        &body.to_string(),
+        &[("Authorization", &auth)],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "a jwks_uri-only FAPI registration must not be blocked by the inline-only guard: {body}"
+    );
+}
+
+// ========================================================================
 // RFC 7591 Section 2: Unknown fields MUST be ignored
 // ========================================================================
 

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7592.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7592.rs
@@ -27,6 +27,298 @@ async fn register_dynamic_client(app: &axum::Router) -> (String, String) {
     (client_id, token)
 }
 
+/// Register a FAPI 2.0 client (`dpop_bound_access_tokens`, the given
+/// `auth_method`, and the given inline JWKS) via POST /oauth/register.
+/// Returns `(client_id, registration_access_token)`.
+async fn register_fapi_dynamic_client(
+    app: &axum::Router,
+    auth_method: &str,
+    jwks: serde_json::Value,
+) -> (String, String) {
+    let body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "dpop_bound_access_tokens": true,
+        "token_endpoint_auth_method": auth_method,
+        "jwks": jwks,
+        "client_name": "RFC7592 FAPI Test Client"
+    });
+
+    let (status, body) = http_post_json(app, "/oauth/register", &body.to_string(), &[]).await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "FAPI registration failed: {body}"
+    );
+
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let client_id = json["client_id"].as_str().expect("client_id").to_string();
+    let token = json["registration_access_token"]
+        .as_str()
+        .expect("registration_access_token")
+        .to_string();
+
+    (client_id, token)
+}
+
+/// A valid ES256 JWK — usable with FAPI 2.0's algorithm allowlist.
+fn es256_jwk() -> serde_json::Value {
+    serde_json::json!({
+        "kty": "EC",
+        "crv": "P-256",
+        "x": "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+        "y": "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
+        "use": "sig",
+        "alg": "ES256"
+    })
+}
+
+// =========================================================================
+// FAPI 2.0 JWKS algorithm usability on PUT — RFC 7592 §2.2 is a full
+// replacement, so a PUT that swaps in an RS256-only JWKS must be rejected
+// exactly like initial registration. See db::jwks_has_fapi_allowed_key.
+// =========================================================================
+
+#[tokio::test]
+async fn test_rfc7592_put_rejects_rs256_only_jwks_for_fapi_client() {
+    let (app, _state) = test_app().await;
+    let (client_id, token) = register_fapi_dynamic_client(
+        &app,
+        "private_key_jwt",
+        serde_json::json!({"keys": [es256_jwk()]}),
+    )
+    .await;
+
+    let update_body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "jwks": {
+            "keys": [{"kty": "RSA", "alg": "RS256", "n": "n", "e": "AQAB"}]
+        }
+    });
+
+    let (status, body) = http_request(
+        &app,
+        "PUT",
+        &format!("/oauth/register/{client_id}"),
+        Some(update_body.to_string()),
+        &[
+            ("Authorization", &format!("Bearer {token}")),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "RS256-only JWKS must be rejected on a FAPI client's PUT: {body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(json["error"], "invalid_client_metadata");
+}
+
+#[tokio::test]
+async fn test_rfc7592_put_accepts_unpinned_rsa_jwks_for_fapi_client() {
+    let (app, _state) = test_app().await;
+    let (client_id, token) = register_fapi_dynamic_client(
+        &app,
+        "private_key_jwt",
+        serde_json::json!({"keys": [es256_jwk()]}),
+    )
+    .await;
+
+    let update_body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "jwks": {
+            "keys": [{"kty": "RSA", "n": "n", "e": "AQAB"}]
+        }
+    });
+
+    let (status, body) = http_request(
+        &app,
+        "PUT",
+        &format!("/oauth/register/{client_id}"),
+        Some(update_body.to_string()),
+        &[
+            ("Authorization", &format!("Bearer {token}")),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "an unpinned RSA key must pass a FAPI client's PUT: {body}"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc7592_put_accepts_rs256_only_jwks_for_non_fapi_client() {
+    let (app, _state) = test_app().await;
+    let body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "token_endpoint_auth_method": "private_key_jwt",
+        "jwks": {"keys": [es256_jwk()]}
+    });
+    let (status, reg_body) = http_post_json(&app, "/oauth/register", &body.to_string(), &[]).await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "registration failed: {reg_body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&reg_body).expect("Valid JSON");
+    let client_id = json["client_id"].as_str().expect("client_id");
+    let token = json["registration_access_token"]
+        .as_str()
+        .expect("registration_access_token");
+
+    let update_body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "jwks": {
+            "keys": [{"kty": "RSA", "alg": "RS256", "n": "n", "e": "AQAB"}]
+        }
+    });
+
+    let (status, body) = http_request(
+        &app,
+        "PUT",
+        &format!("/oauth/register/{client_id}"),
+        Some(update_body.to_string()),
+        &[
+            ("Authorization", &format!("Bearer {token}")),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "RS256 must remain unrestricted for a non-FAPI client's PUT: {body}"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc7592_put_rejects_fapi_mtls_client_clearing_jwks() {
+    // RFC 7592 §2.2 full replacement: an update that omits both jwks and
+    // jwks_uri must not silently clear a FAPI client's key material, even
+    // for an mTLS auth method the algorithm-usability guard doesn't apply to
+    // (that guard is private_key_jwt-only; this presence check is not).
+    let (app, _state) = test_app().await;
+    let cert_der = make_test_cert_der("fapi-mtls-put-client");
+    let x5c_b64 = base64::engine::general_purpose::STANDARD.encode(&cert_der);
+    let (client_id, token) = register_fapi_dynamic_client(
+        &app,
+        "self_signed_tls_client_auth",
+        serde_json::json!({"keys": [{"kty": "RSA", "x5c": [x5c_b64]}]}),
+    )
+    .await;
+
+    let update_body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"]
+    });
+
+    let (status, body) = http_request(
+        &app,
+        "PUT",
+        &format!("/oauth/register/{client_id}"),
+        Some(update_body.to_string()),
+        &[
+            ("Authorization", &format!("Bearer {token}")),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "a FAPI mTLS client's PUT must not be able to clear its key material: {body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(json["error"], "invalid_client_metadata");
+}
+
+#[tokio::test]
+async fn test_rfc7592_put_accepts_jwks_uri_only_for_fapi_client() {
+    // A remote jwks_uri can't be inspected synchronously, so the algorithm
+    // guard only applies to an inline jwks — documented scope limit.
+    let (app, _state) = test_app().await;
+    let (client_id, token) = register_fapi_dynamic_client(
+        &app,
+        "private_key_jwt",
+        serde_json::json!({"keys": [es256_jwk()]}),
+    )
+    .await;
+
+    let update_body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "jwks_uri": "https://example.com/.well-known/jwks.json"
+    });
+
+    let (status, body) = http_request(
+        &app,
+        "PUT",
+        &format!("/oauth/register/{client_id}"),
+        Some(update_body.to_string()),
+        &[
+            ("Authorization", &format!("Bearer {token}")),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "a jwks_uri-only PUT must not be blocked by the inline-only guard: {body}"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc7592_put_accepts_rs256_alg_pinned_x5c_jwks_for_fapi_mtls_client() {
+    // RFC 8705 §2.2.2: a self_signed_tls_client_auth JWKS conveys the
+    // client's certificate via x5c; alg/kty are not utilized in this
+    // context. The FAPI client-assertion algorithm guard must not apply to
+    // this auth method on PUT either — same carve-out as registration.
+    let (app, _state) = test_app().await;
+    let initial_cert = make_test_cert_der("fapi-mtls-put-initial");
+    let initial_x5c = base64::engine::general_purpose::STANDARD.encode(&initial_cert);
+    let (client_id, token) = register_fapi_dynamic_client(
+        &app,
+        "self_signed_tls_client_auth",
+        serde_json::json!({"keys": [{"kty": "RSA", "x5c": [initial_x5c]}]}),
+    )
+    .await;
+
+    let new_cert = make_test_cert_der("fapi-mtls-put-updated");
+    let new_x5c = base64::engine::general_purpose::STANDARD.encode(&new_cert);
+    let update_body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "jwks": {
+            "keys": [{"kty": "RSA", "alg": "RS256", "x5c": [new_x5c]}]
+        }
+    });
+
+    let (status, body) = http_request(
+        &app,
+        "PUT",
+        &format!("/oauth/register/{client_id}"),
+        Some(update_body.to_string()),
+        &[
+            ("Authorization", &format!("Bearer {token}")),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "an alg-pinned RS256 x5c JWKS must pass a FAPI mTLS client's PUT: {body}"
+    );
+}
+
 // =========================================================================
 // PUT /oauth/register/:client_id — Update Client Configuration
 // =========================================================================

--- a/crates/vouch-server/src/services/oidc/registration.rs
+++ b/crates/vouch-server/src/services/oidc/registration.rs
@@ -22,6 +22,7 @@ use crate::crypto::{generate_random_bytes, hash_token};
 use crate::db::{
     self, CreateOAuthClientParams, FapiProfile, JwsAlgorithm, OAuthClient, OAuthClientType,
     OAuthEventType, RegistrationSource, TokenEndpointAuthMethod, UpdateClientRegistrationParams,
+    jwks_has_fapi_allowed_key,
 };
 use crate::error::{OAuthErrorCode, ServiceError};
 use crate::services::oidc::grant_type::OAuthGrantType;
@@ -387,6 +388,23 @@ pub async fn register_client(
             return Err(ServiceError::oauth(
                 OAuthErrorCode::InvalidClientMetadata,
                 "FAPI 2.0 requires jwks or jwks_uri",
+            ));
+        }
+        // Only for private_key_jwt: its JWKS carries client-assertion signing
+        // keys, so an inline JWKS must have at least one key usable with
+        // FAPI_ALLOWED (ES256/PS256/EdDSA) — see db::jwks_has_fapi_allowed_key.
+        // Without this, a client could register as FAPI 2.0 with an
+        // RS256-only JWKS and be unable to authenticate at the token endpoint
+        // from the start. tls_client_auth/self_signed_tls_client_auth JWKS
+        // conveys certificates via x5c instead (RFC 8705 §2.2.2), so this
+        // check does not apply to them.
+        if jwks_auth.auth_method == TokenEndpointAuthMethod::PrivateKeyJwt
+            && let Some(ref jwks) = jwks_auth.jwks_value
+            && !jwks_has_fapi_allowed_key(jwks)
+        {
+            return Err(ServiceError::oauth(
+                OAuthErrorCode::InvalidClientMetadata,
+                "FAPI 2.0 requires a JWKS key usable with ES256, PS256, or EdDSA",
             ));
         }
         FapiProfile::Fapi2Security
@@ -1238,15 +1256,41 @@ pub async fn update_client_configuration(
 
     // PUT is a full replacement, so re-check the auth-method/JWKS
     // relationship enforced at initial registration against the client's
-    // (immutable) registered auth method. Without this, a private_key_jwt
-    // client could clear its JWKS and end up unable to authenticate.
-    if client.token_endpoint_auth_method == TokenEndpointAuthMethod::PrivateKeyJwt
+    // (immutable) registered auth method and FAPI profile. A private_key_jwt
+    // client (FAPI or not) needs key material to authenticate at all; a FAPI
+    // 2.0 client of any auth method needs it too — register_client requires
+    // jwks/jwks_uri for every FAPI client, not just private_key_jwt ones
+    // (RFC 7592 §2.2: omitted fields are treated as cleared, so a PUT that
+    // drops both would otherwise silently strip a client's only key material).
+    if (client.is_fapi()
+        || client.token_endpoint_auth_method == TokenEndpointAuthMethod::PrivateKeyJwt)
         && mutable_request.jwks.is_none()
         && mutable_request.jwks_uri.is_none()
     {
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidClientMetadata,
-            "private_key_jwt requires jwks or jwks_uri",
+            "FAPI 2.0 or private_key_jwt requires jwks or jwks_uri",
+        ));
+    }
+
+    // FAPI 2.0's profile is immutable post-registration (see the comment
+    // below), so `client.fapi_profile` already reflects what this update
+    // preserves. Only for private_key_jwt: its JWKS carries client-assertion
+    // signing keys, so an inline JWKS replacing the client's key material
+    // must have at least one key usable with FAPI_ALLOWED — see
+    // db::jwks_has_fapi_allowed_key. tls_client_auth/self_signed_tls_client_auth
+    // JWKS conveys certificates via x5c instead (RFC 8705 §2.2.2), so this
+    // check does not apply to them. A remote jwks_uri can't be inspected
+    // synchronously, so this only guards the inline case, same as
+    // registration and the admin application API.
+    if client.is_fapi()
+        && client.token_endpoint_auth_method == TokenEndpointAuthMethod::PrivateKeyJwt
+        && let Some(ref jwks) = mutable_request.jwks
+        && !jwks_has_fapi_allowed_key(jwks)
+    {
+        return Err(ServiceError::oauth(
+            OAuthErrorCode::InvalidClientMetadata,
+            "FAPI 2.0 requires a JWKS key usable with ES256, PS256, or EdDSA",
         ));
     }
 


### PR DESCRIPTION
## Summary

Stacked on #1011 (which stacks on #1010). Closes the last unguarded write path for the FAPI-lockout class: RFC 7591 `POST /oauth/register` and RFC 7592 `PUT /oauth/register/:client_id` never algorithm-checked a client's JWKS, so a FAPI 2.0 `private_key_jwt` client could register (or PUT) an RS256-only JWKS and permanently lock itself out at first authentication. A prior complete enumeration of `OAuthClientDoc` mutation sites confirmed these were the only remaining unguarded paths.

- `jwks_has_fapi_allowed_key` moves to `db/oauth.rs` (shared by handlers and services; services→handlers imports are barred by arch_boundaries) and gains a third filter: keys whose `use` is present and not `"sig"` are skipped, matching all three filters the runtime key matcher applies (`alg`, `kty`, `use`).
- The guard is enforced at registration create and RFC 7592 update, gated on `private_key_jwt`. mTLS clients (`tls_client_auth`, `self_signed_tls_client_auth`) are exempt: per RFC 8705 §2.2.2 (<https://www.rfc-editor.org/rfc/rfc8705>, fetched and independently re-verified this session), their JWKS conveys certificates — "A certificate is represented with the `x5c` parameter of an individual JWK within the set" — and the public-key members "will be present even though they are not utilized in this context".
- The admin update path gates on the *effective* auth method (`validated.is_fapi || stored == private_key_jwt`), the exact boolean form of what `compute_fapi_update_fields` persists — verified equivalent by truth table. This keeps dynamically-registered mTLS FAPI clients editable through the admin API while still checking explicit FAPI upgrades that force the method to `private_key_jwt`.
- The RFC 7592 key-material presence check widens from `private_key_jwt`-only to `(is_fapi() || private_key_jwt)`: §2.2 (<https://www.rfc-editor.org/rfc/rfc7592>, fetched this session) — "Omitted fields MUST be treated as null or empty values by the server, indicating the client's request to delete them" — so a FAPI mTLS client PUTting without `jwks`/`jwks_uri` no longer silently strips its only certificate carrier. The union matches exactly what registration requires, so nothing legal to register is rejected on update.
- Rejections return 400 `invalid_client_metadata` per RFC 7591 §3.2.2 (verified against the fetched text).

Out of scope, documented in review artifacts: type-invalid JWK members (e.g. `"alg": true`) read as absent by the guard but fail JWKS parsing at runtime (pre-existing class; the structural fix is validating submitted JWKS through `JwkSet` at registration), and non-FAPI mTLS clients registering without a JWKS (pre-existing, symmetric between create and update).

## Testing

- `cargo test -p vouch-server --all-features` → 3088 passed, 0 failed; clippy `-D warnings` clean
- Mutation-verified: deleting either registration guard call site, the PUT-side mTLS exemption, or the admin-path gate each fails a named test; making the helper unconditionally accept kills 9 tests spanning admin and registration coverage
- New tests: RS256-only JWKS rejected at register and PUT for FAPI `private_key_jwt` clients; mTLS FAPI registration and PUT with alg-pinned x5c JWKS accepted; FAPI mTLS PUT clearing key material rejected; `jwks_uri`-only carve-out pinned on both sides; non-FAPI clients unaffected (POST and PUT); enc-only-`use` key rejected at the helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens OAuth client registration/update validation for FAPI clients. Incorrect gating could lock out mTLS clients or still allow unauthenticatable private_key_jwt JWKS.
> 
> **Overview**
> Closes the remaining FAPI lockout path: RFC 7591/7592 dynamic registration now rejects a FAPI `private_key_jwt` client whose inline JWKS has no key usable with ES256/PS256/EdDSA (e.g. RS256-only), matching the admin application API.
> 
> `jwks_has_fapi_allowed_key` moves to `db/oauth.rs` so handlers and services share one rule, and it now also skips keys with `use` other than `sig`. The algorithm check is **private_key_jwt-only**; mTLS JWKS (`x5c`) is exempt per RFC 8705. Admin updates use the *effective* auth method so FAPI upgrades still force the check while mTLS FAPI clients stay editable.
> 
> RFC 7592 PUT now requires `jwks` or `jwks_uri` for any FAPI client (not just `private_key_jwt`), so a full replacement cannot silently strip mTLS certificate material. Rejections are `400 invalid_client_metadata`. Remote `jwks_uri` is still not inspected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13a913ff8dec86b233576f6eef238ff008b01f51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->