### PR TITLE
test(agent): remove accept race in inflight shutdown test

### DIFF
--- a/crates/vouch-agent/tests/graceful_shutdown.rs
+++ b/crates/vouch-agent/tests/graceful_shutdown.rs
@@ -206,11 +206,27 @@ async fn inflight_request_completes_on_sigterm() {
     let mut agent = spawn_agent();
     let socket = wait_for_socket(&agent).await;
 
-    // Connect and send a ping, but do NOT read the response yet.
     let mut client = UnixStream::connect(&socket).await.expect("connect");
-    client.write_all(&encode_ping()).await.expect("write ping");
 
-    // Send SIGTERM immediately — the request is in-flight.
+    // Complete one request first. `connect` + `write_all` only place bytes in
+    // the kernel buffer; they do not mean the agent has accepted the
+    // connection. Reading a response proves the accept loop took it and
+    // spawned its handler task — the state `drain_connections` waits on. Test
+    // the drain guarantee only once the connection is in that state; SIGTERM
+    // before the accept breaks the listener loop, and the queued connection is
+    // dropped unaccepted.
+    client.write_all(&encode_ping()).await.expect("write ping");
+    let resp = read_response(&mut client).await;
+    assert_eq!(resp["result"], "pong");
+
+    // Now the request that must survive: written to a connection the agent is
+    // already servicing, so the biased read in `handle_connection` serves it
+    // even when shutdown fires in the same tick.
+    client
+        .write_all(&encode_ping())
+        .await
+        .expect("write in-flight ping");
+
     send_sigterm(&agent.child);
 
     // The response should still arrive (drain lets the handler finish).


### PR DESCRIPTION
`inflight_request_completes_on_sigterm` fails on the macOS runner, blocking #1024 (which touches no `vouch-agent` files — that crate depends only on `vouch-common`).

## The race

The test connected, wrote a ping, and signalled immediately, treating the write as proof the request was in flight:

```rust
let mut client = UnixStream::connect(&socket).await.expect("connect");
client.write_all(&encode_ping()).await.expect("write ping");
send_sigterm(&agent.child);   // "the request is in-flight"
```

`connect` and `write_all` only place bytes in the kernel socket buffer. They do not mean the agent has accepted the connection.

When SIGTERM won that race, the `shutdown.changed()` branch of the `select!` in `run_listener` broke the accept loop, and `drain_connections` drained only tasks that had already been spawned. The queued connection was never accepted, so the client read EOF and `read_response` panicked with `UnexpectedEof` at `graceful_shutdown.rs:119`.

The agent behaved correctly — refusing new connections on shutdown while draining in-flight ones is the intended contract. The test's premise was wrong.

## The fix

Complete one request before signalling. Reading that response proves the accept loop took the connection and spawned its handler task, which is the state `drain_connections` actually waits on. The second ping is then genuinely in-flight, and the `biased` read in `handle_connection` serves it — the guarantee that comment already documents:

> Biased: poll the read first so a request that has already arrived is served even if shutdown fires in the same tick.

The test still asserts what it always meant to: an in-flight request survives graceful shutdown. It just establishes the precondition instead of assuming it.

## Verification, stated honestly

**I could not reproduce the CI failure locally**, so this fix is not verified by reproduction:

- 25 isolated runs of `inflight_request_completes_on_sigterm` on the original: 25 passed.
- 20 runs of the full file on the original, under 8 background CPU-spinner processes to approximate a loaded runner: 20 passed.
- 25 isolated runs on the fixed version: 25 passed.

The evidence is the differential in CI rather than a local repro. In the failing run the other four tests passed, including two that connect, ping, and successfully read a response — so accept, peer-credential authorization, and the handler all work on that runner. The only test that failed is the only one that signals before reading a response. That is exactly the discriminator this diagnosis predicts, and the fix makes the failing test behave like the four passing ones.

Real verification is CI on this branch.

## Not the same as the 2026-08-22 main failure

Run 32539718037 on `main` failed all three `read_response` sites (`:119`, `:173`, `:191`), meaning the agent answered nothing at all. That is a systemic startup failure, not this race, and it is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
