### PR TITLE
fix(oidc): one redirect_uri rule for every registration path

### DIFF
--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -140,15 +140,16 @@ pub(crate) use oauth::JwtAssertionJtiClaim;
 pub use oauth::{
     CreateOAuthClientParams, JwkEntry, JwkSet, KeyType, MAX_ACTIVE_SECRETS,
     MAX_POST_LOGOUT_REDIRECT_URIS, OAuthClient, OAuthClientSecret, OAuthEventType, OAuthUsageStats,
-    RecordOAuthEventParams, UpdateClientRegistrationParams, UpdateOAuthClientParams,
-    create_oauth_client, create_oauth_client_secret, delete_expired_jwt_assertion_jtis,
-    delete_oauth_client, get_oauth_client_by_client_id, get_oauth_client_by_id,
-    get_oauth_client_secret_by_id, get_oauth_client_secrets, get_oauth_clients_for_user,
-    get_oauth_secret_by_hash, get_oauth_usage_stats, is_valid_post_logout_redirect_uri_str,
-    jwks_has_fapi_allowed_key, jwks_has_x5c, parse_jwks_set, record_oauth_event,
-    revoke_all_oauth_client_secrets, revoke_oauth_client_secret, store_jwt_assertion_jti,
-    update_oauth_client, update_oauth_client_last_used, update_oauth_client_registration,
-    validate_oauth_client_credentials,
+    RecordOAuthEventParams, RedirectUriError, UpdateClientRegistrationParams,
+    UpdateOAuthClientParams, create_oauth_client, create_oauth_client_secret,
+    delete_expired_jwt_assertion_jtis, delete_oauth_client, get_oauth_client_by_client_id,
+    get_oauth_client_by_id, get_oauth_client_secret_by_id, get_oauth_client_secrets,
+    get_oauth_clients_for_user, get_oauth_secret_by_hash, get_oauth_usage_stats,
+    is_loopback_redirect_host, is_valid_post_logout_redirect_uri_str, jwks_has_fapi_allowed_key,
+    jwks_has_x5c, parse_jwks_set, record_oauth_event, revoke_all_oauth_client_secrets,
+    revoke_oauth_client_secret, store_jwt_assertion_jti, update_oauth_client,
+    update_oauth_client_last_used, update_oauth_client_registration,
+    validate_oauth_client_credentials, validate_redirect_uri,
 };
 
 // Re-export test-only OAuth client helpers

--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -165,8 +165,35 @@ impl From<Document<OAuthClientDoc>> for OAuthClient {
 
 impl OAuthClient {
     #[must_use]
+    /// Whether `uri` may be redirected to for this client.
+    ///
+    /// OIDC Core §3.1.2.1 requires the requested URI to "exactly match one of
+    /// the Redirection URI values for the Client pre-registered at the OpenID
+    /// Provider, with the matching performed as described in Section 6.2.1 of
+    /// [RFC3986] (Simple String Comparison)", which is the default here.
+    ///
+    /// Two departures:
+    ///
+    /// - A fragment is refused outright. RFC 6749 §3.1.2 says the redirection
+    ///   endpoint URI "MUST NOT include a fragment component", so one can
+    ///   never be a legitimate target even if it reached storage.
+    /// - For loopback IP literals the port is ignored, because RFC 8252 §7.3
+    ///   says "The authorization server MUST allow any port to be specified at
+    ///   the time of the request for loopback IP redirect URIs, to accommodate
+    ///   clients that obtain an available ephemeral port from the operating
+    ///   system at the time of the request." Scheme, host, and path must still
+    ///   match exactly, and every non-loopback URI keeps simple string
+    ///   comparison.
     pub fn is_valid_redirect_uri(&self, uri: &str) -> bool {
-        self.redirect_uris.iter().any(|u| u == uri)
+        let Ok(requested) = url::Url::parse(uri) else {
+            return false;
+        };
+        if requested.fragment().is_some() {
+            return false;
+        }
+        self.redirect_uris.iter().any(|registered| {
+            registered == uri || loopback_matches_ignoring_port(registered, &requested)
+        })
     }
 
     #[must_use]
@@ -205,6 +232,115 @@ impl OAuthClient {
 /// self-service application creation time (handlers layer).
 pub const MAX_POST_LOGOUT_REDIRECT_URIS: usize = 10;
 
+/// Whether a registered loopback IP redirect URI matches a requested one that
+/// differs only in port — the RFC 8252 §7.3 any-port rule.
+///
+/// Everything but the port must match exactly, and both sides must be `http`
+/// on a loopback IP literal, so this can never relax matching for a URI the
+/// rule does not cover.
+fn loopback_matches_ignoring_port(registered: &str, requested: &url::Url) -> bool {
+    let Ok(registered) = url::Url::parse(registered) else {
+        return false;
+    };
+    registered.scheme() == "http"
+        && requested.scheme() == "http"
+        && registered.host_str().is_some_and(is_loopback_ip_literal)
+        && registered.host_str() == requested.host_str()
+        && registered.path() == requested.path()
+        && registered.query() == requested.query()
+}
+
+/// The hosts an `http://` redirect URI may use.
+///
+/// OIDC Registration §2 and OIDC Core §3.1.2.1 both name exactly this set:
+/// "loopback URLs use "localhost" or the IP loopback literals "127.0.0.1" or
+/// "[::1]" as the hostname".
+///
+/// Deliberately not [`vouch_common::is_loopback_host`], which also accepts
+/// `host.docker.internal` and all of `127.0.0.0/8`. That helper exists for the
+/// dev-mode RP-ID and origin checks; `host.docker.internal` resolves off-device,
+/// which would break the assumption RFC 8252 §8.3 rests on — "This is
+/// acceptable for loopback interface redirect URIs as the HTTP request never
+/// leaves the device."
+#[must_use]
+pub fn is_loopback_redirect_host(host: &str) -> bool {
+    matches!(host, "localhost" | "127.0.0.1" | "[::1]")
+}
+
+/// The IP literals RFC 8252 §7.3 calls "loopback IP redirect URIs", which are
+/// the ones its any-port rule covers. `localhost` is a name, not an IP literal,
+/// so it is matched on its exact registered port like every other URI.
+fn is_loopback_ip_literal(host: &str) -> bool {
+    matches!(host, "127.0.0.1" | "[::1]")
+}
+
+/// Why a redirect URI was rejected at registration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RedirectUriError {
+    /// RFC 6749 §3.1.2: "The redirection endpoint URI MUST be an absolute URI".
+    NotAbsolute,
+    /// RFC 6749 §3.1.2: "The endpoint URI MUST NOT include a fragment component."
+    HasFragment,
+    /// `http` is permitted only for the loopback hosts above.
+    HttpNonLoopback,
+    /// OIDC Registration §2: "Native Clients MUST only register "redirect_uris"
+    /// using custom URI schemes or loopback URLs using the "http" scheme".
+    /// Everything else registers `https` (or loopback `http`).
+    CustomSchemeNotNative,
+}
+
+impl std::fmt::Display for RedirectUriError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let msg = match self {
+            Self::NotAbsolute => "must be an absolute URI",
+            Self::HasFragment => "must not contain a fragment component",
+            Self::HttpNonLoopback => "http:// is allowed only for localhost, 127.0.0.1, or [::1]",
+            Self::CustomSchemeNotNative => "a custom URI scheme is allowed only for native clients",
+        };
+        f.write_str(msg)
+    }
+}
+
+/// Validate one `redirect_uri` for registration, for a client of this type.
+///
+/// The single rule for every write path — dynamic client registration and both
+/// self-service paths — so a URI one path accepts cannot be a URI another
+/// rejects.
+///
+/// # Errors
+///
+/// Returns the specific [`RedirectUriError`] rather than a boolean, so each
+/// rejection reason can be reported to the client and tested on its own.
+pub fn validate_redirect_uri(
+    uri: &str,
+    application_type: OAuthClientType,
+) -> Result<(), RedirectUriError> {
+    let parsed = url::Url::parse(uri).map_err(|_| RedirectUriError::NotAbsolute)?;
+    if parsed.fragment().is_some() {
+        return Err(RedirectUriError::HasFragment);
+    }
+    match parsed.scheme() {
+        "https" => Ok(()),
+        "http" => {
+            if is_loopback_redirect_host(parsed.host_str().unwrap_or_default()) {
+                Ok(())
+            } else {
+                Err(RedirectUriError::HttpNonLoopback)
+            }
+        }
+        // OIDC Core §3.1.2.1: "The Redirection URI MAY use an alternate scheme,
+        // such as one that is intended to identify a callback into a native
+        // application." RFC 8252 §7.1's reverse-domain format is a MUST on the
+        // app, not on us, so the scheme's shape is not checked here.
+        _ => match application_type {
+            OAuthClientType::Native => Ok(()),
+            OAuthClientType::Web | OAuthClientType::Spa | OAuthClientType::Service => {
+                Err(RedirectUriError::CustomSchemeNotNative)
+            }
+        },
+    }
+}
+
 /// Return `true` when `uri` is a syntactically valid post-logout redirect URI.
 ///
 /// Valid URIs must:
