### PR TITLE
fix(fido2): verify ES256 signature encoding and the COSE key triple

### DIFF
--- a/crates/vouch-server/src/crypto/cose.rs
+++ b/crates/vouch-server/src/crypto/cose.rs
@@ -14,6 +14,121 @@ pub(crate) enum CoseError {
     Cbor(String),
 }
 
+/// COSE key type (`kty`, label 1) — IANA "COSE Key Types" registry.
+pub(crate) mod kty {
+    pub(crate) const OKP: i64 = 1;
+    pub(crate) const EC2: i64 = 2;
+    pub(crate) const RSA: i64 = 3;
+}
+
+/// COSE algorithm (`alg`, label 3) — IANA "COSE Algorithms" registry.
+pub(crate) mod alg {
+    pub(crate) const ES256: i64 = -7;
+    pub(crate) const EDDSA: i64 = -8;
+    pub(crate) const RS256: i64 = -257;
+}
+
+/// COSE elliptic curve (`crv`, label -1) — IANA "COSE Elliptic Curves" registry.
+pub(crate) mod curve {
+    pub(crate) const P256: i64 = 1;
+    pub(crate) const P384: i64 = 2;
+    pub(crate) const P521: i64 = 3;
+    pub(crate) const ED25519: i64 = 6;
+    pub(crate) const ED448: i64 = 7;
+}
+
+/// A `(kty, alg, crv)` combination this server is able to verify.
+///
+/// RFC 9053 Section 2.1: "Implementations need to check that the key type and
+/// curve are correct when creating and verifying a signature." Reading `alg`
+/// alone leaves `crv` unchecked, which lets an EC2 key that declares ES256 but
+/// carries P-384 coordinates reach a P-256 verifier and fail deep inside the
+/// crypto library instead of at the boundary.
+///
+/// The specific ES256-with-P-256 pairing is *suggested* rather than required
+/// by RFC 9053 ("it is suggested that SHA-256 be used only with curve P-256"),
+/// so pinning it is our decision: it is the only curve `verify_es256`
+/// implements, and the only one WebAuthn registration requests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum VerifiableCoseKey {
+    /// EC2 key, ES256, P-256.
+    Es256,
+    /// RSA key, RS256. RSA keys carry no curve.
+    Rs256,
+    /// OKP key, EdDSA, Ed25519.
+    Ed25519,
+}
+
+/// Why a COSE key cannot be used for signature verification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CoseKeyError {
+    /// The `alg` value names an algorithm this server does not verify.
+    UnsupportedAlgorithm(i64),
+    /// The `alg` is supported but the `kty` is not the one it requires.
+    KeyTypeMismatch { alg: i64, expected: i64, got: i64 },
+    /// The `alg` is supported but the `crv` is not the one it requires.
+    CurveMismatch { alg: i64, expected: i64, got: i64 },
+    /// A curve-bearing key type carried no `crv` label.
+    MissingCurve(i64),
+}
+
+impl std::fmt::Display for CoseKeyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnsupportedAlgorithm(alg) => write!(f, "unsupported COSE alg {alg}"),
+            Self::KeyTypeMismatch { alg, expected, got } => write!(
+                f,
+                "COSE alg {alg} requires kty {expected}, but the key declares kty {got}"
+            ),
+            Self::CurveMismatch { alg, expected, got } => write!(
+                f,
+                "COSE alg {alg} requires crv {expected}, but the key declares crv {got}"
+            ),
+            Self::MissingCurve(alg) => write!(f, "COSE alg {alg} requires a crv label"),
+        }
+    }
+}
+
+impl VerifiableCoseKey {
+    /// Resolve a COSE `(kty, alg, crv)` triple, rejecting any inconsistency.
+    ///
+    /// `crv` is `None` when the key carried no `-1` label, which is correct
+    /// only for RSA.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoseKeyError`] naming the offending label and both the
+    /// expected and actual value.
+    pub(crate) fn from_triple(kty: i64, alg: i64, crv: Option<i64>) -> Result<Self, CoseKeyError> {
+        let (expected_kty, expected_crv, resolved) = match alg {
+            alg::ES256 => (kty::EC2, Some(curve::P256), Self::Es256),
+            alg::RS256 => (kty::RSA, None, Self::Rs256),
+            alg::EDDSA => (kty::OKP, Some(curve::ED25519), Self::Ed25519),
+            other => return Err(CoseKeyError::UnsupportedAlgorithm(other)),
+        };
+
+        if kty != expected_kty {
+            return Err(CoseKeyError::KeyTypeMismatch {
+                alg,
+                expected: expected_kty,
+                got: kty,
+            });
+        }
+
+        if let Some(expected) = expected_crv {
+            match crv {
+                Some(got) if got == expected => {}
+                Some(got) => {
+                    return Err(CoseKeyError::CurveMismatch { alg, expected, got });
+                }
+                None => return Err(CoseKeyError::MissingCurve(alg)),
+            }
+        }
+
+        Ok(resolved)
+    }
+}
+
 /// Convert a webauthn-rs `COSEKey` to raw CBOR bytes for storage.
 ///
 /// This produces the same format expected by our WebAuthn verification code:
