### PR TITLE
refactor(oidc): derive token_type and cnf from one binding value

### DIFF
--- a/crates/vouch-common/src/protocol.rs
+++ b/crates/vouch-common/src/protocol.rs
@@ -287,6 +287,20 @@ pub const ACCESS_TOKEN_TYPE_BEARER: &str = "Bearer";
 /// <https://www.rfc-editor.org/rfc/rfc9449#section-5>
 pub const ACCESS_TOKEN_TYPE_DPOP: &str = "DPoP";
 
+/// RFC 8693 §2.2.1 (Successful Response) — `token_type` when the issued token
+/// is not an access token.
+///
+/// > If the issued token is not an access token or usable as an access token,
+/// > then the "token_type" value "N_A" is used to indicate that an OAuth 2.0
+/// > "token_type" identifier is not applicable in that context.
+///
+/// Registered in the IANA "OAuth Access Token Types" subregistry by RFC 8693
+/// §5.1. An exchanged OIDC ID token is a federation assertion, not something
+/// the client presents as an access token, so it carries this value.
+///
+/// <https://www.rfc-editor.org/rfc/rfc8693#section-2.2.1>
+pub const TOKEN_TYPE_NOT_APPLICABLE: &str = "N_A";
+
 /// WebAuthn Level 2 §5.1.3 (Create a New Credential) — registration.
 ///
 /// The client sets `CollectedClientData.type` when building the credential:

--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -30,8 +30,8 @@ use crate::handlers::session::{create_session_cookie, get_auth_context};
 use crate::impl_template_response;
 use crate::redact_email;
 use crate::services::auth::{
-    ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenIssuanceProof,
-    create_oauth_access_token,
+    ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenBinding,
+    TokenIssuanceProof, create_oauth_access_token,
 };
 use crate::services::oidc::ScopeSet;
 use askama::Template;
