### PR TITLE
refactor(server): retype OAuth error chokepoints to OAuthErrorCode

### DIFF
--- a/crates/vouch-server/src/error.rs
+++ b/crates/vouch-server/src/error.rs
@@ -141,9 +141,9 @@ pub enum OAuthErrorCode {
     UnsupportedGrantType,
     /// RFC 6749 Section 5.2: The requested scope is invalid or unknown.
     InvalidScope,
-    /// RFC 6749 Section 5.2: The authorization server encountered an unexpected condition.
+    /// RFC 6749 Section 4.1.2.1: The authorization server encountered an unexpected condition.
     ServerError,
-    /// RFC 6749 Section 5.2: The authorization server is temporarily unavailable.
+    /// RFC 6749 Section 4.1.2.1: The authorization server is temporarily unavailable.
     TemporarilyUnavailable,
     /// RFC 8628 Section 3.5: The authorization request is still pending.
     AuthorizationPending,
@@ -180,6 +180,13 @@ pub enum OAuthErrorCode {
     InvalidAuthorizationDetails,
     /// OIDC Core Section 6.2: The request_uri parameter value is invalid.
     InvalidRequestUri,
+    /// OIDC Core Section 3.1.2.6: "The Authorization Server requires
+    /// End-User authentication. This error MAY be returned when the prompt
+    /// parameter value in the Authentication Request is none, but the
+    /// Authentication Request cannot be completed without displaying a user
+    /// interface for End-User authentication."
+    /// <https://openid.net/specs/openid-connect-core-1_0.html#AuthError>
+    LoginRequired,
 }
 
 impl std::fmt::Display for OAuthErrorCode {
@@ -202,7 +209,11 @@ impl OAuthErrorCode {
             | Self::InvalidRedirectUri
             | Self::InvalidClientMetadata
             | Self::InvalidAuthorizationDetails
-            | Self::InvalidRequestUri => StatusCode::BAD_REQUEST,
+            | Self::InvalidRequestUri
+            // `login_required` only ever travels as a redirect query
+            // parameter (OIDC Core 3.1.2.6), never as an HTTP status on a
+            // direct response, so this arm is currently unreachable.
+            | Self::LoginRequired => StatusCode::BAD_REQUEST,
             Self::InvalidClient | Self::UnauthorizedClient => StatusCode::UNAUTHORIZED,
             Self::InsufficientUserAuthentication => StatusCode::UNAUTHORIZED,
             Self::InvalidGrant
@@ -246,6 +257,7 @@ impl OAuthErrorCode {
             Self::InvalidClientMetadata => "invalid_client_metadata",
             Self::InvalidAuthorizationDetails => "invalid_authorization_details",
             Self::InvalidRequestUri => "invalid_request_uri",
+            Self::LoginRequired => "login_required",
         }
     }
 }
@@ -355,7 +367,7 @@ impl ServiceError {
             Self::NotFound(entity) => (
                 StatusCode::NOT_FOUND,
                 Json(OAuthErrorResponse {
-                    error: "invalid_request".to_string(),
+                    error: OAuthErrorCode::InvalidRequest.as_str().to_string(),
                     error_description: Some(format!("{entity} not found")),
                     error_uri: None,
                 }),
@@ -363,7 +375,7 @@ impl ServiceError {
             Self::Validation(msg) => (
                 StatusCode::BAD_REQUEST,
                 Json(OAuthErrorResponse {
-                    error: "invalid_request".to_string(),
+                    error: OAuthErrorCode::InvalidRequest.as_str().to_string(),
                     error_description: Some(msg),
                     error_uri: None,
                 }),
@@ -411,7 +423,7 @@ impl ServiceError {
             Self::Forbidden(_) => (
                 StatusCode::FORBIDDEN,
                 Json(OAuthErrorResponse {
-                    error: "access_denied".to_string(),
+                    error: OAuthErrorCode::AccessDenied.as_str().to_string(),
                     error_description: Some("Access denied".to_string()),
                     error_uri: None,
                 }),
@@ -429,7 +441,7 @@ impl ServiceError {
             _ => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(OAuthErrorResponse {
-                    error: "server_error".to_string(),
+                    error: OAuthErrorCode::ServerError.as_str().to_string(),
                     error_description: Some("Internal server error".to_string()),
                     error_uri: None,
                 }),
@@ -440,7 +452,12 @@ impl ServiceError {
     /// Build a `WWW-Authenticate` header value for RFC 9470 step-up challenges.
     fn build_www_authenticate(acr_values: &Option<String>, max_age: &Option<u64>) -> String {
         let mut params = vec![
-            ("error", "insufficient_user_authentication".to_string()),
+            (
+                "error",
+                OAuthErrorCode::InsufficientUserAuthentication
+                    .as_str()
+                    .to_string(),
+            ),
             (
                 "error_description",
                 "A recent authentication is required".to_string(),

--- a/crates/vouch-server/src/handlers/certification.rs
+++ b/crates/vouch-server/src/handlers/certification.rs
@@ -30,6 +30,7 @@ use jiff::Timestamp;
 
 use crate::{
     AppState, db,
+    error::OAuthErrorCode,
     handlers::browser_login::hmac_sha256_base64url,
     handlers::session::create_session_cookie,
     services::auth::{
@@ -290,7 +291,7 @@ pub(crate) async fn deny_login(
         &state,
         &client,
         &pending.redirect_uri,
-        "access_denied",
+        OAuthErrorCode::AccessDenied,
         "User rejected authentication",
         pending.state.as_deref(),
         pending.response_mode,

--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -237,7 +237,7 @@ pub(crate) async fn device_token(
             return Err(oauth_error(
                 StatusCode::BAD_REQUEST,
                 OAuthError {
-                    error: "unsupported_grant_type".to_string(),
+                    error: OAuthErrorCode::UnsupportedGrantType.as_str().to_string(),
                     error_description: Some("Expected device_code grant type".to_string()),
                 },
             ));
@@ -334,7 +334,7 @@ pub(crate) async fn device_token(
                         return Err(oauth_error(
                             StatusCode::INTERNAL_SERVER_ERROR,
                             OAuthError {
-                                error: "server_error".to_string(),
+                                error: OAuthErrorCode::ServerError.as_str().to_string(),
                                 error_description: Some(e.to_string()),
                             },
                         ));
@@ -343,7 +343,7 @@ pub(crate) async fn device_token(
                         return Err(oauth_error(
                             StatusCode::BAD_REQUEST,
                             OAuthError {
-                                error: "invalid_dpop_proof".to_string(),
+                                error: OAuthErrorCode::InvalidDpopProof.as_str().to_string(),
                                 error_description: Some(e.to_string()),
                             },
                         ));
@@ -367,7 +367,7 @@ pub(crate) async fn device_token(
                         return Err(oauth_error(
                             StatusCode::UNAUTHORIZED,
                             OAuthError {
-                                error: "invalid_client".to_string(),
+                                error: OAuthErrorCode::InvalidClient.as_str().to_string(),
                                 error_description: Some(
                                     "Unknown client_id for device authorization".to_string(),
                                 ),

--- a/crates/vouch-server/src/handlers/oidc/authorize.rs
+++ b/crates/vouch-server/src/handlers/oidc/authorize.rs
@@ -13,6 +13,7 @@ use super::{
 use crate::AppState;
 use crate::db::ResponseMode;
 use crate::db::{self, Authenticator, CreatePendingOAuthParams, OAuthClient, Session, User};
+use crate::error::OAuthErrorCode;
 use crate::impl_template_response;
 use crate::services::oidc::ScopeSet;
 use crate::services::oidc::authorization::{
@@ -224,7 +225,7 @@ impl ResolvedClient {
     async fn error_redirect(
         &self,
         state: &Arc<AppState>,
-        error: &str,
+        error: OAuthErrorCode,
         description: &str,
         oauth_state: Option<&str>,
     ) -> Response {
@@ -273,7 +274,7 @@ async fn run_security_pipeline(
         return Err(resolved
             .error_redirect(
                 state,
-                "invalid_request",
+                OAuthErrorCode::InvalidRequest,
                 &e.oauth_description(),
                 validated.state(),
             )
@@ -290,7 +291,7 @@ async fn run_security_pipeline(
         return Err(resolved
             .error_redirect(
                 state,
-                "invalid_request",
+                OAuthErrorCode::InvalidRequest,
                 &e.oauth_description(),
                 validated.state(),
             )
@@ -305,7 +306,7 @@ async fn run_security_pipeline(
         return Err(resolved
             .error_redirect(
                 state,
-                "invalid_request",
+                OAuthErrorCode::InvalidRequest,
                 "This client requires a signed Request Object (RFC 9101)",
                 validated.state(),
             )
@@ -358,7 +359,7 @@ async fn check_session_and_authorize(
                 return resolved
                     .error_redirect(
                         state,
-                        "login_required",
+                        OAuthErrorCode::LoginRequired,
                         "User is not authenticated and prompt=none was requested",
                         validated.state(),
                     )
@@ -558,7 +559,7 @@ async fn handle_direct_request(
                 return resolved
                     .error_redirect(
                         state,
-                        "invalid_request",
+                        OAuthErrorCode::InvalidRequest,
                         &format!(
                             "Unsupported prompt value. Supported values: {}",
                             crate::services::oidc::authorization::Prompt::supported_values()
@@ -594,9 +595,9 @@ async fn handle_direct_request(
         Err(e) => {
             let (error_code, description) = match &e {
                 crate::error::ServiceError::OAuth { code, description } => {
-                    (code.as_str(), description.clone())
+                    (*code, description.clone())
                 }
-                _ => ("server_error", e.to_string()),
+                _ => (OAuthErrorCode::ServerError, e.to_string()),
             };
             return resolved
                 .error_redirect(state, error_code, &description, params.state.as_deref())
@@ -689,9 +690,9 @@ async fn handle_jar_request(
         Err(e) => {
             let (error_code, description) = match &e {
                 crate::error::ServiceError::OAuth { code, description } => {
-                    (code.as_str(), description.clone())
+                    (*code, description.clone())
                 }
-                _ => ("server_error", e.to_string()),
+                _ => (OAuthErrorCode::ServerError, e.to_string()),
             };
             return resolved
                 .error_redirect(state, error_code, &description, query.state.as_deref())
@@ -753,7 +754,7 @@ async fn lookup_par(
                             state,
                             &client,
                             uri,
-                            "invalid_request_uri",
+                            OAuthErrorCode::InvalidRequestUri,
                             "Invalid or expired request_uri",
                             None,
                             response_mode,
@@ -851,9 +852,9 @@ async fn handle_par_request(
         Err(e) => {
             let (error_code, description) = match &e {
                 crate::error::ServiceError::OAuth { code, description } => {
-                    (code.as_str(), description.clone())
+                    (*code, description.clone())
                 }
-                _ => ("server_error", e.to_string()),
+                _ => (OAuthErrorCode::ServerError, e.to_string()),
             };
             return resolved
                 .error_redirect(state, error_code, &description, par.state.as_deref())
@@ -911,9 +912,9 @@ async fn handle_request_uri_fetch(
         Err(e) => {
             let (error_code, description) = match &e {
                 crate::error::ServiceError::OAuth { code, description } => {
-                    (code.as_str(), description.clone())
+                    (*code, description.clone())
                 }
-                _ => ("server_error", e.to_string()),
+                _ => (OAuthErrorCode::ServerError, e.to_string()),
             };
             return resolved
                 .error_redirect(state, error_code, &description, query.state.as_deref())
@@ -1180,7 +1181,7 @@ async fn complete_pending_auth(
             return resolved
                 .error_redirect(
                     state,
-                    "login_required",
+                    OAuthErrorCode::LoginRequired,
                     "Session exceeds requested max_age",
                     pending.state.as_deref(),
                 )
@@ -1202,7 +1203,7 @@ async fn complete_pending_auth(
                 return resolved
                     .error_redirect(
                         state,
-                        "invalid_request",
+                        OAuthErrorCode::InvalidRequest,
                         "The request_uri has already been used",
                         pending.state.as_deref(),
                     )
@@ -1213,7 +1214,7 @@ async fn complete_pending_auth(
                 return resolved
                     .error_redirect(
                         state,
-                        "server_error",
+                        OAuthErrorCode::ServerError,
                         "Failed to process pushed authorization request",
                         pending.state.as_deref(),
                     )
@@ -1424,7 +1425,7 @@ async fn store_pending_and_redirect(
                 state,
                 target.client,
                 validated.redirect_uri(),
-                "server_error",
+                OAuthErrorCode::ServerError,
                 "Failed to initiate login",
                 validated.state(),
                 target.response_mode,
@@ -1525,7 +1526,7 @@ async fn authorize_authenticated_user(
             state,
             oauth_client,
             validated.redirect_uri(),
-            "login_required",
+            OAuthErrorCode::LoginRequired,
             "Re-authentication required but prompt=none was requested",
             validated.state(),
             response_mode,
@@ -1589,7 +1590,7 @@ async fn issue_code_after_reauth_check(
                 state,
                 oauth_client,
                 validated.redirect_uri(),
-                "unmet_authentication_requirements",
+                OAuthErrorCode::UnmetAuthenticationRequirements,
                 "The requested authentication context class is not supported",
                 validated.state(),
                 response_mode,
@@ -1606,7 +1607,7 @@ async fn issue_code_after_reauth_check(
             state,
             oauth_client,
             validated.redirect_uri(),
-            "invalid_target",
+            OAuthErrorCode::InvalidTarget,
             "The requested resource is not registered for this client",
             validated.state(),
             response_mode,
@@ -1630,7 +1631,7 @@ async fn issue_code_after_reauth_check(
                     state,
                     oauth_client,
                     validated.redirect_uri(),
-                    "invalid_request",
+                    OAuthErrorCode::InvalidRequest,
                     "The request_uri has already been used or is invalid",
                     validated.state(),
                     response_mode,
@@ -1643,7 +1644,7 @@ async fn issue_code_after_reauth_check(
                     state,
                     oauth_client,
                     validated.redirect_uri(),
-                    "server_error",
+                    OAuthErrorCode::ServerError,
                     "Failed to process pushed authorization request",
                     validated.state(),
                     response_mode,
@@ -1720,7 +1721,7 @@ async fn issue_code_and_redirect(
                             state,
                             oauth_client,
                             redirect_uri,
-                            "server_error",
+                            OAuthErrorCode::ServerError,
                             "Failed to generate authorization response",
                             oauth_state,
                             response_mode,
@@ -1762,7 +1763,7 @@ async fn issue_code_and_redirect(
                 state,
                 oauth_client,
                 redirect_uri,
-                "server_error",
+                OAuthErrorCode::ServerError,
                 "Failed to generate authorization code",
                 oauth_state,
                 response_mode,
@@ -1895,7 +1896,7 @@ mod tests {
             &state,
             &client,
             "https://example.com/callback",
-            "access_denied",
+            OAuthErrorCode::AccessDenied,
             "user denied",
             Some("opaque-state"),
             ResponseMode::Jwt,

--- a/crates/vouch-server/src/handlers/oidc/authorize/error_response.rs
+++ b/crates/vouch-server/src/handlers/oidc/authorize/error_response.rs
@@ -35,7 +35,7 @@ pub(crate) async fn oauth_error_response(
     app_state: &Arc<AppState>,
     client: &OAuthClient,
     redirect_uri: &str,
-    error: &str,
+    error: OAuthErrorCode,
     description: &str,
     oauth_state: Option<&str>,
     response_mode: ResponseMode,
@@ -54,7 +54,7 @@ pub(crate) async fn oauth_error_response(
         }
         ResponseMode::FormPost => {
             let mut params = vec![
-                ("error".to_string(), error.to_string()),
+                ("error".to_string(), error.as_str().to_string()),
                 ("error_description".to_string(), description.to_string()),
                 ("iss".to_string(), app_state.config().base_url.to_string()),
             ];
@@ -69,7 +69,10 @@ pub(crate) async fn oauth_error_response(
         }
         ResponseMode::Query => {
             let issuer = &app_state.config().base_url;
-            let mut params = vec![("error", error), ("error_description", description)];
+            let mut params = vec![
+                ("error", error.as_str()),
+                ("error_description", description),
+            ];
             if let Some(state_param) = oauth_state {
                 params.push(("state", state_param));
             }
@@ -87,7 +90,7 @@ pub(super) async fn oauth_error_redirect_jarm(
     state: &Arc<AppState>,
     client: &OAuthClient,
     redirect_uri: &str,
-    error: &str,
+    error: OAuthErrorCode,
     description: &str,
     oauth_state: Option<&str>,
 ) -> Response {

--- a/crates/vouch-server/src/handlers/oidc/client_auth.rs
+++ b/crates/vouch-server/src/handlers/oidc/client_auth.rs
@@ -5,7 +5,7 @@
 //! (RFC 6749 Section 3.2) and the PAR endpoint (RFC 9126 Section 2).
 
 use crate::AppState;
-use crate::error::OAuthErrorResponse;
+use crate::error::{OAuthErrorCode, OAuthErrorResponse};
 use crate::services::oidc::{
     jwt_bearer::client_auth::{PendingJti, authenticate_client_jwt},
     token::{AuthenticatedClient, ClientCredentials, authenticate_client},
@@ -124,7 +124,7 @@ pub(crate) fn extract_client_auth<T: ClientAuthFields>(
     // RFC 7521 Section 4.2: MUST NOT use more than one method
     if has_client_assertion && (has_basic || has_client_secret) {
         return Err(oauth_error_response(
-            "invalid_request",
+            OAuthErrorCode::InvalidRequest,
             "client_assertion cannot be combined with Basic auth or client_secret",
         ));
     }
@@ -135,7 +135,7 @@ pub(crate) fn extract_client_auth<T: ClientAuthFields>(
         let assertion_type = params.client_assertion_type().unwrap_or("");
         if assertion_type != JWT_BEARER_CLIENT_ASSERTION_TYPE {
             return Err(oauth_error_response(
-                "invalid_request",
+                OAuthErrorCode::InvalidRequest,
                 &format!(
                     "Unsupported client_assertion_type. Expected: {JWT_BEARER_CLIENT_ASSERTION_TYPE}"
                 ),
@@ -242,11 +242,11 @@ pub(crate) async fn complete_client_auth(
 }
 
 /// Build an OAuth error response for parameter validation failures.
-fn oauth_error_response(error: &str, description: &str) -> Response {
+fn oauth_error_response(code: OAuthErrorCode, description: &str) -> Response {
     (
         StatusCode::BAD_REQUEST,
         Json(OAuthErrorResponse {
-            error: error.to_string(),
+            error: code.as_str().to_string(),
             error_description: Some(description.to_string()),
             error_uri: None,
         }),

--- a/crates/vouch-server/src/handlers/oidc/fido2_challenge.rs
+++ b/crates/vouch-server/src/handlers/oidc/fido2_challenge.rs
@@ -12,6 +12,7 @@
 use crate::AppState;
 use crate::crypto::jwt::JwtType;
 use crate::db;
+use crate::error::OAuthErrorCode;
 use crate::handlers::generate_challenge;
 use axum::{
     Json,
@@ -59,7 +60,7 @@ pub(crate) async fn fido2_challenge(State(state): State<Arc<AppState>>) -> Respo
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(serde_json::json!({
-                    "error": "server_error",
+                    "error": OAuthErrorCode::ServerError.as_str(),
                     "error_description": "Failed to generate challenge"
                 })),
             )
@@ -91,7 +92,7 @@ pub(crate) async fn fido2_challenge(State(state): State<Arc<AppState>>) -> Respo
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(serde_json::json!({
-                    "error": "server_error",
+                    "error": OAuthErrorCode::ServerError.as_str(),
                     "error_description": "Failed to create challenge state"
                 })),
             )

--- a/crates/vouch-server/src/handlers/oidc/par.rs
+++ b/crates/vouch-server/src/handlers/oidc/par.rs
@@ -4,6 +4,7 @@
 use super::client_auth::{ClientAuthFields, complete_client_auth, extract_client_auth};
 use crate::AppState;
 use crate::db::{self, CreateParParams, PAR_EXPIRES_IN};
+use crate::error::OAuthErrorCode;
 use crate::error::OAuthErrorResponse;
 use crate::error::ServiceError;
 use crate::services::auth::{ClientAuthProof, ParCreationProof};
@@ -182,7 +183,7 @@ pub(crate) async fn par(
     if params.request_uri.is_some() {
         return par_error_response(
             StatusCode::BAD_REQUEST,
-            "invalid_request",
+            OAuthErrorCode::InvalidRequest,
             "request_uri must not be provided in a pushed authorization request",
         );
     }
@@ -196,7 +197,7 @@ pub(crate) async fn par(
     {
         return par_error_response(
             StatusCode::BAD_REQUEST,
-            "invalid_request_object",
+            OAuthErrorCode::InvalidRequestObject,
             &e.oauth_description(),
         );
     }
@@ -214,7 +215,7 @@ pub(crate) async fn par(
     }) else {
         return par_error_response(
             StatusCode::UNAUTHORIZED,
-            "invalid_client",
+            OAuthErrorCode::InvalidClient,
             "Client authentication is required for pushed authorization requests",
         );
     };
@@ -238,7 +239,7 @@ pub(crate) async fn par(
         let Some(cert) = client_cert.0.as_ref() else {
             return par_error_response(
                 StatusCode::UNAUTHORIZED,
-                "invalid_client",
+                OAuthErrorCode::InvalidClient,
                 "mTLS client certificate required",
             );
         };
@@ -276,7 +277,7 @@ pub(crate) async fn par(
     ) {
         return par_error_response(
             StatusCode::UNAUTHORIZED,
-            "invalid_client",
+            OAuthErrorCode::InvalidClient,
             &e.oauth_description(),
         );
     }
@@ -291,7 +292,7 @@ pub(crate) async fn par(
     {
         return par_error_response(
             StatusCode::BAD_REQUEST,
-            "invalid_request",
+            OAuthErrorCode::InvalidRequest,
             "This client requires a signed Request Object (RFC 9101)",
         );
     }
@@ -311,7 +312,7 @@ pub(crate) async fn par(
                     nonce.to_string(),
                 )],
                 Json(OAuthErrorResponse {
-                    error: "use_dpop_nonce".to_string(),
+                    error: OAuthErrorCode::UseDpopNonce.as_str().to_string(),
                     error_description: Some(
                         "Authorization server requires nonce in DPoP proof".to_string(),
                     ),
@@ -323,14 +324,14 @@ pub(crate) async fn par(
         Err(e @ DpopError::Database(_)) => {
             return par_error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                "server_error",
+                OAuthErrorCode::ServerError,
                 &e.to_string(),
             );
         }
         Err(e) => {
             return par_error_response(
                 StatusCode::BAD_REQUEST,
-                "invalid_dpop_proof",
+                OAuthErrorCode::InvalidDpopProof,
                 &e.to_string(),
             );
         }
@@ -344,17 +345,17 @@ pub(crate) async fn par(
         if !is_match {
             return par_error_response(
                 StatusCode::BAD_REQUEST,
-                "invalid_dpop_proof",
+                OAuthErrorCode::InvalidDpopProof,
                 "dpop_jkt parameter does not match DPoP proof JWK thumbprint",
             );
         }
     }
 
     // Helper: convert ServiceError to PAR error response fields.
-    let service_error_codes = |e: &ServiceError| -> (&str, String) {
+    let service_error_codes = |e: &ServiceError| -> (OAuthErrorCode, String) {
         match e {
-            ServiceError::OAuth { code, description } => (code.as_str(), description.clone()),
-            _ => ("server_error", e.to_string()),
+            ServiceError::OAuth { code, description } => (*code, description.clone()),
+            _ => (OAuthErrorCode::ServerError, e.to_string()),
         }
     };
 
@@ -376,7 +377,7 @@ pub(crate) async fn par(
         if request_params.client_id != authenticated_client.client.client_id {
             return par_error_response(
                 StatusCode::BAD_REQUEST,
-                "invalid_request_object",
+                OAuthErrorCode::InvalidRequestObject,
                 "client_id in Request Object does not match authenticated client",
             );
         }
@@ -400,7 +401,7 @@ pub(crate) async fn par(
                 None => {
                     return par_error_response(
                         StatusCode::BAD_REQUEST,
-                        "invalid_request",
+                        OAuthErrorCode::InvalidRequest,
                         &format!(
                             "Unsupported prompt value. Supported values: {}",
                             crate::services::oidc::authorization::Prompt::supported_values()
@@ -443,7 +444,7 @@ pub(crate) async fn par(
     if let Err(e) = require_pkce_for_client(&validated, &authenticated_client.client) {
         return par_error_response(
             StatusCode::BAD_REQUEST,
-            "invalid_request",
+            OAuthErrorCode::InvalidRequest,
             &e.oauth_description(),
         );
     }
@@ -455,7 +456,7 @@ pub(crate) async fn par(
     {
         return par_error_response(
             StatusCode::BAD_REQUEST,
-            "invalid_request",
+            OAuthErrorCode::InvalidRequest,
             "redirect_uri is not registered for this client",
         );
     }
@@ -466,7 +467,7 @@ pub(crate) async fn par(
     {
         return par_error_response(
             StatusCode::BAD_REQUEST,
-            "invalid_target",
+            OAuthErrorCode::InvalidTarget,
             "The requested resource is not registered for this client",
         );
     }
@@ -486,7 +487,7 @@ pub(crate) async fn par(
         if !is_match {
             return par_error_response(
                 StatusCode::BAD_REQUEST,
-                "invalid_dpop_proof",
+                OAuthErrorCode::InvalidDpopProof,
                 "dpop_jkt does not match DPoP proof JWK thumbprint",
             );
         }
@@ -506,7 +507,7 @@ pub(crate) async fn par(
             None => {
                 return par_error_response(
                     StatusCode::BAD_REQUEST,
-                    "invalid_request",
+                    OAuthErrorCode::InvalidRequest,
                     &format!(
                         "Unsupported response_mode. Supported values: {}",
                         crate::db::documents::oauth::ResponseMode::supported_values()
@@ -546,12 +547,12 @@ pub(crate) async fn par(
                 return match e {
                     ClientAuthError::InvalidCredentials => par_error_response(
                         StatusCode::UNAUTHORIZED,
-                        "invalid_client",
+                        OAuthErrorCode::InvalidClient,
                         "Client authentication failed",
                     ),
                     _ => par_error_response(
                         StatusCode::INTERNAL_SERVER_ERROR,
-                        "server_error",
+                        OAuthErrorCode::ServerError,
                         "Failed to complete client authentication",
                     ),
                 };
@@ -602,7 +603,7 @@ pub(crate) async fn par(
             tracing::error!("Failed to create pushed authorization request: {}", e);
             par_error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                "server_error",
+                OAuthErrorCode::ServerError,
                 "Failed to store pushed authorization request",
             )
         }
@@ -610,11 +611,11 @@ pub(crate) async fn par(
 }
 
 /// Build a PAR error response.
-fn par_error_response(status: StatusCode, error: &str, description: &str) -> Response {
+fn par_error_response(status: StatusCode, error: OAuthErrorCode, description: &str) -> Response {
     (
         status,
         Json(OAuthErrorResponse {
-            error: error.to_string(),
+            error: error.as_str().to_string(),
             error_description: Some(description.to_string()),
             error_uri: None,
         }),

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -233,7 +233,7 @@ pub(crate) async fn token(
         && !is_valid_pkce_verifier(v)
     {
         return token_error_response(
-            "invalid_request",
+            OAuthErrorCode::InvalidRequest,
             "code_verifier must be 43-128 characters and contain only [A-Za-z0-9\\-._~]",
         );
     }
@@ -241,7 +241,7 @@ pub(crate) async fn token(
         && v.len() > MAX_TOKEN_REDIRECT_URI_LEN
     {
         return token_error_response(
-            "invalid_request",
+            OAuthErrorCode::InvalidRequest,
             &format!("redirect_uri exceeds maximum length of {MAX_TOKEN_REDIRECT_URI_LEN}"),
         );
     }
@@ -249,7 +249,7 @@ pub(crate) async fn token(
         && v.len() > MAX_TOKEN_CLIENT_ID_LEN
     {
         return token_error_response(
-            "invalid_request",
+            OAuthErrorCode::InvalidRequest,
             &format!("client_id exceeds maximum length of {MAX_TOKEN_CLIENT_ID_LEN}"),
         );
     }
@@ -257,7 +257,7 @@ pub(crate) async fn token(
         && v.len() > MAX_TOKEN_SCOPE_LEN
     {
         return token_error_response(
-            "invalid_request",
+            OAuthErrorCode::InvalidRequest,
             &format!("scope exceeds maximum length of {MAX_TOKEN_SCOPE_LEN}"),
         );
     }
@@ -265,7 +265,7 @@ pub(crate) async fn token(
         && v.len() > MAX_TOKEN_RESOURCE_LEN
     {
         return token_error_response(
-            "invalid_request",
+            OAuthErrorCode::InvalidRequest,
             &format!("resource exceeds maximum length of {MAX_TOKEN_RESOURCE_LEN}"),
         );
     }
@@ -273,7 +273,7 @@ pub(crate) async fn token(
         && v.expose_secret().len() > MAX_ASSERTION_LEN
     {
         return token_error_response(
-            "invalid_request",
+            OAuthErrorCode::InvalidRequest,
             &format!("client_assertion exceeds maximum length of {MAX_ASSERTION_LEN}"),
         );
     }
@@ -281,7 +281,7 @@ pub(crate) async fn token(
         && v.expose_secret().len() > MAX_ASSERTION_LEN
     {
         return token_error_response(
-            "invalid_request",
+            OAuthErrorCode::InvalidRequest,
             &format!("assertion exceeds maximum length of {MAX_ASSERTION_LEN}"),
         );
     }
@@ -290,7 +290,7 @@ pub(crate) async fn token(
         && v.len() > MAX_ASSERTION_LEN
     {
         return token_error_response(
-            "invalid_authorization_details",
+            OAuthErrorCode::InvalidAuthorizationDetails,
             &format!("authorization_details exceeds maximum length of {MAX_ASSERTION_LEN}"),
         );
     }
@@ -303,15 +303,10 @@ pub(crate) async fn token(
         Ok(parsed) => parsed,
         Err(_) => {
             let supported = OAuthGrantType::supported_wire_values().join(", ");
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(OAuthErrorResponse {
-                    error: "unsupported_grant_type".to_string(),
-                    error_description: Some(format!("Supported grant types: {supported}")),
-                    error_uri: None,
-                }),
-            )
-                .into_response();
+            return token_error_response(
+                OAuthErrorCode::UnsupportedGrantType,
+                &format!("Supported grant types: {supported}"),
+            );
         }
     };
 
@@ -497,15 +492,7 @@ async fn handle_authorization_code_grant(
     let code = match &params.code {
         Some(c) => c,
         None => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(OAuthErrorResponse {
-                    error: "invalid_request".to_string(),
-                    error_description: Some("Missing code parameter".to_string()),
-                    error_uri: None,
-                }),
-            )
-                .into_response();
+            return token_error_response(OAuthErrorCode::InvalidRequest, "Missing code parameter");
         }
     };
 
@@ -1077,7 +1064,7 @@ async fn handle_fido2_assertion_grant(
         Some(a) => a.clone(),
         None => {
             return token_error_response(
-                "invalid_request",
+                OAuthErrorCode::InvalidRequest,
                 "Missing assertion parameter for fido2-assertion grant",
             );
         }
@@ -1099,7 +1086,7 @@ async fn handle_fido2_assertion_grant(
         },
         _ => {
             return token_error_response(
-                "invalid_client",
+                OAuthErrorCode::InvalidClient,
                 "fido2-assertion grant requires private_key_jwt client authentication",
             );
         }
@@ -1293,7 +1280,7 @@ pub(crate) fn dpop_use_nonce_response(nonce: &str) -> Response {
             nonce.to_string(),
         )],
         Json(OAuthErrorResponse {
-            error: "use_dpop_nonce".to_string(),
+            error: OAuthErrorCode::UseDpopNonce.as_str().to_string(),
             error_description: Some(
                 "Authorization server requires nonce in DPoP proof".to_string(),
             ),
@@ -1304,11 +1291,11 @@ pub(crate) fn dpop_use_nonce_response(nonce: &str) -> Response {
 }
 
 /// Build an OAuth error response for parameter validation failures.
-fn token_error_response(error: &str, description: &str) -> Response {
+fn token_error_response(code: OAuthErrorCode, description: &str) -> Response {
     (
         StatusCode::BAD_REQUEST,
         Json(OAuthErrorResponse {
-            error: error.to_string(),
+            error: code.as_str().to_string(),
             error_description: Some(description.to_string()),
             error_uri: None,
         }),

--- a/crates/vouch-server/src/handlers/oidc/userinfo.rs
+++ b/crates/vouch-server/src/handlers/oidc/userinfo.rs
@@ -101,7 +101,7 @@ pub(crate) async fn userinfo(
         } else {
             return oauth_error(
                 StatusCode::UNAUTHORIZED,
-                "invalid_token",
+                OAuthErrorCode::InvalidToken,
                 "Unsupported authorization scheme. Use Bearer or DPoP",
             );
         }
@@ -125,7 +125,7 @@ pub(crate) async fn userinfo(
         if headers.get_all("DPoP").iter().count() > 1 {
             return oauth_error(
                 StatusCode::BAD_REQUEST,
-                OAuthErrorCode::InvalidDpopProof.as_str(),
+                OAuthErrorCode::InvalidDpopProof,
                 "Request must contain exactly one DPoP header",
             );
         }
@@ -134,7 +134,7 @@ pub(crate) async fn userinfo(
             None => {
                 return oauth_error(
                     StatusCode::BAD_REQUEST,
-                    OAuthErrorCode::InvalidDpopProof.as_str(),
+                    OAuthErrorCode::InvalidDpopProof,
                     "DPoP scheme requires DPoP proof header",
                 );
             }
@@ -171,7 +171,7 @@ pub(crate) async fn userinfo(
                     None => {
                         return oauth_error(
                             StatusCode::UNAUTHORIZED,
-                            "invalid_token",
+                            OAuthErrorCode::InvalidToken,
                             "Invalid or expired token",
                         );
                     }
@@ -183,7 +183,7 @@ pub(crate) async fn userinfo(
                         if !is_valid {
                             return oauth_error(
                                 StatusCode::UNAUTHORIZED,
-                                OAuthErrorCode::InvalidDpopProof.as_str(),
+                                OAuthErrorCode::InvalidDpopProof,
                                 "DPoP proof key does not match token binding",
                             );
                         }
@@ -193,7 +193,7 @@ pub(crate) async fn userinfo(
                         // but DPoP scheme was used
                         return oauth_error(
                             StatusCode::UNAUTHORIZED,
-                            OAuthErrorCode::InvalidDpopProof.as_str(),
+                            OAuthErrorCode::InvalidDpopProof,
                             "DPoP scheme used but token is not DPoP-bound",
                         );
                     }
@@ -216,14 +216,14 @@ pub(crate) async fn userinfo(
             Err(e @ DpopError::Database(_)) => {
                 return oauth_error(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    OAuthErrorCode::ServerError.as_str(),
+                    OAuthErrorCode::ServerError,
                     &e.to_string(),
                 );
             }
             Err(e) => {
                 return oauth_error(
                     StatusCode::UNAUTHORIZED,
-                    OAuthErrorCode::InvalidDpopProof.as_str(),
+                    OAuthErrorCode::InvalidDpopProof,
                     &e.to_string(),
                 );
             }
@@ -239,7 +239,7 @@ pub(crate) async fn userinfo(
         {
             return oauth_error(
                 StatusCode::UNAUTHORIZED,
-                "invalid_token",
+                OAuthErrorCode::InvalidToken,
                 "Token is DPoP-bound but was presented with Bearer scheme. Use DPoP scheme instead",
             );
         }
@@ -261,14 +261,14 @@ pub(crate) async fn userinfo(
         Ok(None) => {
             return oauth_error(
                 StatusCode::UNAUTHORIZED,
-                "invalid_token",
+                OAuthErrorCode::InvalidToken,
                 "Invalid or expired token",
             );
         }
         Err(e) => {
             return oauth_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                "server_error",
+                OAuthErrorCode::ServerError,
                 &e.to_string(),
             );
         }
@@ -328,7 +328,7 @@ async fn build_signed_userinfo_response(
             tracing::error!("Cannot determine client_id for signed userinfo response");
             return oauth_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                "server_error",
+                OAuthErrorCode::ServerError,
                 "Cannot determine client identity for signed userinfo",
             );
         }
@@ -352,7 +352,7 @@ async fn build_signed_userinfo_response(
                 );
                 return oauth_error(
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    "server_error",
+                    OAuthErrorCode::ServerError,
                     "RS256 signing key unavailable",
                 );
             }
@@ -364,7 +364,7 @@ async fn build_signed_userinfo_response(
             tracing::error!("Unsupported userinfo signing algorithm: {other}");
             return oauth_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                "server_error",
+                OAuthErrorCode::ServerError,
                 "Unsupported userinfo signing algorithm",
             );
         }
@@ -380,7 +380,7 @@ async fn build_signed_userinfo_response(
             tracing::error!("Failed to sign userinfo response: {e}");
             oauth_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                "server_error",
+                OAuthErrorCode::ServerError,
                 "Failed to generate signed userinfo response",
             )
         }
@@ -422,7 +422,7 @@ fn verify_mtls_binding(
         None => {
             return Err(Box::new(oauth_error(
                 StatusCode::UNAUTHORIZED,
-                "invalid_token",
+                OAuthErrorCode::InvalidToken,
                 "Token is certificate-bound but no client certificate was presented",
             )));
         }
@@ -433,7 +433,7 @@ fn verify_mtls_binding(
     if !is_valid {
         return Err(Box::new(oauth_error(
             StatusCode::UNAUTHORIZED,
-            "invalid_token",
+            OAuthErrorCode::InvalidToken,
             "Client certificate does not match token certificate binding",
         )));
     }
@@ -445,7 +445,8 @@ fn verify_mtls_binding(
 ///
 /// RFC 6750 Section 3: When the resource server returns a 401, it includes a
 /// `WWW-Authenticate` header indicating the supported scheme(s).
-fn oauth_error(status: StatusCode, error: &str, description: &str) -> Response {
+fn oauth_error(status: StatusCode, error: OAuthErrorCode, description: &str) -> Response {
+    let error = error.as_str();
     let body = Json(OAuthErrorResponse {
         error: error.to_string(),
         error_description: Some(description.to_string()),

--- a/crates/vouch-server/src/handlers/session.rs
+++ b/crates/vouch-server/src/handlers/session.rs
@@ -173,7 +173,7 @@ async fn extract_resource_token(
                             // the fresh nonce lets the caller retry once.
                             return Err(ServiceError::api_with_header(
                                 StatusCode::UNAUTHORIZED,
-                                "use_dpop_nonce",
+                                crate::error::OAuthErrorCode::UseDpopNonce.as_str(),
                                 "Authorization server requires nonce in DPoP proof",
                                 ("DPoP-Nonce", nonce.as_str()),
                             ));

--- a/crates/vouch-server/src/lib.rs
+++ b/crates/vouch-server/src/lib.rs
@@ -29,6 +29,11 @@ pub mod services;
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
 
+/// `error` stays `pub(crate)`; this is the only type from it that needs to
+/// be nameable outside the crate, since `services::oidc::jarm::build_jarm_error_jwt`
+/// is unconditionally `pub` and takes it by value.
+pub use error::OAuthErrorCode;
+
 use arc_swap::ArcSwap;
 use axum::{
     Router,

--- a/crates/vouch-server/src/services/oidc/jarm.rs
+++ b/crates/vouch-server/src/services/oidc/jarm.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 
 use crate::AppState;
 use crate::db::OAuthClient;
+use crate::error::OAuthErrorCode;
 
 /// JARM JWT lifetime in seconds (10 minutes per the specification).
 const JARM_JWT_LIFETIME_SECONDS: i64 = 600;
@@ -99,7 +100,7 @@ pub async fn build_jarm_success_jwt(
 pub async fn build_jarm_error_jwt(
     state: &Arc<AppState>,
     client: &OAuthClient,
-    error: &str,
+    error: OAuthErrorCode,
     description: Option<&str>,
     state_param: Option<&str>,
 ) -> Result<String> {
@@ -111,7 +112,7 @@ pub async fn build_jarm_error_jwt(
         iss: issuer,
         aud: client.client_id.clone(),
         exp,
-        error: error.to_string(),
+        error: error.as_str().to_string(),
         error_description: description.map(str::to_string),
         state: state_param.map(str::to_string),
     };

--- a/crates/vouch-tests/tests/oidc_jarm.rs
+++ b/crates/vouch-tests/tests/oidc_jarm.rs
@@ -9,6 +9,7 @@
 )]
 
 use serde_json::Value;
+use vouch_server::OAuthErrorCode;
 use vouch_server::db::{self, JwsAlgorithm, OAuthClient};
 use vouch_server::services::oidc::jarm::{build_jarm_error_jwt, build_jarm_success_jwt};
 use vouch_server::test_utils;
@@ -121,7 +122,7 @@ async fn rs256_without_rsa_key_returns_error() {
     let err = build_jarm_error_jwt(
         &harness.state,
         &client,
-        "invalid_request",
+        OAuthErrorCode::InvalidRequest,
         Some("bad request"),
         None,
     )
@@ -142,7 +143,7 @@ async fn error_jwt_carries_error_claims() {
     let jwt = build_jarm_error_jwt(
         &harness.state,
         &client,
-        "invalid_scope",
+        OAuthErrorCode::InvalidScope,
         Some("unknown scope"),
         Some("abc"),
     )
@@ -171,9 +172,15 @@ async fn error_jwt_omits_optional_fields() {
         .expect("create user");
     let client = client_with_alg(&harness, &user.id, None).await;
 
-    let jwt = build_jarm_error_jwt(&harness.state, &client, "access_denied", None, None)
-        .await
-        .expect("build minimal error jwt");
+    let jwt = build_jarm_error_jwt(
+        &harness.state,
+        &client,
+        OAuthErrorCode::AccessDenied,
+        None,
+        None,
+    )
+    .await
+    .expect("build minimal error jwt");
 
     let (_header, payload) = decode_jwt_unverified(&jwt);
     assert_eq!(


### PR DESCRIPTION
Closes #1004.

## What this does

Retypes the OAuth error chokepoints from `error: &str` to `error: OAuthErrorCode`, so an error-code typo is now a compile error instead of a wire defect. Same mechanism family as #1000/#1001: retype the chokepoint, let E0308 find every bypass.

- Retyped signatures: `token_error_response` (token.rs), `oauth_error_response` (authorize/error_response.rs and the local one in client_auth.rs), `oauth_error_redirect_jarm`, `build_jarm_error_jwt` (jarm.rs), `par_error_response` (par.rs, 22 call sites), `oauth_error` (userinfo.rs, 17 call sites). Status parameters stay explicit parameters — no status derivation from the code (moving `invalid_client` from 400 to 401 is a separate roadmap decision).
- Inline literal conversions on OAuth-wire paths: device.rs (4), fido2_challenge.rs (2), the `use_dpop_nonce` nonce responses in token.rs/par.rs/session.rs, `build_www_authenticate` and `into_oauth_response()` in error.rs, and one hand-built `unsupported_grant_type` response in token.rs now routed through `token_error_response`.
- New variant `OAuthErrorCode::LoginRequired`, doc-commented with the verbatim OIDC Core Section 3.1.2.6 definition: "The Authorization Server requires End-User authentication. This error MAY be returned when the prompt parameter value in the Authentication Request is none, but the Authentication Request cannot be completed without displaying a user interface for End-User authentication." (https://openid.net/specs/openid-connect-core-1_0.html#AuthError). Its `status_code()` arm is documented-unreachable: the code only travels as a redirect parameter.
- `pub use error::OAuthErrorCode;` at the crate root (the `error` module stays `pub(crate)`) so the unconditionally-`pub` `build_jarm_error_jwt` has a nameable parameter type.
- Doc citation fix: `ServerError` and `TemporarilyUnavailable` are defined in RFC 6749 Section 4.1.2.1, not Section 5.2 — Section 5.2's token-endpoint list is exactly `invalid_request`, `invalid_client`, `invalid_grant`, `unauthorized_client`, `unsupported_grant_type`, `invalid_scope` (verified against https://www.rfc-editor.org/rfc/rfc6749.txt).

Deliberately unchanged, per the issue's scope guard: every `ServiceError::api()` / `api_with_header()` signature and all `/v1`-envelope code strings (their codes are not spec-constrained); the `invalid_request_object` string in authorize.rs that feeds template display text rather than the wire; a register.rs test fixture.

## Evidence of no behavior change

Every existing rfc6749/oidc_core/rfc8628/rfc9449 wire-string test assertion passes untouched. Each swept site was verified (twice, independently) to serialize to the exact literal it replaced with an unchanged status. `cargo test --workspace --all-features` fully green (vouch-server lib 3120 tests), `cargo clippy --all-targets --all-features -- -D warnings` clean, `arch_boundaries` passes with the new crate-root export. The pre-existing `prompt=none`-without-session test asserts `error=login_required` on the redirect and now exercises the typed path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches every OAuth/OIDC error-response path (authorize, token, PAR, userinfo, JARM). Intended as a no-behavior type change, but a wrong variant at a call site would still change the wire `error` string.
> 
> **Overview**
> Retypes OAuth error chokepoints from `error: &str` to `OAuthErrorCode`, so an invalid wire code is a compile error instead of a protocol defect. HTTP status stays an explicit parameter; this does not start deriving status from the code.
> 
> Adds `OAuthErrorCode::LoginRequired` (`login_required`, OIDC Core 3.1.2.6) for `prompt=none` / `max_age` redirect errors. Replaces remaining OAuth-wire string literals (token, PAR, userinfo, device, JARM, certification deny-login, `into_oauth_response`) with `as_str()`. Re-exports `OAuthErrorCode` at the crate root so public `build_jarm_error_jwt` can take it.
> 
> Also corrects RFC citations for `ServerError` / `TemporarilyUnavailable` (RFC 6749 §4.1.2.1, not §5.2). `/v1` API error strings and `ServiceError::api*` stay untyped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ff2d771732a4c95fbe996cfa251eaf3ec92728f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->