### PR TITLE
refactor(fido2): make attestation evidence unforgeable and type the origin policy

### DIFF
--- a/crates/vouch-server/src/config.rs
+++ b/crates/vouch-server/src/config.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Server configuration.
 
+use crate::crypto::webauthn_verify::OriginPolicy;
 use anyhow::{Context, Result};
 use aws_config::FrameworkMetadata;
 use clap::{ArgAction, CommandFactory, Parser, parser::ValueSource};
@@ -1289,6 +1290,20 @@ impl ServerConfig {
         }
 
         Ok(())
+    }
+}
+
+impl From<&ServerConfig> for OriginPolicy {
+    /// A TLS-configured server is a real deployment, where an origin mismatch
+    /// is always an error. Without TLS the server is a local development
+    /// instance reached over loopback, where the browser's origin may differ
+    /// from the configured one by host spelling or port.
+    fn from(config: &ServerConfig) -> Self {
+        if config.tls_configured() {
+            Self::Strict
+        } else {
+            Self::AllowLoopbackVariations
+        }
     }
 }
 

--- a/crates/vouch-server/src/crypto/attestation_chain.rs
+++ b/crates/vouch-server/src/crypto/attestation_chain.rs
@@ -64,11 +64,31 @@ pub enum AttestationChainError {
     UnsupportedAlgorithm(String),
 }
 
-/// Successful result of attestation chain validation.
-#[derive(Debug, Clone)]
-pub struct AttestationChainResult {
+/// Evidence that an attestation certificate chain was validated.
+///
+/// Returned only by [`validate_attestation_chain`], and its field is private,
+/// so a value of this type cannot be produced without having run the
+/// validation. Callers therefore record attestation status as
+/// `Option<AttestationProof>` and derive the stored boolean with `is_some`,
+/// rather than carrying a boolean anyone can set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttestationProof {
     /// AAGUID extracted from the leaf certificate's FIDO extension.
-    pub cert_aaguid: Option<String>,
+    cert_aaguid: Option<String>,
+}
+
+impl AttestationProof {
+    /// The AAGUID from the leaf certificate's FIDO extension, if present.
+    #[must_use]
+    pub fn cert_aaguid(&self) -> Option<&str> {
+        self.cert_aaguid.as_deref()
+    }
+
+    /// Consume the proof, yielding the certificate AAGUID.
+    #[must_use]
+    pub fn into_cert_aaguid(self) -> Option<String> {
+        self.cert_aaguid
+    }
 }
 
 // ============================================================================
@@ -89,7 +109,7 @@ pub struct AttestationChainResult {
 pub fn validate_attestation_chain(
     x5c_certs: &[Vec<u8>],
     auth_data_aaguid: Option<&str>,
-) -> Result<AttestationChainResult, AttestationChainError> {
+) -> Result<AttestationProof, AttestationChainError> {
     if x5c_certs.is_empty() {
         return Err(AttestationChainError::EmptyChain);
     }
@@ -163,7 +183,7 @@ pub fn validate_attestation_chain(
         });
     }
 
-    Ok(AttestationChainResult { cert_aaguid })
+    Ok(AttestationProof { cert_aaguid })
 }
 
 // ============================================================================

--- a/crates/vouch-server/src/crypto/webauthn_verify.rs
+++ b/crates/vouch-server/src/crypto/webauthn_verify.rs
@@ -28,6 +28,7 @@ use aws_lc_rs::digest::{self, SHA256};
 use aws_lc_rs::signature::{self, UnparsedPublicKey};
 use der::Decode;
 
+use super::attestation_chain::AttestationProof;
 use super::{cose, oid};
 use thiserror::Error;
 use vouch_common::protocol;
@@ -423,8 +424,11 @@ pub struct RegistrationVerificationResult {
     pub aaguid: Option<String>,
     /// The counter value from registration (usually 0).
     pub counter: u32,
-    /// Whether the attestation was cryptographically verified via x5c chain.
-    pub attestation_verified: bool,
+    /// The verified attestation chain, when one was validated.
+    ///
+    /// `Some` is only obtainable from `validate_attestation_chain`, so its
+    /// presence is itself the evidence that a chain was checked.
+    pub attestation: Option<AttestationProof>,
 }
 
 /// Parameters for WebAuthn registration (attestation) verification
