### PR TITLE
refactor(oidc): type the RFC 8693 token pairs and browser WebAuthn wire fields

### DIFF
--- a/crates/vouch-common/src/api.rs
+++ b/crates/vouch-common/src/api.rs
@@ -5,8 +5,11 @@ use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::encoding::Raw;
-use crate::fido2_types::{AttestationObject, Challenge, ClientDataJson, CoseKey, CredentialId};
+use crate::encoding::{Base64Url, Raw};
+use crate::fido2_types::{
+    AttestationObject, AuthData, Challenge, ClientDataJson, CoseKey, CredentialId, Signature,
+    UserHandle,
+};
 
 // ============================================================================
 // Registration
@@ -252,16 +255,20 @@ impl OAuthError {
 // ============================================================================
 
 /// Response containing `WebAuthn` options for browser registration.
+///
+/// The binary fields carry [`Base64Url`], the encoding the browser
+/// `credentials.create()` API expects, so they serialize as base64url strings
+/// without the handler encoding them by hand.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BrowserRegisterStartResponse {
-    /// Random challenge bytes (base64url encoded for browser).
-    pub challenge: String,
+    /// Random challenge bytes.
+    pub challenge: Challenge<Base64Url>,
     /// Relying Party ID.
     pub rp_id: String,
     /// Relying Party name.
     pub rp_name: String,
-    /// User ID (base64url encoded).
-    pub user_id: String,
+    /// User ID, sent as the `WebAuthn` user handle.
+    pub user_id: UserHandle<Base64Url>,
     /// User's email address.
     pub user_email: String,
     /// User's display name.
@@ -270,23 +277,27 @@ pub struct BrowserRegisterStartResponse {
     pub algorithms: Vec<i32>,
     /// Registration state token.
     pub state: String,
-    /// Credential IDs to exclude (base64url encoded).
+    /// Credential IDs to exclude.
     /// Used to prevent duplicate registrations of the same key.
     #[serde(default)]
-    pub exclude_credential_ids: Vec<String>,
+    pub exclude_credential_ids: Vec<CredentialId<Base64Url>>,
 }
 
 /// Request to complete browser-based `WebAuthn` registration.
+///
+/// The binary fields decode during deserialization, so a malformed base64url
+/// value is rejected at the request boundary rather than partway through the
+/// handler.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BrowserRegisterCompleteRequest {
     /// Registration state token.
     pub state: String,
-    /// Credential ID (base64url encoded).
-    pub credential_id: String,
-    /// Attestation object (base64url encoded).
-    pub attestation_object: String,
-    /// Client data JSON (base64url encoded).
-    pub client_data_json: String,
+    /// Credential ID from the authenticator.
+    pub credential_id: CredentialId<Base64Url>,
+    /// Attestation object from the authenticator.
+    pub attestation_object: AttestationObject<Base64Url>,
+    /// Client data JSON, as built by the browser.
+    pub client_data_json: ClientDataJson<Base64Url>,
 }
 
 // ============================================================================
