### PR TITLE
refactor(httpsig): prove coverage and digest checks with a typestate chain

### DIFF
--- a/crates/vouch-httpsig/src/lib.rs
+++ b/crates/vouch-httpsig/src/lib.rs
@@ -31,4 +31,4 @@ pub use error::HttpSigError;
 pub use sig_policy::requires_signature;
 pub use sign::SignatureBuilder;
 pub use signature_params::SignatureParams;
-pub use verify::verify_request_signature;
+pub use verify::{CoverageChecked, CryptoVerified, DigestEnforced, verify_request_signature};

--- a/crates/vouch-httpsig/src/middleware.rs
+++ b/crates/vouch-httpsig/src/middleware.rs
@@ -39,11 +39,10 @@ use axum::{
 
 use crate::algorithm::VerifyingAlgorithm;
 use crate::component::ComponentIdentifier;
-use crate::digest::verify_content_digest;
 use crate::error::HttpSigError;
 use crate::sig_policy::requires_signature;
 use crate::signature_params::SignatureParams;
-use crate::verify::{extract_signature_labels, validate_coverage, verify_request_signature};
+use crate::verify::{DigestEnforced, extract_signature_labels, verify_request_signature};
 
 /// Minimum components a signature must cover for the middleware to accept it.
 ///
@@ -112,12 +111,35 @@ fn build_accept_signature(has_body: bool) -> Option<http::HeaderValue> {
 /// Verified HTTP signature data stored as a request extension.
 ///
 /// Handlers can retrieve this via `req.extensions().get::<VerifiedSignature>()`.
+///
+/// Constructing one requires a [`DigestEnforced`] proof, which is only
+/// reachable by moving through signature verification, coverage checking, and
+/// body-digest enforcement in that order. A handler that reads this extension
+/// therefore knows every step ran — the guarantee comes from the type, not
+/// from statement order in the middleware.
 #[derive(Debug, Clone)]
 pub struct VerifiedSignature {
     /// The label of the verified signature (e.g., `"sig1"`).
     pub label: String,
-    /// The parsed and verified signature parameters.
-    pub params: SignatureParams,
+    /// The parsed and fully checked signature parameters.
+    params: SignatureParams,
+}
+
+impl VerifiedSignature {
+    /// Build from a completed verification chain.
+    #[must_use]
+    pub fn new(label: String, proof: DigestEnforced) -> Self {
+        Self {
+            label,
+            params: proof.into_params(),
+        }
+    }
+
+    /// The verified signature parameters.
+    #[must_use]
+    pub fn params(&self) -> &SignatureParams {
+        &self.params
+    }
 }
 
 /// Async key resolver trait for looking up verification keys by `keyid`.
@@ -221,11 +243,11 @@ pub const DEFAULT_MAX_AGE: i64 = 300;
 /// failure → 500), or `None` when there is no nonce or it was accepted.
 async fn enforce_nonce<R: KeyResolver>(
     resolver: &R,
-    params: &SignatureParams,
+    proof: &DigestEnforced,
     label: &str,
     keyid: &str,
 ) -> Option<Response> {
-    let nonce = params.nonce.as_deref()?;
+    let nonce = proof.params().nonce.as_deref()?;
     match resolver.validate_nonce(nonce).await {
         NonceValidation::Valid => None,
         NonceValidation::Invalid => {
@@ -361,27 +383,30 @@ pub async fn require_signature<R: KeyResolver>(
     };
 
     match verify_request_signature(&req, &label, verifier.as_ref(), Some(max_age)) {
-        Ok(params) => {
+        Ok(verified) => {
             // Reject signatures that don't cover minimum required components;
             // advertise the expected set so the client can fix and retry.
-            if let Err(e) = validate_coverage(&params, REQUIRED_COVERAGE) {
-                tracing::debug!(
-                    label = %label,
-                    keyid = %keyid,
-                    error = %e,
-                    "HTTP signature insufficient coverage"
-                );
-                let mut resp = (StatusCode::UNAUTHORIZED, SIG_VERIFY_FAILED).into_response();
-                if let Some(accept_sig) = build_accept_signature(has_body) {
-                    resp.headers_mut().insert("accept-signature", accept_sig);
+            let covered = match verified.require_coverage(REQUIRED_COVERAGE) {
+                Ok(covered) => covered,
+                Err(e) => {
+                    tracing::debug!(
+                        label = %label,
+                        keyid = %keyid,
+                        error = %e,
+                        "HTTP signature insufficient coverage"
+                    );
+                    let mut resp = (StatusCode::UNAUTHORIZED, SIG_VERIFY_FAILED).into_response();
+                    if let Some(accept_sig) = build_accept_signature(has_body) {
+                        resp.headers_mut().insert("accept-signature", accept_sig);
+                    }
+                    return resp;
                 }
-                return resp;
-            }
+            };
 
             tracing::debug!(
                 label = %label,
                 keyid = %keyid,
-                alg = ?params.alg,
+                alg = ?covered.params().alg,
                 "HTTP signature verified"
             );
             // Enforce RFC 9530 body integrity for signed requests that carry a
@@ -394,33 +419,37 @@ pub async fn require_signature<R: KeyResolver>(
                     return (StatusCode::UNAUTHORIZED, SIG_VERIFY_FAILED).into_response();
                 }
             };
-            if let Err(e) = enforce_body_digest(&params, &parts.headers, &bytes) {
-                tracing::debug!(
-                    label = %label,
-                    keyid = %keyid,
-                    error = %e,
-                    "signed request body integrity check failed"
-                );
-                let mut resp = (StatusCode::UNAUTHORIZED, SIG_VERIFY_FAILED).into_response();
-                // A coverage failure (signature verified but content-digest not
-                // covered) gets the same Accept-Signature remediation hint as the
-                // base-component coverage failure above.
-                if matches!(e, HttpSigError::MissingDigest)
-                    && let Some(accept_sig) = build_accept_signature(has_body)
-                {
-                    resp.headers_mut().insert("accept-signature", accept_sig);
+            let enforced = match covered.enforce_body_digest(&parts.headers, &bytes) {
+                Ok(enforced) => enforced,
+                Err(e) => {
+                    tracing::debug!(
+                        label = %label,
+                        keyid = %keyid,
+                        error = %e,
+                        "signed request body integrity check failed"
+                    );
+                    let mut resp = (StatusCode::UNAUTHORIZED, SIG_VERIFY_FAILED).into_response();
+                    // A coverage failure (signature verified but content-digest
+                    // not covered) gets the same Accept-Signature remediation
+                    // hint as the base-component coverage failure above.
+                    if matches!(e, HttpSigError::MissingDigest)
+                        && let Some(accept_sig) = build_accept_signature(has_body)
+                    {
+                        resp.headers_mut().insert("accept-signature", accept_sig);
+                    }
+                    return resp;
                 }
-                return resp;
-            }
+            };
             // Validate and consume the server-issued nonce when the signature
             // carries one (enforce-when-present; see KeyResolver::validate_nonce).
-            if let Some(resp) = enforce_nonce(resolver.as_ref(), &params, &label, &keyid).await {
+            // Taking `&DigestEnforced` is what keeps this after the digest check:
+            // the proof cannot exist until the full chain has run.
+            if let Some(resp) = enforce_nonce(resolver.as_ref(), &enforced, &label, &keyid).await {
                 return resp;
             }
-            parts.extensions.insert(VerifiedSignature {
-                label: label.clone(),
-                params,
-            });
+            parts
+                .extensions
+                .insert(VerifiedSignature::new(label.clone(), enforced));
             let req = Request::from_parts(parts, axum::body::Body::from(bytes));
             let mut response = next.run(req).await;
 
@@ -448,38 +477,6 @@ pub async fn require_signature<R: KeyResolver>(
             (StatusCode::UNAUTHORIZED, SIG_VERIFY_FAILED).into_response()
         }
     }
-}
-
-/// Enforce RFC 9530 Content-Digest integrity for a signed request body.
-///
-/// A signed request that carries a non-empty body MUST cover `content-digest`
-/// in its signature and present a matching `Content-Digest` header. Coverage is
-/// required because an unsigned digest header could be swapped alongside the
-/// body. Empty bodies (GET and bodyless POST requests) are exempt.
-///
-/// # Errors
-///
-/// Returns [`HttpSigError::MissingDigest`] when the body is not bound by a
-/// covered, present `Content-Digest`, or [`HttpSigError::DigestMismatch`] when
-/// the digest does not match the body.
-fn enforce_body_digest(
-    params: &SignatureParams,
-    headers: &http::HeaderMap,
-    body: &[u8],
-) -> Result<(), HttpSigError> {
-    if body.is_empty() {
-        return Ok(());
-    }
-
-    validate_coverage(params, &["content-digest"]).map_err(|_| HttpSigError::MissingDigest)?;
-
-    let header = headers
-        .get("content-digest")
-        .ok_or(HttpSigError::MissingDigest)?
-        .to_str()
-        .map_err(|e| HttpSigError::SfvParse(format!("Content-Digest: {e}")))?;
-
-    verify_content_digest(header, body)
 }
 
 /// Extract the `keyid` parameter from a Signature-Input header value for a given label.
@@ -599,24 +596,6 @@ mod tests {
                 resolver,
                 require_signature::<InMemoryKeyResolver>,
             ))
-    }
-
-    fn params_covering(components: Vec<crate::ComponentIdentifier>) -> SignatureParams {
-        SignatureParams {
-            components,
-            alg: None,
-            keyid: None,
-            created: None,
-            expires: None,
-            nonce: None,
-            tag: None,
-        }
-    }
-
-    fn digest_header(body: &[u8]) -> http::HeaderValue {
-        crate::digest::content_digest(body, crate::digest::DigestAlgorithm::Sha256)
-            .parse()
-            .unwrap()
     }
 
     #[tokio::test]
@@ -742,59 +721,6 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-    }
-
-    #[test]
-    fn test_enforce_body_digest_empty_body_is_exempt() {
-        let params = params_covering(vec![]);
-        let headers = http::HeaderMap::new();
-        enforce_body_digest(&params, &headers, b"").unwrap();
-    }
-
-    #[test]
-    fn test_enforce_body_digest_valid() {
-        let body = b"{\"x\":1}";
-        let params = params_covering(vec![
-            crate::ComponentIdentifier::method(),
-            crate::ComponentIdentifier::field("content-digest"),
-        ]);
-        let mut headers = http::HeaderMap::new();
-        headers.insert("content-digest", digest_header(body));
-        enforce_body_digest(&params, &headers, body).unwrap();
-    }
-
-    #[test]
-    fn test_enforce_body_digest_missing_header() {
-        let body = b"body";
-        let params = params_covering(vec![crate::ComponentIdentifier::field("content-digest")]);
-        let headers = http::HeaderMap::new();
-        assert!(matches!(
-            enforce_body_digest(&params, &headers, body),
-            Err(HttpSigError::MissingDigest)
-        ));
-    }
-
-    #[test]
-    fn test_enforce_body_digest_not_covered() {
-        let body = b"body";
-        let params = params_covering(vec![crate::ComponentIdentifier::method()]);
-        let mut headers = http::HeaderMap::new();
-        headers.insert("content-digest", digest_header(body));
-        assert!(matches!(
-            enforce_body_digest(&params, &headers, body),
-            Err(HttpSigError::MissingDigest)
-        ));
-    }
-
-    #[test]
-    fn test_enforce_body_digest_mismatch() {
-        let params = params_covering(vec![crate::ComponentIdentifier::field("content-digest")]);
-        let mut headers = http::HeaderMap::new();
-        headers.insert("content-digest", digest_header(b"other body"));
-        assert!(matches!(
-            enforce_body_digest(&params, &headers, b"body"),
-            Err(HttpSigError::DigestMismatch(_))
-        ));
     }
 
     #[tokio::test]

--- a/crates/vouch-httpsig/src/verify.rs
+++ b/crates/vouch-httpsig/src/verify.rs
@@ -30,7 +30,7 @@ pub fn verify_request_signature<T>(
     label: &str,
     verifier: &dyn VerifyingAlgorithm,
     max_age: Option<i64>,
-) -> Result<SignatureParams, HttpSigError> {
+) -> Result<CryptoVerified, HttpSigError> {
     let (params, params_str, signature_bytes) = extract_signature_parts(req.headers(), label)?;
     validate_algorithm(&params, verifier)?;
     validate_timestamps(&params, max_age)?;
@@ -38,7 +38,123 @@ pub fn verify_request_signature<T>(
     let base = build_request_base_with_params_str(req, &params, &params_str)?;
     verifier.verify(&base, &signature_bytes)?;
 
-    Ok(params)
+    Ok(CryptoVerified { params })
+}
+
+/// A signature whose cryptographic verification has succeeded.
+///
+/// First link in the verification chain. It proves the signature is authentic
+/// over whatever components it happens to cover — not that those components
+/// include anything meaningful, and not that a request body was bound. The
+/// only way forward is [`CryptoVerified::require_coverage`].
+#[derive(Debug)]
+pub struct CryptoVerified {
+    params: SignatureParams,
+}
+
+impl CryptoVerified {
+    /// The verified signature parameters.
+    #[must_use]
+    pub fn params(&self) -> &SignatureParams {
+        &self.params
+    }
+
+    /// Check that the signature covers every component in `required`
+    /// (RFC 9421 Section 7.2.1).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HttpSigError::InvalidSignature`] when a required component is
+    /// not among the signature's covered components.
+    pub fn require_coverage(self, required: &[&str]) -> Result<CoverageChecked, HttpSigError> {
+        validate_coverage(&self.params, required)?;
+        Ok(CoverageChecked {
+            params: self.params,
+        })
+    }
+}
+
+/// A verified signature that covers the caller's required components.
+///
+/// Still insufficient for a request carrying a body: an unsigned
+/// `Content-Digest` header could be swapped alongside the payload. The only
+/// way forward is [`CoverageChecked::enforce_body_digest`].
+#[derive(Debug)]
+pub struct CoverageChecked {
+    params: SignatureParams,
+}
+
+impl CoverageChecked {
+    /// The verified signature parameters.
+    #[must_use]
+    pub fn params(&self) -> &SignatureParams {
+        &self.params
+    }
+
+    /// Enforce RFC 9530 `Content-Digest` integrity for a signed request body.
+    ///
+    /// A signed request carrying a non-empty body must cover `content-digest`
+    /// in its signature *and* present a matching header. Coverage is required
+    /// because an unsigned digest header could be swapped alongside the body.
+    /// Empty bodies (GET, bodyless POST) are exempt.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HttpSigError::MissingDigest`] when the body is not bound by a
+    /// covered, present `Content-Digest`, or [`HttpSigError::DigestMismatch`]
+    /// when the digest does not match the body.
+    pub fn enforce_body_digest(
+        self,
+        headers: &http::HeaderMap,
+        body: &[u8],
+    ) -> Result<DigestEnforced, HttpSigError> {
+        if body.is_empty() {
+            return Ok(DigestEnforced {
+                params: self.params,
+            });
+        }
+
+        validate_coverage(&self.params, &["content-digest"])
+            .map_err(|_| HttpSigError::MissingDigest)?;
+
+        let header = headers
+            .get("content-digest")
+            .ok_or(HttpSigError::MissingDigest)?
+            .to_str()
+            .map_err(|e| HttpSigError::SfvParse(format!("Content-Digest: {e}")))?;
+
+        crate::digest::verify_content_digest(header, body)?;
+
+        Ok(DigestEnforced {
+            params: self.params,
+        })
+    }
+}
+
+/// A fully checked signature: verified, coverage-checked, and body-bound.
+///
+/// Reaching this state is the only way to build the `VerifiedSignature`
+/// request extension, so a downstream handler cannot observe a signature
+/// result that skipped a step. Producing one requires moving through
+/// [`CryptoVerified`] and [`CoverageChecked`] in order — the sequence is
+/// enforced by the types rather than by statement order in a caller.
+#[derive(Debug)]
+pub struct DigestEnforced {
+    params: SignatureParams,
+}
+
+impl DigestEnforced {
+    /// The verified signature parameters.
+    #[must_use]
+    pub fn params(&self) -> &SignatureParams {
+        &self.params
+    }
+
+    /// Consume the proof, yielding the verified parameters.
+    #[must_use]
+    pub fn into_params(self) -> SignatureParams {
+        self.params
+    }
 }
 
 /// Validate that a signature covers at least the required components (RFC 9421 §7.2.1).
@@ -47,11 +163,18 @@ pub fn verify_request_signature<T>(
 /// appropriate for the application context. An empty covered components list
 /// means the signature proves key possession but does not bind to any message content.
 ///
+/// Private on purpose: a coverage check that returns `Ok(())` and nothing else
+/// leaves no evidence it ran, which is the failure mode the verification chain
+/// exists to remove. Callers reach it through
+/// [`CryptoVerified::require_coverage`], which hands back a
+/// [`CoverageChecked`] proof. Shared here because both that transition and
+/// [`CoverageChecked::enforce_body_digest`] need the same comparison.
+///
 /// # Errors
 ///
 /// Returns [`HttpSigError::InvalidSignature`] if any required component is missing
 /// from the signature's covered components.
-pub fn validate_coverage(params: &SignatureParams, required: &[&str]) -> Result<(), HttpSigError> {
+fn validate_coverage(params: &SignatureParams, required: &[&str]) -> Result<(), HttpSigError> {
     for req_name in required {
         let found = params.components.iter().any(|c| {
             // Extract the bare component name without parameters
@@ -494,5 +617,87 @@ mod tests {
             tag: None,
         };
         validate_coverage(&params, &[]).unwrap();
+    }
+
+    fn params_covering(components: Vec<crate::ComponentIdentifier>) -> SignatureParams {
+        SignatureParams {
+            components,
+            alg: None,
+            keyid: None,
+            created: None,
+            expires: None,
+            nonce: None,
+            tag: None,
+        }
+    }
+
+    /// Enter the chain at the digest step. Only reachable here because the
+    /// tests are a child module of `verify` — outside the crate the sole
+    /// route to `CoverageChecked` is `CryptoVerified::require_coverage`.
+    fn coverage_checked(components: Vec<crate::ComponentIdentifier>) -> CoverageChecked {
+        CoverageChecked {
+            params: params_covering(components),
+        }
+    }
+
+    fn digest_header(body: &[u8]) -> http::HeaderValue {
+        crate::digest::content_digest(body, crate::digest::DigestAlgorithm::Sha256)
+            .parse()
+            .unwrap()
+    }
+
+    #[test]
+    fn test_enforce_body_digest_empty_body_is_exempt() {
+        let headers = http::HeaderMap::new();
+        coverage_checked(vec![])
+            .enforce_body_digest(&headers, b"")
+            .unwrap();
+    }
+
+    #[test]
+    fn test_enforce_body_digest_valid() {
+        let body = b"{\"x\":1}";
+        let mut headers = http::HeaderMap::new();
+        headers.insert("content-digest", digest_header(body));
+        coverage_checked(vec![
+            crate::ComponentIdentifier::method(),
+            crate::ComponentIdentifier::field("content-digest"),
+        ])
+        .enforce_body_digest(&headers, body)
+        .unwrap();
+    }
+
+    #[test]
+    fn test_enforce_body_digest_missing_header() {
+        let body = b"body";
+        let headers = http::HeaderMap::new();
+        assert!(matches!(
+            coverage_checked(vec![crate::ComponentIdentifier::field("content-digest")])
+                .enforce_body_digest(&headers, body),
+            Err(HttpSigError::MissingDigest)
+        ));
+    }
+
+    #[test]
+    fn test_enforce_body_digest_not_covered() {
+        let body = b"body";
+        let mut headers = http::HeaderMap::new();
+        headers.insert("content-digest", digest_header(body));
+        assert!(matches!(
+            coverage_checked(vec![crate::ComponentIdentifier::method()])
+                .enforce_body_digest(&headers, body),
+            Err(HttpSigError::MissingDigest)
+        ));
+    }
+
+    #[test]
+    fn test_enforce_body_digest_mismatch() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert("content-digest", digest_header(b"other body"));
+        assert!(matches!(
+            coverage_checked(vec![crate::ComponentIdentifier::field("content-digest")])
+                .enforce_body_digest(&headers, b"body"),
+            Err(HttpSigError::DigestMismatch(_))
+        ));
     }
 }


### PR DESCRIPTION
Closes #1038.

`verify_request_signature` returned bare `SignatureParams`. The middleware then ran the coverage check and the body-digest check in statement order, and nothing in the result recorded that either had happened. Reordering those statements, or reaching the public re-export directly, dropped a guarantee the middleware documents as load-bearing — with no compile-time signal.

## The chain

Verification now returns a three-link typestate. Each state holds its parameters privately, so the only route to the next one is the transition that performs the check:

| state | produced by | proves |
|---|---|---|
| `CryptoVerified` | `verify_request_signature` | the signature is authentic over whatever it covers |
| `CoverageChecked` | `require_coverage` | the covered components include the required set |
| `DigestEnforced` | `enforce_body_digest` | a non-empty body is bound by a covered `Content-Digest` |

`VerifiedSignature` — the request extension — now requires a `DigestEnforced` to construct and keeps its `params` private. A handler that reads it knows every step ran.

Three supporting changes fall out of this:

- `enforce_body_digest` moves out of the axum-gated middleware into the chain, so the states are usable (and testable) without the `axum` feature.
- `validate_coverage` becomes private. A coverage check that returns `Ok(())` and nothing else is the exact shape this PR replaces, so leaving a second public way to do it would have undercut the change. Its five behavioral tests moved to `verify.rs` alongside it.
- `enforce_nonce` takes `&DigestEnforced` rather than `&SignatureParams`. The nonce comment already said consumption must follow signature, coverage, and digest checks; the parameter type now enforces that rather than describing it.

## Naming

The first state was initially `SignatureVerified`, which is a coin-flip away from the existing `VerifiedSignature` extension. Renamed to `CryptoVerified` so the states read as a consistent family — `CryptoVerified`, `CoverageChecked`, `DigestEnforced` — with no collision.

## Proving the violation

Both violations fail to compile from `tests/`, which sees only the public API.

Skipping the coverage step:

```
error[E0599]: no method named `enforce_body_digest` found for struct `CryptoVerified` in the current scope
 --> crates/vouch-httpsig/tests/tmp_violation.rs:5:15
  |
5 |     let _ = v.enforce_body_digest(headers, b"x");
  |               ^^^^^^^^^^^^^^^^^^^ method not found in `CryptoVerified`
```

Forging the final proof from bare params:

```
error[E0451]: field `params` of struct `DigestEnforced` is private
 --> crates/vouch-httpsig/tests/tmp_violation.rs:5:22
  |
5 |     DigestEnforced { params }
  |                      ^^^^^^ private field
```

Both were scratch files, captured and deleted; neither is in the diff.

## Notes

No behavioral change — the same checks run in the same order for the same requests, and all 206 `vouch-httpsig` tests pass unmodified apart from the five relocated digest tests.

This layer is not covered by the FAPI 2.0 conformance suite (that is the external `vouch-sh/conformance` repo, which exercises `/oauth/*` only), so its guarantees rest entirely on this crate's own tests.

`make fmt`, `make lint`, `make test`, `make test-integration`, and `prek run` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)