### PR TITLE
refactor(oidc): require a PAR consumption proof to issue auth codes

### DIFF
--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -188,8 +188,8 @@ pub use github::{
 // Re-export PAR types and functions (RFC 9126)
 pub(crate) use par::create_pushed_authorization_request;
 pub use par::{
-    CreateParParams, PAR_EXPIRES_IN, ParConsumptionMode, PushedAuthorizationRequest,
-    consume_pushed_authorization_request, delete_expired_pushed_authorization_requests,
+    CreateParParams, PAR_EXPIRES_IN, ParConsumptionMode, ParConsumptionProof, ParRef,
+    ParStateClaim, PushedAuthorizationRequest, delete_expired_pushed_authorization_requests,
     extend_par_expiration, get_pushed_authorization_request,
 };
 

--- a/crates/vouch-server/src/db/par.rs
+++ b/crates/vouch-server/src/db/par.rs
@@ -188,77 +188,138 @@ pub enum ParConsumptionMode {
 
 /// Witness that a PAR record (RFC 9126) was atomically consumed by this
 /// caller. Construction is private to this module — the only path to an
-/// instance is a successful return from
-/// [`consume_pushed_authorization_request`], whose
+/// instance is a winning [`ParConsumptionProof::consume`], whose
 /// optimistic-concurrency `compare_and_update` guarantees that at most one
 /// concurrent caller succeeds. Holding a `ParStateClaim` is compile-time
 /// evidence that this caller's PAR consume "won" the OCC race.
 ///
-/// Intentionally not `Clone`. The `#[must_use]` ensures the witness is
-/// bound at the call site; today it is dropped immediately after
-/// consumption (the immediate consumer issues an auth code rather than a
-/// token), but the type exists so future code can require it as a
-/// precondition for PAR-derived downstream operations.
+/// Intentionally not `Clone`. The witness is carried by
+/// [`ParConsumptionProof`], which authorization-code issuance requires, so
+/// a flow that turns a pushed request into a code cannot leave the
+/// `request_uri` replayable for the rest of its lifetime.
 #[must_use = "the PAR record was atomically consumed; bind this witness so \
-              future code can require it as a precondition"]
+              authorization-code issuance can require it as a precondition"]
 #[derive(Debug)]
 pub struct ParStateClaim {
     _private: (),
 }
 
-/// Consume a pushed authorization request (single-use).
+/// The pushed authorization request an authorization flow is completing.
 ///
-/// On success returns a [`ParStateClaim`] witness — proof that this caller
-/// won the optimistic-concurrency consume. On any "lost" case (PAR not
-/// found, client_id mismatch, already consumed, or expired when expiry is
-/// enforced) returns [`ClaimError::AlreadyConsumed`]. These cases are
-/// deliberately indistinguishable from the caller's perspective: each is
-/// rejected as an invalid request_uri.
+/// Names the record to consume (RFC 9126 Section 2.2) together with the
+/// client it was issued to (Section 2.3) and the expiry policy that applies
+/// at consume time.
+#[derive(Debug, Clone, Copy)]
+pub struct ParRef<'a> {
+    /// The `request_uri` the client presented at the authorization endpoint.
+    pub request_uri: &'a str,
+    /// The client the `request_uri` was issued to.
+    pub client_id: &'a str,
+    /// Whether the PAR lifetime is still enforced for this consume.
+    pub mode: ParConsumptionMode,
+}
+
+/// Proof that the single-use obligation attached to an authorization request
+/// has been discharged: either the request never went through the PAR
+/// endpoint, or its record was consumed by this caller.
 ///
-/// # Client Binding
+/// Required by
+/// [`issue_authorization_code`](crate::services::oidc::authorization::issue_authorization_code).
+/// [`Self::consume`] is the only constructor that accepts a pushed request,
+/// and it carries the [`ParStateClaim`] the consume produced — so a code
+/// cannot be issued for a pushed request while its `request_uri` is still
+/// replayable for the rest of its lifetime.
 ///
-/// RFC 9126 Section 2.3: The authorization server MUST validate that the
-/// `client_id` form parameter matches the `client_id` that was used when
-/// the `request_uri` was created.
-pub async fn consume_pushed_authorization_request(
-    store: &DocumentStore,
-    request_uri: &str,
-    client_id: &str,
-    mode: ParConsumptionMode,
-) -> std::result::Result<ParStateClaim, ClaimError> {
-    let now = Timestamp::now();
+/// RFC 9126 Section 2.2 describes the reference:
+///
+/// > This URI is a single-use reference to the respective request data in
+/// > the subsequent authorization request.
+///
+/// and Section 7.3 states the requirement as a SHOULD:
+///
+/// > An attacker could replay a request URI captured from a legitimate
+/// > authorization request.  In order to cope with such attacks, the
+/// > authorization server SHOULD make the request URIs one-time use.
+#[must_use = "the proof was constructed to authorize a single code issuance; \
+              dropping it without calling issue_authorization_code is a bug"]
+#[derive(Debug)]
+pub struct ParConsumptionProof {
+    /// Held rather than dropped: the witness is the evidence this proof
+    /// asserts. `None` when the request was never pushed.
+    _claim: Option<ParStateClaim>,
+}
 
-    let doc = store
-        .find_one::<PushedAuthorizationRequestDoc>("request_uri", request_uri)
-        .await
-        .map_err(|e| ClaimError::Database(e.to_string()))?;
+impl ParConsumptionProof {
+    /// Consume the pushed authorization request backing this authorization.
+    ///
+    /// Consumption is single-use. Every "lost" case — record not found,
+    /// `client_id` mismatch, already consumed, or expired when expiry is
+    /// enforced — returns [`ClaimError::AlreadyConsumed`]. These are
+    /// deliberately indistinguishable from the caller's perspective: each is
+    /// rejected as an invalid `request_uri`.
+    ///
+    /// # Client Binding
+    ///
+    /// RFC 9126 Section 2.3: The authorization server MUST validate that the
+    /// `client_id` form parameter matches the `client_id` that was used when
+    /// the `request_uri` was created.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ClaimError::AlreadyConsumed`] when the record cannot be
+    /// claimed, and [`ClaimError::Database`] on a storage failure.
+    pub async fn consume(
+        store: &DocumentStore,
+        par: ParRef<'_>,
+    ) -> std::result::Result<Self, ClaimError> {
+        let now = Timestamp::now();
 
-    let Some(doc) = doc else {
-        return Err(ClaimError::AlreadyConsumed);
-    };
+        let doc = store
+            .find_one::<PushedAuthorizationRequestDoc>("request_uri", par.request_uri)
+            .await
+            .map_err(|e| ClaimError::Database(e.to_string()))?;
 
-    if doc.data.client_id != client_id || doc.data.consumed_at.is_some() {
-        return Err(ClaimError::AlreadyConsumed);
+        let Some(doc) = doc else {
+            return Err(ClaimError::AlreadyConsumed);
+        };
+
+        if doc.data.client_id != par.client_id || doc.data.consumed_at.is_some() {
+            return Err(ClaimError::AlreadyConsumed);
+        }
+
+        if par.mode == ParConsumptionMode::EnforceExpiry && doc.data.expires_at <= now {
+            return Err(ClaimError::AlreadyConsumed);
+        }
+
+        // Atomic consume via optimistic concurrency. If a concurrent caller
+        // already consumed this PAR between our read and write,
+        // compare_and_update returns false (version mismatch) — that caller
+        // wins the race and we report AlreadyConsumed.
+        let mut data = doc.data;
+        data.consumed_at = Some(now);
+        let won = store
+            .compare_and_update(&doc.id, doc.version, &data)
+            .await
+            .map_err(|e| ClaimError::Database(e.to_string()))?;
+        if won {
+            Ok(Self {
+                _claim: Some(ParStateClaim { _private: () }),
+            })
+        } else {
+            Err(ClaimError::AlreadyConsumed)
+        }
     }
 
-    if mode == ParConsumptionMode::EnforceExpiry && doc.data.expires_at <= now {
-        return Err(ClaimError::AlreadyConsumed);
-    }
-
-    // Atomic consume via optimistic concurrency. If a concurrent caller
-    // already consumed this PAR between our read and write,
-    // compare_and_update returns false (version mismatch) — that caller
-    // wins the race and we report AlreadyConsumed.
-    let mut data = doc.data;
-    data.consumed_at = Some(now);
-    let won = store
-        .compare_and_update(&doc.id, doc.version, &data)
-        .await
-        .map_err(|e| ClaimError::Database(e.to_string()))?;
-    if won {
-        Ok(ParStateClaim { _private: () })
-    } else {
-        Err(ClaimError::AlreadyConsumed)
+    /// Evidence that the authorization request carried no `request_uri`, so
+    /// there is no PAR record to consume.
+    ///
+    /// Use **only** where the request demonstrably did not come through the
+    /// PAR endpoint. Adding new call sites is an audit-relevant decision:
+    /// grep for this constructor before merging any change that introduces a
+    /// new caller — a flow that reaches code issuance holding a `request_uri`
+    /// must call [`Self::consume`] instead.
+    pub fn not_pushed() -> Self {
+        Self { _claim: None }
     }
 }
 

--- a/crates/vouch-server/src/handlers/oidc/authorize.rs
+++ b/crates/vouch-server/src/handlers/oidc/authorize.rs
@@ -329,7 +329,7 @@ async fn check_session_and_authorize(
     validated: ValidatedAuthRequest,
     jar: &CookieJar,
     reauth_policy: ReauthPolicy,
-    par_to_consume: Option<(&str, &str)>,
+    par_to_consume: Option<db::ParRef<'_>>,
 ) -> Response {
     let session_token = jar
         .get(vouch_common::SESSION_COOKIE_NAME)
@@ -373,7 +373,7 @@ async fn check_session_and_authorize(
                     response_mode: resolved.response_mode,
                 },
                 None,
-                par_to_consume.map(|(uri, _)| uri),
+                par_to_consume.map(|par| par.request_uri),
             )
             .await
         }
@@ -882,7 +882,11 @@ async fn handle_par_request(
         validated,
         &jar,
         ReauthPolicy::Always,
-        Some((ctx.request_uri, ctx.client_id)),
+        Some(db::ParRef {
+            request_uri: ctx.request_uri,
+            client_id: ctx.client_id,
+            mode: db::ParConsumptionMode::EnforceExpiry,
+        }),
     )
     .await
 }
@@ -1189,39 +1193,40 @@ async fn complete_pending_auth(
         }
     }
 
-    if let Some(ref request_uri) = pending.par_request_uri {
-        match db::consume_pushed_authorization_request(
-            &state.store,
-            request_uri,
-            &pending.client_id,
-            db::ParConsumptionMode::SkipExpiry,
-        )
-        .await
-        {
-            Ok(_claim) => {} // successfully consumed
-            Err(db::claim::ClaimError::AlreadyConsumed) => {
-                return resolved
-                    .error_redirect(
-                        state,
-                        OAuthErrorCode::InvalidRequest,
-                        "The request_uri has already been used",
-                        pending.state.as_deref(),
-                    )
-                    .await;
-            }
-            Err(e) => {
-                tracing::error!("Failed to consume PAR at code issuance: {e}");
-                return resolved
-                    .error_redirect(
-                        state,
-                        OAuthErrorCode::ServerError,
-                        "Failed to process pushed authorization request",
-                        pending.state.as_deref(),
-                    )
-                    .await;
+    let par_proof = match pending.par_request_uri {
+        None => db::ParConsumptionProof::not_pushed(),
+        Some(ref request_uri) => {
+            let par = db::ParRef {
+                request_uri,
+                client_id: &pending.client_id,
+                mode: db::ParConsumptionMode::SkipExpiry,
+            };
+            match db::ParConsumptionProof::consume(&state.store, par).await {
+                Ok(proof) => proof,
+                Err(db::claim::ClaimError::AlreadyConsumed) => {
+                    return resolved
+                        .error_redirect(
+                            state,
+                            OAuthErrorCode::InvalidRequest,
+                            "The request_uri has already been used",
+                            pending.state.as_deref(),
+                        )
+                        .await;
+                }
+                Err(e) => {
+                    tracing::error!("Failed to consume PAR at code issuance: {e}");
+                    return resolved
+                        .error_redirect(
+                            state,
+                            OAuthErrorCode::ServerError,
+                            "Failed to process pushed authorization request",
+                            pending.state.as_deref(),
+                        )
+                        .await;
+                }
             }
         }
-    }
+    };
 
     let scope_set = ScopeSet::parse(pending.scope.as_deref().unwrap_or("openid"));
     let code_params = AuthorizationCodeParams {
@@ -1244,6 +1249,7 @@ async fn complete_pending_auth(
         auth_code_lifetime_seconds: auth_code_lifetime,
         authorization_details: pending.authorization_details.as_ref(),
         auth_time: Some(auth_session.created_at.as_second()),
+        par: par_proof,
     };
 
     issue_code_and_redirect(
@@ -1472,7 +1478,7 @@ async fn authorize_authenticated_user(
     auth_session: &Session,
     authenticator: &Authenticator,
     reauth_policy: ReauthPolicy,
-    par_to_consume: Option<(&str, &str)>,
+    par_to_consume: Option<db::ParRef<'_>>,
     response_mode: ResponseMode,
 ) -> Response {
     // Step 1: Check client access.
@@ -1544,7 +1550,7 @@ async fn authorize_authenticated_user(
                 response_mode,
             },
             Some(Prompt::Login),
-            par_to_consume.map(|(uri, _)| uri),
+            par_to_consume.map(|par| par.request_uri),
         )
         .await;
     }
@@ -1577,7 +1583,7 @@ async fn issue_code_after_reauth_check(
     user: &User,
     auth_session: &Session,
     authenticator: &Authenticator,
-    par_to_consume: Option<(&str, &str)>,
+    par_to_consume: Option<db::ParRef<'_>>,
     response_mode: ResponseMode,
 ) -> Response {
     // Step 5: Validate requested ACR (RFC 9470).
@@ -1616,16 +1622,10 @@ async fn issue_code_after_reauth_check(
     }
 
     // Step 7: Consume PAR if applicable (code issuance, not initial authorize visit).
-    if let Some((request_uri, client_id)) = par_to_consume {
-        match db::consume_pushed_authorization_request(
-            &state.store,
-            request_uri,
-            client_id,
-            db::ParConsumptionMode::EnforceExpiry,
-        )
-        .await
-        {
-            Ok(_claim) => {} // Successfully consumed
+    let par_proof = match par_to_consume {
+        None => db::ParConsumptionProof::not_pushed(),
+        Some(par) => match db::ParConsumptionProof::consume(&state.store, par).await {
+            Ok(proof) => proof,
             Err(db::claim::ClaimError::AlreadyConsumed) => {
                 return oauth_error_response(
                     state,
@@ -1651,8 +1651,8 @@ async fn issue_code_after_reauth_check(
                 )
                 .await;
             }
-        }
-    }
+        },
+    };
 
     // Step 8: Issue authorization code.
     let auth_code_lifetime = crate::services::oidc::fapi::auth_code_lifetime_seconds(oauth_client);
@@ -1674,6 +1674,7 @@ async fn issue_code_after_reauth_check(
         auth_code_lifetime_seconds: auth_code_lifetime,
         authorization_details: ad_value.as_ref(),
         auth_time: Some(auth_session.created_at.as_second()),
+        par: par_proof,
     };
 
     issue_code_and_redirect(

--- a/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
@@ -290,6 +290,7 @@ async fn test_fapi2_dpop_code_binding_matching_key() {
                 crate::services::oidc::fapi::FAPI_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -375,6 +376,7 @@ async fn test_fapi2_dpop_code_binding_mismatching_key() {
                 crate::services::oidc::fapi::FAPI_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -462,6 +464,7 @@ async fn test_fapi2_dpop_code_binding_missing_dpop_at_token() {
                 crate::services::oidc::fapi::FAPI_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -680,6 +683,7 @@ async fn test_fapi2_token_rejects_without_dpop() {
                 crate::services::oidc::fapi::FAPI_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -771,6 +775,7 @@ async fn test_fapi2_non_fapi_client_standard_flow() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await

--- a/crates/vouch-server/src/handlers/oidc/tests/fido2_grant.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/fido2_grant.rs
@@ -712,6 +712,7 @@ async fn test_client_assertion_jti_committed_on_success_and_rejected_on_replay()
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -758,6 +759,7 @@ async fn test_client_assertion_jti_committed_on_success_and_rejected_on_replay()
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await

--- a/crates/vouch-server/src/handlers/oidc/tests/helpers.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/helpers.rs
@@ -59,6 +59,7 @@ pub(super) async fn issue_oauth_access_token_with_scope(
             crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
         authorization_details: None,
         auth_time: None,
+        par: crate::db::ParConsumptionProof::not_pushed(),
     };
 
     let code = issue_authorization_code(state, code_params)

--- a/crates/vouch-server/src/handlers/oidc/tests/oidc_core.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/oidc_core.rs
@@ -60,6 +60,7 @@ async fn test_oidc_id_token_nonce_echo() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -206,6 +207,7 @@ async fn test_oidc_scope_based_claim_filtering() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -405,6 +407,7 @@ async fn test_oidc_nonce_echo_in_id_token() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc6749_token.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc6749_token.rs
@@ -157,6 +157,7 @@ async fn test_rfc6749_successful_authorization_code_exchange() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -261,6 +262,7 @@ async fn test_rfc6749_token_response_no_error_field_on_success() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -332,6 +334,7 @@ async fn test_token_exchange_rejects_revoked_authenticator() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -401,6 +404,7 @@ async fn test_rfc6749_token_client_secret_post_succeeds() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7523.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7523.rs
@@ -214,6 +214,7 @@ async fn test_rfc7523_private_key_jwt_client_auth_full_flow() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -280,6 +281,7 @@ async fn test_rfc7523_private_key_jwt_jti_replay_rejected() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -360,6 +362,7 @@ async fn test_rfc7523_private_key_jwt_expired_assertion_rejected() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -428,6 +431,7 @@ async fn test_rfc7523_private_key_jwt_wrong_audience() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -490,6 +494,7 @@ async fn test_rfc7523_private_key_jwt_wrong_key() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -544,6 +549,7 @@ async fn test_rfc7523_private_key_jwt_iss_sub_mismatch() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -613,6 +619,7 @@ async fn test_rfc7521_mutual_exclusion_secret_and_assertion() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -908,6 +915,7 @@ async fn test_rfc7523_authorization_code_grant_accepts_non_fapi_jwt_without_jti(
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -1148,6 +1156,7 @@ async fn test_jwt_assertion_jti_concurrent_replay_authorization_code() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -1230,6 +1239,7 @@ async fn test_jwt_assertion_jti_concurrent_replay_token_exchange() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -1441,6 +1451,7 @@ async fn test_jwt_assertion_dpop_use_nonce_retry_succeeds() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -1547,6 +1558,7 @@ async fn pkjwt_issue_code(
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7591.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7591.rs
@@ -1526,6 +1526,7 @@ async fn test_rfc7591_e2e_registered_client_auth_code_flow() {
             crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
         authorization_details: None,
         auth_time: None,
+        par: crate::db::ParConsumptionProof::not_pushed(),
     };
 
     let code = issue_authorization_code(&state, code_params)

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7636.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7636.rs
@@ -64,6 +64,7 @@ async fn test_rfc7636_code_verifier_too_short() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -168,6 +169,7 @@ async fn test_rfc7636_end_to_end_pkce_flow() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -235,6 +237,7 @@ async fn test_rfc7636_wrong_verifier_rejected() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -301,6 +304,7 @@ async fn test_rfc7636_code_verifier_length_too_short() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -363,6 +367,7 @@ async fn test_rfc7636_code_verifier_too_long() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -424,6 +429,7 @@ async fn test_rfc7636_complete_pkce_s256_flow() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -485,6 +491,7 @@ async fn issue_pkce_code(
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7662.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7662.rs
@@ -518,6 +518,7 @@ async fn test_rfc7662_introspect_with_private_key_jwt_succeeds() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc8705.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc8705.rs
@@ -244,6 +244,7 @@ async fn issue_test_authorization_code(
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc8707.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc8707.rs
@@ -74,6 +74,7 @@ async fn test_rfc8707_resource_passthrough_authorize_to_token() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
@@ -1087,11 +1087,13 @@ async fn test_rfc9126_consume_par_with_stale_version_returns_false() {
     .unwrap();
 
     // First consumption should succeed.
-    let _claim = db::consume_pushed_authorization_request(
+    let _proof = db::ParConsumptionProof::consume(
         &state.store,
-        &request_uri,
-        &client.client_id,
-        db::ParConsumptionMode::EnforceExpiry,
+        db::ParRef {
+            request_uri: &request_uri,
+            client_id: &client.client_id,
+            mode: db::ParConsumptionMode::EnforceExpiry,
+        },
     )
     .await
     .expect("First consumption should succeed");
@@ -1109,11 +1111,13 @@ async fn test_rfc9126_consume_par_with_stale_version_returns_false() {
     );
 
     // Second consumption should fail (already consumed — pre-check catches it).
-    let result = db::consume_pushed_authorization_request(
+    let result = db::ParConsumptionProof::consume(
         &state.store,
-        &request_uri,
-        &client.client_id,
-        db::ParConsumptionMode::EnforceExpiry,
+        db::ParRef {
+            request_uri: &request_uri,
+            client_id: &client.client_id,
+            mode: db::ParConsumptionMode::EnforceExpiry,
+        },
     )
     .await;
     assert!(
@@ -1170,20 +1174,24 @@ async fn test_rfc9126_consume_par_concurrent_replay() {
     let client_id_b = client.client_id.clone();
     let (result_a, result_b) = tokio::join!(
         async move {
-            db::consume_pushed_authorization_request(
+            db::ParConsumptionProof::consume(
                 &store_a,
-                &request_uri_a,
-                &client_id_a,
-                db::ParConsumptionMode::EnforceExpiry,
+                db::ParRef {
+                    request_uri: &request_uri_a,
+                    client_id: &client_id_a,
+                    mode: db::ParConsumptionMode::EnforceExpiry,
+                },
             )
             .await
         },
         async move {
-            db::consume_pushed_authorization_request(
+            db::ParConsumptionProof::consume(
                 &store_b,
-                &request_uri_b,
-                &client_id_b,
-                db::ParConsumptionMode::EnforceExpiry,
+                db::ParRef {
+                    request_uri: &request_uri_b,
+                    client_id: &client_id_b,
+                    mode: db::ParConsumptionMode::EnforceExpiry,
+                },
             )
             .await
         },
@@ -1379,6 +1387,99 @@ async fn test_rfc9126_par_not_consumed_when_reauth_required() {
 }
 
 #[tokio::test]
+async fn test_rfc9126_par_consumed_when_code_issued_after_login() {
+    // RFC 9126 Section 7.3: "the authorization server SHOULD make the request
+    // URIs one-time use". The deferred path issues the code on the return trip
+    // from login, so that is where the PAR referenced by the pending record
+    // must be consumed — a replay of the request_uri afterwards fails.
+    use crate::db::documents::par::PushedAuthorizationRequestDoc;
+
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "par-deferred@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+
+    let request_uri = create_par_request(&app, &client).await;
+    let cookie = format!("__Host-vouch_session={session_token}");
+
+    // First visit: PAR flow always re-authenticates, so this parks the request
+    // in a pending record and redirects to login.
+    let response = http_get_full(
+        &app,
+        &format!(
+            "/oauth/authorize?client_id={}&request_uri={}",
+            client.client_id,
+            urlencoding::encode(&request_uri),
+        ),
+        &[("Cookie", &cookie)],
+    )
+    .await;
+    let location = response.headers.get("location").expect("redirect location");
+    let pending_id = location
+        .to_str()
+        .unwrap()
+        .strip_prefix("/login?pending_auth=")
+        .expect("login redirect carries the pending auth id")
+        .to_string();
+
+    // Return trip from login: the code is issued here.
+    let completed = http_get_full(
+        &app,
+        &format!("/oauth/authorize?pending_auth={pending_id}"),
+        &[("Cookie", &cookie)],
+    )
+    .await;
+    let completed_location = completed
+        .headers
+        .get("location")
+        .expect("code redirect location")
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert!(
+        completed_location.starts_with("https://example.com/callback?code="),
+        "Return from login should redirect with an authorization code, got: \
+         {completed_location} (status {})",
+        completed.status
+    );
+
+    // The PAR backing the issued code must now be consumed.
+    let doc = state
+        .store
+        .find_one::<PushedAuthorizationRequestDoc>("request_uri", &request_uri)
+        .await
+        .unwrap()
+        .expect("PAR doc should still exist");
+    assert!(
+        doc.data.consumed_at.is_some(),
+        "PAR must be consumed once the authorization code is issued"
+    );
+
+    // And the request_uri is no longer usable.
+    let replay = http_get_full(
+        &app,
+        &format!(
+            "/oauth/authorize?client_id={}&request_uri={}",
+            client.client_id,
+            urlencoding::encode(&request_uri),
+        ),
+        &[("Cookie", &cookie)],
+    )
+    .await;
+    assert_eq!(
+        replay.status,
+        StatusCode::OK,
+        "Replaying a consumed request_uri should return the error page"
+    );
+    assert!(
+        !replay.body.contains("pending_auth"),
+        "Replaying a consumed request_uri must not start a new authorization"
+    );
+}
+
+#[tokio::test]
 async fn test_rfc9126_par_reuse_succeeds_after_reauth_redirect() {
     // FAPI 2.0 Section 5.3.2.2 Note 3: request_uri can be reused before
     // authorization completes, even on the re-auth path.
@@ -1452,11 +1553,13 @@ async fn test_rfc9126_par_already_consumed_returns_error_not_login() {
     let request_uri = create_par_request(&app, &client).await;
 
     // Consume the PAR directly via DB before the authorize request arrives.
-    let _claim = crate::db::consume_pushed_authorization_request(
+    let _proof = crate::db::ParConsumptionProof::consume(
         &state.store,
-        &request_uri,
-        &client.client_id,
-        crate::db::ParConsumptionMode::EnforceExpiry,
+        crate::db::ParRef {
+            request_uri: &request_uri,
+            client_id: &client.client_id,
+            mode: crate::db::ParConsumptionMode::EnforceExpiry,
+        },
     )
     .await
     .expect("Pre-consumption should succeed");

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9396.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9396.rs
@@ -40,6 +40,7 @@ async fn test_authorization_details_in_token_response() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: Some(&ad_value),
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -101,6 +102,7 @@ async fn test_no_authorization_details_omitted_from_response() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -163,6 +165,7 @@ async fn test_token_request_downscoping_subset_accepted() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: Some(&granted),
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -225,6 +228,7 @@ async fn test_token_request_downscoping_non_subset_rejected() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: Some(&granted),
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -283,6 +287,7 @@ async fn test_token_request_ad_when_none_granted_rejected() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -344,6 +349,7 @@ async fn test_invalid_authorization_details_json() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: Some(&ad_value),
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -401,6 +407,7 @@ async fn test_authorization_details_must_be_array() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: Some(&ad_value),
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -465,6 +472,7 @@ async fn test_introspection_includes_authorization_details() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: Some(&ad_value),
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -572,6 +580,7 @@ async fn test_token_exchange_inherits_authorization_details() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: Some(&ad_value),
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -651,6 +660,7 @@ async fn test_token_exchange_narrows_authorization_details() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: Some(&ad_value),
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -729,6 +739,7 @@ async fn test_token_exchange_narrow_non_subset_rejected() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: Some(&ad_value),
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -808,6 +819,7 @@ async fn test_multiple_authorization_detail_entries() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: Some(&ad_value),
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -864,6 +876,7 @@ async fn test_scope_and_authorization_details_coexist() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: Some(&ad_value),
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9449.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9449.rs
@@ -999,6 +999,7 @@ async fn test_rfc9449_dpop_nonce_required_token_endpoint_returns_nonce_header() 
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -1081,6 +1082,7 @@ async fn test_rfc9449_dpop_nonce_required_retry_with_nonce_succeeds() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -1382,6 +1384,7 @@ async fn test_rfc9449_token_public_client_dpop_use_dpop_nonce() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -1453,6 +1456,7 @@ async fn test_rfc9449_token_confidential_client_requires_client_auth_with_dpop()
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -1536,6 +1540,7 @@ async fn test_rfc9449_token_mtls_registered_client_without_cert_rejected() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9470.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9470.rs
@@ -687,6 +687,7 @@ async fn test_rfc9470_acr_values_carried_to_token() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -762,6 +763,7 @@ async fn test_rfc9470_unsatisfiable_acr_in_token_exchange_rejected() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9700.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9700.rs
@@ -125,6 +125,7 @@ async fn test_rfc9700_client_id_matching_at_token_endpoint() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -182,6 +183,7 @@ async fn test_rfc9700_redirect_uri_exact_match_at_token() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -240,6 +242,7 @@ async fn test_rfc9700_redirect_uri_required_when_present_in_auth() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await
@@ -302,6 +305,7 @@ async fn test_rfc9700_authorization_code_single_use() {
                 crate::services::oidc::fapi::STANDARD_AUTH_CODE_LIFETIME_SECONDS,
             authorization_details: None,
             auth_time: None,
+            par: crate::db::ParConsumptionProof::not_pushed(),
         },
     )
     .await

--- a/crates/vouch-server/src/services/oidc/authorization.rs
+++ b/crates/vouch-server/src/services/oidc/authorization.rs
@@ -7,7 +7,10 @@
 
 use crate::AppState;
 use crate::crypto::jwt::JwtType;
-use crate::db::{AccessScope, Authenticator, OAuthClient, Session, TokenEndpointAuthMethod, User};
+use crate::db::{
+    AccessScope, Authenticator, OAuthClient, ParConsumptionProof, Session, TokenEndpointAuthMethod,
+    User,
+};
 use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
 use crate::services::oidc::ScopeSet;
 use jiff::{Span, Timestamp};
@@ -177,6 +180,14 @@ pub struct AuthorizationCodeParams<'a> {
     /// in the id_token reflects the actual authentication event, not code issuance.
     /// When `None`, falls back to the code's `iat`.
     pub auth_time: Option<i64>,
+    /// RFC 9126: proof that the pushed authorization request backing this
+    /// authorization was consumed, or that the request was never pushed.
+    ///
+    /// Naming it here means every code-issuing flow has to say which case it
+    /// is in: a flow holding a `request_uri` can only obtain the proof from
+    /// [`ParConsumptionProof::consume`], so it cannot issue a code and leave
+    /// the `request_uri` replayable for the rest of its lifetime.
+    pub par: ParConsumptionProof,
 }
 
 /// Authorization request parameters (from query string).
@@ -665,6 +676,10 @@ pub async fn check_session_for_authorization(
 /// Stores the code hash in the database for single-use enforcement
 /// per RFC 6749 Section 10.5.
 ///
+/// `params.par` is the RFC 9126 chokepoint: the caller must supply a
+/// [`ParConsumptionProof`], so a pushed request reaches this function only
+/// after its `request_uri` has been consumed.
+///
 /// # Arguments
 /// * `state` - Application state
 /// * `params` - Parameters for the authorization code
@@ -678,6 +693,8 @@ pub async fn issue_authorization_code(
     state: &Arc<AppState>,
     params: AuthorizationCodeParams<'_>,
 ) -> ServiceResult<String> {
+    tracing::debug!(par = ?params.par, "PAR consumption proof consumed");
+
     let now = Timestamp::now();
     // Use the caller-supplied lifetime (FAPI 2.0 uses 60s, standard uses 300s).
     // Fallback to the supplied value if Span arithmetic overflows (shouldn't happen


### PR DESCRIPTION
Closes one item from #1007: the `ParStateClaim` witness type.

## Problem

`ParStateClaim` existed and documented itself as a witness, but nothing
required it. Both consume sites wrote `Ok(_claim) => {}` and dropped it,
and `issue_authorization_code` had no relationship to PAR consumption —
the consume was an `if let` side effect on an `Option<(&str, &str)>`
threaded through three functions. A flow that passed `None` compiled and
left the `request_uri` usable for the rest of its lifetime.

## What this does

`AuthorizationCodeParams` gains a required `par: ParConsumptionProof`,
so `issue_authorization_code` cannot be reached without stating the PAR
origin of the request.

`ParConsumptionProof` is a sealed struct holding the `ParStateClaim` its
consume produced. Two named constructors:

- `consume(store, ParRef)` — performs the OCC consume and carries the
  witness. `ParRef` names the `request_uri`, the `client_id` it was
  issued to, and the expiry mode.
- `not_pushed()` — the documented escape for a request that never went
  through the PAR endpoint.

`consume_pushed_authorization_request` is inlined into `consume()` and
deleted, so consuming a PAR without producing the proof is no longer
expressible. The authorization flows thread `Option<ParRef<'_>>` in
place of `Option<(&str, &str)>`.

Behavior is unchanged: same error responses, same expiry modes
(`EnforceExpiry` direct, `SkipExpiry` deferred), same FAPI 2.0
reuse-before-completion semantics.

## Compiler errors from attempting the violations

Omitting the field (62 sites):

```
error[E0063]: missing field `par` in initializer of `AuthorizationCodeParams<'_>`
    --> crates/vouch-server/src/handlers/oidc/tests/helpers.rs:43:23
```

Fabricating the proof:

```
error[E0451]: field `_claim` of struct `ParConsumptionProof` is private
    --> crates/vouch-server/src/handlers/oidc/authorize.rs:1196:45
```

Consuming without producing the proof:

```
error[E0425]: cannot find function `consume_pushed_authorization_request` in module `db`
```

## What remains expressible

A future flow holding a `request_uri` can still call `not_pushed()`.
What is now impossible: issuing a code without deciding the PAR case,
fabricating the proof, consuming without producing it, and dropping the
witness at the consume site. The two production sites derive the choice
from the request itself.

## Tests

Adds `test_rfc9126_par_consumed_when_code_issued_after_login`, covering
the deferred path (login, then the return trip that issues the code) —
the branch with no prior coverage of consumption. Verified it catches
the defect: with consumption skipped it fails on the `consumed_at`
assertion.

`make lint`, `make test`, `make test-integration`, and `prek run` on the
changed files all pass.

## Spec

RFC 9126 Section 2.2, fetched 2026-08-22 from
https://www.rfc-editor.org/rfc/rfc9126.txt, describes the reference:

> This URI is a single-use reference to the respective request data in
> the subsequent authorization request.

Section 7.3 states the requirement, as a SHOULD:

> An attacker could replay a request URI captured from a legitimate
> authorization request.  In order to cope with such attacks, the
> authorization server SHOULD make the request URIs one-time use.

Both are quoted verbatim in the type's docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)