### PR TITLE
fix(oidc): emit WWW-Authenticate on client_secret_basic auth failures

### DIFF
--- a/crates/vouch-server/src/handlers/oidc/client_auth.rs
+++ b/crates/vouch-server/src/handlers/oidc/client_auth.rs
@@ -12,7 +12,7 @@ use crate::services::oidc::{
 };
 use axum::{
     Json,
-    http::{HeaderMap, StatusCode, header},
+    http::{HeaderMap, HeaderValue, StatusCode, header},
     response::{IntoResponse, Response},
 };
 use base64::Engine;
@@ -33,7 +33,10 @@ const JWT_BEARER_CLIENT_ASSERTION_TYPE: &str = protocol::CLIENT_ASSERTION_TYPE_J
 /// can use at OAuth endpoints (RFC 7521 Section 4.2).
 pub(crate) enum ExtractedClientAuth {
     /// Client secret via Basic header or body params.
-    Secret(ClientCredentials),
+    Secret {
+        creds: ClientCredentials,
+        presentation: ClientAuthPresentation,
+    },
     /// JWT assertion (RFC 7523).
     JwtAssertion {
         client_assertion: String,
@@ -66,15 +69,89 @@ fn strip_basic_scheme(header: &str) -> Option<&str> {
     scheme.eq_ignore_ascii_case("Basic").then_some(rest)
 }
 
+/// Where the client presented its credentials (RFC 6749 Section 2.3.1).
+///
+/// Recorded because RFC 6749 Section 5.2 makes the `WWW-Authenticate`
+/// response header mandatory on a 401 only when the client authenticated
+/// via the `Authorization` request header field. That condition is a
+/// property of the request, not of the error code, so it has to travel
+/// with the credentials rather than be re-derived at each failure site.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum ClientAuthPresentation {
+    /// `Authorization: Basic` header — `client_secret_basic`.
+    AuthorizationHeader,
+    /// Request-body parameters — `client_secret_post`, or a bare `client_id`.
+    RequestBody,
+}
+
+impl ClientAuthPresentation {
+    /// Classify how the client presented credentials on this request.
+    ///
+    /// A malformed `Authorization: Basic` header still counts as
+    /// [`Self::AuthorizationHeader`]: RFC 6749 Section 5.2 binds on the
+    /// client having *attempted* header authentication, not on the attempt
+    /// having parsed.
+    pub(crate) fn of(headers: &HeaderMap) -> Self {
+        let used_header = headers
+            .get(header::AUTHORIZATION)
+            .and_then(|h| h.to_str().ok())
+            .is_some_and(|h| strip_basic_scheme(h).is_some());
+        if used_header {
+            Self::AuthorizationHeader
+        } else {
+            Self::RequestBody
+        }
+    }
+
+    /// The `WWW-Authenticate` challenge matching the scheme the client used,
+    /// or `None` when the client did not use the `Authorization` header.
+    fn challenge(self) -> Option<HeaderValue> {
+        match self {
+            Self::AuthorizationHeader => Some(HeaderValue::from_static("Basic")),
+            Self::RequestBody => None,
+        }
+    }
+}
+
+/// Attach the RFC 6749 Section 5.2 `WWW-Authenticate` challenge to a
+/// client-authentication failure.
+///
+/// RFC 6749 Section 5.2, `specs/rfc/rfc6749.txt:2493-2498`: "If the client
+/// attempted to authenticate via the "Authorization" request header field,
+/// the authorization server MUST respond with an HTTP 401 (Unauthorized)
+/// status code and include the "WWW-Authenticate" response header field
+/// matching the authentication scheme used by the client."
+///
+/// Only 401s are touched. `OAuthErrorCode::status_code` already maps
+/// `invalid_client` to 401, so every failure this MUST binds arrives here
+/// with that status; a non-401 response means the failure was something
+/// other than client authentication and carries no challenge.
+pub(crate) fn with_client_auth_challenge(
+    presentation: ClientAuthPresentation,
+    mut response: Response,
+) -> Response {
+    if response.status() == StatusCode::UNAUTHORIZED
+        && let Some(challenge) = presentation.challenge()
+        && !response.headers().contains_key(header::WWW_AUTHENTICATE)
+    {
+        response
+            .headers_mut()
+            .insert(header::WWW_AUTHENTICATE, challenge);
+    }
+    response
+}
+
 /// Extract client credentials from Authorization header or request body.
 ///
 /// Supports both `client_secret_basic` (RFC 6749 Section 2.3.1) and
 /// `client_secret_post` (RFC 6749 Section 2.3.1) authentication methods.
+/// The returned [`ClientAuthPresentation`] records which of the two the
+/// client used, so a later failure can emit the matching challenge.
 pub(crate) fn extract_client_credentials(
     headers: &HeaderMap,
     client_id_param: Option<&str>,
     client_secret_param: Option<SecretString>,
-) -> Option<ClientCredentials> {
+) -> Option<(ClientCredentials, ClientAuthPresentation)> {
     // Try Authorization header first (client_secret_basic)
     if let Some(auth_header) = headers
         .get(header::AUTHORIZATION)
@@ -91,16 +168,27 @@ pub(crate) fn extract_client_credentials(
             urlencoding::decode(id).map_or_else(|_| id.to_string(), |d| d.into_owned());
         let decoded_secret =
             urlencoding::decode(secret).map_or_else(|_| secret.to_string(), |d| d.into_owned());
-        return Some(ClientCredentials {
-            client_id: decoded_id,
-            client_secret: Some(SecretString::from(decoded_secret)),
-        });
+        return Some((
+            ClientCredentials {
+                client_id: decoded_id,
+                client_secret: Some(SecretString::from(decoded_secret)),
+            },
+            ClientAuthPresentation::AuthorizationHeader,
+        ));
     }
 
-    // Fall back to request body parameters (client_secret_post)
-    client_id_param.map(|id| ClientCredentials {
-        client_id: id.to_string(),
-        client_secret: client_secret_param,
+    // Fall back to request body parameters (client_secret_post). The
+    // presentation is still classified from the headers: a client whose
+    // `Authorization: Basic` header failed to decode attempted header
+    // authentication and is owed the matching challenge.
+    client_id_param.map(|id| {
+        (
+            ClientCredentials {
+                client_id: id.to_string(),
+                client_secret: client_secret_param,
+            },
+            ClientAuthPresentation::of(headers),
+        )
     })
 }
 
@@ -152,11 +240,14 @@ pub(crate) fn extract_client_auth<T: ClientAuthFields>(
     }
 
     // Secret-based auth (Basic header or body params)
-    if let Some(creds) =
+    if let Some((creds, presentation)) =
         extract_client_credentials(headers, params.client_id(), params.client_secret())
     {
         if creds.client_secret.is_some() || has_basic {
-            return Ok(ExtractedClientAuth::Secret(creds));
+            return Ok(ExtractedClientAuth::Secret {
+                creds,
+                presentation,
+            });
         }
         // client_id only, no secret
         return Ok(ExtractedClientAuth::PublicClient {
@@ -194,7 +285,10 @@ pub(crate) async fn complete_client_auth(
     auth: ExtractedClientAuth,
 ) -> Result<Option<ClientAuthOutcome>, Response> {
     match auth {
-        ExtractedClientAuth::Secret(creds) => {
+        ExtractedClientAuth::Secret {
+            creds,
+            presentation,
+        } => {
             let client_id = creds.client_id.clone();
             match authenticate_client(state, &creds).await {
                 Ok((client, secret_verification)) => Ok(Some(ClientAuthOutcome {
@@ -204,7 +298,10 @@ pub(crate) async fn complete_client_auth(
                     jwt_auth: None,
                     secret_verification,
                 })),
-                Err(e) => Err(e.into_service_error().into_oauth_response().into_response()),
+                Err(e) => Err(with_client_auth_challenge(
+                    presentation,
+                    e.into_service_error().into_oauth_response().into_response(),
+                )),
             }
         }
         ExtractedClientAuth::JwtAssertion {
@@ -322,10 +419,36 @@ mod tests {
             let headers = basic_header(scheme);
             let creds = extract_client_credentials(&headers, None, None);
             assert!(creds.is_some(), "{scheme} scheme must be accepted");
-            let creds = creds.expect("checked above");
+            let (creds, presentation) = creds.expect("checked above");
             assert_eq!(creds.client_id, "client-1", "{scheme}");
             assert!(creds.client_secret.is_some(), "{scheme}");
+            assert_eq!(
+                presentation,
+                ClientAuthPresentation::AuthorizationHeader,
+                "{scheme} is header authentication regardless of casing"
+            );
         }
+    }
+
+    /// RFC 6749 Section 5.2 binds on the client having *attempted* header
+    /// authentication, so an undecodable header still classifies as one.
+    #[test]
+    fn test_presentation_classifies_malformed_header_as_an_attempt() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::AUTHORIZATION,
+            "Basic !!!not-base64!!!".parse().expect("valid header"),
+        );
+        assert_eq!(
+            ClientAuthPresentation::of(&headers),
+            ClientAuthPresentation::AuthorizationHeader
+        );
+
+        // A body-authenticated request carries no challenge obligation.
+        assert_eq!(
+            ClientAuthPresentation::of(&HeaderMap::new()),
+            ClientAuthPresentation::RequestBody
+        );
     }
 
     #[test]

--- a/crates/vouch-server/src/handlers/oidc/client_auth.rs
+++ b/crates/vouch-server/src/handlers/oidc/client_auth.rs
@@ -82,24 +82,29 @@ pub(crate) enum ClientAuthPresentation {
     AuthorizationHeader,
     /// Request-body parameters — `client_secret_post`, or a bare `client_id`.
     RequestBody,
+    /// The request carried no client credentials at all.
+    NoCredentials,
 }
 
 impl ClientAuthPresentation {
-    /// Classify how the client presented credentials on this request.
+    /// Classify how the client presented credentials on this request, by
+    /// inspecting both the `Authorization` header and the request body.
     ///
     /// A malformed `Authorization: Basic` header still counts as
     /// [`Self::AuthorizationHeader`]: RFC 6749 Section 5.2 binds on the
     /// client having *attempted* header authentication, not on the attempt
     /// having parsed.
-    pub(crate) fn of(headers: &HeaderMap) -> Self {
+    pub(crate) fn of<T: ClientAuthFields>(headers: &HeaderMap, params: &T) -> Self {
         let used_header = headers
             .get(header::AUTHORIZATION)
             .and_then(|h| h.to_str().ok())
             .is_some_and(|h| strip_basic_scheme(h).is_some());
         if used_header {
             Self::AuthorizationHeader
-        } else {
+        } else if params.client_id().is_some() || params.client_secret().is_some() {
             Self::RequestBody
+        } else {
+            Self::NoCredentials
         }
     }
 
@@ -108,7 +113,10 @@ impl ClientAuthPresentation {
     fn challenge(self) -> Option<HeaderValue> {
         match self {
             Self::AuthorizationHeader => Some(HeaderValue::from_static("Basic")),
-            Self::RequestBody => None,
+            // RFC 6749 Section 5.2 mandates a challenge only for header
+            // authentication. Advertising `Basic` to a client that used
+            // neither would name a scheme it did not attempt.
+            Self::RequestBody | Self::NoCredentials => None,
         }
     }
 }
@@ -145,12 +153,11 @@ pub(crate) fn with_client_auth_challenge(
 ///
 /// Supports both `client_secret_basic` (RFC 6749 Section 2.3.1) and
 /// `client_secret_post` (RFC 6749 Section 2.3.1) authentication methods.
-/// The returned [`ClientAuthPresentation`] records which of the two the
-/// client used, so a later failure can emit the matching challenge.
-pub(crate) fn extract_client_credentials(
+/// The returned [`ClientAuthPresentation`] records which the client used,
+/// so a later failure can emit the matching challenge.
+pub(crate) fn extract_client_credentials<T: ClientAuthFields>(
     headers: &HeaderMap,
-    client_id_param: Option<&str>,
-    client_secret_param: Option<SecretString>,
+    params: &T,
 ) -> Option<(ClientCredentials, ClientAuthPresentation)> {
     // Try Authorization header first (client_secret_basic)
     if let Some(auth_header) = headers
@@ -177,17 +184,14 @@ pub(crate) fn extract_client_credentials(
         ));
     }
 
-    // Fall back to request body parameters (client_secret_post). The
-    // presentation is still classified from the headers: a client whose
-    // `Authorization: Basic` header failed to decode attempted header
-    // authentication and is owed the matching challenge.
-    client_id_param.map(|id| {
+    // Fall back to request body parameters (client_secret_post).
+    params.client_id().map(|id| {
         (
             ClientCredentials {
                 client_id: id.to_string(),
-                client_secret: client_secret_param,
+                client_secret: params.client_secret(),
             },
-            ClientAuthPresentation::of(headers),
+            ClientAuthPresentation::of(headers, params),
         )
     })
 }
@@ -240,9 +244,7 @@ pub(crate) fn extract_client_auth<T: ClientAuthFields>(
     }
 
     // Secret-based auth (Basic header or body params)
-    if let Some((creds, presentation)) =
-        extract_client_credentials(headers, params.client_id(), params.client_secret())
-    {
+    if let Some((creds, presentation)) = extract_client_credentials(headers, params) {
         if creds.client_secret.is_some() || has_basic {
             return Ok(ExtractedClientAuth::Secret {
                 creds,
@@ -411,13 +413,35 @@ mod tests {
         headers
     }
 
+    /// Request body carrying whichever client credentials a test needs.
+    #[derive(Default)]
+    struct BodyParams {
+        client_id: Option<String>,
+        client_secret: Option<String>,
+    }
+
+    impl ClientAuthFields for BodyParams {
+        fn client_id(&self) -> Option<&str> {
+            self.client_id.as_deref()
+        }
+        fn client_secret(&self) -> Option<SecretString> {
+            self.client_secret.clone().map(SecretString::from)
+        }
+        fn client_assertion(&self) -> Option<&str> {
+            None
+        }
+        fn client_assertion_type(&self) -> Option<&str> {
+            None
+        }
+    }
+
     /// RFC 9110 Section 11.1 / RFC 7617 Section 2: the auth-scheme token is
     /// case-insensitive, so `basic` and `BASIC` must work like `Basic`.
     #[test]
     fn test_extract_client_credentials_scheme_case_insensitive() {
         for scheme in ["Basic", "basic", "BASIC", "bAsIc"] {
             let headers = basic_header(scheme);
-            let creds = extract_client_credentials(&headers, None, None);
+            let creds = extract_client_credentials(&headers, &BodyParams::default());
             assert!(creds.is_some(), "{scheme} scheme must be accepted");
             let (creds, presentation) = creds.expect("checked above");
             assert_eq!(creds.client_id, "client-1", "{scheme}");
@@ -430,24 +454,54 @@ mod tests {
         }
     }
 
-    /// RFC 6749 Section 5.2 binds on the client having *attempted* header
-    /// authentication, so an undecodable header still classifies as one.
+    /// Each variant must be a fact the classifier established, not an
+    /// assumption: `RequestBody` requires credentials actually in the body,
+    /// and a request with none at all is neither.
     #[test]
-    fn test_presentation_classifies_malformed_header_as_an_attempt() {
-        let mut headers = HeaderMap::new();
-        headers.insert(
+    fn test_presentation_distinguishes_header_body_and_absent_credentials() {
+        let mut malformed = HeaderMap::new();
+        malformed.insert(
             header::AUTHORIZATION,
             "Basic !!!not-base64!!!".parse().expect("valid header"),
         );
+
+        let empty_body = BodyParams::default();
+        let id_only = BodyParams {
+            client_id: Some("client-1".to_string()),
+            client_secret: None,
+        };
+        let secret_only = BodyParams {
+            client_id: None,
+            client_secret: Some("s3cret".to_string()),
+        };
+
+        // RFC 6749 Section 5.2 binds on the client having *attempted* header
+        // authentication, so an undecodable header still classifies as one —
+        // and outranks body credentials.
         assert_eq!(
-            ClientAuthPresentation::of(&headers),
+            ClientAuthPresentation::of(&malformed, &empty_body),
+            ClientAuthPresentation::AuthorizationHeader
+        );
+        assert_eq!(
+            ClientAuthPresentation::of(&malformed, &id_only),
             ClientAuthPresentation::AuthorizationHeader
         );
 
-        // A body-authenticated request carries no challenge obligation.
+        // Either body credential alone is enough to be body authentication.
         assert_eq!(
-            ClientAuthPresentation::of(&HeaderMap::new()),
+            ClientAuthPresentation::of(&HeaderMap::new(), &id_only),
             ClientAuthPresentation::RequestBody
+        );
+        assert_eq!(
+            ClientAuthPresentation::of(&HeaderMap::new(), &secret_only),
+            ClientAuthPresentation::RequestBody
+        );
+
+        // No header, no body credentials: previously mislabelled as
+        // `RequestBody` on the strength of the header check alone.
+        assert_eq!(
+            ClientAuthPresentation::of(&HeaderMap::new(), &empty_body),
+            ClientAuthPresentation::NoCredentials
         );
     }
 

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc6749_token.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc6749_token.rs
@@ -631,3 +631,152 @@ fn test_token_request_debug_never_prints_credential_material() {
         "non-secrets stay visible: {debug}"
     );
 }
+
+// ========================================================================
+// RFC 6749 Section 5.2 — `invalid_client` challenge on header auth
+// ========================================================================
+//
+// `specs/rfc/rfc6749.txt:2493-2498`:
+//
+// > If the client attempted to authenticate via the "Authorization"
+// > request header field, the authorization server MUST respond with an
+// > HTTP 401 (Unauthorized) status code and include the "WWW-Authenticate"
+// > response header field matching the authentication scheme used by the
+// > client.
+//
+// The MUST has two conjuncts. The status half was already satisfied by
+// `OAuthErrorCode::status_code`; these cover the header half, and pin the
+// condition so the challenge does not leak onto body-authenticated
+// clients (for whom the RFC requires nothing).
+
+#[tokio::test]
+async fn test_token_basic_auth_failure_challenges_with_basic() {
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "tok-basic-challenge@example.com").await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+
+    let encoded = base64::engine::general_purpose::STANDARD
+        .encode(format!("{}:wrong-secret", client.client_id).as_bytes());
+    let auth = format!("Basic {encoded}");
+
+    let response = http_post_form_full(
+        &app,
+        "/oauth/token",
+        "grant_type=authorization_code&code=irrelevant\
+         &redirect_uri=https%3A%2F%2Fexample.com%2Fcallback",
+        &[("Authorization", &auth)],
+    )
+    .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::UNAUTHORIZED,
+        "bad client_secret_basic must be 401: {}",
+        response.body
+    );
+    assert_eq!(
+        www_authenticate(&response),
+        "Basic",
+        "a 401 for a client that used the Authorization header MUST carry a \
+         matching WWW-Authenticate challenge"
+    );
+}
+
+#[tokio::test]
+async fn test_token_body_auth_failure_has_no_challenge() {
+    // The client authenticated via `client_secret_post`, not the
+    // Authorization header, so RFC 6749 Section 5.2 requires no challenge.
+    // Emitting one would advertise a scheme the client did not use.
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "tok-post-challenge@example.com").await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+
+    let body = format!(
+        "grant_type=authorization_code&code=irrelevant\
+         &redirect_uri=https%3A%2F%2Fexample.com%2Fcallback\
+         &client_id={}&client_secret=wrong-secret",
+        client.client_id
+    );
+
+    let response = http_post_form_full(&app, "/oauth/token", &body, &[]).await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::UNAUTHORIZED,
+        "bad client_secret_post must still be 401: {}",
+        response.body
+    );
+    assert_eq!(
+        www_authenticate(&response),
+        "",
+        "client_secret_post failure must not advertise a Basic challenge"
+    );
+}
+
+#[tokio::test]
+async fn test_token_malformed_basic_header_challenges_with_basic() {
+    // RFC 6749 Section 5.2 binds on the client having *attempted* header
+    // authentication. A header that fails to base64-decode is still an
+    // attempt, so the challenge is owed.
+    let (app, _state) = test_app().await;
+
+    let response = http_post_form_full(
+        &app,
+        "/oauth/token",
+        "grant_type=authorization_code&code=irrelevant\
+         &redirect_uri=https%3A%2F%2Fexample.com%2Fcallback",
+        &[("Authorization", "Basic !!!not-base64!!!")],
+    )
+    .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::UNAUTHORIZED,
+        "malformed Basic credentials must be 401: {}",
+        response.body
+    );
+    assert_eq!(
+        www_authenticate(&response),
+        "Basic",
+        "an unparseable Authorization header is still an authentication attempt"
+    );
+}
+
+#[tokio::test]
+async fn test_par_basic_auth_failure_challenges_with_basic() {
+    // PAR reaches the failure through `complete_client_auth` rather than the
+    // token endpoint's own path, so it needs its own coverage.
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "par-basic-challenge@example.com").await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+
+    let encoded = base64::engine::general_purpose::STANDARD
+        .encode(format!("{}:wrong-secret", client.client_id).as_bytes());
+    let auth = format!("Basic {encoded}");
+
+    let body = format!(
+        "response_type=code&client_id={}\
+         &redirect_uri=https%3A%2F%2Fexample.com%2Fcallback\
+         &code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM\
+         &code_challenge_method=S256",
+        client.client_id
+    );
+
+    let response =
+        http_post_form_full(&app, "/oauth/par", &body, &[("Authorization", &auth)]).await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::UNAUTHORIZED,
+        "bad client_secret_basic at PAR must be 401: {}",
+        response.body
+    );
+    assert_eq!(
+        www_authenticate(&response),
+        "Basic",
+        "PAR must carry the same challenge as the token endpoint"
+    );
+}

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -374,11 +374,7 @@ async fn resolve_non_jwt_auth(
     ),
     Response,
 > {
-    let creds = extract_client_credentials(
-        headers,
-        params.client_id.as_deref(),
-        params.client_secret.clone(),
-    );
+    let creds = extract_client_credentials(headers, params);
     let Some((c, _presentation)) = creds else {
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidClient,
@@ -561,7 +557,10 @@ async fn handle_authorization_code_grant(
             // client-authentication failure, so a client that used
             // `Authorization: Basic` is owed the matching challenge on the 401.
             Err(resp) => {
-                return with_client_auth_challenge(ClientAuthPresentation::of(&headers), resp);
+                return with_client_auth_challenge(
+                    ClientAuthPresentation::of(&headers, &params),
+                    resp,
+                );
             }
         }
     };

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -2,8 +2,8 @@
 //! Token endpoint handler.
 
 use super::client_auth::{
-    ClientAuthFields, ExtractedClientAuth, complete_client_auth, extract_client_auth,
-    extract_client_credentials,
+    ClientAuthFields, ClientAuthPresentation, ExtractedClientAuth, complete_client_auth,
+    extract_client_auth, extract_client_credentials, with_client_auth_challenge,
 };
 use crate::AppState;
 use crate::db::JwtAssertionJtiClaim;
@@ -379,7 +379,7 @@ async fn resolve_non_jwt_auth(
         params.client_id.as_deref(),
         params.client_secret.clone(),
     );
-    let Some(c) = creds else {
+    let Some((c, _presentation)) = creds else {
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidClient,
             "Client authentication or client_id required",
@@ -557,7 +557,12 @@ async fn handle_authorization_code_grant(
     } else {
         match resolve_non_jwt_auth(&state, &headers, &params, &client_cert).await {
             Ok(pair) => Some(pair),
-            Err(resp) => return resp,
+            // RFC 6749 §5.2: every failure inside `resolve_non_jwt_auth` is a
+            // client-authentication failure, so a client that used
+            // `Authorization: Basic` is owed the matching challenge on the 401.
+            Err(resp) => {
+                return with_client_auth_challenge(ClientAuthPresentation::of(&headers), resp);
+            }
         }
     };
 


### PR DESCRIPTION
RFC 6749 §5.2 (`specs/rfc/rfc6749.txt:2493-2498`):

> If the client attempted to authenticate via the "Authorization" request header field, the authorization server MUST respond with an HTTP 401 (Unauthorized) status code and include the "WWW-Authenticate" response header field matching the authentication scheme used by the client.

The MUST has two conjuncts. `OAuthErrorCode::status_code` already mapped `invalid_client` to 401, so the status half held, but no `WWW-Authenticate` header was emitted anywhere on `/oauth/token` or `/oauth/par`. A `client_secret_basic` client whose secret failed verification received a conformant status and a non-conformant response.

## What changed

`extract_client_credentials` now returns a `ClientAuthPresentation` alongside the credentials, recording whether the client used the `Authorization` header or request-body parameters. It is the one function that makes that determination, so the condition is derived at its source rather than re-tested at each failure site. `with_client_auth_challenge` attaches `WWW-Authenticate: Basic` to a 401 when the presentation was header-based.

Two call sites cover every reachable failure:

- `complete_client_auth`'s secret-auth branch — PAR, introspection, revocation, and the non-`authorization_code` grants.
- the `resolve_non_jwt_auth` call site — the `authorization_code` grant.

Wrapping at the `resolve_non_jwt_auth` call site rather than inside it also covers the case where an undecodable `Authorization: Basic` header combined with no body `client_id` yields no credentials at all and fails at a different return.

A malformed header still classifies as `AuthorizationHeader`, since the RFC binds on the client having *attempted* header authentication.

Introspection and revocation already emitted the challenge and are unchanged. `client_secret_post` failures continue to carry no challenge, which the RFC does not require.

## Tests

Four endpoint tests in `rfc6749_token.rs` (token with Basic, token with a malformed Basic header, PAR with Basic, and a negative control asserting `client_secret_post` gets no challenge) plus a unit test for the presentation classifier. Neutralising the challenge fails the three positive tests and leaves the negative control passing.

`make fmt`, `make lint`, `make test`, `make test-integration`, and `prek run` are clean.

Refs #1046. The issue stays open: it also asks whether the HTTP status should be derived from `OAuthErrorCode::status_code` at the remaining explicit call sites, which this does not settle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)