@@ -612,7 +616,7 @@ pub fn verify_registration_with_verifier<V: CoseVerifier>(
     )?;
 
     // 4. Verify attestation statement based on format
-    let mut attestation_verified = false;
+    let mut attestation = None;
 
     match fmt.as_str() {
         "none" => {
@@ -630,11 +634,11 @@ pub fn verify_registration_with_verifier<V: CoseVerifier>(
                     verifier,
                 )?;
                 if let Some(result) = packed_result {
-                    attestation_verified = result.attestation_verified;
                     // If the chain provided a cert AAGUID, prefer it
                     if aaguid.is_none() {
-                        aaguid = result.cert_aaguid;
+                        aaguid = result.cert_aaguid().map(str::to_owned);
                     }
+                    attestation = Some(result);
                 }
             }
             // No attStmt with packed format is invalid, but we're lenient
@@ -652,17 +656,8 @@ pub fn verify_registration_with_verifier<V: CoseVerifier>(
         public_key_cose: cose_key_bytes,
         aaguid,
         counter,
-        attestation_verified,
+        attestation,
     })
-}
-
-/// Result of packed attestation verification with x5c chain.
-#[derive(Debug)]
-pub struct PackedAttestationResult {
-    /// Whether the attestation chain was cryptographically verified.
-    pub attestation_verified: bool,
-    /// AAGUID extracted from the x5c leaf certificate.
-    pub cert_aaguid: Option<String>,
 }
 
 /// Verify a packed attestation statement.
@@ -683,7 +678,7 @@ fn verify_packed_attestation<V: CoseVerifier>(
     cose_key_bytes: &[u8],
     auth_data_aaguid: Option<&str>,
     verifier: &V,
-) -> Result<Option<PackedAttestationResult>, VerifyError> {
+) -> Result<Option<AttestationProof>, VerifyError> {
     // Extract x5c certificate chain if present
     let x5c_certs = extract_x5c_certs(stmt_map);
 
@@ -713,14 +708,11 @@ fn verify_packed_attestation<V: CoseVerifier>(
 
         tracing::info!(
             attestation_verified = true,
-            cert_aaguid = ?chain_result.cert_aaguid,
+            cert_aaguid = ?chain_result.cert_aaguid(),
             "x5c attestation chain validated"
         );
 
-        return Ok(Some(PackedAttestationResult {
-            attestation_verified: true,
-            cert_aaguid: chain_result.cert_aaguid,
-        }));
+        return Ok(Some(chain_result));
     }
 
     // Self-attestation: extract sig from attStmt

--- a/crates/vouch-server/src/crypto/webauthn_verify.rs
+++ b/crates/vouch-server/src/crypto/webauthn_verify.rs
@@ -124,6 +124,29 @@ impl CoseVerifier for TestCoseVerifier {
     }
 }
 
+/// Whether loopback origin variations are tolerated when comparing the
+/// client-data origin against the expected one.
+///
+/// Lives here because the crypto layer consumes it and may not import
+/// `ServerConfig`; the conversion from configuration is in `config.rs`, which
+/// is a composition root rather than a layer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OriginPolicy {
+    /// An origin mismatch is always rejected.
+    Strict,
+    /// Tolerate loopback variations (`localhost` vs `127.0.0.1`, port
+    /// differences). Development only.
+    AllowLoopbackVariations,
+}
+
+impl OriginPolicy {
+    /// Whether loopback variations are tolerated.
+    #[must_use]
+    pub fn allows_loopback_variation(self) -> bool {
+        matches!(self, Self::AllowLoopbackVariations)
+    }
+}
+
 /// Errors during WebAuthn assertion verification.
 #[derive(Debug, Error)]
 pub enum VerifyError {
@@ -209,9 +232,8 @@ pub struct AssertionParams<'a> {
     pub stored_counter: u32,
     /// Whether to require the UV flag.
     pub require_user_verification: bool,
-    /// Whether to tolerate loopback origin variations. Development only; pass
-    /// `false` in production so an origin mismatch is always rejected.
-    pub allow_localhost_origin: bool,
+    /// Whether loopback origin variations are tolerated.
+    pub origin_policy: OriginPolicy,
 }
 
 /// Verify a WebAuthn assertion using the default COSE verifier.