@@ -30,13 +145,13 @@ pub(crate) fn cose_key_to_cbor(key: &COSEKey) -> Result<Vec<u8>, CoseError> {
             // COSE EC2 key: {1: 2 (kty), 3: alg, -1: curve, -2: x, -3: y}
             let alg = key.type_ as i64;
             let curve = match ec2.curve {
-                ECDSACurve::SECP256R1 => 1,
-                ECDSACurve::SECP384R1 => 2,
-                ECDSACurve::SECP521R1 => 3,
+                ECDSACurve::SECP256R1 => curve::P256,
+                ECDSACurve::SECP384R1 => curve::P384,
+                ECDSACurve::SECP521R1 => curve::P521,
             };
             vec![
-                (Value::Integer(1.into()), Value::Integer(2.into())), // kty = EC2
-                (Value::Integer(3.into()), Value::Integer(alg.into())), // alg
+                (Value::Integer(1.into()), Value::Integer(kty::EC2.into())), // kty = EC2
+                (Value::Integer(3.into()), Value::Integer(alg.into())),      // alg
                 (
                     Value::Integer((-1_i64).into()),
                     Value::Integer(curve.into()),
@@ -55,8 +170,8 @@ pub(crate) fn cose_key_to_cbor(key: &COSEKey) -> Result<Vec<u8>, CoseError> {
             // COSE RSA key: {1: 3 (kty), 3: alg, -1: n, -2: e}
             let alg = key.type_ as i64;
             vec![
-                (Value::Integer(1.into()), Value::Integer(3.into())), // kty = RSA
-                (Value::Integer(3.into()), Value::Integer(alg.into())), // alg
+                (Value::Integer(1.into()), Value::Integer(kty::RSA.into())), // kty = RSA
+                (Value::Integer(3.into()), Value::Integer(alg.into())),      // alg
                 (
                     Value::Integer((-1_i64).into()),
                     Value::Bytes(rsa.n.to_vec()),
@@ -71,12 +186,12 @@ pub(crate) fn cose_key_to_cbor(key: &COSEKey) -> Result<Vec<u8>, CoseError> {
             // COSE OKP key: {1: 1 (kty), 3: alg, -1: curve, -2: x}
             let alg = key.type_ as i64;
             let curve = match okp.curve {
-                EDDSACurve::ED25519 => 6,
-                EDDSACurve::ED448 => 7,
+                EDDSACurve::ED25519 => curve::ED25519,
+                EDDSACurve::ED448 => curve::ED448,
             };
             vec![
-                (Value::Integer(1.into()), Value::Integer(1.into())), // kty = OKP
-                (Value::Integer(3.into()), Value::Integer(alg.into())), // alg
+                (Value::Integer(1.into()), Value::Integer(kty::OKP.into())), // kty = OKP
+                (Value::Integer(3.into()), Value::Integer(alg.into())),      // alg
                 (
                     Value::Integer((-1_i64).into()),
                     Value::Integer(curve.into()),

--- a/crates/vouch-server/src/crypto/webauthn_verify.rs
+++ b/crates/vouch-server/src/crypto/webauthn_verify.rs
@@ -952,22 +952,21 @@ fn verify_es256(
     point.extend_from_slice(&x);
     point.extend_from_slice(&y);
 
-    // Try raw format first (64 bytes, r || s) - used by browser WebAuthn
-    // Then try DER/ASN.1 format (70-72 bytes) - used by CTAP2/YubiKey
-    if signature.len() == 64 {
-        let public_key = UnparsedPublicKey::new(&signature::ECDSA_P256_SHA256_FIXED, &point);
-        public_key.verify(message, signature).map_err(|e| {
-            tracing::warn!("verify_es256: FIXED verification failed: {e:?}");
-            VerifyError::SignatureInvalid
-        })
-    } else {
-        // DER-encoded signature from CTAP2
-        let public_key = UnparsedPublicKey::new(&signature::ECDSA_P256_SHA256_ASN1, &point);
-        public_key.verify(message, signature).map_err(|e| {
-            tracing::warn!("verify_es256: ASN1 verification failed: {e:?}");
-            VerifyError::SignatureInvalid
-        })
-    }
+    // WebAuthn Level 2 Section 6.5.5: "For COSEAlgorithmIdentifier -7 (ES256),
+    // and other ECDSA-based algorithms, the sig value MUST be encoded as an
+    // ASN.1 DER Ecdsa-Sig-Value, as defined in [RFC3279] section 2.2.3."
+    //
+    // That covers both entry points. The adjacent Note records that CTAP2
+    // authenticators emit the same encoding as CTAP1/U2F "for consistency
+    // reasons", and browsers pass the authenticator's signature through
+    // unchanged. There is therefore no conformant client that sends a raw
+    // r||s pair, and accepting one on the strength of its length would admit
+    // an encoding the specification forbids.
+    let public_key = UnparsedPublicKey::new(&signature::ECDSA_P256_SHA256_ASN1, &point);
+    public_key.verify(message, signature).map_err(|e| {
+        tracing::warn!("verify_es256: ASN1 verification failed: {e:?}");
+        VerifyError::SignatureInvalid
+    })
 }
 
 /// Verify RS256 (RSA PKCS#1 v1.5 with SHA-256) signature.

--- a/crates/vouch-server/src/crypto/webauthn_verify.rs
+++ b/crates/vouch-server/src/crypto/webauthn_verify.rs
@@ -24,6 +24,8 @@
 use aws_lc_rs::digest::{self, SHA256};
 use aws_lc_rs::signature::{self, UnparsedPublicKey};
 use der::Decode;
+
+use super::cose;
 use thiserror::Error;
 use vouch_common::protocol;
 
@@ -882,14 +884,26 @@ fn verify_cose_signature(
     // Extract algorithm (alg) - label 3
     let alg = get_cose_int(&map, 3)?;
 
-    match (kty, alg) {
-        // EC2 key with ES256 (-7)
-        (2, -7) => verify_es256(&map, message, signature),
-        // RSA key with RS256 (-257)
-        (3, -257) => verify_rs256(&map, message, signature),
-        // OKP key with EdDSA (-8)
-        (1, -8) => verify_eddsa(&map, message, signature),
-        _ => Err(VerifyError::UnsupportedAlgorithm(alg)),
+    // Curve (crv) - label -1. Read non-fatally: RSA has no curve (its -1 label
+    // holds the modulus), and an absent or non-integer label must not preempt
+    // the algorithm check below, which gives the more useful diagnosis.
+    let crv = match kty {
+        cose::kty::EC2 | cose::kty::OKP => get_cose_int(&map, -1).ok(),
+        _ => None,
+    };
+
+    // RFC 9053 Section 2.1 requires implementations to check the key type and
+    // curve, not just the algorithm. Resolving the whole triple here means a
+    // key whose labels disagree is rejected at the boundary with a message
+    // naming the mismatch, rather than reaching a verifier it does not fit.
+    match cose::VerifiableCoseKey::from_triple(kty, alg, crv) {
+        Ok(cose::VerifiableCoseKey::Es256) => verify_es256(&map, message, signature),
+        Ok(cose::VerifiableCoseKey::Rs256) => verify_rs256(&map, message, signature),
+        Ok(cose::VerifiableCoseKey::Ed25519) => verify_eddsa(&map, message, signature),
+        Err(cose::CoseKeyError::UnsupportedAlgorithm(alg)) => {
+            Err(VerifyError::UnsupportedAlgorithm(alg))
+        }
+        Err(e) => Err(VerifyError::InvalidCoseKey(e.to_string())),
     }
 }
 

--- a/crates/vouch-server/src/crypto/webauthn_verify/tests.rs
+++ b/crates/vouch-server/src/crypto/webauthn_verify/tests.rs
@@ -195,6 +195,10 @@ fn test_cose_key_ec2_missing_x() {
             ciborium::Value::Integer((-7).into()),
         ),
         (
+            ciborium::Value::Integer((-1).into()), // crv = P-256
+            ciborium::Value::Integer(1.into()),
+        ),
+        (
             ciborium::Value::Integer((-3).into()), // y only
             ciborium::Value::Bytes(vec![0u8; 32]),
         ),
@@ -219,6 +223,10 @@ fn test_cose_key_ec2_missing_y() {
             ciborium::Value::Integer((-7).into()),
         ),
         (
+            ciborium::Value::Integer((-1).into()), // crv = P-256
+            ciborium::Value::Integer(1.into()),
+        ),
+        (
             ciborium::Value::Integer((-2).into()), // x only
             ciborium::Value::Bytes(vec![0u8; 32]),
         ),
@@ -241,6 +249,10 @@ fn test_cose_key_okp_missing_x() {
         (
             ciborium::Value::Integer(3.into()), // alg = EdDSA
             ciborium::Value::Integer((-8).into()),
+        ),
+        (
+            ciborium::Value::Integer((-1).into()), // crv = Ed25519
+            ciborium::Value::Integer(6.into()),
         ),
     ]);
     ciborium::into_writer(&key, &mut buf).unwrap();
@@ -1357,4 +1369,144 @@ fn test_es256_der_signature_over_wrong_message_is_rejected() {
         verify_cose_signature(&cose_key, b"different message", &der),
         Err(VerifyError::SignatureInvalid)
     ));
+}
+
+// =========================================================================
+// COSE (kty, alg, crv) triple validation (RFC 9053 Section 2.1)
+// =========================================================================
+
+/// Build an EC2 COSE key with an explicitly chosen `alg` and `crv`, so a
+/// mismatched pair can be constructed for testing.
+fn make_ec2_cose_key_with(alg: i64, crv: i64, x: &[u8], y: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    let key = ciborium::Value::Map(vec![
+        (
+            ciborium::Value::Integer(1.into()),
+            ciborium::Value::Integer(2.into()), // kty = EC2
+        ),
+        (
+            ciborium::Value::Integer(3.into()),
+            ciborium::Value::Integer(alg.into()),
+        ),
+        (
+            ciborium::Value::Integer((-1).into()),
+            ciborium::Value::Integer(crv.into()),
+        ),
+        (
+            ciborium::Value::Integer((-2).into()),
+            ciborium::Value::Bytes(x.to_vec()),
+        ),
+        (
+            ciborium::Value::Integer((-3).into()),
+            ciborium::Value::Bytes(y.to_vec()),
+        ),
+    ]);
+    ciborium::into_writer(&key, &mut buf).unwrap();
+    buf
+}
+
+/// An EC2 key declaring ES256 but carrying P-384 must be rejected for the
+/// curve, not passed to a P-256 verifier that fails opaquely inside aws-lc.
+///
+/// RFC 9053 Section 2.1: "Implementations need to check that the key type and
+/// curve are correct when creating and verifying a signature."
+#[test]
+fn test_es256_with_p384_curve_is_rejected() {
+    let message = b"webauthn assertion signing input";
+    let (_, der, _) = es256_fixture(message);
+
+    // Real P-256 coordinates, but the key claims the P-384 curve.
+    let cose_key = make_ec2_cose_key_with(-7, 2, &[1u8; 32], &[2u8; 32]);
+
+    let err = verify_cose_signature(&cose_key, message, &der).unwrap_err();
+    assert!(
+        matches!(err, VerifyError::InvalidCoseKey(ref m) if m.contains("crv")),
+        "error must name the curve mismatch, got: {err:?}"
+    );
+}
+
+/// The mismatch must be caught even when the signature itself is well-formed
+/// and the coordinates are a genuine P-256 point.
+#[test]
+fn test_es256_curve_mismatch_precedes_signature_check() {
+    use p256::ecdsa::{Signature, SigningKey, signature::Signer};
+
+    let message = b"webauthn assertion signing input";
+    let signing_key = SigningKey::from_bytes(&[7u8; 32].into()).unwrap();
+    let point = signing_key.verifying_key().to_encoded_point(false);
+    let signature: Signature = signing_key.sign(message);
+
+    // Same key and a signature that would verify, but crv says P-521.
+    let cose_key = make_ec2_cose_key_with(-7, 3, point.x().unwrap(), point.y().unwrap());
+
+    assert!(matches!(
+        verify_cose_signature(&cose_key, message, signature.to_der().as_bytes()),
+        Err(VerifyError::InvalidCoseKey(_))
+    ));
+}
+
+/// An EdDSA key declaring the wrong key type must be rejected.
+#[test]
+fn test_eddsa_with_ec2_key_type_is_rejected() {
+    // kty = EC2 (2) but alg = EdDSA (-8), which requires OKP.
+    let cose_key = make_ec2_cose_key_with(-8, 6, &[1u8; 32], &[2u8; 32]);
+
+    let err = verify_cose_signature(&cose_key, b"message", &[0u8; 64]).unwrap_err();
+    assert!(
+        matches!(err, VerifyError::InvalidCoseKey(ref m) if m.contains("kty")),
+        "error must name the key-type mismatch, got: {err:?}"
+    );
+}
+
+/// An unknown algorithm still reports `UnsupportedAlgorithm`, not a mismatch.
+#[test]
+fn test_unknown_algorithm_reports_unsupported() {
+    let cose_key = make_ec2_cose_key_with(-999, 1, &[1u8; 32], &[2u8; 32]);
+
+    assert!(matches!(
+        verify_cose_signature(&cose_key, b"message", &[0u8; 64]),
+        Err(VerifyError::UnsupportedAlgorithm(-999))
+    ));
+}
+
+/// The conformant triple still verifies, so the check is not simply refusing
+/// everything.
+#[test]
+fn test_conformant_es256_p256_triple_still_verifies() {
+    let message = b"webauthn assertion signing input";
+    let (cose_key, der, _raw) = es256_fixture(message);
+
+    assert!(verify_cose_signature(&cose_key, message, &der).is_ok());
+}
+
+/// An EC2 key carrying no `crv` label is malformed: RFC 9053 Section 2.1
+/// requires the curve be checked, which is impossible when it is absent.
+#[test]
+fn test_ec2_key_without_curve_is_rejected() {
+    let mut buf = Vec::new();
+    let key = ciborium::Value::Map(vec![
+        (
+            ciborium::Value::Integer(1.into()), // kty = EC2
+            ciborium::Value::Integer(2.into()),
+        ),
+        (
+            ciborium::Value::Integer(3.into()), // alg = ES256
+            ciborium::Value::Integer((-7).into()),
+        ),
+        (
+            ciborium::Value::Integer((-2).into()),
+            ciborium::Value::Bytes(vec![1u8; 32]),
+        ),
+        (
+            ciborium::Value::Integer((-3).into()),
+            ciborium::Value::Bytes(vec![2u8; 32]),
+        ),
+    ]);
+    ciborium::into_writer(&key, &mut buf).unwrap();
+
+    let err = verify_cose_signature(&buf, b"message", &[0u8; 70]).unwrap_err();
+    assert!(
+        matches!(err, VerifyError::InvalidCoseKey(ref m) if m.contains("crv")),
+        "a curveless EC2 key must be rejected for the missing crv, got: {err:?}"
+    );
 }

--- a/crates/vouch-server/src/crypto/webauthn_verify/tests.rs
+++ b/crates/vouch-server/src/crypto/webauthn_verify/tests.rs
@@ -1267,3 +1267,94 @@ fn test_registration_localhost_origin_relaxation_rejected_when_disabled() {
     );
     assert!(matches!(result, Err(VerifyError::InvalidOrigin)));
 }
+
+// =========================================================================
+// ES256 signature encoding (WebAuthn Level 2 Section 6.5.5)
+// =========================================================================
+
+/// Build an EC2/P-256/ES256 COSE key from an uncompressed SEC1 point.
+fn make_es256_cose_key(x: &[u8], y: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    let key = ciborium::Value::Map(vec![
+        (
+            ciborium::Value::Integer(1.into()), // kty = EC2
+            ciborium::Value::Integer(2.into()),
+        ),
+        (
+            ciborium::Value::Integer(3.into()), // alg = ES256 (-7)
+            ciborium::Value::Integer((-7).into()),
+        ),
+        (
+            ciborium::Value::Integer((-1).into()), // crv = P-256 (1)
+            ciborium::Value::Integer(1.into()),
+        ),
+        (
+            ciborium::Value::Integer((-2).into()), // x
+            ciborium::Value::Bytes(x.to_vec()),
+        ),
+        (
+            ciborium::Value::Integer((-3).into()), // y
+            ciborium::Value::Bytes(y.to_vec()),
+        ),
+    ]);
+    ciborium::into_writer(&key, &mut buf).unwrap();
+    buf
+}
+
+/// Sign `message` with a deterministic P-256 key, returning the COSE key
+/// alongside the signature in both encodings.
+fn es256_fixture(message: &[u8]) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+    use p256::ecdsa::{Signature, SigningKey, signature::Signer};
+
+    let signing_key = SigningKey::from_bytes(&[7u8; 32].into()).unwrap();
+    let point = signing_key.verifying_key().to_encoded_point(false);
+    let cose_key = make_es256_cose_key(point.x().unwrap(), point.y().unwrap());
+
+    let signature: Signature = signing_key.sign(message);
+    (
+        cose_key,
+        signature.to_der().as_bytes().to_vec(),
+        signature.to_bytes().to_vec(),
+    )
+}
+
+/// WebAuthn Level 2 Section 6.5.5: "the sig value MUST be encoded as an
+/// ASN.1 DER Ecdsa-Sig-Value". Both browsers and CTAP2 authenticators emit
+/// this encoding, so it is the only one a conformant client produces.
+#[test]
+fn test_es256_der_signature_is_accepted() {
+    let message = b"webauthn assertion signing input";
+    let (cose_key, der, _raw) = es256_fixture(message);
+
+    assert!(verify_cose_signature(&cose_key, message, &der).is_ok());
+}
+
+/// A raw r||s pair is a valid signature over the same message, but not a
+/// conformant encoding. Accepting it on the strength of its 64-byte length
+/// was the heuristic this replaces, so rejection is the property under test.
+#[test]
+fn test_es256_raw_rs_signature_is_rejected() {
+    let message = b"webauthn assertion signing input";
+    let (cose_key, _der, raw) = es256_fixture(message);
+
+    assert_eq!(raw.len(), 64, "r||s for P-256 is 64 bytes");
+    assert!(
+        matches!(
+            verify_cose_signature(&cose_key, message, &raw),
+            Err(VerifyError::SignatureInvalid)
+        ),
+        "a non-conformant raw r||s signature must not verify"
+    );
+}
+
+/// A DER signature over a different message must still fail, so the test
+/// above is not passing merely because DER parsing succeeded.
+#[test]
+fn test_es256_der_signature_over_wrong_message_is_rejected() {
+    let (cose_key, der, _raw) = es256_fixture(b"original message");
+
+    assert!(matches!(
+        verify_cose_signature(&cose_key, b"different message", &der),
+        Err(VerifyError::SignatureInvalid)
+    ));
+}

--- a/crates/vouch-tests/tests/integration.rs
+++ b/crates/vouch-tests/tests/integration.rs
@@ -1755,9 +1755,17 @@ mod es256_flow {
         );
     }
 
-    /// Test ES256 signature verification with raw/fixed format (like browser WebAuthn).
+    /// A raw r||s ES256 signature must be rejected.
+    ///
+    /// This test previously asserted the opposite, on the premise that
+    /// browsers emit the fixed format. WebAuthn Level 2 Section 6.5.5 says
+    /// otherwise: "For COSEAlgorithmIdentifier -7 (ES256), and other
+    /// ECDSA-based algorithms, the sig value MUST be encoded as an ASN.1 DER
+    /// Ecdsa-Sig-Value, as defined in [RFC3279] section 2.2.3." The adjacent
+    /// Note confirms CTAP2 authenticators use that same encoding, and
+    /// browsers relay the authenticator's signature unchanged.
     #[test]
-    fn test_es256_fixed_signature_verification() {
+    fn test_es256_fixed_signature_is_rejected() {
         let rng = SystemRandom::new();
 
         // Generate an ECDSA P-256 key pair (fixed/raw signatures - r||s format)
@@ -1794,10 +1802,10 @@ mod es256_flow {
         let signature = key_pair.sign(&rng, &message).expect("Failed to sign");
         let signature_bytes = signature.as_ref();
 
-        println!("ES256 FIXED test:");
-        println!(
-            "  signature: {} bytes (should be 64 for fixed)",
-            signature_bytes.len()
+        assert_eq!(
+            signature_bytes.len(),
+            64,
+            "the fixed signer produces a 64-byte r||s pair"
         );
 
         // Verify using the server's verification code
@@ -1805,8 +1813,9 @@ mod es256_flow {
         let result = verifier.verify(&cose_key, &message, signature_bytes);
 
         assert!(
-            result.is_ok(),
-            "ES256 FIXED signature verification should succeed: {:?}",
+            result.is_err(),
+            "a raw r||s ES256 signature is not a conformant WebAuthn encoding \
+             and must not verify: {:?}",
             result
         );
     }


### PR DESCRIPTION
Items 1 and 2 of #1034 — the two entries in that issue that sit inside signature verification rather than being typing hygiene. The remaining five items are typing changes and are not in this PR.

Two commits, reviewable independently.

## 1. ES256 signatures must be DER

`verify_es256` picked its verifier by signature length: 64 bytes was treated as a raw `r||s` pair "used by browser WebAuthn", anything else as DER. That premise is wrong.

WebAuthn Level 2 §6.5.5:

> For COSEAlgorithmIdentifier -7 (ES256), and other ECDSA-based algorithms, the sig value MUST be encoded as an ASN.1 DER Ecdsa-Sig-Value, as defined in [RFC3279] section 2.2.3.

> Note: As CTAP1/U2F authenticators are already producing signatures values in this format, CTAP2 authenticators will also produce signatures values in the same format, for consistency reasons.

Both entry points therefore produce DER, and browsers relay the authenticator's signature unchanged. The length branch was not disambiguating two legitimate encodings — it accepted one the specification forbids. It is gone; verification is DER-only.

`test_es256_fixed_signature_verification` asserted the removed behaviour, and its own doc comment repeated the same mistaken premise ("raw/fixed format (like browser WebAuthn)"). It now asserts rejection and is renamed. `test_browser_enrollment_cli_login_es256_flow`, which models the real browser-enrollment-then-CLI-login path, already used DER and is untouched.

## 2. Check the key type and curve, not just the algorithm

`verify_cose_signature` dispatched on a `(kty, alg)` tuple of literals and never read `crv`. An EC2 key declaring ES256 while carrying P-384 coordinates reached `verify_es256` — a P-256-only verifier — and failed inside aws-lc with nothing indicating the key's own labels disagreed.

RFC 9053 §2.1:

> This document requires that the curves be encoded using the "EC2" (two coordinate elliptic curve) key type. Implementations need to check that the key type and curve are correct when creating and verifying a signature.

`VerifiableCoseKey::from_triple` now resolves `(kty, alg, crv)` and rejects any inconsistency, naming the offending label and both the expected and actual value. The registry numbers moved into `kty`, `alg`, and `curve` modules in `cose.rs`, so the writer and the verifier read the same constants rather than restating them.

**Stated accurately:** binding ES256 to P-256 is our decision, not the RFC's. RFC 9053 only *suggests* that pairing ("it is suggested that SHA-256 be used only with curve P-256"). We pin it because it is the only curve `verify_es256` implements and the only one WebAuthn registration requests. The *checking* of key type and curve is what the RFC directs implementations to do.

## Test changes worth review

`crv` is read non-fatally, so an unsupported algorithm is still reported as `UnsupportedAlgorithm` rather than being preempted by a curve complaint.

Three existing fixtures (`ec2_missing_x`, `ec2_missing_y`, `okp_missing_x`) carried no `crv` at all. With the triple check they stopped isolating the missing coordinate under test and failed on the curve instead, so each gained a conformant `crv`. A curveless key is now its own rejection case.

New tests: DER accepted, raw `r||s` rejected, DER-over-wrong-message rejected, ES256-with-P-384 rejected, curve mismatch caught ahead of the signature check, EdDSA-with-EC2 rejected, unknown algorithm still reported as unsupported, and the conformant triple still verifying.

## Verification

Item 1 was mutation-checked: restoring the old length branch fails the rejection test, so it is not vacuous.

`make fmt`, `make lint`, `make test`, `make test-integration`, and `prek run` are clean. Enrollment and login were exercised locally against item 1 before item 2 was written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)