### PR TITLE
fix(server): validate client JWKS and auth-method invariants at write time

### DIFF
--- a/crates/vouch-server/src/db/documents/oauth.rs
+++ b/crates/vouch-server/src/db/documents/oauth.rs
@@ -187,6 +187,17 @@ impl TokenEndpointAuthMethod {
             Self::SelfSignedTlsClientAuth => "self_signed_tls_client_auth",
         }
     }
+
+    /// Returns `true` for the auth methods FAPI 2.0 clients may use:
+    /// `private_key_jwt` (client-assertion signing) or mTLS
+    /// (`tls_client_auth`, `self_signed_tls_client_auth`).
+    #[must_use]
+    pub fn is_fapi_compatible(&self) -> bool {
+        matches!(
+            self,
+            Self::PrivateKeyJwt | Self::TlsClientAuth | Self::SelfSignedTlsClientAuth
+        )
+    }
 }
 
 impl std::str::FromStr for TokenEndpointAuthMethod {

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -138,16 +138,17 @@ pub use documents::oauth::{
 // Re-export OAuth domain types and functions
 pub(crate) use oauth::JwtAssertionJtiClaim;
 pub use oauth::{
-    CreateOAuthClientParams, MAX_ACTIVE_SECRETS, MAX_POST_LOGOUT_REDIRECT_URIS, OAuthClient,
-    OAuthClientSecret, OAuthEventType, OAuthUsageStats, RecordOAuthEventParams,
+    CreateOAuthClientParams, JwkEntry, JwkSet, MAX_ACTIVE_SECRETS, MAX_POST_LOGOUT_REDIRECT_URIS,
+    OAuthClient, OAuthClientSecret, OAuthEventType, OAuthUsageStats, RecordOAuthEventParams,
     UpdateClientRegistrationParams, UpdateOAuthClientParams, create_oauth_client,
     create_oauth_client_secret, delete_expired_jwt_assertion_jtis, delete_oauth_client,
     get_oauth_client_by_client_id, get_oauth_client_by_id, get_oauth_client_secret_by_id,
     get_oauth_client_secrets, get_oauth_clients_for_user, get_oauth_secret_by_hash,
     get_oauth_usage_stats, is_valid_post_logout_redirect_uri_str, jwks_has_fapi_allowed_key,
-    record_oauth_event, revoke_all_oauth_client_secrets, revoke_oauth_client_secret,
-    store_jwt_assertion_jti, update_oauth_client, update_oauth_client_last_used,
-    update_oauth_client_registration, validate_oauth_client_credentials,
+    jwks_has_x5c, parse_jwks_set, record_oauth_event, revoke_all_oauth_client_secrets,
+    revoke_oauth_client_secret, store_jwt_assertion_jti, update_oauth_client,
+    update_oauth_client_last_used, update_oauth_client_registration,
+    validate_oauth_client_credentials,
 };
 
 // Re-export test-only OAuth client helpers

--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -14,6 +14,7 @@ use crate::error::ServiceError;
 use anyhow::Result;
 use axum::http::StatusCode;
 use jiff::Timestamp;
+use serde::Deserialize;
 
 /// Maximum number of active (non-revoked, non-expired) secrets per OAuth client.
 ///
@@ -235,6 +236,74 @@ pub fn is_valid_post_logout_redirect_uri_str(uri: &str) -> bool {
 // lives in exactly one place)
 // ============================================================================
 
+/// A JSON Web Key Set (RFC 7517 Section 5).
+///
+/// The typed representation shared by write-time acceptance checks (this
+/// module: `jwks_has_fapi_allowed_key`, `jwks_has_x5c`) and the runtime RFC
+/// 7523 client-assertion verifier (`services/oidc/jwt_bearer/jwks.rs`), so a
+/// member of the wrong JSON type (e.g. `"alg": true`) is rejected the same
+/// way in both places instead of silently read as absent by a separate,
+/// more lenient parser. Two other JWKS consumers still parse leniently from
+/// raw `serde_json::Value` and are unaffected by this type: the mTLS `x5c`
+/// matcher (`services/oidc/mtls.rs::verify_self_signed_tls_client_auth`) and
+/// the RFC 9421 signature key resolver (`infra/httpsig.rs`).
+#[derive(Debug, Deserialize)]
+pub struct JwkSet {
+    /// The keys in the set.
+    pub keys: Vec<JwkEntry>,
+}
+
+/// A single JWK entry in a JWKS.
+#[derive(Debug, Deserialize)]
+pub struct JwkEntry {
+    /// Key type (e.g., "EC", "RSA", "OKP").
+    pub kty: String,
+    /// Key ID (optional).
+    #[serde(default)]
+    pub kid: Option<String>,
+    /// Algorithm (optional).
+    #[serde(default)]
+    pub alg: Option<String>,
+    /// Key use (optional, e.g., "sig").
+    #[serde(rename = "use", default)]
+    pub use_: Option<String>,
+
+    // EC key components
+    #[serde(default)]
+    pub crv: Option<String>,
+    #[serde(default)]
+    pub x: Option<String>,
+    #[serde(default)]
+    pub y: Option<String>,
+
+    // RSA key components
+    #[serde(default)]
+    pub n: Option<String>,
+    #[serde(default)]
+    pub e: Option<String>,
+
+    /// X.509 certificate chain (RFC 7517 §4.7) — the certificate carrier for
+    /// `self_signed_tls_client_auth` (RFC 8705 §2.2.2).
+    #[serde(default)]
+    pub x5c: Option<Vec<String>>,
+}
+
+/// Parse a raw JWKS JSON value into the typed [`JwkSet`].
+///
+/// Deserialization is strict: a member of the wrong JSON type (e.g. a
+/// boolean `alg`) fails the whole parse rather than being read as absent.
+/// Write paths (application create/update, RFC 7591/7592 registration) use
+/// this to reject a malformed submission outright. Callers evaluating a
+/// JWKS that may be pre-existing stored data (which could predate this
+/// check) should treat a parse failure as "no usable key" rather than a
+/// hard error — see `jwks_has_fapi_allowed_key`'s callers.
+///
+/// # Errors
+/// Returns the `serde_json` deserialization error on a shape mismatch.
+pub fn parse_jwks_set(value: &serde_json::Value) -> Result<JwkSet, serde_json::Error> {
+    serde_json::from_value(value.clone())
+}
+
 /// Returns `true` when `jwks` contains at least one key the FAPI 2.0
 /// client-assertion validator (`FapiProfile::client_assertion_algorithms`, which
 /// yields `JwsAlgorithm::FAPI_ALLOWED` for `FapiProfile::Fapi2Security`) could
@@ -258,27 +327,41 @@ pub fn is_valid_post_logout_redirect_uri_str(uri: &str) -> bool {
 /// application creation and update (`handlers/applications/validate.rs`) and
 /// RFC 7591/7592 dynamic client registration (`services/oidc/registration.rs`).
 #[must_use]
-pub fn jwks_has_fapi_allowed_key(jwks: &serde_json::Value) -> bool {
-    let Some(keys) = jwks.get("keys").and_then(|k| k.as_array()) else {
-        return false;
-    };
-    keys.iter().any(|key| {
-        let use_is_sig = key
-            .get("use")
-            .and_then(|u| u.as_str())
-            .is_none_or(|u| u == "sig");
+pub fn jwks_has_fapi_allowed_key(jwks: &JwkSet) -> bool {
+    jwks.keys.iter().any(|key| {
+        let use_is_sig = key.use_.as_deref().is_none_or(|u| u == "sig");
         if !use_is_sig {
             return false;
         }
-        let Some(alg) = key.get("alg").and_then(|a| a.as_str()) else {
-            return key
-                .get("kty")
-                .and_then(|v| v.as_str())
-                .is_some_and(|kty| matches!(kty, "EC" | "RSA" | "OKP"));
+        let Some(alg) = key.alg.as_deref() else {
+            return matches!(key.kty.as_str(), "EC" | "RSA" | "OKP");
         };
         alg.parse::<JwsAlgorithm>()
             .is_ok_and(|parsed| JwsAlgorithm::FAPI_ALLOWED.contains(&parsed))
     })
+}
+
+/// Returns `true` when `jwks` contains at least one key with a non-empty
+/// `x5c` member — `self_signed_tls_client_auth`'s certificate carrier (RFC
+/// 8705 §2.2.2 describes this representation; it is not itself a MUST). A
+/// JWKS with no `x5c` anywhere passes a bare presence check but leaves the
+/// client permanently unable to complete mTLS authentication:
+/// `verify_self_signed_tls_client_auth` (`services/oidc/mtls.rs`) only
+/// matches keys carrying an `x5c` entry and returns
+/// `CertificateNotRegistered` if none do — the same "accepted at
+/// registration, unusable forever after" class `jwks_has_fapi_allowed_key`
+/// closes for `private_key_jwt`.
+///
+/// Used wherever a `self_signed_tls_client_auth` client's inline JWKS is
+/// accepted or replaced: application creation and update
+/// (`handlers/applications/validate.rs`) and RFC 7591/7592 dynamic client
+/// registration (`services/oidc/registration.rs`). Not applicable to a
+/// `jwks_uri`, which can't be inspected synchronously.
+#[must_use]
+pub fn jwks_has_x5c(jwks: &JwkSet) -> bool {
+    jwks.keys
+        .iter()
+        .any(|key| key.x5c.as_ref().is_some_and(|c| !c.is_empty()))
 }
 
 /// Parameters for creating a new OAuth client application.
@@ -1347,6 +1430,85 @@ mod tests {
         ));
         // Garbage / relative URIs are rejected.
         assert!(!is_valid_post_logout_redirect_uri_str("not-a-url"));
+    }
+
+    // RFC 7517 §4.1 (<https://www.rfc-editor.org/rfc/rfc7517#section-4.1>):
+    // "The 'kty' value is a case-sensitive string. This member MUST be
+    // present in a JWK." No other member the struct models is required, and
+    // members it doesn't model (mTLS `x5t`, future extensions) must pass
+    // through rather than being rejected — `JwkEntry` has no
+    // `#[serde(deny_unknown_fields)]`, so the write-path shape gate only
+    // ever rejects a *known* member of the wrong JSON type, never an
+    // unrecognized one. `x5c` is itself a known, typed member (needed by
+    // `jwks_has_x5c`): a type-invalid `x5c` (e.g. a string instead of an
+    // array) now fails the parse the same way a type-invalid `alg` does —
+    // see `test_parse_jwks_set_rejects_type_invalid_x5c` below.
+    #[test]
+    fn test_parse_jwks_set_ignores_unknown_members_but_requires_kty() {
+        let with_x5c_and_future_member = serde_json::json!({
+            "keys": [{
+                "kty": "RSA",
+                "x5c": ["ZmFrZS1jZXJ0"],
+                "x5t#S256": "ZmFrZS10aHVtYnByaW50",
+                "some_future_extension": {"nested": true}
+            }]
+        });
+        let set = parse_jwks_set(&with_x5c_and_future_member)
+            .expect("unknown/future JWK members must not fail the parse");
+        assert_eq!(set.keys.len(), 1);
+        assert_eq!(
+            set.keys.first().and_then(|k| k.x5c.as_ref()),
+            Some(&vec!["ZmFrZS1jZXJ0".to_string()]),
+            "x5c is a known, typed member and must populate the struct"
+        );
+
+        let missing_kty = serde_json::json!({"keys": [{"alg": "ES256"}]});
+        assert!(
+            parse_jwks_set(&missing_kty).is_err(),
+            "kty is the only REQUIRED JWK member and must fail its absence"
+        );
+    }
+
+    #[test]
+    fn test_parse_jwks_set_rejects_type_invalid_x5c() {
+        let string_x5c = serde_json::json!({"keys": [{"kty": "RSA", "x5c": "not-an-array"}]});
+        assert!(parse_jwks_set(&string_x5c).is_err());
+
+        let non_string_entry = serde_json::json!({"keys": [{"kty": "RSA", "x5c": [123]}]});
+        assert!(parse_jwks_set(&non_string_entry).is_err());
+    }
+
+    #[test]
+    fn test_jwks_has_x5c() {
+        let with_x5c = parse_jwks_set(&serde_json::json!({
+            "keys": [{"kty": "RSA", "x5c": ["ZmFrZS1jZXJ0"]}]
+        }))
+        .expect("valid fixture");
+        assert!(jwks_has_x5c(&with_x5c));
+
+        let empty_x5c = parse_jwks_set(&serde_json::json!({
+            "keys": [{"kty": "RSA", "x5c": []}]
+        }))
+        .expect("valid fixture");
+        assert!(
+            !jwks_has_x5c(&empty_x5c),
+            "an empty x5c array carries no certificate"
+        );
+
+        let no_x5c = parse_jwks_set(&serde_json::json!({
+            "keys": [{"kty": "RSA", "n": "n", "e": "AQAB"}]
+        }))
+        .expect("valid fixture");
+        assert!(!jwks_has_x5c(&no_x5c));
+
+        let mixed = parse_jwks_set(&serde_json::json!({
+            "keys": [
+                {"kty": "RSA", "n": "n", "e": "AQAB"},
+                {"kty": "RSA", "x5c": ["ZmFrZS1jZXJ0"]}
+            ]
+        }))
+        .expect("valid fixture");
+        assert!(jwks_has_x5c(&mixed), "one x5c-bearing key is enough");
     }
 
     #[test]

--- a/crates/vouch-server/src/handlers/applications/validate.rs
+++ b/crates/vouch-server/src/handlers/applications/validate.rs
@@ -12,7 +12,7 @@ use axum::http::StatusCode;
 
 use crate::db::{
     AccessScope, CreateOAuthClientParams, FapiProfile, JwsAlgorithm, OAuthClient, OAuthClientType,
-    RegistrationSource, TokenEndpointAuthMethod, jwks_has_fapi_allowed_key,
+    RegistrationSource, TokenEndpointAuthMethod, jwks_has_fapi_allowed_key, jwks_has_x5c,
 };
 use crate::error::ServiceError;
 use crate::services::oidc::ResourceUri;
@@ -32,11 +32,13 @@ pub(super) enum AppValidationError {
     InvalidResourceUri { uri: String, detail: String },
     FapiRequiresConfidentialClient,
     FapiMissingJwks,
-    PrivateKeyJwtMissingJwks,
+    AuthMethodMissingJwks,
     FapiDowngradeUnsupported,
     FapiJwksNoAllowedAlgorithm,
+    SelfSignedJwksMissingX5c,
     JwksNotJson,
     JwksMissingKeys,
+    JwksInvalidKeyShape,
     InvalidJwksUri,
 }
 
@@ -52,10 +54,11 @@ impl AppValidationError {
             Self::InvalidPostLogoutRedirectUris(_) => "invalid_post_logout_redirect_uris",
             Self::InvalidResourceUri { .. } => "invalid_resource_uri",
             Self::FapiRequiresConfidentialClient => "invalid_fapi_profile",
-            Self::FapiMissingJwks | Self::PrivateKeyJwtMissingJwks => "missing_jwks",
+            Self::FapiMissingJwks | Self::AuthMethodMissingJwks => "missing_jwks",
             Self::FapiDowngradeUnsupported => "fapi_downgrade_unsupported",
             Self::FapiJwksNoAllowedAlgorithm => "fapi_jwks_algorithm_unsupported",
-            Self::JwksNotJson | Self::JwksMissingKeys => "invalid_jwks",
+            Self::SelfSignedJwksMissingX5c => "self_signed_jwks_missing_x5c",
+            Self::JwksNotJson | Self::JwksMissingKeys | Self::JwksInvalidKeyShape => "invalid_jwks",
             Self::InvalidJwksUri => "invalid_jwks_uri",
         }
     }
@@ -94,9 +97,10 @@ impl AppValidationError {
             Self::FapiMissingJwks => {
                 "FAPI 2.0 requires jwks or jwks_uri for private_key_jwt authentication".to_string()
             }
-            Self::PrivateKeyJwtMissingJwks => {
-                "This application authenticates with private_key_jwt, so it must keep a \
-                 jwks or jwks_uri. Provide one, or change its authentication method first."
+            Self::AuthMethodMissingJwks => {
+                "This application authenticates with a method that requires key material \
+                 (private_key_jwt or self_signed_tls_client_auth), so it must keep a jwks or \
+                 jwks_uri. Provide one, or change its authentication method first."
                     .to_string()
             }
             Self::FapiDowngradeUnsupported => {
@@ -113,9 +117,21 @@ impl AppValidationError {
                  an existing one's alg/kty/use."
                     .to_string()
             }
+            Self::SelfSignedJwksMissingX5c => {
+                "This application authenticates with self_signed_tls_client_auth, whose \
+                 certificate is carried in a JWKS key's x5c member (RFC 8705 §2.2.2). None \
+                 of the configured keys carry one, so the application could never complete \
+                 mTLS authentication. Add a key with an x5c certificate."
+                    .to_string()
+            }
             Self::JwksNotJson => "JWKS must be valid JSON".to_string(),
             Self::JwksMissingKeys => {
                 "JWKS must be a JSON object with a non-empty \"keys\" array".to_string()
+            }
+            Self::JwksInvalidKeyShape => {
+                "JWKS contains a key with an invalid field type (e.g. \"alg\" or \"use\" \
+                 must be a string)"
+                    .to_string()
             }
             Self::InvalidJwksUri => "JWKS URI must be a valid https:// URL".to_string(),
         }
@@ -223,7 +239,7 @@ pub(super) fn validate_create_application<'a>(
     // inline case; the same is true of validate_update_fapi.
     if is_fapi
         && let Some(ref parsed_jwks) = jwks
-        && !jwks_has_fapi_allowed_key(parsed_jwks)
+        && !crate::db::parse_jwks_set(parsed_jwks).is_ok_and(|set| jwks_has_fapi_allowed_key(&set))
     {
         return Err(AppValidationError::FapiJwksNoAllowedAlgorithm);
     }
@@ -348,6 +364,35 @@ fn effective_fapi_profile(validated: &ValidatedUpdateApp<'_>, client: &OAuthClie
     }
 }
 
+/// The token endpoint auth method the client will have once this update is
+/// applied.
+///
+/// An explicit `fapi_profile` upgrade forces `private_key_jwt` only when the
+/// client's stored method isn't already FAPI-compatible — a stored mTLS
+/// method (`tls_client_auth`, `self_signed_tls_client_auth`) is preserved
+/// rather than silently converted, since that conversion would end mTLS
+/// authentication for a method RFC 7592 otherwise treats as immutable. A
+/// stored non-FAPI-compatible method (e.g. `client_secret_basic`) is still
+/// forced to `private_key_jwt`, so an upgrade from a secret-based method
+/// keeps the existing lockout protection: it has no signing key to fall back
+/// on otherwise.
+///
+/// Shared by [`validate_update_fapi`] (to decide whether the JWKS
+/// algorithm-usability check applies) and [`compute_fapi_update_fields`] (to
+/// build the persisted `token_endpoint_auth_method`), so the two cannot
+/// disagree about what "the client will authenticate with after this
+/// update" means — mirrors [`effective_fapi_profile`] above.
+fn effective_token_endpoint_auth_method(
+    validated: &ValidatedUpdateApp<'_>,
+    client: &OAuthClient,
+) -> TokenEndpointAuthMethod {
+    if validated.is_fapi && !client.token_endpoint_auth_method.is_fapi_compatible() {
+        TokenEndpointAuthMethod::PrivateKeyJwt
+    } else {
+        client.token_endpoint_auth_method
+    }
+}
+
 /// Validate semantic rules for an update against the existing client record.
 ///
 /// Call after authentication and the ownership check.  This covers rules that
@@ -408,16 +453,13 @@ pub(super) fn validate_update_fapi(
     // keys, so an inline JWKS (submitted or already on the client) must have
     // at least one key usable with FAPI_ALLOWED. tls_client_auth/
     // self_signed_tls_client_auth JWKS conveys certificates via x5c instead
-    // (RFC 8705 §2.2.2), so this check does not apply to them. The effective
-    // auth method — not just the stored one — matters here: an explicit
-    // `fapi_profile` in this request forces private_key_jwt regardless of
-    // what the client currently uses (`compute_fapi_update_fields`), so this
-    // mirrors that same computation rather than re-deriving a second one.
-    let effective_is_private_key_jwt = validated.is_fapi
-        || client.token_endpoint_auth_method == TokenEndpointAuthMethod::PrivateKeyJwt;
-    if effective_is_private_key_jwt
+    // (RFC 8705 §2.2.2), so this check does not apply to them. Uses the same
+    // effective-auth-method computation `compute_fapi_update_fields` persists
+    // by, so the two cannot disagree about which clients this check covers.
+    if effective_token_endpoint_auth_method(validated, client)
+        == TokenEndpointAuthMethod::PrivateKeyJwt
         && let Some(jwks) = validated.jwks.as_ref().or(client.jwks.as_ref())
-        && !jwks_has_fapi_allowed_key(jwks)
+        && !crate::db::parse_jwks_set(jwks).is_ok_and(|set| jwks_has_fapi_allowed_key(&set))
     {
         return Err(AppValidationError::FapiJwksNoAllowedAlgorithm);
     }
@@ -525,24 +567,18 @@ pub(super) struct FapiUpdateFields<'a> {
 /// client record.
 ///
 /// An absent `fapi_profile` preserves the client's current profile, auth
-/// method, JWKS, and DPoP binding. A provided FAPI profile enforces
-/// `private_key_jwt` + DPoP. A provided non-FAPI value clears the profile,
-/// JWKS, and DPoP binding of a client that was not already FAPI; downgrading
-/// a FAPI client is rejected upstream by [`validate_update_fapi`].
+/// method, JWKS, and DPoP binding. A provided FAPI profile enforces DPoP and
+/// an auth method — see [`effective_token_endpoint_auth_method`] for the
+/// forcing rule. A provided non-FAPI value clears the profile, JWKS, and
+/// DPoP binding of a client that was not already FAPI; downgrading a FAPI
+/// client is rejected upstream by [`validate_update_fapi`].
 pub(super) fn compute_fapi_update_fields<'a>(
     validated: &'a ValidatedUpdateApp<'_>,
     client: &'a OAuthClient,
 ) -> Result<FapiUpdateFields<'a>, AppValidationError> {
     let is_fapi = validated.is_fapi;
     let fapi_profile = effective_fapi_profile(validated, client);
-
-    // A FAPI→standard transition never reaches here: `validate_update_fapi`
-    // rejects it, because the client has no secret to fall back to.
-    let token_endpoint_auth_method = if is_fapi {
-        TokenEndpointAuthMethod::PrivateKeyJwt
-    } else {
-        client.token_endpoint_auth_method
-    };
+    let token_endpoint_auth_method = effective_token_endpoint_auth_method(validated, client);
 
     let jwks = if validated.jwks.is_some() {
         validated.jwks.as_ref()
@@ -571,14 +607,34 @@ pub(super) fn compute_fapi_update_fields<'a>(
     };
 
     // A `private_key_jwt` client authenticates with a key and has no secret to
-    // fall back on, so a result with neither `jwks` nor `jwks_uri` can never
-    // authenticate again and cannot be repaired through this endpoint. Refuse
-    // rather than persist it, whatever combination of fields produced it.
-    if token_endpoint_auth_method == TokenEndpointAuthMethod::PrivateKeyJwt
-        && jwks.is_none()
+    // fall back on; a `self_signed_tls_client_auth` client's certificate is
+    // carried in the JWKS's `x5c` member (RFC 8705 §2.2.2). Either way, a
+    // result with neither `jwks` nor `jwks_uri` can never authenticate again
+    // and cannot be repaired through this endpoint. Refuse rather than
+    // persist it, whatever combination of fields produced it.
+    if matches!(
+        token_endpoint_auth_method,
+        TokenEndpointAuthMethod::PrivateKeyJwt | TokenEndpointAuthMethod::SelfSignedTlsClientAuth
+    ) && jwks.is_none()
         && jwks_uri.is_none()
     {
-        return Err(AppValidationError::PrivateKeyJwtMissingJwks);
+        return Err(AppValidationError::AuthMethodMissingJwks);
+    }
+
+    // self_signed_tls_client_auth's certificate is carried by a key's `x5c`
+    // member; an inline JWKS with none anywhere would pass the presence
+    // check above but leave the client unable to ever complete mTLS
+    // authentication — see db::jwks_has_x5c. Applies to both a freshly
+    // submitted and a stored (pre-existing) inline JWKS, and regardless of
+    // FAPI status (this auth method exists for non-FAPI clients too) —
+    // this function runs on every update, unlike the FAPI-gated checks in
+    // `validate_update_fapi`. A remote jwks_uri can't be inspected
+    // synchronously, so this only guards the inline case.
+    if token_endpoint_auth_method == TokenEndpointAuthMethod::SelfSignedTlsClientAuth
+        && let Some(jwks) = jwks
+        && !crate::db::parse_jwks_set(jwks).is_ok_and(|set| jwks_has_x5c(&set))
+    {
+        return Err(AppValidationError::SelfSignedJwksMissingX5c);
     }
 
     Ok(FapiUpdateFields {
@@ -629,6 +685,14 @@ fn parse_jwks(jwks_json: &str) -> Result<serde_json::Value, AppValidationError> 
         .is_some_and(|k| k.is_array() && !k.as_array().is_some_and(|a| a.is_empty()))
     {
         return Err(AppValidationError::JwksMissingKeys);
+    }
+    // Reject a type-invalid member (e.g. "alg": true) through the same typed
+    // representation the RFC 7523 client-assertion verifier uses at runtime
+    // — see db::JwkSet. Otherwise the application would be created/updated
+    // here but permanently unable to authenticate once the runtime verifier
+    // fails to parse the same document.
+    if crate::db::parse_jwks_set(&val).is_err() {
+        return Err(AppValidationError::JwksInvalidKeyShape);
     }
     Ok(val)
 }
@@ -879,6 +943,36 @@ mod tests {
             .expect("client exists")
     }
 
+    /// A FAPI client whose stored JWKS predates the strict write-path shape
+    /// gate: its only key has a type-invalid `alg` (a boolean, not a
+    /// string), so it fails `parse_jwks_set` rather than merely lacking a
+    /// usable algorithm. Distinguishes "wrong algorithm" (`stale_jwks_fapi_client`)
+    /// from "malformed shape" as the reason the stored JWKS is unusable.
+    async fn type_invalid_shape_jwks_fapi_client(
+        state: &crate::AppState,
+        email: &str,
+    ) -> crate::db::OAuthClient {
+        let user = create_test_user(&state.store, email).await;
+        let jwks = serde_json::json!({"keys": [{"kty": "EC", "alg": true}]});
+        let created = create_test_client(
+            &state.store,
+            &user.id,
+            TestClientSpec {
+                token_endpoint_auth_method: Some(TokenEndpointAuthMethod::PrivateKeyJwt),
+                jwks: TestJwks::Custom(jwks),
+                dpop_bound_access_tokens: true,
+                fapi_profile: Some(FapiProfile::Fapi2Security),
+                with_secret: false,
+                ..Default::default()
+            },
+        )
+        .await;
+        crate::db::get_oauth_client_by_id(&state.store, &created.app_id)
+            .await
+            .expect("db lookup")
+            .expect("client exists")
+    }
+
     // A non-FAPI client that authenticates with `private_key_jwt` and carries
     // JWKS — the shape produced by authenticated dynamic registration (RFC
     // 7591) when the caller supplies `token_endpoint_auth_method=private_key_jwt`
@@ -891,6 +985,35 @@ mod tests {
             TestClientSpec {
                 token_endpoint_auth_method: Some(TokenEndpointAuthMethod::PrivateKeyJwt),
                 jwks: TestJwks::Custom(serde_json::json!({"keys": [{"kty": "EC"}]})),
+                fapi_profile: None,
+                with_secret: false,
+                ..Default::default()
+            },
+        )
+        .await;
+        crate::db::get_oauth_client_by_id(&state.store, &created.app_id)
+            .await
+            .expect("db lookup")
+            .expect("client exists")
+    }
+
+    // A non-FAPI client authenticating with `self_signed_tls_client_auth` —
+    // the shape produced by RFC 7591 dynamic registration when the caller
+    // supplies that auth method plus a JWKS carrying its certificate,
+    // without requesting a FAPI profile.
+    async fn non_fapi_self_signed_client(
+        state: &crate::AppState,
+        email: &str,
+    ) -> crate::db::OAuthClient {
+        let user = create_test_user(&state.store, email).await;
+        let created = create_test_client(
+            &state.store,
+            &user.id,
+            TestClientSpec {
+                token_endpoint_auth_method: Some(TokenEndpointAuthMethod::SelfSignedTlsClientAuth),
+                jwks: TestJwks::Custom(
+                    serde_json::json!({"keys": [{"kty": "RSA", "x5c": ["ZmFrZS1jZXJ0"]}]}),
+                ),
                 fapi_profile: None,
                 with_secret: false,
                 ..Default::default()
@@ -1288,6 +1411,51 @@ mod tests {
         );
     }
 
+    // An explicit `fapi_profile: fapi2_security` re-declaration must not
+    // flip a FAPI mTLS client's auth method to private_key_jwt: that would
+    // silently end mTLS authentication for a method RFC 7592 otherwise
+    // treats as immutable. Uses the same RS256-only x5c JWKS as the
+    // metadata-only case above to also prove the algorithm-usability check
+    // (private_key_jwt-only) still doesn't fire.
+    #[tokio::test]
+    async fn fapi_reconfirm_preserves_mtls_auth_method_and_skips_algorithm_check() {
+        let state = test_app_state().await;
+        let user = create_test_user(&state.store, "fapi-mtls-reconfirm@example.com").await;
+        let created = create_test_client(
+            &state.store,
+            &user.id,
+            TestClientSpec {
+                token_endpoint_auth_method: Some(TokenEndpointAuthMethod::SelfSignedTlsClientAuth),
+                jwks: TestJwks::Custom(
+                    serde_json::json!({"keys": [{"kty": "RSA", "alg": "RS256", "x5c": ["ZmFrZS1jZXJ0"]}]}),
+                ),
+                dpop_bound_access_tokens: true,
+                fapi_profile: Some(FapiProfile::Fapi2Security),
+                with_secret: false,
+                ..Default::default()
+            },
+        )
+        .await;
+        let client = crate::db::get_oauth_client_by_id(&state.store, &created.app_id)
+            .await
+            .expect("db lookup")
+            .expect("client exists");
+
+        let validated = update_input(Some("fapi2_security"));
+        validate_update_fapi(&validated, &client).expect(
+            "re-declaring fapi2_security on a FAPI mTLS client must not trigger the \
+             private_key_jwt-only algorithm guard",
+        );
+
+        let fields = compute_fapi_update_fields(&validated, &client).expect("merge should succeed");
+        assert_eq!(
+            fields.token_endpoint_auth_method,
+            TokenEndpointAuthMethod::SelfSignedTlsClientAuth,
+            "re-declaring the FAPI profile must preserve the client's mTLS auth method, \
+             not force it to private_key_jwt"
+        );
+    }
+
     // Reverse edge: a request that omits `fapi_profile` AND `jwks` still
     // validates the STORED jwks, because the client remains FAPI regardless.
     // Simulates a client whose stored JWKS predates this guard (e.g. created
@@ -1301,6 +1469,25 @@ mod tests {
         let validated = update_input(None);
         let err = validate_update_fapi(&validated, &client)
             .expect_err("a metadata-only update must surface a pre-existing unusable stored JWKS");
+        assert_eq!(err.code(), "fapi_jwks_algorithm_unsupported");
+    }
+
+    // Same reverse edge, but the stored JWKS predates the strict shape gate
+    // (item 1) rather than merely using the wrong algorithm: a type-invalid
+    // member (a boolean `alg`) fails `parse_jwks_set` entirely. The
+    // fallback in `validate_update_fapi` treats a parse failure as "no
+    // usable key" (documented on `db::parse_jwks_set`), so this collapses
+    // to the same `fapi_jwks_algorithm_unsupported` error as a wrong
+    // algorithm, without panicking.
+    #[tokio::test]
+    async fn fapi_metadata_only_update_rejected_when_stored_jwks_has_type_invalid_shape() {
+        let state = test_app_state().await;
+        let client =
+            type_invalid_shape_jwks_fapi_client(&state, "fapi-stale-shape@example.com").await;
+
+        let validated = update_input(None);
+        let err = validate_update_fapi(&validated, &client)
+            .expect_err("a metadata-only update must surface a pre-existing malformed stored JWKS");
         assert_eq!(err.code(), "fapi_jwks_algorithm_unsupported");
     }
 
@@ -1398,38 +1585,47 @@ mod tests {
         .expect("an OKP/EdDSA key must pass FAPI creation");
     }
 
+    /// Parses a test-fixture JWKS through the same typed representation the
+    /// function under test now requires.
+    fn jwk_set(json: serde_json::Value) -> crate::db::JwkSet {
+        crate::db::parse_jwks_set(&json).expect("test fixture JWKS must parse")
+    }
+
     #[test]
     fn jwks_has_fapi_allowed_key_covers_alg_and_kty_cases() {
         let no_alg = serde_json::json!({"keys": [{"kty": "EC"}]});
-        assert!(jwks_has_fapi_allowed_key(&no_alg), "no alg field survives");
+        assert!(
+            jwks_has_fapi_allowed_key(&jwk_set(no_alg)),
+            "no alg field survives"
+        );
 
         // The nuance that motivated this guard: an RSA key normally used for
         // RS256 survives if it declares no alg constraint, because it can then
         // be presented with PS256 instead.
         let unpinned_rsa = serde_json::json!({"keys": [{"kty": "RSA"}]});
         assert!(
-            jwks_has_fapi_allowed_key(&unpinned_rsa),
+            jwks_has_fapi_allowed_key(&jwk_set(unpinned_rsa)),
             "an RSA key with no alg field survives (usable with PS256)"
         );
 
         let es256 = serde_json::json!({"keys": [{"kty": "EC", "alg": "ES256"}]});
-        assert!(jwks_has_fapi_allowed_key(&es256));
+        assert!(jwks_has_fapi_allowed_key(&jwk_set(es256)));
 
         let ps256 = serde_json::json!({"keys": [{"kty": "RSA", "alg": "PS256"}]});
-        assert!(jwks_has_fapi_allowed_key(&ps256));
+        assert!(jwks_has_fapi_allowed_key(&jwk_set(ps256)));
 
         let eddsa = serde_json::json!({"keys": [{"kty": "OKP", "alg": "EdDSA"}]});
-        assert!(jwks_has_fapi_allowed_key(&eddsa));
+        assert!(jwks_has_fapi_allowed_key(&jwk_set(eddsa)));
 
         let rs256_only = serde_json::json!({"keys": [{"kty": "RSA", "alg": "RS256"}]});
-        assert!(!jwks_has_fapi_allowed_key(&rs256_only));
+        assert!(!jwks_has_fapi_allowed_key(&jwk_set(rs256_only)));
 
         // A kty the runtime matcher never selects for ES256/PS256/EdDSA (e.g. a
         // symmetric "oct" key) must not survive just because it omits alg —
         // it's unmatchable at runtime regardless.
         let unmatchable_kty_no_alg = serde_json::json!({"keys": [{"kty": "oct"}]});
         assert!(
-            !jwks_has_fapi_allowed_key(&unmatchable_kty_no_alg),
+            !jwks_has_fapi_allowed_key(&jwk_set(unmatchable_kty_no_alg)),
             "a kty outside EC/RSA/OKP must not survive on a missing alg"
         );
 
@@ -1437,7 +1633,7 @@ mod tests {
             "keys": [{"kty": "RSA", "alg": "RS256"}, {"kty": "EC", "alg": "ES256"}]
         });
         assert!(
-            jwks_has_fapi_allowed_key(&mixed),
+            jwks_has_fapi_allowed_key(&jwk_set(mixed)),
             "one usable key is enough"
         );
 
@@ -1447,7 +1643,7 @@ mod tests {
             "keys": [{"kty": "EC", "alg": "ES256", "use": "enc"}]
         });
         assert!(
-            !jwks_has_fapi_allowed_key(&enc_only),
+            !jwks_has_fapi_allowed_key(&jwk_set(enc_only)),
             "a use: enc key must not survive even with an allowed alg"
         );
 
@@ -1455,15 +1651,35 @@ mod tests {
             "keys": [{"kty": "EC", "alg": "ES256", "use": "sig"}]
         });
         assert!(
-            jwks_has_fapi_allowed_key(&explicit_sig),
+            jwks_has_fapi_allowed_key(&jwk_set(explicit_sig)),
             "an explicit use: sig key survives"
         );
 
         let empty = serde_json::json!({"keys": []});
-        assert!(!jwks_has_fapi_allowed_key(&empty));
+        assert!(!jwks_has_fapi_allowed_key(&jwk_set(empty)));
+    }
 
+    #[test]
+    fn jwks_missing_keys_field_fails_to_parse() {
+        // RFC 7517 §5 (<https://www.rfc-editor.org/rfc/rfc7517#section-5>):
+        // "A JWK Set is a JSON object that represents a set of JWKs. The
+        // JSON object MUST have a 'keys' member, with its value being an
+        // array of JWKs." The typed parse rejects an object that omits it,
+        // rather than the previous loose check silently treating it as "no
+        // usable key."
         let no_keys_field = serde_json::json!({});
-        assert!(!jwks_has_fapi_allowed_key(&no_keys_field));
+        assert!(crate::db::parse_jwks_set(&no_keys_field).is_err());
+    }
+
+    #[test]
+    fn jwks_with_type_invalid_member_fails_to_parse() {
+        // A non-string "alg"/"use" must fail the typed parse instead of
+        // being silently read as absent — the bug class this guard closes.
+        let bad_alg = serde_json::json!({"keys": [{"kty": "EC", "alg": true}]});
+        assert!(crate::db::parse_jwks_set(&bad_alg).is_err());
+
+        let bad_use = serde_json::json!({"keys": [{"kty": "EC", "use": 123}]});
+        assert!(crate::db::parse_jwks_set(&bad_use).is_err());
     }
 
     // ========================================================================
@@ -1556,7 +1772,56 @@ mod tests {
 
         let err = compute_fapi_update_fields(&validated, &client)
             .expect_err("must refuse to leave a private_key_jwt client without keys");
-        assert!(matches!(err, AppValidationError::PrivateKeyJwtMissingJwks));
+        assert!(matches!(err, AppValidationError::AuthMethodMissingJwks));
+    }
+
+    // Same as above for `self_signed_tls_client_auth`: its certificate is
+    // carried in the JWKS's x5c member (RFC 8705 §2.2.2), so clearing it
+    // leaves the client just as unable to authenticate. A client registered
+    // dynamically (RFC 7591) with this auth method and no FAPI profile can
+    // reach the admin update path, where nothing but this guard stops a bare
+    // `fapi_profile: "none"` re-declaration from silently dropping its only
+    // key material — `validate_update_fapi` returns early for non-FAPI
+    // clients before any JWKS-presence check runs.
+    #[tokio::test]
+    async fn explicit_none_is_refused_when_it_would_strip_a_self_signed_client_of_keys() {
+        let state = test_app_state().await;
+        let client = non_fapi_self_signed_client(&state, "self-signed-clear@example.com").await;
+        assert!(client.jwks.is_some(), "client must start with JWKS");
+
+        let validated = update_input(Some("none"));
+        validate_update_fapi(&validated, &client).expect("non-FAPI -> non-FAPI is allowed");
+
+        let err = compute_fapi_update_fields(&validated, &client)
+            .expect_err("must refuse to leave a self_signed_tls_client_auth client without keys");
+        assert!(matches!(err, AppValidationError::AuthMethodMissingJwks));
+    }
+
+    // A JWKS-only update can swap in a JWKS that still satisfies the bare
+    // presence check but carries no x5c anywhere — `jwks_has_x5c` must catch
+    // this the same way the FAPI algorithm-usability check catches an
+    // RS256-only JWKS for private_key_jwt.
+    #[tokio::test]
+    async fn self_signed_jwks_only_update_rejected_when_new_jwks_has_no_x5c() {
+        let state = test_app_state().await;
+        let client = non_fapi_self_signed_client(&state, "self-signed-swap@example.com").await;
+
+        let jwks = serde_json::json!({"keys": [{"kty": "RSA", "n": "n", "e": "AQAB"}]}).to_string();
+        let validated = validate_update_format(UpdateAppInput {
+            redirect_uris: None,
+            resource_uris: None,
+            post_logout_redirect_uris: None,
+            access_scope: None,
+            fapi_profile: None,
+            jwks: Some(&jwks),
+            jwks_uri: None,
+        })
+        .expect("valid update input");
+
+        let err = compute_fapi_update_fields(&validated, &client)
+            .expect_err("a certificate-less JWKS must be rejected for self_signed_tls_client_auth");
+        assert!(matches!(err, AppValidationError::SelfSignedJwksMissingX5c));
+        assert_eq!(err.code(), "self_signed_jwks_missing_x5c");
     }
 
     // Leaving the FAPI profile stops mandating DPoP but must not silently turn
@@ -1698,6 +1963,30 @@ mod tests {
         }
     }
 
+    // A type-invalid JWK member (e.g. a boolean "alg") must be rejected at
+    // creation, through the same typed representation the RFC 7523
+    // client-assertion verifier uses at runtime — otherwise the application
+    // is created but can never authenticate.
+    #[test]
+    fn create_rejects_jwks_with_type_invalid_key_member() {
+        let redirect_uris = vec!["https://example.com/cb".to_string()];
+        let jwks = serde_json::json!({"keys": [{"kty": "EC", "alg": true}]}).to_string();
+        let err = validate_create_application(CreateAppInput {
+            name: "App",
+            application_type: "web",
+            redirect_uris: &redirect_uris,
+            resource_uris: &[],
+            post_logout_redirect_uris: None,
+            access_scope: None,
+            fapi_profile: None,
+            jwks: Some(&jwks),
+            jwks_uri: None,
+        })
+        .expect_err("type-invalid JWK member must be rejected");
+        assert!(matches!(err, AppValidationError::JwksInvalidKeyShape));
+        assert_eq!(err.code(), "invalid_jwks");
+    }
+
     fn base_update_input<'a>(
         access_scope: Option<&'a str>,
         fapi_profile: Option<&'a str>,
@@ -1734,5 +2023,22 @@ mod tests {
         let err = validate_update_format(base_update_input(None, Some("fapi1_adv")))
             .expect_err("invalid profile must be rejected");
         assert_eq!(err.code(), "invalid_fapi_profile");
+    }
+
+    #[test]
+    fn update_rejects_jwks_with_type_invalid_key_member() {
+        let jwks = serde_json::json!({"keys": [{"kty": "EC", "use": 123}]}).to_string();
+        let err = validate_update_format(UpdateAppInput {
+            redirect_uris: None,
+            resource_uris: None,
+            post_logout_redirect_uris: None,
+            access_scope: None,
+            fapi_profile: None,
+            jwks: Some(&jwks),
+            jwks_uri: None,
+        })
+        .expect_err("type-invalid JWK member must be rejected");
+        assert!(matches!(err, AppValidationError::JwksInvalidKeyShape));
+        assert_eq!(err.code(), "invalid_jwks");
     }
 }

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7591.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7591.rs
@@ -1199,6 +1199,191 @@ async fn test_rfc7591_accepts_fapi_registration_with_jwks_uri_only() {
 }
 
 // ========================================================================
+// RFC 8705 §2.2.2: self_signed_tls_client_auth's certificate is carried in
+// the JWKS's x5c member, so — unlike tls_client_auth, which authenticates
+// via PKI subject DN/SAN — it needs key material to authenticate at all,
+// FAPI or not.
+// ========================================================================
+
+#[tokio::test]
+async fn test_rfc7591_rejects_self_signed_registration_without_jwks() {
+    let (app, state) = test_app().await;
+    let auth = bearer_token_unique(&state, "self-signed-no-jwks").await;
+
+    let body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "token_endpoint_auth_method": "self_signed_tls_client_auth",
+    });
+
+    let (status, body) = http_post_json(
+        &app,
+        "/oauth/register",
+        &body.to_string(),
+        &[("Authorization", &auth)],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "self_signed_tls_client_auth without jwks or jwks_uri must be rejected: {body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(json["error"], "invalid_client_metadata");
+}
+
+#[tokio::test]
+async fn test_rfc7591_accepts_self_signed_registration_with_jwks_uri_only() {
+    let (app, state) = test_app().await;
+    let auth = bearer_token_unique(&state, "self-signed-jwks-uri").await;
+
+    let body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "token_endpoint_auth_method": "self_signed_tls_client_auth",
+        "jwks_uri": "https://example.com/.well-known/jwks.json"
+    });
+
+    let (status, body) = http_post_json(
+        &app,
+        "/oauth/register",
+        &body.to_string(),
+        &[("Authorization", &auth)],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "self_signed_tls_client_auth with jwks_uri only must be accepted: {body}"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc7591_rejects_self_signed_registration_with_certificate_less_jwks() {
+    // `jwks_has_x5c`: a self-signed client's inline JWKS carrying no x5c
+    // passes the bare presence check but leaves the client unable to ever
+    // complete mTLS authentication — verify_self_signed_tls_client_auth
+    // (services/oidc/mtls.rs) matches only on x5c.
+    let (app, state) = test_app().await;
+    let auth = bearer_token_unique(&state, "self-signed-no-x5c").await;
+
+    let body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "token_endpoint_auth_method": "self_signed_tls_client_auth",
+        "jwks": {"keys": [{"kty": "RSA", "n": "n", "e": "AQAB"}]}
+    });
+
+    let (status, body) = http_post_json(
+        &app,
+        "/oauth/register",
+        &body.to_string(),
+        &[("Authorization", &auth)],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "a certificate-less JWKS must be rejected for self_signed_tls_client_auth: {body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(json["error"], "invalid_client_metadata");
+}
+
+#[tokio::test]
+async fn test_rfc7591_accepts_self_signed_registration_with_x5c_jwks() {
+    let (app, state) = test_app().await;
+    let auth = bearer_token_unique(&state, "self-signed-with-x5c").await;
+
+    let cert_der = make_test_cert_der("self-signed-with-x5c-client");
+    let x5c_b64 = base64::engine::general_purpose::STANDARD.encode(&cert_der);
+    let body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "token_endpoint_auth_method": "self_signed_tls_client_auth",
+        "jwks": {"keys": [{"kty": "RSA", "x5c": [x5c_b64]}]}
+    });
+
+    let (status, body) = http_post_json(
+        &app,
+        "/oauth/register",
+        &body.to_string(),
+        &[("Authorization", &auth)],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "an x5c-bearing JWKS must be accepted for self_signed_tls_client_auth: {body}"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc7591_accepts_tls_client_auth_registration_without_jwks() {
+    // tls_client_auth authenticates via PKI subject DN/SAN, not a JWKS — it
+    // must remain unaffected by the self_signed_tls_client_auth requirement.
+    let (app, state) = test_app().await;
+    let auth = bearer_token_unique(&state, "tls-client-auth-no-jwks").await;
+
+    let body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "token_endpoint_auth_method": "tls_client_auth",
+        "tls_client_auth_subject_dn": "CN=test-client"
+    });
+
+    let (status, body) = http_post_json(
+        &app,
+        "/oauth/register",
+        &body.to_string(),
+        &[("Authorization", &auth)],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "tls_client_auth without a JWKS must remain accepted: {body}"
+    );
+}
+
+// ========================================================================
+// JWKS write-path shape validation — a type-invalid member (e.g. a boolean
+// "alg") must be rejected at registration through the same typed
+// representation the RFC 7523 client-assertion verifier uses at runtime,
+// rather than silently accepted and left permanently unauthenticatable.
+// ========================================================================
+
+#[tokio::test]
+async fn test_rfc7591_rejects_jwks_with_type_invalid_key_member() {
+    let (app, state) = test_app().await;
+    let auth = bearer_token_unique(&state, "type-invalid-jwks").await;
+
+    let body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "token_endpoint_auth_method": "private_key_jwt",
+        "jwks": {
+            "keys": [{"kty": "EC", "alg": true}]
+        }
+    });
+
+    let (status, body) = http_post_json(
+        &app,
+        "/oauth/register",
+        &body.to_string(),
+        &[("Authorization", &auth)],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "a type-invalid JWK member must be rejected: {body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(json["error"], "invalid_client_metadata");
+}
+
+// ========================================================================
 // RFC 7591 Section 2: Unknown fields MUST be ignored
 // ========================================================================
 

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7592.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7592.rs
@@ -320,6 +320,141 @@ async fn test_rfc7592_put_accepts_rs256_alg_pinned_x5c_jwks_for_fapi_mtls_client
 }
 
 // =========================================================================