@@ -753,8 +753,7 @@ pub(crate) async fn browser_login_complete(
             authenticator_id: Some(&authenticator.id),
             client_id: &client_id,
             scope: Some(ScopeSet::all()),
-            dpop_proof: None,
-            mtls_cert_thumbprint: None,
+            binding: TokenBinding::Bearer,
             act: None,
             audience: None,
             auth_time: Some(auth_now.as_second()),

--- a/crates/vouch-server/src/handlers/certification.rs
+++ b/crates/vouch-server/src/handlers/certification.rs
@@ -34,7 +34,7 @@ use crate::{
     handlers::browser_login::hmac_sha256_base64url,
     handlers::session::create_session_cookie,
     services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof,
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenBinding,
         TokenIssuanceProof, create_oauth_access_token,
     },
     services::oidc::ScopeSet,
@@ -169,8 +169,7 @@ pub(crate) async fn complete_login(
             authenticator_id: Some(&authenticator_id),
             client_id: &session_client_id,
             scope: Some(ScopeSet::all()),
-            dpop_proof: None,
-            mtls_cert_thumbprint: None,
+            binding: TokenBinding::Bearer,
             act: None,
             audience: None,
             auth_time: Some(Timestamp::now().as_second()),

--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -5,8 +5,8 @@ use crate::AppState;
 use crate::db::{self, DeviceAuthState};
 use crate::handlers::extractors::{OAuthForm, OptionalClientCert};
 use crate::services::auth::{
-    ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenIssuanceProof,
-    create_oauth_access_token,
+    ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenBinding,
+    TokenIssuanceProof, create_oauth_access_token,
 };
 use crate::services::oidc::ScopeSet;
 use crate::services::oidc::dpop::DpopError;
@@ -504,8 +504,7 @@ pub(crate) async fn device_token(
                     authenticator_id: Some(&authenticator_id),
                     client_id: &client_id,
                     scope: Some(ScopeSet::all()),
-                    dpop_proof: dpop_proof.as_ref(),
-                    mtls_cert_thumbprint: mtls_cert_thumbprint.as_deref(),
+                    binding: TokenBinding::new(dpop_proof.as_ref(), mtls_cert_thumbprint.as_ref()),
                     act: None,
                     audience: None,
                     auth_time: Some(now_secs),
@@ -545,6 +544,7 @@ pub(crate) async fn device_token(
 
             let token = session_result.token;
             let expires_in = session_result.expires_in;
+            let token_type = session_result.token_type;
 
             // Record issuance like the other token-endpoint grants; the
             // device-code grant otherwise leaves no oauth_token_issued trail.
@@ -574,16 +574,6 @@ pub(crate) async fn device_token(
                 "Device authorization complete for: {}",
                 redact_email(&user_email)
             );
-
-            // RFC 9449 Section 5: token_type is DPoP when the token is
-            // sender-constrained (bound to a DPoP proof key), otherwise
-            // Bearer. RFC-compliant clients that require DPoP protection
-            // MUST discard a response advertising a different token_type.
-            let token_type = if dpop_proof.is_some() {
-                protocol::ACCESS_TOKEN_TYPE_DPOP
-            } else {
-                protocol::ACCESS_TOKEN_TYPE_BEARER
-            };
 
             Ok(Json(DeviceTokenResponse {
                 // Clone the SecretString rather than rebuilding it via

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -33,8 +33,8 @@ use super::{
 use crate::error::ServiceError;
 use crate::redact_email;
 use crate::services::auth::{
-    ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenIssuanceProof,
-    create_oauth_access_token,
+    ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenBinding,
+    TokenIssuanceProof, create_oauth_access_token,
 };
 use crate::services::idp::IdentityResult;
 use crate::services::keys as key_svc;
@@ -834,8 +834,7 @@ pub(crate) async fn complete_enrollment_after_identity(
             authenticator_id: authenticator_id.as_deref(),
             client_id: &client_id_for_token,
             scope: Some(ScopeSet::all()),
-            dpop_proof: None,
-            mtls_cert_thumbprint: None,
+            binding: TokenBinding::Bearer,
             act: None,
             audience: None,
             auth_time: Some(now.as_second()),
@@ -1666,8 +1665,7 @@ pub(crate) async fn browser_register_complete(
             authenticator_id: Some(&authenticator_id),
             client_id: &enroll_client_id,
             scope: Some(ScopeSet::all()),
-            dpop_proof: None,
-            mtls_cert_thumbprint: None,
+            binding: TokenBinding::Bearer,
             act: None,
             audience: None,
             auth_time: Some(auth_now.as_second()),

--- a/crates/vouch-server/src/handlers/oidc/tests/helpers.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/helpers.rs
@@ -334,8 +334,8 @@ pub(super) fn make_test_cert_der(cn: &str) -> Vec<u8> {
 }
 
 /// Compute the base64url SHA-256 thumbprint of DER bytes.
-pub(super) fn cert_thumbprint(der: &[u8]) -> String {
-    URL_SAFE_NO_PAD.encode(aws_lc_rs::digest::digest(&SHA256, der).as_ref())
+pub(super) fn cert_thumbprint(der: &[u8]) -> crate::services::oidc::mtls::CertThumbprint {
+    crate::services::oidc::mtls::compute_cert_thumbprint(der)
 }
 
 // ========================================================================

--- a/crates/vouch-server/src/handlers/oidc/tests/oidc_userinfo.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/oidc_userinfo.rs
@@ -82,7 +82,7 @@ async fn test_userinfo_no_email_when_scope_is_none() {
     // "full access" — it must return only `sub`, never the user's email.
     use crate::services::auth::{
         ClientAuthProof, CreateOAuthTokenParams, GrantProof, HardwareVerification, NoClientAuth,
-        SenderConstraintProof, TokenIssuanceProof, create_oauth_access_token,
+        SenderConstraintProof, TokenBinding, TokenIssuanceProof, create_oauth_access_token,
     };
     use secrecy::ExposeSecret;
 
@@ -99,8 +99,7 @@ async fn test_userinfo_no_email_when_scope_is_none() {
             authenticator_id: Some(&auth_id),
             client_id: &state.config().base_url,
             scope: None,
-            dpop_proof: None,
-            mtls_cert_thumbprint: None,
+            binding: TokenBinding::Bearer,
             act: None,
             audience: None,
             auth_time: Some(jiff::Timestamp::now().as_second()),

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc8693.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc8693.rs
@@ -842,9 +842,14 @@ async fn test_rfc8693_id_token_request_returns_clean_id_token() {
         response["issued_token_type"], ID_TOKEN_TYPE,
         "issued_token_type must report id_token"
     );
+    // RFC 8693 §2.2.1: "If the issued token is not an access token or usable
+    // as an access token, then the "token_type" value "N_A" is used to
+    // indicate that an OAuth 2.0 "token_type" identifier is not applicable in
+    // that context." The exchanged ID token is a federation assertion, not a
+    // credential the client presents to this server.
     assert_eq!(
-        response["token_type"], "Bearer",
-        "ID tokens are not sender-constrained"
+        response["token_type"], "N_A",
+        "an exchanged ID token is not usable as an access token"
     );
 
     let id_token = response["access_token"]

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc8705.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc8705.rs
@@ -173,7 +173,8 @@ async fn test_rfc8705_cnf_claim_present_in_mtls_bound_token() {
         .expect("x5t#S256 must be a string");
 
     assert_eq!(
-        x5t, thumbprint,
+        x5t,
+        thumbprint.as_str(),
         "RFC 8705: x5t#S256 in cnf must match the certificate thumbprint"
     );
 }
@@ -297,7 +298,7 @@ async fn test_rfc8705_token_mtls_authorization_code_succeeds() {
     let x5t = claims["cnf"]["x5t#S256"]
         .as_str()
         .expect("cnf.x5t#S256 must be present in mTLS-bound token");
-    assert_eq!(x5t, thumbprint);
+    assert_eq!(x5t, thumbprint.as_str());
 }
 
 /// RFC 8705 §2.1: An already-consumed authorization code must be rejected
@@ -702,5 +703,67 @@ async fn test_rfc8705_userinfo_mtls_bound_token_with_dpop_scheme_rejected() {
             .unwrap_or("")
             .contains("DPoP scheme requires DPoP proof header"),
         "error_description must mention DPoP proof requirement: {body}"
+    );
+}
+
+/// One response, one binding. A certificate-bound client used to receive
+/// `cnf.x5t#S256` in its access token and no `cnf` at all in the ID token
+/// issued beside it, because the ID token's confirmation was built from the
+/// DPoP proof alone. Both tokens now carry the binding the client actually
+/// proved.
+///
+/// RFC 8705 §3.1 defines `x5t#S256` for certificate-bound tokens; RFC 7800
+/// §3.1 permits `cnf` in any JWT ("The 'cnf' claim is used in the JWT to
+/// contain members used to identify the proof-of-possession key"). Neither
+/// requires it on an ID token — binding the token that goes to the party that
+/// proved the key is this server's rule, and this test is what keeps the two
+/// token kinds from drifting apart again.
+#[tokio::test]
+async fn test_rfc8705_id_token_carries_the_same_binding_as_the_access_token() {
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "mtls-id-token-cnf@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+
+    let (client, pkcs8_bytes) =
+        create_private_key_jwt_client_with_cert_binding(&state.store, &user.id).await;
+
+    let cert_der = make_test_cert_der("mtls-id-token-cnf");
+    let thumbprint = cert_thumbprint(&cert_der);
+
+    let code =
+        issue_test_authorization_code(&state, &client.client_id, &user, &auth_id, None).await;
+    let token_endpoint = format!("{}/oauth/token", state.config().base_url);
+    let assertion = build_client_assertion(&client.client_id, &token_endpoint, &pkcs8_bytes, None);
+
+    let body = format!(
+        "grant_type=authorization_code&code={code}&redirect_uri={}\
+         &client_id={}\
+         &client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer\
+         &client_assertion={assertion}",
+        urlencoding::encode("https://example.com/callback"),
+        client.client_id,
+    );
+
+    let (status, response_body) =
+        http_post_form_with_cert(&app, "/oauth/token", &body, &[], Some(cert_der)).await;
+    assert_eq!(status, StatusCode::OK, "{response_body}");
+
+    let json: serde_json::Value = serde_json::from_str(&response_body).expect("Valid JSON");
+    let access_claims = decode_jwt_payload(json["access_token"].as_str().expect("access_token"));
+    let id_claims = decode_jwt_payload(json["id_token"].as_str().expect("id_token"));
+
+    assert_eq!(
+        access_claims["cnf"]["x5t#S256"].as_str(),
+        Some(thumbprint.as_str()),
+        "the access token must be certificate-bound"
+    );
+    assert_eq!(
+        id_claims["cnf"]["x5t#S256"].as_str(),
+        Some(thumbprint.as_str()),
+        "the ID token must carry the same confirmation as the access token"
+    );
+    assert!(
+        id_claims["cnf"]["jkt"].is_null(),
+        "no DPoP proof was presented, so there is no jkt to confirm"
     );
 }

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -11,11 +11,12 @@ use crate::error::OAuthErrorResponse;
 use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
 use crate::handlers::extractors::{OAuthForm, OptionalClientCert};
 use crate::services::auth::{
-    ClientAuthProof, GrantProof, SenderConstraintProof, TokenIssuanceProof,
+    ClientAuthProof, GrantProof, SenderConstraintProof, TokenBinding, TokenIssuanceProof,
 };
+use crate::services::oidc::mtls::CertThumbprint;
 use crate::services::oidc::{
     ScopeSet,
-    client_credentials::{ClientCredentialsBindings, exchange_client_credentials},
+    client_credentials::exchange_client_credentials,
     exchange::{ActorToken, SubjectToken, TokenExchangeParams, TokenType, exchange_token},
     grant_type::{OAuthGrantType, ParseOAuthGrantTypeError},
     jwt_bearer::client_auth::{PendingJti, authenticate_client_jwt},
@@ -790,11 +791,10 @@ async fn handle_authorization_code_grant(
         redirect_uri: params.redirect_uri.as_deref(),
         authenticated_client: Some(&authenticated_client),
         code_verifier: params.code_verifier.as_deref(),
-        dpop_proof,
+        binding: TokenBinding::new(dpop_proof.as_ref(), mtls_thumbprint.as_ref()),
         client_id: &authenticated_client.client.client_id,
         resource: params.resource.as_deref(),
         authorization_details: params.authorization_details.as_deref(),
-        mtls_cert_thumbprint: mtls_thumbprint.as_deref(),
     };
 
     match exchange_authorization_code(&state, exchange_params, client_auth, sender_constraint).await
@@ -959,10 +959,7 @@ async fn handle_client_credentials_grant(
         &state,
         &authenticated_client.client,
         params.scope.as_deref(),
-        ClientCredentialsBindings {
-            dpop_proof: dpop_proof.as_ref(),
-            mtls_cert_thumbprint: mtls_thumbprint.as_deref(),
-        },
+        TokenBinding::new(dpop_proof.as_ref(), mtls_thumbprint.as_ref()),
         proof,
     )
     .await
@@ -1171,9 +1168,8 @@ async fn handle_token_exchange_grant(
         scope: params.scope.as_deref(),
         requested_token_type: tokens.requested_token_type,
         client_id: &authenticated_client.client.client_id,
-        dpop_proof: dpop_proof.as_ref(),
+        binding: TokenBinding::new(dpop_proof.as_ref(), mtls_thumbprint.as_ref()),
         authorization_details: params.authorization_details.as_deref(),
-        mtls_cert_thumbprint: mtls_thumbprint.as_deref(),
         client_ip: client_info.client_ip,
     };
 
@@ -1341,11 +1337,10 @@ async fn handle_fido2_assertion_grant(
             client: jwt_authenticated.client,
             is_public: false,
         },
-        dpop_proof,
+        binding: TokenBinding::new(dpop_proof.as_ref(), mtls_thumbprint.as_ref()),
         scope: params.scope.as_deref(),
         authorization_details: params.authorization_details.as_deref(),
         client_info,
-        mtls_cert_thumbprint: mtls_thumbprint.as_deref(),
     };
 
     // FIDO2 assertion grant requires `private_key_jwt` client auth (the
@@ -1432,7 +1427,7 @@ async fn validate_mtls_client_auth(
 fn extract_mtls_thumbprint(
     client: &crate::services::oidc::token::AuthenticatedClient,
     client_cert: &OptionalClientCert,
-) -> Option<String> {
+) -> Option<CertThumbprint> {
     if client.client.tls_client_certificate_bound_access_tokens {
         client_cert.0.as_ref().map(|c| c.thumbprint.clone())
     } else {

--- a/crates/vouch-server/src/handlers/oidc/userinfo.rs
+++ b/crates/vouch-server/src/handlers/oidc/userinfo.rs
@@ -435,7 +435,12 @@ fn verify_mtls_binding(
     };
 
     // Constant-time comparison prevents timing-based thumbprint enumeration.
-    let is_valid: bool = cert.thumbprint.as_bytes().ct_eq(expected.as_bytes()).into();
+    let is_valid: bool = cert
+        .thumbprint
+        .as_str()
+        .as_bytes()
+        .ct_eq(expected.as_bytes())
+        .into();
     if !is_valid {
         return Err(Box::new(oauth_error(
             StatusCode::UNAUTHORIZED,

--- a/crates/vouch-server/src/handlers/session.rs
+++ b/crates/vouch-server/src/handlers/session.rs
@@ -236,6 +236,7 @@ async fn extract_resource_token(
             Some(cert) => {
                 let is_match: bool = cert
                     .thumbprint
+                    .as_str()
                     .as_bytes()
                     .ct_eq(expected_thumbprint.as_bytes())
                     .into();

--- a/crates/vouch-server/src/handlers/session/tests.rs
+++ b/crates/vouch-server/src/handlers/session/tests.rs
@@ -133,7 +133,7 @@ async fn test_mtls_bound_token_without_cert_rejected() {
         &user.id,
         &user.email,
         &auth_id,
-        "fake-cert-thumbprint-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        &crate::services::oidc::mtls::compute_cert_thumbprint(b"fake-cert-der"),
     )
     .await;
 

--- a/crates/vouch-server/src/services/auth.rs
+++ b/crates/vouch-server/src/services/auth.rs
@@ -20,6 +20,7 @@ use crate::crypto::hash_token;
 use crate::crypto::keys::OidcSigningKey;
 use crate::crypto::webauthn_verify::{self, OriginPolicy};
 use crate::db::{self, Authenticator, SessionPurpose, User};
+use crate::services::oidc::mtls::CertThumbprint;
 use crate::services::oidc::{CnfClaim, ScopeSet, ValidatedDpopProof};
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -30,6 +31,7 @@ use std::fmt;
 use uuid::Uuid;
 
 use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
+use vouch_common::protocol;
 
 // ============================================================================
 // Authentication Method References (RFC 8176)
@@ -685,13 +687,11 @@ pub(crate) struct CreateOAuthTokenParams<'a> {
     pub client_id: &'a str,
     /// Granted OAuth scope.
     pub scope: Option<ScopeSet>,
-    /// RFC 9449 §6: the validated DPoP proof whose `jkt` binds this token
-    /// via `cnf.jkt`. Taking the witness rather than a bare thumbprint means
-    /// a sender-constrained token cannot be minted from a string that never
+    /// How this token is bound to its holder (RFC 9449 §6 / RFC 8705 §3).
+    /// Taking the DPoP witness rather than a bare thumbprint means a
+    /// sender-constrained token cannot be minted from a string that never
     /// passed signature, `htm`/`htu`, nonce, and replay validation.
-    pub dpop_proof: Option<&'a ValidatedDpopProof>,
-    /// mTLS certificate thumbprint for sender-constrained binding (RFC 8705).
-    pub mtls_cert_thumbprint: Option<&'a str>,
+    pub binding: TokenBinding<'a>,
     /// Actor claim for delegation chains (token exchange).
     pub act: Option<ActorClaim>,
     /// Optional audience override (for token exchange with explicit audience).
@@ -714,12 +714,89 @@ pub(crate) struct CreateOAuthTokenParams<'a> {
     pub org_domain: Option<&'a str>,
 }
 
+/// How an issued token is bound to the party that may present it.
+///
+/// One value decides both halves of sender-constraining: the `cnf` claim
+/// stamped into the token and the `token_type` advertised for it. Deriving
+/// them separately is what let the two disagree — six call sites each spelled
+/// `if dpop.is_some() { DPoP } else { Bearer }` while `cnf` was built from a
+/// different pair of options a layer away.
+///
+/// DPoP wins when a request carries both: the proof is per-request evidence of
+/// possession, so it is the stronger statement about who holds this token, and
+/// `cnf` has room for only one confirmation method (RFC 7800 §3.1).
+#[derive(Debug, Clone, Copy)]
+pub enum TokenBinding<'a> {
+    /// RFC 9449 §6: bound to the DPoP proof's key, confirmed by `cnf.jkt`.
+    Dpop(&'a ValidatedDpopProof),
+    /// RFC 8705 §3: bound to the client certificate, confirmed by
+    /// `cnf.x5t#S256`.
+    MutualTls(&'a CertThumbprint),
+    /// A bearer token: whoever holds it may present it.
+    Bearer,
+}
+
+impl<'a> TokenBinding<'a> {
+    /// Resolve the binding from the two things a request can carry. Both
+    /// absent is a bearer token; both present is DPoP.
+    #[must_use]
+    pub fn new(
+        dpop_proof: Option<&'a ValidatedDpopProof>,
+        mtls_cert_thumbprint: Option<&'a CertThumbprint>,
+    ) -> Self {
+        match (dpop_proof, mtls_cert_thumbprint) {
+            (Some(proof), _) => Self::Dpop(proof),
+            (None, Some(thumbprint)) => Self::MutualTls(thumbprint),
+            (None, None) => Self::Bearer,
+        }
+    }
+
+    /// The confirmation claim this binding stamps into the token.
+    #[must_use]
+    pub fn cnf(self) -> Option<CnfClaim> {
+        match self {
+            Self::Dpop(proof) => Some(CnfClaim {
+                jkt: Some(proof.jkt.clone()),
+                x5t_s256: None,
+            }),
+            Self::MutualTls(thumbprint) => Some(CnfClaim {
+                jkt: None,
+                x5t_s256: Some(thumbprint.as_str().to_string()),
+            }),
+            Self::Bearer => None,
+        }
+    }
+
+    /// The `token_type` advertised for a token carrying this binding, derived
+    /// from the same `cnf` the token will carry.
+    #[must_use]
+    pub fn token_type(self) -> &'static str {
+        self.cnf()
+            .as_ref()
+            .map_or(protocol::ACCESS_TOKEN_TYPE_BEARER, CnfClaim::token_type)
+    }
+
+    /// The DPoP proof, when this binding is one. Callers that record the
+    /// binding server-side (session rows, introspection) need the thumbprint
+    /// rather than the claim.
+    #[must_use]
+    pub fn dpop_proof(self) -> Option<&'a ValidatedDpopProof> {
+        match self {
+            Self::Dpop(proof) => Some(proof),
+            Self::MutualTls(_) | Self::Bearer => None,
+        }
+    }
+}
+
 /// Result of creating a session token.
 pub(crate) struct CreateSessionResult {
     /// The JWT token.
     pub token: SecretString,
     /// Token lifetime in seconds.
     pub expires_in: u64,
+    /// RFC 6749 §5.1 `token_type`, derived from the binding stamped into the
+    /// token so the advertisement cannot contradict the `cnf` claim.
+    pub token_type: &'static str,
 }
 
 /// Create an OAuth 2.0 access token per RFC 9068.
@@ -780,19 +857,9 @@ pub(crate) async fn create_oauth_access_token(
         .as_ref()
         .is_some_and(|s| s.contains(crate::services::oidc::OAuthScope::Email));
 
-    // RFC 9449 / RFC 8705: Include cnf claim for sender-constrained tokens.
-    // DPoP (jkt) takes priority over mTLS (x5t#S256).
-    let cnf = match (params.dpop_proof, params.mtls_cert_thumbprint) {
-        (Some(proof), _) => Some(CnfClaim {
-            jkt: Some(proof.jkt.clone()),
-            x5t_s256: None,
-        }),
-        (None, Some(x5t)) => Some(CnfClaim {
-            jkt: None,
-            x5t_s256: Some(x5t.to_string()),
-        }),
-        (None, None) => None,
-    };
+    // RFC 9449 / RFC 8705: the binding decides the confirmation claim and the
+    // advertised token type together.
+    let cnf = params.binding.cnf();
 
     let claims = AccessTokenClaims {
         iss: state.config().base_url.to_string(),
@@ -846,6 +913,7 @@ pub(crate) async fn create_oauth_access_token(
     let expires_in = state.config().session_hours.saturating_mul(3600);
 
     Ok(CreateSessionResult {
+        token_type: params.binding.token_type(),
         token: SecretString::from(token),
         expires_in,
     })

--- a/crates/vouch-server/src/services/oidc/claims.rs
+++ b/crates/vouch-server/src/services/oidc/claims.rs
@@ -2,6 +2,7 @@
 //! OIDC token claims for cloud provider identity federation.
 
 use serde::{Deserialize, Serialize};
+use vouch_common::protocol;
 
 /// Confirmation claim for sender-constrained token binding.
 ///
@@ -16,6 +17,29 @@ pub struct CnfClaim {
     /// Certificate thumbprint (mTLS).
     #[serde(default, rename = "x5t#S256", skip_serializing_if = "Option::is_none")]
     pub x5t_s256: Option<String>,
+}
+
+impl CnfClaim {
+    /// The `token_type` a token carrying this confirmation is advertised with.
+    ///
+    /// RFC 9449 §5: "A token_type of DPoP MUST be included in the access token
+    /// response to signal to the client that the access token was bound to its
+    /// DPoP key". A certificate-bound token has no such signal — RFC 8705 §3.1
+    /// defines the `x5t#S256` confirmation without changing the token type — so
+    /// it stays `Bearer`.
+    ///
+    /// Issuance derives the advertised type from the binding it is about to
+    /// stamp in, and introspection derives it from the claim it reads back
+    /// (RFC 7662 §2.2 `token_type`). Both go through here, so the two answers
+    /// cannot disagree about the same token.
+    #[must_use]
+    pub fn token_type(&self) -> &'static str {
+        if self.jkt.is_some() {
+            protocol::ACCESS_TOKEN_TYPE_DPOP
+        } else {
+            protocol::ACCESS_TOKEN_TYPE_BEARER
+        }
+    }
 }
 
 /// Standard OIDC ID token claims with Vouch extensions.

--- a/crates/vouch-server/src/services/oidc/client_credentials.rs
+++ b/crates/vouch-server/src/services/oidc/client_credentials.rs
@@ -12,11 +12,10 @@ use crate::AppState;
 use crate::db::{OAuthClient, SessionPurpose};
 use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
 use crate::services::auth::{
-    CreateOAuthTokenParams, TokenIssuanceProof, create_oauth_access_token,
+    CreateOAuthTokenParams, TokenBinding, TokenIssuanceProof, create_oauth_access_token,
 };
-use crate::services::oidc::{ScopeSet, ValidatedDpopProof};
+use crate::services::oidc::ScopeSet;
 use std::sync::Arc;
-use vouch_common::protocol;
 
 /// Result of a client credentials grant exchange.
 pub struct ClientCredentialsResult {
@@ -41,21 +40,11 @@ pub struct ClientCredentialsResult {
 /// # Errors
 /// Returns `unauthorized_client` if the client does not have the
 /// `client_credentials` grant type registered.
-/// Sender-constraint bindings to stamp into the issued access token.
-///
-/// RFC 9449 (`cnf.jkt`) and RFC 8705 (`cnf.x5t#S256`) — DPoP takes priority
-/// over mTLS in `create_oauth_access_token`.
-pub(crate) struct ClientCredentialsBindings<'a> {
-    /// RFC 9449 §6: the validated DPoP proof supplying `cnf.jkt`.
-    pub(crate) dpop_proof: Option<&'a ValidatedDpopProof>,
-    pub(crate) mtls_cert_thumbprint: Option<&'a str>,
-}
-
 pub(crate) async fn exchange_client_credentials(
     state: &Arc<AppState>,
     client: &OAuthClient,
     requested_scope: Option<&str>,
-    bindings: ClientCredentialsBindings<'_>,
+    binding: TokenBinding<'_>,
     proof: TokenIssuanceProof,
 ) -> ServiceResult<ClientCredentialsResult> {
     // Verify client has client_credentials in its registered grant_types
@@ -88,8 +77,7 @@ pub(crate) async fn exchange_client_credentials(
             authenticator_id: None,
             client_id: &client.client_id,
             scope: scope.clone(),
-            dpop_proof: bindings.dpop_proof,
-            mtls_cert_thumbprint: bindings.mtls_cert_thumbprint,
+            binding,
             act: None,
             audience: None,
             auth_time: None,
@@ -108,16 +96,9 @@ pub(crate) async fn exchange_client_credentials(
         client.client_id
     );
 
-    // RFC 9449 Section 5: token_type is DPoP when the token is sender-constrained
-    let token_type = if bindings.dpop_proof.is_some() {
-        protocol::ACCESS_TOKEN_TYPE_DPOP
-    } else {
-        protocol::ACCESS_TOKEN_TYPE_BEARER
-    };
-
     Ok(ClientCredentialsResult {
         access_token: session_result.token.clone(),
-        token_type: token_type.to_string(),
+        token_type: session_result.token_type.to_string(),
         expires_in: session_result.expires_in,
         scope,
     })
@@ -204,15 +185,12 @@ mod tests {
 
         let client = client_record;
 
-        let thumbprint = "test-mtls-thumbprint-xxxxxxxxxxxxxxxxxxxxxxxxxxx";
+        let thumbprint = crate::services::oidc::mtls::compute_cert_thumbprint(b"test-cert-der");
         let result = exchange_client_credentials(
             &state,
             &client,
             None,
-            ClientCredentialsBindings {
-                dpop_proof: None,
-                mtls_cert_thumbprint: Some(thumbprint),
-            },
+            TokenBinding::MutualTls(&thumbprint),
             TokenIssuanceProof {
                 grant: GrantProof::ClientCredentials,
                 client_auth: ClientAuthProof::MutualTls(
@@ -240,7 +218,7 @@ mod tests {
         };
         assert_eq!(
             cnf.x5t_s256.as_deref(),
-            Some(thumbprint),
+            Some(thumbprint.as_str()),
             "cnf.x5t#S256 must match the supplied thumbprint"
         );
         assert!(

--- a/crates/vouch-server/src/services/oidc/exchange.rs
+++ b/crates/vouch-server/src/services/oidc/exchange.rs
@@ -10,12 +10,12 @@ use crate::db;
 use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
 use crate::redact_email;
 use crate::services::auth::{
-    ActorClaim, CreateOAuthTokenParams, MAX_DELEGATION_DEPTH, TokenIssuanceProof,
+    ActorClaim, CreateOAuthTokenParams, MAX_DELEGATION_DEPTH, TokenBinding, TokenIssuanceProof,
     create_oauth_access_token, decode_token,
 };
+use crate::services::oidc::ScopeSet;
 use crate::services::oidc::authorization_details::AuthorizationDetails;
 use crate::services::oidc::claims::OidcIdTokenClaimsBuilder;
-use crate::services::oidc::{ScopeSet, ValidatedDpopProof};
 use jiff::Timestamp;
 use secrecy::{ExposeSecret, SecretString};
 use std::sync::Arc;
@@ -187,19 +187,15 @@ pub struct TokenExchangeParams<'a> {
     pub requested_token_type: Option<TokenType>,
     /// OAuth client_id of the requesting client.
     pub client_id: &'a str,
-    /// RFC 9449 §6: the validated DPoP proof binding the issued token via
-    /// `cnf.jkt`. The witness travels instead of its thumbprint so an
-    /// exchanged token cannot be sender-constrained to a key that was never
-    /// proven.
-    pub dpop_proof: Option<&'a ValidatedDpopProof>,
+    /// RFC 9449 §6 / RFC 8705 §3: how the issued token is bound. The DPoP
+    /// witness travels instead of its thumbprint so an exchanged token cannot
+    /// be sender-constrained to a key that was never proven.
+    pub binding: TokenBinding<'a>,
     /// Client IP from the TCP peer socket, for temporal policy correlation
     /// (e.g. the exchange-IP-consistency policy).
     pub client_ip: Option<std::net::IpAddr>,
     /// RFC 9396 Section 6: Authorization details for narrowing.
     pub authorization_details: Option<&'a str>,
-    /// RFC 8705 Section 3: mTLS certificate thumbprint for token binding.
-    /// Only set when the client has `tls_client_certificate_bound_access_tokens = true`.
-    pub mtls_cert_thumbprint: Option<&'a str>,
 }
 
 /// Result of a token exchange (RFC 8693 Section 2.2).
@@ -515,8 +511,7 @@ pub(crate) async fn exchange_token(
             authenticator_id,
             client_id: params.client_id,
             scope: granted_scope.clone(),
-            dpop_proof: params.dpop_proof,
-            mtls_cert_thumbprint: params.mtls_cert_thumbprint,
+            binding: params.binding,
             act: actor_claim,
             audience,
             // Token exchange does not carry auth_time from the subject token
@@ -596,17 +591,10 @@ pub(crate) async fn exchange_token(
         params.audience
     );
 
-    // RFC 9449 Section 5: token_type is DPoP when the token is sender-constrained
-    let token_type = if params.dpop_proof.is_some() {
-        protocol::ACCESS_TOKEN_TYPE_DPOP
-    } else {
-        protocol::ACCESS_TOKEN_TYPE_BEARER
-    };
-
     Ok(TokenExchangeResult {
         access_token: session_result.token.clone(),
         issued_token_type: TokenType::AccessToken.as_urn().to_string(),
-        token_type: token_type.to_string(),
+        token_type: session_result.token_type.to_string(),
         expires_in,
         scope: granted_scope,
         authorization_details: effective_ad,
@@ -639,6 +627,15 @@ struct IdTokenContext<'a> {
 /// The token carries only the standard OIDC claim set (no AWS tags, no
 /// `authorization_details`) and is never persisted as a session — it is
 /// meant to be presented immediately to an external relying party.
+///
+/// [`IdTokenContext`] carries no [`TokenBinding`], which is the rule rather
+/// than an omission: an ID token is bound when it goes to the party that
+/// proved the key, and this one is minted as an assertion for a third party
+/// (Kubernetes, Vault, AWS/GCP/Azure workload identity) that cannot check a
+/// confirmation — there is no DPoP proof in this exchange for a consumer to
+/// verify a thumbprint against. What protects it is its TTL, its audience,
+/// and TLS. Having no binding to pass is what keeps that decision from
+/// drifting.
 async fn issue_id_token(
     state: &Arc<AppState>,
     ctx: IdTokenContext<'_>,
@@ -745,7 +742,11 @@ async fn issue_id_token(
     Ok(TokenExchangeResult {
         access_token: id_token.into(),
         issued_token_type: TokenType::IdToken.as_urn().to_string(),
-        token_type: protocol::ACCESS_TOKEN_TYPE_BEARER.to_string(),
+        // RFC 8693 §2.2.1: "If the issued token is not an access token or
+        // usable as an access token, then the "token_type" value "N_A" is
+        // used". This token is a federation assertion presented to an external
+        // relying party, not a credential the client presents here.
+        token_type: protocol::TOKEN_TYPE_NOT_APPLICABLE.to_string(),
         expires_in,
         scope: None,
         authorization_details: None,

--- a/crates/vouch-server/src/services/oidc/fido2_grant.rs
+++ b/crates/vouch-server/src/services/oidc/fido2_grant.rs
@@ -19,12 +19,12 @@ use crate::db::{self, AuthEventParams, AuthEventType};
 use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
 use crate::services::auth::{
     AuthenticatorLookupParams, ClientAuthProof, CreateOAuthTokenParams, GrantProof,
-    LoginAssertionParams, SenderConstraintProof, TokenIssuanceProof, create_oauth_access_token,
-    lookup_and_verify_authenticator, verify_login_assertion,
+    LoginAssertionParams, SenderConstraintProof, TokenBinding, TokenIssuanceProof,
+    create_oauth_access_token, lookup_and_verify_authenticator, verify_login_assertion,
 };
+use crate::services::oidc::ScopeSet;
 use crate::services::oidc::authorization_details::AuthorizationDetails;
 use crate::services::oidc::token::AuthenticatedClient;
-use crate::services::oidc::{ScopeSet, ValidatedDpopProof};
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use serde::{Deserialize, Serialize};
@@ -32,7 +32,6 @@ use std::sync::Arc;
 use uuid::Uuid;
 use vouch_common::encoding::Raw;
 use vouch_common::fido2_types::Challenge;
-use vouch_common::protocol;
 
 /// State embedded in the challenge JWT (must match the challenge endpoint).
 #[derive(Debug, Serialize, Deserialize)]
@@ -66,17 +65,14 @@ pub struct Fido2AssertionParams<'a> {
     pub assertion: &'a str,
     /// Authenticated client (via `private_key_jwt`).
     pub client: &'a AuthenticatedClient,
-    /// Validated DPoP proof (if present).
-    pub dpop_proof: Option<ValidatedDpopProof>,
+    /// RFC 9449 §6 / RFC 8705 §3: how the issued token is bound.
+    pub binding: TokenBinding<'a>,
     /// Requested scope.
     pub scope: Option<&'a str>,
     /// RFC 9396: Raw authorization_details JSON string.
     pub authorization_details: Option<&'a str>,
     /// Client metadata extracted from HTTP headers.
     pub client_info: crate::db::ClientInfo,
-    /// RFC 8705 Section 3: mTLS certificate thumbprint for token binding.
-    /// Only set when the client has `tls_client_certificate_bound_access_tokens = true`.
-    pub mtls_cert_thumbprint: Option<&'a str>,
 }
 
 /// Result of a successful FIDO2 assertion grant exchange.
@@ -373,8 +369,7 @@ pub(crate) async fn exchange_fido2_assertion(
             authenticator_id: Some(&authenticator.id),
             client_id: &params.client.client.client_id,
             scope: Some(scope.clone()),
-            dpop_proof: params.dpop_proof.as_ref(),
-            mtls_cert_thumbprint: params.mtls_cert_thumbprint,
+            binding: params.binding,
             act: None,
             audience: None,
             auth_time: Some(now),
@@ -403,15 +398,9 @@ pub(crate) async fn exchange_fido2_assertion(
     )
     .await;
 
-    let token_type = if params.dpop_proof.is_some() {
-        protocol::ACCESS_TOKEN_TYPE_DPOP
-    } else {
-        protocol::ACCESS_TOKEN_TYPE_BEARER
-    };
-
     Ok(Fido2AssertionResult {
         access_token: session_result.token.clone(),
-        token_type: token_type.to_string(),
+        token_type: session_result.token_type.to_string(),
         expires_in: session_result.expires_in,
         scope: Some(scope),
         email: user.email,

--- a/crates/vouch-server/src/services/oidc/introspection.rs
+++ b/crates/vouch-server/src/services/oidc/introspection.rs
@@ -13,6 +13,7 @@ use crate::error::ServiceError;
 use crate::error::ServiceResult;
 use crate::redact_email;
 use crate::services::auth::{DecodedToken, decode_token};
+use crate::services::oidc::CnfClaim;
 use crate::services::oidc::ScopeSet;
 use serde::Serialize;
 use std::sync::Arc;
@@ -216,14 +217,12 @@ pub async fn introspect_token(
     // RFC 9396: authorization_details from session (already a Value).
     let authorization_details = session.authorization_details;
 
-    // RFC 9449 §7: DPoP-bound tokens report token_type DPoP.
-    // mTLS-bound tokens (x5t#S256 only, no jkt) report Bearer.
-    let is_dpop = claims.cnf.as_ref().is_some_and(|c| c.jkt.is_some());
-    let token_type = if is_dpop {
-        protocol::ACCESS_TOKEN_TYPE_DPOP
-    } else {
-        protocol::ACCESS_TOKEN_TYPE_BEARER
-    };
+    // RFC 7662 §2.2 `token_type`: derived from the confirmation claim the
+    // token actually carries, by the same rule issuance used to advertise it.
+    let token_type = claims
+        .cnf
+        .as_ref()
+        .map_or(protocol::ACCESS_TOKEN_TYPE_BEARER, CnfClaim::token_type);
 
     // RFC 9068 access token — populate client_id from the JWT
     Ok(IntrospectionResult {

--- a/crates/vouch-server/src/services/oidc/mtls.rs
+++ b/crates/vouch-server/src/services/oidc/mtls.rs
@@ -17,12 +17,35 @@ use x509_cert::ext::pkix::name::GeneralName;
 /// Subject Alternative Name extension OID (2.5.29.17).
 const SAN_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("2.5.29.17");
 
+/// RFC 8705 §3.1 `x5t#S256`: the base64url-encoded SHA-256 of a certificate's
+/// DER encoding.
+///
+/// Only [`compute_cert_thumbprint`] builds one, so a `cnf.x5t#S256` cannot be
+/// minted from a string that never came from a presented certificate — the
+/// same guarantee `ValidatedDpopProof` gives the `jkt` half of the binding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CertThumbprint(String);
+
+impl CertThumbprint {
+    /// The wire value, for the `cnf` claim and for comparisons.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for CertThumbprint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
 /// Parsed client certificate with extracted identity fields.
 #[derive(Debug, Clone)]
 pub(crate) struct ClientCertificate {
     /// `x5t#S256`: base64url-encoded SHA-256 of the DER certificate.
     /// RFC 8705 Section 3.1 / RFC 7515 Section 4.1.8.
-    pub thumbprint: String,
+    pub thumbprint: CertThumbprint,
     /// RFC 4514 subject distinguished name string.
     pub subject_dn: Option<String>,
     /// Subject Alternative Name — DNS names.
@@ -52,9 +75,9 @@ pub(crate) enum MtlsError {
 /// Compute the `x5t#S256` thumbprint of a DER-encoded certificate.
 ///
 /// RFC 8705 Section 3.1: base64url(SHA-256(DER(cert))).
-pub(crate) fn compute_cert_thumbprint(der: &[u8]) -> String {
+pub(crate) fn compute_cert_thumbprint(der: &[u8]) -> CertThumbprint {
     let digest = aws_lc_rs::digest::digest(&aws_lc_rs::digest::SHA256, der);
-    URL_SAFE_NO_PAD.encode(digest.as_ref())
+    CertThumbprint(URL_SAFE_NO_PAD.encode(digest.as_ref()))
 }
 
 /// Parse a DER-encoded X.509 certificate into a [`ClientCertificate`].
@@ -218,8 +241,9 @@ pub(crate) fn verify_self_signed_tls_client_auth(
                     if let Ok(x5c_der) = STANDARD.decode(x5c_b64) {
                         let x5c_thumbprint = compute_cert_thumbprint(&x5c_der);
                         let is_match: bool = x5c_thumbprint
+                            .as_str()
                             .as_bytes()
-                            .ct_eq(cert.thumbprint.as_bytes())
+                            .ct_eq(cert.thumbprint.as_str().as_bytes())
                             .into();
                         if is_match {
                             return Ok(());
@@ -251,9 +275,9 @@ mod tests {
     fn test_compute_cert_thumbprint() {
         let cert_der = make_test_cert("test-thumbprint");
         let thumbprint = compute_cert_thumbprint(&cert_der);
-        assert!(!thumbprint.is_empty());
+        assert!(!thumbprint.as_str().is_empty());
         // base64url encoded SHA-256 should be 43 chars (256 bits)
-        assert_eq!(thumbprint.len(), 43);
+        assert_eq!(thumbprint.as_str().len(), 43);
     }
 
     #[test]
@@ -268,7 +292,7 @@ mod tests {
             "subject_dn should contain CN, got: {:?}",
             cert.subject_dn
         );
-        assert!(!cert.thumbprint.is_empty());
+        assert!(!cert.thumbprint.as_str().is_empty());
     }
 
     #[test]

--- a/crates/vouch-server/src/services/oidc/token.rs
+++ b/crates/vouch-server/src/services/oidc/token.rs
@@ -17,7 +17,7 @@ use crate::infra::jwks::JwksOrigin;
 use crate::redact_email;
 use crate::services::auth::{
     AuthMethod, ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof,
-    TokenIssuanceProof, create_oauth_access_token, decode_token,
+    TokenBinding, TokenIssuanceProof, create_oauth_access_token, decode_token,
 };
 use aws_lc_rs::digest::{self, SHA256};
 use base64::Engine;
@@ -27,7 +27,6 @@ use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use subtle::ConstantTimeEq;
-use vouch_common::protocol;
 
 use super::authorization::{AuthorizationCode, decode_authorization_code};
 
@@ -56,17 +55,14 @@ pub struct AuthCodeExchangeParams<'a> {
     pub authenticated_client: Option<&'a AuthenticatedClient>,
     /// RFC 7636 Section 4.5: The PKCE code verifier.
     pub code_verifier: Option<&'a str>,
-    /// RFC 9449 Section 5: Validated DPoP proof (if present).
-    pub dpop_proof: Option<ValidatedDpopProof>,
+    /// RFC 9449 §6 / RFC 8705 §3: how the issued token is bound.
+    pub binding: TokenBinding<'a>,
     /// RFC 8725 §3.9: Client ID for audience validation of the authorization code.
     pub client_id: &'a str,
     /// RFC 8707 Section 2: Target resource indicator (OPTIONAL).
     pub resource: Option<&'a str>,
     /// RFC 9396 Section 6: Authorization details for downscoping.
     pub authorization_details: Option<&'a str>,
-    /// RFC 8705 Section 3: mTLS certificate thumbprint for token binding.
-    /// Only set when the client has `tls_client_certificate_bound_access_tokens = true`.
-    pub mtls_cert_thumbprint: Option<&'a str>,
 }
 
 /// Client credentials for authentication (RFC 6749 Section 2.3).
@@ -332,7 +328,7 @@ pub(crate) async fn exchange_authorization_code(
         &auth_code,
         params.redirect_uri,
         params.code_verifier,
-        params.dpop_proof.as_ref(),
+        params.binding.dpop_proof(),
     )?;
 
     // RFC 9396 + RFC 8707: Resolve authorization details and resource audience
@@ -372,8 +368,7 @@ pub(crate) async fn exchange_authorization_code(
             authenticator_id: Some(&auth_code.authenticator_id),
             client_id: &auth_code.client_id,
             scope: Some(auth_code.scope.clone()),
-            dpop_proof: params.dpop_proof.as_ref(),
-            mtls_cert_thumbprint: params.mtls_cert_thumbprint,
+            binding: params.binding,
             act: None,
             audience: grants.audience.as_deref(),
             auth_time: Some(auth_code.auth_time.unwrap_or(auth_code.iat)),
@@ -403,7 +398,7 @@ pub(crate) async fn exchange_authorization_code(
             email: &auth_code.email,
             nonce: auth_code.nonce.as_deref(),
             expires_in,
-            dpop_proof: params.dpop_proof.as_ref(),
+            binding: params.binding,
             scope: &auth_code.scope,
             auth_time: Some(auth_code.auth_time.unwrap_or(auth_code.iat)),
             hardware_verification: crate::services::auth::HardwareVerification::Verified,
@@ -425,8 +420,8 @@ pub(crate) async fn exchange_authorization_code(
                 ip_address: None,
                 user_agent: None,
                 details: params
-                    .dpop_proof
-                    .as_ref()
+                    .binding
+                    .dpop_proof()
                     .map(|p| format!("dpop_jkt={}", p.jkt))
                     .as_deref(),
             },
@@ -434,14 +429,7 @@ pub(crate) async fn exchange_authorization_code(
         .await;
     }
 
-    // RFC 9449 Section 5: Token type is DPoP if proof was provided, otherwise Bearer
-    let token_type = if params.dpop_proof.is_some() {
-        protocol::ACCESS_TOKEN_TYPE_DPOP
-    } else {
-        protocol::ACCESS_TOKEN_TYPE_BEARER
-    };
-
-    if let Some(ref proof) = params.dpop_proof {
+    if let Some(proof) = params.binding.dpop_proof() {
         tracing::info!(
             "Issued DPoP-bound token for user {} with jkt={}",
             redact_email(&auth_code.email),
@@ -451,7 +439,7 @@ pub(crate) async fn exchange_authorization_code(
 
     Ok(AuthCodeExchangeResult {
         access_token,
-        token_type: token_type.to_string(),
+        token_type: session_result.token_type.to_string(),
         expires_in,
         id_token: id_token.into(),
         scope: auth_code.scope,
@@ -889,9 +877,10 @@ struct IdTokenParams<'a> {
     email: &'a str,
     nonce: Option<&'a str>,
     expires_in: u64,
-    /// RFC 9449 §6 / RFC 7800 §3.1: the validated DPoP proof supplying the
-    /// ID token's `cnf.jkt`.
-    dpop_proof: Option<&'a ValidatedDpopProof>,
+    /// RFC 9449 §6 / RFC 8705 §3 / RFC 7800 §3.1: how this ID token is bound.
+    /// The same binding the access token carries, so a client that proved a
+    /// key receives the same confirmation on both tokens of one response.
+    binding: TokenBinding<'a>,
     scope: &'a ScopeSet,
     /// Time when the user authenticated (FIDO2 session creation time).
     auth_time: Option<i64>,
@@ -916,11 +905,10 @@ async fn generate_id_token(
         .checked_add(expires_seconds)
         .ok_or_else(|| ServiceError::Internal("Expiration time overflow".to_string()))?;
 
-    // RFC 9449 / RFC 8705: Include cnf claim for sender-constrained tokens.
-    let cnf = params.dpop_proof.map(|proof| CnfClaim {
-        jkt: Some(proof.jkt.clone()),
-        x5t_s256: None,
-    });
+    // RFC 9449 / RFC 8705 / RFC 7800 §3.1: the ID token goes to the client
+    // that proved the key, so it carries the same confirmation as the access
+    // token issued beside it — `jkt` for DPoP, `x5t#S256` for mTLS.
+    let cnf = params.binding.cnf();
 
     let has_email = params.scope.contains(OAuthScope::Email);
 

--- a/crates/vouch-server/src/test_utils.rs
+++ b/crates/vouch-server/src/test_utils.rs
@@ -890,7 +890,7 @@ pub async fn create_test_session(
     auth_id: &str,
 ) -> String {
     use crate::services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof,
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenBinding,
         TokenIssuanceProof, create_oauth_access_token,
     };
     use crate::services::oidc::ScopeSet;
@@ -907,8 +907,7 @@ pub async fn create_test_session(
             authenticator_id: Some(auth_id),
             client_id: &state.config().base_url,
             scope: Some(ScopeSet::all()),
-            dpop_proof: None,
-            mtls_cert_thumbprint: None,
+            binding: TokenBinding::Bearer,
             act: None,
             audience: None,
             auth_time: Some(jiff::Timestamp::now().as_second()),
@@ -951,7 +950,7 @@ pub async fn create_test_session_with_audience(
     audience: &str,
 ) -> String {
     use crate::services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof,
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenBinding,
         TokenIssuanceProof, create_oauth_access_token,
     };
     use crate::services::oidc::ScopeSet;
@@ -968,8 +967,7 @@ pub async fn create_test_session_with_audience(
             authenticator_id: Some(auth_id),
             client_id,
             scope: Some(ScopeSet::all()),
-            dpop_proof: None,
-            mtls_cert_thumbprint: None,
+            binding: TokenBinding::Bearer,
             act: None,
             audience: Some(audience),
             auth_time: Some(jiff::Timestamp::now().as_second()),
@@ -1001,7 +999,7 @@ pub async fn create_test_session_with_audience(
 /// sessions (e.g., the RFC 8693 ID-token fork).
 pub async fn create_test_bootstrap_session(state: &AppState, user_id: &str, email: &str) -> String {
     use crate::services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof,
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenBinding,
         TokenIssuanceProof, create_oauth_access_token,
     };
     use crate::services::oidc::ScopeSet;
@@ -1017,8 +1015,7 @@ pub async fn create_test_bootstrap_session(state: &AppState, user_id: &str, emai
             authenticator_id: None,
             client_id: &state.config().base_url,
             scope: Some(ScopeSet::all()),
-            dpop_proof: None,
-            mtls_cert_thumbprint: None,
+            binding: TokenBinding::Bearer,
             act: None,
             audience: None,
             auth_time: Some(jiff::Timestamp::now().as_second()),
@@ -1057,7 +1054,7 @@ pub async fn create_test_bootstrap_session_with_authenticator(
     auth_id: &str,
 ) -> String {
     use crate::services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof,
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenBinding,
         TokenIssuanceProof, create_oauth_access_token,
     };
     use crate::services::oidc::ScopeSet;
@@ -1074,8 +1071,7 @@ pub async fn create_test_bootstrap_session_with_authenticator(
             authenticator_id: Some(auth_id),
             client_id: &state.config().base_url,
             scope: Some(ScopeSet::all()),
-            dpop_proof: None,
-            mtls_cert_thumbprint: None,
+            binding: TokenBinding::Bearer,
             act: None,
             audience: None,
             auth_time: Some(jiff::Timestamp::now().as_second()),
@@ -1111,7 +1107,7 @@ pub async fn create_test_session_with_iat(
     iat: i64,
 ) -> String {
     use crate::services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof,
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenBinding,
         TokenIssuanceProof, create_oauth_access_token,
     };
     use crate::services::oidc::ScopeSet;
@@ -1128,8 +1124,7 @@ pub async fn create_test_session_with_iat(
             authenticator_id: Some(auth_id),
             client_id: &state.config().base_url,
             scope: Some(ScopeSet::all()),
-            dpop_proof: None,
-            mtls_cert_thumbprint: None,
+            binding: TokenBinding::Bearer,
             act: None,
             audience: None,
             auth_time: Some(iat),
@@ -1165,7 +1160,7 @@ pub async fn create_test_session_for_client(
     client_id: &str,
 ) -> String {
     use crate::services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof,
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenBinding,
         TokenIssuanceProof, create_oauth_access_token,
     };
     use crate::services::oidc::ScopeSet;
@@ -1182,8 +1177,7 @@ pub async fn create_test_session_for_client(
             authenticator_id: Some(auth_id),
             client_id,
             scope: Some(ScopeSet::all()),
-            dpop_proof: None,
-            mtls_cert_thumbprint: None,
+            binding: TokenBinding::Bearer,
             act: None,
             audience: None,
             auth_time: Some(jiff::Timestamp::now().as_second()),
@@ -1219,7 +1213,7 @@ pub async fn create_test_session_with_dpop(
     dpop_jkt: &str,
 ) -> String {
     use crate::services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof,
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenBinding,
         TokenIssuanceProof, create_oauth_access_token,
     };
     use crate::services::oidc::{ScopeSet, ValidatedDpopProof};
@@ -1242,8 +1236,7 @@ pub async fn create_test_session_with_dpop(
             authenticator_id: Some(auth_id),
             client_id: &state.config().base_url,
             scope: Some(ScopeSet::all()),
-            dpop_proof: Some(&dpop_proof),
-            mtls_cert_thumbprint: None,
+            binding: TokenBinding::new(Some(&dpop_proof), None),
             act: None,
             audience: None,
             auth_time: Some(jiff::Timestamp::now().as_second()),
@@ -1276,10 +1269,10 @@ pub async fn create_test_session_with_mtls(
     user_id: &str,
     email: &str,
     auth_id: &str,
-    mtls_cert_thumbprint: &str,
+    mtls_cert_thumbprint: &crate::services::oidc::mtls::CertThumbprint,
 ) -> String {
     use crate::services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof,
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenBinding,
         TokenIssuanceProof, create_oauth_access_token,
     };
     use crate::services::oidc::ScopeSet;
@@ -1296,8 +1289,7 @@ pub async fn create_test_session_with_mtls(
             authenticator_id: Some(auth_id),
             client_id: &state.config().base_url,
             scope: Some(ScopeSet::all()),
-            dpop_proof: None,
-            mtls_cert_thumbprint: Some(mtls_cert_thumbprint),
+            binding: TokenBinding::new(None, Some(mtls_cert_thumbprint)),
             act: None,
             audience: None,
             auth_time: Some(jiff::Timestamp::now().as_second()),


### PR DESCRIPTION
Closes #1030

## What changed

`token_type` was derived independently at six sites, each spelling `if <binding>.is_some() { DPoP } else { Bearer }`, while the `cnf` claim was built from a different pair of options a layer away. Nothing tied the advertisement to the confirmation the token actually carried.

`TokenBinding` is a three-valued enum — `Dpop(&ValidatedDpopProof)`, `MutualTls(&CertThumbprint)`, `Bearer` — and both halves come off it:

- `CreateSessionResult` returns the `token_type` matching the `cnf` it just stamped, deleting the derivation at all five issuance sites (`services/oidc/{token,exchange,client_credentials,fido2_grant}.rs`, `handlers/device.rs`).
- Introspection reads the sixth off the claim it decodes, through the same `CnfClaim::token_type` rule, so a token cannot be introspected as a different type than it was issued as.

It is three-valued rather than two deliberately: a `Dpop | None` enum would have dropped `x5t#S256` from mTLS-bound access tokens, turning this cleanup into a FAPI 2.0 regression.

The binding is resolved once per request at the token endpoint and threaded down, so `AuthCodeExchangeParams`, `TokenExchangeParams`, `Fido2AssertionParams`, and `CreateOAuthTokenParams` each carry one value instead of two independent options. `ClientCredentialsBindings` — which was exactly that pair — is gone. Three files no longer import `vouch_common::protocol` at all.

### The mTLS thumbprint is now typed

The DPoP arm took an unforgeable witness while the mTLS arm took any `&str`, so `TokenBinding::MutualTls("whatever")` compiled. `CertThumbprint` is a newtype with a private field, built only by `compute_cert_thumbprint`, so the `x5t#S256` half of a binding cannot be minted from a string that never came from a presented certificate — the guarantee `ValidatedDpopProof` already gave the `jkt` half. It also collapsed a second implementation of the RFC 8705 §3.1 hash that lived in the test helpers, and forced two tests that fabricated thumbprint strings to hash real bytes.

## Wire-visible consequences

**1. An ID token issued beside a certificate-bound access token now carries the same `cnf.x5t#S256`.** Its confirmation was built from `params.dpop_proof` alone, so an mTLS client received a bound access token and an unbound ID token from the same response.

This is a product decision, not a conformance one, and it is the one thing here worth a second opinion. RFC 8705 says nothing about ID tokens. RFC 7800 §3.1 permits the claim in any JWT — "The 'cnf' claim is used in the JWT to contain members used to identify the proof-of-possession key" — and requires it nowhere. The rule applied is the one #1030 settled: bind a token when it goes to the party that proved the key. The auth-code path already stamped `cnf.jkt` into ID tokens, so this makes mTLS behave the way DPoP already did rather than introducing a new practice.

**2. An exchanged ID token reports `token_type` `N_A` rather than `Bearer`.** RFC 8693 §2.2.1 (specs/rfc/rfc8693.txt:460-463, https://www.rfc-editor.org/rfc/rfc8693.txt):

> If the issued token is not an access token or usable as an access token, then the "token_type" value "N_A" is used to indicate that an OAuth 2.0 "token_type" identifier is not applicable in that context.

The value is IANA-registered in the OAuth Access Token Types subregistry (§5.1, line 977). The strength is declarative rather than an RFC 2119 MUST, so this is a smell fixed rather than a violation closed. Nothing in-tree reads it: `credential/wif.rs` documents that the CLI takes the token from `access_token` regardless of `issued_token_type`, and neither it nor `credential/openai.rs` reads `token_type`.

`IdTokenContext` still carries no binding. That is the federation-assertion decision made structural rather than remembered: there is no DPoP proof in that exchange for a consumer to check a thumbprint against, and the consumers (Kubernetes, Vault, AWS/GCP/Azure workload identity) do not read `cnf`. The type now says so in a comment instead of looking like an omission.

## Testing

- New: `test_rfc8705_id_token_carries_the_same_binding_as_the_access_token` drives a `private_key_jwt` + certificate-bound client through `/oauth/token` and asserts both tokens of one response carry the same `x5t#S256`, and that no `jkt` appears when no DPoP proof was presented. **Mutation-checked**: reverting `params.binding.cnf()` to the old DPoP-only map fails it.
- Updated: `test_rfc8693_id_token_request_returns_clean_id_token` asserted `Bearer` for the exchanged ID token; it now asserts `N_A` with the §2.2.1 quote.
- The issue's note about `test_dpop_token_exchange_with_proof` asserting only the advertisement is already covered — `test_rfc9449_exchanged_token_cnf_jkt_matches_proof_key` asserts the thumbprint itself.
- `cargo test -p vouch-server` 3204 pass, `cargo test -p vouch-tests` 398 pass, `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo fmt --all` applied. Re-run after this branch was rebased onto merged main.
- **Live** against a running `vouch-server`: `client_credentials` issuance advertising `Bearer` with no `cnf`, and introspection of that same token reporting `Bearer` — the two ends of the shared rule agreeing at the wire.
- **Not live-tested:** the DPoP, mTLS, and `N_A` paths, which need a client certificate or a hardware-verified subject token. Those go through the production router in the test suite instead.