### PR TITLE
refactor(oidc): single-source the RFC 7638 JWK thumbprint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7636,6 +7636,7 @@ name = "vouch-common"
 version = "2026.8.5"
 dependencies = [
  "anyhow",
+ "aws-lc-rs",
  "base64 0.23.1",
  "dirs",
  "hex",

--- a/crates/vouch-cli/src/fapi/key.rs
+++ b/crates/vouch-cli/src/fapi/key.rs
@@ -22,7 +22,6 @@
 //! 2. Binding `client_id` to FIDO2 `credential_id` at first registration
 //! 3. Using Secure Enclave / TPM for client key generation
 
-use std::collections::BTreeMap;
 use std::path::Path;
 
 use aws_lc_rs::{
@@ -33,6 +32,7 @@ use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use jsonwebtoken::EncodingKey;
 use serde::{Deserialize, Serialize};
+use vouch_common::jwk::JwkThumbprintKey;
 use zeroize::Zeroizing;
 
 use super::error::FapiError;
@@ -132,7 +132,7 @@ impl ClientKey {
         let der_bytes = Zeroizing::new(pkcs8_bytes.as_ref().to_vec());
 
         let (x, y) = extract_ec_coordinates(&key_pair)?;
-        let kid = compute_thumbprint(&x, &y)?;
+        let kid = compute_thumbprint(&x, &y);
 
         Ok(Self {
             key_pair,
@@ -161,7 +161,7 @@ impl ClientKey {
             .map_err(|e| FapiError::InvalidKeyFormat(format!("PKCS#8 parse error: {e}")))?;
 
         let (x, y) = extract_ec_coordinates(&key_pair)?;
-        let computed_kid = compute_thumbprint(&x, &y)?;
+        let computed_kid = compute_thumbprint(&x, &y);
 
         if computed_kid != key_file.kid {
             return Err(FapiError::InvalidKeyFormat(format!(
@@ -325,22 +325,8 @@ fn extract_ec_coordinates(key_pair: &EcdsaKeyPair) -> Result<(String, String), F
 }
 
 /// Compute the RFC 7638 JWK thumbprint for a P-256 public key.
-///
-/// The canonical JSON is: `{"crv":"P-256","kty":"EC","x":"...","y":"..."}`
-/// (lexicographically ordered keys). The thumbprint is `base64url(SHA-256(canonical_json))`.
-fn compute_thumbprint(x: &str, y: &str) -> Result<String, FapiError> {
-    // RFC 7638 requires lexicographic key ordering — use BTreeMap to guarantee this.
-    let mut map = BTreeMap::new();
-    map.insert("crv", "P-256");
-    map.insert("kty", "EC");
-    map.insert("x", x);
-    map.insert("y", y);
-
-    let canonical_json = serde_json::to_vec(&map)
-        .map_err(|e| FapiError::ThumbprintComputation(format!("JSON serialization: {e}")))?;
-
-    let digest = aws_lc_rs::digest::digest(&aws_lc_rs::digest::SHA256, &canonical_json);
-    Ok(URL_SAFE_NO_PAD.encode(digest.as_ref()))
+fn compute_thumbprint(x: &str, y: &str) -> String {
+    JwkThumbprintKey::Ec { crv: "P-256", x, y }.thumbprint()
 }
 
 #[cfg(test)]
@@ -445,8 +431,8 @@ mod tests {
     fn test_thumbprint_is_deterministic() {
         let key = ClientKey::generate().unwrap();
         let jwk = key.public_jwk().unwrap();
-        let t1 = compute_thumbprint(&jwk.x, &jwk.y).unwrap();
-        let t2 = compute_thumbprint(&jwk.x, &jwk.y).unwrap();
+        let t1 = compute_thumbprint(&jwk.x, &jwk.y);
+        let t2 = compute_thumbprint(&jwk.x, &jwk.y);
         assert_eq!(t1, t2);
     }
 }

--- a/crates/vouch-common/Cargo.toml
+++ b/crates/vouch-common/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
+aws-lc-rs = { workspace = true }
 base64 = { workspace = true, features = ["std"] }
 dirs = { workspace = true }
 hex = { workspace = true, features = ["std"] }

--- a/crates/vouch-common/src/jwk.rs
+++ b/crates/vouch-common/src/jwk.rs
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! RFC 7638 JWK Thumbprint.
+//!
+//! Shared by the server (DPoP proof keys, `cnf.jkt`) and the CLI (its FAPI
+//! client key). The thumbprint is an identity that one party computes and
+//! another compares, so the canonicalization has a single definition here.
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+/// The public key material a thumbprint is computed over.
+///
+/// Each variant carries exactly the members RFC 7638 Section 3.2 lists as
+/// required for that key type. Optional members such as `alg` and `kid` are
+/// not representable and so cannot reach the hash.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JwkThumbprintKey<'a> {
+    /// Elliptic curve public key. Required members: `crv`, `kty`, `x`, `y`.
+    Ec {
+        /// The `crv` member, e.g. `"P-256"`.
+        crv: &'a str,
+        /// The `x` coordinate, base64url.
+        x: &'a str,
+        /// The `y` coordinate, base64url.
+        y: &'a str,
+    },
+    /// RSA public key. Required members: `e`, `kty`, `n`.
+    Rsa {
+        /// The `e` exponent, base64url.
+        e: &'a str,
+        /// The `n` modulus, base64url.
+        n: &'a str,
+    },
+    /// Octet key pair (RFC 8037). Required members: `crv`, `kty`, `x`.
+    Okp {
+        /// The `crv` member, e.g. `"Ed25519"`.
+        crv: &'a str,
+        /// The public key, base64url.
+        x: &'a str,
+    },
+}
+
+impl<'a> JwkThumbprintKey<'a> {
+    /// Read the required members from a JWK, dispatching on `kty`.
+    ///
+    /// Returns `None` when `kty` is unrecognised or a required member is
+    /// absent or not a string.
+    #[must_use]
+    pub fn from_json(jwk: &'a serde_json::Value) -> Option<Self> {
+        let member = |name: &str| jwk.get(name)?.as_str();
+        match jwk.get("kty")?.as_str()? {
+            "EC" => Some(Self::Ec {
+                crv: member("crv")?,
+                x: member("x")?,
+                y: member("y")?,
+            }),
+            "RSA" => Some(Self::Rsa {
+                e: member("e")?,
+                n: member("n")?,
+            }),
+            "OKP" => Some(Self::Okp {
+                crv: member("crv")?,
+                x: member("x")?,
+            }),
+            _ => None,
+        }
+    }
+
+    /// The `kty` value for this key type.
+    fn kty(&self) -> &'static str {
+        match self {
+            Self::Ec { .. } => "EC",
+            Self::Rsa { .. } => "RSA",
+            Self::Okp { .. } => "OKP",
+        }
+    }
+
+    /// Compute the RFC 7638 JWK Thumbprint, base64url-encoded.
+    ///
+    /// SHA-256 is the hash: RFC 9449 Section 6.1 requires it for `jkt`, and
+    /// RFC 7638 Section 3.4 names it the default choice.
+    ///
+    /// RFC 7638 Section 3:
+    ///
+    /// > 1. Construct a JSON object [RFC7159] containing only the required
+    /// >    members of a JWK representing the key and with no whitespace or
+    /// >    line breaks before or after any syntactic elements and with the
+    /// >    required members ordered lexicographically by the Unicode
+    /// >    [UNICODE] code points of the member names.
+    /// > 2. Hash the octets of the UTF-8 representation of this JSON object
+    /// >    with a cryptographic hash function H.
+    ///
+    /// Members are written in lexicographic order per variant. `serde_json`
+    /// escapes the values and emits no whitespace.
+    #[must_use]
+    pub fn thumbprint(&self) -> String {
+        let kty = self.kty();
+        let canonical = match *self {
+            Self::Ec { crv, x, y } => {
+                serde_json::json!({ "crv": crv, "kty": kty, "x": x, "y": y })
+            }
+            Self::Rsa { e, n } => serde_json::json!({ "e": e, "kty": kty, "n": n }),
+            Self::Okp { crv, x } => serde_json::json!({ "crv": crv, "kty": kty, "x": x }),
+        };
+
+        // `serde_json::Map` sorts its keys unless `preserve_order` is enabled,
+        // which it is not, so serialization emits the required order.
+        let bytes = serde_json::to_vec(&canonical).unwrap_or_default();
+        let digest = aws_lc_rs::digest::digest(&aws_lc_rs::digest::SHA256, &bytes);
+        URL_SAFE_NO_PAD.encode(digest.as_ref())
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
+mod tests {
+    use super::*;
+
+    /// The RSA key from RFC 7638 Section 3.1, wrapped for line width.
+    const RFC7638_N: &str = "\
+         0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu\
+         1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-\
+         5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-\
+         65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajr\
+         n1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-\
+         G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw";
+
+    /// RFC 7638 Section 3.1 states the thumbprint of the example key.
+    #[test]
+    fn rfc7638_worked_example() {
+        let key = JwkThumbprintKey::Rsa {
+            e: "AQAB",
+            n: RFC7638_N,
+        };
+        assert_eq!(
+            key.thumbprint(),
+            "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs"
+        );
+    }
+
+    /// RFC 9449 Section 6.1 states the `jkt` for the EC key in its DPoP proof
+    /// examples, covering the EC member set and ordering.
+    #[test]
+    fn rfc9449_ec_key_thumbprint() {
+        let key = JwkThumbprintKey::Ec {
+            crv: "P-256",
+            x: "l8tFrhx-34tV3hRICRDY9zCkDlpBhF42UQUfWVAWBFs",
+            y: "9VE4jf_Ok_o64zbTTlcuNJajHmt6v9TDVrU0CdvGRDA",
+        };
+        assert_eq!(
+            key.thumbprint(),
+            "0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I"
+        );
+    }
+
+    /// Each key type has a distinct required-member set.
+    #[test]
+    fn key_types_produce_distinct_thumbprints() {
+        let ec = JwkThumbprintKey::Ec {
+            crv: "P-256",
+            x: "aaa",
+            y: "bbb",
+        }
+        .thumbprint();
+        let okp = JwkThumbprintKey::Okp {
+            crv: "P-256",
+            x: "aaa",
+        }
+        .thumbprint();
+        let rsa = JwkThumbprintKey::Rsa { e: "aaa", n: "bbb" }.thumbprint();
+
+        assert_ne!(ec, okp);
+        assert_ne!(ec, rsa);
+        assert_ne!(okp, rsa);
+    }
+
+    /// `kty` is determined by the variant, not supplied by the caller.
+    #[test]
+    fn kty_comes_from_the_variant() {
+        assert_eq!(
+            JwkThumbprintKey::Ec {
+                crv: "P-256",
+                x: "",
+                y: ""
+            }
+            .kty(),
+            "EC"
+        );
+        assert_eq!(JwkThumbprintKey::Rsa { e: "", n: "" }.kty(), "RSA");
+        assert_eq!(JwkThumbprintKey::Okp { crv: "", x: "" }.kty(), "OKP");
+    }
+
+    /// A quote inside a member value is escaped rather than interpolated, so
+    /// it cannot reproduce another key's canonical form.
+    #[test]
+    fn values_are_escaped_not_interpolated() {
+        let honest = JwkThumbprintKey::Ec {
+            crv: "P-256",
+            x: "a",
+            y: "b",
+        }
+        .thumbprint();
+        let forged = JwkThumbprintKey::Ec {
+            crv: "P-256",
+            x: r#"a","y":"b"#,
+            y: "b",
+        }
+        .thumbprint();
+        assert_ne!(honest, forged);
+    }
+
+    /// `from_json` reads the members `kty` selects, and nothing else.
+    #[test]
+    fn from_json_reads_the_required_members_per_kty() {
+        let ec = serde_json::json!({
+            "kty": "EC", "crv": "P-256", "x": "xx", "y": "yy",
+            "alg": "ES256", "kid": "ignored"
+        });
+        assert_eq!(
+            JwkThumbprintKey::from_json(&ec),
+            Some(JwkThumbprintKey::Ec {
+                crv: "P-256",
+                x: "xx",
+                y: "yy"
+            })
+        );
+
+        let rsa = serde_json::json!({"kty": "RSA", "e": "AQAB", "n": "nn"});
+        assert_eq!(
+            JwkThumbprintKey::from_json(&rsa),
+            Some(JwkThumbprintKey::Rsa { e: "AQAB", n: "nn" })
+        );
+
+        let okp = serde_json::json!({"kty": "OKP", "crv": "Ed25519", "x": "xx"});
+        assert_eq!(
+            JwkThumbprintKey::from_json(&okp),
+            Some(JwkThumbprintKey::Okp {
+                crv: "Ed25519",
+                x: "xx"
+            })
+        );
+    }
+
+    /// An optional member present in the JWK does not change the thumbprint.
+    #[test]
+    fn optional_members_do_not_affect_the_thumbprint() {
+        let bare = serde_json::json!({"kty": "EC", "crv": "P-256", "x": "xx", "y": "yy"});
+        let adorned = serde_json::json!({
+            "kty": "EC", "crv": "P-256", "x": "xx", "y": "yy",
+            "alg": "ES256", "kid": "k1", "use": "sig"
+        });
+        assert_eq!(
+            JwkThumbprintKey::from_json(&bare).unwrap().thumbprint(),
+            JwkThumbprintKey::from_json(&adorned).unwrap().thumbprint()
+        );
+    }
+
+    /// A missing required member or an unknown `kty` yields `None` rather than
+    /// a thumbprint over empty strings.
+    #[test]
+    fn from_json_rejects_incomplete_and_unknown_keys() {
+        for jwk in [
+            serde_json::json!({"kty": "EC", "crv": "P-256", "x": "xx"}),
+            serde_json::json!({"kty": "RSA", "e": "AQAB"}),
+            serde_json::json!({"kty": "OKP", "crv": "Ed25519"}),
+            serde_json::json!({"kty": "oct", "k": "kk"}),
+            serde_json::json!({"crv": "P-256", "x": "xx", "y": "yy"}),
+            serde_json::json!({"kty": "EC", "crv": 256, "x": "xx", "y": "yy"}),
+        ] {
+            assert_eq!(JwkThumbprintKey::from_json(&jwk), None, "{jwk}");
+        }
+    }
+}

--- a/crates/vouch-common/src/lib.rs
+++ b/crates/vouch-common/src/lib.rs
@@ -13,6 +13,7 @@ pub mod fido2_types;
 pub mod fixtures;
 pub mod fs;
 pub mod http;
+pub mod jwk;
 pub mod paths;
 pub mod posture;
 pub mod protocol;

--- a/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
@@ -209,14 +209,9 @@ async fn acquire_dpop_nonce(
 ///
 /// The canonical form for EC keys is `{"crv":"...","kty":"...","x":"...","y":"..."}`.
 fn compute_jwk_thumbprint(jwk: &serde_json::Value) -> String {
-    let canonical = format!(
-        r#"{{"crv":"{}","kty":"{}","x":"{}","y":"{}"}}"#,
-        jwk["crv"].as_str().unwrap(),
-        jwk["kty"].as_str().unwrap(),
-        jwk["x"].as_str().unwrap(),
-        jwk["y"].as_str().unwrap(),
-    );
-    sha256_base64url(&canonical)
+    vouch_common::jwk::JwkThumbprintKey::from_json(jwk)
+        .expect("test JWK carries the required members")
+        .thumbprint()
 }
 
 /// Create a FAPI 2.0-compliant test OAuth client.

--- a/crates/vouch-server/src/handlers/oidc/tests/helpers.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/helpers.rs
@@ -369,15 +369,9 @@ pub(super) fn generate_dpop_key_pair() -> (EcdsaKeyPair, serde_json::Value) {
 /// Compute the RFC 7638 JWK thumbprint for a DPoP JWK (lexicographic JSON
 /// of the required members: crv, kty, x, y).
 pub(super) fn dpop_jkt(jwk: &serde_json::Value) -> String {
-    let canonical = serde_json::json!({
-        "crv": jwk["crv"],
-        "kty": jwk["kty"],
-        "x": jwk["x"],
-        "y": jwk["y"]
-    });
-    let bytes = serde_json::to_vec(&canonical).expect("serialize JWK");
-    let digest = aws_lc_rs::digest::digest(&SHA256, &bytes);
-    URL_SAFE_NO_PAD.encode(digest.as_ref())
+    vouch_common::jwk::JwkThumbprintKey::from_json(jwk)
+        .expect("test JWK carries the required members")
+        .thumbprint()
 }
 
 /// Create and sign a DPoP proof JWT for the given method and URI.

--- a/crates/vouch-server/src/handlers/session/tests.rs
+++ b/crates/vouch-server/src/handlers/session/tests.rs
@@ -303,20 +303,9 @@ fn generate_dpop_key_pair() -> (aws_lc_rs::signature::EcdsaKeyPair, serde_json::
 /// RFC 7638 JWK thumbprint for a DPoP public JWK (canonical JSON of
 /// crv, kty, x, y → base64url SHA-256).
 fn dpop_jkt(jwk: &serde_json::Value) -> String {
-    use base64::Engine;
-    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-
-    let canonical = serde_json::json!({
-        "crv": jwk.get("crv"),
-        "kty": jwk.get("kty"),
-        "x": jwk.get("x"),
-        "y": jwk.get("y")
-    });
-    let bytes = serde_json::to_vec(&canonical).expect("serialize JWK");
-    URL_SAFE_NO_PAD.encode(aws_lc_rs::digest::digest(
-        &aws_lc_rs::digest::SHA256,
-        &bytes,
-    ))
+    vouch_common::jwk::JwkThumbprintKey::from_json(jwk)
+        .expect("test JWK carries the required members")
+        .thumbprint()
 }
 
 /// Build and sign a DPoP proof JWT (RFC 9449 §4.2) for the given method,

--- a/crates/vouch-server/src/services/oidc/dpop.rs
+++ b/crates/vouch-server/src/services/oidc/dpop.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use subtle::ConstantTimeEq;
 
 use crate::db::{self, JwsAlgorithm, store::DocumentStore};
+use vouch_common::jwk::JwkThumbprintKey;
 
 /// Nonce validity in seconds (5 minutes).
 const NONCE_VALIDITY_SECONDS: i64 = 300;
@@ -98,49 +99,29 @@ pub struct OkpJwk {
 }
 
 impl DpopJwk {
-    /// Compute the JWK thumbprint (RFC 7638).
+    /// Compute the JWK thumbprint (RFC 7638) of this key.
     ///
-    /// The thumbprint is a base64url-encoded SHA-256 hash of the canonical
-    /// JSON representation of the required JWK members.
-    ///
-    /// Uses `BTreeMap` to guarantee lexicographic key ordering per RFC 7638 Section 3.2,
-    /// and `serde_json` for proper escaping of values.
-    ///
-    /// # Errors
-    ///
-    /// Returns `DpopError::InvalidFormat` if canonical JSON serialization fails.
-    pub fn thumbprint(&self) -> Result<String, DpopError> {
-        use std::collections::BTreeMap;
-
-        let mut members = BTreeMap::new();
-        match self {
-            DpopJwk::Ec(ec) => {
-                // RFC 7638 Section 3.2: Required EC members in lexicographic order
-                members.insert("crv", ec.crv.as_str());
-                members.insert("kty", ec.kty.as_str());
-                members.insert("x", ec.x.as_str());
-                members.insert("y", ec.y.as_str());
-            }
-            DpopJwk::Rsa(rsa) => {
-                // RFC 7638 Section 3.2: Required RSA members in lexicographic order
-                members.insert("e", rsa.e.as_str());
-                members.insert("kty", rsa.kty.as_str());
-                members.insert("n", rsa.n.as_str());
-            }
-            DpopJwk::Okp(okp) => {
-                // RFC 7638 Section 3.2: Required OKP members in lexicographic order
-                members.insert("crv", okp.crv.as_str());
-                members.insert("kty", okp.kty.as_str());
-                members.insert("x", okp.x.as_str());
-            }
+    /// `kty` is taken from the variant rather than the declared member;
+    /// `build_decoding_key` rejects a key whose declared `kty` disagrees, and
+    /// runs before any caller reaches this.
+    #[must_use]
+    pub fn thumbprint(&self) -> String {
+        let key = match self {
+            DpopJwk::Ec(ec) => JwkThumbprintKey::Ec {
+                crv: &ec.crv,
+                x: &ec.x,
+                y: &ec.y,
+            },
+            DpopJwk::Rsa(rsa) => JwkThumbprintKey::Rsa {
+                e: &rsa.e,
+                n: &rsa.n,
+            },
+            DpopJwk::Okp(okp) => JwkThumbprintKey::Okp {
+                crv: &okp.crv,
+                x: &okp.x,
+            },
         };
-
-        // BTreeMap iteration is lexicographic, serde_json handles escaping
-        let canonical = serde_json::to_string(&members).map_err(|e| {
-            DpopError::InvalidFormat(format!("JWK thumbprint serialization failed: {e}"))
-        })?;
-        let hash = digest::digest(&SHA256, canonical.as_bytes());
-        Ok(URL_SAFE_NO_PAD.encode(hash.as_ref()))
+        key.thumbprint()
     }
 }
 
@@ -622,7 +603,7 @@ async fn validate_dpop_common(
         }
     }
 
-    let jkt = header.jwk.thumbprint()?;
+    let jkt = header.jwk.thumbprint();
     Ok(ValidatedDpopProof {
         jkt,
         jti: claims.jti,
@@ -719,7 +700,7 @@ mod tests {
             y: "test_y".to_string(),
         });
 
-        let thumbprint = jwk.thumbprint().expect("thumbprint");
+        let thumbprint = jwk.thumbprint();
         assert!(!thumbprint.is_empty());
         // Thumbprint should be base64url encoded SHA-256 (43 chars)
         assert_eq!(thumbprint.len(), 43);

--- a/crates/vouch-server/src/services/oidc/dpop/rfc9449_vectors.rs
+++ b/crates/vouch-server/src/services/oidc/dpop/rfc9449_vectors.rs
@@ -79,7 +79,7 @@ const FIGURE_14_ATH: &str = "fUHyO2r2Z3DZ53EsNrWBb0xWXoaNy59IiKCAqksmQEo";
 fn thumbprint_matches_published_jkt() {
     let jwk: DpopJwk = serde_json::from_str(FIGURE_4_JWK).expect("Figure 4 JWK parses");
     assert_eq!(
-        jwk.thumbprint().expect("thumbprint computes"),
+        jwk.thumbprint(),
         FIGURE_9_JKT,
         "RFC 7638 thumbprint must match the jkt published in RFC 9449 Figure 9"
     );
@@ -112,10 +112,7 @@ fn figure_2_proof_signature_verifies() {
 fn figure_2_embedded_key_has_published_thumbprint() {
     let (header, _) =
         parse_and_verify_dpop_proof(FIGURE_2_PROOF).expect("Figure 2 proof must verify");
-    assert_eq!(
-        header.jwk.thumbprint().expect("thumbprint computes"),
-        FIGURE_9_JKT
-    );
+    assert_eq!(header.jwk.thumbprint(), FIGURE_9_JKT);
 }
 
 /// The protected-resource proof verifies and carries the published `ath`.


### PR DESCRIPTION
Closes #1033.

Five hand-rolled canonicalizations computed the same value:

| spelling | kind |
|---|---|
| `services/oidc/dpop.rs` — `DpopJwk::thumbprint` | production (server) |
| `vouch-cli/src/fapi/key.rs` — `compute_thumbprint` | production (CLI) |
| `handlers/oidc/tests/fapi2.rs` — `compute_jwk_thumbprint` | test |
| `handlers/oidc/tests/helpers.rs` — `dpop_jkt` | test |
| `handlers/session/tests.rs` — `dpop_jkt` | test |

A thumbprint is an identity one party computes and another compares, so a disagreement between any two of them breaks sender-constrained tokens silently.

**A correction to the issue.** It describes "two production implementations plus a third hand-rolled copy in test code" — three. There are **three test copies**, so five spellings. The `session/tests.rs` one is not mentioned anywhere in the issue.

## The shared implementation

`vouch_common::jwk`, placed there because `vouch-server` and `vouch-cli` both use it.

`JwkThumbprintKey` carries exactly the members RFC 7638 §3.2 requires per key type, so an optional member such as `alg` or `kid` is not representable and cannot reach the hash — the failure mode a hand-built JSON object invites.

Two constructors, following review feedback on this PR's first draft:

- `from_json(&serde_json::Value)` — reads the required members, dispatching on `kty`. Three of the five call sites hold a `Value`, and each was repeating the extraction. Returns `None` when `kty` is unknown or a member is missing, rather than hashing empty strings.
- struct literals, for the two sites that already hold typed components.

`thumbprint()` is an inherent method rather than a free function taking the key.

## Production changes

Both production implementations become delegations and lose their `Result` — neither failure mode survived. `serde_json::to_vec` over a fixed-shape object cannot fail, and the CLI's `FapiError::ThumbprintComputation` remains in use for coordinate extraction.

`kty` now comes from the variant rather than the JWK's declared member. This is equivalent on every reachable path: `build_decoding_key` rejects a key whose declared `kty` disagrees with its shape (`ec.kty != "EC"` and so on) and runs before any caller reaches the thumbprint.

## Vectors

Two published values, both quoted from copies in `specs/` whose sha256 I checked against `specs/manifest.tsv` before quoting:

- RFC 7638 §3.1 worked example → `NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs`. I extracted the modulus from the spec text programmatically after a hand transcription of it failed the test.
- RFC 9449 §6.1 published `jkt` → `0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I`.

These matter more than usual here. The duplicate implementations were accidentally cross-checking each other — during #1041 I found that injecting a canonicalization defect into the server's copy was caught by three handler tests, because two test helpers hand-rolled their own. Consolidating removes that. The vectors are the replacement, and they are anchored to published values rather than to a second guess at the spec. #1052 landing first is what made this safe to do.

Plus coverage for the member-set rules: optional members do not change the thumbprint, each key type produces a distinct one, `kty` is not caller-supplied, an embedded quote is escaped rather than interpolated, and incomplete or unknown-`kty` JWKs yield `None`.

`make fmt`, `make lint`, `make test`, `make test-integration`, and `prek run` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)