### PR TITLE
refactor(oauth): share dpop, token type, and webauthn wire literals (#1006)

### DIFF
--- a/crates/vouch-cli/src/client.rs
+++ b/crates/vouch-cli/src/client.rs
@@ -14,6 +14,7 @@ use vouch_cli::http::{
     HttpClient, HttpResponse, ReqwestClient, format_http_error, parse_www_authenticate,
 };
 use vouch_cli::{tr, tr_args};
+use vouch_common::protocol;
 
 /// Parameters for building RFC 9421 HTTP signature headers.
 struct SignRequestParams<'a> {
@@ -164,7 +165,7 @@ impl<H: HttpClient> VouchClient<H> {
     ///
     /// When a FAPI key is present, generates a DPoP proof bound to the access
     /// token hash and returns `("DPoP <token>", Some("<proof>"))`.
-    /// If proof generation fails, falls back to `("Bearer <token>", None)`.
+    /// If proof generation fails, falls back to the Bearer scheme.
     ///
     /// When no FAPI key is present, returns `("Bearer <token>", None)`.
     fn build_auth(&self, method: &str, url: &str) -> Result<(String, Option<String>)> {
@@ -179,7 +180,10 @@ impl<H: HttpClient> VouchClient<H> {
             match builder.build(key) {
                 Ok(proof) => {
                     tracing::debug!("Using DPoP auth for {method} {url} (kid={})", key.kid());
-                    return Ok((format!("DPoP {token_str}"), Some(proof)));
+                    return Ok((
+                        format!("{} {token_str}", protocol::AUTH_SCHEME_DPOP),
+                        Some(proof),
+                    ));
                 }
                 Err(e) => {
                     // Non-fatal: fall through to Bearer auth.
@@ -200,7 +204,10 @@ impl<H: HttpClient> VouchClient<H> {
             tracing::debug!("Using Bearer auth for {method} {url} (no FAPI key)");
         }
 
-        Ok((format!("Bearer {token_str}"), None))
+        Ok((
+            format!("{} {token_str}", protocol::AUTH_SCHEME_BEARER),
+            None,
+        ))
     }
 
     /// Build the full URL for a path.
@@ -360,7 +367,7 @@ impl<H: HttpClient> VouchClient<H> {
                     // Collect all extra headers (DPoP proof + HTTP signature)
                     let mut extra_headers: Vec<(String, String)> = Vec::new();
                     if let Some(ref proof) = dpop_proof {
-                        extra_headers.push(("DPoP".to_string(), proof.clone()));
+                        extra_headers.push((protocol::HEADER_DPOP.to_string(), proof.clone()));
                     }
 
                     // Sign with RFC 9421 HTTP message signatures when FAPI key is present
@@ -443,7 +450,7 @@ impl<H: HttpClient> VouchClient<H> {
             "POST",
             path,
             Some(form.as_bytes()),
-            Some("application/x-www-form-urlencoded"),
+            Some(protocol::CONTENT_TYPE_FORM_URLENCODED),
             Auth::None,
         )
         .await

--- a/crates/vouch-cli/src/commands/credential/wif.rs
+++ b/crates/vouch-cli/src/commands/credential/wif.rs
@@ -35,7 +35,8 @@ use crate::session::resolve_token;
 use vouch_cli::fapi::key_store::load_client_key;
 use vouch_cli::fapi::{ClientAssertionBuilder, ClientKey, DpopProofBuilder};
 use vouch_common::protocol::{
-    ERROR_USE_DPOP_NONCE, GRANT_TYPE_TOKEN_EXCHANGE, TOKEN_TYPE_ACCESS_TOKEN, TOKEN_TYPE_ID_TOKEN,
+    CONTENT_TYPE_FORM_URLENCODED, ERROR_USE_DPOP_NONCE, GRANT_TYPE_TOKEN_EXCHANGE, HEADER_DPOP,
+    HEADER_DPOP_NONCE, TOKEN_TYPE_ACCESS_TOKEN, TOKEN_TYPE_ID_TOKEN,
 };
 
 /// Number of seconds shaved off the provider's stated `expires_in` when
@@ -181,8 +182,8 @@ async fn send_exchange(
 
     let response = http
         .post(endpoint)
-        .header("content-type", "application/x-www-form-urlencoded")
-        .header("DPoP", dpop_proof)
+        .header("content-type", CONTENT_TYPE_FORM_URLENCODED)
+        .header(HEADER_DPOP, dpop_proof)
         .body(body)
         .send()
         .await
@@ -191,7 +192,7 @@ async fn send_exchange(
     let status = response.status();
     let nonce = response
         .headers()
-        .get("dpop-nonce")
+        .get(HEADER_DPOP_NONCE)
         .and_then(|v| v.to_str().ok())
         .map(String::from);
     let text = response

--- a/crates/vouch-cli/src/commands/diag.rs
+++ b/crates/vouch-cli/src/commands/diag.rs
@@ -36,6 +36,7 @@ use vouch_cli::{tr, tr_args};
 use vouch_common::fixtures::{
     AuthenticationFixture, Fido2Fixture, FixtureMetadata, RegistrationFixture,
 };
+use vouch_common::protocol;
 
 /// Test relying party ID used for the local diagnostic flow.
 const RP_ID: &str = "diag.test.local";
@@ -186,7 +187,7 @@ fn run_registration(json: bool, device: &FidoKeyHid, pin: &str) -> Result<Regist
 
     // Build client data for registration
     let client_data = serde_json::json!({
-        "type": "webauthn.create",
+        "type": protocol::CLIENT_DATA_TYPE_CREATE,
         "challenge": URL_SAFE_NO_PAD.encode(&challenge),
         "origin": format!("https://{}", RP_ID),
         "crossOrigin": false
@@ -344,7 +345,7 @@ fn run_authentication(
 
     // Build client data for authentication
     let client_data = serde_json::json!({
-        "type": "webauthn.get",
+        "type": protocol::CLIENT_DATA_TYPE_GET,
         "challenge": URL_SAFE_NO_PAD.encode(&challenge),
         "origin": format!("https://{}", RP_ID),
         "crossOrigin": false

--- a/crates/vouch-cli/src/commands/enroll.rs
+++ b/crates/vouch-cli/src/commands/enroll.rs
@@ -383,7 +383,7 @@ async fn poll_once(
         }
         match dpop_builder.build(key) {
             Ok(proof) => {
-                builder = builder.header("DPoP", proof);
+                builder = builder.header(protocol::HEADER_DPOP, proof);
             }
             Err(e) => {
                 tracing::debug!("Failed to build DPoP proof: {e}");
@@ -413,7 +413,7 @@ async fn poll_once(
     // Capture DPoP-Nonce header for use_dpop_nonce flow (RFC 9449)
     let response_dpop_nonce = response
         .headers()
-        .get("dpop-nonce")
+        .get(protocol::HEADER_DPOP_NONCE)
         .and_then(|v| v.to_str().ok())
         .map(String::from);
 

--- a/crates/vouch-cli/src/commands/login.rs
+++ b/crates/vouch-cli/src/commands/login.rs
@@ -142,7 +142,7 @@ async fn run_fapi_login(
     let response = client
         .raw_client()
         .post(&challenge_url)
-        .header("DPoP", dpop_proof)
+        .header(protocol::HEADER_DPOP, dpop_proof)
         .header(fapi_headers[0].0, fapi_headers[0].1)
         .header(fapi_headers[1].0, fapi_headers[1].1)
         .json(&serde_json::json!({}))
@@ -163,7 +163,7 @@ async fn run_fapi_login(
     // include it in the token request, avoiding a use_dpop_nonce rejection.
     let challenge_dpop_nonce = response
         .headers()
-        .get("dpop-nonce")
+        .get(protocol::HEADER_DPOP_NONCE)
         .and_then(|v| v.to_str().ok())
         .map(String::from);
 
@@ -273,8 +273,8 @@ async fn run_fapi_login(
     let token_resp = client
         .raw_client()
         .post(&token_endpoint_url)
-        .header("Content-Type", "application/x-www-form-urlencoded")
-        .header("DPoP", dpop_proof)
+        .header("Content-Type", protocol::CONTENT_TYPE_FORM_URLENCODED)
+        .header(protocol::HEADER_DPOP, dpop_proof)
         .header(fapi_headers[0].0, fapi_headers[0].1)
         .header(fapi_headers[1].0, fapi_headers[1].1)
         .body(form_body)
@@ -287,7 +287,7 @@ async fn run_fapi_login(
     // Capture DPoP-Nonce for potential retry (RFC 9449 nonce flow).
     let dpop_nonce = token_resp
         .headers()
-        .get("dpop-nonce")
+        .get(protocol::HEADER_DPOP_NONCE)
         .and_then(|v| v.to_str().ok())
         .map(String::from);
 
@@ -385,8 +385,8 @@ async fn run_fapi_login_with_nonce(
     let token_resp = client
         .raw_client()
         .post(&token_endpoint_url)
-        .header("Content-Type", "application/x-www-form-urlencoded")
-        .header("DPoP", dpop_proof)
+        .header("Content-Type", protocol::CONTENT_TYPE_FORM_URLENCODED)
+        .header(protocol::HEADER_DPOP, dpop_proof)
         .header(fapi_headers[0].0, fapi_headers[0].1)
         .header(fapi_headers[1].0, fapi_headers[1].1)
         .body(form_body)

--- a/crates/vouch-cli/src/commands/logout.rs
+++ b/crates/vouch-cli/src/commands/logout.rs
@@ -8,7 +8,7 @@ use vouch_agent::{AgentClient, AgentError};
 
 use crate::config::Config;
 use vouch_cli::tr_println;
-use vouch_common::clear_cookie;
+use vouch_common::{clear_cookie, protocol};
 
 /// Run the logout command.
 pub(crate) async fn run(server: &str) -> Result<()> {
@@ -116,7 +116,7 @@ async fn revoke_on_server(config: &Config) {
             "POST",
             &revoke_url,
             Some(form_body.as_bytes()),
-            Some("application/x-www-form-urlencoded"),
+            Some(protocol::CONTENT_TYPE_FORM_URLENCODED),
             None,
             None,
         )

--- a/crates/vouch-cli/src/fapi/dpop.rs
+++ b/crates/vouch-cli/src/fapi/dpop.rs
@@ -12,6 +12,7 @@
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use serde::Serialize;
+use vouch_common::protocol;
 
 use super::error::FapiError;
 use super::key::{ClientKey, PublicEcJwk};
@@ -21,7 +22,7 @@ use super::key::{ClientKey, PublicEcJwk};
 struct DpopHeader<'a> {
     /// Token type — must be "dpop+jwt" per RFC 9449.
     typ: &'a str,
-    /// Algorithm — "ES256" for P-256 ECDSA with SHA-256.
+    /// Algorithm — [`protocol::JWS_ALG_ES256`] for P-256 ECDSA with SHA-256.
     alg: &'a str,
     /// Public key confirming possession of the corresponding private key.
     jwk: PublicEcJwk,
@@ -132,7 +133,7 @@ impl DpopProofBuilder {
 
         let header = DpopHeader {
             typ: "dpop+jwt",
-            alg: "ES256",
+            alg: protocol::JWS_ALG_ES256,
             jwk,
         };
 

--- a/crates/vouch-cli/src/fido2/mod.rs
+++ b/crates/vouch-cli/src/fido2/mod.rs
@@ -42,6 +42,7 @@ use vouch_common::encoding::Raw;
 use vouch_common::fido2_types::{
     AttestationObject, AuthData, ClientDataJson, CoseKey, CredentialId, Signature, UserHandle,
 };
+use vouch_common::protocol;
 
 #[cfg(not(target_os = "windows"))]
 pub(crate) mod unix;
@@ -190,7 +191,7 @@ pub(crate) struct ClientData {
 impl ClientData {
     pub(crate) fn new_create(challenge: &[u8], rp_id: &str) -> Self {
         Self {
-            typ: "webauthn.create",
+            typ: protocol::CLIENT_DATA_TYPE_CREATE,
             challenge: URL_SAFE_NO_PAD.encode(challenge),
             origin: format!("https://{rp_id}"),
             cross_origin: false,
@@ -199,7 +200,7 @@ impl ClientData {
 
     pub(crate) fn new_get(challenge: &[u8], rp_id: &str) -> Self {
         Self {
-            typ: "webauthn.get",
+            typ: protocol::CLIENT_DATA_TYPE_GET,
             challenge: URL_SAFE_NO_PAD.encode(challenge),
             origin: format!("https://{rp_id}"),
             cross_origin: false,

--- a/crates/vouch-cli/src/http.rs
+++ b/crates/vouch-cli/src/http.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Serialize, de::DeserializeOwned};
-use vouch_common::ApiError;
+use vouch_common::{ApiError, protocol};
 
 /// Total timeout for interactive CLI operations.
 const INTERACTIVE_TOTAL: Duration = Duration::from_secs(30);
@@ -151,7 +151,7 @@ fn extract_response_headers(
     };
 
     let dpop_nonce = headers
-        .get("dpop-nonce")
+        .get(protocol::HEADER_DPOP_NONCE)
         .and_then(|v| v.to_str().ok())
         .map(String::from);
 
@@ -378,7 +378,7 @@ pub trait HttpClientExt: HttpClient {
         Req: Serialize + Sync,
         Resp: DeserializeOwned,
     {
-        let auth = format!("Bearer {}", token.expose_secret());
+        let auth = format!("{} {}", protocol::AUTH_SCHEME_BEARER, token.expose_secret());
         async move {
             let json = serde_json::to_vec(body).context(tr!("err-failed-serialize-request"))?;
             let response = self
@@ -413,7 +413,7 @@ pub trait HttpClientExt: HttpClient {
                     "POST",
                     url,
                     Some(form.as_bytes()),
-                    Some("application/x-www-form-urlencoded"),
+                    Some(protocol::CONTENT_TYPE_FORM_URLENCODED),
                     None,
                     None,
                 )
@@ -482,7 +482,10 @@ pub struct StepUpChallenge {
 /// Returns `None` for non-step-up Bearer challenges (e.g., `error="invalid_token"`).
 pub fn parse_www_authenticate(header: &str) -> Option<StepUpChallenge> {
     // Must be a Bearer challenge
-    if !header.starts_with("Bearer ") {
+    if header
+        .strip_prefix(protocol::AUTH_SCHEME_BEARER)
+        .is_none_or(|rest| !rest.starts_with(' '))
+    {
         return None;
     }
 
@@ -568,7 +571,7 @@ fn redact_request_headers(
 fn string_to_static(s: &str) -> &'static str {
     // For known header names, return static strings to avoid leaking
     match s {
-        "DPoP" => "dpop",
+        protocol::HEADER_DPOP => protocol::HEADER_DPOP,
         "Signature" => "signature",
         "Signature-Input" => "signature-input",
         "Content-Digest" => "content-digest",

--- a/crates/vouch-common/src/api.rs
+++ b/crates/vouch-common/src/api.rs
@@ -155,7 +155,9 @@ pub struct DeviceTokenResponse {
     /// JWT access token.
     #[serde(serialize_with = "serialize_secret_string")]
     pub access_token: secrecy::SecretString,
-    /// Token type ("Bearer" or "DPoP" for sender-constrained tokens).
+    /// Token type ([`crate::protocol::ACCESS_TOKEN_TYPE_BEARER`], or
+    /// [`crate::protocol::ACCESS_TOKEN_TYPE_DPOP`] for sender-constrained
+    /// tokens).
     pub token_type: String,
     /// Seconds until token expires.
     pub expires_in: u64,

--- a/crates/vouch-common/src/fixtures.rs
+++ b/crates/vouch-common/src/fixtures.rs
@@ -147,7 +147,10 @@ mod tests {
             },
             registration: RegistrationFixture {
                 challenge_hex: "00".repeat(32),
-                client_data_json: r#"{"type":"webauthn.create"}"#.to_string(),
+                client_data_json: format!(
+                    r#"{{"type":"{}"}}"#,
+                    crate::protocol::CLIENT_DATA_TYPE_CREATE
+                ),
                 credential_id_hex: "01".repeat(32),
                 public_key_cose_hex: "a5".to_string(),
                 auth_data_hex: "00".repeat(37),
@@ -157,7 +160,10 @@ mod tests {
             },
             authentication: AuthenticationFixture {
                 challenge_hex: "ff".repeat(32),
-                client_data_json: r#"{"type":"webauthn.get"}"#.to_string(),
+                client_data_json: format!(
+                    r#"{{"type":"{}"}}"#,
+                    crate::protocol::CLIENT_DATA_TYPE_GET
+                ),
                 auth_data_hex: "00".repeat(37),
                 signature_hex: "3045".to_string(),
                 user_handle_hex: None,

--- a/crates/vouch-common/src/protocol.rs
+++ b/crates/vouch-common/src/protocol.rs
@@ -1,19 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//! OAuth 2.0 wire literals shared by the Vouch server and CLI.
+//! Wire literals shared by the Vouch server and CLI.
 //!
 //! These are the exact bytes that cross the wire between the two crates:
 //! `grant_type` and `client_assertion_type` values sent by the CLI and
-//! dispatched by the server, RFC 8693 token type URNs, and the error codes
-//! the CLI string-matches on to drive retries. Spelling them once means a
-//! typo is a compile error on both sides instead of a runtime mismatch.
+//! dispatched by the server, RFC 8693 token type URNs, the error codes the
+//! CLI string-matches on to drive retries, the DPoP and Bearer header and
+//! scheme names, the WebAuthn client-data types the CLI produces and the
+//! server verifies, and the JWS algorithm both sides sign with. Spelling
+//! them once means a typo is a compile error on both sides instead of a
+//! runtime mismatch.
 //!
 //! Every constant carries the verbatim normative text that fixes its value,
 //! with the section number and the URL it was fetched from.
 //!
 //! # Scope
 //!
-//! What belongs here is the CLI↔server contract, not every OAuth string the
-//! workspace types. Two neighbours are deliberately absent:
+//! What belongs here is the CLI↔server contract, not every wire string the
+//! workspace types. Four neighbours are deliberately absent:
 //!
 //! - `urn:ietf:params:oauth:grant-type:jwt-bearer` (RFC 7523 §2.1) is used
 //!   by the CLI against AWS IAM Identity Center, Anthropic, and OpenAI,
@@ -21,15 +24,48 @@
 //!   their own literals: they answer to the provider's contract, not ours.
 //! - The PAR `request_uri` URN prefix (RFC 9126 §2.2) is server-only; it
 //!   lives in `vouch_server::db::par`.
+//! - The `application/x-www-form-urlencoded` content type sent to AWS STS
+//!   and IAM Identity Center (`vouch_cli::integrations::aws`) keeps its own
+//!   literal for the same reason the `jwt-bearer` grant does, even though
+//!   [`CONTENT_TYPE_FORM_URLENCODED`] holds the identical bytes.
+//! - The `Bearer` scheme the server sends to the GitHub API
+//!   (`vouch_server::services::integrations::github`) likewise stays put: it
+//!   answers to GitHub's contract, not to what Vouch's own clients send.
 //!
 //! [`TOKEN_TYPE_JWT`] is the one constant here that vouch-server alone
 //! sends. It is admitted because RFC 8693 §3 defines the three token type
 //! identifiers as one group and the server matches on all three; splitting
 //! the group across two crates would be worse than carrying it.
 //!
-//! Behavior stays where it is: `OAuthGrantType` and `OAuthErrorCode` remain
-//! server-side enums, and their `as_str()` arms return these constants. The
-//! enums own dispatch; this module owns bytes.
+//! Behavior stays where it is: `OAuthGrantType`, `OAuthErrorCode`, and
+//! `JwsAlgorithm` remain server-side enums, and their `as_str()` arms
+//! return these constants. The enums own dispatch; this module owns bytes.
+//!
+//! # `DPoP` is three contracts, not one
+//!
+//! RFC 9449 spells `DPoP` in three independent places — the proof header
+//! field ([`HEADER_DPOP`]), the `Authorization` scheme
+//! ([`AUTH_SCHEME_DPOP`]), and the `token_type` response value
+//! ([`ACCESS_TOKEN_TYPE_DPOP`]). Each has its own constant so a call site
+//! names the contract it is in and cites the section that fixes it. The
+//! same split applies to Bearer, whose scheme (RFC 6750 §2.1) and access
+//! token type (RFC 6750 §6.1.1) are registered separately.
+//!
+//! # Header-name case
+//!
+//! [`HEADER_DPOP`] and [`HEADER_DPOP_NONCE`] are lowercase. RFC 9449 §4.1
+//! is explicit that this does not change the wire:
+//!
+//! > Note that per \[RFC9110\], header field names are case insensitive;
+//! > thus, DPoP, DPOP, dpop, etc., are all valid and equivalent header
+//! > field names.  However, case is significant in the header field value.
+//!
+//! <https://www.rfc-editor.org/rfc/rfc9449#section-4.1>
+//!
+//! Lowercase is the spelling `http::HeaderName` normalizes to on
+//! construction, so it is what already goes out on the wire regardless of
+//! how a call site spells it, and it is the only spelling
+//! `HeaderName::from_static` accepts.
 
 /// RFC 8628 §3.4 (Device Access Token Request) — device authorization grant.
 ///
@@ -94,7 +130,7 @@ pub const TOKEN_TYPE_ID_TOKEN: &str = "urn:ietf:params:oauth:token-type:id_token
 /// RFC 8693 §3 (Token Type Identifiers) — bare JWT.
 ///
 /// > The value "urn:ietf:params:oauth:token-type:jwt", which is defined in
-/// > Section 9 of [JWT], indicates that the token is a JWT.
+/// > Section 9 of \[JWT\], indicates that the token is a JWT.
 ///
 /// <https://www.rfc-editor.org/rfc/rfc8693#section-3>
 ///
@@ -108,7 +144,7 @@ pub const TOKEN_TYPE_JWT: &str = "urn:ietf:params:oauth:token-type:jwt";
 /// > An authorization server MAY supply a nonce value to be included by
 /// > the client in DPoP proofs sent.  In this case, the authorization
 /// > server responds to requests that do not include a nonce with an HTTP
-/// > 400 (Bad Request) error response per Section 5.2 of [RFC6749] using
+/// > 400 (Bad Request) error response per Section 5.2 of \[RFC6749\] using
 /// > use_dpop_nonce as the error code value.
 ///
 /// <https://www.rfc-editor.org/rfc/rfc9449#section-8>
@@ -158,6 +194,164 @@ pub const ERROR_ACCESS_DENIED: &str = "access_denied";
 ///
 /// <https://www.rfc-editor.org/rfc/rfc8628#section-3.5>
 pub const ERROR_EXPIRED_TOKEN: &str = "expired_token";
+
+/// RFC 9449 §4.1 (The DPoP HTTP Header) — carries the DPoP proof JWT.
+///
+/// > A DPoP proof is included in an HTTP request using the following
+/// > request header field.
+/// >
+/// > DPoP:  A JWT that adheres to the structure and syntax of Section 4.2.
+///
+/// <https://www.rfc-editor.org/rfc/rfc9449#section-4.1>
+///
+/// Registered permanently as an HTTP field name in RFC 9449 §12.8.
+/// Lowercase per the module's header-name note.
+pub const HEADER_DPOP: &str = "dpop";
+
+/// RFC 9449 §8 (Authorization Server-Provided Nonce) — carries the nonce.
+///
+/// > The authorization server includes a DPoP-Nonce HTTP header in the
+/// > response supplying a nonce value to be used when sending the
+/// > subsequent request.  Nonce values MUST be unpredictable.
+///
+/// <https://www.rfc-editor.org/rfc/rfc9449#section-8>
+///
+/// The same section requires browsers be able to read it, which is why the
+/// server lists it in `Access-Control-Expose-Headers`:
+///
+/// > In order for the application to obtain and use the DPoP-Nonce HTTP
+/// > response header value, the server needs to make it available to the
+/// > application by including DPoP-Nonce in the Access-Control-Expose-
+/// > Headers response header list value.
+///
+/// Registered permanently as an HTTP field name in RFC 9449 §12.8.
+/// Lowercase per the module's header-name note.
+pub const HEADER_DPOP_NONCE: &str = "dpop-nonce";
+
+/// RFC 6750 §2.1 (Authorization Request Header Field) — the Bearer scheme.
+///
+/// > When sending the access token in the "Authorization" request header
+/// > field defined by HTTP/1.1 \[RFC2617\], the client uses the "Bearer"
+/// > authentication scheme to transmit the access token.
+///
+/// The section's ABNF fixes the spelling:
+///
+/// > credentials = "Bearer" 1*SP b64token
+///
+/// <https://www.rfc-editor.org/rfc/rfc6750#section-2.1>
+pub const AUTH_SCHEME_BEARER: &str = "Bearer";
+
+/// RFC 9449 §7.1 (The DPoP Authentication Scheme) — the DPoP scheme.
+///
+/// > A DPoP-bound access token is sent using the Authorization request
+/// > header field per Section 11.6.2 of \[RFC9110\] with an authentication
+/// > scheme of DPoP.
+///
+/// The section's ABNF fixes the spelling:
+///
+/// > credentials = "DPoP" 1*SP token68
+///
+/// <https://www.rfc-editor.org/rfc/rfc9449#section-7.1>
+///
+/// Distinct from [`HEADER_DPOP`]: this is the `Authorization` scheme that
+/// carries the access token, not the field that carries the proof. RFC 9449
+/// §7.1 requires both on the same request.
+pub const AUTH_SCHEME_DPOP: &str = "DPoP";
+
+/// RFC 6750 §6.1.1 (The "Bearer" OAuth Access Token Type) — `token_type`.
+///
+/// > Type name:
+/// >    Bearer
+/// >
+/// > Additional Token Endpoint Response Parameters:
+/// >    (none)
+/// >
+/// > HTTP Authentication Scheme(s):
+/// >    Bearer
+///
+/// <https://www.rfc-editor.org/rfc/rfc6750#section-6.1.1>
+///
+/// RFC 6749 §5.1 says of the response parameter this value fills: "The type
+/// of the token issued as described in Section 7.1.  Value is case
+/// insensitive." Vouch emits the registered spelling.
+///
+/// <https://www.rfc-editor.org/rfc/rfc6749#section-5.1>
+pub const ACCESS_TOKEN_TYPE_BEARER: &str = "Bearer";
+
+/// RFC 9449 §5 (DPoP Access Token Request) — `token_type` when bound.
+///
+/// > A token_type of DPoP MUST be included in the access token response to
+/// > signal to the client that the access token was bound to its DPoP key
+/// > and can be used as described in Section 7.1.
+///
+/// <https://www.rfc-editor.org/rfc/rfc9449#section-5>
+pub const ACCESS_TOKEN_TYPE_DPOP: &str = "DPoP";
+
+/// WebAuthn Level 2 §5.1.3 (Create a New Credential) — registration.
+///
+/// The client sets `CollectedClientData.type` when building the credential:
+///
+/// > Let collectedClientData be a new CollectedClientData instance whose
+/// > fields are:
+/// >
+/// > type
+/// >    The string "webauthn.create".
+///
+/// <https://www.w3.org/TR/webauthn-2/#sctn-createCredential>
+///
+/// §7.1 (Registering a New Credential) step 7 is the matching check the
+/// server performs: "Verify that the value of C.type is webauthn.create."
+///
+/// <https://www.w3.org/TR/webauthn-2/#sctn-registering-a-new-credential>
+pub const CLIENT_DATA_TYPE_CREATE: &str = "webauthn.create";
+
+/// WebAuthn Level 2 §5.1.4.1 (`[[DiscoverFromExternalSource]]`) — assertion.
+///
+/// The client sets `CollectedClientData.type` when building the assertion:
+///
+/// > Let collectedClientData be a new CollectedClientData instance whose
+/// > fields are:
+/// >
+/// > type
+/// >    The string "webauthn.get".
+///
+/// <https://www.w3.org/TR/webauthn-2/#sctn-discover-from-external-source>
+///
+/// §7.2 (Verifying an Authentication Assertion) step 11 is the matching
+/// check: "Verify that the value of C.type is the string webauthn.get."
+///
+/// <https://www.w3.org/TR/webauthn-2/#sctn-verifying-assertion>
+///
+/// §5.8.1 states why the two values must never be interchanged: the member
+/// exists "to prevent certain types of signature confusion attacks (where
+/// an attacker substitutes one legitimate signature for another)".
+///
+/// <https://www.w3.org/TR/webauthn-2/#dictionary-client-data>
+pub const CLIENT_DATA_TYPE_GET: &str = "webauthn.get";
+
+/// RFC 7518 §3.1 (`"alg"` Header Parameter Values for JWS) — P-256 ECDSA.
+///
+/// The registry table gives the identifier and what it denotes:
+///
+/// > | ES256        | ECDSA using P-256 and SHA-256 | Recommended+       |
+///
+/// <https://www.rfc-editor.org/rfc/rfc7518#section-3.1>
+///
+/// This is the algorithm FAPI 2.0 permits and Vouch signs every
+/// FAPI-scoped JWT with — DPoP proofs, client assertions, access and ID
+/// tokens. `vouch_server::db::JwsAlgorithm` owns the enum; this is the
+/// spelling its `Es256` arm serializes to.
+pub const JWS_ALG_ES256: &str = "ES256";
+
+/// RFC 6749 §4.1.3 (Access Token Request) — token endpoint request body.
+///
+/// > The client makes a request to the token endpoint by sending the
+/// > following parameters using the "application/x-www-form-urlencoded"
+/// > format per Appendix B with a character encoding of UTF-8 in the HTTP
+/// > request entity-body:
+///
+/// <https://www.rfc-editor.org/rfc/rfc6749#section-4.1.3>
+pub const CONTENT_TYPE_FORM_URLENCODED: &str = "application/x-www-form-urlencoded";
 
 #[cfg(test)]
 mod tests {
@@ -244,5 +438,68 @@ mod tests {
     #[test]
     fn rfc8628_expired_token_error_code() {
         assert_eq!(ERROR_EXPIRED_TOKEN, "expired_token");
+    }
+
+    #[test]
+    fn rfc9449_dpop_proof_header_name() {
+        assert_eq!(HEADER_DPOP, "dpop");
+    }
+
+    #[test]
+    fn rfc9449_dpop_nonce_header_name() {
+        assert_eq!(HEADER_DPOP_NONCE, "dpop-nonce");
+    }
+
+    #[test]
+    fn rfc6750_bearer_auth_scheme() {
+        assert_eq!(AUTH_SCHEME_BEARER, "Bearer");
+    }
+
+    #[test]
+    fn rfc9449_dpop_auth_scheme() {
+        assert_eq!(AUTH_SCHEME_DPOP, "DPoP");
+    }
+
+    #[test]
+    fn rfc6750_bearer_access_token_type() {
+        assert_eq!(ACCESS_TOKEN_TYPE_BEARER, "Bearer");
+    }
+
+    #[test]
+    fn rfc9449_dpop_access_token_type() {
+        assert_eq!(ACCESS_TOKEN_TYPE_DPOP, "DPoP");
+    }
+
+    #[test]
+    fn webauthn2_create_client_data_type() {
+        assert_eq!(CLIENT_DATA_TYPE_CREATE, "webauthn.create");
+    }
+
+    #[test]
+    fn webauthn2_get_client_data_type() {
+        assert_eq!(CLIENT_DATA_TYPE_GET, "webauthn.get");
+    }
+
+    #[test]
+    fn rfc7518_es256_jws_algorithm() {
+        assert_eq!(JWS_ALG_ES256, "ES256");
+    }
+
+    #[test]
+    fn rfc6749_form_urlencoded_content_type() {
+        assert_eq!(
+            CONTENT_TYPE_FORM_URLENCODED,
+            "application/x-www-form-urlencoded"
+        );
+    }
+
+    // The header-name constants are lowercase while the scheme and token
+    // type constants that share their bytes are not. RFC 9449 §4.1 makes
+    // field names case-insensitive and §7.1 fixes the scheme spelling, so
+    // the two must not be collapsed into one constant.
+    #[test]
+    fn dpop_header_and_scheme_spellings_are_independent() {
+        assert_ne!(HEADER_DPOP, AUTH_SCHEME_DPOP);
+        assert_eq!(HEADER_DPOP, AUTH_SCHEME_DPOP.to_ascii_lowercase());
     }
 }

--- a/crates/vouch-server/src/crypto/keys.rs
+++ b/crates/vouch-server/src/crypto/keys.rs
@@ -21,6 +21,7 @@ use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header};
 use serde::Serialize;
+use vouch_common::protocol;
 use zeroize::Zeroizing;
 
 use crate::crypto::kms_signer::{KmsSignerP256, KmsSignerRsa3072, parse_spki_rsa};
@@ -222,7 +223,7 @@ impl OidcSigningKey {
                 Ok(EcJwk {
                     kty: "EC".to_string(),
                     crv: "P-256".to_string(),
-                    alg: "ES256".to_string(),
+                    alg: protocol::JWS_ALG_ES256.to_string(),
                     kid: key_id.clone(),
                     key_use: "sig".to_string(),
                     x,
@@ -232,7 +233,7 @@ impl OidcSigningKey {
             Self::Kms { signer, key_id, .. } => Ok(EcJwk {
                 kty: "EC".to_string(),
                 crv: "P-256".to_string(),
-                alg: "ES256".to_string(),
+                alg: protocol::JWS_ALG_ES256.to_string(),
                 kid: key_id.clone(),
                 key_use: "sig".to_string(),
                 x: signer.x_b64(),
@@ -341,7 +342,7 @@ struct KmsJwtHeader<'a> {
 /// Manually construct and sign a JWT using KMS.
 ///
 /// Steps:
-/// 1. Build header JSON with `alg: "ES256"`, `typ`, and `kid`
+/// 1. Build header JSON with [`protocol::JWS_ALG_ES256`], `typ`, and `kid`
 /// 2. Serialize claims to JSON
 /// 3. Base64url-encode header and payload, join with "."
 /// 4. Call `signer.sign_raw(signing_input)` → DER signature
@@ -356,7 +357,7 @@ async fn sign_jwt_with_kms<T: Serialize>(
     use crate::crypto::kms_signer::der_ecdsa_to_jwt;
 
     let header = KmsJwtHeader {
-        alg: "ES256",
+        alg: protocol::JWS_ALG_ES256,
         typ: typ.unwrap_or("JWT"),
         kid: key_id,
     };
@@ -412,7 +413,7 @@ pub struct EcJwk {
     pub kty: String,
     /// RFC 7518 Section 6.2.1.1: Curve — "P-256" for NIST P-256.
     pub crv: String,
-    /// RFC 7517 Section 4.4: Algorithm — "ES256" (ECDSA using P-256 and SHA-256).
+    /// RFC 7517 Section 4.4: Algorithm — [`protocol::JWS_ALG_ES256`].
     pub alg: String,
     /// RFC 7517 Section 4.5: Key ID.
     pub kid: String,

--- a/crates/vouch-server/src/crypto/webauthn_verify.rs
+++ b/crates/vouch-server/src/crypto/webauthn_verify.rs
@@ -25,6 +25,7 @@ use aws_lc_rs::digest::{self, SHA256};
 use aws_lc_rs::signature::{self, UnparsedPublicKey};
 use der::Decode;
 use thiserror::Error;
+use vouch_common::protocol;
 
 /// Trait for COSE signature verification.
 ///
@@ -353,9 +354,10 @@ fn verify_assertion_inner<V: CoseVerifier>(
         .map_err(|e| VerifyError::InvalidClientData(e.to_string()))?;
 
     // Verify type
-    if client_data.type_ != "webauthn.get" {
+    if client_data.type_ != protocol::CLIENT_DATA_TYPE_GET {
         return Err(VerifyError::InvalidClientData(format!(
-            "Expected type 'webauthn.get', got '{}'",
+            "Expected type '{}', got '{}'",
+            protocol::CLIENT_DATA_TYPE_GET,
             client_data.type_
         )));
     }
@@ -571,9 +573,10 @@ pub fn verify_registration_with_verifier<V: CoseVerifier>(
     let client_data: ClientData = serde_json::from_slice(client_data_json)
         .map_err(|e| VerifyError::InvalidClientData(e.to_string()))?;
 
-    if client_data.type_ != "webauthn.create" {
+    if client_data.type_ != protocol::CLIENT_DATA_TYPE_CREATE {
         return Err(VerifyError::InvalidClientData(format!(
-            "Expected type 'webauthn.create', got '{}'",
+            "Expected type '{}', got '{}'",
+            protocol::CLIENT_DATA_TYPE_CREATE,
             client_data.type_
         )));
     }

--- a/crates/vouch-server/src/db/documents/oauth.rs
+++ b/crates/vouch-server/src/db/documents/oauth.rs
@@ -237,6 +237,11 @@ impl std::fmt::Display for TokenEndpointAuthMethod {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum JwsAlgorithm {
     /// ECDSA using P-256 and SHA-256.
+    ///
+    /// A `serde(rename)` takes a literal, so this is the one spelling of
+    /// `ES256` that cannot reference [`vouch_common::protocol::JWS_ALG_ES256`]
+    /// directly; `jws_algorithm_serde_matches_protocol_constant` pins the two
+    /// together instead.
     #[default]
     #[serde(rename = "ES256")]
     Es256,
@@ -256,7 +261,7 @@ impl JwsAlgorithm {
     #[must_use]
     pub fn as_str(&self) -> &'static str {
         match self {
-            Self::Es256 => "ES256",
+            Self::Es256 => vouch_common::protocol::JWS_ALG_ES256,
             Self::Rs256 => "RS256",
             Self::Ps256 => "PS256",
             Self::EdDsa => "EdDSA",
@@ -294,7 +299,7 @@ impl std::str::FromStr for JwsAlgorithm {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "ES256" => Ok(Self::Es256),
+            vouch_common::protocol::JWS_ALG_ES256 => Ok(Self::Es256),
             "RS256" => Ok(Self::Rs256),
             "PS256" => Ok(Self::Ps256),
             "EdDSA" => Ok(Self::EdDsa),
@@ -662,6 +667,25 @@ mod tests {
         TokenEndpointAuthMethod,
     };
     use std::str::FromStr;
+
+    /// `Es256`'s `serde(rename)` is a literal and its `as_str`/`FromStr` arms
+    /// are the shared constant. Serialize, deserialize, and parse all have to
+    /// agree with `JWS_ALG_ES256`, or a stored client's signing algorithm
+    /// stops round-tripping.
+    #[test]
+    fn jws_algorithm_serde_matches_protocol_constant() {
+        let alg = vouch_common::protocol::JWS_ALG_ES256;
+        assert_eq!(
+            serde_json::to_string(&JwsAlgorithm::Es256).unwrap(),
+            format!("\"{alg}\"")
+        );
+        assert_eq!(
+            serde_json::from_str::<JwsAlgorithm>(&format!("\"{alg}\"")).unwrap(),
+            JwsAlgorithm::Es256
+        );
+        assert_eq!(JwsAlgorithm::Es256.as_str(), alg);
+        assert_eq!(JwsAlgorithm::from_str(alg).unwrap(), JwsAlgorithm::Es256);
+    }
 
     #[test]
     fn test_access_scope_from_str_case_insensitive() {

--- a/crates/vouch-server/src/error.rs
+++ b/crates/vouch-server/src/error.rs
@@ -313,10 +313,11 @@ impl ServiceError {
     /// Create a structured API error that carries an additional response header.
     ///
     /// Produces the same `{"code": "...", "message": "..."}` body as
-    /// [`Self::api`] but attaches a header such as `DPoP-Nonce` (RFC 9449) to
-    /// the response so the client can retry. The header name is parsed with
-    /// case-insensitive matching (`"DPoP-Nonce"` → `dpop-nonce`); the value is
-    /// stored verbatim and must be a valid HTTP header value.
+    /// [`Self::api`] but attaches a header such as
+    /// [`protocol::HEADER_DPOP_NONCE`] (RFC 9449) to the response so the
+    /// client can retry. The header name is parsed with case-insensitive
+    /// matching (`"DPoP-Nonce"` → `dpop-nonce`); the value is stored verbatim
+    /// and must be a valid HTTP header value.
     #[must_use]
     pub fn api_with_header(
         status: StatusCode,

--- a/crates/vouch-server/src/handlers/admin/audit_api.rs
+++ b/crates/vouch-server/src/handlers/admin/audit_api.rs
@@ -19,6 +19,7 @@ use axum::{Json, body::Body};
 use axum_extra::extract::cookie::CookieJar;
 use jiff::{Span, Timestamp};
 use serde::{Deserialize, Serialize};
+use vouch_common::protocol;
 
 use super::ocsf::{self, RawOrValue};
 use crate::AppState;
@@ -152,7 +153,7 @@ async fn authenticate(
         ));
     };
 
-    if let Some(token) = crate::http::strip_auth_scheme(auth_header, "Bearer") {
+    if let Some(token) = crate::http::strip_auth_scheme(auth_header, protocol::AUTH_SCHEME_BEARER) {
         let token_hash = hex::encode(digest::digest(&SHA256, token.as_bytes()));
         let token_record = db::get_scim_token_by_hash(&state.store, &token_hash)
             .await
@@ -201,8 +202,9 @@ async fn authenticate(
     // doesn't match a known bearer scheme is a hard 401 here rather than
     // being allowed to fall through to that cookie fallback.
     //
-    let scheme_valid = crate::http::strip_auth_scheme(auth_header, "DPoP").is_some()
-        || crate::http::strip_auth_scheme(auth_header, "Bearer").is_some();
+    let scheme_valid = crate::http::strip_auth_scheme(auth_header, protocol::AUTH_SCHEME_DPOP)
+        .is_some()
+        || crate::http::strip_auth_scheme(auth_header, protocol::AUTH_SCHEME_BEARER).is_some();
     if !scheme_valid {
         return Err(ServiceError::api(
             StatusCode::UNAUTHORIZED,

--- a/crates/vouch-server/src/handlers/auth.rs
+++ b/crates/vouch-server/src/handlers/auth.rs
@@ -14,7 +14,7 @@ use axum::{
 use axum_extra::extract::cookie::CookieJar;
 use jiff::Timestamp;
 use std::sync::Arc;
-use vouch_common::SessionStatus;
+use vouch_common::{SessionStatus, protocol};
 
 use super::{clear_session_cookie, hash_token};
 use crate::db::ClientInfo;
@@ -39,8 +39,8 @@ pub(crate) async fn status(
     // `starts_with`. An unrecognized scheme (or no header at all) yields
     // `authenticated: false` — this endpoint never 401s.
     let token = match auth_header.and_then(|h| {
-        crate::http::strip_auth_scheme(h, "Bearer")
-            .or_else(|| crate::http::strip_auth_scheme(h, "DPoP"))
+        crate::http::strip_auth_scheme(h, protocol::AUTH_SCHEME_BEARER)
+            .or_else(|| crate::http::strip_auth_scheme(h, protocol::AUTH_SCHEME_DPOP))
     }) {
         Some(tok) => tok,
         None => {

--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -50,7 +50,7 @@ use std::sync::Arc;
 use uuid::Uuid;
 use vouch_common::{
     BrowserLoginCompleteRequest, BrowserLoginCompleteResponse, BrowserLoginStartRequest,
-    BrowserLoginStartResponse,
+    BrowserLoginStartResponse, protocol,
 };
 
 /// Compute an HMAC-SHA256 tag over `message` using `secret`, returning the
@@ -596,7 +596,7 @@ pub(crate) async fn browser_login_complete(
         )
     })?;
 
-    if client_data.typ != "webauthn.get" {
+    if client_data.typ != protocol::CLIENT_DATA_TYPE_GET {
         return Err(ServiceError::api(
             StatusCode::BAD_REQUEST,
             "invalid_input",

--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -24,6 +24,7 @@ use jiff::{Span, Timestamp};
 use std::sync::Arc;
 use vouch_common::{
     DeviceCodeRequest, DeviceCodeResponse, DeviceTokenRequest, DeviceTokenResponse, OAuthError,
+    protocol,
 };
 
 use crate::error::{OAuthErrorCode, ServiceError};
@@ -84,7 +85,7 @@ fn hash_device_code(code: &str) -> String {
 /// POST /oauth/device
 ///
 /// RFC 8628 Section 3.1: The client makes a request using
-/// "application/x-www-form-urlencoded" format.
+/// [`protocol::CONTENT_TYPE_FORM_URLENCODED`] format.
 pub(crate) async fn device_code(
     State(state): State<Arc<AppState>>,
     axum::Form(req): axum::Form<DeviceCodeRequest>,
@@ -323,7 +324,9 @@ pub(crate) async fn device_token(
             // burn the single-use code — the client can retry with a
             // corrected proof. Consistent with the authorization code
             // grant, which validates DPoP before exchanging the code.
-            let dpop_header = headers.get("DPoP").and_then(|v| v.to_str().ok());
+            let dpop_header = headers
+                .get(protocol::HEADER_DPOP)
+                .and_then(|v| v.to_str().ok());
             let dpop_proof =
                 match validate_dpop_if_present(&state, dpop_header, "POST", "/oauth/token").await {
                     Ok(proof) => proof,
@@ -595,11 +598,15 @@ pub(crate) async fn device_token(
                 redact_email(&user_email)
             );
 
-            // RFC 9449 Section 5: token_type is "DPoP" when the token is
+            // RFC 9449 Section 5: token_type is DPoP when the token is
             // sender-constrained (bound to a DPoP proof key), otherwise
-            // "Bearer". RFC-compliant clients that require DPoP protection
+            // Bearer. RFC-compliant clients that require DPoP protection
             // MUST discard a response advertising a different token_type.
-            let token_type = if dpop_jkt.is_some() { "DPoP" } else { "Bearer" };
+            let token_type = if dpop_jkt.is_some() {
+                protocol::ACCESS_TOKEN_TYPE_DPOP
+            } else {
+                protocol::ACCESS_TOKEN_TYPE_BEARER
+            };
 
             Ok(Json(DeviceTokenResponse {
                 // Clone the SecretString rather than rebuilding it via

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -22,7 +22,7 @@ use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use uuid::Uuid;
-use vouch_common::{BrowserRegisterCompleteRequest, BrowserRegisterStartResponse};
+use vouch_common::{BrowserRegisterCompleteRequest, BrowserRegisterStartResponse, protocol};
 
 use super::session::AuthContext;
 use super::{
@@ -1428,7 +1428,7 @@ pub(crate) async fn browser_register_complete(
         )
     })?;
 
-    if client_data.typ != "webauthn.create" {
+    if client_data.typ != protocol::CLIENT_DATA_TYPE_CREATE {
         return Err(ServiceError::api(
             StatusCode::BAD_REQUEST,
             "invalid_client_data",

--- a/crates/vouch-server/src/handlers/oidc/fido2_challenge.rs
+++ b/crates/vouch-server/src/handlers/oidc/fido2_challenge.rs
@@ -25,6 +25,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use vouch_common::encoding::{Base64Url, ConvertEncoding, Raw};
 use vouch_common::fido2_types::Challenge;
+use vouch_common::protocol;
 
 /// State embedded in the challenge JWT.
 #[derive(Debug, Serialize, Deserialize)]
@@ -124,7 +125,9 @@ pub(crate) async fn fido2_challenge(State(state): State<Arc<AppState>>) -> Respo
     if let Ok(ref nonce) = dpop_nonce
         && let Ok(value) = axum::http::HeaderValue::from_str(nonce)
     {
-        response.headers_mut().insert("dpop-nonce", value);
+        response
+            .headers_mut()
+            .insert(protocol::HEADER_DPOP_NONCE, value);
     }
 
     response

--- a/crates/vouch-server/src/handlers/oidc/par.rs
+++ b/crates/vouch-server/src/handlers/oidc/par.rs
@@ -24,6 +24,7 @@ use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use subtle::ConstantTimeEq;
+use vouch_common::protocol;
 
 /// PAR response (RFC 9126 Section 2.2).
 #[derive(Serialize)]
@@ -300,7 +301,9 @@ pub(crate) async fn par(
     // RFC 9449 Section 10: Capture DPoP proof at PAR for authorization code binding.
     // If a DPoP proof is provided, bind the JWK thumbprint to the PAR record so
     // that the same key must be used at the token endpoint.
-    let dpop_header = headers.get("DPoP").and_then(|v| v.to_str().ok());
+    let dpop_header = headers
+        .get(protocol::HEADER_DPOP)
+        .and_then(|v| v.to_str().ok());
     let dpop_proof = match validate_dpop_if_present(&state, dpop_header, "POST", "/oauth/par").await
     {
         Ok(proof) => proof,
@@ -308,7 +311,7 @@ pub(crate) async fn par(
             return (
                 StatusCode::BAD_REQUEST,
                 [(
-                    axum::http::header::HeaderName::from_static("dpop-nonce"),
+                    axum::http::header::HeaderName::from_static(protocol::HEADER_DPOP_NONCE),
                     nonce.to_string(),
                 )],
                 Json(OAuthErrorResponse {

--- a/crates/vouch-server/src/handlers/oidc/register.rs
+++ b/crates/vouch-server/src/handlers/oidc/register.rs
@@ -26,6 +26,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use std::sync::Arc;
+use vouch_common::protocol;
 
 /// POST /oauth/register — RFC 7591 Dynamic Client Registration.
 ///
@@ -206,8 +207,9 @@ fn into_registration_response(err: crate::error::ServiceError) -> Response {
             status,
             [(
                 axum::http::header::WWW_AUTHENTICATE,
-                axum::http::HeaderValue::from_str(&www_auth)
-                    .unwrap_or_else(|_| axum::http::HeaderValue::from_static("Bearer")),
+                axum::http::HeaderValue::from_str(&www_auth).unwrap_or_else(|_| {
+                    axum::http::HeaderValue::from_static(protocol::AUTH_SCHEME_BEARER)
+                }),
             )],
             json,
         )

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -29,6 +29,7 @@ use axum::{
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use vouch_common::protocol;
 
 /// Token response (RFC 6749 Section 5.1).
 #[derive(Serialize)]
@@ -36,7 +37,8 @@ pub(super) struct TokenResponse {
     /// The access token issued by the authorization server.
     #[serde(serialize_with = "vouch_common::serialize_secret_string")]
     pub access_token: SecretString,
-    /// The type of the token issued ("Bearer" or "DPoP").
+    /// The type of the token issued ([`protocol::ACCESS_TOKEN_TYPE_BEARER`]
+    /// or [`protocol::ACCESS_TOKEN_TYPE_DPOP`]).
     pub token_type: String,
     /// The lifetime in seconds of the access token.
     pub expires_in: u64,
@@ -181,7 +183,7 @@ pub(super) struct TokenExchangeResponse {
     pub access_token: SecretString,
     /// RFC 8693 Section 2.2.1: The type of the issued security token.
     pub issued_token_type: String,
-    /// The type of the token issued (e.g., "Bearer").
+    /// The type of the token issued (e.g. [`protocol::ACCESS_TOKEN_TYPE_BEARER`]).
     pub token_type: String,
     /// The lifetime in seconds of the access token.
     pub expires_in: u64,
@@ -525,7 +527,9 @@ async fn handle_authorization_code_grant(
     // BEFORE client-auth resolution so the `use_dpop_nonce` recovery
     // path (nonce header in the response) fires regardless of whether
     // the request also has invalid client auth.
-    let dpop_header = headers.get("DPoP").and_then(|v| v.to_str().ok());
+    let dpop_header = headers
+        .get(protocol::HEADER_DPOP)
+        .and_then(|v| v.to_str().ok());
     let dpop_proof =
         match validate_dpop_if_present(&state, dpop_header, "POST", "/oauth/token").await {
             Ok(proof) => proof,
@@ -703,7 +707,9 @@ async fn handle_client_credentials_grant(
 
     // RFC 9449 Section 5: Validate the DPoP proof if present so the issued
     // token carries a `cnf.jkt` binding.
-    let dpop_header = headers.get("DPoP").and_then(|v| v.to_str().ok());
+    let dpop_header = headers
+        .get(protocol::HEADER_DPOP)
+        .and_then(|v| v.to_str().ok());
     let dpop_proof =
         match validate_dpop_if_present(&state, dpop_header, "POST", "/oauth/token").await {
             Ok(proof) => proof,
@@ -886,7 +892,9 @@ async fn handle_token_exchange_grant(
     let secret_verification = any_auth.secret_verification;
 
     // RFC 9449 Section 5: Validate DPoP proof if present at the token endpoint
-    let dpop_header = headers.get("DPoP").and_then(|v| v.to_str().ok());
+    let dpop_header = headers
+        .get(protocol::HEADER_DPOP)
+        .and_then(|v| v.to_str().ok());
     let dpop_proof =
         match validate_dpop_if_present(&state, dpop_header, "POST", "/oauth/token").await {
             Ok(proof) => proof,
@@ -1093,7 +1101,9 @@ async fn handle_fido2_assertion_grant(
     };
 
     // Validate DPoP proof if present
-    let dpop_header = headers.get("DPoP").and_then(|v| v.to_str().ok());
+    let dpop_header = headers
+        .get(protocol::HEADER_DPOP)
+        .and_then(|v| v.to_str().ok());
     let dpop_proof =
         match validate_dpop_if_present(&state, dpop_header, "POST", "/oauth/token").await {
             Ok(proof) => proof,
@@ -1276,7 +1286,7 @@ pub(crate) fn dpop_use_nonce_response(nonce: &str) -> Response {
     (
         StatusCode::BAD_REQUEST,
         [(
-            axum::http::header::HeaderName::from_static("dpop-nonce"),
+            axum::http::header::HeaderName::from_static(protocol::HEADER_DPOP_NONCE),
             nonce.to_string(),
         )],
         Json(OAuthErrorResponse {

--- a/crates/vouch-server/src/handlers/oidc/userinfo.rs
+++ b/crates/vouch-server/src/handlers/oidc/userinfo.rs
@@ -27,6 +27,7 @@ use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use subtle::ConstantTimeEq;
+use vouch_common::protocol;
 
 /// User info response (OIDC Core Section 5.3.2).
 ///
@@ -94,9 +95,11 @@ pub(crate) async fn userinfo(
     };
 
     let (token, is_dpop_scheme) = if let Some(ref auth_header) = auth_header_value {
-        if let Some(tok) = crate::http::strip_auth_scheme(auth_header, "DPoP") {
+        if let Some(tok) = crate::http::strip_auth_scheme(auth_header, protocol::AUTH_SCHEME_DPOP) {
             (tok.to_string(), true)
-        } else if let Some(tok) = crate::http::strip_auth_scheme(auth_header, "Bearer") {
+        } else if let Some(tok) =
+            crate::http::strip_auth_scheme(auth_header, protocol::AUTH_SCHEME_BEARER)
+        {
             (tok.to_string(), false)
         } else {
             return oauth_error(
@@ -122,14 +125,17 @@ pub(crate) async fn userinfo(
     // RFC 9449 Section 7.1: If DPoP scheme is used, validate the DPoP proof at resource endpoint
     if is_dpop_scheme {
         // RFC 9449 Section 7.1: There MUST NOT be more than one DPoP header.
-        if headers.get_all("DPoP").iter().count() > 1 {
+        if headers.get_all(protocol::HEADER_DPOP).iter().count() > 1 {
             return oauth_error(
                 StatusCode::BAD_REQUEST,
                 OAuthErrorCode::InvalidDpopProof,
                 "Request must contain exactly one DPoP header",
             );
         }
-        let dpop_header = match headers.get("DPoP").and_then(|v| v.to_str().ok()) {
+        let dpop_header = match headers
+            .get(protocol::HEADER_DPOP)
+            .and_then(|v| v.to_str().ok())
+        {
             Some(h) => h,
             None => {
                 return oauth_error(
@@ -202,7 +208,7 @@ pub(crate) async fn userinfo(
             Err(DpopError::UseNonce(nonce)) => {
                 return (
                     StatusCode::UNAUTHORIZED,
-                    [("DPoP-Nonce", nonce.as_str())],
+                    [(protocol::HEADER_DPOP_NONCE, nonce.as_str())],
                     Json(OAuthErrorResponse {
                         error: OAuthErrorCode::UseDpopNonce.as_str().to_string(),
                         error_description: Some(

--- a/crates/vouch-server/src/handlers/scim/mod.rs
+++ b/crates/vouch-server/src/handlers/scim/mod.rs
@@ -26,6 +26,7 @@ use axum::{
 use crate::AppState;
 use crate::db;
 use crate::db::{ScimScope, ScimScopeSet};
+use vouch_common::protocol;
 
 // Re-export types for convenience (used by tests via `use super::*`)
 pub(crate) use types::*;
@@ -159,12 +160,13 @@ pub(crate) async fn authenticate_scim(
             )
         })?;
 
-    let token = crate::http::strip_auth_scheme(auth_header, "Bearer").ok_or_else(|| {
-        (
-            StatusCode::UNAUTHORIZED,
-            Json(ScimError::new(401, "Invalid Authorization header format")),
-        )
-    })?;
+    let token = crate::http::strip_auth_scheme(auth_header, protocol::AUTH_SCHEME_BEARER)
+        .ok_or_else(|| {
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(ScimError::new(401, "Invalid Authorization header format")),
+            )
+        })?;
     let token_hash = hex::encode(digest::digest(&SHA256, token.as_bytes()));
 
     // Verify token exists and is valid

--- a/crates/vouch-server/src/handlers/session.rs
+++ b/crates/vouch-server/src/handlers/session.rs
@@ -12,6 +12,7 @@ use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use std::sync::Arc;
 use subtle::ConstantTimeEq;
 use time::Duration;
+use vouch_common::protocol;
 
 // ============================================================================
 // Authentication Context for Templates
@@ -129,7 +130,9 @@ async fn extract_resource_token(
         match auth_scheme {
             AuthScheme::DPoP => {
                 // Validate DPoP proof header against cnf.jkt
-                let dpop_header = headers.get("DPoP").and_then(|v| v.to_str().ok());
+                let dpop_header = headers
+                    .get(protocol::HEADER_DPOP)
+                    .and_then(|v| v.to_str().ok());
                 if let Some(proof) = dpop_header {
                     let full_uri = format!("{}{}", config.base_url, uri);
                     match crate::services::oidc::dpop::validate_dpop_at_resource(
@@ -175,7 +178,7 @@ async fn extract_resource_token(
                                 StatusCode::UNAUTHORIZED,
                                 crate::error::OAuthErrorCode::UseDpopNonce.as_str(),
                                 "Authorization server requires nonce in DPoP proof",
-                                ("DPoP-Nonce", nonce.as_str()),
+                                (protocol::HEADER_DPOP_NONCE, nonce.as_str()),
                             ));
                         }
                         Err(e) => {
@@ -507,10 +510,13 @@ fn extract_token_from_request(
 
     // Check Authorization header
     if let Some(auth_value) = headers.get(AUTHORIZATION).and_then(|v| v.to_str().ok()) {
-        if let Some(token) = crate::http::strip_auth_scheme(auth_value, "DPoP") {
+        if let Some(token) = crate::http::strip_auth_scheme(auth_value, protocol::AUTH_SCHEME_DPOP)
+        {
             return Ok((token.to_string(), AuthScheme::DPoP));
         }
-        if let Some(token) = crate::http::strip_auth_scheme(auth_value, "Bearer") {
+        if let Some(token) =
+            crate::http::strip_auth_scheme(auth_value, protocol::AUTH_SCHEME_BEARER)
+        {
             return Ok((token.to_string(), AuthScheme::Bearer));
         }
     }

--- a/crates/vouch-server/src/http.rs
+++ b/crates/vouch-server/src/http.rs
@@ -5,6 +5,8 @@
 //! every layer, so handlers and infra parse and build `Authorization` /
 //! `WWW-Authenticate` values through one implementation.
 
+use vouch_common::protocol;
+
 /// Extract the token from an `Authorization` header value when its
 /// auth-scheme matches `scheme`.
 ///
@@ -31,7 +33,7 @@ pub(crate) fn bearer_token(headers: &axum::http::HeaderMap) -> Option<&str> {
         .get(axum::http::header::AUTHORIZATION)?
         .to_str()
         .ok()?;
-    strip_auth_scheme(value, "Bearer")
+    strip_auth_scheme(value, protocol::AUTH_SCHEME_BEARER)
 }
 
 /// Filter a challenge parameter value to RFC 6750 Section 3's permitted set
@@ -60,14 +62,14 @@ pub(crate) fn sanitize_challenge_value(value: &str) -> String {
 /// RFC 9110 Section 11.6.1's challenge grammar (auth-params are optional).
 pub(crate) fn bearer_challenge(params: &[(&str, &str)]) -> String {
     if params.is_empty() {
-        return "Bearer".to_string();
+        return protocol::AUTH_SCHEME_BEARER.to_string();
     }
     let mut rendered = Vec::with_capacity(params.len());
     for (name, value) in params {
         let value = sanitize_challenge_value(value);
         rendered.push(format!("{name}=\"{value}\""));
     }
-    format!("Bearer {}", rendered.join(", "))
+    format!("{} {}", protocol::AUTH_SCHEME_BEARER, rendered.join(", "))
 }
 
 #[cfg(test)]

--- a/crates/vouch-server/src/infra/httpsig.rs
+++ b/crates/vouch-server/src/infra/httpsig.rs
@@ -12,6 +12,7 @@ use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use p256::elliptic_curve::sec1::ToEncodedPoint;
 
+use vouch_common::protocol;
 use vouch_httpsig::algorithm::VerifyingAlgorithm;
 use vouch_httpsig::algorithm::ecdsa_p256::EcdsaP256Verifier;
 use vouch_httpsig::middleware::KeyResolver;
@@ -179,8 +180,8 @@ fn extract_client_id(headers: &http::HeaderMap, _state: &AppState) -> Option<Str
 
     // Accepts the same schemes as `extract_token_from_request` — both go
     // through the shared matcher, so they cannot drift.
-    let token = crate::http::strip_auth_scheme(auth_header, "DPoP")
-        .or_else(|| crate::http::strip_auth_scheme(auth_header, "Bearer"))?;
+    let token = crate::http::strip_auth_scheme(auth_header, protocol::AUTH_SCHEME_DPOP)
+        .or_else(|| crate::http::strip_auth_scheme(auth_header, protocol::AUTH_SCHEME_BEARER))?;
 
     // Parse JWT payload (second segment) without verification
     let parts: Vec<&str> = token.split('.').collect();

--- a/crates/vouch-server/src/infra/security_headers.rs
+++ b/crates/vouch-server/src/infra/security_headers.rs
@@ -12,6 +12,7 @@ use axum::{
 };
 use tower_http::cors::CorsLayer;
 use tower_http::set_header::SetResponseHeaderLayer;
+use vouch_common::protocol;
 
 use crate::{AppState, config, services::idp};
 
@@ -35,9 +36,12 @@ pub fn build_api_cors_layer() -> CorsLayer {
             header::AUTHORIZATION,
             header::CONTENT_TYPE,
             header::ACCEPT,
-            HeaderName::from_static("dpop"),
+            HeaderName::from_static(protocol::HEADER_DPOP),
         ])
-        .expose_headers([HeaderName::from_static("dpop-nonce"), header::LINK])
+        .expose_headers([
+            HeaderName::from_static(protocol::HEADER_DPOP_NONCE),
+            header::LINK,
+        ])
         .max_age(std::time::Duration::from_hours(1))
 }
 

--- a/crates/vouch-server/src/services/oidc/client_credentials.rs
+++ b/crates/vouch-server/src/services/oidc/client_credentials.rs
@@ -16,12 +16,13 @@ use crate::services::auth::{
 };
 use crate::services::oidc::ScopeSet;
 use std::sync::Arc;
+use vouch_common::protocol;
 
 /// Result of a client credentials grant exchange.
 pub struct ClientCredentialsResult {
     /// The issued access token.
     pub access_token: secrecy::SecretString,
-    /// Token type ("Bearer").
+    /// Token type ([`protocol::ACCESS_TOKEN_TYPE_BEARER`]).
     pub token_type: String,
     /// Expiration in seconds.
     pub expires_in: u64,
@@ -106,11 +107,11 @@ pub(crate) async fn exchange_client_credentials(
         client.client_id
     );
 
-    // RFC 9449 Section 5: token_type is "DPoP" when the token is sender-constrained
+    // RFC 9449 Section 5: token_type is DPoP when the token is sender-constrained
     let token_type = if bindings.dpop_jkt.is_some() {
-        "DPoP"
+        protocol::ACCESS_TOKEN_TYPE_DPOP
     } else {
-        "Bearer"
+        protocol::ACCESS_TOKEN_TYPE_BEARER
     };
 
     Ok(ClientCredentialsResult {

--- a/crates/vouch-server/src/services/oidc/exchange.rs
+++ b/crates/vouch-server/src/services/oidc/exchange.rs
@@ -19,6 +19,7 @@ use crate::services::oidc::claims::OidcIdTokenClaimsBuilder;
 use jiff::Timestamp;
 use secrecy::ExposeSecret;
 use std::sync::Arc;
+use vouch_common::protocol;
 
 /// Token type URNs for RFC 8693 §3, re-exported under the names this module
 /// uses. The values live in [`vouch_common::protocol`] so the CLI's exchange
@@ -76,7 +77,8 @@ pub struct TokenExchangeResult {
     pub access_token: secrecy::SecretString,
     /// RFC 8693 Section 2.2.1: The type of the issued security token.
     pub issued_token_type: String,
-    /// RFC 6749 Section 7.1: The type of the token issued (e.g., "Bearer").
+    /// RFC 6749 Section 7.1: The type of the token issued (e.g.
+    /// [`protocol::ACCESS_TOKEN_TYPE_BEARER`]).
     pub token_type: String,
     /// The lifetime in seconds of the access token.
     pub expires_in: u64,
@@ -493,11 +495,11 @@ pub(crate) async fn exchange_token(
         params.audience
     );
 
-    // RFC 9449 Section 5: token_type is "DPoP" when the token is sender-constrained
+    // RFC 9449 Section 5: token_type is DPoP when the token is sender-constrained
     let token_type = if params.dpop_jkt.is_some() {
-        "DPoP"
+        protocol::ACCESS_TOKEN_TYPE_DPOP
     } else {
-        "Bearer"
+        protocol::ACCESS_TOKEN_TYPE_BEARER
     };
 
     Ok(TokenExchangeResult {
@@ -642,7 +644,7 @@ async fn issue_id_token(
     Ok(TokenExchangeResult {
         access_token: id_token.into(),
         issued_token_type: token_types::ID_TOKEN.to_string(),
-        token_type: "Bearer".to_string(),
+        token_type: protocol::ACCESS_TOKEN_TYPE_BEARER.to_string(),
         expires_in,
         scope: None,
         authorization_details: None,

--- a/crates/vouch-server/src/services/oidc/fido2_grant.rs
+++ b/crates/vouch-server/src/services/oidc/fido2_grant.rs
@@ -32,6 +32,7 @@ use std::sync::Arc;
 use uuid::Uuid;
 use vouch_common::encoding::Raw;
 use vouch_common::fido2_types::Challenge;
+use vouch_common::protocol;
 
 /// State embedded in the challenge JWT (must match the challenge endpoint).
 #[derive(Debug, Serialize, Deserialize)]
@@ -82,7 +83,8 @@ pub struct Fido2AssertionParams<'a> {
 pub struct Fido2AssertionResult {
     /// The OAuth access token.
     pub access_token: secrecy::SecretString,
-    /// Token type ("DPoP" or "Bearer").
+    /// Token type ([`protocol::ACCESS_TOKEN_TYPE_DPOP`] or
+    /// [`protocol::ACCESS_TOKEN_TYPE_BEARER`]).
     pub token_type: String,
     /// Expires in seconds.
     pub expires_in: u64,
@@ -403,9 +405,9 @@ pub(crate) async fn exchange_fido2_assertion(
     .await;
 
     let token_type = if params.dpop_proof.is_some() {
-        "DPoP"
+        protocol::ACCESS_TOKEN_TYPE_DPOP
     } else {
-        "Bearer"
+        protocol::ACCESS_TOKEN_TYPE_BEARER
     };
 
     Ok(Fido2AssertionResult {

--- a/crates/vouch-server/src/services/oidc/introspection.rs
+++ b/crates/vouch-server/src/services/oidc/introspection.rs
@@ -16,6 +16,7 @@ use crate::services::auth::{DecodedToken, decode_token};
 use crate::services::oidc::ScopeSet;
 use serde::Serialize;
 use std::sync::Arc;
+use vouch_common::protocol;
 
 /// Result of token introspection (RFC 7662 Section 2.2).
 #[derive(Debug, Serialize)]
@@ -31,7 +32,8 @@ pub struct IntrospectionResult {
     /// RFC 7662 Section 2.2: Human-readable identifier for the resource owner (typically email).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub username: Option<String>,
-    /// RFC 7662 Section 2.2: Type of the token (e.g., "Bearer").
+    /// RFC 7662 Section 2.2: Type of the token (e.g.
+    /// [`protocol::ACCESS_TOKEN_TYPE_BEARER`]).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token_type: Option<String>,
     /// RFC 7662 Section 2.2: Integer timestamp indicating when the token expires.
@@ -214,10 +216,14 @@ pub async fn introspect_token(
     // RFC 9396: authorization_details from session (already a Value).
     let authorization_details = session.authorization_details;
 
-    // RFC 9449 §7: DPoP-bound tokens report token_type "DPoP".
-    // mTLS-bound tokens (x5t#S256 only, no jkt) report "Bearer".
+    // RFC 9449 §7: DPoP-bound tokens report token_type DPoP.
+    // mTLS-bound tokens (x5t#S256 only, no jkt) report Bearer.
     let is_dpop = claims.cnf.as_ref().is_some_and(|c| c.jkt.is_some());
-    let token_type = if is_dpop { "DPoP" } else { "Bearer" };
+    let token_type = if is_dpop {
+        protocol::ACCESS_TOKEN_TYPE_DPOP
+    } else {
+        protocol::ACCESS_TOKEN_TYPE_BEARER
+    };
 
     // RFC 9068 access token — populate client_id from the JWT
     Ok(IntrospectionResult {

--- a/crates/vouch-server/src/services/oidc/jarm.rs
+++ b/crates/vouch-server/src/services/oidc/jarm.rs
@@ -11,6 +11,7 @@ use anyhow::Result;
 use jiff::Timestamp;
 use serde::Serialize;
 use std::sync::Arc;
+use vouch_common::protocol;
 
 use crate::AppState;
 use crate::db::OAuthClient;
@@ -52,9 +53,9 @@ struct JarmErrorClaims {
 fn select_alg(_state: &AppState, client: &OAuthClient) -> &'static str {
     match client.authorization_signed_response_alg {
         Some(crate::db::JwsAlgorithm::Rs256) => "RS256",
-        Some(crate::db::JwsAlgorithm::Es256) | None => "ES256",
+        Some(crate::db::JwsAlgorithm::Es256) | None => protocol::JWS_ALG_ES256,
         // Validated at registration; only RS256 and ES256 are accepted for JARM.
-        Some(_) => "ES256",
+        Some(_) => protocol::JWS_ALG_ES256,
     }
 }
 

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/jwks.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/jwks.rs
@@ -9,6 +9,7 @@ use crate::db::documents::jwks_cache::JwksCacheDoc;
 use crate::db::store::DocumentStore;
 use crate::db::{JwkEntry, JwkSet, KeyType};
 use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
+use vouch_common::protocol;
 
 /// Resolve the JWKS for a client — from inline `jwks` or fetched `jwks_uri`.
 ///
@@ -121,7 +122,7 @@ pub fn find_matching_key(
 
     // Fall back to matching by algorithm/key type
     let expected_kty = match header.alg.as_str() {
-        "ES256" => KeyType::Ec,
+        protocol::JWS_ALG_ES256 => KeyType::Ec,
         "RS256" | "PS256" => KeyType::Rsa,
         "EdDSA" => KeyType::Okp,
         _ => {
@@ -228,7 +229,7 @@ fn build_decoding_key_from_jwk(
     alg: &str,
 ) -> ServiceResult<jsonwebtoken::DecodingKey> {
     match (&key.kty, alg) {
-        (KeyType::Ec, "ES256") => {
+        (KeyType::Ec, protocol::JWS_ALG_ES256) => {
             let x = key.x.as_deref().ok_or_else(|| {
                 ServiceError::oauth(OAuthErrorCode::InvalidClient, "EC key missing x component")
             })?;

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/validate.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/validate.rs
@@ -10,6 +10,7 @@ use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
+use vouch_common::protocol;
 
 /// Clock skew tolerance in seconds.
 ///
@@ -318,7 +319,7 @@ pub fn decode_claims_unverified(assertion: &str) -> ServiceResult<JwtAssertionCl
 /// Map a JWT algorithm string to a `jsonwebtoken::Algorithm`.
 pub fn map_algorithm(alg: &str) -> ServiceResult<jsonwebtoken::Algorithm> {
     match alg {
-        "ES256" => Ok(jsonwebtoken::Algorithm::ES256),
+        protocol::JWS_ALG_ES256 => Ok(jsonwebtoken::Algorithm::ES256),
         "RS256" => Ok(jsonwebtoken::Algorithm::RS256),
         "PS256" => Ok(jsonwebtoken::Algorithm::PS256),
         "EdDSA" => Ok(jsonwebtoken::Algorithm::EdDSA),

--- a/crates/vouch-server/src/services/oidc/token.rs
+++ b/crates/vouch-server/src/services/oidc/token.rs
@@ -27,6 +27,7 @@ use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use subtle::ConstantTimeEq;
+use vouch_common::protocol;
 
 use super::authorization::{AuthorizationCode, decode_authorization_code};
 
@@ -87,7 +88,8 @@ pub struct ClientCredentials {
 pub struct AuthCodeExchangeResult {
     /// The access token.
     pub access_token: SecretString,
-    /// Token type ("Bearer" or "DPoP").
+    /// Token type ([`protocol::ACCESS_TOKEN_TYPE_BEARER`] or
+    /// [`protocol::ACCESS_TOKEN_TYPE_DPOP`]).
     pub token_type: String,
     /// Expiration in seconds.
     pub expires_in: u64,
@@ -433,11 +435,11 @@ pub(crate) async fn exchange_authorization_code(
         .await;
     }
 
-    // RFC 9449 Section 5: Token type is "DPoP" if proof was provided, otherwise "Bearer"
+    // RFC 9449 Section 5: Token type is DPoP if proof was provided, otherwise Bearer
     let token_type = if params.dpop_proof.is_some() {
-        "DPoP"
+        protocol::ACCESS_TOKEN_TYPE_DPOP
     } else {
-        "Bearer"
+        protocol::ACCESS_TOKEN_TYPE_BEARER
     };
 
     if let Some(ref proof) = params.dpop_proof {

--- a/crates/vouch-tests/src/contracts.rs
+++ b/crates/vouch-tests/src/contracts.rs
@@ -26,6 +26,7 @@
 //! ```
 
 use thiserror::Error;
+use vouch_common::protocol;
 
 /// Errors from contract validation.
 #[derive(Debug, Error)]
@@ -452,8 +453,8 @@ pub fn validate_client_data_json(data: &[u8]) -> ContractResult<()> {
     // Validate type field value
     if let Some(type_val) = obj.get("type")
         && let Some(type_str) = type_val.as_str()
-        && type_str != "webauthn.create"
-        && type_str != "webauthn.get"
+        && type_str != protocol::CLIENT_DATA_TYPE_CREATE
+        && type_str != protocol::CLIENT_DATA_TYPE_GET
     {
         return Err(ContractError::InvalidClientDataJson(format!(
             "invalid type: expected 'webauthn.create' or 'webauthn.get', got '{type_str}'"

--- a/crates/vouch-tests/src/harness.rs
+++ b/crates/vouch-tests/src/harness.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use anyhow::Result;
 
 use vouch_cli::{HttpClient, TestHttpClient};
+use vouch_common::protocol;
 use vouch_server::{AppState, db, test_utils};
 
 /// Unified test harness for integration tests.
@@ -256,7 +257,7 @@ impl TestHarness {
         token: &str,
     ) -> Result<vouch_cli::HttpResponse> {
         let url = self.url(path);
-        let auth = format!("Bearer {}", token);
+        let auth = format!("{} {}", protocol::AUTH_SCHEME_BEARER, token);
         let sig = self.v1_sig_headers("GET", &url, None);
         let sig_refs: Vec<(&str, &str)> =
             sig.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
@@ -275,7 +276,7 @@ impl TestHarness {
     ) -> Result<vouch_cli::HttpResponse> {
         let url = self.url(path);
         let json = serde_json::to_vec(body)?;
-        let auth = format!("Bearer {}", token);
+        let auth = format!("{} {}", protocol::AUTH_SCHEME_BEARER, token);
         let sig = self.v1_sig_headers("POST", &url, Some(&json));
         let sig_refs: Vec<(&str, &str)> =
             sig.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
@@ -299,7 +300,7 @@ impl TestHarness {
         token: &str,
     ) -> Result<vouch_cli::HttpResponse> {
         let url = self.url(path);
-        let auth = format!("Bearer {}", token);
+        let auth = format!("{} {}", protocol::AUTH_SCHEME_BEARER, token);
         let sig = self.v1_sig_headers("DELETE", &url, None);
         let sig_refs: Vec<(&str, &str)> =
             sig.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
@@ -318,7 +319,7 @@ impl TestHarness {
     ) -> Result<vouch_cli::HttpResponse> {
         let url = self.url(path);
         let json = serde_json::to_vec(body)?;
-        let auth = format!("Bearer {}", token);
+        let auth = format!("{} {}", protocol::AUTH_SCHEME_BEARER, token);
         let sig = self.v1_sig_headers("PATCH", &url, Some(&json));
         let sig_refs: Vec<(&str, &str)> =
             sig.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
@@ -344,7 +345,7 @@ impl TestHarness {
     ) -> Result<vouch_cli::HttpResponse> {
         let url = self.url(path);
         let json = serde_json::to_vec(body)?;
-        let auth = format!("Bearer {}", token);
+        let auth = format!("{} {}", protocol::AUTH_SCHEME_BEARER, token);
         let sig = self.v1_sig_headers("PUT", &url, Some(&json));
         let sig_refs: Vec<(&str, &str)> =
             sig.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
@@ -369,7 +370,7 @@ impl TestHarness {
                 "POST",
                 &url,
                 Some(body.as_bytes()),
-                Some("application/x-www-form-urlencoded"),
+                Some(protocol::CONTENT_TYPE_FORM_URLENCODED),
                 None,
                 None,
             )
@@ -384,13 +385,13 @@ impl TestHarness {
         token: &str,
     ) -> Result<vouch_cli::HttpResponse> {
         let url = self.url(path);
-        let auth = format!("Bearer {}", token);
+        let auth = format!("{} {}", protocol::AUTH_SCHEME_BEARER, token);
         self.http_client
             .request(
                 "POST",
                 &url,
                 Some(body.as_bytes()),
-                Some("application/x-www-form-urlencoded"),
+                Some(protocol::CONTENT_TYPE_FORM_URLENCODED),
                 Some(&auth),
                 None,
             )
@@ -410,7 +411,7 @@ impl TestHarness {
                 "POST",
                 &url,
                 Some(body.as_bytes()),
-                Some("application/x-www-form-urlencoded"),
+                Some(protocol::CONTENT_TYPE_FORM_URLENCODED),
                 Some(auth_header),
                 None,
             )


### PR DESCRIPTION
Follow-up to #1005, extending `crates/vouch-common/src/protocol.rs` to the remaining literals the CLI and server spelled independently. Values are unchanged — this is wire-identical.

## The DPoP nonce header had two spellings

`DPoP-Nonce` in `handlers/session.rs` and `oidc/userinfo.rs`, `dpop-nonce` everywhere else. **This was already harmless on the wire**, for two independent reasons — stated here so the reviewer does not have to re-derive it:

- `http::HeaderName` lowercases every field name on construction. In `http-1.4.2`, `src/header/name.rs`'s `HEADER_CHARS` table maps bytes 65–90 (`A`–`Z`) to `a`–`z`, so `.header("DPoP", …)` has always emitted `dpop`.
- RFC 9449 §4.1 says so normatively:
  > Note that per [RFC9110], header field names are case insensitive; thus, DPoP, DPOP, dpop, etc., are all valid and equivalent header field names. However, case is significant in the header field value.

Two spellings still invite drift in any consumer that compares strings, so the canonical constants are lowercase — which is also the only spelling `HeaderName::from_static` accepts.

## Constants added

Ten, each carrying the verbatim normative text that fixes its value plus section and URL, same convention as #1005.

| Constant | Value | Source |
|---|---|---|
| `HEADER_DPOP` | `dpop` | RFC 9449 §4.1, registered §12.8 |
| `HEADER_DPOP_NONCE` | `dpop-nonce` | RFC 9449 §8, registered §12.8 |
| `AUTH_SCHEME_BEARER` | `Bearer` | RFC 6750 §2.1 |
| `AUTH_SCHEME_DPOP` | `DPoP` | RFC 9449 §7.1 |
| `ACCESS_TOKEN_TYPE_BEARER` | `Bearer` | RFC 6750 §6.1.1 |
| `ACCESS_TOKEN_TYPE_DPOP` | `DPoP` | RFC 9449 §5 |
| `CLIENT_DATA_TYPE_CREATE` | `webauthn.create` | WebAuthn L2 §5.1.3, verified §7.1 |
| `CLIENT_DATA_TYPE_GET` | `webauthn.get` | WebAuthn L2 §5.1.4.1, verified §7.2 |
| `JWS_ALG_ES256` | `ES256` | RFC 7518 §3.1 |
| `CONTENT_TYPE_FORM_URLENCODED` | `application/x-www-form-urlencoded` | RFC 6749 §4.1.3 |

## `DPoP` is three contracts, not one

RFC 9449 spells `DPoP` in three independent places, so it gets three constants:

- the proof header field (§4.1) — `HEADER_DPOP`
- the `Authorization` scheme (§7.1, ABNF `credentials = "DPoP" 1*SP token68`) — `AUTH_SCHEME_DPOP`
- the `token_type` response value (§5, "A token_type of DPoP MUST be included in the access token response") — `ACCESS_TOKEN_TYPE_DPOP`

A call site now names which contract it is in and cites the section that fixes it. Bearer splits the same way: RFC 6750 registers its scheme (§2.1) and its access token type (§6.1.1) separately.

```rust
headers.get(protocol::HEADER_DPOP)
strip_auth_scheme(h, protocol::AUTH_SCHEME_BEARER)
token_type: protocol::ACCESS_TOKEN_TYPE_DPOP
```

## `JwsAlgorithm` and the one literal that has to stay

`JwsAlgorithm` joins `OAuthGrantType` and `OAuthErrorCode` in returning these constants from its `as_str` arm, and its `FromStr` arm matches on the constant. Its `serde(rename)` takes a literal and cannot, so `jws_algorithm_serde_matches_protocol_constant` asserts serialize, deserialize, `as_str`, and `FromStr` all agree with `JWS_ALG_ES256` — otherwise a stored client's signing algorithm stops round-tripping. The test was checked against a mutation (`rename = "ES999"`) and fails as intended.

## Deliberately out of scope

Recorded in the module doc, following the rule #1005 set for `grant-type:jwt-bearer` — these answer to a provider's contract, not to what Vouch's own clients send:

- `application/x-www-form-urlencoded` sent to AWS STS and IAM Identity Center (`vouch_cli::integrations::aws`)
- the `Bearer` scheme the server sends to the GitHub API (`vouch_server::services::integrations::github`)

Tests keep spelling literals by hand; that duplication is the lock-in property #1005 introduced.

## Verification

- An audit over 366 production files finds exactly one hand-spelled literal left — the `serde(rename)` above, which is pinned by the test.
- `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo test --all-features` and `cargo test --package vouch-tests` both pass; `prek run` passes on the changed files.
- Also escaped two pre-existing broken rustdoc intra-doc links in `protocol.rs` (`[JWT]`, `[RFC6749]` inside verbatim RFC quotes) so the file is warning-free.

Closes #1006

🤖 Generated with [Claude Code](https://claude.com/claude-code)
