### PR TITLE
refactor(oidc): resolve the token request to its grant at the boundary

### DIFF
--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -3,13 +3,13 @@
 
 use crate::AppState;
 use crate::db::{self, DeviceAuthState};
+use crate::handlers::extractors::{OAuthForm, OptionalClientCert};
 use crate::services::auth::{
     ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenIssuanceProof,
     create_oauth_access_token,
 };
 use crate::services::oidc::ScopeSet;
 use crate::services::oidc::dpop::DpopError;
-use crate::services::oidc::grant_type::OAuthGrantType;
 use crate::services::oidc::token::validate_dpop_if_present;
 use aws_lc_rs::digest::{self, SHA256};
 use axum::{
@@ -23,8 +23,7 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use jiff::{Span, Timestamp};
 use std::sync::Arc;
 use vouch_common::{
-    DeviceCodeRequest, DeviceCodeResponse, DeviceTokenRequest, DeviceTokenResponse, OAuthError,
-    protocol,
+    DeviceCodeRequest, DeviceCodeResponse, DeviceTokenResponse, OAuthError, protocol,
 };
 
 use crate::error::{OAuthErrorCode, ServiceError};
@@ -88,7 +87,7 @@ fn hash_device_code(code: &str) -> String {
 /// [`protocol::CONTENT_TYPE_FORM_URLENCODED`] format.
 pub(crate) async fn device_code(
     State(state): State<Arc<AppState>>,
-    axum::Form(req): axum::Form<DeviceCodeRequest>,
+    OAuthForm(req): OAuthForm<DeviceCodeRequest>,
 ) -> Result<Json<DeviceCodeResponse>, ServiceError> {
     tracing::info!("Device authorization request");
 
@@ -220,35 +219,14 @@ async fn revoke_sessions_for_device_replay(state: &AppState, user_id: &str) {
 pub(crate) async fn device_token(
     State(state): State<Arc<AppState>>,
     client_info: db::ClientInfo,
-    client_cert: crate::handlers::extractors::OptionalClientCert,
+    client_cert: OptionalClientCert,
     headers: HeaderMap,
-    Json(req): Json<DeviceTokenRequest>,
+    device_code: &str,
 ) -> Result<Json<DeviceTokenResponse>, Response> {
-    // Validate grant type through the owning enum; exhaustive so a new
-    // grant variant forces this dispatch to be revisited.
-    match req.grant_type.parse::<OAuthGrantType>() {
-        Ok(OAuthGrantType::DeviceCode) => {}
-        Ok(
-            OAuthGrantType::AuthorizationCode
-            | OAuthGrantType::ClientCredentials
-            | OAuthGrantType::TokenExchange
-            | OAuthGrantType::Fido2Assertion,
-        )
-        | Err(_) => {
-            return Err(oauth_error(
-                StatusCode::BAD_REQUEST,
-                OAuthError {
-                    error: OAuthErrorCode::UnsupportedGrantType.as_str().to_string(),
-                    error_description: Some("Expected device_code grant type".to_string()),
-                },
-            ));
-        }
-    }
-
     // Validate device_code format before hashing and DB lookup.
     // Generated codes are 32 random bytes base64url-encoded (43 chars).
     // Reject obviously invalid inputs to avoid unnecessary work.
-    if req.device_code.is_empty() || req.device_code.len() > 128 {
+    if device_code.is_empty() || device_code.len() > 128 {
         return Err(oauth_error(
             StatusCode::BAD_REQUEST,
             OAuthError::invalid_grant(),
@@ -256,7 +234,7 @@ pub(crate) async fn device_token(
     }
 
     // Hash the device code and look it up
-    let device_code_hash = hash_device_code(&req.device_code);
+    let device_code_hash = hash_device_code(device_code);
     let request = db::get_device_auth_by_code_hash(&state.store, &device_code_hash)
         .await
         .map_err(|e| {
@@ -1128,22 +1106,37 @@ mod tests {
     // Device Code Input Validation Tests
     // ========================================================================
 
+    /// RFC 6749 §3.2: "Parameters sent without a value MUST be treated as if
+    /// they were omitted from the request." `device_code=` is therefore a
+    /// request missing a REQUIRED parameter — `invalid_request` under §5.2 —
+    /// and must answer exactly as omitting it does.
     #[tokio::test]
-    async fn test_device_code_rejects_empty() {
-        // Empty device_code should be rejected before DB lookup
+    async fn test_device_code_empty_is_treated_as_omitted() {
         let (app, _state) = test_app().await;
 
-        let (status, body) = http_post_form(
+        let (empty_status, empty_body) = http_post_form(
             &app,
             "/oauth/token",
             "grant_type=urn:ietf:params:oauth:grant-type:device_code&device_code=",
             &[],
         )
         .await;
+        let (omitted_status, omitted_body) = http_post_form(
+            &app,
+            "/oauth/token",
+            "grant_type=urn:ietf:params:oauth:grant-type:device_code",
+            &[],
+        )
+        .await;
 
-        assert_eq!(status, StatusCode::BAD_REQUEST);
-        let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
-        assert_eq!(error["error"], "invalid_grant");
+        assert_eq!(empty_status, StatusCode::BAD_REQUEST);
+        assert_eq!(empty_status, omitted_status);
+        assert_eq!(
+            empty_body, omitted_body,
+            "an empty parameter must answer exactly as an omitted one"
+        );
+        let error: serde_json::Value = serde_json::from_str(&empty_body).expect("Valid JSON");
+        assert_eq!(error["error"], "invalid_request");
     }
 
     #[tokio::test]

--- a/crates/vouch-server/src/handlers/extractors.rs
+++ b/crates/vouch-server/src/handlers/extractors.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use axum::extract::rejection::PathRejection;
 use axum::extract::{FromRequest, FromRequestParts, Path};
 use axum::http::{HeaderMap, StatusCode};
+use axum::response::IntoResponse;
 use http::request::Parts;
 use serde::Deserialize;
 
@@ -108,6 +109,115 @@ where
                 rejection.body_text(),
             )),
         }
+    }
+}
+
+/// Deserialize form-encoded parameters with the empty-valued ones dropped.
+///
+/// RFC 6749 §3.1 (authorization endpoint) and §3.2 (token endpoint) carry the
+/// same paragraph:
+///
+/// > Parameters sent without a value MUST be treated as if they were omitted
+/// > from the request. The authorization server MUST ignore unrecognized
+/// > request parameters. Request and response parameters MUST NOT be included
+/// > more than once.
+///
+/// Dropping the empty-valued pairs before deserialization is what makes
+/// `scope=` and an omitted `scope` arrive as the same `None`. Unrecognized
+/// parameters are ignored by `T`'s derived deserializer, which also rejects a
+/// repeated recognized one — RFC 6749 §5.2 defines `invalid_request` as
+/// covering a request that "includes a parameter more than once". A repeated
+/// *unrecognized* parameter stays ignored, since the sentence before it
+/// requires exactly that.
+fn deserialize_present_params<T: serde::de::DeserializeOwned>(encoded: &[u8]) -> Result<T, String> {
+    let pairs: Vec<(String, String)> =
+        serde_urlencoded::from_bytes(encoded).map_err(|e| e.to_string())?;
+    let present: Vec<(String, String)> = pairs.into_iter().filter(|(_, v)| !v.is_empty()).collect();
+    let reencoded = serde_urlencoded::to_string(&present).map_err(|e| e.to_string())?;
+    serde_urlencoded::from_str::<T>(&reencoded).map_err(|e| e.to_string())
+}
+
+/// Build the OAuth `invalid_request` envelope (RFC 6749 §5.2) for a request
+/// whose parameters could not be read.
+fn reject_oauth_params(description: String) -> axum::response::Response {
+    ServiceError::oauth(crate::error::OAuthErrorCode::InvalidRequest, description)
+        .into_oauth_response()
+        .into_response()
+}
+
+/// Form-body extractor for the OAuth endpoints, applying the RFC 6749 §3.2
+/// parameter rules that `axum::Form` does not — see
+/// [`deserialize_present_params`].
+///
+/// Rejections carry the OAuth error envelope rather than axum's `text/plain`
+/// body, so a client parsing `error`/`error_description` reads a malformed
+/// request the same way it reads every other failure.
+pub(crate) struct OAuthForm<T>(pub T);
+
+impl<T, S> FromRequest<S> for OAuthForm<T>
+where
+    T: serde::de::DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = axum::response::Response;
+
+    async fn from_request(req: axum::extract::Request, state: &S) -> Result<Self, Self::Rejection> {
+        // RFC 6749 §4.1.3: request parameters are sent "in the HTTP request
+        // entity-body using the application/x-www-form-urlencoded format".
+        // Any other media type is unsupported rather than malformed.
+        let is_form = req
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|v| {
+                // The media type may carry parameters (`; charset=utf-8`).
+                let media_type = v.split(';').next().unwrap_or(v).trim();
+                media_type.eq_ignore_ascii_case("application/x-www-form-urlencoded")
+            });
+        if !is_form {
+            return Err((
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                axum::Json(crate::error::OAuthErrorResponse {
+                    error: crate::error::OAuthErrorCode::InvalidRequest
+                        .as_str()
+                        .to_string(),
+                    error_description: Some(
+                        "Expected application/x-www-form-urlencoded request body".to_string(),
+                    ),
+                    error_uri: None,
+                }),
+            )
+                .into_response());
+        }
+
+        let body = axum::body::Bytes::from_request(req, state)
+            .await
+            .map_err(|e| reject_oauth_params(e.body_text()))?;
+
+        deserialize_present_params(&body)
+            .map(Self)
+            .map_err(reject_oauth_params)
+    }
+}
+
+/// Query-string extractor for the OAuth endpoints, applying the RFC 6749 §3.1
+/// parameter rules that `axum::extract::Query` does not — see
+/// [`deserialize_present_params`]. The authorization endpoint's counterpart to
+/// [`OAuthForm`].
+pub(crate) struct OAuthQuery<T>(pub T);
+
+impl<T, S> FromRequestParts<S> for OAuthQuery<T>
+where
+    T: serde::de::DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = axum::response::Response;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let query = parts.uri.query().unwrap_or_default();
+        deserialize_present_params(query.as_bytes())
+            .map(Self)
+            .map_err(reject_oauth_params)
     }
 }
 
@@ -533,5 +643,75 @@ mod tests {
             output.to_lowercase(),
             "output must be lowercase: {output}"
         );
+    }
+}
+
+#[cfg(test)]
+mod oauth_params_tests {
+    #![expect(
+        clippy::expect_used,
+        reason = "test code: panic on assertion failure is acceptable"
+    )]
+    use super::deserialize_present_params;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize, PartialEq, Eq)]
+    struct Params {
+        required: String,
+        #[serde(default)]
+        optional: Option<String>,
+    }
+
+    /// RFC 6749 §3.1/§3.2: "Parameters sent without a value MUST be treated as
+    /// if they were omitted from the request."
+    #[test]
+    fn empty_valued_parameter_arrives_as_omitted() {
+        let empty: Params =
+            deserialize_present_params(b"required=r&optional=").expect("empty value is dropped");
+        let omitted: Params = deserialize_present_params(b"required=r").expect("valid");
+        assert_eq!(empty, omitted);
+        assert_eq!(empty.optional, None);
+    }
+
+    /// The same rule applied to a REQUIRED parameter: emptying it makes the
+    /// request one that is missing it, rather than one carrying an empty value.
+    #[test]
+    fn empty_required_parameter_is_missing_not_empty() {
+        let err = deserialize_present_params::<Params>(b"required=&optional=o")
+            .expect_err("an emptied REQUIRED parameter is a missing one");
+        assert!(
+            err.contains("required"),
+            "the rejection must name the missing field, got: {err}"
+        );
+    }
+
+    /// "The authorization server MUST ignore unrecognized request parameters."
+    #[test]
+    fn unrecognized_parameters_are_ignored() {
+        let value: Params = deserialize_present_params(b"required=r&surprise=1&surprise=2")
+            .expect("unrecognized parameters are ignored, repeated or not");
+        assert_eq!(value.required, "r");
+    }
+
+    /// "Request and response parameters MUST NOT be included more than once."
+    /// A repeated *recognized* parameter fails, which the callers report as
+    /// `invalid_request` (RFC 6749 §5.2: "includes a parameter more than once").
+    #[test]
+    fn repeated_recognized_parameter_is_rejected() {
+        let err = deserialize_present_params::<Params>(b"required=a&required=b")
+            .expect_err("a repeated recognized parameter must not deserialize");
+        assert!(
+            err.contains("duplicate"),
+            "expected a duplicate-field rejection, got: {err}"
+        );
+    }
+
+    /// A value that is only *syntactically* empty after decoding still counts:
+    /// `%20` is a space, not nothing, so it is a present value.
+    #[test]
+    fn whitespace_value_is_present() {
+        let value: Params =
+            deserialize_present_params(b"required=r&optional=%20").expect("a space is a value");
+        assert_eq!(value.optional.as_deref(), Some(" "));
     }
 }

