### PR TITLE
refactor(oauth): share cross-crate wire literals via vouch-common (#1005)

### DIFF
--- a/crates/vouch-cli/src/commands/credential/wif.rs
+++ b/crates/vouch-cli/src/commands/credential/wif.rs
@@ -34,18 +34,14 @@ use crate::config::Config;
 use crate::session::resolve_token;
 use vouch_cli::fapi::key_store::load_client_key;
 use vouch_cli::fapi::{ClientAssertionBuilder, ClientKey, DpopProofBuilder};
+use vouch_common::protocol::{
+    ERROR_USE_DPOP_NONCE, GRANT_TYPE_TOKEN_EXCHANGE, TOKEN_TYPE_ACCESS_TOKEN, TOKEN_TYPE_ID_TOKEN,
+};
 
 /// Number of seconds shaved off the provider's stated `expires_in` when
 /// computing the cache expiry — gives callers a window to refresh before
 /// the token actually expires.
 const REFRESH_MARGIN_SECS: i64 = 60;
-
-/// RFC 8693 grant type for OAuth 2.0 token exchange.
-const GRANT_TYPE_TOKEN_EXCHANGE: &str = "urn:ietf:params:oauth:grant-type:token-exchange";
-/// RFC 8693 token type URN for an access token (the subject token).
-const TOKEN_TYPE_ACCESS_TOKEN: &str = "urn:ietf:params:oauth:token-type:access_token";
-/// RFC 8693 token type URN for an ID token (the requested token).
-const TOKEN_TYPE_ID_TOKEN: &str = "urn:ietf:params:oauth:token-type:id_token";
 
 /// Subset of the RFC 8693 token-exchange response we consume. Per RFC 8693
 /// §2.2.1 the issued security token — an OIDC ID token here — is always
@@ -218,7 +214,7 @@ async fn send_exchange(
     // RFC 9449: a `use_dpop_nonce` error carries a fresh nonce to retry with.
     let parsed_err = serde_json::from_str::<vouch_common::OAuthError>(&text).ok();
     if let Some(err) = &parsed_err
-        && err.error == "use_dpop_nonce"
+        && err.error == ERROR_USE_DPOP_NONCE
         && let Some(nonce) = nonce
     {
         return Ok(ExchangeOutcome::NeedNonce(nonce));

--- a/crates/vouch-cli/src/commands/enroll.rs
+++ b/crates/vouch-cli/src/commands/enroll.rs
@@ -6,7 +6,7 @@ use secrecy::{ExposeSecret, SecretString};
 use std::io::{IsTerminal, Write, stdout};
 use vouch_common::{
     DeviceCodeRequest, DeviceCodeResponse, DeviceTokenRequest, OAuthError, RegisterCompleteRequest,
-    RegisterCompleteResponse, RegisterStartRequest, RegisterStartResponse,
+    RegisterCompleteResponse, RegisterStartRequest, RegisterStartResponse, protocol,
 };
 
 use crate::client::VouchClient;
@@ -266,7 +266,7 @@ async fn poll_for_token(
     fapi_key: Option<&vouch_cli::fapi::ClientKey>,
 ) -> Result<DeviceTokenResponse> {
     let request = DeviceTokenRequest {
-        grant_type: "urn:ietf:params:oauth:grant-type:device_code".to_string(),
+        grant_type: protocol::GRANT_TYPE_DEVICE_CODE.to_string(),
         device_code: device_response.device_code.clone(),
     };
 
@@ -430,13 +430,13 @@ async fn poll_once(
 
     if let Ok(oauth_error) = serde_json::from_str::<OAuthError>(&error_text) {
         match oauth_error.error.as_str() {
-            "authorization_pending" => {
+            protocol::ERROR_AUTHORIZATION_PENDING => {
                 return Err(PollError::Pending);
             }
-            "slow_down" => return Err(PollError::SlowDown),
-            "access_denied" => return Err(PollError::Denied),
-            "expired_token" => return Err(PollError::Expired),
-            "use_dpop_nonce" => {
+            protocol::ERROR_SLOW_DOWN => return Err(PollError::SlowDown),
+            protocol::ERROR_ACCESS_DENIED => return Err(PollError::Denied),
+            protocol::ERROR_EXPIRED_TOKEN => return Err(PollError::Expired),
+            protocol::ERROR_USE_DPOP_NONCE => {
                 // RFC 9449: Server requires a DPoP nonce
                 if let Some(nonce) = response_dpop_nonce {
                     return Err(PollError::DpopNonce(nonce));

--- a/crates/vouch-cli/src/commands/login.rs
+++ b/crates/vouch-cli/src/commands/login.rs
@@ -22,7 +22,7 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use secrecy::ExposeSecret;
 use serde::Serialize;
 use vouch_cli::fapi::{ClientAssertionBuilder, ClientKey, DpopProofBuilder, FapiInteraction};
-use vouch_common::Fido2ChallengeResponse;
+use vouch_common::{Fido2ChallengeResponse, protocol};
 
 use super::enroll::expiry_offset_seconds;
 use crate::client::VouchClient;
@@ -255,8 +255,8 @@ async fn run_fapi_login(
         .context(tr!("err-failed-build-dpop-proof-token-request"))?;
 
     let token_request = Fido2AssertionTokenRequest {
-        grant_type: "urn:ietf:params:oauth:grant-type:fido2-assertion",
-        client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+        grant_type: protocol::GRANT_TYPE_FIDO2_ASSERTION,
+        client_assertion_type: protocol::CLIENT_ASSERTION_TYPE_JWT_BEARER,
         client_assertion: client_assertion.assertion,
         assertion: assertion_b64.into(),
         scope: "openid email",
@@ -296,7 +296,7 @@ async fn run_fapi_login(
 
         // RFC 9449: if use_dpop_nonce is returned, retry once with the nonce.
         if let Ok(oauth_err) = serde_json::from_str::<vouch_common::OAuthError>(&body)
-            && oauth_err.error == "use_dpop_nonce"
+            && oauth_err.error == protocol::ERROR_USE_DPOP_NONCE
             && let Some(nonce) = dpop_nonce
         {
             return run_fapi_login_with_nonce(

--- a/crates/vouch-cli/src/fapi/client_assertion.rs
+++ b/crates/vouch-cli/src/fapi/client_assertion.rs
@@ -47,8 +47,9 @@ impl std::fmt::Debug for ClientAssertion {
 }
 
 impl ClientAssertion {
-    /// The `client_assertion_type` value for `private_key_jwt` per RFC 7523.
-    pub const TYPE: &'static str = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+    /// The `client_assertion_type` value for `private_key_jwt` per RFC 7523
+    /// §2.2. Shared with the server via [`vouch_common::protocol`].
+    pub const TYPE: &'static str = vouch_common::protocol::CLIENT_ASSERTION_TYPE_JWT_BEARER;
 }
 
 /// Builder for `private_key_jwt` client assertions.

--- a/crates/vouch-cli/src/fapi/registration.rs
+++ b/crates/vouch-cli/src/fapi/registration.rs
@@ -13,6 +13,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 use super::key::ClientKey;
+use vouch_common::protocol;
 
 /// RFC 7591 client registration request body.
 ///
@@ -112,8 +113,8 @@ pub async fn register_fapi_client(
     let request = RegistrationRequest {
         token_endpoint_auth_method: "private_key_jwt",
         grant_types: vec![
-            "urn:ietf:params:oauth:grant-type:device_code",
-            "urn:ietf:params:oauth:grant-type:fido2-assertion",
+            protocol::GRANT_TYPE_DEVICE_CODE,
+            protocol::GRANT_TYPE_FIDO2_ASSERTION,
         ],
         response_types: vec![],
         dpop_bound_access_tokens: true,

--- a/crates/vouch-common/src/api.rs
+++ b/crates/vouch-common/src/api.rs
@@ -138,7 +138,12 @@ pub struct DeviceCodeResponse {
 /// Request to exchange device code for token.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DeviceTokenRequest {
-    /// Must be "urn:ietf:params:oauth:grant-type:device_code".
+    /// Must be [`crate::protocol::GRANT_TYPE_DEVICE_CODE`].
+    ///
+    /// Kept as `String` rather than a serde-renamed enum: the token handler
+    /// rejects a bad value with the RFC 6749 §5.2 error envelope, which a
+    /// deserialization failure would replace with an axum `JsonRejection`
+    /// carrying a different status and body.
     pub grant_type: String,
     /// Device code from device authorization response.
     pub device_code: String,

--- a/crates/vouch-common/src/lib.rs
+++ b/crates/vouch-common/src/lib.rs
@@ -15,6 +15,7 @@ pub mod fs;
 pub mod http;
 pub mod paths;
 pub mod posture;
+pub mod protocol;
 pub(crate) mod url;
 
 #[cfg(test)]

--- a/crates/vouch-common/src/protocol.rs
+++ b/crates/vouch-common/src/protocol.rs
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! OAuth 2.0 wire literals shared by the Vouch server and CLI.
+//!
+//! These are the exact bytes that cross the wire between the two crates:
+//! `grant_type` and `client_assertion_type` values sent by the CLI and
+//! dispatched by the server, RFC 8693 token type URNs, and the error codes
+//! the CLI string-matches on to drive retries. Spelling them once means a
+//! typo is a compile error on both sides instead of a runtime mismatch.
+//!
+//! Every constant carries the verbatim normative text that fixes its value,
+//! with the section number and the URL it was fetched from.
+//!
+//! # Scope
+//!
+//! What belongs here is the CLI↔server contract, not every OAuth string the
+//! workspace types. Two neighbours are deliberately absent:
+//!
+//! - `urn:ietf:params:oauth:grant-type:jwt-bearer` (RFC 7523 §2.1) is used
+//!   by the CLI against AWS IAM Identity Center, Anthropic, and OpenAI,
+//!   never against vouch-server — which rejects it. Those call sites keep
+//!   their own literals: they answer to the provider's contract, not ours.
+//! - The PAR `request_uri` URN prefix (RFC 9126 §2.2) is server-only; it
+//!   lives in `vouch_server::db::par`.
+//!
+//! [`TOKEN_TYPE_JWT`] is the one constant here that vouch-server alone
+//! sends. It is admitted because RFC 8693 §3 defines the three token type
+//! identifiers as one group and the server matches on all three; splitting
+//! the group across two crates would be worse than carrying it.
+//!
+//! Behavior stays where it is: `OAuthGrantType` and `OAuthErrorCode` remain
+//! server-side enums, and their `as_str()` arms return these constants. The
+//! enums own dispatch; this module owns bytes.
+
+/// RFC 8628 §3.4 (Device Access Token Request) — device authorization grant.
+///
+/// > grant_type
+/// >    REQUIRED.  Value MUST be set to
+/// >    "urn:ietf:params:oauth:grant-type:device_code".
+///
+/// <https://www.rfc-editor.org/rfc/rfc8628#section-3.4>
+pub const GRANT_TYPE_DEVICE_CODE: &str = "urn:ietf:params:oauth:grant-type:device_code";
+
+/// RFC 8693 §2.1 (Request) — token exchange grant.
+///
+/// > grant_type
+/// >    REQUIRED.  The value "urn:ietf:params:oauth:grant-type:token-
+/// >    exchange" indicates that a token exchange is being performed.
+///
+/// <https://www.rfc-editor.org/rfc/rfc8693#section-2.1>
+pub const GRANT_TYPE_TOKEN_EXCHANGE: &str = "urn:ietf:params:oauth:grant-type:token-exchange";
+
+/// Vouch's FIDO2 assertion grant — an extension grant, not IETF-registered.
+///
+/// RFC 6749 §4.5 (Extension Grants) is the authority for minting it:
+///
+/// > The client uses an extension grant type by specifying the grant type
+/// > using an absolute URI (defined by the authorization server) as the
+/// > value of the "grant_type" parameter of the token endpoint, and by
+/// > adding any additional parameters necessary.
+///
+/// <https://www.rfc-editor.org/rfc/rfc6749#section-4.5>
+///
+/// Because no registry fixes this value, the CLI and server agreeing on it
+/// is entirely on us — which is the strongest reason for it to live here.
+pub const GRANT_TYPE_FIDO2_ASSERTION: &str = "urn:ietf:params:oauth:grant-type:fido2-assertion";
+
+/// RFC 7523 §2.2 (Using JWTs for Client Authentication) — `private_key_jwt`.
+///
+/// > The value of the "client_assertion_type" is
+/// > "urn:ietf:params:oauth:client-assertion-type:jwt-bearer".
+///
+/// <https://www.rfc-editor.org/rfc/rfc7523#section-2.2>
+pub const CLIENT_ASSERTION_TYPE_JWT_BEARER: &str =
+    "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+
+/// RFC 8693 §3 (Token Type Identifiers) — OAuth 2.0 access token.
+///
+/// > urn:ietf:params:oauth:token-type:access_token
+/// >    Indicates that the token is an OAuth 2.0 access token issued by
+/// >    the given authorization server.
+///
+/// <https://www.rfc-editor.org/rfc/rfc8693#section-3>
+pub const TOKEN_TYPE_ACCESS_TOKEN: &str = "urn:ietf:params:oauth:token-type:access_token";
+
+/// RFC 8693 §3 (Token Type Identifiers) — OIDC ID Token.
+///
+/// > urn:ietf:params:oauth:token-type:id_token
+/// >    Indicates that the token is an ID Token as defined in Section 2 of
+/// >    [OpenID.Core].
+///
+/// <https://www.rfc-editor.org/rfc/rfc8693#section-3>
+pub const TOKEN_TYPE_ID_TOKEN: &str = "urn:ietf:params:oauth:token-type:id_token";
+
+/// RFC 8693 §3 (Token Type Identifiers) — bare JWT.
+///
+/// > The value "urn:ietf:params:oauth:token-type:jwt", which is defined in
+/// > Section 9 of [JWT], indicates that the token is a JWT.
+///
+/// <https://www.rfc-editor.org/rfc/rfc8693#section-3>
+///
+/// Distinct from [`TOKEN_TYPE_ACCESS_TOKEN`]: the same RFC 8693 §3 notes
+/// that an access token "represents a delegated authorization decision,
+/// whereas JWT is a token format".
+pub const TOKEN_TYPE_JWT: &str = "urn:ietf:params:oauth:token-type:jwt";
+
+/// RFC 9449 §8 (Authorization Server-Provided Nonce) — retry with a nonce.
+///
+/// > An authorization server MAY supply a nonce value to be included by
+/// > the client in DPoP proofs sent.  In this case, the authorization
+/// > server responds to requests that do not include a nonce with an HTTP
+/// > 400 (Bad Request) error response per Section 5.2 of [RFC6749] using
+/// > use_dpop_nonce as the error code value.
+///
+/// <https://www.rfc-editor.org/rfc/rfc9449#section-8>
+///
+/// Resource servers use the same code in a `WWW-Authenticate: DPoP`
+/// challenge, per RFC 9449 §7.1 (The DPoP Authentication Scheme):
+///
+/// > The value use_dpop_nonce can be used as described in Section 9 to
+/// > signal that a nonce is needed in the DPoP proof of a subsequent
+/// > request(s).
+///
+/// <https://www.rfc-editor.org/rfc/rfc9449#section-7.1>
+pub const ERROR_USE_DPOP_NONCE: &str = "use_dpop_nonce";
+
+/// RFC 8628 §3.5 (Device Access Token Response) — keep polling.
+///
+/// > authorization_pending
+/// >    The authorization request is still pending as the end user hasn't
+/// >    yet completed the user-interaction steps (Section 3.3).
+///
+/// <https://www.rfc-editor.org/rfc/rfc8628#section-3.5>
+pub const ERROR_AUTHORIZATION_PENDING: &str = "authorization_pending";
+
+/// RFC 8628 §3.5 (Device Access Token Response) — poll less often.
+///
+/// > slow_down
+/// >    A variant of "authorization_pending", the authorization request is
+/// >    still pending and polling should continue, but the interval MUST
+/// >    be increased by 5 seconds for this and all subsequent requests.
+///
+/// <https://www.rfc-editor.org/rfc/rfc8628#section-3.5>
+pub const ERROR_SLOW_DOWN: &str = "slow_down";
+
+/// RFC 8628 §3.5 (Device Access Token Response) — the user said no.
+///
+/// > access_denied
+/// >    The authorization request was denied.
+///
+/// <https://www.rfc-editor.org/rfc/rfc8628#section-3.5>
+pub const ERROR_ACCESS_DENIED: &str = "access_denied";
+
+/// RFC 8628 §3.5 (Device Access Token Response) — the device code is dead.
+///
+/// > expired_token
+/// >    The "device_code" has expired, and the device authorization
+/// >    session has concluded.
+///
+/// <https://www.rfc-editor.org/rfc/rfc8628#section-3.5>
+pub const ERROR_EXPIRED_TOKEN: &str = "expired_token";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Each constant is asserted against its literal spelled out a second
+    // time. The duplication is the point: centralizing these values makes a
+    // single typo change a URN everywhere at once, so an edit has to touch
+    // both the constant and the RFC-named test that pins it.
+
+    #[test]
+    fn rfc8628_device_code_grant_type_urn() {
+        assert_eq!(
+            GRANT_TYPE_DEVICE_CODE,
+            "urn:ietf:params:oauth:grant-type:device_code"
+        );
+    }
+
+    #[test]
+    fn rfc8693_token_exchange_grant_type_urn() {
+        assert_eq!(
+            GRANT_TYPE_TOKEN_EXCHANGE,
+            "urn:ietf:params:oauth:grant-type:token-exchange"
+        );
+    }
+
+    #[test]
+    fn vouch_fido2_assertion_grant_type_urn() {
+        assert_eq!(
+            GRANT_TYPE_FIDO2_ASSERTION,
+            "urn:ietf:params:oauth:grant-type:fido2-assertion"
+        );
+    }
+
+    #[test]
+    fn rfc7523_client_assertion_type_urn() {
+        assert_eq!(
+            CLIENT_ASSERTION_TYPE_JWT_BEARER,
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+        );
+    }
+
+    #[test]
+    fn rfc8693_access_token_type_urn() {
+        assert_eq!(
+            TOKEN_TYPE_ACCESS_TOKEN,
+            "urn:ietf:params:oauth:token-type:access_token"
+        );
+    }
+
+    #[test]
+    fn rfc8693_id_token_type_urn() {
+        assert_eq!(
+            TOKEN_TYPE_ID_TOKEN,
+            "urn:ietf:params:oauth:token-type:id_token"
+        );
+    }
+
+    #[test]
+    fn rfc8693_jwt_token_type_urn() {
+        assert_eq!(TOKEN_TYPE_JWT, "urn:ietf:params:oauth:token-type:jwt");
+    }
+
+    #[test]
+    fn rfc9449_use_dpop_nonce_error_code() {
+        assert_eq!(ERROR_USE_DPOP_NONCE, "use_dpop_nonce");
+    }
+
+    #[test]
+    fn rfc8628_authorization_pending_error_code() {
+        assert_eq!(ERROR_AUTHORIZATION_PENDING, "authorization_pending");
+    }
+
+    #[test]
+    fn rfc8628_slow_down_error_code() {
+        assert_eq!(ERROR_SLOW_DOWN, "slow_down");
+    }
+
+    #[test]
+    fn rfc8628_access_denied_error_code() {
+        assert_eq!(ERROR_ACCESS_DENIED, "access_denied");
+    }
+
+    #[test]
+    fn rfc8628_expired_token_error_code() {
+        assert_eq!(ERROR_EXPIRED_TOKEN, "expired_token");
+    }
+}

--- a/crates/vouch-server/src/error.rs
+++ b/crates/vouch-server/src/error.rs
@@ -12,7 +12,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use serde::Serialize;
-use vouch_common::ApiError;
+use vouch_common::{ApiError, protocol};
 
 /// Service layer errors with protocol-aware conversions.
 #[derive(Debug, thiserror::Error)]
@@ -242,13 +242,13 @@ impl OAuthErrorCode {
             Self::InvalidScope => "invalid_scope",
             Self::ServerError => "server_error",
             Self::TemporarilyUnavailable => "temporarily_unavailable",
-            Self::AuthorizationPending => "authorization_pending",
-            Self::SlowDown => "slow_down",
-            Self::ExpiredToken => "expired_token",
-            Self::AccessDenied => "access_denied",
+            Self::AuthorizationPending => protocol::ERROR_AUTHORIZATION_PENDING,
+            Self::SlowDown => protocol::ERROR_SLOW_DOWN,
+            Self::ExpiredToken => protocol::ERROR_EXPIRED_TOKEN,
+            Self::AccessDenied => protocol::ERROR_ACCESS_DENIED,
             Self::InvalidToken => "invalid_token",
             Self::InvalidDpopProof => "invalid_dpop_proof",
-            Self::UseDpopNonce => "use_dpop_nonce",
+            Self::UseDpopNonce => protocol::ERROR_USE_DPOP_NONCE,
             Self::InvalidTarget => "invalid_target",
             Self::InsufficientUserAuthentication => "insufficient_user_authentication",
             Self::UnmetAuthenticationRequirements => "unmet_authentication_requirements",

--- a/crates/vouch-server/src/handlers/oidc/client_auth.rs
+++ b/crates/vouch-server/src/handlers/oidc/client_auth.rs
@@ -19,10 +19,13 @@ use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use secrecy::SecretString;
 use std::sync::Arc;
+use vouch_common::protocol;
 
 /// RFC 7521 Section 4.2: Expected client assertion type for JWT bearer.
-const JWT_BEARER_CLIENT_ASSERTION_TYPE: &str =
-    "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+///
+/// The value itself is fixed by RFC 7523 §2.2 and shared with the CLI via
+/// [`vouch_common::protocol`].
+const JWT_BEARER_CLIENT_ASSERTION_TYPE: &str = protocol::CLIENT_ASSERTION_TYPE_JWT_BEARER;
 
 /// Extracted client authentication method from a request.
 ///

--- a/crates/vouch-server/src/services/oidc/exchange.rs
+++ b/crates/vouch-server/src/services/oidc/exchange.rs
@@ -20,14 +20,16 @@ use jiff::Timestamp;
 use secrecy::ExposeSecret;
 use std::sync::Arc;
 
-/// Token type URNs for RFC 8693.
+/// Token type URNs for RFC 8693 §3, re-exported under the names this module
+/// uses. The values live in [`vouch_common::protocol`] so the CLI's exchange
+/// requests are spelled from the same constants the server matches on.
 pub mod token_types {
     /// Access token type.
-    pub const ACCESS_TOKEN: &str = "urn:ietf:params:oauth:token-type:access_token";
+    pub use vouch_common::protocol::TOKEN_TYPE_ACCESS_TOKEN as ACCESS_TOKEN;
     /// ID token type.
-    pub const ID_TOKEN: &str = "urn:ietf:params:oauth:token-type:id_token";
+    pub use vouch_common::protocol::TOKEN_TYPE_ID_TOKEN as ID_TOKEN;
     /// JWT type.
-    pub const JWT: &str = "urn:ietf:params:oauth:token-type:jwt";
+    pub use vouch_common::protocol::TOKEN_TYPE_JWT as JWT;
 }
 
 /// Default lifetime for an exchanged OIDC ID token
@@ -750,11 +752,16 @@ mod tests {
         assert_eq!(result, Some(ScopeSet::parse("openid email")));
     }
 
+    /// The `token_types` aliases must map to the matching `protocol`
+    /// constants. A swapped `pub use` would still compile and would still
+    /// carry the RFC 8693 §3 prefix, so the prefix alone proves nothing.
     #[test]
-    fn test_token_type_urns() {
-        assert!(token_types::ACCESS_TOKEN.starts_with("urn:ietf:params:oauth:token-type:"));
-        assert!(token_types::ID_TOKEN.starts_with("urn:ietf:params:oauth:token-type:"));
-        assert!(token_types::JWT.starts_with("urn:ietf:params:oauth:token-type:"));
+    fn test_token_type_aliases_match_protocol_constants() {
+        use vouch_common::protocol;
+
+        assert_eq!(token_types::ACCESS_TOKEN, protocol::TOKEN_TYPE_ACCESS_TOKEN);
+        assert_eq!(token_types::ID_TOKEN, protocol::TOKEN_TYPE_ID_TOKEN);
+        assert_eq!(token_types::JWT, protocol::TOKEN_TYPE_JWT);
     }
 
     // =========================================================================

--- a/crates/vouch-server/src/services/oidc/grant_type.rs
+++ b/crates/vouch-server/src/services/oidc/grant_type.rs
@@ -5,6 +5,11 @@
 //! The token handler (parsing and dispatch) and the discovery document
 //! (`grant_types_supported`) both derive from it, so the advertised set can
 //! never drift from the accepted set.
+//!
+//! The URN wire values come from [`vouch_common::protocol`], which the CLI
+//! spells its requests with — the enum owns dispatch, vouch-common owns bytes.
+
+use vouch_common::protocol;
 
 /// OAuth grant types supported by this server's token endpoint.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -59,9 +64,9 @@ impl OAuthGrantType {
         match self {
             Self::AuthorizationCode => "authorization_code",
             Self::ClientCredentials => "client_credentials",
-            Self::DeviceCode => "urn:ietf:params:oauth:grant-type:device_code",
-            Self::TokenExchange => "urn:ietf:params:oauth:grant-type:token-exchange",
-            Self::Fido2Assertion => "urn:ietf:params:oauth:grant-type:fido2-assertion",
+            Self::DeviceCode => protocol::GRANT_TYPE_DEVICE_CODE,
+            Self::TokenExchange => protocol::GRANT_TYPE_TOKEN_EXCHANGE,
+            Self::Fido2Assertion => protocol::GRANT_TYPE_FIDO2_ASSERTION,
         }
     }
 


### PR DESCRIPTION
The CLI and server spelled the same OAuth wire strings independently: grant-type URNs, the `private_key_jwt` client-assertion type, RFC 8693 token-type URNs, and the error codes the CLI string-matches to drive device-flow polling and DPoP nonce retries. A typo on either side compiled and failed at runtime against the other.

New `crates/vouch-common/src/protocol.rs` holds 12 `&'static str` constants. Every one carries the verbatim normative text that fixes its value, with the section number and the URL it was fetched from.

| Constant(s) | Authority |
|---|---|
| `GRANT_TYPE_DEVICE_CODE` | RFC 8628 §3.4 |
| `GRANT_TYPE_TOKEN_EXCHANGE` | RFC 8693 §2.1 |
| `GRANT_TYPE_FIDO2_ASSERTION` | RFC 6749 §4.5 (extension grant) |
| `CLIENT_ASSERTION_TYPE_JWT_BEARER` | RFC 7523 §2.2 |
| `TOKEN_TYPE_ACCESS_TOKEN` / `_ID_TOKEN` / `_JWT` | RFC 8693 §3 |
| `ERROR_USE_DPOP_NONCE` | RFC 9449 §8 and §7.1 |
| `ERROR_AUTHORIZATION_PENDING` / `_SLOW_DOWN` / `_ACCESS_DENIED` / `_EXPIRED_TOKEN` | RFC 8628 §3.5 |

`GRANT_TYPE_FIDO2_ASSERTION` is the one value no registry fixes — RFC 6749 §4.5 only grants the authorization server the right to mint an absolute URI — so the CLI and server agreeing on it rests entirely on us. That is the strongest case for centralizing it.

## What moved and what didn't

`OAuthGrantType` and `OAuthErrorCode` stay in vouch-server; their `as_str` arms now return these constants, and `services/oidc/exchange.rs::token_types` re-exports rather than redefines. The enums own dispatch, vouch-common owns bytes.

`DeviceTokenRequest.grant_type` stays a `String`. A serde-renamed enum would move rejection from the handler's RFC 6749 §5.2 error envelope to an axum `JsonRejection` with a different status and body; the field doc now points at the constant and says why.

Deliberately excluded, recorded in the module doc: `urn:ietf:params:oauth:grant-type:jwt-bearer` (spoken by the CLI only to AWS IAM Identity Center, Anthropic, and OpenAI — never to vouch-server, which rejects it) and the PAR `request_uri` prefix (server-only). Those call sites keep their own literals because they answer to the provider's contract, not ours. `TOKEN_TYPE_JWT` is the one constant here that only vouch-server sends; it is admitted so RFC 8693 §3's three token type identifiers stay together rather than being split across two crates.

## Two changes beyond mechanical substitution

`exchange.rs::test_token_type_urns` only asserted the URN prefix. After the switch to `pub use`, a swapped alias would still compile and still carry the prefix, so it now pins each alias to its matching `protocol` constant instead.

The per-constant lock-in tests spell each literal a second time. The duplication is deliberate: centralizing these values means one typo changes a URN everywhere at once, so an edit has to touch both the constant and the RFC-named test that pins it.

## Verification

Values are unchanged — the diff is wire-identical.

- `make lint` — zero warnings
- `make test` — exit 0 (workspace, `--all-features`)
- `make test-integration` — 296 tests, 0 failures
- `prek run` — all hooks pass

Every quote above was fetched from `rfc-editor.org` this session and then re-checked line by line against the raw `.txt`, because the fetch tool's rendering differed from the normative text in whitespace in a few places. The committed quotes match the raw source.

The tests were checked against a real regression rather than assumed: typo'ing `device_code` to `device-code` failed the vouch-common lock-in test plus four downstream server tests (`from_str_device_code`, `allowed_grant_types_includes_expected`, `oidc_discovery_supported_grant_types`, `rfc8414_grant_types_supported`).

## Scope note

Two additions beyond the issue's literal enumeration, both chosen deliberately. The four RFC 8628 §3.5 device-flow error codes are included so `enroll.rs`'s five-arm match isn't left with one typed arm and four bare literals. `TOKEN_TYPE_JWT` is included for the reason above.

Closes #1005

🤖 Generated with [Claude Code](https://claude.com/claude-code)