### PR TITLE
refactor: guard advertised-vs-enforced drift and type the httpsig identifiers

### DIFF
--- a/crates/vouch-cli/src/fapi/httpsig.rs
+++ b/crates/vouch-cli/src/fapi/httpsig.rs
@@ -61,8 +61,8 @@ impl ClientKeySigner {
 }
 
 impl SigningAlgorithm for ClientKeySigner {
-    fn algorithm_id(&self) -> &str {
-        "ecdsa-p256-sha256"
+    fn algorithm(&self) -> vouch_httpsig::algorithm::SignatureAlgorithm {
+        vouch_httpsig::algorithm::SignatureAlgorithm::EcdsaP256Sha256
     }
 
     fn key_id(&self) -> &str {

--- a/crates/vouch-httpsig/src/algorithm/ecdsa_p256.rs
+++ b/crates/vouch-httpsig/src/algorithm/ecdsa_p256.rs
@@ -70,8 +70,8 @@ impl std::fmt::Debug for EcdsaP256Signer {
 }
 
 impl SigningAlgorithm for EcdsaP256Signer {
-    fn algorithm_id(&self) -> &str {
-        "ecdsa-p256-sha256"
+    fn algorithm(&self) -> super::SignatureAlgorithm {
+        super::SignatureAlgorithm::EcdsaP256Sha256
     }
 
     fn key_id(&self) -> &str {
@@ -105,8 +105,8 @@ impl EcdsaP256Verifier {
 }
 
 impl VerifyingAlgorithm for EcdsaP256Verifier {
-    fn algorithm_id(&self) -> &str {
-        "ecdsa-p256-sha256"
+    fn algorithm(&self) -> super::SignatureAlgorithm {
+        super::SignatureAlgorithm::EcdsaP256Sha256
     }
 
     fn verify(&self, base: &[u8], signature: &[u8]) -> Result<(), HttpSigError> {
@@ -147,10 +147,10 @@ mod tests {
     }
 
     #[test]
-    fn test_algorithm_id() {
+    fn test_algorithm_identifier() {
         let signer = EcdsaP256Signer::generate("k1").unwrap();
-        assert_eq!(signer.algorithm_id(), "ecdsa-p256-sha256");
-        assert_eq!(signer.verifier().algorithm_id(), "ecdsa-p256-sha256");
+        assert_eq!(signer.algorithm().as_str(), "ecdsa-p256-sha256");
+        assert_eq!(signer.verifier().algorithm().as_str(), "ecdsa-p256-sha256");
     }
 
     #[test]

--- a/crates/vouch-httpsig/src/algorithm/ed25519.rs
+++ b/crates/vouch-httpsig/src/algorithm/ed25519.rs
@@ -61,8 +61,8 @@ impl std::fmt::Debug for Ed25519Signer {
 }
 
 impl SigningAlgorithm for Ed25519Signer {
-    fn algorithm_id(&self) -> &str {
-        "ed25519"
+    fn algorithm(&self) -> super::SignatureAlgorithm {
+        super::SignatureAlgorithm::Ed25519
     }
 
     fn key_id(&self) -> &str {
@@ -92,8 +92,8 @@ impl Ed25519Verifier {
 }
 
 impl VerifyingAlgorithm for Ed25519Verifier {
-    fn algorithm_id(&self) -> &str {
-        "ed25519"
+    fn algorithm(&self) -> super::SignatureAlgorithm {
+        super::SignatureAlgorithm::Ed25519
     }
 
     fn verify(&self, base: &[u8], sig: &[u8]) -> Result<(), HttpSigError> {
@@ -143,10 +143,10 @@ mod tests {
     }
 
     #[test]
-    fn test_algorithm_id() {
+    fn test_algorithm_identifier() {
         let signer = Ed25519Signer::generate("k").unwrap();
-        assert_eq!(signer.algorithm_id(), "ed25519");
-        assert_eq!(signer.verifier().algorithm_id(), "ed25519");
+        assert_eq!(signer.algorithm().as_str(), "ed25519");
+        assert_eq!(signer.verifier().algorithm().as_str(), "ed25519");
     }
 
     #[test]

--- a/crates/vouch-httpsig/src/algorithm/hmac_sha256.rs
+++ b/crates/vouch-httpsig/src/algorithm/hmac_sha256.rs
@@ -35,8 +35,8 @@ impl std::fmt::Debug for HmacSha256Key {
 }
 
 impl SigningAlgorithm for HmacSha256Key {
-    fn algorithm_id(&self) -> &str {
-        "hmac-sha256"
+    fn algorithm(&self) -> super::SignatureAlgorithm {
+        super::SignatureAlgorithm::HmacSha256
     }
 
     fn key_id(&self) -> &str {
@@ -50,8 +50,8 @@ impl SigningAlgorithm for HmacSha256Key {
 }
 
 impl VerifyingAlgorithm for HmacSha256Key {
-    fn algorithm_id(&self) -> &str {
-        "hmac-sha256"
+    fn algorithm(&self) -> super::SignatureAlgorithm {
+        super::SignatureAlgorithm::HmacSha256
     }
 
     fn verify(&self, base: &[u8], signature: &[u8]) -> Result<(), HttpSigError> {
@@ -116,9 +116,9 @@ mod tests {
     }
 
     #[test]
-    fn test_algorithm_id() {
+    fn test_algorithm_identifier() {
         let key = HmacSha256Key::new(b"s", "k");
-        assert_eq!(SigningAlgorithm::algorithm_id(&key), "hmac-sha256");
-        assert_eq!(VerifyingAlgorithm::algorithm_id(&key), "hmac-sha256");
+        assert_eq!(SigningAlgorithm::algorithm(&key).as_str(), "hmac-sha256");
+        assert_eq!(VerifyingAlgorithm::algorithm(&key).as_str(), "hmac-sha256");
     }
 }

--- a/crates/vouch-httpsig/src/algorithm/mod.rs
+++ b/crates/vouch-httpsig/src/algorithm/mod.rs
@@ -8,9 +8,43 @@ pub mod hmac_sha256;
 use crate::error::HttpSigError;
 
 /// Trait for algorithms that can sign a signature base.
+/// RFC 9421 signature algorithm identifiers.
+///
+/// The wire value is a bare string compared by equality, so a typo in a new
+/// implementation would compile and simply never match. Naming the set means
+/// both the signer and the verifier return a value from it, and the
+/// `Accept-Signature` advertisement spells the same bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignatureAlgorithm {
+    /// `ecdsa-p256-sha256` — RFC 9421 Section 3.3.4. DER-encoded signatures.
+    EcdsaP256Sha256,
+    /// `ed25519` — RFC 9421 Section 3.3.6. Raw 64-byte signatures.
+    Ed25519,
+    /// `hmac-sha256` — RFC 9421 Section 3.3.3.
+    HmacSha256,
+}
+
+impl SignatureAlgorithm {
+    /// The identifier as it appears in a `Signature-Input` `alg` parameter.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::EcdsaP256Sha256 => "ecdsa-p256-sha256",
+            Self::Ed25519 => "ed25519",
+            Self::HmacSha256 => "hmac-sha256",
+        }
+    }
+}
+
+impl std::fmt::Display for SignatureAlgorithm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 pub trait SigningAlgorithm: Send + Sync {
-    /// The RFC 9421 algorithm identifier (e.g., `"ecdsa-p256-sha256"`).
-    fn algorithm_id(&self) -> &str;
+    /// The RFC 9421 algorithm identifier.
+    fn algorithm(&self) -> SignatureAlgorithm;
 
     /// The key identifier for the `keyid` signature parameter.
     fn key_id(&self) -> &str;
@@ -25,8 +59,8 @@ pub trait SigningAlgorithm: Send + Sync {
 
 /// Trait for algorithms that can verify a signature against a base.
 pub trait VerifyingAlgorithm: Send + Sync {
-    /// The RFC 9421 algorithm identifier (e.g., `"ecdsa-p256-sha256"`).
-    fn algorithm_id(&self) -> &str;
+    /// The RFC 9421 algorithm identifier.
+    fn algorithm(&self) -> SignatureAlgorithm;
 
     /// Verify that `signature` is valid for the given `base` bytes.
     ///

--- a/crates/vouch-httpsig/src/component.rs
+++ b/crates/vouch-httpsig/src/component.rs
@@ -68,6 +68,24 @@ pub enum ComponentIdentifier {
 }
 
 impl ComponentIdentifier {
+    /// The bare component name, without parameters.
+    #[must_use]
+    pub fn name(&self) -> String {
+        match self {
+            Self::Field { name, .. } => name.clone(),
+            Self::Derived { component, .. } => derived_component_name(component),
+        }
+    }
+
+    /// Whether this covered component satisfies a requirement for `required`.
+    ///
+    /// Compares by name: a requirement for `@path` is met by the signature's
+    /// `@path` regardless of the parameters either carries.
+    #[must_use]
+    pub fn covers(&self, required: &Self) -> bool {
+        self.name() == required.name()
+    }
+
     /// Create a derived `@method` component.
     #[must_use]
     pub fn method() -> Self {

--- a/crates/vouch-httpsig/src/digest.rs
+++ b/crates/vouch-httpsig/src/digest.rs
@@ -22,11 +22,28 @@ pub enum DigestAlgorithm {
 }
 
 impl DigestAlgorithm {
+    /// Every algorithm this crate accepts, paired with its RFC 9530 name.
+    ///
+    /// Both directions read this table, so adding a variant cannot leave the
+    /// parse side stale — the compiler rejects a missing match arm in
+    /// `algorithm_name`, and `from_name` iterates the table rather than
+    /// repeating it.
+    const NAMED: &'static [(Self, &'static str)] =
+        &[(Self::Sha256, "sha-256"), (Self::Sha512, "sha-512")];
+
     fn algorithm_name(self) -> &'static str {
         match self {
             Self::Sha256 => "sha-256",
             Self::Sha512 => "sha-512",
         }
+    }
+
+    /// Resolve an RFC 9530 algorithm name, or `None` when unrecognised.
+    fn from_name(name: &str) -> Option<Self> {
+        Self::NAMED
+            .iter()
+            .find(|(_, known)| *known == name)
+            .map(|(algorithm, _)| *algorithm)
     }
 
     fn digest_algorithm(self) -> &'static digest::Algorithm {
@@ -81,10 +98,8 @@ pub fn verify_content_digest(header_value: &str, body: &[u8]) -> Result<(), Http
     let mut found_recognized = false;
 
     for (algo_name, member) in &dict.entries {
-        let algorithm = match algo_name.as_str() {
-            "sha-256" => DigestAlgorithm::Sha256,
-            "sha-512" => DigestAlgorithm::Sha512,
-            _ => continue,
+        let Some(algorithm) = DigestAlgorithm::from_name(algo_name.as_str()) else {
+            continue;
         };
 
         let expected = match member {

--- a/crates/vouch-httpsig/src/middleware.rs
+++ b/crates/vouch-httpsig/src/middleware.rs
@@ -43,12 +43,14 @@ use crate::error::HttpSigError;
 use crate::sig_policy::requires_signature;
 use crate::signature_params::SignatureParams;
 use crate::verify::{DigestEnforced, extract_signature_labels, verify_request_signature};
+use std::sync::LazyLock;
 
 /// Minimum components a signature must cover for the middleware to accept it.
 ///
 /// Ensures signatures protect the request method and target, preventing
 /// replay attacks where an attacker moves a signature to a different endpoint.
-const REQUIRED_COVERAGE: &[&str] = &["@method", "@path"];
+static REQUIRED_COVERAGE: LazyLock<[ComponentIdentifier; 2]> =
+    LazyLock::new(|| [ComponentIdentifier::method(), ComponentIdentifier::path()]);
 
 /// Maximum signed request body buffered for Content-Digest verification.
 ///
@@ -94,7 +96,11 @@ fn build_accept_signature(has_body: bool) -> Option<http::HeaderValue> {
     // Components-only params: no created/keyid so serialize() emits no trailing `;`.
     let params = SignatureParams {
         components,
-        alg: Some("ecdsa-p256-sha256".to_string()),
+        alg: Some(
+            crate::algorithm::SignatureAlgorithm::EcdsaP256Sha256
+                .as_str()
+                .to_string(),
+        ),
         keyid: None,
         created: None,
         expires: None,
@@ -386,7 +392,7 @@ pub async fn require_signature<R: KeyResolver>(
         Ok(verified) => {
             // Reject signatures that don't cover minimum required components;
             // advertise the expected set so the client can fix and retry.
-            let covered = match verified.require_coverage(REQUIRED_COVERAGE) {
+            let covered = match verified.require_coverage(&*REQUIRED_COVERAGE) {
                 Ok(covered) => covered,
                 Err(e) => {
                     tracing::debug!(

--- a/crates/vouch-httpsig/src/sign.rs
+++ b/crates/vouch-httpsig/src/sign.rs
@@ -194,7 +194,7 @@ impl SignatureBuilder {
     fn build_params(&self, signer: &dyn SigningAlgorithm) -> SignatureParams {
         SignatureParams {
             components: self.components.clone(),
-            alg: Some(signer.algorithm_id().to_string()),
+            alg: Some(signer.algorithm().as_str().to_string()),
             keyid: Some(signer.key_id().to_string()),
             created: self.created,
             expires: self.expires,

--- a/crates/vouch-httpsig/src/verify.rs
+++ b/crates/vouch-httpsig/src/verify.rs
@@ -2,6 +2,7 @@
 //! RFC 9421 signature verification.
 
 use crate::algorithm::VerifyingAlgorithm;
+use crate::component::ComponentIdentifier;
 use crate::error::HttpSigError;
 use crate::sfv::parse::parse_dictionary;
 use crate::sfv::serialize::serialize_inner_list_to_string;
@@ -66,7 +67,10 @@ impl CryptoVerified {
     ///
     /// Returns [`HttpSigError::InvalidSignature`] when a required component is
     /// not among the signature's covered components.
-    pub fn require_coverage(self, required: &[&str]) -> Result<CoverageChecked, HttpSigError> {
+    pub fn require_coverage(
+        self,
+        required: &[ComponentIdentifier],
+    ) -> Result<CoverageChecked, HttpSigError> {
         validate_coverage(&self.params, required)?;
         Ok(CoverageChecked {
             params: self.params,
@@ -114,8 +118,11 @@ impl CoverageChecked {
             });
         }
 
-        validate_coverage(&self.params, &["content-digest"])
-            .map_err(|_| HttpSigError::MissingDigest)?;
+        validate_coverage(
+            &self.params,
+            &[ComponentIdentifier::field("content-digest")],
+        )
+        .map_err(|_| HttpSigError::MissingDigest)?;
 
         let header = headers
             .get("content-digest")
@@ -174,21 +181,16 @@ impl DigestEnforced {
 ///
 /// Returns [`HttpSigError::InvalidSignature`] if any required component is missing
 /// from the signature's covered components.
-fn validate_coverage(params: &SignatureParams, required: &[&str]) -> Result<(), HttpSigError> {
-    for req_name in required {
-        let found = params.components.iter().any(|c| {
-            // Extract the bare component name without parameters
-            let name = match c {
-                crate::component::ComponentIdentifier::Field { name, .. } => name.clone(),
-                crate::component::ComponentIdentifier::Derived { component, .. } => {
-                    crate::component::derived_component_name(component)
-                }
-            };
-            name == *req_name
-        });
+fn validate_coverage(
+    params: &SignatureParams,
+    required: &[ComponentIdentifier],
+) -> Result<(), HttpSigError> {
+    for req in required {
+        let found = params.components.iter().any(|c| c.covers(req));
         if !found {
             return Err(HttpSigError::InvalidSignature(format!(
-                "signature does not cover required component: {req_name}"
+                "signature does not cover required component: {}",
+                req.name()
             )));
         }
     }
@@ -300,11 +302,11 @@ fn validate_algorithm(
     verifier: &dyn VerifyingAlgorithm,
 ) -> Result<(), HttpSigError> {
     if let Some(alg) = &params.alg
-        && alg != verifier.algorithm_id()
+        && alg != verifier.algorithm().as_str()
     {
         return Err(HttpSigError::UnsupportedAlgorithm(format!(
             "signature claims alg=\"{alg}\", but verifier implements \"{}\"",
-            verifier.algorithm_id()
+            verifier.algorithm()
         )));
     }
     Ok(())
@@ -587,7 +589,14 @@ mod tests {
             nonce: None,
             tag: None,
         };
-        validate_coverage(&params, &["@method", "@authority"]).unwrap();
+        validate_coverage(
+            &params,
+            &[
+                ComponentIdentifier::method(),
+                ComponentIdentifier::authority(),
+            ],
+        )
+        .unwrap();
     }
 
     #[test]
@@ -601,7 +610,13 @@ mod tests {
             nonce: None,
             tag: None,
         };
-        let result = validate_coverage(&params, &["@method", "@authority"]);
+        let result = validate_coverage(
+            &params,
+            &[
+                ComponentIdentifier::method(),
+                ComponentIdentifier::authority(),
+            ],
+        );
         assert!(result.is_err());
     }
 

--- a/crates/vouch-server/src/handlers/scim/discovery.rs
+++ b/crates/vouch-server/src/handlers/scim/discovery.rs
@@ -8,6 +8,7 @@ use super::types::{
     ScimAttribute, ScimAuthScheme, ScimBulkConfig, ScimFilterConfig, ScimListResponse,
     ScimResourceType, ScimSchema, ScimServiceProviderConfig, ScimSupported,
 };
+use super::urn;
 use crate::AppState;
 
 /// GET /scim/v2/ServiceProviderConfig (RFC 7644 Section 4).
@@ -20,7 +21,7 @@ pub(crate) async fn service_provider_config(
     let base_url = &state.config().base_url;
 
     Json(ScimServiceProviderConfig {
-        schemas: vec!["urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig".to_string()],
+        schemas: vec![urn::SERVICE_PROVIDER_CONFIG.to_string()],
         documentation_uri: format!("{base_url}/docs/scim"),
         patch: ScimSupported { supported: true },
         bulk: ScimBulkConfig {
@@ -49,7 +50,7 @@ pub(crate) async fn service_provider_config(
 /// Returns the schema definitions for supported resource types (RFC 7643 Section 7).
 pub(crate) async fn schemas() -> impl IntoResponse {
     let user_schema = ScimSchema {
-        id: "urn:ietf:params:scim:schemas:core:2.0:User".to_string(),
+        id: urn::USER.to_string(),
         name: "User".to_string(),
         description: "User Account".to_string(),
         attributes: vec![
@@ -97,7 +98,7 @@ pub(crate) async fn schemas() -> impl IntoResponse {
     };
 
     let group_schema = ScimSchema {
-        id: "urn:ietf:params:scim:schemas:core:2.0:Group".to_string(),
+        id: urn::GROUP.to_string(),
         name: "Group".to_string(),
         description: "Group".to_string(),
         attributes: vec![
@@ -125,9 +126,9 @@ pub(crate) async fn schemas() -> impl IntoResponse {
     };
 
     Json(ScimListResponse {
-        schemas: vec!["urn:ietf:params:scim:api:messages:2.0:ListResponse".to_string()],
-        total_results: 2,
-        items_per_page: 2,
+        schemas: vec![urn::LIST_RESPONSE.to_string()],
+        total_results: urn::RESOURCE_SCHEMAS.len(),
+        items_per_page: urn::RESOURCE_SCHEMAS.len(),
         start_index: 1,
         resources: vec![user_schema, group_schema],
     })
@@ -140,27 +141,25 @@ pub(crate) async fn resource_types(State(state): State<Arc<AppState>>) -> impl I
     let base_url = &state.config().base_url;
 
     Json(ScimListResponse {
-        schemas: vec!["urn:ietf:params:scim:api:messages:2.0:ListResponse".to_string()],
+        schemas: vec![urn::LIST_RESPONSE.to_string()],
         total_results: 2,
         items_per_page: 2,
         start_index: 1,
-        resources: vec![
-            ScimResourceType {
-                schemas: vec!["urn:ietf:params:scim:schemas:core:2.0:ResourceType".to_string()],
-                id: "User".to_string(),
-                name: "User".to_string(),
-                endpoint: format!("{base_url}/scim/v2/Users"),
-                description: "User Account".to_string(),
-                schema: "urn:ietf:params:scim:schemas:core:2.0:User".to_string(),
-            },
-            ScimResourceType {
-                schemas: vec!["urn:ietf:params:scim:schemas:core:2.0:ResourceType".to_string()],
-                id: "Group".to_string(),
-                name: "Group".to_string(),
-                endpoint: format!("{base_url}/scim/v2/Groups"),
-                description: "Group".to_string(),
-                schema: "urn:ietf:params:scim:schemas:core:2.0:Group".to_string(),
-            },
-        ],
+        // Derived from `urn::RESOURCE_SCHEMAS` so an advertised resource type
+        // and the schema its handler emits cannot be edited apart.
+        resources: urn::RESOURCE_SCHEMAS
+            .iter()
+            .map(|(schema, endpoint)| {
+                let name = endpoint.trim_start_matches('/').trim_end_matches('s');
+                ScimResourceType {
+                    schemas: vec![urn::RESOURCE_TYPE.to_string()],
+                    id: name.to_string(),
+                    name: name.to_string(),
+                    endpoint: format!("{base_url}/scim/v2{endpoint}"),
+                    description: name.to_string(),
+                    schema: (*schema).to_string(),
+                }
+            })
+            .collect(),
     })
 }

--- a/crates/vouch-server/src/handlers/scim/groups.rs
+++ b/crates/vouch-server/src/handlers/scim/groups.rs
@@ -15,6 +15,7 @@ use super::types::{
     ScimError, ScimGroup, ScimGroupMember, ScimListQuery, ScimListResponse, ScimMeta, ScimPatchOp,
     ScimPatchOpType, ScimPatchRequest,
 };
+use super::urn;
 use crate::AppState;
 use crate::db;
 use crate::db::{ScimFilterError, ScimScope};
@@ -113,7 +114,7 @@ pub(crate) async fn list_groups(
     }
 
     Json(ScimListResponse {
-        schemas: vec!["urn:ietf:params:scim:api:messages:2.0:ListResponse".to_string()],
+        schemas: vec![urn::LIST_RESPONSE.to_string()],
         total_results: total,
         items_per_page: resources.len(),
         start_index,
@@ -714,7 +715,7 @@ pub(crate) fn db_group_to_scim(
     members: Vec<ScimGroupMember>,
 ) -> ScimGroup {
     ScimGroup {
-        schemas: vec!["urn:ietf:params:scim:schemas:core:2.0:Group".to_string()],
+        schemas: vec![urn::GROUP.to_string()],
         id: Some(group.id.clone()),
         external_id: group.external_id,
         display_name: group.display_name,

--- a/crates/vouch-server/src/handlers/scim/mod.rs
+++ b/crates/vouch-server/src/handlers/scim/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod discovery;
 pub(crate) mod groups;
 pub(crate) mod patch;
 pub(crate) mod types;
+pub(crate) mod urn;
 pub(crate) mod users;
 
 use aws_lc_rs::digest::{self, SHA256};

--- a/crates/vouch-server/src/handlers/scim/tests/protocol.rs
+++ b/crates/vouch-server/src/handlers/scim/tests/protocol.rs
@@ -427,3 +427,98 @@ async fn member_op_error_unique_string_still_maps_to_500() {
         "no uniqueness scimType for infrastructure errors: {body}"
     );
 }
+
+// =========================================================================
+// Advertised-vs-emitted schema guard
+// =========================================================================
+
+/// A resource the handlers actually emit must carry a schema that
+/// `/ResourceTypes` advertises.
+///
+/// Creating a real user and reading back its `schemas` is the point: an
+/// assertion that compares discovery output against the constant discovery
+/// is derived from would agree with itself no matter what either side said.
+#[tokio::test]
+async fn emitted_user_schema_is_advertised_by_resource_types() {
+    let (app, state) = test_app().await;
+    let token = create_test_scim_token(&state.store, "advertised-vs-emitted", "test-org").await;
+
+    let (status, body) = http_post_json(
+        &app,
+        "/scim/v2/Users",
+        r#"{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"], "userName": "drift@test-org.example.com", "active": true}"#,
+        &[("Authorization", &format!("Bearer {token}"))],
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{body}");
+    let user: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+
+    let emitted: Vec<&str> = user["schemas"]
+        .as_array()
+        .expect("created user carries a schemas array")
+        .iter()
+        .filter_map(serde_json::Value::as_str)
+        .collect();
+
+    let (status, body) = http_get(&app, "/scim/v2/ResourceTypes", &[]).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let types: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let advertised: Vec<&str> = types["Resources"]
+        .as_array()
+        .expect("Resources array")
+        .iter()
+        .filter_map(|r| r["schema"].as_str())
+        .collect();
+
+    for schema in &emitted {
+        assert!(
+            advertised.contains(schema),
+            "the User handler emits {schema}, which /ResourceTypes does not \
+             advertise; advertised: {advertised:?}"
+        );
+    }
+}
+
+/// Each advertised resource type's endpoint must be a live route, so a
+/// resource cannot be advertised without somewhere to serve it.
+#[tokio::test]
+async fn advertised_resource_type_endpoints_are_routed() {
+    let (app, _state) = test_app().await;
+
+    // Unauthenticated: a 401 proves the route exists just as well as a 200,
+    // and avoids minting a token to answer a routing question.
+    for (_, endpoint) in crate::handlers::scim::urn::RESOURCE_SCHEMAS {
+        let path = format!("/scim/v2{endpoint}");
+        let (status, _) = http_get(&app, &path, &[]).await;
+        assert_ne!(
+            status,
+            StatusCode::NOT_FOUND,
+            "advertised resource endpoint {path} is not routed"
+        );
+    }
+}
+
+/// A resource the handlers emit must appear in `/Schemas` as well, so the two
+/// discovery endpoints cannot disagree with each other.
+#[tokio::test]
+async fn schemas_endpoint_lists_every_emitted_resource_schema() {
+    let (app, _state) = test_app().await;
+
+    let (status, body) = http_get(&app, "/scim/v2/Schemas", &[]).await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let listed: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+
+    let ids: Vec<&str> = listed["Resources"]
+        .as_array()
+        .expect("Resources array")
+        .iter()
+        .filter_map(|r| r["id"].as_str())
+        .collect();
+
+    for (schema, _) in crate::handlers::scim::urn::RESOURCE_SCHEMAS {
+        assert!(
+            ids.contains(schema),
+            "/Schemas does not list {schema}, which the handlers emit; listed: {ids:?}"
+        );
+    }
+}

--- a/crates/vouch-server/src/handlers/scim/types.rs
+++ b/crates/vouch-server/src/handlers/scim/types.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! SCIM 2.0 types (RFC 7643).
 
+use super::urn;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
@@ -17,7 +18,7 @@ pub(crate) struct ScimError {
 impl ScimError {
     pub(crate) fn new(status: u16, detail: impl Into<String>) -> Self {
         Self {
-            schemas: vec!["urn:ietf:params:scim:api:messages:2.0:Error".to_string()],
+            schemas: vec![urn::ERROR.to_string()],
             status: status.to_string(),
             scim_type: None,
             detail: detail.into(),

--- a/crates/vouch-server/src/handlers/scim/urn.rs
+++ b/crates/vouch-server/src/handlers/scim/urn.rs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! SCIM 2.0 schema URNs.
+//!
+//! Discovery advertises these (`/scim/v2/Schemas`, `/ResourceTypes`,
+//! `/ServiceProviderConfig`) and the user and group handlers emit them on
+//! every resource. Both sides read the constants below, so an advertised URN
+//! and an emitted one cannot drift apart by editing only one of them.
+
+/// `urn:ietf:params:scim:schemas:core:2.0:User` — RFC 7643 Section 4.1.
+pub(crate) const USER: &str = "urn:ietf:params:scim:schemas:core:2.0:User";
+
+/// `urn:ietf:params:scim:schemas:core:2.0:Group` — RFC 7643 Section 4.2.
+pub(crate) const GROUP: &str = "urn:ietf:params:scim:schemas:core:2.0:Group";
+
+/// `urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig` — RFC 7643
+/// Section 5.
+pub(crate) const SERVICE_PROVIDER_CONFIG: &str =
+    "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig";
+
+/// `urn:ietf:params:scim:schemas:core:2.0:ResourceType` — RFC 7643 Section 6.
+pub(crate) const RESOURCE_TYPE: &str = "urn:ietf:params:scim:schemas:core:2.0:ResourceType";
+
+/// `urn:ietf:params:scim:api:messages:2.0:ListResponse` — RFC 7644
+/// Section 3.4.2.
+pub(crate) const LIST_RESPONSE: &str = "urn:ietf:params:scim:api:messages:2.0:ListResponse";
+
+/// `urn:ietf:params:scim:api:messages:2.0:Error` — RFC 7644 Section 3.12.
+pub(crate) const ERROR: &str = "urn:ietf:params:scim:api:messages:2.0:Error";
+
+/// The resource schemas this server serves, paired with the endpoint that
+/// serves each.
+///
+/// Discovery derives `/ResourceTypes` from this table, and the guard in
+/// `tests::protocol` checks the handlers emit the same set, so adding a
+/// resource requires touching one place rather than three.
+pub(crate) const RESOURCE_SCHEMAS: &[(&str, &str)] = &[(USER, "/Users"), (GROUP, "/Groups")];

--- a/crates/vouch-server/src/handlers/scim/users.rs
+++ b/crates/vouch-server/src/handlers/scim/users.rs
@@ -15,6 +15,7 @@ use super::types::{
     ScimEmail, ScimError, ScimListQuery, ScimListResponse, ScimMeta, ScimName, ScimPatchRequest,
     ScimUser,
 };
+use super::urn;
 use crate::AppState;
 use crate::db;
 use crate::db::{ScimFilterError, ScimScope};
@@ -109,7 +110,7 @@ pub(crate) async fn list_users(
     }
 
     Json(ScimListResponse {
-        schemas: vec!["urn:ietf:params:scim:api:messages:2.0:ListResponse".to_string()],
+        schemas: vec![urn::LIST_RESPONSE.to_string()],
         total_results: total,
         items_per_page: resources.len(),
         start_index,
@@ -645,7 +646,7 @@ pub(crate) async fn delete_user(
 /// Convert database user to SCIM user.
 pub(crate) fn db_user_to_scim(base_url: &str, user: db::ScimUserRecord) -> ScimUser {
     ScimUser {
-        schemas: vec!["urn:ietf:params:scim:schemas:core:2.0:User".to_string()],
+        schemas: vec![urn::USER.to_string()],
         id: Some(user.id.clone()),
         external_id: user.external_id,
         user_name: user.email.clone(),

--- a/crates/vouch-tests/tests/sig_policy.rs
+++ b/crates/vouch-tests/tests/sig_policy.rs
@@ -573,3 +573,69 @@ fn walk_for_literal(dir: &std::path::Path, needle: &str, found: &mut Vec<String>
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// PUBLIC_V1_PATHS <-> registered routes
+// ---------------------------------------------------------------------------
+//
+// `test_router_v1_literals_all_in_route_table` above covers one direction:
+// every `/v1` route in router.rs is accounted for in `V1_ROUTES`, which
+// `test_signature_policy_per_route` checks against `requires_signature`.
+//
+// The other direction was unguarded. `PUBLIC_V1_PATHS` exempts paths from
+// signature enforcement, and nothing tied its entries back to real routes:
+// a renamed route silently loses its exemption and starts demanding
+// signatures, while an entry for a route that was removed, or never existed,
+// exempts nothing and gives no signal at all.
+
+/// Replace `{param}` segments with a placeholder so a route template can be
+/// requested as a concrete path.
+fn concrete_path(template: &str) -> String {
+    template
+        .split('/')
+        .map(|segment| {
+            if segment.starts_with('{') && segment.ends_with('}') {
+                "1"
+            } else {
+                segment
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// Probe whether `path` is routed, using a method no route declares.
+///
+/// Axum answers 405 when the path matches a route whose method set excludes
+/// the request, and 404 when no route matches at all. Reading route existence
+/// this way keeps the result independent of whatever a handler would return.
+async fn route_is_registered(harness: &TestHarness, path: &str) -> bool {
+    let (status, _, _) = unsigned_request(harness, "TRACE", path, "").await;
+    status != StatusCode::NOT_FOUND
+}
+
+#[tokio::test]
+async fn test_public_v1_paths_all_resolve_to_registered_routes() {
+    let harness = TestHarness::new().await;
+
+    for template in vouch_httpsig::sig_policy::PUBLIC_V1_PATHS {
+        let path = concrete_path(template);
+        assert!(
+            route_is_registered(&harness, &path).await,
+            "PUBLIC_V1_PATHS entry {template} does not resolve to a registered \
+             route (requested as {path}); it exempts nothing from signature \
+             enforcement"
+        );
+    }
+}
+
+/// The probe must be able to fail, or the test above asserts nothing.
+#[tokio::test]
+async fn test_route_existence_probe_reports_absent_routes() {
+    let harness = TestHarness::new().await;
+
+    assert!(
+        !route_is_registered(&harness, "/v1/credentials/ssh/definitely-absent").await,
+        "an unregistered path must be distinguishable from a registered one"
+    );
+}


### PR DESCRIPTION
Closes #1040
Closes #1042 
Closes #1039

Three commits, reviewable independently. The first two are the same problem twice; the third finishes the `vouch-httpsig` typing.

## #1040 — `PUBLIC_V1_PATHS` entries name real routes

`crates/vouch-tests/tests/sig_policy.rs` already guarded one direction: every `/v1` literal in `router.rs` must appear in `V1_ROUTES`, which is checked against `requires_signature`. The other direction was unguarded — nothing tied `PUBLIC_V1_PATHS` entries back to registered routes. A renamed route silently loses its exemption and starts demanding signatures; an entry for a route that was removed, or never existed, exempts nothing and gives no signal.

Route existence is probed with a method no route declares. Axum answers **405** when the path matches a route whose method set excludes the request and **404** when nothing matches, so the result is independent of whatever a handler would return. A companion test drives the probe against an absent path so it cannot silently stop discriminating.

Compile-time linkage is not reachable here — axum builds the route table at runtime — so this is the behavioural fallback the issue calls for.

## #1042 — SCIM advertised vs emitted

Discovery advertised schema URNs and the handlers emitted them, with each URN spelled inline at **fourteen sites across five files**. Nothing related the two sides.

Both now read `scim::urn`, and `/ResourceTypes` is derived from `RESOURCE_SCHEMAS` rather than listing User and Group by hand.

Three tests cover what single-sourcing cannot:

1. Creates a user through the API and checks the schema it comes back with is one `/ResourceTypes` advertises.
2. Checks every advertised endpoint is routed.
3. Checks `/Schemas` lists every schema the handlers emit.

**The first test was wrong in its first draft**, and mutation testing caught it: it compared `/ResourceTypes` output against the constant `/ResourceTypes` is derived from, so it agreed with itself and passed even with a phantom resource injected. It now exercises a real created resource. Mutation-verified in both directions — emitting an unadvertised schema fails the first test, a phantom `RESOURCE_SCHEMAS` entry fails the other two.

## #1039 — three stringly-typed identifiers

- `algorithm_id() -> &str` becomes `algorithm() -> SignatureAlgorithm`. A typo'd identifier in a new implementation previously compiled and simply never matched. `as_str` is now the single spelling, used by both traits, the verifier's algorithm check, and the `Accept-Signature` advertisement, which had repeated the literal.
- `require_coverage` / `validate_coverage` take `&[ComponentIdentifier]` instead of `&[&str]`. The middleware held its required set as strings and `validate_coverage` converted each covered `ComponentIdentifier` back to a string to compare — the enum existed and was discarded at the comparison. `ComponentIdentifier::covers` now compares structurally.
- `DigestAlgorithm` had a forward variant-to-name map and a reverse map with a wildcard arm, so adding a variant compiled with the parse side stale. Both directions read one `NAMED` table.

This got easier after #1038: `validate_coverage` is private now, so the signature change touches no public API.

## Notes

I first put #1040's tests in `router.rs`, where the negative control's `/v1` literal tripped the existing source scan in `sig_policy.rs` — a useful failure, since the tests belong beside their siblings. They live in `sig_policy.rs` now.

`ENTERPRISE_USER` was dropped from `scim::urn` before commit: nothing consumes it. The only appearance of that URN is a `patch.rs` test fixture asserting an unclaimed *attribute path* is ignored, which wants a literal.

`make fmt`, `make lint`, `make test`, `make test-integration`, and `prek run` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)