+// RFC 8705 §2.2.2: self_signed_tls_client_auth's certificate is carried in
+// the JWKS's x5c member, so a PUT that clears it must be rejected even for
+// a non-FAPI client — the earlier test above only covered the FAPI case.
+// =========================================================================
+
+#[tokio::test]
+async fn test_rfc7592_put_rejects_non_fapi_self_signed_client_clearing_jwks() {
+    let (app, _state) = test_app().await;
+    let cert_der = make_test_cert_der("non-fapi-self-signed-put-client");
+    let x5c_b64 = base64::engine::general_purpose::STANDARD.encode(&cert_der);
+    let body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "token_endpoint_auth_method": "self_signed_tls_client_auth",
+        "jwks": {"keys": [{"kty": "RSA", "x5c": [x5c_b64]}]}
+    });
+    let (status, body) = http_post_json(&app, "/oauth/register", &body.to_string(), &[]).await;
+    assert_eq!(status, StatusCode::CREATED, "Registration failed: {body}");
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let client_id = json["client_id"].as_str().expect("client_id").to_string();
+    let token = json["registration_access_token"]
+        .as_str()
+        .expect("registration_access_token")
+        .to_string();
+
+    let update_body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"]
+    });
+
+    let (status, body) = http_request(
+        &app,
+        "PUT",
+        &format!("/oauth/register/{client_id}"),
+        Some(update_body.to_string()),
+        &[
+            ("Authorization", &format!("Bearer {token}")),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "a non-FAPI self_signed_tls_client_auth client's PUT must not be able to clear its \
+         key material: {body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(json["error"], "invalid_client_metadata");
+}
+
+#[tokio::test]
+async fn test_rfc7592_put_rejects_self_signed_client_swapping_in_certificate_less_jwks() {
+    // `jwks_has_x5c`: a PUT can replace the inline JWKS with one that still
+    // satisfies the bare presence check but carries no x5c anywhere — must
+    // be rejected the same as clearing it outright.
+    let (app, _state) = test_app().await;
+    let cert_der = make_test_cert_der("self-signed-put-swap-client");
+    let x5c_b64 = base64::engine::general_purpose::STANDARD.encode(&cert_der);
+    let body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "token_endpoint_auth_method": "self_signed_tls_client_auth",
+        "jwks": {"keys": [{"kty": "RSA", "x5c": [x5c_b64]}]}
+    });
+    let (status, body) = http_post_json(&app, "/oauth/register", &body.to_string(), &[]).await;
+    assert_eq!(status, StatusCode::CREATED, "Registration failed: {body}");
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let client_id = json["client_id"].as_str().expect("client_id").to_string();
+    let token = json["registration_access_token"]
+        .as_str()
+        .expect("registration_access_token")
+        .to_string();
+
+    let update_body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "jwks": {"keys": [{"kty": "RSA", "n": "n", "e": "AQAB"}]}
+    });
+
+    let (status, body) = http_request(
+        &app,
+        "PUT",
+        &format!("/oauth/register/{client_id}"),
+        Some(update_body.to_string()),
+        &[
+            ("Authorization", &format!("Bearer {token}")),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "a certificate-less JWKS must be rejected on PUT for self_signed_tls_client_auth: {body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(json["error"], "invalid_client_metadata");
+}
+
+// =========================================================================
+// JWKS write-path shape validation — a type-invalid member must be rejected
+// on PUT through the same typed representation registration uses.
+// =========================================================================
+
+#[tokio::test]
+async fn test_rfc7592_put_rejects_jwks_with_type_invalid_key_member() {
+    let (app, _state) = test_app().await;
+    let (client_id, token) = register_dynamic_client(&app).await;
+
+    let update_body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "jwks": {"keys": [{"kty": "EC", "use": 123}]}
+    });
+
+    let (status, body) = http_request(
+        &app,
+        "PUT",
+        &format!("/oauth/register/{client_id}"),
+        Some(update_body.to_string()),
+        &[
+            ("Authorization", &format!("Bearer {token}")),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "a type-invalid JWK member must be rejected: {body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(json["error"], "invalid_client_metadata");
+}
+
+// =========================================================================
 // PUT /oauth/register/:client_id — Update Client Configuration
 // =========================================================================
 

--- a/crates/vouch-server/src/services/oidc/fapi.rs
+++ b/crates/vouch-server/src/services/oidc/fapi.rs
@@ -141,7 +141,9 @@ pub fn validate_fapi_algorithm(client: &OAuthClient, algorithm: &str) -> Service
 
 /// Validate that the client authentication method is allowed for FAPI 2.0.
 ///
-/// FAPI 2.0 Section 5.3.2.1 requires `private_key_jwt` (mTLS support is deferred).
+/// FAPI 2.0 Section 5.3.2.1 requires `private_key_jwt` or mTLS
+/// (`tls_client_auth`, `self_signed_tls_client_auth`) —
+/// see [`TokenEndpointAuthMethod::is_fapi_compatible`].
 ///
 /// Non-FAPI clients pass validation unconditionally.
 ///
@@ -153,7 +155,7 @@ pub fn validate_fapi_algorithm(client: &OAuthClient, algorithm: &str) -> Service
 /// # Errors
 ///
 /// Returns `ServiceError::OAuth` with `invalid_client` if the method is not
-/// `private_key_jwt`.
+/// FAPI-compatible.
 pub fn validate_fapi_client_auth_method(
     client: &OAuthClient,
     auth_method: TokenEndpointAuthMethod,
@@ -162,18 +164,16 @@ pub fn validate_fapi_client_auth_method(
         return Ok(());
     }
 
-    match auth_method {
-        TokenEndpointAuthMethod::PrivateKeyJwt
-        | TokenEndpointAuthMethod::TlsClientAuth
-        | TokenEndpointAuthMethod::SelfSignedTlsClientAuth => Ok(()),
-        _ => Err(ServiceError::oauth(
-            OAuthErrorCode::InvalidClient,
-            format!(
-                "FAPI 2.0 requires private_key_jwt or mTLS authentication, got '{}'",
-                auth_method.as_str()
-            ),
-        )),
+    if auth_method.is_fapi_compatible() {
+        return Ok(());
     }
+    Err(ServiceError::oauth(
+        OAuthErrorCode::InvalidClient,
+        format!(
+            "FAPI 2.0 requires private_key_jwt or mTLS authentication, got '{}'",
+            auth_method.as_str()
+        ),
+    ))
 }
 
 /// Return the clock skew tolerance for a client.

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/jwks.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/jwks.rs
@@ -7,45 +7,8 @@
 use super::validate::JwtAssertionHeader;
 use crate::db::documents::jwks_cache::JwksCacheDoc;
 use crate::db::store::DocumentStore;
+use crate::db::{JwkEntry, JwkSet};
 use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
-use serde::Deserialize;
-
-/// A JSON Web Key Set (RFC 7517 Section 5).
-#[derive(Debug, Deserialize)]
-pub struct JwkSet {
-    /// The keys in the set.
-    pub keys: Vec<JwkEntry>,
-}
-
-/// A single JWK entry in a JWKS.
-#[derive(Debug, Deserialize)]
-pub struct JwkEntry {
-    /// Key type (e.g., "EC", "RSA", "OKP").
-    pub kty: String,
-    /// Key ID (optional).
-    #[serde(default)]
-    pub kid: Option<String>,
-    /// Algorithm (optional).
-    #[serde(default)]
-    pub alg: Option<String>,
-    /// Key use (optional, e.g., "sig").
-    #[serde(rename = "use", default)]
-    pub use_: Option<String>,
-
-    // EC key components
-    #[serde(default)]
-    pub crv: Option<String>,
-    #[serde(default)]
-    pub x: Option<String>,
-    #[serde(default)]
-    pub y: Option<String>,
-
-    // RSA key components
-    #[serde(default)]
-    pub n: Option<String>,
-    #[serde(default)]
-    pub e: Option<String>,
-}
 
 /// Resolve the JWKS for a client — from inline `jwks` or fetched `jwks_uri`.
 ///
@@ -109,7 +72,7 @@ async fn resolve_jwks_uri(
 
 /// Parse a JWKS from a `serde_json::Value`.
 fn parse_jwks_value(value: &serde_json::Value) -> ServiceResult<JwkSet> {
-    serde_json::from_value(value.clone()).map_err(|e| {
+    crate::db::parse_jwks_set(value).map_err(|e| {
         tracing::debug!("Failed to parse JWKS value: {e}");
         ServiceError::oauth(OAuthErrorCode::InvalidClient, "Invalid JWKS format")
     })
@@ -355,6 +318,7 @@ mod tests {
             y: Some(EC_Y.to_string()),
             n: None,
             e: None,
+            x5c: None,
         }
     }
 
@@ -369,6 +333,7 @@ mod tests {
             y: None,
             n: Some(RSA_N.to_string()),
             e: Some(RSA_E.to_string()),
+            x5c: None,
         }
     }
 
@@ -386,6 +351,7 @@ mod tests {
             y: None,
             n: None,
             e: None,
+            x5c: None,
         }
     }
 

--- a/crates/vouch-server/src/services/oidc/registration.rs
+++ b/crates/vouch-server/src/services/oidc/registration.rs
@@ -22,7 +22,7 @@ use crate::crypto::{generate_random_bytes, hash_token};
 use crate::db::{
     self, CreateOAuthClientParams, FapiProfile, JwsAlgorithm, OAuthClient, OAuthClientType,
     OAuthEventType, RegistrationSource, TokenEndpointAuthMethod, UpdateClientRegistrationParams,
-    jwks_has_fapi_allowed_key,
+    jwks_has_fapi_allowed_key, jwks_has_x5c,
 };
 use crate::error::{OAuthErrorCode, ServiceError};
 use crate::services::oidc::grant_type::OAuthGrantType;
@@ -370,13 +370,7 @@ pub async fn register_client(
     let is_fapi2 = dpop_bound || cert_bound;
     let fapi_profile = if is_fapi2 {
         // Require FAPI-compliant auth method
-        let is_fapi_auth = matches!(
-            jwks_auth.auth_method,
-            TokenEndpointAuthMethod::PrivateKeyJwt
-                | TokenEndpointAuthMethod::TlsClientAuth
-                | TokenEndpointAuthMethod::SelfSignedTlsClientAuth
-        );
-        if !is_fapi_auth {
+        if !jwks_auth.auth_method.is_fapi_compatible() {
             return Err(ServiceError::oauth(
                 OAuthErrorCode::InvalidClientMetadata,
                 "FAPI 2.0 requires token_endpoint_auth_method \
@@ -400,7 +394,7 @@ pub async fn register_client(
         // check does not apply to them.
         if jwks_auth.auth_method == TokenEndpointAuthMethod::PrivateKeyJwt
             && let Some(ref jwks) = jwks_auth.jwks_value
-            && !jwks_has_fapi_allowed_key(jwks)
+            && !db::parse_jwks_set(jwks).is_ok_and(|set| jwks_has_fapi_allowed_key(&set))
         {
             return Err(ServiceError::oauth(
                 OAuthErrorCode::InvalidClientMetadata,
@@ -1014,15 +1008,28 @@ fn validate_jwks_fields(
             "jwks and jwks_uri are mutually exclusive",
         ));
     }
-    if let Some(jwks) = jwks
-        && !jwks
+    if let Some(jwks) = jwks {
+        if !jwks
             .get("keys")
             .is_some_and(|k| k.is_array() && !k.as_array().is_some_and(|a| a.is_empty()))
-    {
-        return Err(ServiceError::oauth(
-            OAuthErrorCode::InvalidClientMetadata,
-            "jwks must be a JSON object with a non-empty \"keys\" array",
-        ));
+        {
+            return Err(ServiceError::oauth(
+                OAuthErrorCode::InvalidClientMetadata,
+                "jwks must be a JSON object with a non-empty \"keys\" array",
+            ));
+        }
+        // Reject a JWKS with a type-invalid member (e.g. "alg": true) at
+        // submission time, through the same typed representation the RFC
+        // 7523 client-assertion verifier uses at runtime — see
+        // db::JwkSet. Otherwise the client would be accepted here but
+        // permanently unable to authenticate once the runtime verifier
+        // fails to parse the same document.
+        if db::parse_jwks_set(jwks).is_err() {
+            return Err(ServiceError::oauth(
+                OAuthErrorCode::InvalidClientMetadata,
+                "jwks contains a key with an invalid field type",
+            ));
+        }
     }
     if let Some(uri) = jwks_uri {
         match url::Url::parse(uri) {
@@ -1055,13 +1062,36 @@ fn validate_jwks_and_auth_method(
         )
     })?;
 
-    if auth_method == TokenEndpointAuthMethod::PrivateKeyJwt
-        && jwks_value.is_none()
+    // private_key_jwt authenticates with a client-assertion signing key, and
+    // self_signed_tls_client_auth's certificate is carried in the JWKS's
+    // `x5c` member (RFC 8705 §2.2.2) — both need key material to
+    // authenticate at all. tls_client_auth authenticates via PKI subject
+    // DN/SAN instead, so it needs none.
+    if matches!(
+        auth_method,
+        TokenEndpointAuthMethod::PrivateKeyJwt | TokenEndpointAuthMethod::SelfSignedTlsClientAuth
+    ) && jwks_value.is_none()
         && jwks_uri.is_none()
     {
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidClientMetadata,
-            "private_key_jwt requires jwks or jwks_uri",
+            "private_key_jwt and self_signed_tls_client_auth require jwks or jwks_uri",
+        ));
+    }
+
+    // self_signed_tls_client_auth's certificate is carried by a key's `x5c`
+    // member; an inline JWKS with none anywhere would pass the presence
+    // check above but leave the client unable to ever complete mTLS
+    // authentication — see db::jwks_has_x5c. A remote jwks_uri can't be
+    // inspected synchronously, so this only guards the inline case, same as
+    // the FAPI algorithm-usability check.
+    if auth_method == TokenEndpointAuthMethod::SelfSignedTlsClientAuth
+        && let Some(ref jwks) = jwks_value
+        && !db::parse_jwks_set(jwks).is_ok_and(|set| jwks_has_x5c(&set))
+    {
+        return Err(ServiceError::oauth(
+            OAuthErrorCode::InvalidClientMetadata,
+            "self_signed_tls_client_auth requires a JWKS key with an x5c certificate",
         ));
     }
 
@@ -1257,19 +1287,44 @@ pub async fn update_client_configuration(
     // PUT is a full replacement, so re-check the auth-method/JWKS
     // relationship enforced at initial registration against the client's
     // (immutable) registered auth method and FAPI profile. A private_key_jwt
-    // client (FAPI or not) needs key material to authenticate at all; a FAPI
-    // 2.0 client of any auth method needs it too — register_client requires
-    // jwks/jwks_uri for every FAPI client, not just private_key_jwt ones
-    // (RFC 7592 §2.2: omitted fields are treated as cleared, so a PUT that
-    // drops both would otherwise silently strip a client's only key material).
+    // or self_signed_tls_client_auth client (FAPI or not) needs key material
+    // to authenticate at all — the former for client-assertion signing keys,
+    // the latter for its certificate, carried in the JWKS's `x5c` member
+    // (RFC 8705 §2.2.2). A FAPI 2.0 client of any auth method needs it too —
+    // register_client requires jwks/jwks_uri for every FAPI client, not just
+    // these two (RFC 7592 §2.2: omitted fields are treated as cleared, so a
+    // PUT that drops both would otherwise silently strip a client's only key
+    // material).
     if (client.is_fapi()
-        || client.token_endpoint_auth_method == TokenEndpointAuthMethod::PrivateKeyJwt)
+        || matches!(
+            client.token_endpoint_auth_method,
+            TokenEndpointAuthMethod::PrivateKeyJwt
+                | TokenEndpointAuthMethod::SelfSignedTlsClientAuth
+        ))
         && mutable_request.jwks.is_none()
         && mutable_request.jwks_uri.is_none()
     {
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidClientMetadata,
-            "FAPI 2.0 or private_key_jwt requires jwks or jwks_uri",
+            "FAPI 2.0, private_key_jwt, or self_signed_tls_client_auth requires jwks or jwks_uri",
+        ));
+    }
+
+    // self_signed_tls_client_auth's certificate is carried by a key's `x5c`
+    // member (RFC 8705 §2.2.2 describes this representation); an inline JWKS
+    // replacing the client's key material with none would pass the presence
+    // check above but leave the client unable to ever complete mTLS
+    // authentication again — see db::jwks_has_x5c. Applies regardless of
+    // FAPI status, unlike the algorithm-usability check below (this auth
+    // method exists for non-FAPI clients too). A remote jwks_uri can't be
+    // inspected synchronously, so this only guards the inline case.
+    if client.token_endpoint_auth_method == TokenEndpointAuthMethod::SelfSignedTlsClientAuth
+        && let Some(ref jwks) = mutable_request.jwks
+        && !db::parse_jwks_set(jwks).is_ok_and(|set| jwks_has_x5c(&set))
+    {
+        return Err(ServiceError::oauth(
+            OAuthErrorCode::InvalidClientMetadata,
+            "self_signed_tls_client_auth requires a JWKS key with an x5c certificate",
         ));
     }
 
@@ -1286,7 +1341,7 @@ pub async fn update_client_configuration(
     if client.is_fapi()
         && client.token_endpoint_auth_method == TokenEndpointAuthMethod::PrivateKeyJwt
         && let Some(ref jwks) = mutable_request.jwks
-        && !jwks_has_fapi_allowed_key(jwks)
+        && !db::parse_jwks_set(jwks).is_ok_and(|set| jwks_has_fapi_allowed_key(&set))
     {
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidClientMetadata,

--- a/crates/vouch-server/src/services/oidc/registration/tests.rs
+++ b/crates/vouch-server/src/services/oidc/registration/tests.rs
@@ -1226,9 +1226,11 @@ fn test_validate_tls_client_auth_with_san_ip() {
 }
 
 /// self_signed_tls_client_auth does not require identity fields — accepted without them.
+/// It does require a jwks or jwks_uri (its certificate carrier, RFC 8705
+/// §2.2.2), supplied here so this test isolates the identity-fields concern.
 #[test]
 fn test_validate_self_signed_tls_client_auth_accepted_without_identity() {
-    let mut req = make_request_with_jwks(None, None);
+    let mut req = make_request_with_jwks(None, Some("https://example.com/jwks.json"));
     let result = validate_jwks_and_auth_method(&mut req, "self_signed_tls_client_auth");
     let validated = result.expect("self_signed_tls_client_auth must succeed without identity");
     assert_eq!(


### PR DESCRIPTION
## Summary

Follows the #1010/#1011/#1013 series (all merged). Closes the remaining write-path gaps that let OAuth clients register or update into states that can never authenticate, and removes the last duplicated encodings of the FAPI auth-method rules.

- **Strict typed JWKS parsing at every write path.** Submitted JWKS at RFC 7591 registration, RFC 7592 update, and admin create/update now deserialize through the typed `JwkSet` (relocated to `db/oauth.rs`, the same parse the `jwt_bearer` runtime uses — one source). A type-invalid member (`"alg": true`, `"use": 123`, non-array `x5c`) is rejected at write time with the path's existing error code instead of poisoning the whole JWKS at first authentication. Unknown members still pass (certificate JWKS carry `x5c`/`x5t#S256`; the registry is open); `kty` is required per RFC 7517 §4.1 ("This member MUST be present in a JWK" — fetched and quoted in the tests).
- **One effective-auth-method computation.** `effective_token_endpoint_auth_method(validated, client)` is shared by update validation and field persistence (truth-table equivalent, so the gate and the persisted value cannot disagree), and `TokenEndpointAuthMethod::is_fapi_compatible()` replaces three formerly-independent spellings of the FAPI-compatible set.
- **No more silent mTLS→private_key_jwt conversion.** Re-declaring `fapi_profile` on a FAPI mTLS client preserves its stored auth method; only non-FAPI-compatible methods are converted on upgrade (with the existing JWKS algorithm guard still applied to that conversion).
- **`self_signed_tls_client_auth` keeps its key material.** Required `jwks`/`jwks_uri` at every write path — including the admin path, where a bare `fapi_profile: "none"` re-affirmation could previously strip a dynamically-registered client's JWKS — and an inline JWKS must carry at least one `x5c` certificate the mTLS verifier can match (`self_signed_jwks_missing_x5c`). This is a usability guard, not a spec mandate: RFC 8705 §2.2.2's `x5c` language is descriptive ("A certificate is represented with the `x5c` parameter of an individual JWK within the set"), but the verifier matches only on `x5c`, so a certificate-less JWKS is a guaranteed permanent authentication failure.

## Disclosed behavior changes

- One malformed entry rejects the **whole** submitted JWK Set. RFC 7517 §5.1 says implementations "SHOULD ignore JWKs within a JWK Set that ... are missing required members" — we choose strict parity with the runtime parser (which is already all-or-nothing) over the SHOULD, and say so here.
- A client with a malformed **stored** JWKS (any client, not only FAPI): the admin edit form re-submits the stored JWKS as input, so edits are blocked with `invalid_jwks` until the JWKS is corrected in place. This is broader than the class disclosed in #1011 (which covered FAPI clients with wrong-algorithm keys); the recovery is the same — overwrite the JWKS with a valid one.
- `missing_jwks` `error_description` text widened to cover self-signed clients (the `error` code is unchanged).
- Type-invalid `x5c` values are now rejected at write time (previously ignored as unknown data).

## Testing

- `cargo test -p vouch-server --all-features` → 3108 passed, 0 failed; clippy `-D warnings` clean; arch_boundaries clean — all independently re-run at review
- Mutation-verified: removing the strict-parse gate, widening `is_fapi_compatible`, reverting the forcing rule, and dropping either self-signed requirement each fail named tests
- 19 new tests across rfc7591/rfc7592/applications-validate/db-oauth, including the previously-untested legacy stored malformed-shape fallback (probe-verified, now pinned)

A follow-up PR this session implements the mTLS `jwks_uri` fetch (a self-signed client registered with `jwks_uri` currently can never authenticate because the token endpoint only reads the JWKS cache and nothing on the mTLS path populates it — RFC 8705 permits the form, so registration correctly accepts it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens OAuth client metadata validation (JWKS shape, self-signed mTLS key material, FAPI auth-method forcing). Behavior is more restrictive at write time; stored malformed JWKS can now block admin edits until corrected.
> 
> **Overview**
> Rejects OAuth client create/update/registration that would leave a client permanently unable to authenticate, and unifies FAPI auth-method rules.
> 
> **Typed JWKS at write time.** `JwkSet`/`JwkEntry` move to `db/oauth.rs` and are shared with the RFC 7523 runtime parser. Admin create/update and RFC 7591/7592 now reject type-invalid members (`"alg": true`, bad `x5c`) instead of storing a document the verifier cannot parse. Unknown JWK members still pass; `kty` is required.
> 
> **self_signed_tls_client_auth keeps key material.** Registration and updates require `jwks`/`jwks_uri`, and an inline JWKS must carry a non-empty `x5c` (`jwks_has_x5c`). `tls_client_auth` is unchanged (PKI identity, no JWKS).
> 
> **No silent mTLS→JWT conversion.** `TokenEndpointAuthMethod::is_fapi_compatible()` is the single FAPI method set. Admin FAPI upgrades force `private_key_jwt` only when the stored method is not already FAPI-compatible, so re-declaring `fapi_profile` preserves mTLS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e503ece6870d2c913a81508831c297f8d11452b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->