@@ -235,7 +257,7 @@ pub fn verify_assertion_with_verifier<V: CoseVerifier>(
 
 /// Verify the client-data origin for both assertion and registration flows.
 ///
-/// `allow_localhost_origin` gates the loopback origin-variation relaxation
+/// `origin_policy` gates the loopback origin-variation relaxation
 /// (e.g. `localhost` ↔ `127.0.0.1`): it must be `true` only in development
 /// (no TLS). Production threads `false` so an origin mismatch is always
 /// rejected even on a misconfigured loopback `rp_id`.
@@ -246,7 +268,7 @@ pub fn verify_assertion_with_verifier<V: CoseVerifier>(
 fn verify_origin(
     presented_origin: &str,
     expected_origin: &str,
-    allow_localhost_origin: bool,
+    origin_policy: OriginPolicy,
     flow: &str,
 ) -> Result<(), VerifyError> {
     if presented_origin == expected_origin {
@@ -262,7 +284,7 @@ fn verify_origin(
         .and_then(|u| u.host_str().map(String::from))
         .is_some_and(|h| vouch_common::is_loopback_host(&h));
 
-    if allow_localhost_origin && expected_is_local && origin_is_local {
+    if origin_policy.allows_loopback_variation() && expected_is_local && origin_is_local {
         tracing::warn!(
             target: "security",
             flow,
@@ -279,7 +301,7 @@ fn verify_origin(
 
 /// Core WebAuthn assertion verification.
 ///
-/// `params.allow_localhost_origin` gates the loopback origin-variation
+/// `params.origin_policy` gates the loopback origin-variation
 /// relaxation: it must be `true` only in development (no TLS). Production
 /// threads `false` so an origin mismatch is always rejected even on a
 /// misconfigured loopback `rp_id`.
@@ -297,7 +319,7 @@ fn verify_assertion_inner<V: CoseVerifier>(
         expected_origin,
         stored_counter,
         require_user_verification,
-        allow_localhost_origin,
+        origin_policy,
     } = params;
 
     // 1. Verify authenticator data structure
@@ -390,7 +412,7 @@ fn verify_assertion_inner<V: CoseVerifier>(
     verify_origin(
         &client_data.origin,
         expected_origin,
-        allow_localhost_origin,
+        origin_policy,
         "assertion",
     )?;
 
@@ -450,9 +472,8 @@ pub struct RegistrationParams<'a> {
     pub expected_origin: &'a str,
     /// Whether to require the UV flag.
     pub require_user_verification: bool,
-    /// Whether to tolerate loopback origin variations. Development only; pass
-    /// `false` in production so an origin mismatch is always rejected.
-    pub allow_localhost_origin: bool,
+    /// Whether loopback origin variations are tolerated.
+    pub origin_policy: OriginPolicy,
 }
 
 /// Verify a WebAuthn registration (attestation) response.
@@ -485,7 +506,7 @@ pub fn verify_registration_with_verifier<V: CoseVerifier>(
         expected_challenge,
         expected_origin,
         require_user_verification,
-        allow_localhost_origin,
+        origin_policy,
     } = params;
 
     // 1. Parse attestation_object CBOR
@@ -611,7 +632,7 @@ pub fn verify_registration_with_verifier<V: CoseVerifier>(
     verify_origin(
         &client_data.origin,
         expected_origin,
-        allow_localhost_origin,
+        origin_policy,
         "registration",
     )?;
 

--- a/crates/vouch-server/src/crypto/webauthn_verify/tests.rs
+++ b/crates/vouch-server/src/crypto/webauthn_verify/tests.rs
@@ -383,7 +383,7 @@ fn test_auth_data_minimum_length() {
             expected_origin: "https://example.com",
             stored_counter: 0,
             require_user_verification: false,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &verifier,
     );
@@ -410,7 +410,7 @@ fn test_auth_data_exactly_minimum_length() {
             expected_origin: "https://example.com",
             stored_counter: 0,
             require_user_verification: false,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &verifier,
     );
@@ -436,7 +436,7 @@ fn test_auth_data_rp_id_mismatch() {
             expected_origin: "https://example.com",
             stored_counter: 0,
             require_user_verification: false,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &verifier,
     );
@@ -463,7 +463,7 @@ fn test_auth_data_user_presence_required() {
             expected_origin: "https://example.com",
             stored_counter: 0,
             require_user_verification: false,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &verifier,
     );
@@ -490,7 +490,7 @@ fn test_auth_data_user_verification_required() {
             expected_origin: "https://example.com",
             stored_counter: 0,
             require_user_verification: true, // Require UV
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &verifier,
     );
@@ -517,7 +517,7 @@ fn test_auth_data_user_verification_not_required() {
             expected_origin: "https://example.com",
             stored_counter: 0,
             require_user_verification: false, // Don't require UV
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &verifier,
     );
@@ -549,7 +549,7 @@ fn test_counter_must_increase() {
             expected_origin: "https://example.com",
             stored_counter: 4, // stored counter
             require_user_verification: false,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &verifier,
     );
@@ -578,7 +578,7 @@ fn test_counter_exact_match_rejected() {
             expected_origin: "https://example.com",
             stored_counter: 5, // Same as auth_data counter
             require_user_verification: false,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &verifier,
     );
@@ -606,7 +606,7 @@ fn test_counter_decrease_rejected() {
             expected_origin: "https://example.com",
             stored_counter: 5, // stored counter is higher
             require_user_verification: false,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &verifier,
     );
@@ -635,7 +635,7 @@ fn test_counter_zero_special_case() {
             expected_origin: "https://example.com",
             stored_counter: 0, // stored counter also 0
             require_user_verification: false,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &verifier,
     );
@@ -663,7 +663,7 @@ fn test_counter_zero_to_nonzero() {
             expected_origin: "https://example.com",
             stored_counter: 0, // Initial stored counter
             require_user_verification: false,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &verifier,
     );
@@ -691,7 +691,7 @@ fn test_counter_u32_max_boundary() {
             expected_origin: "https://example.com",
             stored_counter: u32::MAX - 1, // stored counter just below max
             require_user_verification: false,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &verifier,
     );
@@ -723,7 +723,7 @@ fn test_counter_regression_to_zero_rejected() {
             expected_origin: "https://example.com",
             stored_counter: 5, // stored counter was nonzero
             require_user_verification: false,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &verifier,
     );
@@ -756,7 +756,7 @@ fn test_localhost_origin_relaxation_allowed_when_enabled() {
             expected_origin: "http://localhost:8080",
             stored_counter: 0,
             require_user_verification: false,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &verifier,
     );
@@ -786,7 +786,7 @@ fn test_localhost_origin_relaxation_rejected_when_disabled() {
             expected_origin: "http://localhost:8080",
             stored_counter: 0,
             require_user_verification: false,
-            allow_localhost_origin: false,
+            origin_policy: OriginPolicy::Strict,
         },
         &verifier,
     );
@@ -816,7 +816,7 @@ fn test_client_data_invalid_json() {
             expected_origin: "https://example.com",
             stored_counter: 0,
             require_user_verification: false,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &verifier,
     );
@@ -844,7 +844,7 @@ fn test_client_data_wrong_type() {
             expected_origin: "https://example.com",
             stored_counter: 0,
             require_user_verification: false,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &verifier,
     );
@@ -873,7 +873,7 @@ fn test_client_data_challenge_mismatch() {
             expected_origin: "https://example.com",
             stored_counter: 0,
             require_user_verification: false,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &verifier,
     );
@@ -899,7 +899,7 @@ fn test_client_data_origin_mismatch() {
             expected_origin: "https://example.com",
             stored_counter: 0,
             require_user_verification: false,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &verifier,
     );
@@ -927,7 +927,7 @@ fn test_client_data_localhost_variations_allowed() {
             expected_origin: "https://localhost:8080",
             stored_counter: 0,
             require_user_verification: false,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &verifier,
     );
@@ -955,7 +955,7 @@ fn test_client_data_docker_internal_to_localhost_allowed() {
             expected_origin: "http://host.docker.internal:3000",
             stored_counter: 0,
             require_user_verification: false,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &verifier,
     );
@@ -982,7 +982,7 @@ fn test_client_data_ipv6_loopback_to_localhost_allowed() {
             expected_origin: "http://localhost:3000",
             stored_counter: 0,
             require_user_verification: false,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &verifier,
     );
@@ -1010,7 +1010,7 @@ fn test_client_data_loopback_vs_remote_rejected() {
             expected_origin: "https://example.com",
             stored_counter: 0,
             require_user_verification: false,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &verifier,
     );
@@ -1037,7 +1037,7 @@ fn test_client_data_remote_vs_loopback_rejected() {
             expected_origin: "http://localhost:3000",
             stored_counter: 0,
             require_user_verification: false,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &verifier,
     );
@@ -1070,7 +1070,7 @@ fn test_client_data_localhost_in_path_not_matched() {
             expected_origin: "http://localhost:3000",
             stored_counter: 0,
             require_user_verification: false,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &verifier,
     );
@@ -1101,7 +1101,7 @@ fn test_verify_assertion_success() {
             expected_origin: "https://example.com",
             stored_counter: 0,
             require_user_verification: false,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &verifier,
     );
@@ -1132,7 +1132,7 @@ fn test_verify_assertion_signature_invalid() {
             expected_origin: "https://example.com",
             stored_counter: 0,
             require_user_verification: false,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &verifier,
     );
@@ -1185,7 +1185,7 @@ fn test_verify_registration_empty_cose_key_returns_invalid_cose_key() {
             expected_challenge: challenge,
             expected_origin: origin,
             require_user_verification: true,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &TestCoseVerifier::always_succeed(),
     )
@@ -1215,7 +1215,7 @@ fn test_verify_registration_truncated_attested_data_returns_invalid_auth_data_le
             expected_challenge: challenge,
             expected_origin: origin,
             require_user_verification: true,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &TestCoseVerifier::always_succeed(),
     )
@@ -1246,7 +1246,7 @@ fn test_registration_localhost_origin_relaxation_allowed_when_enabled() {
             expected_challenge: challenge,
             expected_origin: "http://localhost:8080",
             require_user_verification: true,
-            allow_localhost_origin: true,
+            origin_policy: OriginPolicy::AllowLoopbackVariations,
         },
         &TestCoseVerifier::always_succeed(),
     );
@@ -1273,7 +1273,7 @@ fn test_registration_localhost_origin_relaxation_rejected_when_disabled() {
             expected_challenge: challenge,
             expected_origin: "http://localhost:8080",
             require_user_verification: true,
-            allow_localhost_origin: false,
+            origin_policy: OriginPolicy::Strict,
         },
         &TestCoseVerifier::always_succeed(),
     );

--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -686,7 +686,7 @@ pub(crate) async fn browser_login_complete(
         challenge: auth_state.challenge.clone(),
         stored_counter,
         // Tolerate loopback origin variations only in development (no TLS).
-        allow_localhost_origin: !state.config().tls_configured(),
+        origin_policy: state.config().as_ref().into(),
     })
     .await
     .map_err(|e| {

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -1530,8 +1530,8 @@ pub(crate) async fn browser_register_complete(
             &x5c_certs,
             validated.aaguid.as_deref(),
         ) {
-            Ok(_chain_result) => {
-                validated.attestation_verified = true;
+            Ok(chain_result) => {
+                validated.attestation = Some(chain_result);
                 tracing::info!(
                     attestation_verified = true,
                     "Browser enrollment: x5c chain validated"
@@ -1573,7 +1573,7 @@ pub(crate) async fn browser_register_complete(
             public_key: &public_key_cbor,
             aaguid: validated.aaguid.as_deref(),
             user_handle: Some(&user_handle),
-            attestation_verified: validated.attestation_verified,
+            attestation_verified: validated.attestation.is_some(),
         },
     )
     .await?;

--- a/crates/vouch-server/src/handlers/keys.rs
+++ b/crates/vouch-server/src/handlers/keys.rs
@@ -280,8 +280,8 @@ pub(crate) async fn register_complete(
     )?;
 
     // Propagate x5c chain results from webauthn_verify into validated
-    if verified.attestation_verified {
-        validated.attestation_verified = true;
+    if verified.attestation.is_some() {
+        validated.attestation = verified.attestation;
     }
 
     // Use server-verified AAGUID if available, fall back to client-provided
@@ -304,7 +304,7 @@ pub(crate) async fn register_complete(
             public_key: &verified_public_key,
             aaguid: aaguid.as_deref(),
             user_handle: Some(&user_handle),
-            attestation_verified: validated.attestation_verified,
+            attestation_verified: validated.attestation.is_some(),
         },
     )
     .await?;

--- a/crates/vouch-server/src/handlers/keys.rs
+++ b/crates/vouch-server/src/handlers/keys.rs
@@ -242,7 +242,7 @@ pub(crate) async fn register_complete(
         require_user_verification: true,
         // Loopback origin relaxation is development-only: disabled as soon
         // as TLS is configured, matching assertion verification.
-        allow_localhost_origin: !config.tls_configured(),
+        origin_policy: config.as_ref().into(),
     })
     .map_err(|e| {
         tracing::warn!("Registration attestation verification failed: {e}");

--- a/crates/vouch-server/src/handlers/registration.rs
+++ b/crates/vouch-server/src/handlers/registration.rs
@@ -12,7 +12,7 @@ pub(crate) struct ValidatedAttestation {
     /// The device name determined from the AAGUID.
     pub device_name: String,
     /// Whether the attestation was cryptographically verified via x5c chain.
-    pub attestation_verified: bool,
+    pub attestation: Option<crate::crypto::attestation_chain::AttestationProof>,
 }
 
 /// Validate a WebAuthn registration attestation.
@@ -120,7 +120,7 @@ pub(crate) fn validate_registration_attestation(
     Ok(ValidatedAttestation {
         aaguid,
         device_name,
-        attestation_verified: false,
+        attestation: None,
     })
 }
 
@@ -239,7 +239,7 @@ mod tests {
             validate_registration_attestation(&att, &vouch_common::AaguidPolicy::Any, false);
         let validated = result.expect("should succeed");
         assert!(validated.aaguid.is_some());
-        assert!(!validated.attestation_verified);
+        assert!(validated.attestation.is_none());
     }
 
     #[test]

--- a/crates/vouch-server/src/infra/ssrf.rs
+++ b/crates/vouch-server/src/infra/ssrf.rs
@@ -88,7 +88,7 @@ pub(crate) fn is_non_global(ip: &IpAddr) -> bool {
 /// `allow_loopback` permits loopback destinations (`127.0.0.0/8`, `::1`,
 /// `localhost`) for local development and testing — wired from
 /// `!ServerConfig::tls_configured()`, matching the WebAuthn
-/// `allow_localhost_origin` relaxation. It only relaxes **loopback**: private,
+/// `OriginPolicy` loopback relaxation. It only relaxes **loopback**: private,
 /// link-local, CGNAT and other internal ranges (e.g. the `169.254.169.254`
 /// cloud metadata endpoint) stay blocked even in development.
 ///

--- a/crates/vouch-server/src/services/auth.rs
+++ b/crates/vouch-server/src/services/auth.rs
@@ -18,7 +18,7 @@
 use crate::AppState;
 use crate::crypto::hash_token;
 use crate::crypto::keys::OidcSigningKey;
-use crate::crypto::webauthn_verify;
+use crate::crypto::webauthn_verify::{self, OriginPolicy};
 use crate::db::{self, Authenticator, SessionPurpose, User};
 use crate::services::oidc::{CnfClaim, ScopeSet, ValidatedDpopProof};
 use base64::Engine;
@@ -222,7 +222,7 @@ pub(crate) struct LoginAssertionParams {
     /// Whether to tolerate loopback origin variations (development only).
     /// Set to `false` whenever TLS is configured so a production deployment
     /// never weakens origin binding, even with a loopback `rp_id`.
-    pub allow_localhost_origin: bool,
+    pub origin_policy: OriginPolicy,
 }
 
 /// Result of WebAuthn assertion verification.
@@ -261,7 +261,7 @@ pub(crate) async fn verify_login_assertion(
             expected_origin: &params.expected_origin,
             stored_counter: params.stored_counter,
             require_user_verification: true,
-            allow_localhost_origin: params.allow_localhost_origin,
+            origin_policy: params.origin_policy,
         })
         .map_err(|e| {
             ServiceError::oauth(
@@ -1308,7 +1308,7 @@ mod tests {
             challenge,
             stored_counter: 0,
             // Exact-match origins here; relaxation is irrelevant to this test.
-            allow_localhost_origin: false,
+            origin_policy: OriginPolicy::Strict,
         };
 
         let err = verify_login_assertion(params)

--- a/crates/vouch-server/src/services/oidc/fido2_grant.rs
+++ b/crates/vouch-server/src/services/oidc/fido2_grant.rs
@@ -247,7 +247,7 @@ pub(crate) async fn exchange_fido2_assertion(
         challenge: challenge_state.challenge.as_bytes().to_vec(),
         stored_counter,
         // Tolerate loopback origin variations only in development (no TLS).
-        allow_localhost_origin: !state.config().tls_configured(),
+        origin_policy: state.config().as_ref().into(),
     })
     .await
     .map_err(|e| {

--- a/crates/vouch-server/src/services/oidc/jar.rs
+++ b/crates/vouch-server/src/services/oidc/jar.rs
@@ -375,7 +375,7 @@ pub async fn validate_request_object(
     };
 
     // Loopback JWKS destinations are permitted only in local development
-    // (no TLS configured), matching the WebAuthn `allow_localhost_origin`
+    // (no TLS configured), matching the WebAuthn `OriginPolicy`
     // relaxation; private/link-local targets stay blocked.
     let allow_loopback = !state.config().tls_configured();
 

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
@@ -344,7 +344,7 @@ async fn resolve_client_decoding_key(
     };
 
     // Loopback JWKS destinations are permitted only in local development
-    // (no TLS configured), matching the WebAuthn `allow_localhost_origin`
+    // (no TLS configured), matching the WebAuthn `OriginPolicy`
     // relaxation; private/link-local targets stay blocked.
     let allow_loopback = !state.config().tls_configured();
 

--- a/crates/vouch-tests/tests/integration.rs
+++ b/crates/vouch-tests/tests/integration.rs
@@ -2619,7 +2619,8 @@ mod encoding_verification {
                 expected_origin: "https://test.local",
                 stored_counter: 0,
                 require_user_verification: true,
-                allow_localhost_origin: true,
+                origin_policy:
+                    vouch_server::crypto::webauthn_verify::OriginPolicy::AllowLoopbackVariations,
             },
             &verifier,
         );


### PR DESCRIPTION
Closes #1034. Items 3 and 4, the last two; items 1, 2, 5, 6 and 7 landed in #1053 and #1054.

Two commits, reviewable independently. No behaviour change in either.

## Item 3 — a verified chain becomes unforgeable

`attestation_verified` was a plain `bool` carried through the crypto layer, the registration handlers and the stored authenticator document. Any caller could set it, so "this chain was verified" was only as good as whichever code path happened to write it.

The fix turned out smaller than the issue proposes. `AttestationChainResult` **already** encoded the fact — it is returned solely by `validate_attestation_chain`, and only on success — but its `cert_aaguid` field was `pub`, so the struct could be built by anyone and its presence proved nothing. Making that field private is sufficient; no parallel evidence enum is needed. The type is renamed `AttestationProof`, matching the `ClientAuthProof` / `GrantProof` / `TokenIssuanceProof` vocabulary already in the crate.

In-memory the field is now `Option<AttestationProof>`; the persisted boolean is derived with `is_some` at the two database boundaries.

`PackedAttestationResult` is deleted. It existed only for the chain-verified case, where it carried `attestation_verified: true` unconditionally alongside the AAGUID that `AttestationProof` already holds, so `verify_packed_attestation` returns the proof directly.

**`None` is the ordinary case, not a failure.** `fmt="none"` never reaches this code — `validate_registration_attestation` rejects software passkeys and platform authenticators by format before storage. `fido-u2f` and packed self-attestation are accepted without a chain unless `require_attestation_cert` is set, which is a deliberate default: enterprise YubiKeys ship per-deployment AAGUIDs, so an allowlist is not workable.

## Item 4 — origin policy instead of a bool

`allow_localhost_origin: bool` was threaded through the assertion and registration paths, and all three production call sites spelled the same derivation, `!config.tls_configured()`. A fourth site passing a bare `true` would have compiled and silently disabled origin checking.

`OriginPolicy` (`Strict` / `AllowLoopbackVariations`) is derived once via `From<&ServerConfig>`, so the rule relating TLS configuration to origin strictness exists in one place.

**A note on the shape.** The issue proposes a type "constructible only from `&ServerConfig`". That is not available: `arch_boundaries` enforces `crypto -> (no other layer)`, so a type living where it is consumed cannot name `ServerConfig`. The enum therefore sits in `crypto/webauthn_verify.rs` next to its consumer, and the conversion sits in `config.rs`, which that same test documents as a composition root and explicitly does not scan.

`make fmt`, `make lint`, `make test`, `make test-integration`, and `prek run` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)