@@ -222,10 +358,7 @@ pub fn is_valid_post_logout_redirect_uri_str(uri: &str) -> bool {
     }
     match parsed.scheme() {
         "https" => true,
-        "http" => {
-            let host = parsed.host_str().unwrap_or("");
-            matches!(host, "localhost" | "127.0.0.1" | "[::1]")
-        }
+        "http" => is_loopback_redirect_host(parsed.host_str().unwrap_or_default()),
         _ => false,
     }
 }

--- a/crates/vouch-server/src/db/tests/oauth_clients.rs
+++ b/crates/vouch-server/src/db/tests/oauth_clients.rs
@@ -618,3 +618,206 @@ fn test_oauth_client_secret_is_valid_no_expiry() {
         "Secret with no expiry and not revoked must be valid"
     );
 }
+
+// ─────────────────────────────────────────────────────────────────────────
+// Redirect URI validation — the one rule shared by every write path
+// ─────────────────────────────────────────────────────────────────────────
+
+use crate::db::{OAuthClientType, RedirectUriError, validate_redirect_uri};
+
+/// RFC 6749 §3.1.2: "The endpoint URI MUST NOT include a fragment component."
+/// Rejected for every client kind, which is the change here — the self-service
+/// path had no fragment check at all.
+#[test]
+fn redirect_uri_with_a_fragment_is_rejected_for_every_client_kind() {
+    for kind in [
+        OAuthClientType::Web,
+        OAuthClientType::Native,
+        OAuthClientType::Spa,
+        OAuthClientType::Service,
+    ] {
+        assert_eq!(
+            validate_redirect_uri("https://app.example/cb#x", kind),
+            Err(RedirectUriError::HasFragment),
+            "{kind:?} must not be able to register a fragment"
+        );
+    }
+}
+
+/// OIDC Registration §2: "Native Clients MUST only register "redirect_uris"
+/// using custom URI schemes or loopback URLs using the "http" scheme".
+/// Dynamic client registration accepted a custom scheme for any client and
+/// self-service rejected it for all of them; the rule is per client kind.
+#[test]
+fn custom_scheme_is_registrable_only_by_native_clients() {
+    assert_eq!(
+        validate_redirect_uri("com.example.app://cb", OAuthClientType::Native),
+        Ok(())
+    );
+    for kind in [
+        OAuthClientType::Web,
+        OAuthClientType::Spa,
+        OAuthClientType::Service,
+    ] {
+        assert_eq!(
+            validate_redirect_uri("com.example.app://cb", kind),
+            Err(RedirectUriError::CustomSchemeNotNative),
+            "{kind:?} is not a native client"
+        );
+    }
+}
+
+/// RFC 8252 §7.1's reverse-domain scheme format is a MUST on the app, not on
+/// the authorization server, so a scheme that does not follow it still
+/// registers.
+#[test]
+fn a_custom_scheme_is_not_required_to_be_reverse_domain() {
+    assert_eq!(
+        validate_redirect_uri("myapp://cb", OAuthClientType::Native),
+        Ok(())
+    );
+}
+
+/// The loopback set is exactly what OIDC Registration §2 and OIDC Core
+/// §3.1.2.1 enumerate — notably not `host.docker.internal`, which
+/// `vouch_common::is_loopback_host` accepts and which resolves off-device.
+#[test]
+fn http_is_registrable_only_for_the_three_loopback_hosts() {
+    for accepted in [
+        "http://localhost:8080/cb",
+        "http://127.0.0.1:8080/cb",
+        "http://[::1]:8080/cb",
+    ] {
+        assert_eq!(
+            validate_redirect_uri(accepted, OAuthClientType::Native),
+            Ok(()),
+            "{accepted} is a loopback redirect"
+        );
+    }
+    for rejected in [
+        "http://app.example/cb",
+        "http://127.0.0.2:8080/cb",
+        "http://host.docker.internal/cb",
+    ] {
+        assert_eq!(
+            validate_redirect_uri(rejected, OAuthClientType::Native),
+            Err(RedirectUriError::HttpNonLoopback),
+            "{rejected} is not a loopback redirect"
+        );
+    }
+}
+
+#[test]
+fn a_relative_uri_is_not_a_redirect_uri() {
+    assert_eq!(
+        validate_redirect_uri("/callback", OAuthClientType::Web),
+        Err(RedirectUriError::NotAbsolute)
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Redirect URI matching at the authorization endpoint
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Persist a client with these redirect URIs and hand back the stored record,
+/// so matching is exercised against a real row rather than a literal.
+async fn client_with_redirect_uris(uris: &[&str]) -> OAuthClient {
+    let (store, _audit) = test_db().await;
+    let (user_id, _) = upsert_user(&store, "redirect-match@example.com", None)
+        .await
+        .expect("create user");
+    let redirect_uris: Vec<String> = uris.iter().map(|u| (*u).to_string()).collect();
+    let (client, _) = create_oauth_client(
+        &store,
+        &CreateOAuthClientParams {
+            user_id: Some(&user_id),
+            name: "Redirect Match",
+            description: None,
+            application_type: OAuthClientType::Native,
+            redirect_uris: &redirect_uris,
+            access_scope: AccessScope::default(),
+            org_id: None,
+            resource_uris: &[],
+            token_endpoint_auth_method: TokenEndpointAuthMethod::None,
+            jwks: None,
+            jwks_uri: None,
+            fapi_profile: None,
+            dpop_bound_access_tokens: None,
+            grant_types: None,
+            response_types: None,
+            software_id: None,
+            software_version: None,
+            registration_source: RegistrationSource::Manual,
+            registration_access_token_hash: None,
+            registration_metadata: None,
+            id_token_signed_response_alg: JwsAlgorithm::Rs256,
+            tls_client_auth_subject_dn: None,
+            tls_client_auth_san_dns: None,
+            tls_client_auth_san_uri: None,
+            tls_client_auth_san_ip: None,
+            tls_client_auth_san_email: None,
+            tls_client_certificate_bound_access_tokens: None,
+            authorization_signed_response_alg: None,
+            introspection_signed_response_alg: None,
+            request_object_signing_alg: None,
+            require_signed_request_object: None,
+            userinfo_signed_response_alg: None,
+            request_uris: None,
+            post_logout_redirect_uris: None,
+        },
+    )
+    .await
+    .expect("create client");
+    client
+}
+
+/// RFC 8252 §7.3: "The authorization server MUST allow any port to be
+/// specified at the time of the request for loopback IP redirect URIs, to
+/// accommodate clients that obtain an available ephemeral port from the
+/// operating system at the time of the request."
+#[tokio::test]
+async fn a_loopback_ip_redirect_matches_on_any_port() {
+    let client = client_with_redirect_uris(&["http://127.0.0.1:51004/cb"]).await;
+    assert!(client.is_valid_redirect_uri("http://127.0.0.1:61023/cb"));
+    assert!(client.is_valid_redirect_uri("http://127.0.0.1:51004/cb"));
+
+    let client = client_with_redirect_uris(&["http://[::1]:51004/cb"]).await;
+    assert!(client.is_valid_redirect_uri("http://[::1]:61023/cb"));
+}
+
+/// The any-port rule is scoped to what §7.3 calls "loopback IP redirect URIs".
+/// `localhost` is a name, not an IP literal, so it keeps exact matching.
+#[tokio::test]
+async fn localhost_does_not_get_the_any_port_exemption() {
+    let client = client_with_redirect_uris(&["http://localhost:51004/cb"]).await;
+    assert!(client.is_valid_redirect_uri("http://localhost:51004/cb"));
+    assert!(!client.is_valid_redirect_uri("http://localhost:61023/cb"));
+}
+
+/// Everything but the port must still match: the exemption cannot be used to
+/// reach a different path, host, or scheme.
+#[tokio::test]
+async fn the_any_port_exemption_relaxes_only_the_port() {
+    let client = client_with_redirect_uris(&["http://127.0.0.1:51004/cb"]).await;
+    assert!(!client.is_valid_redirect_uri("http://127.0.0.1:61023/other"));
+    assert!(!client.is_valid_redirect_uri("http://127.0.0.1:61023/cb?x=1"));
+    assert!(!client.is_valid_redirect_uri("https://127.0.0.1:61023/cb"));
+    assert!(!client.is_valid_redirect_uri("http://[::1]:61023/cb"));
+}
+
+/// OIDC Core §3.1.2.1 keeps simple string comparison for everything else.
+#[tokio::test]
+async fn a_non_loopback_redirect_still_matches_exactly() {
+    let client = client_with_redirect_uris(&["https://app.example/cb"]).await;
+    assert!(client.is_valid_redirect_uri("https://app.example/cb"));
+    assert!(!client.is_valid_redirect_uri("https://app.example/cb2"));
+    assert!(!client.is_valid_redirect_uri("https://app.example:8443/cb"));
+}
+
+/// A fragment can never be a legitimate redirect target (RFC 6749 §3.1.2), so
+/// it is refused at the endpoint too rather than only at registration.
+#[tokio::test]
+async fn a_requested_uri_with_a_fragment_is_never_matched() {
+    let client = client_with_redirect_uris(&["https://app.example/cb"]).await;
+    assert!(!client.is_valid_redirect_uri("https://app.example/cb#x"));
+}

--- a/crates/vouch-server/src/handlers/applications/mod.rs
+++ b/crates/vouch-server/src/handlers/applications/mod.rs
@@ -130,33 +130,27 @@ pub(crate) fn validate_post_logout_redirect_uris(uris: &[String]) -> Result<(), 
     }
 }
 
