### PR TITLE
fix(oidc): reject kty/alg-incompatible keys in FAPI JWKS validation (#1019)

### DIFF
--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -360,10 +360,11 @@ pub fn parse_jwks_set(value: &serde_json::Value) -> Result<JwkSet, serde_json::E
 /// keys would leave a FAPI client with no algorithm it is both allowed to use
 /// and has a matching key for, and a JWKS made only of `use: "enc"` keys would
 /// leave it with no key the search selects at all — both permanently
-/// unauthenticatable. The `kty` check on the no-`alg` branch closes the same
-/// bug class for an incompatible or missing `kty` (e.g. `oct`): the runtime
-/// matcher only ever selects `EC`/`RSA`/`OKP` for ES256/PS256/EdDSA, so a key
-/// with any other `kty` is unmatchable regardless of `alg`.
+/// unauthenticatable. The `kty` check on both branches closes the same bug
+/// class for an incompatible or missing `kty`: the runtime matcher only ever
+/// selects `EC` for ES256, `RSA` for PS256, and `OKP` for EdDSA, so a key
+/// whose `kty` is anything else (e.g. `oct`, or `RSA` declaring `alg: ES256`)
+/// is unmatchable regardless of `alg`.
 ///
 /// Used at every point a FAPI 2.0 client's JWKS is accepted or replaced:
 /// application creation and update (`handlers/applications/validate.rs`) and
@@ -388,8 +389,26 @@ pub fn jwks_has_fapi_allowed_key(jwks: &JwkSet) -> bool {
                 KeyType::Other(_) => false,
             };
         };
-        alg.parse::<JwsAlgorithm>()
-            .is_ok_and(|parsed| JwsAlgorithm::FAPI_ALLOWED.contains(&parsed))
+        let Ok(parsed) = alg.parse::<JwsAlgorithm>() else {
+            return false;
+        };
+        if !JwsAlgorithm::FAPI_ALLOWED.contains(&parsed) {
+            return false;
+        }
+        // Same kty-per-alg selection rule as the runtime matcher
+        // (`jwt_bearer::jwks::find_matching_key` /
+        // `build_decoding_key_from_jwk`): a key whose `kty` can't carry its
+        // declared `alg` is unmatchable, so declaring an allowed `alg` alone
+        // must not count. Exhaustive for the same reason as the no-`alg`
+        // branch above.
+        let expected_kty = match parsed {
+            JwsAlgorithm::Es256 => KeyType::Ec,
+            JwsAlgorithm::Ps256 => KeyType::Rsa,
+            JwsAlgorithm::EdDsa => KeyType::Okp,
+            // Not FAPI-allowed; already rejected by the contains() gate.
+            JwsAlgorithm::Rs256 => return false,
+        };
+        key.kty == expected_kty
     })
 }
 

--- a/crates/vouch-server/src/handlers/applications/validate.rs
+++ b/crates/vouch-server/src/handlers/applications/validate.rs
@@ -1629,6 +1629,34 @@ mod tests {
             "a kty outside EC/RSA/OKP must not survive on a missing alg"
         );
 
+        // An allowed alg must not rescue a kty that can't carry it: the
+        // runtime matcher selects EC for ES256, RSA for PS256, and OKP for
+        // EdDSA, so any other pairing is unmatchable at runtime even though
+        // the declared alg is FAPI-allowed.
+        let oct_with_allowed_alg = serde_json::json!({"keys": [{"kty": "oct", "alg": "ES256"}]});
+        assert!(
+            !jwks_has_fapi_allowed_key(&jwk_set(oct_with_allowed_alg)),
+            "an oct key must not survive by declaring an allowed alg"
+        );
+
+        let rsa_with_es256 = serde_json::json!({"keys": [{"kty": "RSA", "alg": "ES256"}]});
+        assert!(
+            !jwks_has_fapi_allowed_key(&jwk_set(rsa_with_es256)),
+            "an RSA key declaring ES256 is unmatchable at runtime"
+        );
+
+        let ec_with_ps256 = serde_json::json!({"keys": [{"kty": "EC", "alg": "PS256"}]});
+        assert!(
+            !jwks_has_fapi_allowed_key(&jwk_set(ec_with_ps256)),
+            "an EC key declaring PS256 is unmatchable at runtime"
+        );
+
+        let okp_with_es256 = serde_json::json!({"keys": [{"kty": "OKP", "alg": "ES256"}]});
+        assert!(
+            !jwks_has_fapi_allowed_key(&jwk_set(okp_with_es256)),
+            "an OKP key declaring ES256 is unmatchable at runtime"
+        );
+
         let mixed = serde_json::json!({
             "keys": [{"kty": "RSA", "alg": "RS256"}, {"kty": "EC", "alg": "ES256"}]
         });


### PR DESCRIPTION
Closes #1019.

## Problem

`jwks_has_fapi_allowed_key` (`crates/vouch-server/src/db/oauth.rs`) — the shared write-time check used by application create/update and RFC 7591/7592 dynamic client registration — only checked `kty` on the branch where a key declares no `alg`. A key declaring a FAPI-allowed `alg` with a `kty` that cannot carry it (e.g. `{"kty": "oct", "alg": "ES256"}` or `{"kty": "RSA", "alg": "ES256"}`) passed validation, while the runtime matcher (`services/oidc/jwt_bearer/jwks.rs`) rejects such a key on both its paths: the alg-fallback path filters by expected `kty`, and the kid path fails in `build_decoding_key_from_jwk`. That is exactly the "accepted at registration, unusable forever after" class the function's own doc comment describes itself as closing. The gap was untested rather than deliberate — the existing unit test covered `oct` with no `alg`, but had no case pairing an allowed `alg` with an incompatible `kty`.

Severity is low: the write path failed open but the runtime fails closed, so nothing authenticates that shouldn't. The cost is diagnostic — the error surfaced at first authentication instead of at registration.

## Fix

On the `alg`-present branch, after the `FAPI_ALLOWED` gate, also require the `kty` the runtime matcher selects for that algorithm (EC for ES256, RSA for PS256, OKP for EdDSA), using an exhaustive match consistent with the no-`alg` branch. Doc comment updated to match. No handler changes — all four write paths call this one shared function.

## Tests

Extended `jwks_has_fapi_allowed_key_covers_alg_and_kty_cases` (`handlers/applications/validate.rs`) with the mismatch cases: `oct`+ES256 (the issue's reproducer), RSA+ES256, EC+PS256, and OKP+ES256, all now rejected; the existing compatible-pair cases still assert the accepting side.

- `make fmt` — clean
- `make lint` (clippy `-D warnings`) — clean
- `cargo test --all-features` — 4950 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E1FRAWoTmK4KtBHtSfgiN9

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1FRAWoTmK4KtBHtSfgiN9)_