@@ -308,8 +319,8 @@ pub struct BrowserLoginStartRequest {
 /// Uses discoverable credentials (passkeys) so the authenticator identifies the user.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BrowserLoginStartResponse {
-    /// Random challenge bytes (base64url encoded for browser).
-    pub challenge: String,
+    /// Random challenge bytes.
+    pub challenge: Challenge<Base64Url>,
     /// Relying Party ID.
     pub rp_id: String,
     /// Authentication state token.
@@ -321,20 +332,24 @@ pub struct BrowserLoginStartResponse {
 }
 
 /// Request to complete browser-based `WebAuthn` login.
+///
+/// The binary fields decode during deserialization, so a malformed base64url
+/// value is rejected at the request boundary rather than partway through the
+/// handler.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BrowserLoginCompleteRequest {
     /// Authentication state token from start response.
     pub state: String,
-    /// Credential ID (base64url encoded).
-    pub credential_id: String,
-    /// Authenticator data (base64url encoded).
-    pub authenticator_data: String,
-    /// Client data JSON (base64url encoded).
-    pub client_data_json: String,
-    /// Signature (base64url encoded).
-    pub signature: String,
-    /// User handle (base64url encoded) - identifies the user from discoverable credential.
-    pub user_handle: String,
+    /// Credential ID from the authenticator.
+    pub credential_id: CredentialId<Base64Url>,
+    /// Authenticator data from the assertion.
+    pub authenticator_data: AuthData<Base64Url>,
+    /// Client data JSON, as built by the browser.
+    pub client_data_json: ClientDataJson<Base64Url>,
+    /// Assertion signature.
+    pub signature: Signature<Base64Url>,
+    /// User handle - identifies the user from the discoverable credential.
+    pub user_handle: UserHandle<Base64Url>,
     /// Pending OAuth authorization ID (to resume OAuth flow after login).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pending_auth: Option<String>,

--- a/crates/vouch-common/src/api_tests.rs
+++ b/crates/vouch-common/src/api_tests.rs
@@ -13,6 +13,9 @@
 )]
 mod tests {
     use crate::api::*;
+    use crate::encoding::ConvertEncoding;
+    use crate::fido2_types::{Challenge, CredentialId, UserHandle};
+    use serde_json::Value;
     use uuid::Uuid;
 
     // =========================================================================
@@ -285,6 +288,127 @@ mod tests {
     // =========================================================================
     // Unicode and Special Character Tests
     // =========================================================================
+
+    // =========================================================================
+    // Browser WebAuthn Wire Format
+    //
+    // The browser flows are the one place where a wire change is invisible to
+    // the compiler: the JSON is produced by hand in JS, not by these types. A
+    // base64url field must stay a base64url string in both directions.
+    // =========================================================================
+
+    #[test]
+    fn test_browser_register_start_response_emits_base64url_strings() {
+        let response = BrowserRegisterStartResponse {
+            challenge: Challenge::from_raw(vec![1, 2, 3]).to_base64url(),
+            rp_id: "test.com".to_string(),
+            rp_name: "Test".to_string(),
+            user_id: UserHandle::from_raw(vec![4, 5, 6]).to_base64url(),
+            user_email: "user@example.com".to_string(),
+            user_display_name: "user@example.com".to_string(),
+            algorithms: vec![-7],
+            state: "state".to_string(),
+            exclude_credential_ids: vec![CredentialId::from_raw(vec![7, 8, 9]).to_base64url()],
+        };
+
+        let json = serde_json::to_value(&response).unwrap();
+        assert_eq!(json.get("challenge").and_then(Value::as_str), Some("AQID"));
+        assert_eq!(json.get("user_id").and_then(Value::as_str), Some("BAUG"));
+        assert_eq!(
+            json.get("exclude_credential_ids")
+                .and_then(|ids| ids.get(0))
+                .and_then(Value::as_str),
+            Some("BwgJ")
+        );
+    }
+
+    #[test]
+    fn test_browser_login_start_response_emits_base64url_challenge() {
+        let response = BrowserLoginStartResponse {
+            challenge: Challenge::from_raw(vec![1, 2, 3]).to_base64url(),
+            rp_id: "test.com".to_string(),
+            state: "state".to_string(),
+            timeout: 300_000,
+            user_verification: "required".to_string(),
+        };
+
+        let json = serde_json::to_value(&response).unwrap();
+        assert_eq!(json.get("challenge").and_then(Value::as_str), Some("AQID"));
+    }
+
+    #[test]
+    fn test_browser_register_complete_request_accepts_browser_json() {
+        // Exactly the body keys.js builds via bufferToBase64url().
+        let body = r#"{
+            "state": "state-token",
+            "credential_id": "AQID",
+            "attestation_object": "BAUG",
+            "client_data_json": "BwgJ"
+        }"#;
+        let request: BrowserRegisterCompleteRequest = serde_json::from_str(body).unwrap();
+        assert_eq!(request.credential_id.as_bytes(), &[1, 2, 3]);
+        assert_eq!(request.attestation_object.as_bytes(), &[4, 5, 6]);
+        assert_eq!(request.client_data_json.as_bytes(), &[7, 8, 9]);
+    }
+
+    #[test]
+    fn test_browser_login_complete_request_accepts_browser_json() {
+        // Exactly the body login.js builds via bufferToBase64url().
+        let body = r#"{
+            "state": "state-token",
+            "credential_id": "AQID",
+            "authenticator_data": "BAUG",
+            "client_data_json": "BwgJ",
+            "signature": "CgsM",
+            "user_handle": "DQ4P",
+            "pending_auth": null
+        }"#;
+        let request: BrowserLoginCompleteRequest = serde_json::from_str(body).unwrap();
+        assert_eq!(request.credential_id.as_bytes(), &[1, 2, 3]);
+        assert_eq!(request.authenticator_data.as_bytes(), &[4, 5, 6]);
+        assert_eq!(request.client_data_json.as_bytes(), &[7, 8, 9]);
+        assert_eq!(request.signature.as_bytes(), &[10, 11, 12]);
+        assert_eq!(request.user_handle.as_bytes(), &[13, 14, 15]);
+        assert!(request.pending_auth.is_none());
+    }
+
+    /// The decode that used to live in the handler now happens in serde, so a
+    /// malformed field fails the whole body rather than one branch. Naming the
+    /// offending field is `serde_path_to_error`'s job inside axum's `Json`, so
+    /// that half is asserted in the handler tests, not here.
+    #[test]
+    fn test_browser_complete_requests_reject_malformed_base64url() {
+        let body = r#"{
+            "state": "state-token",
+            "credential_id": "!!not-base64url!!",
+            "attestation_object": "BAUG",
+            "client_data_json": "BwgJ"
+        }"#;
+        assert!(serde_json::from_str::<BrowserRegisterCompleteRequest>(body).is_err());
+
+        let body = r#"{
+            "state": "state-token",
+            "credential_id": "AQID",
+            "authenticator_data": "BAUG",
+            "client_data_json": "BwgJ",
+            "signature": "not base64!",
+            "user_handle": "DQ4P"
+        }"#;
+        assert!(serde_json::from_str::<BrowserLoginCompleteRequest>(body).is_err());
+    }
+
+    /// A base64url field must reject a JSON value of the wrong type outright,
+    /// not coerce it.
+    #[test]
+    fn test_browser_complete_request_rejects_wrong_json_type() {
+        let body = r#"{
+            "state": "state-token",
+            "credential_id": 42,
+            "attestation_object": "BAUG",
+            "client_data_json": "BwgJ"
+        }"#;
+        assert!(serde_json::from_str::<BrowserRegisterCompleteRequest>(body).is_err());
+    }
 
     #[test]
     fn test_register_start_response_unicode_names() {

--- a/crates/vouch-server/src/crypto/webauthn_verify.rs
+++ b/crates/vouch-server/src/crypto/webauthn_verify.rs
@@ -17,12 +17,12 @@
 //!
 //! # Inputs are untyped byte slices
 //!
-//! Verification takes `&[u8]`. Callers hold
-//! [`vouch_common::encoding::Encoded<T, E>`], whose compile-time markers keep
-//! a credential ID from being passed where a signature belongs, but they decode
-//! before calling in — this module never sees the marker. Extending the typed
-//! representation inward would only pay off alongside the browser WebAuthn
-//! request types, which are still `String`; that migration is tracked in #1037.
+//! Verification takes `&[u8]`. Every caller now holds
+//! [`vouch_common::encoding::Encoded<T, E>`], whose compile-time markers keep a
+//! credential ID from being passed where a signature belongs, but they unwrap
+//! to bytes before calling in — this module never sees the marker. Extending
+//! the typed representation inward would mean threading the markers through
+//! `CoseVerifier` and the assertion structs as well.
 
 use aws_lc_rs::digest::{self, SHA256};
 use aws_lc_rs::signature::{self, UnparsedPublicKey};

--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -25,6 +25,7 @@ use crate::crypto::hash_token;
 use crate::db::ClientInfo;
 use crate::db::{self, AuthEventParams, AuthEventType};
 use crate::error::ServiceError;
+use crate::handlers::extractors::ValidJson;
 use crate::handlers::session::{create_session_cookie, get_auth_context};
 use crate::impl_template_response;
 use crate::redact_email;
@@ -48,6 +49,8 @@ use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use uuid::Uuid;
+use vouch_common::encoding::ConvertEncoding;
+use vouch_common::fido2_types::Challenge;
 use vouch_common::{
     BrowserLoginCompleteRequest, BrowserLoginCompleteResponse, BrowserLoginStartRequest,
     BrowserLoginStartResponse, protocol,
@@ -99,27 +102,23 @@ impl_template_response!(LoginTemplate);
 // Validation Constants
 // ============================================================================
 
-/// Maximum encoded length for `credential_id` (base64url).
-/// WebAuthn spec allows up to 1023 bytes raw ≈ 1364 chars encoded.
-const MAX_CREDENTIAL_ID_LEN: usize = 1400;
-
-/// Maximum encoded length for `authenticator_data` (base64url).
+/// Maximum decoded byte length for `authenticator_data`.
 /// Authenticator data is typically 37+ bytes; with extensions it can be larger.
-const MAX_AUTHENTICATOR_DATA_LEN: usize = 4 * 1024;
+const MAX_AUTHENTICATOR_DATA_BYTES: usize = 3 * 1024;
 
-/// Maximum encoded length for `client_data_json` (base64url).
+/// Maximum decoded byte length for `client_data_json`.
 /// Client data JSON is a small JSON object (origin, type, challenge).
-const MAX_CLIENT_DATA_JSON_LEN: usize = 4 * 1024;
+const MAX_CLIENT_DATA_JSON_BYTES: usize = 3 * 1024;
 
-/// Maximum encoded length for `signature` (base64url).
+/// Maximum decoded byte length for `signature`.
 /// ECDSA/EdDSA signatures are typically under 100 bytes.
-const MAX_SIGNATURE_LEN: usize = 1024;
+const MAX_SIGNATURE_BYTES: usize = 768;
 
-/// Maximum encoded length for `user_handle` (base64url).
-/// User handles are 16-byte UUIDs ≈ 22 chars encoded.
-const MAX_USER_HANDLE_LEN: usize = 256;
+/// Maximum decoded byte length for `user_handle`.
+/// User handles are 16-byte UUIDs.
+const MAX_USER_HANDLE_BYTES: usize = 192;
 
-/// Maximum encoded length for the authentication `state` JWT.
+/// Maximum length for the authentication `state` JWT.
 const MAX_STATE_TOKEN_LEN: usize = 8 * 1024;
 
 /// Minimum decoded byte length for a valid credential ID.
@@ -394,7 +393,7 @@ pub(crate) async fn browser_login_start(
     })?;
 
     Ok(Json(BrowserLoginStartResponse {
-        challenge: URL_SAFE_NO_PAD.encode(&challenge),
+        challenge: Challenge::from_slice(&challenge).to_base64url(),
         rp_id: state.config().rp_id.clone(),
         state: state_token,
         timeout: 300_000, // 5 minutes in milliseconds
@@ -406,14 +405,17 @@ pub(crate) async fn browser_login_start(
 ///
 /// Verify WebAuthn assertion and create session.
 ///
+/// The binary fields arrive decoded: [`BrowserLoginCompleteRequest`] types
+/// them as `Encoded<_, Base64Url>`, so a malformed base64url value is rejected
+/// by [`ValidJson`] before the handler runs.
+///
 /// Validation is ordered to fail fast before any database access:
 /// 1. Origin header validation (CSRF protection)
 /// 2. Field length bounds (reject obviously oversized/empty fields)
 /// 3. State JWT decode + expiration check
-/// 4. Base64url decode all fields
-/// 5. Credential ID byte length validation
-/// 6. Client data JSON structure validation (type, origin)
-/// 7. Database operations (authenticator lookup, signature verification)
+/// 4. Credential ID byte length validation
+/// 5. Client data JSON structure validation (type, origin)
+/// 6. Database operations (authenticator lookup, signature verification)
 #[expect(
     clippy::too_many_lines,
     reason = "FAPI 2.0 browser login orchestrates assertion verification and session issuance"
@@ -423,7 +425,7 @@ pub(crate) async fn browser_login_complete(
     client_info: ClientInfo,
     headers: HeaderMap,
     jar: CookieJar,
-    Json(req): Json<BrowserLoginCompleteRequest>,
+    ValidJson(req): ValidJson<BrowserLoginCompleteRequest>,
 ) -> Result<Response, ServiceError> {
     // ── Phase 1: Origin header validation ────────────────────────────────
     validate_origin(&headers, &state.config().base_url)?;
@@ -439,15 +441,8 @@ pub(crate) async fn browser_login_complete(
             "State token exceeds maximum length",
         ));
     }
-    if req.credential_id.is_empty() || req.credential_id.len() > MAX_CREDENTIAL_ID_LEN {
-        return Err(ServiceError::api(
-            StatusCode::BAD_REQUEST,
-            "invalid_input",
-            "Credential ID is empty or exceeds maximum length",
-        ));
-    }
     if req.authenticator_data.is_empty()
-        || req.authenticator_data.len() > MAX_AUTHENTICATOR_DATA_LEN
+        || req.authenticator_data.len() > MAX_AUTHENTICATOR_DATA_BYTES
     {
         return Err(ServiceError::api(
             StatusCode::BAD_REQUEST,
@@ -455,21 +450,21 @@ pub(crate) async fn browser_login_complete(
             "Authenticator data is empty or exceeds maximum length",
         ));
     }
-    if req.client_data_json.is_empty() || req.client_data_json.len() > MAX_CLIENT_DATA_JSON_LEN {
+    if req.client_data_json.is_empty() || req.client_data_json.len() > MAX_CLIENT_DATA_JSON_BYTES {
         return Err(ServiceError::api(
             StatusCode::BAD_REQUEST,
             "invalid_input",
             "Client data JSON is empty or exceeds maximum length",
         ));
     }
-    if req.signature.is_empty() || req.signature.len() > MAX_SIGNATURE_LEN {
+    if req.signature.is_empty() || req.signature.len() > MAX_SIGNATURE_BYTES {
         return Err(ServiceError::api(
             StatusCode::BAD_REQUEST,
             "invalid_input",
             "Signature is empty or exceeds maximum length",
         ));
     }
-    if req.user_handle.is_empty() || req.user_handle.len() > MAX_USER_HANDLE_LEN {
+    if req.user_handle.is_empty() || req.user_handle.len() > MAX_USER_HANDLE_BYTES {
         return Err(ServiceError::api(
             StatusCode::BAD_REQUEST,
             "invalid_input",
@@ -516,52 +511,9 @@ pub(crate) async fn browser_login_complete(
             }
         };
 
-    // ── Phase 4: Base64url decode all fields ─────────────────────────────
-    let credential_id = URL_SAFE_NO_PAD.decode(&req.credential_id).map_err(|_| {
-        ServiceError::api(
-            StatusCode::BAD_REQUEST,
-            "invalid_input",
-            "Invalid credential_id",
-        )
-    })?;
-
-    let authenticator_data = URL_SAFE_NO_PAD
-        .decode(&req.authenticator_data)
-        .map_err(|_| {
-            ServiceError::api(
-                StatusCode::BAD_REQUEST,
-                "invalid_input",
-                "Invalid authenticator_data",
-            )
-        })?;
-
-    let client_data_json = URL_SAFE_NO_PAD.decode(&req.client_data_json).map_err(|_| {
-        ServiceError::api(
-            StatusCode::BAD_REQUEST,
-            "invalid_input",
-            "Invalid client_data_json",
-        )
-    })?;
-
-    let signature = URL_SAFE_NO_PAD.decode(&req.signature).map_err(|_| {
-        ServiceError::api(
-            StatusCode::BAD_REQUEST,
-            "invalid_input",
-            "Invalid signature",
-        )
-    })?;
-
-    let user_handle = URL_SAFE_NO_PAD.decode(&req.user_handle).map_err(|_| {
-        ServiceError::api(
-            StatusCode::BAD_REQUEST,
-            "invalid_input",
-            "Invalid user_handle",
-        )
-    })?;
-
-    // ── Phase 5: Credential ID byte length validation ────────────────────
-    if credential_id.len() < MIN_CREDENTIAL_ID_BYTES
-        || credential_id.len() > MAX_CREDENTIAL_ID_BYTES
+    // ── Phase 4: Credential ID byte length validation ────────────────────
+    if req.credential_id.len() < MIN_CREDENTIAL_ID_BYTES
+        || req.credential_id.len() > MAX_CREDENTIAL_ID_BYTES
     {
         return Err(ServiceError::api(
             StatusCode::BAD_REQUEST,
@@ -570,9 +522,9 @@ pub(crate) async fn browser_login_complete(
         ));
     }
 
-    // ── Phase 6: Client data JSON structure validation ───────────────────
+    // ── Phase 5: Client data JSON structure validation ───────────────────
     // Parse and validate client data before any DB or crypto operations.
-    let client_data_str = std::str::from_utf8(&client_data_json).map_err(|_| {
+    let client_data_str = std::str::from_utf8(&req.client_data_json).map_err(|_| {
         ServiceError::api(
             StatusCode::BAD_REQUEST,
             "invalid_input",
@@ -613,7 +565,7 @@ pub(crate) async fn browser_login_complete(
     }
 
     // Parse user_handle as UUID to identify the user
-    let user_id = Uuid::from_slice(&user_handle).map_err(|_| {
+    let user_id = Uuid::from_slice(&req.user_handle).map_err(|_| {
         ServiceError::api(
             StatusCode::BAD_REQUEST,
             "invalid_user_handle",
@@ -643,7 +595,7 @@ pub(crate) async fn browser_login_complete(
     let lookup_result = lookup_and_verify_authenticator(
         &state,
         AuthenticatorLookupParams {
-            credential_id: &credential_id,
+            credential_id: req.credential_id.as_bytes(),
             user_id,
         },
     )
@@ -675,9 +627,9 @@ pub(crate) async fn browser_login_complete(
 
     use crate::services::auth::{LoginAssertionParams, verify_login_assertion};
     let verification_result = verify_login_assertion(LoginAssertionParams {
-        authenticator_data,
-        client_data_json,
-        signature,
+        authenticator_data: req.authenticator_data.into_bytes(),
+        client_data_json: req.client_data_json.into_bytes(),
+        signature: req.signature.into_bytes(),
         public_key: authenticator.public_key.clone(),
         rp_id: auth_state.rp_id.clone(),
         // Browser sets clientDataJSON.origin to the calling page's origin
@@ -1162,6 +1114,76 @@ mod tests {
     // Browser Auth State Tests
     // ========================================================================
 
+    /// `credential_id` and friends are `Encoded<_, Base64Url>`, so a malformed
+    /// value is a deserialization failure. `ValidJson` reports it in the JSON
+    /// envelope `login.js` reads out of `errResp.message`.
+    #[tokio::test]
+    async fn test_browser_login_complete_rejects_malformed_base64url() {
+        let (app, state) = crate::test_utils::test_app().await;
+
+        let dummy = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(vec![0u8; 32]);
+        let body = serde_json::json!({
+            "state": "state-token",
+            "credential_id": "!!not-base64url!!",
+            "authenticator_data": dummy,
+            "client_data_json": dummy,
+            "signature": dummy,
+            "user_handle": dummy,
+        })
+        .to_string();
+
+        let (status, resp_body) = crate::test_utils::http_post_json(
+            &app,
+            "/login/webauthn/complete",
+            &body,
+            &[("Origin", state.config().base_url.as_str())],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{resp_body}");
+        assert!(
+            resp_body.contains("invalid_request"),
+            "expected 'invalid_request' in body, got: {resp_body}"
+        );
+        assert!(
+            resp_body.contains("credential_id"),
+            "the rejection must name the offending field, got: {resp_body}"
+        );
+    }
+
+    /// The rejection body must be JSON — the browser calls `.json()` on it and
+    /// shows `errResp.message`. Axum's own rejection answers `text/plain`.
+    #[tokio::test]
+    async fn test_browser_login_complete_rejection_is_json() {
+        let (app, state) = crate::test_utils::test_app().await;
+
+        // Omit every field but `state`.
+        let body = serde_json::json!({ "state": "state-token" }).to_string();
+
+        let (status, resp_body) = crate::test_utils::http_post_json(
+            &app,
+            "/login/webauthn/complete",
+            &body,
+            &[("Origin", state.config().base_url.as_str())],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{resp_body}");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&resp_body).expect("rejection body must be JSON");
+        assert_eq!(
+            parsed.get("code").and_then(serde_json::Value::as_str),
+            Some("invalid_request"),
+            "{resp_body}"
+        );
+        assert!(
+            parsed
+                .get("message")
+                .is_some_and(serde_json::Value::is_string),
+            "browser reads errResp.message: {resp_body}"
+        );
+    }
+
     #[tokio::test]
     async fn test_browser_auth_state_decode_wrong_secret() {
         let signer = crate::crypto::jwt::StateTokenSigner::local(b"correct-secret".to_vec());
@@ -1214,9 +1236,9 @@ mod tests {
             .expect("pre-consume must succeed");
 
         // POST to `/login/webauthn/complete` with the already-consumed state
-        // and length-bounded dummy fields. The replay check runs in Phase
-        // 3b (after state decode, before base64 decode), so plain
-        // base64url-of-zero-bytes fields are sufficient to reach it.
+        // and length-bounded dummy fields. The replay check runs in Phase 3b,
+        // before any of these values is used, so base64url-of-zero-bytes
+        // fields are sufficient to reach it.
         let dummy = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(vec![0u8; 32]);
         let body = serde_json::json!({
             "state": state_jwt,

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -15,15 +15,16 @@ use axum::{
     response::{IntoResponse, Redirect, Response},
 };
 use axum_extra::extract::cookie::CookieJar;
-use base64::Engine;
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use jiff::{Span, Timestamp};
 use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use uuid::Uuid;
+use vouch_common::encoding::{Base64Url, ConvertEncoding};
+use vouch_common::fido2_types::{Challenge, CredentialId, UserHandle};
 use vouch_common::{BrowserRegisterCompleteRequest, BrowserRegisterStartResponse, protocol};
 
+use super::extractors::ValidJson;
 use super::session::AuthContext;
 use super::{
     create_session_cookie, extract_session_from_cookie, hash_token,
@@ -1149,14 +1150,13 @@ pub(crate) async fn browser_register_start(
         .map(|a| webauthn_rs::prelude::CredentialID::from(a.credential_id.clone()))
         .collect();
 
-    // Build exclude_credential_ids for browser (base64url encoded)
-    let exclude_credential_ids: Vec<String> = existing_auths
+    let exclude_credential_ids: Vec<CredentialId<Base64Url>> = existing_auths
         .iter()
         .map(|a| {
-            let encoded = URL_SAFE_NO_PAD.encode(&a.credential_id);
+            let encoded = CredentialId::from_slice(&a.credential_id).to_base64url();
             tracing::debug!(
                 "Excluding credential: {} (len={})",
-                encoded,
+                encoded.as_base64url(),
                 a.credential_id.len()
             );
             encoded
@@ -1224,13 +1224,12 @@ pub(crate) async fn browser_register_start(
     // Extract challenge from webauthn-rs generated options
     // The challenge is exposed via the public_key.challenge field
     let challenge_bytes: &[u8] = ccr.public_key.challenge.as_ref();
-    let challenge = URL_SAFE_NO_PAD.encode(challenge_bytes);
 
     Ok(Json(BrowserRegisterStartResponse {
-        challenge,
+        challenge: Challenge::from_slice(challenge_bytes).to_base64url(),
         rp_id: state.config().rp_id.clone(),
         rp_name: state.config().rp_name.clone(),
-        user_id: URL_SAFE_NO_PAD.encode(user_id.as_bytes()),
+        user_id: UserHandle::from_slice(user_id.as_bytes()).to_base64url(),
         user_email: user_email.clone(),
         user_display_name: user_email,
         algorithms: vec![-7, -257], // ES256, RS256
@@ -1239,20 +1238,16 @@ pub(crate) async fn browser_register_start(
     }))
 }
 
-/// Maximum encoded length for `credential_id` (base64url).
-/// WebAuthn spec allows up to 1023 bytes raw ≈ 1364 chars encoded.
-const MAX_CREDENTIAL_ID_LEN: usize = 1400;
-
-/// Maximum encoded length for `attestation_object` (base64url).
-/// Hardware key attestations with certificate chains are typically under 4 KB.
-const MAX_ATTESTATION_OBJECT_LEN: usize = 16 * 1024;
-
-/// Maximum encoded length for `client_data_json` (base64url).
-/// Client data JSON is a small JSON object (origin, type, challenge).
-const MAX_CLIENT_DATA_JSON_LEN: usize = 4 * 1024;
-
-/// Maximum encoded length for the registration `state` JWT.
+/// Maximum length for the registration `state` JWT.
 const MAX_STATE_TOKEN_LEN: usize = 8 * 1024;
+
+/// Maximum decoded byte length for `attestation_object`.
+/// Hardware key attestations with certificate chains are typically under 4 KB.
+const MAX_ATTESTATION_OBJECT_BYTES: usize = 12 * 1024;
+
+/// Maximum decoded byte length for `client_data_json`.
+/// Client data JSON is a small JSON object (origin, type, challenge).
+const MAX_CLIENT_DATA_JSON_BYTES: usize = 3 * 1024;
 
 /// Minimum decoded byte length for a valid credential ID.
 const MIN_CREDENTIAL_ID_BYTES: usize = 16;
@@ -1263,15 +1258,18 @@ const MAX_CREDENTIAL_ID_BYTES: usize = 1023;
 /// Complete browser-based `WebAuthn` registration.
 /// POST /enroll/webauthn/complete
 ///
+/// The binary fields arrive decoded: [`BrowserRegisterCompleteRequest`] types
+/// them as `Encoded<_, Base64Url>`, so a malformed base64url value is rejected
+/// by [`ValidJson`] before the handler runs.
+///
 /// Validation is ordered to fail fast before any database access:
 /// 1. Field length bounds (reject obviously oversized/empty fields)
 /// 2. State JWT decode + expiration check
-/// 3. Base64url decode all fields
-/// 4. Credential ID byte length validation
-/// 5. Client data JSON structure validation (type, origin)
-/// 6. Hardware attestation validation (reject software passkeys)
-/// 7. WebAuthn cryptographic verification
-/// 8. Database operations (duplicate check, store, authorize)
+/// 3. Credential ID byte length validation
+/// 4. Client data JSON structure validation (type, origin)
+/// 5. Hardware attestation validation (reject software passkeys)
+/// 6. WebAuthn cryptographic verification
+/// 7. Database operations (duplicate check, store, authorize)
 #[expect(
     clippy::too_many_lines,
     reason = "axum handler; FIDO2 registration completion: attestation, db, session"
@@ -1279,7 +1277,7 @@ const MAX_CREDENTIAL_ID_BYTES: usize = 1023;
 pub(crate) async fn browser_register_complete(
     State(state): State<Arc<AppState>>,
     client_info: ClientInfo,
-    Json(req): Json<BrowserRegisterCompleteRequest>,
+    ValidJson(req): ValidJson<BrowserRegisterCompleteRequest>,
 ) -> Result<impl IntoResponse, ServiceError> {
     // ── Phase 1: Field length bounds ────────────────────────────────────
     // Reject obviously oversized or empty fields before any processing.
@@ -1290,15 +1288,8 @@ pub(crate) async fn browser_register_complete(
             "State token exceeds maximum length",
         ));
     }
-    if req.credential_id.is_empty() || req.credential_id.len() > MAX_CREDENTIAL_ID_LEN {
-        return Err(ServiceError::api(
-            StatusCode::BAD_REQUEST,
-            "invalid_credential",
-            "Credential ID is empty or exceeds maximum length",
-        ));
-    }
     if req.attestation_object.is_empty()
-        || req.attestation_object.len() > MAX_ATTESTATION_OBJECT_LEN
+        || req.attestation_object.len() > MAX_ATTESTATION_OBJECT_BYTES
     {
         return Err(ServiceError::api(
             StatusCode::BAD_REQUEST,
@@ -1306,7 +1297,7 @@ pub(crate) async fn browser_register_complete(
             "Attestation object is empty or exceeds maximum length",
         ));
     }
-    if req.client_data_json.is_empty() || req.client_data_json.len() > MAX_CLIENT_DATA_JSON_LEN {
+    if req.client_data_json.is_empty() || req.client_data_json.len() > MAX_CLIENT_DATA_JSON_BYTES {
         return Err(ServiceError::api(
             StatusCode::BAD_REQUEST,
             "invalid_client_data",
@@ -1376,32 +1367,9 @@ pub(crate) async fn browser_register_complete(
         }
     };
 
-    // ── Phase 3: Base64url decode all fields ────────────────────────────
-    let credential_id_bytes = URL_SAFE_NO_PAD.decode(&req.credential_id).map_err(|e| {
-        ServiceError::api(StatusCode::BAD_REQUEST, "invalid_credential", e.to_string())
-    })?;
-
-    let attestation_object = URL_SAFE_NO_PAD
-        .decode(&req.attestation_object)
-        .map_err(|e| {
-            ServiceError::api(
-                StatusCode::BAD_REQUEST,
-                "invalid_attestation",
-                e.to_string(),
-            )
-        })?;
-
-    let client_data_json = URL_SAFE_NO_PAD.decode(&req.client_data_json).map_err(|e| {
-        ServiceError::api(
-            StatusCode::BAD_REQUEST,
-            "invalid_client_data",
-            e.to_string(),
-        )
-    })?;
-
-    // ── Phase 4: Credential ID byte length validation ───────────────────
-    if credential_id_bytes.len() < MIN_CREDENTIAL_ID_BYTES
-        || credential_id_bytes.len() > MAX_CREDENTIAL_ID_BYTES
+    // ── Phase 3: Credential ID byte length validation ───────────────────
+    if req.credential_id.len() < MIN_CREDENTIAL_ID_BYTES
+        || req.credential_id.len() > MAX_CREDENTIAL_ID_BYTES
     {
         return Err(ServiceError::api(
             StatusCode::BAD_REQUEST,
@@ -1410,9 +1378,9 @@ pub(crate) async fn browser_register_complete(
         ));
     }
 
-    // ── Phase 5: Client data JSON structure validation ──────────────────
+    // ── Phase 4: Client data JSON structure validation ──────────────────
     // Parse and validate the client data before any DB or crypto operations.
-    let client_data_str = std::str::from_utf8(&client_data_json).map_err(|_| {
+    let client_data_str = std::str::from_utf8(&req.client_data_json).map_err(|_| {
         ServiceError::api(
             StatusCode::BAD_REQUEST,
             "invalid_client_data",
@@ -1451,25 +1419,25 @@ pub(crate) async fn browser_register_complete(
         ));
     }
 
-    // ── Phase 6: Hardware attestation validation ────────────────────────
+    // ── Phase 5: Hardware attestation validation ────────────────────────
     // Reject software passkeys, platform authenticators, and disallowed AAGUIDs.
     let validated = validate_registration_attestation(
-        &attestation_object,
+        &req.attestation_object,
         &state.config().allowed_aaguids,
         state.config().require_attestation_cert,
     )?;
 
-    // ── Phase 6b: Extract x5c certs before attestation_object is moved ─
-    let x5c_certs = crate::attestation::extract_x5c_from_attestation(&attestation_object);
+    let x5c_certs = crate::attestation::extract_x5c_from_attestation(&req.attestation_object);
 
-    // ── Phase 7: WebAuthn cryptographic verification ────────────────────
+    // ── Phase 6: WebAuthn cryptographic verification ────────────────────
     use webauthn_rs::prelude::Base64UrlSafeData;
+    let credential_id_bytes = req.credential_id.as_bytes().to_vec();
     let reg_credential = webauthn_rs_proto::RegisterPublicKeyCredential {
-        id: req.credential_id.clone(),
+        id: req.credential_id.as_base64url(),
         raw_id: Base64UrlSafeData::from(credential_id_bytes.clone()),
         response: webauthn_rs_proto::AuthenticatorAttestationResponseRaw {
-            attestation_object: Base64UrlSafeData::from(attestation_object),
-            client_data_json: Base64UrlSafeData::from(client_data_json),
+            attestation_object: Base64UrlSafeData::from(req.attestation_object.into_bytes()),
+            client_data_json: Base64UrlSafeData::from(req.client_data_json.into_bytes()),
             transports: None,
         },
         extensions: webauthn_rs_proto::RegistrationExtensionsClientOutputs::default(),
@@ -1488,7 +1456,7 @@ pub(crate) async fn browser_register_complete(
             )
         })?;
 
-    // ── Phase 8: Database operations ────────────────────────────────────
+    // ── Phase 7: Database operations ────────────────────────────────────
     // All cheap validation passed — now check for duplicate credentials.
     if let Some(_existing) =
         db::get_authenticator_by_credential_id(&state.store, &credential_id_bytes).await?
@@ -1521,7 +1489,7 @@ pub(crate) async fn browser_register_complete(
     // rather than the one from the request, to ensure consistency with what the YubiKey has stored.
     let cred_id_to_store = passkey.cred_id().to_vec();
 
-    // ── Phase 8b: x5c attestation chain validation (browser enrollment) ──
+    // ── Phase 7b: x5c attestation chain validation (browser enrollment) ──
     // The browser enrollment path uses webauthn-rs for verification, so we
     // additionally validate the x5c chain here for attestation_verified status.
     let mut validated = validated;

--- a/crates/vouch-server/src/handlers/enroll/tests.rs
+++ b/crates/vouch-server/src/handlers/enroll/tests.rs
@@ -75,10 +75,15 @@ async fn test_enrollment_complete_missing_state() {
     })
     .to_string();
 
-    let (status, _body) = http_post_json(&app, "/enroll/webauthn/complete", &body, &[]).await;
+    let (status, resp_body) = http_post_json(&app, "/enroll/webauthn/complete", &body, &[]).await;
 
-    // Missing required JSON field → 422 Unprocessable Entity (axum extractor error)
-    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    // `ValidJson` reports every body rejection in the JSON envelope the
+    // browser reads, so a missing field is a 400 like any other bad body.
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        resp_body.contains("invalid_request"),
+        "expected 'invalid_request' in body, got: {resp_body}"
+    );
 }
 
 // ── test_enrollment_complete_invalid_state_token ─────────────────────────
@@ -120,9 +125,13 @@ async fn test_enrollment_complete_missing_credential_id() {
     })
     .to_string();
 
-    let (status, _body) = http_post_json(&app, "/enroll/webauthn/complete", &body, &[]).await;
+    let (status, resp_body) = http_post_json(&app, "/enroll/webauthn/complete", &body, &[]).await;
 
-    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        resp_body.contains("credential_id"),
+        "the rejection must name the missing field, got: {resp_body}"
+    );
 }
 
 // ── test_enrollment_complete_oversized_credential_id ─────────────────────
@@ -133,8 +142,8 @@ async fn test_enrollment_complete_oversized_credential_id() {
 
     let valid_state = make_valid_state_token(&state).await;
 
-    // Build a credential_id that exceeds MAX_CREDENTIAL_ID_LEN (1400 chars).
-    let oversized = "A".repeat(MAX_CREDENTIAL_ID_LEN + 1);
+    // A credential ID one byte past the WebAuthn ceiling, encoded.
+    let oversized = URL_SAFE_NO_PAD.encode(vec![0u8; MAX_CREDENTIAL_ID_BYTES + 1]);
 
     let body = serde_json::json!({
         "state": valid_state,
@@ -188,8 +197,8 @@ async fn test_browser_register_complete_rejects_replayed_state() {
         .expect("pre-consume must succeed");
 
     // POST to the complete endpoint with the already-consumed state.
-    // The replay check runs before any base64 decoding, so non-empty base64
-    // strings are sufficient for the request to reach the replay check.
+    // The fields must be well-formed base64url to get past deserialization,
+    // but their contents never matter — the replay check precedes every use.
     let body = serde_json::json!({
         "state": state_jwt,
         "credential_id": valid_credential_id(),
@@ -215,7 +224,9 @@ async fn test_enrollment_complete_invalid_base64_credential_id() {
 
     let valid_state = make_valid_state_token(&state).await;
 
-    // "!!" is not valid base64url.
+    // "!!" is not valid base64url. `credential_id` is typed
+    // `CredentialId<Base64Url>`, so this fails in serde and `ValidJson` reports
+    // it in the JSON envelope the browser reads.
     let body = serde_json::json!({
         "state": valid_state,
         "credential_id": "!!not-base64url!!",
@@ -228,8 +239,39 @@ async fn test_enrollment_complete_invalid_base64_credential_id() {
 
     assert_eq!(status, StatusCode::BAD_REQUEST);
     assert!(
-        resp_body.contains("invalid_credential"),
-        "expected 'invalid_credential' in body, got: {resp_body}"
+        resp_body.contains("invalid_request"),
+        "expected 'invalid_request' in body, got: {resp_body}"
+    );
+    assert!(
+        resp_body.contains("credential_id"),
+        "the rejection must name the offending field, got: {resp_body}"
+    );
+}
+
+// ── test_enrollment_complete_rejects_non_string_field ────────────────────
+
+#[tokio::test]
+async fn test_enrollment_complete_rejects_wrong_json_type() {
+    let (app, state) = test_app().await;
+
+    let valid_state = make_valid_state_token(&state).await;
+
+    // A JSON number where a base64url string belongs. Typing the field is what
+    // turns this into a boundary rejection rather than a handler branch.
+    let body = serde_json::json!({
+        "state": valid_state,
+        "credential_id": 42,
+        "attestation_object": valid_attestation_object(),
+        "client_data_json": valid_client_data_json(),
+    })
+    .to_string();
+
+    let (status, resp_body) = http_post_json(&app, "/enroll/webauthn/complete", &body, &[]).await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        resp_body.contains("invalid_request"),
+        "expected 'invalid_request' in body, got: {resp_body}"
     );
 }
 

--- a/crates/vouch-server/src/handlers/extractors.rs
+++ b/crates/vouch-server/src/handlers/extractors.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use axum::extract::rejection::PathRejection;
-use axum::extract::{FromRequestParts, Path};
+use axum::extract::{FromRequest, FromRequestParts, Path};
 use axum::http::{HeaderMap, StatusCode};
 use http::request::Parts;
 use serde::Deserialize;
@@ -77,6 +77,36 @@ where
                     message,
                 ))
             }
+        }
+    }
+}
+
+/// JSON body extractor that converts `JsonRejection` into `ServiceError`.
+/// Use instead of [`axum::Json`] when the handler returns `ServiceError` and
+/// the caller reads the error out of the JSON envelope.
+///
+/// Axum's own rejection answers with a `text/plain` body, which the browser
+/// WebAuthn flows cannot read — they surface `errResp.message` from the JSON.
+/// Body-typed validation (a `credential_id` that is not base64url, a field of
+/// the wrong JSON type) lands here rather than in the handler, so this keeps
+/// the shape of the response the same either way.
+pub(crate) struct ValidJson<T>(pub T);
+
+impl<T, S> FromRequest<S> for ValidJson<T>
+where
+    T: serde::de::DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = ServiceError;
+
+    async fn from_request(req: axum::extract::Request, state: &S) -> Result<Self, Self::Rejection> {
+        match axum::Json::<T>::from_request(req, state).await {
+            Ok(axum::Json(value)) => Ok(Self(value)),
+            Err(rejection) => Err(ServiceError::api(
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+                rejection.body_text(),
+            )),
         }
     }
 }

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc8693.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc8693.rs
@@ -235,9 +235,13 @@ async fn test_rfc8693_missing_subject_token() {
 
     assert_eq!(status, StatusCode::BAD_REQUEST);
     let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
-    assert!(
-        error["error"] == "invalid_request" || error["error"] == "invalid_grant",
-        "Missing subject_token should be rejected, got: {}",
+    // RFC 6749 §5.2: invalid_request covers a request "missing a required
+    // parameter". Pairing subject_token with subject_token_type is what makes
+    // this reachable — an absent token used to reach the decoder as an empty
+    // string and come back as invalid_grant.
+    assert_eq!(
+        error["error"], "invalid_request",
+        "Missing subject_token should be rejected as invalid_request, got: {}",
         error["error"]
     );
 }
@@ -691,6 +695,70 @@ async fn test_rfc8693_invalid_actor_token_type() {
         status == StatusCode::BAD_REQUEST || status == StatusCode::UNAUTHORIZED,
         "Invalid actor_token_type should be rejected, got {status}: {body}"
     );
+}
+
+#[tokio::test]
+async fn test_rfc8693_actor_token_type_without_actor_token_rejected() {
+    // RFC 8693 §2.1: actor_token_type "is REQUIRED when the `actor_token`
+    // parameter is present in the request but MUST NOT be included otherwise."
+    // That MUST NOT binds the client, so rejecting is our choice — taken so a
+    // client that mislabels its request learns about it instead of receiving a
+    // token with the parameter silently dropped.
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "exchange-lone-actor-type@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+
+    let (access_token, _) = issue_oauth_access_token(&app, &state, &user, &auth_id, &client).await;
+
+    let auth_header = client.basic_auth_header();
+    let (status, body) = http_post_form(
+        &app,
+        "/oauth/token",
+        &format!(
+            "grant_type=urn:ietf:params:oauth:grant-type:token-exchange\
+             &subject_token={access_token}\
+             &subject_token_type=urn:ietf:params:oauth:token-type:access_token\
+             &actor_token_type=urn:ietf:params:oauth:token-type:access_token"
+        ),
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(error["error"], "invalid_request", "{body}");
+}
+
+#[tokio::test]
+async fn test_rfc8693_actor_token_without_actor_token_type_rejected() {
+    // RFC 8693 §2.1: actor_token_type is REQUIRED when actor_token is present.
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "exchange-untyped-actor@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+
+    let (access_token, _) = issue_oauth_access_token(&app, &state, &user, &auth_id, &client).await;
+
+    let auth_header = client.basic_auth_header();
+    let (status, body) = http_post_form(
+        &app,
+        "/oauth/token",
+        &format!(
+            "grant_type=urn:ietf:params:oauth:grant-type:token-exchange\
+             &subject_token={access_token}\
+             &subject_token_type=urn:ietf:params:oauth:token-type:access_token\
+             &actor_token=some-token"
+        ),
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(error["error"], "invalid_request", "{body}");
 }
 
 #[tokio::test]

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -8,14 +8,14 @@ use super::client_auth::{
 use crate::AppState;
 use crate::db::JwtAssertionJtiClaim;
 use crate::error::OAuthErrorResponse;
-use crate::error::{OAuthErrorCode, ServiceError};
+use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
 use crate::services::auth::{
     ClientAuthProof, GrantProof, SenderConstraintProof, TokenIssuanceProof,
 };
 use crate::services::oidc::{
     ScopeSet,
     client_credentials::{ClientCredentialsBindings, exchange_client_credentials},
-    exchange::{TokenExchangeParams, exchange_token},
+    exchange::{ActorToken, SubjectToken, TokenExchangeParams, TokenType, exchange_token},
     grant_type::{OAuthGrantType, ParseOAuthGrantTypeError},
     jwt_bearer::client_auth::{PendingJti, authenticate_client_jwt},
     token::{AuthCodeExchangeParams, exchange_authorization_code, validate_dpop_if_present},
@@ -860,6 +860,50 @@ async fn handle_device_code_grant(
     }
 }
 
+/// The RFC 8693 §2.1 token parameters in typed form: each token carries the
+/// type declared for it, so [`exchange_token`] cannot be reached with a token
+/// whose type went unchecked or a type whose token never arrived.
+struct ExchangeTokens<'a> {
+    /// `subject_token` + `subject_token_type`, both REQUIRED.
+    subject: SubjectToken<'a>,
+    /// `actor_token` + `actor_token_type`, present together or not at all.
+    actor: Option<ActorToken<'a>>,
+    /// `requested_token_type`, OPTIONAL.
+    requested_token_type: Option<TokenType>,
+}
+
+impl<'a> ExchangeTokens<'a> {
+    /// Pair up the flat form parameters at the request boundary.
+    ///
+    /// # Errors
+    ///
+    /// `invalid_request` for a missing REQUIRED parameter, a token type this
+    /// server does not accept, or a token and type that did not arrive
+    /// together.
+    fn from_request(params: &'a TokenRequest) -> ServiceResult<Self> {
+        let requested_token_type = match params.requested_token_type.as_deref() {
+            Some(urn) => Some(TokenType::parse(urn).ok_or_else(|| {
+                ServiceError::oauth(
+                    OAuthErrorCode::InvalidRequest,
+                    "Unsupported requested_token_type",
+                )
+            })?),
+            None => None,
+        };
+        Ok(Self {
+            subject: SubjectToken::from_params(
+                params.subject_token.as_ref(),
+                params.subject_token_type.as_deref(),
+            )?,
+            actor: ActorToken::from_params(
+                params.actor_token.as_ref(),
+                params.actor_token_type.as_deref(),
+            )?,
+            requested_token_type,
+        })
+    }
+}
+
 /// Handle token exchange grant (RFC 8693).
 ///
 /// RFC 8693 Section 2.1: The token exchange grant requires client
@@ -958,17 +1002,17 @@ async fn handle_token_exchange_grant(
         (None, None) => None,
     };
 
+    let tokens = match ExchangeTokens::from_request(&params) {
+        Ok(tokens) => tokens,
+        Err(e) => return e.into_oauth_response().into_response(),
+    };
+
     let exchange_params = TokenExchangeParams {
-        subject_token: params
-            .subject_token
-            .as_ref()
-            .map_or("", |s| s.expose_secret()),
-        subject_token_type: params.subject_token_type.as_deref().unwrap_or_default(),
-        actor_token: params.actor_token.as_ref().map(|s| s.expose_secret()),
-        actor_token_type: params.actor_token_type.as_deref(),
+        subject: tokens.subject,
+        actor: tokens.actor,
         audience: effective_audience,
         scope: params.scope.as_deref(),
-        requested_token_type: params.requested_token_type.as_deref(),
+        requested_token_type: tokens.requested_token_type,
         client_id: &authenticated_client.client.client_id,
         dpop_proof: dpop_proof.as_ref(),
         authorization_details: params.authorization_details.as_deref(),

--- a/crates/vouch-server/src/services/oidc/exchange.rs
+++ b/crates/vouch-server/src/services/oidc/exchange.rs
@@ -17,20 +17,159 @@ use crate::services::oidc::authorization_details::AuthorizationDetails;
 use crate::services::oidc::claims::OidcIdTokenClaimsBuilder;
 use crate::services::oidc::{ScopeSet, ValidatedDpopProof};
 use jiff::Timestamp;
-use secrecy::ExposeSecret;
+use secrecy::{ExposeSecret, SecretString};
 use std::sync::Arc;
 use vouch_common::protocol;
 
-/// Token type URNs for RFC 8693 §3, re-exported under the names this module
-/// uses. The values live in [`vouch_common::protocol`] so the CLI's exchange
+/// An RFC 8693 §3 token type identifier this server accepts.
+///
+/// The URN spellings live in [`vouch_common::protocol`] so the CLI's exchange
 /// requests are spelled from the same constants the server matches on.
-pub mod token_types {
-    /// Access token type.
-    pub use vouch_common::protocol::TOKEN_TYPE_ACCESS_TOKEN as ACCESS_TOKEN;
-    /// ID token type.
-    pub use vouch_common::protocol::TOKEN_TYPE_ID_TOKEN as ID_TOKEN;
-    /// JWT type.
-    pub use vouch_common::protocol::TOKEN_TYPE_JWT as JWT;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenType {
+    /// [`protocol::TOKEN_TYPE_ACCESS_TOKEN`].
+    AccessToken,
+    /// [`protocol::TOKEN_TYPE_ID_TOKEN`].
+    IdToken,
+    /// [`protocol::TOKEN_TYPE_JWT`].
+    Jwt,
+}
+
+impl TokenType {
+    /// The RFC 8693 §3 URN identifying this type on the wire.
+    #[must_use]
+    pub fn as_urn(self) -> &'static str {
+        match self {
+            Self::AccessToken => protocol::TOKEN_TYPE_ACCESS_TOKEN,
+            Self::IdToken => protocol::TOKEN_TYPE_ID_TOKEN,
+            Self::Jwt => protocol::TOKEN_TYPE_JWT,
+        }
+    }
+
+    /// Parse an RFC 8693 §3 URN, or `None` for a type this server neither
+    /// accepts nor issues (`saml1`, `saml2`, `refresh_token`).
+    #[must_use]
+    pub fn parse(urn: &str) -> Option<Self> {
+        match urn {
+            protocol::TOKEN_TYPE_ACCESS_TOKEN => Some(Self::AccessToken),
+            protocol::TOKEN_TYPE_ID_TOKEN => Some(Self::IdToken),
+            protocol::TOKEN_TYPE_JWT => Some(Self::Jwt),
+            _ => None,
+        }
+    }
+}
+
+/// RFC 8693 §2.1 `subject_token` with the `subject_token_type` declared for it.
+/// Both parameters are REQUIRED, so they are one value: a request missing
+/// either cannot be turned into [`TokenExchangeParams`].
+///
+/// Every [`TokenType`] is accepted here. All three URNs denote a JWT this
+/// server issued, and [`decode_token`] does not branch on the declared type.
+///
+/// The token stays wrapped in [`SecretString`] so that [`TokenExchangeParams`],
+/// which derives `Debug`, cannot print a bearer credential.
+#[derive(Debug)]
+pub struct SubjectToken<'a> {
+    /// The token representing the party the exchange is performed for.
+    pub token: &'a SecretString,
+    /// The type the client declared for it.
+    pub token_type: TokenType,
+}
+
+impl<'a> SubjectToken<'a> {
+    /// Pair the two wire parameters.
+    ///
+    /// # Errors
+    ///
+    /// `invalid_request` when either REQUIRED parameter is absent, or when the
+    /// declared type is one this server does not accept.
+    pub fn from_params(
+        token: Option<&'a SecretString>,
+        token_type: Option<&str>,
+    ) -> ServiceResult<Self> {
+        let (Some(token), Some(urn)) = (token, token_type) else {
+            return Err(ServiceError::oauth(
+                OAuthErrorCode::InvalidRequest,
+                "subject_token and subject_token_type are both required",
+            ));
+        };
+        let token_type = TokenType::parse(urn).ok_or_else(|| {
+            ServiceError::oauth(
+                OAuthErrorCode::InvalidRequest,
+                "Unsupported subject_token_type",
+            )
+        })?;
+        Ok(Self { token, token_type })
+    }
+}
+
+/// RFC 8693 §2.1 `actor_token` with the `actor_token_type` declared for it:
+///
+/// > actor_token_type
+/// >    An identifier, as described in Section 3, that indicates the type
+/// >    of the security token in the "actor_token" parameter.  This is
+/// >    REQUIRED when the "actor_token" parameter is present in the
+/// >    request but MUST NOT be included otherwise.
+///
+/// Carrying both in one value is what stops the two parameters from existing
+/// independently. The variants are the accepted `actor_token_type` subset:
+/// [`TokenType::IdToken`] has none because an ID token asserts who a user is,
+/// not who is acting, so admitting it would take a new variant here rather
+/// than an edit to a list shared with the other two parameters.
+///
+/// As with [`SubjectToken`], the token stays wrapped in [`SecretString`].
+#[derive(Debug)]
+pub enum ActorToken<'a> {
+    /// `actor_token_type=urn:ietf:params:oauth:token-type:access_token`.
+    AccessToken(&'a SecretString),
+    /// `actor_token_type=urn:ietf:params:oauth:token-type:jwt`.
+    Jwt(&'a SecretString),
+}
+
+impl<'a> ActorToken<'a> {
+    /// The `actor_token` value.
+    #[must_use]
+    pub fn token(&self) -> &'a SecretString {
+        match *self {
+            Self::AccessToken(token) | Self::Jwt(token) => token,
+        }
+    }
+
+    /// Pair the two wire parameters, or `None` when the request carries
+    /// neither and is therefore not a delegation.
+    ///
+    /// # Errors
+    ///
+    /// `invalid_request` when only one of the pair is present, or when the
+    /// declared type is outside the subset above. RFC 8693 §2.1 addresses the
+    /// lone `actor_token_type` to the client rather than to us, so rejecting
+    /// it is our choice, taken under RFC 6749 §5.2 — `invalid_request` covers
+    /// a request that "is otherwise malformed". Accepting and dropping it
+    /// would hide the client bug that produced it.
+    pub fn from_params(
+        token: Option<&'a SecretString>,
+        token_type: Option<&str>,
+    ) -> ServiceResult<Option<Self>> {
+        match (token, token_type) {
+            (None, None) => Ok(None),
+            (Some(token), Some(urn)) => match TokenType::parse(urn) {
+                Some(TokenType::AccessToken) => Ok(Some(Self::AccessToken(token))),
+                Some(TokenType::Jwt) => Ok(Some(Self::Jwt(token))),
+                Some(TokenType::IdToken) | None => Err(ServiceError::oauth(
+                    OAuthErrorCode::InvalidRequest,
+                    "Invalid actor_token_type",
+                )),
+            },
+            (Some(_), None) => Err(ServiceError::oauth(
+                OAuthErrorCode::InvalidRequest,
+                "actor_token_type is required when actor_token is present",
+            )),
+            (None, Some(_)) => Err(ServiceError::oauth(
+                OAuthErrorCode::InvalidRequest,
+                "actor_token_type must not be present without actor_token",
+            )),
+        }
+    }
 }
 
 /// Default lifetime for an exchanged OIDC ID token
@@ -43,20 +182,17 @@ const DEFAULT_ID_TOKEN_EXPIRES_SECS: u64 = 600;
 /// Parameters for token exchange (RFC 8693 Section 2.1).
 #[derive(Debug)]
 pub struct TokenExchangeParams<'a> {
-    /// RFC 8693 Section 2.1: The subject token (REQUIRED).
-    pub subject_token: &'a str,
-    /// RFC 8693 Section 2.1: An identifier for the type of the subject token (REQUIRED).
-    pub subject_token_type: &'a str,
-    /// RFC 8693 Section 2.1: Optional actor token for delegation chains.
-    pub actor_token: Option<&'a str>,
-    /// RFC 8693 Section 2.1: An identifier for the type of the actor token.
-    pub actor_token_type: Option<&'a str>,
+    /// RFC 8693 Section 2.1: The subject token and its declared type (REQUIRED).
+    pub subject: SubjectToken<'a>,
+    /// RFC 8693 Section 2.1: The actor token and its declared type, for
+    /// delegation chains (OPTIONAL).
+    pub actor: Option<ActorToken<'a>>,
     /// RFC 8693 Section 2.1: The logical name of the target service (OPTIONAL).
     pub audience: Option<&'a str>,
     /// RFC 8693 Section 2.1: The requested scope for the new token (OPTIONAL).
     pub scope: Option<&'a str>,
     /// RFC 8693 Section 2.1: The desired type of the requested security token (OPTIONAL).
-    pub requested_token_type: Option<&'a str>,
+    pub requested_token_type: Option<TokenType>,
     /// OAuth client_id of the requesting client.
     pub client_id: &'a str,
     /// RFC 9449 §6: the validated DPoP proof binding the issued token via
@@ -130,34 +266,11 @@ pub(crate) async fn exchange_token(
     params: TokenExchangeParams<'_>,
     proof: TokenIssuanceProof,
 ) -> ServiceResult<TokenExchangeResult> {
-    // Validate subject token type
-    let valid_token_types = [
-        token_types::ACCESS_TOKEN,
-        token_types::ID_TOKEN,
-        token_types::JWT,
-    ];
-    if !valid_token_types.contains(&params.subject_token_type) {
-        return Err(ServiceError::oauth(
-            OAuthErrorCode::InvalidRequest,
-            "Unsupported subject_token_type",
-        ));
-    }
-
-    // RFC 8693 Section 2.1: Validate requested_token_type if provided
-    if let Some(requested_type) = params.requested_token_type
-        && !valid_token_types.contains(&requested_type)
-    {
-        return Err(ServiceError::oauth(
-            OAuthErrorCode::InvalidRequest,
-            "Unsupported requested_token_type",
-        ));
-    }
-
     // Reject `actor_token` with `requested_token_type=id_token`. The ID-token
     // path issues a clean OIDC claim set and does not carry the `act` claim,
     // so honoring `actor_token` here would silently drop the delegation chain.
     // Refuse the combination explicitly rather than ignore the input.
-    if params.requested_token_type == Some(token_types::ID_TOKEN) && params.actor_token.is_some() {
+    if params.requested_token_type == Some(TokenType::IdToken) && params.actor.is_some() {
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidRequest,
             "actor_token is not supported with requested_token_type=id_token",
@@ -166,7 +279,8 @@ pub(crate) async fn exchange_token(
 
     // Decode and validate the subject token (supports both HS256 and ES256)
     let config = state.config();
-    let subject_decoded = decode_token(params.subject_token, &state.oidc_key, &config.base_url)
+    let subject_token = params.subject.token.expose_secret();
+    let subject_decoded = decode_token(subject_token, &state.oidc_key, &config.base_url)
         .ok_or_else(|| {
             ServiceError::oauth(
                 OAuthErrorCode::InvalidGrant,
@@ -175,7 +289,7 @@ pub(crate) async fn exchange_token(
         })?;
 
     // Verify the subject token's session exists
-    let subject_token_hash = hash_token(params.subject_token);
+    let subject_token_hash = hash_token(subject_token);
     let subject_session = state
         .session_cache
         .get_session_by_token_hash(&state.store, &subject_token_hash)
@@ -224,16 +338,8 @@ pub(crate) async fn exchange_token(
     let subject_email = &subject_user.email;
 
     // Handle actor token if present (for delegation chains)
-    let actor_claim = if let Some(actor_token) = params.actor_token {
-        // Validate actor token type
-        if params.actor_token_type != Some(token_types::ACCESS_TOKEN)
-            && params.actor_token_type != Some(token_types::JWT)
-        {
-            return Err(ServiceError::oauth(
-                OAuthErrorCode::InvalidRequest,
-                "Invalid actor_token_type",
-            ));
-        }
+    let actor_claim = if let Some(actor) = params.actor {
+        let actor_token = actor.token().expose_secret();
 
         // Decode actor token (supports both HS256 and ES256)
         let actor_decoded = decode_token(actor_token, &state.oidc_key, &config.base_url)
@@ -350,7 +456,7 @@ pub(crate) async fn exchange_token(
     // upstream SSO but before FIDO2 registration) from minting a WIF
     // assertion that downstream relying parties trust as hardware-attested,
     // gate the fork on the subject token's hardware verification level.
-    if params.requested_token_type == Some(token_types::ID_TOKEN) {
+    if params.requested_token_type == Some(TokenType::IdToken) {
         if !subject_decoded.hardware_verification().hardware_verified() {
             return Err(ServiceError::oauth(
                 OAuthErrorCode::AccessDenied,
@@ -486,7 +592,7 @@ pub(crate) async fn exchange_token(
                 client_id: params.client_id.to_string(),
                 audience: params.audience.map(String::from),
                 scope: scope_string.clone(),
-                issued_token_type: token_types::ACCESS_TOKEN.to_string(),
+                issued_token_type: TokenType::AccessToken.as_urn().to_string(),
                 token_expires_at: Some(expires_at.to_string()),
             },
         )
@@ -507,7 +613,7 @@ pub(crate) async fn exchange_token(
 
     Ok(TokenExchangeResult {
         access_token: session_result.token.clone(),
-        issued_token_type: token_types::ACCESS_TOKEN.to_string(),
+        issued_token_type: TokenType::AccessToken.as_urn().to_string(),
         token_type: token_type.to_string(),
         expires_in,
         scope: granted_scope,
@@ -631,7 +737,7 @@ async fn issue_id_token(
                 client_id: ctx.client_id.to_string(),
                 audience: ctx.audience.map(String::from),
                 scope: None,
-                issued_token_type: token_types::ID_TOKEN.to_string(),
+                issued_token_type: TokenType::IdToken.as_urn().to_string(),
                 token_expires_at: Some(expires_at.to_string()),
             },
         )
@@ -646,7 +752,7 @@ async fn issue_id_token(
 
     Ok(TokenExchangeResult {
         access_token: id_token.into(),
-        issued_token_type: token_types::ID_TOKEN.to_string(),
+        issued_token_type: TokenType::IdToken.as_urn().to_string(),
         token_type: protocol::ACCESS_TOKEN_TYPE_BEARER.to_string(),
         expires_in,
         scope: None,
@@ -698,6 +804,10 @@ fn calculate_granted_scope(
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
 mod tests {
     use super::*;
 
@@ -757,16 +867,150 @@ mod tests {
         assert_eq!(result, Some(ScopeSet::parse("openid email")));
     }
 
-    /// The `token_types` aliases must map to the matching `protocol`
-    /// constants. A swapped `pub use` would still compile and would still
+    /// Each [`TokenType`] must map to the matching `protocol` constant in both
+    /// directions. Swapped match arms would still compile and would still
     /// carry the RFC 8693 §3 prefix, so the prefix alone proves nothing.
     #[test]
-    fn test_token_type_aliases_match_protocol_constants() {
+    fn test_token_type_urns_match_protocol_constants() {
         use vouch_common::protocol;
 
-        assert_eq!(token_types::ACCESS_TOKEN, protocol::TOKEN_TYPE_ACCESS_TOKEN);
-        assert_eq!(token_types::ID_TOKEN, protocol::TOKEN_TYPE_ID_TOKEN);
-        assert_eq!(token_types::JWT, protocol::TOKEN_TYPE_JWT);
+        assert_eq!(
+            TokenType::AccessToken.as_urn(),
+            protocol::TOKEN_TYPE_ACCESS_TOKEN
+        );
+        assert_eq!(TokenType::IdToken.as_urn(), protocol::TOKEN_TYPE_ID_TOKEN);
+        assert_eq!(TokenType::Jwt.as_urn(), protocol::TOKEN_TYPE_JWT);
+
+        assert_eq!(
+            TokenType::parse(protocol::TOKEN_TYPE_ACCESS_TOKEN),
+            Some(TokenType::AccessToken)
+        );
+        assert_eq!(
+            TokenType::parse(protocol::TOKEN_TYPE_ID_TOKEN),
+            Some(TokenType::IdToken)
+        );
+        assert_eq!(
+            TokenType::parse(protocol::TOKEN_TYPE_JWT),
+            Some(TokenType::Jwt)
+        );
+    }
+
+    /// RFC 8693 §3 lists types this server does not accept; they must not
+    /// parse into a [`TokenType`] at all.
+    #[test]
+    fn test_token_type_rejects_unsupported_urns() {
+        for urn in [
+            "urn:ietf:params:oauth:token-type:saml1",
+            "urn:ietf:params:oauth:token-type:saml2",
+            "urn:ietf:params:oauth:token-type:refresh_token",
+            "",
+            "access_token",
+        ] {
+            assert_eq!(TokenType::parse(urn), None, "{urn} must not parse");
+        }
+    }
+
+    // =========================================================================
+    // RFC 8693 §2.1 parameter pairing
+    //
+    // `actor_token_type` "is REQUIRED when the `actor_token` parameter is
+    // present in the request but MUST NOT be included otherwise", so every
+    // combination of the two has exactly one outcome.
+    // =========================================================================
+
+    #[test]
+    fn test_actor_token_absent_is_not_a_delegation() {
+        let actor = ActorToken::from_params(None, None).expect("neither parameter is valid");
+        assert!(actor.is_none());
+    }
+
+    #[test]
+    fn test_actor_token_pairs_with_declared_type() {
+        let token = SecretString::from("tok");
+
+        let actor = ActorToken::from_params(Some(&token), Some(protocol::TOKEN_TYPE_ACCESS_TOKEN))
+            .expect("access_token is an accepted actor type")
+            .expect("the pair is a delegation");
+        assert!(matches!(actor, ActorToken::AccessToken(_)));
+        assert_eq!(actor.token().expose_secret(), "tok");
+
+        let actor = ActorToken::from_params(Some(&token), Some(protocol::TOKEN_TYPE_JWT))
+            .expect("jwt is an accepted actor type")
+            .expect("the pair is a delegation");
+        assert!(matches!(actor, ActorToken::Jwt(_)));
+        assert_eq!(actor.token().expose_secret(), "tok");
+    }
+
+    /// The subset that diverges from `subject_token_type`: an ID token asserts
+    /// who a user is, not who is acting.
+    #[test]
+    fn test_actor_token_rejects_id_token_type() {
+        let token = SecretString::from("tok");
+        let err = ActorToken::from_params(Some(&token), Some(protocol::TOKEN_TYPE_ID_TOKEN))
+            .expect_err("id_token is not an accepted actor type");
+        assert!(
+            format!("{err:?}").contains("Invalid actor_token_type"),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn test_actor_token_without_type_is_rejected() {
+        let token = SecretString::from("tok");
+        ActorToken::from_params(Some(&token), None)
+            .expect_err("actor_token_type is REQUIRED when actor_token is present");
+    }
+
+    /// The case this pairing exists to catch: before it, the type check lived
+    /// inside `if let Some(actor_token)`, so a lone `actor_token_type` was
+    /// accepted and dropped.
+    #[test]
+    fn test_actor_token_type_without_token_is_rejected() {
+        ActorToken::from_params(None, Some(protocol::TOKEN_TYPE_ACCESS_TOKEN))
+            .expect_err("actor_token_type MUST NOT be included without actor_token");
+    }
+
+    #[test]
+    fn test_subject_token_requires_both_parameters() {
+        let token = SecretString::from("tok");
+        SubjectToken::from_params(None, Some(protocol::TOKEN_TYPE_ACCESS_TOKEN))
+            .expect_err("subject_token is REQUIRED");
+        SubjectToken::from_params(Some(&token), None).expect_err("subject_token_type is REQUIRED");
+        SubjectToken::from_params(None, None).expect_err("both are REQUIRED");
+    }
+
+    /// Every [`TokenType`] is accepted as a subject type — this is the subset
+    /// that must stay wider than [`ActorToken`]'s.
+    #[test]
+    fn test_subject_token_accepts_every_token_type() {
+        let token = SecretString::from("tok");
+        for token_type in [TokenType::AccessToken, TokenType::IdToken, TokenType::Jwt] {
+            let subject = SubjectToken::from_params(Some(&token), Some(token_type.as_urn()))
+                .expect("every token type is a valid subject type");
+            assert_eq!(subject.token_type, token_type);
+            assert_eq!(subject.token.expose_secret(), "tok");
+        }
+    }
+
+    #[test]
+    fn test_subject_token_rejects_unsupported_type() {
+        let token = SecretString::from("tok");
+        SubjectToken::from_params(Some(&token), Some("urn:ietf:params:oauth:token-type:saml2"))
+            .expect_err("saml2 is not a subject type this server accepts");
+    }
+
+    /// [`TokenExchangeParams`] derives `Debug`; holding the tokens as
+    /// [`SecretString`] is what keeps a bearer credential out of that output.
+    #[test]
+    fn test_subject_and_actor_tokens_are_redacted_in_debug() {
+        let token = SecretString::from("exchange-secret-token");
+        let subject = SubjectToken::from_params(Some(&token), Some(protocol::TOKEN_TYPE_JWT))
+            .expect("valid subject pair");
+        let actor = ActorToken::from_params(Some(&token), Some(protocol::TOKEN_TYPE_JWT))
+            .expect("valid actor pair");
+
+        let debug = format!("{subject:?} {actor:?}");
+        assert!(!debug.contains("exchange-secret-token"), "{debug}");
     }
 
     // =========================================================================
@@ -781,7 +1025,7 @@ mod tests {
     fn test_token_exchange_result_debug_redacts_access_token() {
         let result = TokenExchangeResult {
             access_token: "eyJhbGciOiJFUzI1NiJ9.exchange-secret-token".into(),
-            issued_token_type: token_types::ACCESS_TOKEN.to_string(),
+            issued_token_type: TokenType::AccessToken.as_urn().to_string(),
             token_type: "Bearer".to_string(),
             expires_in: 3600,
             scope: Some(ScopeSet::parse("openid")),


### PR DESCRIPTION
Closes #1031. Closes #1037.

Two members of the compile-enforced spec invariants batch. Both convert an invariant that was enforced by statement nesting or by hand-rolled decoding into a type, and both delete what they replace.

## RFC 8693 token pairs (#1031)

`actor_token_type` was validated inside `if let Some(actor_token) = params.actor_token`, so a request carrying the type without the token never reached the check — the parameter was accepted and dropped. Separately, the three token-type parameters kept three different accepted-URN lists inside `exchange.rs`.

A `TokenType` enum replaces the `token_types` alias module, keeping the property #1005 established: `as_urn()` returns the `vouch_common::protocol` constants, so the CLI and server still spell the URNs from one source. Each token is then paired with the type declared for it:

- `SubjectToken` — both parameters are REQUIRED, so they are one value. Every `TokenType` is accepted.
- `ActorToken` — an enum whose two variants *are* the accepted `actor_token_type` subset. There is no `IdToken` variant, so admitting an ID token as an actor would take a code change here rather than an edit to a list shared with the other two parameters.

`ExchangeTokens::from_request` builds them at the request boundary, so `exchange_token` can no longer be reached with a token whose type went unchecked or a type whose token never arrived. Three runtime validation blocks are deleted.

Both tokens are held as `SecretString`. `TokenExchangeParams` derives `Debug` and printed them in full; there is now a test asserting it does not.

### Spec basis

RFC 8693 §2.1 ([`specs/rfc/rfc8693.txt:363-367`](https://www.rfc-editor.org/rfc/rfc8693.txt), sha256 in `specs/manifest.tsv`):

> actor_token_type
>    An identifier, as described in Section 3, that indicates the type
>    of the security token in the "actor_token" parameter.  This is
>    REQUIRED when the "actor_token" parameter is present in the
>    request but MUST NOT be included otherwise.

Stated accurately: that MUST NOT binds the **client**. RFC 8693 does not require the authorization server to reject the combination, so this was us silently accepting a malformed request, not a server-side MUST violation. Rejecting is a deliberate choice, taken so a client that mislabels its request finds out.

The error code is `invalid_request` under RFC 6749 §5.2 ([`specs/rfc/rfc6749.txt:2481-2485`](https://www.rfc-editor.org/rfc/rfc6749.txt)):

> invalid_request
>       The request is missing a required parameter, includes an
>       unsupported parameter value (other than grant type), repeats a
>       parameter, includes multiple credentials, utilizes more than one
>       mechanism for authenticating the client, or is otherwise
>       malformed.

### Behavior changes

- `actor_token_type` without `actor_token` → 400 `invalid_request` (was: accepted, parameter dropped).
- `actor_token` without `actor_token_type` → 400 `invalid_request` (was: also rejected, via the type check; unchanged in effect).
- Missing `subject_token` → 400 `invalid_request` (was: reached the decoder as `""` and came back `invalid_grant`).

No in-tree caller is affected: the CLI never sends `actor_token`.

## Browser WebAuthn wire fields (#1037)

`BrowserRegisterCompleteRequest` and `BrowserLoginCompleteRequest` used bare `String` for the same binary fields the CLI path types as `Encoded<T, Base64Url>`, so each handler opened with a block of hand-rolled `URL_SAFE_NO_PAD.decode` calls.

Both directions are now typed. The Complete requests decode during deserialization, which deletes the decode phase from both handlers. The Start responses encode on serialization, which deletes five hand-rolled encode calls. The wire JSON is unchanged in both directions — the fields were base64url strings before and still are.

Body rejections go through a new `ValidJson` extractor, the `ValidPath` analogue for JSON bodies. Axum's own rejection answers `text/plain`, which `login.js` and `keys.js` cannot read: both call `.json()` and display `errResp.message`.

### Behavior changes

- A malformed or missing field answers 400 with code `invalid_request` and a message naming the field. Previously: per-field codes (`invalid_credential`, `invalid_attestation`, `invalid_client_data`) for a bad base64url value, and 422 with a `text/plain` body for a missing field.
- A request that fails to deserialize no longer consumes the single-use state token, because it never reaches the handler. A user who fumbles no longer burns their enrollment link.
- Length caps that bounded the encoded string now bound the decoded bytes. The per-route body limit is unchanged at 32 KB.

`crypto/webauthn_verify.rs` documented a typed interface "tracked in #1037"; that paragraph is now accurate and no longer forward-references the issue.

## Proof the invariants are compile-enforced

Attempting the violations, with the temporary test removed afterward:

```
error[E0599]: no variant, associated function, or constant named `IdToken`
              found for enum `exchange::ActorToken<'a>`
    |
918 |         let _ = ActorToken::IdToken("tok");
    |                             ^^^^^^^ variant ... not found

error[E0560]: struct `exchange::TokenExchangeParams<'_>` has no field named `actor_token_type`
    |
922 |             actor_token_type: None,
    |             ^^^^^^^^^^^^^^^^
    = note: available fields are: `subject`, `actor`, `audience`, `scope`, `requested_token_type` ...

error[E0308]: mismatched types
    |
309 |             credential_id: "AQID".to_string(),
    |                            ^^^^^^^^^^^^^^^^^^ expected `Encoded<CredentialIdData, Base64Url>`, found `String`

error[E0308]: mismatched types
    |
315 |         let _: CredentialId<Base64Url> = sig;
    |                -----------------------   ^^^ expected `Encoded<CredentialIdData, Base64Url>`,
    |                                              found `Encoded<SignatureData, Base64Url>`
```

## Verification

- `make fmt`, `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `make test` — 49 suites, 0 failures.
- `make test-integration` — 0 failures.
- Live-checked against a running server, since the browser wire format is built by hand in JS and no compiler covers it:
  - `POST /login/webauthn/start` returns `challenge` as a base64url string decoding to 32 bytes, unchanged.
  - `POST /login/webauthn/complete` and `POST /enroll/webauthn/complete` with a malformed field return `400`, `content-type: application/json`, body `{"code":"invalid_request","message":"... credential_id: Invalid symbol 33 ..."}` — the shape `errResp.message` needs.

Not covered: a real WebAuthn ceremony against hardware. The registration and assertion paths are exercised by the existing handler tests with a mock authenticator, and the wire format by the round-trip tests above, but no browser ran a `credentials.create()`/`.get()` against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)