-/// Validate that all redirect URIs are valid URLs with proper schemes.
+/// Validate every redirect URI for a client of this type.
 ///
-/// Per RFC 8252 Section 7.3 and RFC 9700 Section 4.1.3:
-/// - `http://` is only allowed for loopback addresses (`localhost`, `127.0.0.1`, `[::1]`)
-/// - `https://` is required for all other hosts
+/// Delegates to [`db::validate_redirect_uri`], the single rule shared with
+/// dynamic client registration, so the two paths cannot accept different sets.
 ///
-/// Returns `Ok(())` if all URIs are valid, or `Err` with a list of invalid URIs.
-fn validate_redirect_uris(uris: &[String]) -> Result<(), Vec<String>> {
+/// Returns `Ok(())` if all URIs are valid, or `Err` listing the invalid ones.
+/// The rejection reason is deliberately not folded into these strings: they are
+/// rendered into `ApplicationErrorTemplate`, whose message is not yet
+/// translated, and per-reason detail there would be new untranslated UI text.
+/// Dynamic client registration, which answers in JSON, does report the reason.
+fn validate_redirect_uris(
+    uris: &[String],
+    application_type: db::OAuthClientType,
+) -> Result<(), Vec<String>> {
     let invalid: Vec<String> = uris
         .iter()
-        .filter(|uri| {
-            match url::Url::parse(uri) {
-                Ok(parsed) => {
-                    match parsed.scheme() {
-                        "https" => false, // HTTPS is always valid
-                        "http" => {
-                            // RFC 8252 Section 7.3: HTTP only for loopback
-                            let host = parsed.host_str().unwrap_or("");
-                            !matches!(host, "localhost" | "127.0.0.1" | "[::1]")
-                        }
-                        _ => true, // Other schemes are not allowed
-                    }
-                }
-                Err(_) => true,
-            }
+        .filter_map(|uri| {
+            db::validate_redirect_uri(uri, application_type)
+                .err()
+                .map(|_| uri.clone())
         })
-        .cloned()
         .collect();
 
     if invalid.is_empty() {

--- a/crates/vouch-server/src/handlers/applications/validate.rs
+++ b/crates/vouch-server/src/handlers/applications/validate.rs
@@ -78,7 +78,9 @@ impl AppValidationError {
             }
             Self::MissingRedirectUris => "At least one redirect URI is required".to_string(),
             Self::InvalidRedirectUris(invalid) => format!(
-                "Invalid redirect URI(s): {}. Each URI must be a valid http:// or https:// URL.",
+                "Invalid redirect URI(s): {}. Each URI must use https://, or http:// with \
+                 localhost, 127.0.0.1, or [::1], and must not contain a fragment. \
+                 A custom scheme is accepted only for native applications.",
                 invalid.join(", ")
             ),
             Self::InvalidPostLogoutRedirectUris(invalid) => format!(
@@ -195,7 +197,8 @@ pub(super) fn validate_create_application<'a>(
         return Err(AppValidationError::MissingRedirectUris);
     }
 
-    validate_redirect_uris(input.redirect_uris).map_err(AppValidationError::InvalidRedirectUris)?;
+    validate_redirect_uris(input.redirect_uris, app_type)
+        .map_err(AppValidationError::InvalidRedirectUris)?;
 
     if let Some(uris) = input.post_logout_redirect_uris {
         validate_post_logout_redirect_uris(uris)
@@ -298,14 +301,9 @@ pub(super) struct ValidatedUpdateApp<'a> {
 pub(super) fn validate_update_format<'a>(
     input: UpdateAppInput<'a>,
 ) -> Result<ValidatedUpdateApp<'a>, AppValidationError> {
-    if let Some(uris) = input.redirect_uris {
-        // Only validate URIs if the list is non-empty.  An empty list is
-        // accepted here and checked later by `validate_update_fapi` against
-        // the persisted client type.
-        if !uris.is_empty() {
-            validate_redirect_uris(uris).map_err(AppValidationError::InvalidRedirectUris)?;
-        }
-    }
+    // Redirect URIs are validated in `validate_update_fapi`, which is the stage
+    // that has the persisted client type — the type decides whether a custom
+    // URI scheme may be registered, and an update cannot change it.
 
     if let Some(uris) = input.resource_uris {
         validate_resource_uris(uris)?;
@@ -405,11 +403,12 @@ pub(super) fn validate_update_fapi(
     // An explicit empty redirect_uris list is only valid for service apps.
     // We skip this check in the pre-auth format pass (application_type=None
     // there), and enforce it here once we have the persisted client type.
-    if let Some(uris) = validated.redirect_uris
-        && uris.is_empty()
-        && !matches!(client.application_type, OAuthClientType::Service)
-    {
-        return Err(AppValidationError::MissingRedirectUris);
+    if let Some(uris) = validated.redirect_uris {
+        if uris.is_empty() && !matches!(client.application_type, OAuthClientType::Service) {
+            return Err(AppValidationError::MissingRedirectUris);
+        }
+        validate_redirect_uris(uris, client.application_type)
+            .map_err(AppValidationError::InvalidRedirectUris)?;
     }
 
     // A FAPI client authenticates with private_key_jwt and therefore has no

--- a/crates/vouch-server/src/services/oidc/registration.rs
+++ b/crates/vouch-server/src/services/oidc/registration.rs
@@ -77,6 +77,10 @@ const REGISTRATION_TOKEN_LENGTH: usize = 32;
 pub struct RegistrationRequest {
     /// RFC 7591 Section 2: Array of redirection URI strings.
     pub redirect_uris: Option<Vec<String>>,
+    /// OIDC Registration Section 2: `"native"` or `"web"`; the default when
+    /// omitted is `"web"`. Decides whether a custom URI scheme may be
+    /// registered, so it is read before the redirect URIs are validated.
+    pub application_type: Option<String>,
     /// RFC 7591 Section 2: Authentication method for the token endpoint.
     pub token_endpoint_auth_method: Option<String>,
     /// RFC 7591 Section 2: Array of OAuth 2.0 grant type strings.
@@ -353,11 +357,19 @@ pub async fn register_client(
     // 1. Validate grant/response types, apply defaults, check consistency
     let validated = validate_grant_and_response_types(&mut request)?;
 
-    // 7. Validate redirect URIs
-    let redirect_uris = validate_redirect_uris(&mut request, validated.auth_code_grant)?;
-
-    // 8-9. Validate JWKS and auth method
+    // 8-9. Validate JWKS and auth method. This runs before the redirect URIs
+    // because the application type decides whether a custom URI scheme may be
+    // registered, and inferring that type needs the auth method.
     let jwks_auth = validate_jwks_and_auth_method(&mut request, &validated.auth_method_str)?;
+
+    // 7. Resolve the application type, then validate redirect URIs against it.
+    let app_type = resolve_client_type(
+        request.application_type.as_deref(),
+        &validated.grant_types,
+        jwks_auth.auth_method,
+        request.redirect_uris.as_deref().unwrap_or_default(),
+    )?;
+    let redirect_uris = validate_redirect_uris(&mut request, validated.auth_code_grant, app_type)?;
 
     // 10-11. Validate contacts and URI fields
     validate_contacts_and_uris(&request)?;
@@ -569,13 +581,6 @@ pub async fn register_client(
     let require_signed = request
         .require_signed_request_object
         .unwrap_or(fapi_profile != FapiProfile::None && req_obj_alg.is_some());
-
-    // 13. Infer application type
-    let app_type = determine_client_type(
-        &validated.grant_types,
-        jwks_auth.auth_method,
-        &redirect_uris,
-    );
 
     // Build the client name (fallback to software_id or "Unnamed Client")
     let client_name = request.client_name.as_deref().unwrap_or("Unnamed Client");
@@ -965,6 +970,7 @@ fn validate_grant_and_response_types(
 fn validate_redirect_uris(
     request: &mut RegistrationRequest,
     auth_code_grant: AuthorizationCodeGrant,
+    application_type: OAuthClientType,
 ) -> Result<Vec<String>, ServiceError> {
     let redirect_uris = request.redirect_uris.take().unwrap_or_default();
     if auth_code_grant == AuthorizationCodeGrant::Present && redirect_uris.is_empty() {
@@ -980,7 +986,12 @@ fn validate_redirect_uris(
         ));
     }
     for uri in &redirect_uris {
-        validate_registration_redirect_uri(uri)?;
+        db::validate_redirect_uri(uri, application_type).map_err(|e| {
+            ServiceError::oauth(
+                OAuthErrorCode::InvalidRedirectUri,
+                format!("Invalid redirect URI '{uri}': {e}"),
+            )
+        })?;
     }
     Ok(redirect_uris)
 }
@@ -1146,6 +1157,47 @@ fn validate_contacts_and_uris(request: &RegistrationRequest) -> Result<(), Servi
 }
 
 /// Infer OAuth client application type from grants, auth method, and URIs.
+/// Parse the client-declared `application_type` (OIDC Registration §2).
+///
+/// > application_type
+/// >    OPTIONAL.  Kind of the application.  The default, if omitted, is
+/// >    "web".  The defined values are "native" or "web".
+///
+/// Only those two values are defined, so anything else is invalid metadata
+/// rather than a silent fallback.
+fn parse_declared_client_type(declared: &str) -> Result<OAuthClientType, ServiceError> {
+    match declared {
+        "native" => Ok(OAuthClientType::Native),
+        "web" => Ok(OAuthClientType::Web),
+        other => Err(ServiceError::oauth(
+            OAuthErrorCode::InvalidClientMetadata,
+            format!("Unsupported application_type '{other}': expected 'native' or 'web'"),
+        )),
+    }
+}
+
+/// The application type to validate this registration's redirect URIs against.
+///
+/// The client's own `application_type` wins when it sends one, since OIDC
+/// Registration §2 defines it as the client stating what it is. Otherwise it is
+/// inferred from the rest of the request, which is what this server did before
+/// it read the field at all.
+fn resolve_client_type(
+    declared: Option<&str>,
+    grant_types: &[String],
+    auth_method: TokenEndpointAuthMethod,
+    redirect_uris: &[String],
+) -> Result<OAuthClientType, ServiceError> {
+    match declared {
+        Some(value) => parse_declared_client_type(value),
+        None => Ok(determine_client_type(
+            grant_types,
+            auth_method,
+            redirect_uris,
+        )),
+    }
+}
+
 fn determine_client_type(
     grant_types: &[String],
     auth_method: TokenEndpointAuthMethod,
@@ -1156,16 +1208,22 @@ fn determine_client_type(
             .first()
             .is_some_and(|g| g == "client_credentials");
     let is_public = auth_method == TokenEndpointAuthMethod::None;
-    let has_loopback = redirect_uris.iter().any(|u| {
-        url::Url::parse(u)
-            .ok()
-            .and_then(|p| p.host_str().map(|h| h.to_string()))
-            .is_some_and(|h| h == "localhost" || h == "127.0.0.1" || h == "[::1]")
+    // RFC 8252 §7: a native app receives its redirect either on the loopback
+    // interface or through a private-use URI scheme, so either shape is the
+    // signal. Without the scheme half, an app registering only
+    // `com.example.app://cb` would be classified as a browser app and then
+    // refused the very scheme that classification exists to permit.
+    let has_native_redirect = redirect_uris.iter().any(|u| {
+        url::Url::parse(u).is_ok_and(|parsed| match parsed.scheme() {
+            "http" => parsed.host_str().is_some_and(db::is_loopback_redirect_host),
+            "https" => false,
+            _ => true,
+        })
     });
 
     if has_client_credentials_only {
         OAuthClientType::Service
-    } else if is_public && has_loopback {
+    } else if is_public && has_native_redirect {
         OAuthClientType::Native
     } else if is_public {
         OAuthClientType::Spa
@@ -1271,8 +1329,15 @@ pub async fn update_client_configuration(
     let mut mutable_request = request;
     let validated = validate_grant_and_response_types(&mut mutable_request)?;
 
-    // Validate redirect URIs (same cardinality + format rules as initial registration)
-    let redirect_uris = validate_redirect_uris(&mut mutable_request, validated.auth_code_grant)?;
+    // Validate redirect URIs (same cardinality + format rules as initial
+    // registration). An update may restate `application_type`; absent that, the
+    // client keeps the type it registered with.
+    let app_type = match mutable_request.application_type.as_deref() {
+        Some(declared) => parse_declared_client_type(declared)?,
+        None => client.application_type,
+    };
+    let redirect_uris =
+        validate_redirect_uris(&mut mutable_request, validated.auth_code_grant, app_type)?;
 
     // Build updated registration metadata (cosmetic fields)
     let registration_metadata = mutable_request.registration_metadata();
@@ -1565,58 +1630,18 @@ fn metadata_string_array(metadata: &serde_json::Value, key: &str) -> Option<Vec<
 // Validation Helpers
 // ============================================================================
 
-/// Validate a single redirect URI for dynamic registration.
-///
-/// Per RFC 7591 Section 2 and RFC 8252:
-/// - HTTPS is always valid
-/// - HTTP is only allowed for loopback (localhost, 127.0.0.1, [::1])
-/// - Custom schemes are allowed for native apps
-/// - Fragments are forbidden (RFC 6749 Section 3.1.2)
-fn validate_registration_redirect_uri(uri: &str) -> Result<(), ServiceError> {
-    // Check for fragments (forbidden per RFC 6749 Section 3.1.2)
-    if uri.contains('#') {
-        return Err(ServiceError::oauth(
-            OAuthErrorCode::InvalidRedirectUri,
-            format!("Redirect URI must not contain a fragment component: '{uri}'"),
-        ));
-    }
-
-    match url::Url::parse(uri) {
-        Ok(parsed) => {
-            match parsed.scheme() {
-                "https" => Ok(()),
-                "http" => {
-                    // RFC 8252 Section 7.3: HTTP only for loopback
-                    let host = parsed.host_str().unwrap_or("");
-                    if matches!(host, "localhost" | "127.0.0.1" | "[::1]") {
-                        Ok(())
-                    } else {
-                        Err(ServiceError::oauth(
-                            OAuthErrorCode::InvalidRedirectUri,
-                            format!(
-                                "http:// redirect URIs are only allowed for loopback \
-                                 addresses (localhost, 127.0.0.1, [::1]): '{uri}'"
-                            ),
-                        ))
-                    }
-                }
-                // Custom schemes are allowed for native apps (RFC 8252 Section 7.1)
-                _ => Ok(()),
-            }
-        }
-        Err(_) => Err(ServiceError::oauth(
-            OAuthErrorCode::InvalidRedirectUri,
-            format!("Invalid redirect URI: '{uri}'"),
-        )),
-    }
-}
-
-/// Public alias for  exposed for property-based testing.
+/// The shared redirect-URI rule as it applies to a native client, exposed for
+/// property-based testing.
 ///
 /// Only available when the `test-utils` feature is enabled.
 #[cfg(feature = "test-utils")]
 pub fn validate_redirect_uri_for_test(uri: &str) -> Result<(), ServiceError> {
-    validate_registration_redirect_uri(uri)
+    db::validate_redirect_uri(uri, crate::db::OAuthClientType::Native).map_err(|e| {
+        ServiceError::oauth(
+            OAuthErrorCode::InvalidRedirectUri,
+            format!("Invalid redirect URI '{uri}': {e}"),
+        )
+    })
 }
 
 /// Validate that a URI field is HTTPS (if present).

--- a/crates/vouch-server/src/services/oidc/registration/tests.rs
+++ b/crates/vouch-server/src/services/oidc/registration/tests.rs
@@ -19,51 +19,63 @@ fn assert_oauth_error<T: std::fmt::Debug>(
     );
 }
 
+/// The shared redirect-URI rule as it applies to a native client, which is the
+/// client kind these cases describe: `https`, loopback `http`, and a custom
+/// scheme are all registrable, and a fragment is not.
+fn validate_redirect_uri_for_native(uri: &str) -> Result<(), crate::error::ServiceError> {
+    crate::db::validate_redirect_uri(uri, crate::db::OAuthClientType::Native).map_err(|e| {
+        crate::error::ServiceError::oauth(
+            OAuthErrorCode::InvalidRedirectUri,
+            format!("Invalid redirect URI '{uri}': {e}"),
+        )
+    })
+}
+
 // =========================================================================
 // Redirect URI Validation Tests
 // =========================================================================
 
 #[test]
 fn test_accepts_https_redirect_uri() {
-    let result = validate_registration_redirect_uri("https://example.com/callback");
+    let result = validate_redirect_uri_for_native("https://example.com/callback");
     assert!(result.is_ok());
 }
 
 #[test]
 fn test_accepts_http_localhost_redirect_uri() {
-    let result = validate_registration_redirect_uri("http://127.0.0.1:8080/callback");
+    let result = validate_redirect_uri_for_native("http://127.0.0.1:8080/callback");
     assert!(result.is_ok());
 }
 
 #[test]
 fn test_accepts_http_localhost_hostname() {
-    let result = validate_registration_redirect_uri("http://localhost:8080/callback");
+    let result = validate_redirect_uri_for_native("http://localhost:8080/callback");
     assert!(result.is_ok());
 }
 
 #[test]
 fn test_accepts_custom_scheme_redirect_uri() {
-    let result = validate_registration_redirect_uri("myapp://auth");
+    let result = validate_redirect_uri_for_native("myapp://auth");
     assert!(result.is_ok());
 }
 
 #[test]
 fn test_rejects_http_non_loopback() {
-    let result = validate_registration_redirect_uri("http://example.com/callback");
+    let result = validate_redirect_uri_for_native("http://example.com/callback");
     assert!(result.is_err());
     assert_oauth_error(result, OAuthErrorCode::InvalidRedirectUri);
 }
 
 #[test]
 fn test_rejects_redirect_uri_with_fragment() {
-    let result = validate_registration_redirect_uri("https://example.com/callback#anchor");
+    let result = validate_redirect_uri_for_native("https://example.com/callback#anchor");
     assert!(result.is_err());
     assert_oauth_error(result, OAuthErrorCode::InvalidRedirectUri);
 }
 
 #[test]
 fn test_rejects_invalid_redirect_uri() {
-    let result = validate_registration_redirect_uri("not a valid uri !!!");
+    let result = validate_redirect_uri_for_native("not a valid uri !!!");
     assert!(result.is_err());
     assert_oauth_error(result, OAuthErrorCode::InvalidRedirectUri);
 }
@@ -75,7 +87,7 @@ fn test_rejects_invalid_redirect_uri() {
 /// RFC 8252 Section 7.3: IPv6 loopback [::1] must be accepted over HTTP.
 #[test]
 fn test_accepts_http_ipv6_loopback_redirect_uri() {
-    let result = validate_registration_redirect_uri("http://[::1]:7777/callback");
+    let result = validate_redirect_uri_for_native("http://[::1]:7777/callback");
     assert!(
         result.is_ok(),
         "IPv6 loopback [::1] must be accepted: {result:?}"
@@ -85,14 +97,14 @@ fn test_accepts_http_ipv6_loopback_redirect_uri() {
 /// HTTP redirect URIs with a path component at loopback must be accepted.
 #[test]
 fn test_accepts_http_loopback_with_path() {
-    let result = validate_registration_redirect_uri("http://127.0.0.1/callback/deep/path");
+    let result = validate_redirect_uri_for_native("http://127.0.0.1/callback/deep/path");
     assert!(result.is_ok());
 }
 
 /// HTTPS URIs with query strings must be accepted (query is not a fragment).
 #[test]
 fn test_accepts_https_redirect_uri_with_query() {
-    let result = validate_registration_redirect_uri("https://example.com/cb?foo=bar");
+    let result = validate_redirect_uri_for_native("https://example.com/cb?foo=bar");
     assert!(result.is_ok());
 }
 
@@ -100,7 +112,7 @@ fn test_accepts_https_redirect_uri_with_query() {
 #[test]
 fn test_rejects_redirect_uri_with_fragment_before_parse() {
     // A URI that would otherwise be valid https but contains '#'
-    let err = validate_registration_redirect_uri("https://example.com/cb#").unwrap_err();
+    let err = validate_redirect_uri_for_native("https://example.com/cb#").unwrap_err();
     assert!(
         matches!(&err, ServiceError::OAuth { code, .. } if *code == OAuthErrorCode::InvalidRedirectUri)
     );
@@ -112,7 +124,7 @@ fn test_rejects_redirect_uri_with_fragment_before_parse() {
 /// HTTP to a non-loopback private IP (e.g., 192.168.x.x) must be rejected.
 #[test]
 fn test_rejects_http_private_ip_redirect_uri() {
-    let result = validate_registration_redirect_uri("http://192.168.1.1/callback");
+    let result = validate_redirect_uri_for_native("http://192.168.1.1/callback");
     assert!(result.is_err());
     assert_oauth_error(result, OAuthErrorCode::InvalidRedirectUri);
 }
@@ -120,7 +132,7 @@ fn test_rejects_http_private_ip_redirect_uri() {
 /// An empty string is not a valid redirect URI.
 #[test]
 fn test_rejects_empty_redirect_uri() {
-    let result = validate_registration_redirect_uri("");
+    let result = validate_redirect_uri_for_native("");
     assert!(result.is_err());
     assert_oauth_error(result, OAuthErrorCode::InvalidRedirectUri);
 }
@@ -983,14 +995,22 @@ fn make_request_with_redirect_uris(uris: Option<Vec<&str>>) -> RegistrationReque
 #[test]
 fn test_validate_redirect_uris_required_for_auth_code_empty() {
     let mut req = make_request_with_redirect_uris(None);
-    let result = validate_redirect_uris(&mut req, AuthorizationCodeGrant::Present);
+    let result = validate_redirect_uris(
+        &mut req,
+        AuthorizationCodeGrant::Present,
+        crate::db::OAuthClientType::Web,
+    );
     assert_oauth_error(result, OAuthErrorCode::InvalidClientMetadata);
 }
 
 #[test]
 fn test_validate_redirect_uris_not_required_without_auth_code() {
     let mut req = make_request_with_redirect_uris(None);
-    let result = validate_redirect_uris(&mut req, AuthorizationCodeGrant::Absent);
+    let result = validate_redirect_uris(
+        &mut req,
+        AuthorizationCodeGrant::Absent,
+        crate::db::OAuthClientType::Web,
+    );
     let uris = result.expect("Empty redirect_uris allowed without the authorization_code grant");
     assert!(uris.is_empty());
 }
@@ -1001,7 +1021,11 @@ fn test_validate_redirect_uris_too_many() {
         .map(|_| "https://example.com/callback")
         .collect();
     let mut req = make_request_with_redirect_uris(Some(many));
-    let result = validate_redirect_uris(&mut req, AuthorizationCodeGrant::Absent);
+    let result = validate_redirect_uris(
+        &mut req,
+        AuthorizationCodeGrant::Absent,
+        crate::db::OAuthClientType::Web,
+    );
     assert_oauth_error(result, OAuthErrorCode::InvalidClientMetadata);
 }
 
@@ -1011,7 +1035,11 @@ fn test_validate_redirect_uris_valid_uris_pass_through() {
         "https://example.com/callback",
         "http://localhost:8080/callback",
     ]));
-    let result = validate_redirect_uris(&mut req, AuthorizationCodeGrant::Present);
+    let result = validate_redirect_uris(
+        &mut req,
+        AuthorizationCodeGrant::Present,
+        crate::db::OAuthClientType::Web,
+    );
     let uris = result.expect("Valid URIs must pass");
     assert_eq!(uris.len(), 2);
 }
@@ -1019,7 +1047,11 @@ fn test_validate_redirect_uris_valid_uris_pass_through() {
 #[test]
 fn test_validate_redirect_uris_invalid_uri_rejected() {
     let mut req = make_request_with_redirect_uris(Some(vec!["not a uri !!"]));
-    let result = validate_redirect_uris(&mut req, AuthorizationCodeGrant::Absent);
+    let result = validate_redirect_uris(
+        &mut req,
+        AuthorizationCodeGrant::Absent,
+        crate::db::OAuthClientType::Web,
+    );
     assert_oauth_error(result, OAuthErrorCode::InvalidRedirectUri);
 }
 


### PR DESCRIPTION
Closes #1044

## The problem

Three validators disagreed with each other. For the same client:

| | dynamic client registration | self-service |
|---|---|---|
| `com.example.app://cb` | accepted | rejected |
| `https://app.example/cb#x` | rejected | accepted |

Both paths write the same `redirect_uris` field, and the authorization endpoint matched it by string equality with no format check, so a fragment registered through self-service was a URI the server would redirect to. RFC 6749 §3.1.2 (specs/rfc/rfc6749.txt:1052-1057, https://www.rfc-editor.org/rfc/rfc6749):

> The redirection endpoint URI MUST be an absolute URI as defined by [RFC3986] Section 4.3. ... The endpoint URI MUST NOT include a fragment component.

That was the one live conformance defect; the rest were policy differences.

## The rule now

One `db::validate_redirect_uri(uri, application_type)` returning a typed `RedirectUriError`, called by dynamic client registration, self-service create, and self-service update.

| registered URI | before (DCR / self-service) | now |
|---|---|---|
| `https://app.example/cb` | accepted | accepted |
| `https://app.example/cb#x` | rejected / **accepted** | rejected |
| `http://127.0.0.1:51004/cb`, `http://localhost:…`, `http://[::1]:…` | accepted | accepted |
| `http://127.0.0.2/cb`, `http://host.docker.internal/cb`, `http://app.example/cb` | rejected | rejected |
| `com.example.app://cb` | **accepted** / **rejected** | native clients only |

The custom-scheme rule is per client kind because OIDC Registration §2 (specs/openid/openid-connect-registration-1_0.txt:297-309) makes it so:

> Native Clients MUST only register "redirect_uris" using custom URI schemes or loopback URLs using the "http" scheme; loopback URLs use "localhost" or the IP loopback literals "127.0.0.1" or "[::1]" as the hostname.  Authorization Servers MAY place additional constraints on Native Clients.

RFC 8252 §7.1's reverse-domain scheme format is a MUST on the app rather than on us, so `myapp://cb` still registers for a native client.

### `application_type` is now read

§2 defines it as client metadata and dynamic client registration was discarding it. It is now read, accepting the two values §2 defines — anything else is `invalid_client_metadata`. When absent, the existing inference runs, extended so a private-use scheme counts as a native signal alongside a loopback URI. Without that half, an app registering only `com.example.app://cb` would be classified as a browser app and then refused the scheme the classification exists to permit.

The wire field stays a `String` parsed at the boundary rather than a serde-renamed enum, for the reason already recorded for `DeviceTokenRequest.grant_type`: a deserialization failure would replace the RFC 7591 §3.2.2 envelope with a different status and body.

### One loopback predicate

The four hand-rolled `matches!(host, "localhost" | "127.0.0.1" | "[::1]")` sites become one `is_loopback_redirect_host` holding exactly the set OIDC Registration §2 and OIDC Core §3.1.2.1 enumerate.

Deliberately **not** `vouch_common::is_loopback_host`, which the issue originally proposed unifying on: it also accepts `host.docker.internal`, which resolves off-device. That would break what RFC 8252 §8.3 assumes (specs/rfc/rfc8252.txt:601-602) — "This is acceptable for loopback interface redirect URIs as the HTTP request never leaves the device." That helper stays where it belongs, on the dev-mode RP-ID and origin checks.

### Authorization-time matching

`is_valid_redirect_uri` refuses a fragment outright, and matches loopback IP literals on any port, per RFC 8252 §7.3 (specs/rfc/rfc8252.txt:521-524):

> The authorization server MUST allow any port to be specified at the time of the request for loopback IP redirect URIs, to accommodate clients that obtain an available ephemeral port from the operating system at the time of the request.

Scheme, host, path, and query still match exactly, and every non-loopback URI keeps the simple string comparison OIDC Core §3.1.2.1 requires. `localhost` is a name rather than an IP literal, so it falls outside §7.3's rule and keeps its exact port.

## Testing

- Ten unit tests covering every row above, including that `host.docker.internal` stays rejected and that the any-port exemption relaxes only the port — not path, query, host, or scheme.
- **Live** against a running server. Registration: all nine cases, including `application_type=desktop` answering `400 invalid_client_metadata` ("expected 'native' or 'web'"). Authorization, for a client registered with `http://127.0.0.1:51004/cb`: the same port and an ephemeral `:61023` both redirect to the client — the second to the *requested* port, which is the any-port rule end to end — while a different path, a `localhost` port change, and a fragment all land on the not-registered error page.
- `cargo test -p vouch-server` 3214 pass, `cargo test -p vouch-tests` 398 pass, clippy `-D warnings` clean, `cargo fmt` applied.

## Note on the error text

The self-service path reports the invalid URIs without the per-URI reason. `AppValidationError::message()` renders into `ApplicationErrorTemplate`, whose message is not yet translated, so folding the reason in would add new untranslated UI text. Dynamic client registration answers in JSON and does report it. The outer sentence was corrected — it claimed every URI must be `http://` or `https://`, which stopped being true once native clients could register a custom scheme. Giving that template per-reason detail properly means Fluent keys for each variant and making the enum i18n-aware, which is the wider untranslated-message backlog rather than this change.