### PR TITLE
refactor(fido2): single-source X.509 OIDs and correct two false doc claims

### DIFF
--- a/crates/vouch-server/src/crypto/attestation_chain.rs
+++ b/crates/vouch-server/src/crypto/attestation_chain.rs
@@ -7,6 +7,7 @@
 
 use std::sync::LazyLock;
 
+use super::oid;
 use aws_lc_rs::signature;
 use const_oid::ObjectIdentifier;
 use der::{Decode, DecodePem};
@@ -39,9 +40,8 @@ const YUBICO_CA_1_PEM: &str = include_str!("../../root_certs/yubico-ca-1.pem");
 // OID Constants
 // ============================================================================
 
-/// FIDO2 AAGUID extension OID (1.3.6.1.4.1.45724.1.1.4).
-/// Contains a 16-byte AAGUID wrapped in an OCTET STRING.
-const OID_FIDO_AAGUID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.6.1.4.1.45724.1.1.4");
+/// FIDO2 AAGUID extension OID (WebAuthn Level 2 Section 8.2.1).
+const OID_FIDO_AAGUID: ObjectIdentifier = oid::extension::FIDO_GEN_CE_AAGUID;
 
 // ============================================================================
 // Error & Result Types
@@ -213,31 +213,25 @@ fn verify_cert_signature(
     // Determine the signature algorithm from the certificate
     let alg_oid = subject.signature_algorithm.oid;
 
-    // OIDs for supported signature algorithms
-    const ECDSA_SHA256: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.10045.4.3.2");
-    const RSA_SHA256: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.11");
-    const RSA_SHA384: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.12");
-    const RSA_SHA512: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.13");
-
-    if alg_oid == ECDSA_SHA256 {
+    if alg_oid == oid::signature::ECDSA_SHA256 {
         let pk = signature::UnparsedPublicKey::new(&signature::ECDSA_P256_SHA256_ASN1, pk_bytes);
         pk.verify(&tbs_bytes, sig_bytes)
             .map_err(|e| AttestationChainError::SignatureInvalid(format!("ECDSA-SHA256: {e}")))
-    } else if alg_oid == RSA_SHA256 {
+    } else if alg_oid == oid::signature::RSA_SHA256 {
         verify_rsa_signature(
             &signature::RSA_PKCS1_2048_8192_SHA256,
             pk_bytes,
             &tbs_bytes,
             sig_bytes,
         )
-    } else if alg_oid == RSA_SHA384 {
+    } else if alg_oid == oid::signature::RSA_SHA384 {
         verify_rsa_signature(
             &signature::RSA_PKCS1_2048_8192_SHA384,
             pk_bytes,
             &tbs_bytes,
             sig_bytes,
         )
-    } else if alg_oid == RSA_SHA512 {
+    } else if alg_oid == oid::signature::RSA_SHA512 {
         verify_rsa_signature(
             &signature::RSA_PKCS1_2048_8192_SHA512,
             pk_bytes,

--- a/crates/vouch-server/src/crypto/kms_signer.rs
+++ b/crates/vouch-server/src/crypto/kms_signer.rs
@@ -21,20 +21,19 @@ use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use spki::SubjectPublicKeyInfoRef;
 
-/// OID for Ed25519: 1.3.101.112 (RFC 8410 Section 3).
-const OID_ED25519: spki::ObjectIdentifier = spki::ObjectIdentifier::new_unwrap("1.3.101.112");
+use super::oid;
 
-/// OID for EC public key: 1.2.840.10045.2.1 (RFC 5480 Section 2.1.1).
-const OID_EC_PUBLIC_KEY: spki::ObjectIdentifier =
-    spki::ObjectIdentifier::new_unwrap("1.2.840.10045.2.1");
+/// OID for Ed25519 (RFC 8410 Section 3).
+const OID_ED25519: spki::ObjectIdentifier = oid::public_key::ED25519;
 
-/// OID for P-256 (prime256v1): 1.2.840.10045.3.1.7 (RFC 5480 Section 2.1.1.1).
-const OID_PRIME256V1: spki::ObjectIdentifier =
-    spki::ObjectIdentifier::new_unwrap("1.2.840.10045.3.1.7");
+/// OID for EC public key (RFC 5480 Section 2.1.1).
+const OID_EC_PUBLIC_KEY: spki::ObjectIdentifier = oid::public_key::EC;
 
-/// OID for rsaEncryption: 1.2.840.113549.1.1.1 (RFC 3279 Section 2.3.1).
-const OID_RSA_ENCRYPTION: spki::ObjectIdentifier =
-    spki::ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.1");
+/// OID for P-256 / prime256v1 (RFC 5480 Section 2.1.1.1).
+const OID_PRIME256V1: spki::ObjectIdentifier = oid::curve::PRIME256V1;
+
+/// OID for rsaEncryption (RFC 3279 Section 2.3.1).
+const OID_RSA_ENCRYPTION: spki::ObjectIdentifier = oid::public_key::RSA;
 
 // ---------------------------------------------------------------------------
 // SPKI parsing helpers

--- a/crates/vouch-server/src/crypto/mod.rs
+++ b/crates/vouch-server/src/crypto/mod.rs
@@ -13,6 +13,7 @@ pub mod hash;
 pub(crate) mod jwt;
 pub mod keys;
 pub(crate) mod kms_signer;
+pub(crate) mod oid;
 pub(crate) mod pem;
 pub(crate) mod ssh_ca;
 pub(crate) mod tpm_decrypt;

--- a/crates/vouch-server/src/crypto/oid.rs
+++ b/crates/vouch-server/src/crypto/oid.rs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! Object identifiers used when parsing and verifying X.509 material.
+//!
+//! Every OID the crypto layer matches on lives here, so a value is written
+//! once and the arc it belongs to is stated once. Before this module,
+//! `id-ecPublicKey` and `rsaEncryption` were each spelled in two files.
+//!
+//! The constants are grouped by what they identify, because the distinction
+//! decides which one a caller wants:
+//!
+//! * [`public_key`] — the algorithm of a *key*, from a `SubjectPublicKeyInfo`.
+//!   These under-determine a signature: `id-ecPublicKey` names neither a curve
+//!   nor a hash.
+//! * [`signature`] — the algorithm of a *signature*, from a certificate's
+//!   `signatureAlgorithm`. These are self-determining: `ecdsa-with-SHA256`
+//!   fixes both the family and the digest.
+//! * [`curve`] — named elliptic curves, used to confirm a key is on the curve
+//!   a verifier expects.
+//! * [`extension`] — X.509 extensions this server reads.
+
+use const_oid::ObjectIdentifier;
+
+/// Public-key algorithm identifiers, as they appear in a `SubjectPublicKeyInfo`.
+pub(crate) mod public_key {
+    use super::ObjectIdentifier;
+
+    /// `id-ecPublicKey` — RFC 5480 Section 2.1.1.
+    ///
+    /// Names the key family only. The curve is carried separately in the
+    /// algorithm parameters, and the digest is not carried at all, so this
+    /// value alone cannot select a signature verifier.
+    pub(crate) const EC: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.10045.2.1");
+
+    /// `rsaEncryption` — RFC 3279 Section 2.3.1.
+    pub(crate) const RSA: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.1");
+
+    /// `id-Ed25519` — RFC 8410 Section 3.
+    ///
+    /// Unlike [`EC`], this fully determines the signature scheme: RFC 8410
+    /// binds the curve and the hash into the algorithm itself.
+    pub(crate) const ED25519: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.101.112");
+}
+
+/// Signature algorithm identifiers, as they appear in `signatureAlgorithm`.
+pub(crate) mod signature {
+    use super::ObjectIdentifier;
+
+    /// `ecdsa-with-SHA256` — RFC 5758 Section 3.2.
+    pub(crate) const ECDSA_SHA256: ObjectIdentifier =
+        ObjectIdentifier::new_unwrap("1.2.840.10045.4.3.2");
+
+    /// `sha256WithRSAEncryption` — RFC 4055 Section 5.
+    pub(crate) const RSA_SHA256: ObjectIdentifier =
+        ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.11");
+
+    /// `sha384WithRSAEncryption` — RFC 4055 Section 5.
+    pub(crate) const RSA_SHA384: ObjectIdentifier =
+        ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.12");
+
+    /// `sha512WithRSAEncryption` — RFC 4055 Section 5.
+    pub(crate) const RSA_SHA512: ObjectIdentifier =
+        ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.13");
+}
+
+/// Named elliptic curves.
+pub(crate) mod curve {
+    use super::ObjectIdentifier;
+
+    /// `prime256v1` / P-256 — RFC 5480 Section 2.1.1.1.
+    pub(crate) const PRIME256V1: ObjectIdentifier =
+        ObjectIdentifier::new_unwrap("1.2.840.10045.3.1.7");
+}
+
+/// X.509 extensions this server reads.
+pub(crate) mod extension {
+    use super::ObjectIdentifier;
+
+    /// `id-fido-gen-ce-aaguid` — WebAuthn Level 2 Section 8.2.1.
+    ///
+    /// Carries the authenticator's AAGUID, wrapped in two OCTET STRINGs.
+    pub(crate) const FIDO_GEN_CE_AAGUID: ObjectIdentifier =
+        ObjectIdentifier::new_unwrap("1.3.6.1.4.1.45724.1.1.4");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The dotted strings are the point of this module; a typo in one would
+    /// otherwise surface only as a silently unmatched certificate.
+    #[test]
+    fn oids_render_to_their_documented_arcs() {
+        assert_eq!(public_key::EC.to_string(), "1.2.840.10045.2.1");
+        assert_eq!(public_key::RSA.to_string(), "1.2.840.113549.1.1.1");
+        assert_eq!(public_key::ED25519.to_string(), "1.3.101.112");
+        assert_eq!(signature::ECDSA_SHA256.to_string(), "1.2.840.10045.4.3.2");
+        assert_eq!(signature::RSA_SHA256.to_string(), "1.2.840.113549.1.1.11");
+        assert_eq!(signature::RSA_SHA384.to_string(), "1.2.840.113549.1.1.12");
+        assert_eq!(signature::RSA_SHA512.to_string(), "1.2.840.113549.1.1.13");
+        assert_eq!(curve::PRIME256V1.to_string(), "1.2.840.10045.3.1.7");
+        assert_eq!(
+            extension::FIDO_GEN_CE_AAGUID.to_string(),
+            "1.3.6.1.4.1.45724.1.1.4"
+        );
+    }
+
+    /// Public-key and signature OIDs are different namespaces. Matching a
+    /// signature algorithm against a public-key OID never succeeds, which is
+    /// why the two selectors that consume this module stay separate.
+    #[test]
+    fn public_key_and_signature_oids_are_disjoint() {
+        let public_keys = [public_key::EC, public_key::RSA];
+        let signatures = [
+            signature::ECDSA_SHA256,
+            signature::RSA_SHA256,
+            signature::RSA_SHA384,
+            signature::RSA_SHA512,
+        ];
+        for pk in public_keys {
+            assert!(!signatures.contains(&pk), "{pk} appears in both namespaces");
+        }
+    }
+}

--- a/crates/vouch-server/src/crypto/webauthn_verify.rs
+++ b/crates/vouch-server/src/crypto/webauthn_verify.rs
@@ -28,7 +28,7 @@ use aws_lc_rs::digest::{self, SHA256};
 use aws_lc_rs::signature::{self, UnparsedPublicKey};
 use der::Decode;
 
-use super::cose;
+use super::{cose, oid};
 use thiserror::Error;
 use vouch_common::protocol;
 
@@ -782,20 +782,13 @@ fn verify_attestation_sig_with_leaf_cert(
     // Determine algorithm from the certificate's public key algorithm OID
     let pk_alg_oid = spki.algorithm.oid;
 
-    // EC public key OID: 1.2.840.10045.2.1
-    const EC_PUBLIC_KEY: const_oid::ObjectIdentifier =
-        const_oid::ObjectIdentifier::new_unwrap("1.2.840.10045.2.1");
-    // RSA encryption OID: 1.2.840.113549.1.1.1
-    const RSA_ENCRYPTION: const_oid::ObjectIdentifier =
-        const_oid::ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.1");
-
-    if pk_alg_oid == EC_PUBLIC_KEY {
+    if pk_alg_oid == oid::public_key::EC {
         let pk = signature::UnparsedPublicKey::new(&signature::ECDSA_P256_SHA256_ASN1, pk_bytes);
         pk.verify(message, sig).map_err(|e| {
             tracing::warn!("Leaf cert ECDSA verification failed: {e}");
             VerifyError::SignatureInvalid
         })
-    } else if pk_alg_oid == RSA_ENCRYPTION {
+    } else if pk_alg_oid == oid::public_key::RSA {
         let pk =
             signature::UnparsedPublicKey::new(&signature::RSA_PKCS1_2048_8192_SHA256, pk_bytes);
         pk.verify(message, sig).map_err(|e| {

--- a/crates/vouch-server/src/crypto/webauthn_verify.rs
+++ b/crates/vouch-server/src/crypto/webauthn_verify.rs
@@ -15,11 +15,14 @@
 //! The [`CoseVerifier`] trait allows injecting test implementations for integration
 //! testing without requiring real cryptographic keys.
 //!
-//! # Type Safety
+//! # Inputs are untyped byte slices
 //!
-//! This module provides both untyped (`&[u8]`) and typed (`Encoded<T, E>`) interfaces.
-//! The typed interfaces use compile-time markers to prevent mixing up different
-//! binary data types (e.g., passing a credential_id where a signature is expected).
+//! Verification takes `&[u8]`. Callers hold
+//! [`vouch_common::encoding::Encoded<T, E>`], whose compile-time markers keep
+//! a credential ID from being passed where a signature belongs, but they decode
+//! before calling in — this module never sees the marker. Extending the typed
+//! representation inward would only pay off alongside the browser WebAuthn
+//! request types, which are still `String`; that migration is tracked in #1037.
 
 use aws_lc_rs::digest::{self, SHA256};
 use aws_lc_rs::signature::{self, UnparsedPublicKey};
@@ -336,13 +339,26 @@ fn verify_assertion_inner<V: CoseVerifier>(
 
     // 5. Verify counter is increasing.
     //
-    // Per WebAuthn Level 2 §6.1.1, a value of `authData.signCount <=
-    // storedSignCount` is a cloning signal whenever *either* value is nonzero.
-    // We therefore reject as soon as the *stored* counter is nonzero and the
-    // presented counter does not strictly increase — including a regression to
-    // zero. A credential that has ever reported a nonzero counter may never go
-    // backwards (YubiKeys always increment), so a zero arriving after a nonzero
-    // stored value is unambiguous evidence of cloning or forgery.
+    // WebAuthn Level 2 Section 6.1.1: "In subsequent authenticatorGetAssertion
+    // operations, the Relying Party compares the stored signature counter
+    // value with the new signCount value returned in the assertion's
+    // authenticator data. If either is non-zero, and the new signCount value
+    // is less than or equal to the stored value, a cloned authenticator may
+    // exist, or the authenticator may be malfunctioning."
+    //
+    // Rejecting is our choice, not the specification's. Section 7.2 leaves it
+    // open: "Whether the Relying Party updates storedSignCount in this case,
+    // or not, or fails the authentication ceremony or not, is Relying
+    // Party-specific." A malfunctioning authenticator is as consistent with
+    // the observation as a cloned one; we decline to distinguish them and fail
+    // closed, because this is a hardware-backed credential system where a
+    // counter regression should stop the ceremony rather than feed a risk
+    // score.
+    //
+    // The condition below reads `stored_counter != 0` where the specification
+    // says "either is non-zero". The two agree: the only case they treat
+    // differently is a nonzero presented counter against a zero stored
+    // counter, which cannot also satisfy `counter <= stored_counter`.
     //
     // Credentials that have only ever reported zero (counter-less
     // authenticators, e.g. some CTAP1 devices) keep `stored_counter == 0` and


### PR DESCRIPTION
Items 5, 6 and 7 of #1034, continuing from #1053 (now merged). Two commits, reviewable independently. No behaviour change in either.

## Item 5 — single-source the OIDs, but keep two selectors

Four files each declared their own OID constants, and two values were spelled twice: `id-ecPublicKey` and `rsaEncryption` appeared in both `webauthn_verify.rs` and `kms_signer.rs`. Every dotted string now lives in `crypto/oid.rs` and nowhere else.

**A correction to the issue.** #1034 describes "two function-local OID tables" in `webauthn_verify.rs` and `attestation_chain.rs` and proposes "a shared OID module and one selector". Those two files have **disjoint** OID sets, so there was no duplicate between them to remove:

- `webauthn_verify.rs` reads a **public-key** OID from a `SubjectPublicKeyInfo`. These under-determine a signature — `id-ecPublicKey` names neither a curve nor a hash.
- `attestation_chain.rs` reads a **signature-algorithm** OID from a certificate's `signatureAlgorithm`. These are self-determining — `ecdsa-with-SHA256` fixes both family and digest.

The real duplication was `webauthn_verify.rs` ↔ `kms_signer.rs`, which the issue does not mention. So the shared module is justified; a single selector is not, because the two read different fields for different purposes, and merging them would mean inventing a mapping rather than deleting a duplicate. A test asserts the two namespaces are disjoint — the property that makes keeping them separate safe.

Constants are grouped as `public_key`, `signature`, `curve`, and `extension`, because that grouping was the implicit and load-bearing part.

## Items 6 and 7 — documentation that asserted untrue things

The sign-counter comment paraphrased WebAuthn Level 2 §6.1.1 and overstated it twice:

- It called a counter regression "unambiguous evidence of cloning or forgery". The specification says "a cloned authenticator may exist, **or the authenticator may be malfunctioning**".
- It presented rejection as following from the specification. §7.2 says "Whether the Relying Party updates storedSignCount in this case, or not, or fails the authentication ceremony or not, is Relying Party-specific."

Both are now quoted verbatim, with failing closed identified as our decision and justified. The comment also records why `stored_counter != 0` is equivalent to the specification's "if either is non-zero" here, which was previously left to the reader.

The module header claimed the module "provides both untyped (`&[u8]`) and typed (`Encoded<T, E>`) interfaces". No `Encoded` appears anywhere in the file — the type lives in `vouch-common`, and callers decode before calling in. The header now says that, and points at #1037.

## Not doing

**#1037 is not pulled forward.** Item 7 offered "fix the doc or add the interface"; the doc fix stands on its own. A typed interface reaching inward would not pay off from #1037 alone — the verifier legitimately takes bytes, whereas #1037 types the *wire* boundary so malformed base64url fails in serde rather than mid-handler. Real, but independent.

**Items 3 and 4 remain.** Item 4 needs a design note before it can be implemented as written: it proposes "an origin-policy type constructible only from `&ServerConfig`", but `arch_boundaries.rs` enforces `crypto -> (no other layer)`, so that type cannot live in the layer that consumes it. The workable shape is the enum in `crypto` with the `From<&ServerConfig>` conversion in a higher layer.

`make fmt`, `make lint`, `make test`, `make test-integration`, and `prek run` are clean, re-run after rebasing onto merged main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)