### PR TITLE
refactor(server): type JWK kty as an open enum

### DIFF
--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -138,16 +138,16 @@ pub use documents::oauth::{
 // Re-export OAuth domain types and functions
 pub(crate) use oauth::JwtAssertionJtiClaim;
 pub use oauth::{
-    CreateOAuthClientParams, JwkEntry, JwkSet, MAX_ACTIVE_SECRETS, MAX_POST_LOGOUT_REDIRECT_URIS,
-    OAuthClient, OAuthClientSecret, OAuthEventType, OAuthUsageStats, RecordOAuthEventParams,
-    UpdateClientRegistrationParams, UpdateOAuthClientParams, create_oauth_client,
-    create_oauth_client_secret, delete_expired_jwt_assertion_jtis, delete_oauth_client,
-    get_oauth_client_by_client_id, get_oauth_client_by_id, get_oauth_client_secret_by_id,
-    get_oauth_client_secrets, get_oauth_clients_for_user, get_oauth_secret_by_hash,
-    get_oauth_usage_stats, is_valid_post_logout_redirect_uri_str, jwks_has_fapi_allowed_key,
-    jwks_has_x5c, parse_jwks_set, record_oauth_event, revoke_all_oauth_client_secrets,
-    revoke_oauth_client_secret, store_jwt_assertion_jti, update_oauth_client,
-    update_oauth_client_last_used, update_oauth_client_registration,
+    CreateOAuthClientParams, JwkEntry, JwkSet, KeyType, MAX_ACTIVE_SECRETS,
+    MAX_POST_LOGOUT_REDIRECT_URIS, OAuthClient, OAuthClientSecret, OAuthEventType, OAuthUsageStats,
+    RecordOAuthEventParams, UpdateClientRegistrationParams, UpdateOAuthClientParams,
+    create_oauth_client, create_oauth_client_secret, delete_expired_jwt_assertion_jtis,
+    delete_oauth_client, get_oauth_client_by_client_id, get_oauth_client_by_id,
+    get_oauth_client_secret_by_id, get_oauth_client_secrets, get_oauth_clients_for_user,
+    get_oauth_secret_by_hash, get_oauth_usage_stats, is_valid_post_logout_redirect_uri_str,
+    jwks_has_fapi_allowed_key, jwks_has_x5c, parse_jwks_set, record_oauth_event,
+    revoke_all_oauth_client_secrets, revoke_oauth_client_secret, store_jwt_assertion_jti,
+    update_oauth_client, update_oauth_client_last_used, update_oauth_client_registration,
     validate_oauth_client_credentials,
 };
 

--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -253,11 +253,53 @@ pub struct JwkSet {
     pub keys: Vec<JwkEntry>,
 }
 
+/// JWK "kty" (Key Type) value (RFC 7517 §4.1).
+///
+/// The IANA "JSON Web Key Types" registry this parameter draws from is open
+/// to extension: RFC 7518 §7.4 (<https://www.rfc-editor.org/rfc/rfc7518>)
+/// — "This specification establishes the IANA 'JSON Web Key Types' registry
+/// for values of the JWK 'kty' (key type) parameter" — registers only `EC`,
+/// `RSA`, and `oct`. `OKP` was added later, by RFC 8037 §5
+/// (<https://www.rfc-editor.org/rfc/rfc8037>) — "'kty' Parameter Value:
+/// 'OKP'" — and more recently `AKP` by RFC 9964. An unrecognized value must
+/// therefore still parse (`Other`), just as an unrecognized value already
+/// does for the members this crate doesn't model (`x5t`, etc.) — it isn't
+/// selectable by any of the three known variants, so it stays unusable the
+/// same way `oct` or any other unmatched `kty` already is.
+#[derive(Debug, PartialEq, Eq)]
+pub enum KeyType {
+    Ec,
+    Rsa,
+    Okp,
+    /// Any value outside the three this crate matches against. Carries the
+    /// original string for diagnostics; never selected by a signing-key or
+    /// FAPI-allowed-algorithm check.
+    Other(String),
+}
+
+impl<'de> Deserialize<'de> for KeyType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Exact-case match: RFC 7517 §4.1 (quoted above `parse_jwks_set`'s
+        // "kty" test) — "The 'kty' value is a case-sensitive string" — so
+        // e.g. "ec" is a *different*, unrecognized value, not `Ec`.
+        let s = String::deserialize(deserializer)?;
+        Ok(match s.as_str() {
+            "EC" => Self::Ec,
+            "RSA" => Self::Rsa,
+            "OKP" => Self::Okp,
+            _ => Self::Other(s),
+        })
+    }
+}
+
 /// A single JWK entry in a JWKS.
 #[derive(Debug, Deserialize)]
 pub struct JwkEntry {
-    /// Key type (e.g., "EC", "RSA", "OKP").
-    pub kty: String,
+    /// Key type (RFC 7517 §4.1).
+    pub kty: KeyType,
     /// Key ID (optional).
     #[serde(default)]
     pub kid: Option<String>,
@@ -334,7 +376,17 @@ pub fn jwks_has_fapi_allowed_key(jwks: &JwkSet) -> bool {
             return false;
         }
         let Some(alg) = key.alg.as_deref() else {
-            return matches!(key.kty.as_str(), "EC" | "RSA" | "OKP");
+            // An exhaustive match, not `matches!`: `matches!` isn't
+            // exhaustiveness-checked, so a `KeyType` variant added later
+            // without updating this arm would silently keep compiling here
+            // (unlike the exhaustive match in
+            // `jwt_bearer::jwks::build_decoding_key_from_jwk`, which would
+            // fail to compile until updated) instead of forcing the same
+            // explicit decision at both consumers.
+            return match key.kty {
+                KeyType::Ec | KeyType::Rsa | KeyType::Okp => true,
+                KeyType::Other(_) => false,
+            };
         };
         alg.parse::<JwsAlgorithm>()
             .is_ok_and(|parsed| JwsAlgorithm::FAPI_ALLOWED.contains(&parsed))
@@ -1482,6 +1534,32 @@ mod tests {
         assert!(
             parse_jwks_set(&missing_kty).is_err(),
             "kty is the only REQUIRED JWK member and must fail its absence"
+        );
+    }
+
+    #[test]
+    fn test_key_type_accepts_an_unrecognized_kty_registered_later_by_another_rfc() {
+        // "AKP" is a real, currently-registered IANA "kty" value (RFC 9964,
+        // "ML-DSA for JOSE and COSE") — chosen over a made-up string to
+        // prove the open-registry design against a genuine later addition,
+        // not just an arbitrary one this crate will never see.
+        let jwks = serde_json::json!({"keys": [{"kty": "AKP"}]});
+        let set = parse_jwks_set(&jwks).expect("an unrecognized kty must still parse");
+        assert_eq!(
+            set.keys.first().map(|k| &k.kty),
+            Some(&KeyType::Other("AKP".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_key_type_is_case_sensitive() {
+        // RFC 7517 §4.1 (quoted above): "The 'kty' value is a case-sensitive
+        // string" — "ec" is a different, unrecognized value, not `Ec`.
+        let jwks = serde_json::json!({"keys": [{"kty": "ec"}]});
+        let set = parse_jwks_set(&jwks).expect("valid JSON shape must still parse");
+        assert_eq!(
+            set.keys.first().map(|k| &k.kty),
+            Some(&KeyType::Other("ec".to_string()))
         );
     }
 

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/jwks.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/jwks.rs
@@ -7,7 +7,7 @@
 use super::validate::JwtAssertionHeader;
 use crate::db::documents::jwks_cache::JwksCacheDoc;
 use crate::db::store::DocumentStore;
-use crate::db::{JwkEntry, JwkSet};
+use crate::db::{JwkEntry, JwkSet, KeyType};
 use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
 
 /// Resolve the JWKS for a client — from inline `jwks` or fetched `jwks_uri`.
@@ -121,9 +121,9 @@ pub fn find_matching_key(
 
     // Fall back to matching by algorithm/key type
     let expected_kty = match header.alg.as_str() {
-        "ES256" => "EC",
-        "RS256" | "PS256" => "RSA",
-        "EdDSA" => "OKP",
+        "ES256" => KeyType::Ec,
+        "RS256" | "PS256" => KeyType::Rsa,
+        "EdDSA" => KeyType::Okp,
         _ => {
             return Err(ServiceError::oauth(
                 OAuthErrorCode::InvalidClient,
@@ -227,8 +227,8 @@ fn build_decoding_key_from_jwk(
     key: &JwkEntry,
     alg: &str,
 ) -> ServiceResult<jsonwebtoken::DecodingKey> {
-    match (key.kty.as_str(), alg) {
-        ("EC", "ES256") => {
+    match (&key.kty, alg) {
+        (KeyType::Ec, "ES256") => {
             let x = key.x.as_deref().ok_or_else(|| {
                 ServiceError::oauth(OAuthErrorCode::InvalidClient, "EC key missing x component")
             })?;
@@ -240,7 +240,7 @@ fn build_decoding_key_from_jwk(
                 ServiceError::oauth(OAuthErrorCode::InvalidClient, "Invalid key in JWKS")
             })
         }
-        ("RSA", "RS256") | ("RSA", "PS256") => {
+        (KeyType::Rsa, "RS256" | "PS256") => {
             let n = key.n.as_deref().ok_or_else(|| {
                 ServiceError::oauth(OAuthErrorCode::InvalidClient, "RSA key missing n component")
             })?;
@@ -252,7 +252,7 @@ fn build_decoding_key_from_jwk(
                 ServiceError::oauth(OAuthErrorCode::InvalidClient, "Invalid key in JWKS")
             })
         }
-        ("OKP", "EdDSA") => {
+        (KeyType::Okp, "EdDSA") => {
             let x = key.x.as_deref().ok_or_else(|| {
                 ServiceError::oauth(OAuthErrorCode::InvalidClient, "OKP key missing x component")
             })?;
@@ -273,7 +273,18 @@ fn build_decoding_key_from_jwk(
                 ServiceError::oauth(OAuthErrorCode::InvalidClient, "Invalid key in JWKS")
             })
         }
-        _ => Err(ServiceError::oauth(
+        // Known kty, wrong alg for it. Kept as a separate arm from the
+        // `Other` case below rather than merged, so an unrecognized kty is
+        // a deliberate, visible decision here — both produce the same
+        // error today, but the split is what the "Other" case means, not
+        // an accident of a shared wildcard.
+        (KeyType::Ec | KeyType::Rsa | KeyType::Okp, _) => Err(ServiceError::oauth(
+            OAuthErrorCode::InvalidClient,
+            "No matching key found in JWKS",
+        )),
+        // Unrecognized kty (RFC 7517 §4.1's registry is open — see
+        // `KeyType`): never selectable, regardless of alg.
+        (KeyType::Other(_), _) => Err(ServiceError::oauth(
             OAuthErrorCode::InvalidClient,
             "No matching key found in JWKS",
         )),
@@ -312,7 +323,7 @@ mod tests {
 
     fn ec_jwk_entry(kid: Option<&str>, alg: Option<&str>, use_: Option<&str>) -> JwkEntry {
         JwkEntry {
-            kty: "EC".to_string(),
+            kty: KeyType::Ec,
             kid: kid.map(String::from),
             alg: alg.map(String::from),
             use_: use_.map(String::from),
@@ -327,7 +338,7 @@ mod tests {
 
     fn rsa_jwk_entry(kid: Option<&str>, alg: Option<&str>, use_: Option<&str>) -> JwkEntry {
         JwkEntry {
-            kty: "RSA".to_string(),
+            kty: KeyType::Rsa,
             kid: kid.map(String::from),
             alg: alg.map(String::from),
             use_: use_.map(String::from),
@@ -345,7 +356,7 @@ mod tests {
 
     fn okp_jwk_entry(kid: Option<&str>, alg: Option<&str>, use_: Option<&str>) -> JwkEntry {
         JwkEntry {
-            kty: "OKP".to_string(),
+            kty: KeyType::Okp,
             kid: kid.map(String::from),
             alg: alg.map(String::from),
             use_: use_.map(String::from),


### PR DESCRIPTION
## Summary

Stacked on #1015. `JwkEntry.kty` was a bare `String` compared against `"EC"`/`"RSA"`/`"OKP"` literals at each consumer — a typo'd string in a new match site would compile silently. It is now:

```rust
pub enum KeyType { Ec, Rsa, Okp, Other(String) }
```

with an exact-case custom `Deserialize` (unknown values captured as `Other`, `"ec"` lowercase falls to `Other("ec")` per RFC 7517 §4.1's "case-sensitive string"). Every consumer is an exhaustive match with no wildcard on the kty dimension — verified by test-compiling a hypothetical fourth variant, which now fails compilation at both consumers until each site decides what the new type means (the guard's predicate was converted from `matches!`, which is not exhaustiveness-checked, to a real `match` after the critique proved the difference).

Unknown key types still parse and are simply unusable, exactly as before: the IANA JSON Web Key Types registry is open — RFC 7518 §7.4 established it ("This specification establishes the IANA 'JSON Web Key Types' registry for values of the JWK 'kty' (key type) parameter") with EC/RSA/oct, RFC 8037 §5 later registered OKP, and RFC 9964 registered AKP (ML-DSA, post-quantum) — all three verified against the live registry and source RFCs this session. Rejecting unrecognized values would break legitimate future registrations.

Deserialize-only: `JwkSet`/`JwkEntry` are never serialized; the server's outgoing JWKS/DPoP types (`EcJwk`, `DpopJwk`) are separate and untouched. Zero behavior change for every existing input — type-invalid `kty` still fails the strict parse identically (the custom impl's first operation is the same `String::deserialize` the derive generated).

## Testing

- `cargo test -p vouch-server --all-features` → 3120 passed, 0 failed; clippy `-D warnings` clean with zero new allow/expect attributes (the exhaustiveness is real, not silenced); arch_boundaries clean — independently re-run by reviewer and critic
- New tests: `{"kty":"AKP"}` parses to `Other("AKP")`; `{"kty":"ec"}` parses to `Other("ec")` not `Ec`; all 114 pre-existing targeted tests confirmed passing before any new tests were added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches JWT client-assertion key selection and FAPI JWKS acceptance, but is a type-level refactor with unknown kty still unusable and no intended runtime change.
> 
> **Overview**
> Turns `JwkEntry.kty` from a bare `String` into an open `KeyType` enum (`Ec`/`Rsa`/`Okp`/`Other`) so FAPI JWKS checks and RFC 7523 key matching cannot silently miss a new variant.
> 
> Unknown `kty` values still parse (case-sensitive per RFC 7517) and remain unusable. `jwks_has_fapi_allowed_key` and `build_decoding_key_from_jwk` now use exhaustive matches instead of string literals. No intended behavior change for existing inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb2e4d502ed2d67ee25921d016f6ba12644302f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->