--- a/crates/vouch-server/src/handlers/oidc/authorize.rs
+++ b/crates/vouch-server/src/handlers/oidc/authorize.rs
@@ -14,6 +14,7 @@ use crate::AppState;
 use crate::db::ResponseMode;
 use crate::db::{self, Authenticator, CreatePendingOAuthParams, OAuthClient, Session, User};
 use crate::error::OAuthErrorCode;
+use crate::handlers::extractors::{OAuthForm, OAuthQuery};
 use crate::impl_template_response;
 use crate::services::oidc::ScopeSet;
 use crate::services::oidc::authorization::{
@@ -25,8 +26,7 @@ use crate::services::oidc::authorization::{
 use crate::services::oidc::jar::{QueryParamHints, fetch_request_object, validate_request_object};
 use askama::Template;
 use axum::{
-    Form,
-    extract::{Query, State},
+    extract::State,
     response::{IntoResponse, Redirect, Response},
 };
 use axum_extra::extract::cookie::CookieJar;
@@ -408,7 +408,7 @@ async fn check_session_and_authorize(
 /// - RFC 9700: Follows OAuth 2.0 Security BCP
 pub(crate) async fn authorize(
     State(state): State<Arc<AppState>>,
-    Query(params): Query<AuthorizeQuery>,
+    OAuthQuery(params): OAuthQuery<AuthorizeQuery>,
     jar: CookieJar,
 ) -> Response {
     authorize_inner(state, params, jar).await
@@ -510,7 +510,7 @@ async fn authorize_inner(state: Arc<AppState>, params: AuthorizeQuery, jar: Cook
 pub(crate) async fn authorize_post(
     State(state): State<Arc<AppState>>,
     jar: CookieJar,
-    Form(params): Form<AuthorizeQuery>,
+    OAuthForm(params): OAuthForm<AuthorizeQuery>,
 ) -> Response {
     authorize_inner(state, params, jar).await
 }

--- a/crates/vouch-server/src/handlers/oidc/client_auth.rs
+++ b/crates/vouch-server/src/handlers/oidc/client_auth.rs
@@ -50,7 +50,7 @@ pub(crate) enum ExtractedClientAuth {
 
 /// Fields needed for client authentication extraction.
 ///
-/// Both `TokenRequest` and `ParRequest` implement this trait so the shared
+/// Both `ClientAuthParams` and `ParRequest` implement this trait so the shared
 /// extraction logic can work with either.
 pub(crate) trait ClientAuthFields {
     fn client_id(&self) -> Option<&str>;

--- a/crates/vouch-server/src/handlers/oidc/introspect.rs
+++ b/crates/vouch-server/src/handlers/oidc/introspect.rs
@@ -8,6 +8,7 @@
 use crate::AppState;
 use crate::db::ClientInfo;
 use crate::error::ServiceError;
+use crate::handlers::extractors::OAuthForm;
 use crate::services::oidc::introspection::{
     introspect_token as svc_introspect, revoke_token as svc_revoke, sign_introspection_jwt,
 };
@@ -153,7 +154,7 @@ pub(crate) async fn revoke(
     State(state): State<Arc<AppState>>,
     client_info: ClientInfo,
     headers: HeaderMap,
-    axum::Form(params): axum::Form<RevokeRequest>,
+    OAuthForm(params): OAuthForm<RevokeRequest>,
 ) -> Response {
     // RFC 7009 Section 2.1: Authenticate the calling client.
     // Supports client_secret_basic, client_secret_post, and private_key_jwt.
@@ -209,7 +210,7 @@ pub(crate) async fn revoke(
 pub(crate) async fn introspect(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
-    axum::Form(params): axum::Form<IntrospectRequest>,
+    OAuthForm(params): OAuthForm<IntrospectRequest>,
 ) -> Response {
     // RFC 7662 Section 2.1: The introspection endpoint MUST authenticate the caller.
     // Supports client_secret_basic, client_secret_post, and private_key_jwt.

--- a/crates/vouch-server/src/handlers/oidc/par.rs
+++ b/crates/vouch-server/src/handlers/oidc/par.rs
@@ -7,6 +7,7 @@ use crate::db::{self, CreateParParams, PAR_EXPIRES_IN};
 use crate::error::OAuthErrorCode;
 use crate::error::OAuthErrorResponse;
 use crate::error::ServiceError;
+use crate::handlers::extractors::{OAuthForm, OptionalClientCert};
 use crate::services::auth::{ClientAuthProof, ParCreationProof};
 use crate::services::oidc::DpopError;
 use crate::services::oidc::authorization::{
@@ -176,9 +177,9 @@ impl ClientAuthFields for ParRequest {
 )]
 pub(crate) async fn par(
     State(state): State<Arc<AppState>>,
-    client_cert: crate::handlers::extractors::OptionalClientCert,
+    client_cert: OptionalClientCert,
     headers: HeaderMap,
-    axum::Form(params): axum::Form<ParRequest>,
+    OAuthForm(params): OAuthForm<ParRequest>,
 ) -> Response {
     // RFC 9126 Section 2.1: request_uri MUST NOT be provided in a PAR request
     if params.request_uri.is_some() {

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc6749_authorize.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc6749_authorize.rs
@@ -1103,3 +1103,57 @@ async fn test_form_post_error_delivers_html_form() {
         "form_post error must echo the state parameter"
     );
 }
+
+/// RFC 6749 §3.1 carries the same parameter rules as §3.2 for the
+/// authorization endpoint: "Parameters sent without a value MUST be treated as
+/// if they were omitted from the request." Checked on the query string, which
+/// is how this endpoint receives them, and on `prompt`, where the two cases
+/// diverge: `Prompt::parse("")` is `None`, so an empty `prompt` used to be
+/// rejected as an unsupported value while an omitted one requests nothing.
+#[tokio::test]
+async fn test_rfc6749_authorize_empty_parameter_is_treated_as_omitted() {
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "authorize-empty@example.com").await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+
+    let base = format!(
+        "/oauth/authorize?response_type=code&client_id={}&redirect_uri=https://example.com/callback",
+        client.client_id
+    );
+
+    // Both answers are redirects, so the Location header is where they differ:
+    // an unsupported prompt redirects to the client with `error=`, while an
+    // omitted one continues the flow.
+    let empty = http_get_full(&app, &format!("{base}&prompt="), &[]).await;
+    let omitted = http_get_full(&app, &base, &[]).await;
+
+    let location = |r: &crate::test_utils::HttpResponse| {
+        r.headers
+            .get("location")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default()
+            .to_string()
+    };
+
+    // Each answer carries a fresh `pending_auth` id, so compare the target
+    // rather than the whole URL.
+    let target = |r: &crate::test_utils::HttpResponse| {
+        location(r)
+            .split('?')
+            .next()
+            .unwrap_or_default()
+            .to_string()
+    };
+
+    assert_eq!(empty.status, omitted.status);
+    assert_eq!(
+        target(&empty),
+        target(&omitted),
+        "`prompt=` must answer exactly as an omitted `prompt`"
+    );
+    assert!(
+        !location(&empty).contains("error="),
+        "`prompt=` must not be rejected as an unsupported value: {}",
+        location(&empty)
+    );
+}

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc6749_token.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc6749_token.rs
@@ -590,7 +590,7 @@ fn test_token_request_debug_never_prints_credential_material() {
     // Every credential-bearing field must be absent from `{:?}` output —
     // the manual Debug impl prints [REDACTED] and the SecretString fields
     // self-redact even if a future impl prints them directly.
-    let request = crate::handlers::oidc::token::TokenRequest {
+    let request = crate::handlers::oidc::token::TokenRequestForm {
         grant_type: "authorization_code".to_string(),
         code: Some("visible-code".to_string()),
         redirect_uri: None,
@@ -778,5 +778,131 @@ async fn test_par_basic_auth_failure_challenges_with_basic() {
         www_authenticate(&response),
         "Basic",
         "PAR must carry the same challenge as the token endpoint"
+    );
+}
+
+// ========================================================================
+// RFC 6749 Section 3.2 — Token endpoint parameter rules
+// ========================================================================
+//
+// > Parameters sent without a value MUST be treated as if they were omitted
+// > from the request.  The authorization server MUST ignore unrecognized
+// > request parameters.  Request and response parameters MUST NOT be included
+// > more than once.
+//
+// The three cases below are that paragraph, one test each, checked at the
+// endpoint rather than against the request type: they are properties of what
+// the wire produces, and the wire is what a client sees.
+
+/// An empty-valued parameter must produce the same response as omitting it.
+/// `subject_token=` previously deserialized to `Some("")` and reached the
+/// decoder, which answered `invalid_grant` where an omitted `subject_token`
+/// answers `invalid_request`.
+#[tokio::test]
+async fn test_rfc6749_empty_parameter_is_treated_as_omitted() {
+    let (app, _state) = test_app().await;
+
+    let exchange = "grant_type=urn:ietf:params:oauth:grant-type:token-exchange\
+                    &subject_token_type=urn:ietf:params:oauth:token-type:access_token";
+
+    let (empty_status, empty_body) = http_post_form(
+        &app,
+        "/oauth/token",
+        &format!("{exchange}&subject_token="),
+        &[],
+    )
+    .await;
+    let (omitted_status, omitted_body) = http_post_form(&app, "/oauth/token", exchange, &[]).await;
+
+    assert_eq!(empty_status, omitted_status);
+    assert_eq!(
+        empty_body, omitted_body,
+        "`subject_token=` must answer exactly as an omitted `subject_token`"
+    );
+    assert_eq!(empty_status, StatusCode::BAD_REQUEST);
+    let error: serde_json::Value = serde_json::from_str(&empty_body).expect("Valid JSON");
+    assert_eq!(error["error"], "invalid_request");
+}
+
+/// A repeated parameter is `invalid_request` under RFC 6749 §5.2 ("includes a
+/// parameter more than once"), reported in the OAuth error envelope. Axum's
+/// own rejection answered `422` with a `text/plain` body, which a client
+/// parsing `error`/`error_description` cannot read.
+#[tokio::test]
+async fn test_rfc6749_duplicate_parameter_is_rejected_in_the_oauth_envelope() {
+    let (app, _state) = test_app().await;
+
+    let (status, body) = http_post_form(
+        &app,
+        "/oauth/token",
+        "grant_type=urn:ietf:params:oauth:grant-type:token-exchange\
+         &subject_token=a&subject_token=b\
+         &subject_token_type=urn:ietf:params:oauth:token-type:access_token",
+        &[],
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    let error: serde_json::Value =
+        serde_json::from_str(&body).expect("rejection must be the JSON OAuth envelope");
+    assert_eq!(error["error"], "invalid_request");
+}
+
+/// An unrecognized parameter must be ignored, including when repeated: the
+/// "MUST ignore unrecognized request parameters" sentence covers it, and the
+/// duplicate rule must not be read as overriding that.
+#[tokio::test]
+async fn test_rfc6749_unrecognized_parameters_are_ignored() {
+    let (app, _state) = test_app().await;
+
+    let (baseline_status, baseline_body) = http_post_form(
+        &app,
+        "/oauth/token",
+        "grant_type=authorization_code&code=nonexistent",
+        &[],
+    )
+    .await;
+    let (status, body) = http_post_form(
+        &app,
+        "/oauth/token",
+        "grant_type=authorization_code&code=nonexistent&surprise=1&surprise=2",
+        &[],
+    )
+    .await;
+
+    assert_eq!(status, baseline_status);
+    assert_eq!(
+        body, baseline_body,
+        "an unrecognized parameter must not change the response"
+    );
+}
+
+/// A parameter this server implements for a *different* grant is recognized
+/// but foreign: it is unreachable from the handler and, like an unrecognized
+/// one, does not change the response.
+#[tokio::test]
+async fn test_rfc6749_another_grants_parameter_is_ignored() {
+    let (app, _state) = test_app().await;
+
+    let (baseline_status, baseline_body) = http_post_form(
+        &app,
+        "/oauth/token",
+        "grant_type=authorization_code&code=nonexistent",
+        &[],
+    )
+    .await;
+    let (status, body) = http_post_form(
+        &app,
+        "/oauth/token",
+        "grant_type=authorization_code&code=nonexistent\
+         &device_code=dc&subject_token=st&assertion=as",
+        &[],
+    )
+    .await;
+
+    assert_eq!(status, baseline_status);
+    assert_eq!(
+        body, baseline_body,
+        "another grant's parameters must not change this grant's response"
     );
 }

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7662.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7662.rs
@@ -851,3 +851,37 @@ async fn test_introspection_m2m_client_credentials_token_is_active() {
         "M2M token must introspect as active despite having no user row: {response}"
     );
 }
+
+/// RFC 6749 §3.2, which RFC 7662 §2.1 inherits for its error responses:
+/// "Parameters sent without a value MUST be treated as if they were omitted
+/// from the request." `token` is REQUIRED, so `token=` is a request missing it
+/// rather than one introspecting the empty string.
+#[tokio::test]
+async fn test_introspect_empty_token_is_treated_as_omitted() {
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "introspect-empty@example.com").await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+    let auth_header = client.basic_auth_header();
+
+    let (empty_status, empty_body) = http_post_form(
+        &app,
+        "/oauth/introspect",
+        "token=",
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    let (omitted_status, omitted_body) = http_post_form(
+        &app,
+        "/oauth/introspect",
+        "",
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+
+    assert_eq!(empty_status, omitted_status);
+    assert_eq!(
+        empty_body, omitted_body,
+        "`token=` must answer exactly as an omitted `token`"
+    );
+    assert_eq!(empty_status, StatusCode::BAD_REQUEST, "{empty_body}");
+}

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
@@ -3372,3 +3372,49 @@ async fn test_rfc9126_par_deleted_by_cleanup_breaks_deferred_flow() {
          (deleted {deleted} expired records but this one should survive)"
     );
 }
+
+/// RFC 6749 §3.1 applies to the pushed request too: PAR carries the
+/// authorization endpoint's parameters, so an empty-valued one must be treated
+/// as omitted. `prompt` is where the two diverge — `Prompt::parse("")` is
+/// `None`, which the handler rejects as an unsupported value.
+#[tokio::test]
+async fn test_par_empty_parameter_is_treated_as_omitted() {
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "par-empty@example.com").await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+    let auth_header = client.basic_auth_header();
+
+    let (empty_status, empty_body) = http_post_form(
+        &app,
+        "/oauth/par",
+        "response_type=code&redirect_uri=https://example.com/callback&prompt=",
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    let (omitted_status, omitted_body) = http_post_form(
+        &app,
+        "/oauth/par",
+        "response_type=code&redirect_uri=https://example.com/callback",
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+
+    // Each success mints a fresh `request_uri`, so compare the outcome rather
+    // than the body: both must be the same status, and the empty-`prompt`
+    // request must not be rejected as carrying an unsupported value.
+    assert_eq!(
+        empty_status, omitted_status,
+        "`prompt=` must answer as an omitted `prompt`: {empty_body} vs {omitted_body}"
+    );
+    let empty: serde_json::Value = serde_json::from_str(&empty_body).expect("Valid JSON");
+    let omitted: serde_json::Value = serde_json::from_str(&omitted_body).expect("Valid JSON");
+    assert_eq!(
+        empty.get("error"),
+        omitted.get("error"),
+        "`prompt=` must not be rejected as an unsupported value: {empty_body}"
+    );
+    assert!(
+        empty.get("request_uri").is_some(),
+        "the pushed request must be accepted: {empty_body}"
+    );
+}

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -9,6 +9,7 @@ use crate::AppState;
 use crate::db::JwtAssertionJtiClaim;
 use crate::error::OAuthErrorResponse;
 use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
+use crate::handlers::extractors::{OAuthForm, OptionalClientCert};
 use crate::services::auth::{
     ClientAuthProof, GrantProof, SenderConstraintProof, TokenIssuanceProof,
 };
@@ -70,9 +71,13 @@ impl std::fmt::Debug for TokenResponse {
     }
 }
 
-/// Token request for all grant types (RFC 6749 Section 4.1.3, RFC 8628 Section 3.4, RFC 8693 Section 2.1).
+/// The token endpoint's form body as it arrives (RFC 6749 §4.1.3, RFC 8628
+/// §3.4, RFC 8693 §2.1): every parameter of every grant, all optional,
+/// because the wire cannot say which grant is being requested until
+/// `grant_type` is read. [`TokenRequestForm::parse`] resolves it into a
+/// [`TokenRequest`], which is what the handlers see.
 #[derive(Deserialize)]
-pub(crate) struct TokenRequest {
+pub(crate) struct TokenRequestForm {
     /// RFC 6749 Section 4.1.3: The grant type.
     pub grant_type: String,
     /// RFC 6749 Section 4.1.3: The authorization code received from the authorization server.
@@ -132,9 +137,9 @@ pub(crate) struct TokenRequest {
 }
 
 // Custom Debug that redacts secrets to prevent accidental log exposure.
-impl std::fmt::Debug for TokenRequest {
+impl std::fmt::Debug for TokenRequestForm {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("TokenRequest")
+        f.debug_struct("TokenRequestForm")
             .field("grant_type", &self.grant_type)
             .field("code", &self.code)
             .field("redirect_uri", &self.redirect_uri)
@@ -158,20 +163,171 @@ impl std::fmt::Debug for TokenRequest {
     }
 }
 
-/// Token request with a typed `grant_type` validated at the request boundary.
-#[derive(Debug)]
-struct ParsedTokenRequest {
-    grant_type: OAuthGrantType,
-    request: TokenRequest,
+/// RFC 6749 §2.3 client authentication parameters, which every grant carries.
+/// Held beside the per-grant value rather than repeated in each variant.
+struct ClientAuthParams {
+    client_id: Option<String>,
+    client_secret: Option<SecretString>,
+    client_assertion: Option<SecretString>,
+    client_assertion_type: Option<String>,
 }
 
-impl TokenRequest {
-    fn parse(self) -> Result<ParsedTokenRequest, ParseOAuthGrantTypeError> {
-        let grant_type = self.grant_type.parse::<OAuthGrantType>()?;
-        Ok(ParsedTokenRequest {
-            grant_type,
-            request: self,
-        })
+/// RFC 6749 §4.1.3 authorization code grant parameters.
+struct AuthorizationCodeParams {
+    /// REQUIRED.
+    code: String,
+    redirect_uri: Option<String>,
+    code_verifier: Option<String>,
+    resource: Option<String>,
+    authorization_details: Option<String>,
+}
+
+/// RFC 6749 §4.4 client credentials grant parameters.
+struct ClientCredentialsParams {
+    scope: Option<String>,
+}
+
+/// RFC 8628 §3.4 device authorization grant parameters.
+struct DeviceCodeParams {
+    /// REQUIRED.
+    device_code: String,
+}
+
+/// RFC 8693 §2.1 token exchange parameters. `subject_token` and
+/// `subject_token_type` are REQUIRED, so they are resolved here and the pair
+/// is typed by [`ExchangeTokens`] against this value.
+struct TokenExchangeRequestParams {
+    subject_token: SecretString,
+    subject_token_type: String,
+    actor_token: Option<SecretString>,
+    actor_token_type: Option<String>,
+    requested_token_type: Option<String>,
+    audience: Option<String>,
+    resource: Option<String>,
+    scope: Option<String>,
+    authorization_details: Option<String>,
+}
+
+/// FIDO2 assertion grant parameters (RFC 6749 §4.5 extension grant).
+struct Fido2AssertionParams {
+    /// REQUIRED.
+    assertion: SecretString,
+    scope: Option<String>,
+    authorization_details: Option<String>,
+}
+
+/// The parameters of one grant. A grant's parameters are reachable only
+/// through its own variant, so a handler cannot read another grant's.
+enum GrantParams {
+    AuthorizationCode(AuthorizationCodeParams),
+    ClientCredentials(ClientCredentialsParams),
+    DeviceCode(DeviceCodeParams),
+    TokenExchange(TokenExchangeRequestParams),
+    Fido2Assertion(Fido2AssertionParams),
+}
+
+/// A token request resolved to the grant it names, carrying only that grant's
+/// parameters plus the shared client authentication ones. Built by
+/// [`TokenRequestForm::parse`], which is the only way to obtain one.
+struct TokenRequest {
+    auth: ClientAuthParams,
+    grant: GrantParams,
+}
+
+/// Why a token request could not be resolved to a grant.
+enum TokenRequestRejection {
+    /// RFC 6749 §5.2: the `grant_type` names a grant this server does not
+    /// implement.
+    UnsupportedGrantType,
+    /// RFC 6749 §5.2: a parameter this grant declares REQUIRED is absent.
+    MissingParameter(&'static str),
+}
+
+impl TokenRequestRejection {
+    fn into_response(self) -> Response {
+        match self {
+            Self::UnsupportedGrantType => {
+                let supported = OAuthGrantType::supported_wire_values().join(", ");
+                token_error_response(
+                    OAuthErrorCode::UnsupportedGrantType,
+                    &format!("Supported grant types: {supported}"),
+                )
+            }
+            Self::MissingParameter(name) => token_error_response(
+                OAuthErrorCode::InvalidRequest,
+                &format!("Missing {name} parameter"),
+            ),
+        }
+    }
+}
+
+impl TokenRequestForm {
+    /// Resolve the flat wire form into the named grant's parameters.
+    ///
+    /// Parameters belonging to other grants are dropped here: RFC 6749 §3.2
+    /// requires unrecognized parameters to be ignored, and a parameter this
+    /// server implements for a *different* grant is treated the same way —
+    /// representable on the wire, unreachable from the handler.
+    fn parse(self) -> Result<TokenRequest, TokenRequestRejection> {
+        let grant_type = self
+            .grant_type
+            .parse::<OAuthGrantType>()
+            .map_err(|_: ParseOAuthGrantTypeError| TokenRequestRejection::UnsupportedGrantType)?;
+
+        let auth = ClientAuthParams {
+            client_id: self.client_id,
+            client_secret: self.client_secret,
+            client_assertion: self.client_assertion,
+            client_assertion_type: self.client_assertion_type,
+        };
+
+        let grant = match grant_type {
+            OAuthGrantType::AuthorizationCode => {
+                GrantParams::AuthorizationCode(AuthorizationCodeParams {
+                    code: self
+                        .code
+                        .ok_or(TokenRequestRejection::MissingParameter("code"))?,
+                    redirect_uri: self.redirect_uri,
+                    code_verifier: self.code_verifier,
+                    resource: self.resource,
+                    authorization_details: self.authorization_details,
+                })
+            }
+            OAuthGrantType::ClientCredentials => {
+                GrantParams::ClientCredentials(ClientCredentialsParams { scope: self.scope })
+            }
+            OAuthGrantType::DeviceCode => GrantParams::DeviceCode(DeviceCodeParams {
+                device_code: self
+                    .device_code
+                    .ok_or(TokenRequestRejection::MissingParameter("device_code"))?,
+            }),
+            OAuthGrantType::TokenExchange => {
+                GrantParams::TokenExchange(TokenExchangeRequestParams {
+                    subject_token: self
+                        .subject_token
+                        .ok_or(TokenRequestRejection::MissingParameter("subject_token"))?,
+                    subject_token_type: self.subject_token_type.ok_or(
+                        TokenRequestRejection::MissingParameter("subject_token_type"),
+                    )?,
+                    actor_token: self.actor_token,
+                    actor_token_type: self.actor_token_type,
+                    requested_token_type: self.requested_token_type,
+                    audience: self.audience,
+                    resource: self.resource,
+                    scope: self.scope,
+                    authorization_details: self.authorization_details,
+                })
+            }
+            OAuthGrantType::Fido2Assertion => GrantParams::Fido2Assertion(Fido2AssertionParams {
+                assertion: self
+                    .assertion
+                    .ok_or(TokenRequestRejection::MissingParameter("assertion"))?,
+                scope: self.scope,
+                authorization_details: self.authorization_details,
+            }),
+        };
+
+        Ok(TokenRequest { auth, grant })
     }
 }
 
@@ -226,9 +382,9 @@ const MAX_ASSERTION_LEN: usize = 8192;
 pub(crate) async fn token(
     State(state): State<Arc<AppState>>,
     client_info: crate::db::ClientInfo,
-    client_cert: crate::handlers::extractors::OptionalClientCert,
+    client_cert: OptionalClientCert,
     headers: HeaderMap,
-    axum::Form(params): axum::Form<TokenRequest>,
+    OAuthForm(params): OAuthForm<TokenRequestForm>,
 ) -> Response {
     // Input length validation — reject oversized parameters early.
     if let Some(ref v) = params.code_verifier
@@ -297,39 +453,52 @@ pub(crate) async fn token(
         );
     }
 
-    // RFC 6749 Section 5.2: Return unsupported_grant_type error for unknown grants.
-    let ParsedTokenRequest {
-        grant_type,
-        request: params,
-    } = match params.parse() {
-        Ok(parsed) => parsed,
-        Err(_) => {
-            let supported = OAuthGrantType::supported_wire_values().join(", ");
-            return token_error_response(
-                OAuthErrorCode::UnsupportedGrantType,
-                &format!("Supported grant types: {supported}"),
-            );
-        }
+    // RFC 6749 Section 5.2: unknown grant, or a REQUIRED parameter the named
+    // grant did not carry.
+    let TokenRequest { auth, grant } = match params.parse() {
+        Ok(typed) => typed,
+        Err(rejection) => return rejection.into_response(),
     };
 
-    match grant_type {
-        OAuthGrantType::AuthorizationCode => {
-            handle_authorization_code_grant(State(state), client_cert, headers, params).await
+    match grant {
+        GrantParams::AuthorizationCode(params) => {
+            handle_authorization_code_grant(State(state), client_cert, headers, auth, params).await
         }
-        OAuthGrantType::ClientCredentials => {
-            handle_client_credentials_grant(State(state), client_info, client_cert, headers, params)
-                .await
+        GrantParams::ClientCredentials(params) => {
+            handle_client_credentials_grant(
+                State(state),
+                client_info,
+                client_cert,
+                headers,
+                auth,
+                params,
+            )
+            .await
         }
-        OAuthGrantType::DeviceCode => {
+        GrantParams::DeviceCode(params) => {
             handle_device_code_grant(State(state), client_info, client_cert, headers, params).await
         }
-        OAuthGrantType::TokenExchange => {
-            handle_token_exchange_grant(State(state), client_info, client_cert, headers, params)
-                .await
+        GrantParams::TokenExchange(params) => {
+            handle_token_exchange_grant(
+                State(state),
+                client_info,
+                client_cert,
+                headers,
+                auth,
+                params,
+            )
+            .await
         }
-        OAuthGrantType::Fido2Assertion => {
-            handle_fido2_assertion_grant(State(state), client_info, client_cert, headers, params)
-                .await
+        GrantParams::Fido2Assertion(params) => {
+            handle_fido2_assertion_grant(
+                State(state),
+                client_info,
+                client_cert,
+                headers,
+                auth,
+                params,
+            )
+            .await
         }
     }
 }
@@ -365,8 +534,8 @@ async fn commit_optional_jti(
 async fn resolve_non_jwt_auth(
     state: &Arc<AppState>,
     headers: &HeaderMap,
-    params: &TokenRequest,
-    client_cert: &crate::handlers::extractors::OptionalClientCert,
+    auth: &ClientAuthParams,
+    client_cert: &OptionalClientCert,
 ) -> Result<
     (
         crate::services::oidc::token::AuthenticatedClient,
@@ -374,7 +543,7 @@ async fn resolve_non_jwt_auth(
     ),
     Response,
 > {
-    let creds = extract_client_credentials(headers, params);
+    let creds = extract_client_credentials(headers, auth);
     let Some((c, _presentation)) = creds else {
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidClient,
@@ -482,24 +651,17 @@ async fn resolve_non_jwt_auth(
 /// Handle authorization code grant.
 async fn handle_authorization_code_grant(
     State(state): State<Arc<AppState>>,
-    client_cert: crate::handlers::extractors::OptionalClientCert,
+    client_cert: OptionalClientCert,
     headers: HeaderMap,
-    params: TokenRequest,
+    auth: ClientAuthParams,
+    params: AuthorizationCodeParams,
 ) -> Response {
-    // RFC 6749 Section 4.1.3: The "code" parameter is REQUIRED
-    let code = match &params.code {
-        Some(c) => c,
-        None => {
-            return token_error_response(OAuthErrorCode::InvalidRequest, "Missing code parameter");
-        }
-    };
-
     // Extract client credentials from headers or body (including JWT assertion)
-    let has_jwt_assertion = params.client_assertion.is_some();
+    let has_jwt_assertion = auth.client_assertion.is_some();
 
     // For JWT assertion, authenticate and extract the client
     let (jwt_authenticated, jwt_pending_jti, jwt_auth) = if has_jwt_assertion {
-        let client_auth = match extract_client_auth(&headers, &params) {
+        let client_auth = match extract_client_auth(&headers, &auth) {
             Ok(auth) => auth,
             Err(resp) => return resp,
         };
@@ -551,14 +713,14 @@ async fn handle_authorization_code_grant(
     let non_jwt_auth = if has_jwt_assertion {
         None
     } else {
-        match resolve_non_jwt_auth(&state, &headers, &params, &client_cert).await {
+        match resolve_non_jwt_auth(&state, &headers, &auth, &client_cert).await {
             Ok(pair) => Some(pair),
             // RFC 6749 §5.2: every failure inside `resolve_non_jwt_auth` is a
             // client-authentication failure, so a client that used
             // `Authorization: Basic` is owed the matching challenge on the 401.
             Err(resp) => {
                 return with_client_auth_challenge(
-                    ClientAuthPresentation::of(&headers, &params),
+                    ClientAuthPresentation::of(&headers, &auth),
                     resp,
                 );
             }
@@ -624,7 +786,7 @@ async fn handle_authorization_code_grant(
     // Exchange the authorization code. `authenticated_client` is the
     // client_id used for RFC 8725 §3.9 audience validation.
     let exchange_params = AuthCodeExchangeParams {
-        code,
+        code: &params.code,
         redirect_uri: params.redirect_uri.as_deref(),
         authenticated_client: Some(&authenticated_client),
         code_verifier: params.code_verifier.as_deref(),
@@ -663,12 +825,13 @@ async fn handle_authorization_code_grant(
 async fn handle_client_credentials_grant(
     State(state): State<Arc<AppState>>,
     client_info: crate::db::ClientInfo,
-    client_cert: crate::handlers::extractors::OptionalClientCert,
+    client_cert: OptionalClientCert,
     headers: HeaderMap,
-    params: TokenRequest,
+    auth: ClientAuthParams,
+    params: ClientCredentialsParams,
 ) -> Response {
     // RFC 6749 Section 4.4.2: Client authentication is REQUIRED
-    let client_auth = match extract_client_auth(&headers, &params) {
+    let client_auth = match extract_client_auth(&headers, &auth) {
         Ok(auth) => auth,
         Err(resp) => return resp,
     };
@@ -838,20 +1001,16 @@ async fn handle_client_credentials_grant(
 async fn handle_device_code_grant(
     State(state): State<Arc<AppState>>,
     client_info: crate::db::ClientInfo,
-    client_cert: crate::handlers::extractors::OptionalClientCert,
+    client_cert: OptionalClientCert,
     headers: HeaderMap,
-    params: TokenRequest,
+    params: DeviceCodeParams,
 ) -> Response {
-    let device_req = vouch_common::DeviceTokenRequest {
-        grant_type: params.grant_type,
-        device_code: params.device_code.unwrap_or_default(),
-    };
     match super::super::device::device_token(
         State(state),
         client_info,
         client_cert,
         headers,
-        Json(device_req),
+        &params.device_code,
     )
     .await
     {
@@ -880,7 +1039,7 @@ impl<'a> ExchangeTokens<'a> {
     /// `invalid_request` for a missing REQUIRED parameter, a token type this
     /// server does not accept, or a token and type that did not arrive
     /// together.
-    fn from_request(params: &'a TokenRequest) -> ServiceResult<Self> {
+    fn from_request(params: &'a TokenExchangeRequestParams) -> ServiceResult<Self> {
         let requested_token_type = match params.requested_token_type.as_deref() {
             Some(urn) => Some(TokenType::parse(urn).ok_or_else(|| {
                 ServiceError::oauth(
@@ -891,10 +1050,7 @@ impl<'a> ExchangeTokens<'a> {
             None => None,
         };
         Ok(Self {
-            subject: SubjectToken::from_params(
-                params.subject_token.as_ref(),
-                params.subject_token_type.as_deref(),
-            )?,
+            subject: SubjectToken::new(&params.subject_token, &params.subject_token_type)?,
             actor: ActorToken::from_params(
                 params.actor_token.as_ref(),
                 params.actor_token_type.as_deref(),
@@ -912,12 +1068,13 @@ impl<'a> ExchangeTokens<'a> {
 async fn handle_token_exchange_grant(
     State(state): State<Arc<AppState>>,
     client_info: crate::db::ClientInfo,
-    client_cert: crate::handlers::extractors::OptionalClientCert,
+    client_cert: OptionalClientCert,
     headers: HeaderMap,
-    params: TokenRequest,
+    auth: ClientAuthParams,
+    params: TokenExchangeRequestParams,
 ) -> Response {
     // Extract client authentication (supports secret-based and JWT assertion)
-    let client_auth = match extract_client_auth(&headers, &params) {
+    let client_auth = match extract_client_auth(&headers, &auth) {
         Ok(auth) => auth,
         Err(resp) => return resp,
     };
@@ -1084,7 +1241,7 @@ async fn handle_token_exchange_grant(
 
 /// Implement `ClientAuthFields` for `TokenRequest` to enable shared client
 /// authentication extraction.
-impl ClientAuthFields for TokenRequest {
+impl ClientAuthFields for ClientAuthParams {
     fn client_id(&self) -> Option<&str> {
         self.client_id.as_deref()
     }
@@ -1109,23 +1266,15 @@ impl ClientAuthFields for TokenRequest {
 async fn handle_fido2_assertion_grant(
     State(state): State<Arc<AppState>>,
     client_info: crate::db::ClientInfo,
-    client_cert: crate::handlers::extractors::OptionalClientCert,
+    client_cert: OptionalClientCert,
     headers: HeaderMap,
-    params: TokenRequest,
+    auth: ClientAuthParams,
+    params: Fido2AssertionParams,
 ) -> Response {
-    // The assertion parameter is REQUIRED
-    let assertion = match &params.assertion {
-        Some(a) => a.clone(),
-        None => {
-            return token_error_response(
-                OAuthErrorCode::InvalidRequest,
-                "Missing assertion parameter for fido2-assertion grant",
-            );
-        }
-    };
+    let assertion = params.assertion;
 
     // Extract and authenticate client via private_key_jwt
-    let client_auth = match extract_client_auth(&headers, &params) {
+    let client_auth = match extract_client_auth(&headers, &auth) {
         Ok(auth) => auth,
         Err(resp) => return resp,
     };
@@ -1251,7 +1400,7 @@ async fn handle_fido2_assertion_grant(
 async fn validate_mtls_client_auth(
     state: &Arc<AppState>,
     client: &crate::services::oidc::token::AuthenticatedClient,
-    client_cert: &crate::handlers::extractors::OptionalClientCert,
+    client_cert: &OptionalClientCert,
 ) -> Result<Option<crate::services::oidc::token::MtlsCertVerification>, Box<Response>> {
     if client.client.token_endpoint_auth_method != crate::db::TokenEndpointAuthMethod::TlsClientAuth
         && client.client.token_endpoint_auth_method
@@ -1282,7 +1431,7 @@ async fn validate_mtls_client_auth(
 /// `tls_client_certificate_bound_access_tokens` **and** a cert is present.
 fn extract_mtls_thumbprint(
     client: &crate::services::oidc::token::AuthenticatedClient,
-    client_cert: &crate::handlers::extractors::OptionalClientCert,
+    client_cert: &OptionalClientCert,
 ) -> Option<String> {
     if client.client.tls_client_certificate_bound_access_tokens {
         client_cert.0.as_ref().map(|c| c.thumbprint.clone())

--- a/crates/vouch-server/src/services/oidc/exchange.rs
+++ b/crates/vouch-server/src/services/oidc/exchange.rs
@@ -77,22 +77,14 @@ pub struct SubjectToken<'a> {
 }
 
 impl<'a> SubjectToken<'a> {
-    /// Pair the two wire parameters.
+    /// Pair the token with its declared type. Both parameters are REQUIRED,
+    /// so the caller resolves their presence and this takes them by value.
     ///
     /// # Errors
     ///
-    /// `invalid_request` when either REQUIRED parameter is absent, or when the
-    /// declared type is one this server does not accept.
-    pub fn from_params(
-        token: Option<&'a SecretString>,
-        token_type: Option<&str>,
-    ) -> ServiceResult<Self> {
-        let (Some(token), Some(urn)) = (token, token_type) else {
-            return Err(ServiceError::oauth(
-                OAuthErrorCode::InvalidRequest,
-                "subject_token and subject_token_type are both required",
-            ));
-        };
+    /// `invalid_request` when the declared type is one this server does not
+    /// accept.
+    pub fn new(token: &'a SecretString, urn: &str) -> ServiceResult<Self> {
         let token_type = TokenType::parse(urn).ok_or_else(|| {
             ServiceError::oauth(
                 OAuthErrorCode::InvalidRequest,
@@ -970,22 +962,13 @@ mod tests {
             .expect_err("actor_token_type MUST NOT be included without actor_token");
     }
 
-    #[test]
-    fn test_subject_token_requires_both_parameters() {
-        let token = SecretString::from("tok");
-        SubjectToken::from_params(None, Some(protocol::TOKEN_TYPE_ACCESS_TOKEN))
-            .expect_err("subject_token is REQUIRED");
-        SubjectToken::from_params(Some(&token), None).expect_err("subject_token_type is REQUIRED");
-        SubjectToken::from_params(None, None).expect_err("both are REQUIRED");
-    }
-
     /// Every [`TokenType`] is accepted as a subject type — this is the subset
     /// that must stay wider than [`ActorToken`]'s.
     #[test]
     fn test_subject_token_accepts_every_token_type() {
         let token = SecretString::from("tok");
         for token_type in [TokenType::AccessToken, TokenType::IdToken, TokenType::Jwt] {
-            let subject = SubjectToken::from_params(Some(&token), Some(token_type.as_urn()))
+            let subject = SubjectToken::new(&token, token_type.as_urn())
                 .expect("every token type is a valid subject type");
             assert_eq!(subject.token_type, token_type);
             assert_eq!(subject.token.expose_secret(), "tok");
@@ -995,7 +978,7 @@ mod tests {
     #[test]
     fn test_subject_token_rejects_unsupported_type() {
         let token = SecretString::from("tok");
-        SubjectToken::from_params(Some(&token), Some("urn:ietf:params:oauth:token-type:saml2"))
+        SubjectToken::new(&token, "urn:ietf:params:oauth:token-type:saml2")
             .expect_err("saml2 is not a subject type this server accepts");
     }
 
@@ -1004,8 +987,8 @@ mod tests {
     #[test]
     fn test_subject_and_actor_tokens_are_redacted_in_debug() {
         let token = SecretString::from("exchange-secret-token");
-        let subject = SubjectToken::from_params(Some(&token), Some(protocol::TOKEN_TYPE_JWT))
-            .expect("valid subject pair");
+        let subject =
+            SubjectToken::new(&token, protocol::TOKEN_TYPE_JWT).expect("valid subject pair");
         let actor = ActorToken::from_params(Some(&token), Some(protocol::TOKEN_TYPE_JWT))
             .expect("valid actor pair");
 


### PR DESCRIPTION
Closes #1043

## What changed

### One flat struct became five grant-specific ones

`TokenRequest` was 18 optionals plus `grant_type`, shared by all five grants: an `authorization_code` request carrying `device_code` and `subject_token` was representable, parsed fine, and the extra fields were silently ignored.

It is renamed `TokenRequestForm` — the wire shape, where every parameter is optional because the grant is not known until `grant_type` is read — and `TokenRequestForm::parse` resolves it into a `TokenRequest` holding `ClientAuthParams` plus exactly one of `AuthorizationCodeParams`, `ClientCredentialsParams`, `DeviceCodeParams`, `TokenExchangeRequestParams`, or `Fido2AssertionParams`.

Reading another grant's parameter is now a compile error:

```
error[E0609]: no field `device_code` on type `AuthorizationCodeParams`
    |
655 |     let _ = &params.device_code;
    |                     ^^^^^^^^^^^ unknown field
    = note: available fields are: `code`, `redirect_uri`, `code_verifier`, `resource`, `authorization_details`
```

Each grant's REQUIRED parameters are resolved once, in `parse`, and held non-optional. That deletes the per-handler "Missing code parameter" / "Missing assertion parameter" checks, `device_code.unwrap_or_default()`, and the both-are-REQUIRED branch of `SubjectToken::from_params` — now `SubjectToken::new(&SecretString, &str)`, which can only fail on a token type this server does not accept. `device_token` takes the device code directly and no longer re-parses `grant_type`, so the grant is dispatched once rather than twice.

Foreign parameters are ignored, not rejected: RFC 6749 §3.2 requires unrecognized parameters to be ignored, and a parameter this server implements for a *different* grant is treated the same way — representable on the wire, unreachable from the handler.

### Two RFC 6749 §3.2 gaps

A new `OAuthForm` extractor (the `Form` analogue of `ValidJson`) and its `OAuthQuery` counterpart apply the paragraph both §3.1 and §3.2 carry:

> Parameters sent without a value MUST be treated as if they were omitted from the request.  The authorization server MUST ignore unrecognized request parameters.  Request and response parameters MUST NOT be included more than once.

— specs/rfc/rfc6749.txt:1200 (§3.2) and :1015 (§3.1), https://www.rfc-editor.org/rfc/rfc6749.txt

| request | before | after |
|---|---|---|
| `subject_token=` | `400 invalid_grant` ("Invalid or expired subject token") | `400 invalid_request`, byte-identical to omitting it |
| `subject_token=a&subject_token=b` | `422 Unprocessable Entity`, `text/plain` | `400 invalid_request` in the OAuth envelope |
| `token=` on `/oauth/introspect` | introspected the empty string | `400 invalid_request` ("missing field `token`") |
| `prompt=` on `/oauth/authorize` | `error=invalid_request` redirect ("Unsupported prompt value") | continues the flow, as omitting it does |
| JSON content-type | `415`, `text/plain` | `415` in the OAuth envelope |
| unrecognized parameters, repeated or not | ignored | ignored |

Repeated *recognized* parameters fail `T`'s derived deserializer and are reported as `invalid_request`, which §5.2 defines as covering a request that "includes a parameter more than once" (specs/rfc/rfc6749.txt:1990). A repeated *unrecognized* parameter stays ignored, since the sentence before it requires exactly that.

Because §3.1 carries the same paragraph for the authorization endpoint, `/oauth/authorize` (GET and POST), `/oauth/par`, `/oauth/introspect`, `/oauth/revoke`, and `/oauth/device` use the extractors too. `/oauth/logout` does not: OIDC RP-Initiated Logout is silent on parameter handling, and OIDC Core §3.1.2.2 only says Authorization Servers "SHOULD ignore unrecognized request parameters" — no empty-value or duplicate rule to inherit.

## Testing

- Five endpoint tests, one per affected endpoint, each asserting an empty-valued parameter answers exactly as an omitted one, plus tests for the duplicate rejection, unrecognized parameters, and another grant's parameters being ignored.
- Five unit tests on the shared `deserialize_present_params`, covering the paragraph sentence by sentence, including that `%20` is a present value rather than an empty one.
- **Mutation-checked:** with the empty-value filter removed, all five endpoint tests and two of the five unit tests fail; the rest hold, so each guards a distinct property. Two earlier drafts passed with and without the fix — one on `scope=` at the token endpoint and one on `client_id=` at the authorization endpoint, where `resolve_redirect_uri` and scope resolution already collapse the empty case — and were rewritten onto `prompt`, where the two genuinely diverge, or dropped.
- **Live** against a running `vouch-server` on SQLite: every row of the table above verified at the wire, plus `client_credentials` issuance still succeeding with `scope=`, with foreign parameters attached, and with neither.
- `cargo test -p vouch-server` 3203 pass, `cargo test -p vouch-tests` 398 pass, `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo fmt --all` applied.