### PR TITLE
fix(oidc): derive OAuth error status from the error code

### DIFF
--- a/crates/vouch-common/src/api_tests.rs
+++ b/crates/vouch-common/src/api_tests.rs
@@ -159,8 +159,7 @@ mod tests {
 
     #[test]
     fn test_register_complete_short_credential_id_rejected() {
-        // Below `CredentialIdData`'s 16-byte floor. This is the check that
-        // #1069 lost when it was written by hand inside a handler.
+        // Below `CredentialIdData`'s 16-byte floor.
         let json = r#"{
             "state": "test",
             "credential_id": [1, 2, 3],

--- a/crates/vouch-server/src/handlers/oidc/client_auth.rs
+++ b/crates/vouch-server/src/handlers/oidc/client_auth.rs
@@ -108,15 +108,30 @@ impl ClientAuthPresentation {
         }
     }
 
-    /// The `WWW-Authenticate` challenge matching the scheme the client used,
-    /// or `None` when the client did not use the `Authorization` header.
+    /// The `WWW-Authenticate` challenge this failure carries, if any.
+    ///
+    /// `Basic` is the only one of the six methods in
+    /// `token_endpoint_auth_methods_supported` that is an HTTP authentication
+    /// scheme. RFC 9110 Section 11.3 (`specs/rfc/rfc9110.txt:4921`) defines a
+    /// challenge as `auth-scheme [ 1*SP ( token68 / #auth-param ) ]`, and
+    /// `client_secret_post` and `private_key_jwt` travel in the request body
+    /// while the two mTLS methods live in the TLS layer — none has a scheme
+    /// token to name. Clients discover the full set through RFC 8414
+    /// `token_endpoint_auth_methods_supported`.
     fn challenge(self) -> Option<HeaderValue> {
         match self {
+            // RFC 6749 Section 5.2 mandates the challenge here.
             Self::AuthorizationHeader => Some(HeaderValue::from_static("Basic")),
-            // RFC 6749 Section 5.2 mandates a challenge only for header
-            // authentication. Advertising `Basic` to a client that used
-            // neither would name a scheme it did not attempt.
-            Self::RequestBody | Self::NoCredentials => None,
+            // The same section permits it for a caller that presented nothing:
+            // "The authorization server MAY return an HTTP 401 (Unauthorized)
+            // status code to indicate which HTTP authentication schemes are
+            // supported." Answering uniformly means a client discovering the
+            // endpoint gets the same hint wherever it knocks.
+            Self::NoCredentials => Some(HeaderValue::from_static("Basic")),
+            // A client that authenticated in the body did attempt a scheme,
+            // just not an HTTP one. Naming `Basic` would name a scheme it did
+            // not use, which is what the RFC's "matching" rules out.
+            Self::RequestBody => None,
         }
     }
 }

--- a/crates/vouch-server/src/handlers/oidc/introspect.rs
+++ b/crates/vouch-server/src/handlers/oidc/introspect.rs
@@ -23,7 +23,10 @@ use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use std::sync::Arc;
 
-use super::client_auth::{ClientAuthFields, complete_client_auth, extract_client_auth};
+use super::client_auth::{
+    ClientAuthFields, ClientAuthPresentation, complete_client_auth, extract_client_auth,
+    with_client_auth_challenge,
+};
 
 /// Token revocation request (RFC 7009 Section 2.1).
 ///
@@ -166,8 +169,11 @@ pub(crate) async fn revoke(
     let (caller_client_id, pending_jti) = match complete_client_auth(&state, auth).await {
         Ok(Some(a)) => (a.client_id, a.pending_jti),
         Ok(None) => {
-            // No credentials provided → 401
-            return (StatusCode::UNAUTHORIZED, [("www-authenticate", "Basic")]).into_response();
+            // No credentials provided → 401 with the shared challenge.
+            return with_client_auth_challenge(
+                ClientAuthPresentation::of(&headers, &params),
+                StatusCode::UNAUTHORIZED.into_response(),
+            );
         }
         Err(response) => return response,
     };
@@ -222,8 +228,11 @@ pub(crate) async fn introspect(
     let (authenticated_client, pending_jti) = match complete_client_auth(&state, auth).await {
         Ok(Some(a)) => (a.client.client, a.pending_jti),
         Ok(None) => {
-            // No credentials provided → 401
-            return (StatusCode::UNAUTHORIZED, [("www-authenticate", "Basic")]).into_response();
+            // No credentials provided → 401 with the shared challenge.
+            return with_client_auth_challenge(
+                ClientAuthPresentation::of(&headers, &params),
+                StatusCode::UNAUTHORIZED.into_response(),
+            );
         }
         Err(response) => return response,
     };

--- a/crates/vouch-server/src/handlers/oidc/par.rs
+++ b/crates/vouch-server/src/handlers/oidc/par.rs
@@ -184,7 +184,6 @@ pub(crate) async fn par(
     // RFC 9126 Section 2.1: request_uri MUST NOT be provided in a PAR request
     if params.request_uri.is_some() {
         return par_error_response(
-            StatusCode::BAD_REQUEST,
             OAuthErrorCode::InvalidRequest,
             "request_uri must not be provided in a pushed authorization request",
         );
@@ -197,11 +196,7 @@ pub(crate) async fn par(
     if let Some(ref request_jwt) = params.request
         && let Err(e) = validate_request_object_header(request_jwt)
     {
-        return par_error_response(
-            StatusCode::BAD_REQUEST,
-            OAuthErrorCode::InvalidRequestObject,
-            &e.oauth_description(),
-        );
+        return par_error_response(OAuthErrorCode::InvalidRequestObject, &e.oauth_description());
     }
 
     // Extract and authenticate the client (required for PAR)
@@ -216,7 +211,6 @@ pub(crate) async fn par(
         Err(resp) => return resp,
     }) else {
         return par_error_response(
-            StatusCode::UNAUTHORIZED,
             OAuthErrorCode::InvalidClient,
             "Client authentication is required for pushed authorization requests",
         );
@@ -240,7 +234,6 @@ pub(crate) async fn par(
         ) {
         let Some(cert) = client_cert.0.as_ref() else {
             return par_error_response(
-                StatusCode::UNAUTHORIZED,
                 OAuthErrorCode::InvalidClient,
                 "mTLS client certificate required",
             );
@@ -277,11 +270,7 @@ pub(crate) async fn par(
         &authenticated_client.client,
         actual_method,
     ) {
-        return par_error_response(
-            StatusCode::UNAUTHORIZED,
-            OAuthErrorCode::InvalidClient,
-            &e.oauth_description(),
-        );
+        return par_error_response(OAuthErrorCode::InvalidClient, &e.oauth_description());
     }
 
     // RFC 9101: Enforce require_signed_request_object for this client.
@@ -293,7 +282,6 @@ pub(crate) async fn par(
         && params.request.is_none()
     {
         return par_error_response(
-            StatusCode::BAD_REQUEST,
             OAuthErrorCode::InvalidRequest,
             "This client requires a signed Request Object (RFC 9101)",
         );
@@ -326,18 +314,10 @@ pub(crate) async fn par(
                 .into_response();
         }
         Err(e @ DpopError::Database(_)) => {
-            return par_error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                OAuthErrorCode::ServerError,
-                &e.to_string(),
-            );
+            return par_error_response(OAuthErrorCode::ServerError, &e.to_string());
         }
         Err(e) => {
-            return par_error_response(
-                StatusCode::BAD_REQUEST,
-                OAuthErrorCode::InvalidDpopProof,
-                &e.to_string(),
-            );
+            return par_error_response(OAuthErrorCode::InvalidDpopProof, &e.to_string());
         }
     };
     let dpop_jkt = dpop_proof.as_ref().map(|p| p.jkt.as_str());
@@ -348,7 +328,6 @@ pub(crate) async fn par(
         let is_match: bool = proof_jkt.as_bytes().ct_eq(param_jkt.as_bytes()).into();
         if !is_match {
             return par_error_response(
-                StatusCode::BAD_REQUEST,
                 OAuthErrorCode::InvalidDpopProof,
                 "dpop_jkt parameter does not match DPoP proof JWK thumbprint",
             );
@@ -373,14 +352,13 @@ pub(crate) async fn par(
                 Ok(params) => params,
                 Err(e) => {
                     let (error_code, description) = service_error_codes(&e);
-                    return par_error_response(StatusCode::BAD_REQUEST, error_code, &description);
+                    return par_error_response(error_code, &description);
                 }
             };
 
         // client_id from JWT must match the authenticated client
         if request_params.client_id != authenticated_client.client.client_id {
             return par_error_response(
-                StatusCode::BAD_REQUEST,
                 OAuthErrorCode::InvalidRequestObject,
                 "client_id in Request Object does not match authenticated client",
             );
@@ -393,7 +371,7 @@ pub(crate) async fn par(
             Ok(v) => v,
             Err(e) => {
                 let (error_code, description) = service_error_codes(&e);
-                return par_error_response(StatusCode::BAD_REQUEST, error_code, &description);
+                return par_error_response(error_code, &description);
             }
         };
         (v, jar_rm)
@@ -404,7 +382,6 @@ pub(crate) async fn par(
                 Some(prompt) => Some(prompt),
                 None => {
                     return par_error_response(
-                        StatusCode::BAD_REQUEST,
                         OAuthErrorCode::InvalidRequest,
                         &format!(
                             "Unsupported prompt value. Supported values: {}",
@@ -438,7 +415,7 @@ pub(crate) async fn par(
             Ok(v) => v,
             Err(e) => {
                 let (error_code, description) = service_error_codes(&e);
-                return par_error_response(StatusCode::BAD_REQUEST, error_code, &description);
+                return par_error_response(error_code, &description);
             }
         };
         (v, None)
@@ -446,11 +423,7 @@ pub(crate) async fn par(
 
     // RFC 9700: PKCE required for public clients and Native/SPA types.
     if let Err(e) = require_pkce_for_client(&validated, &authenticated_client.client) {
-        return par_error_response(
-            StatusCode::BAD_REQUEST,
-            OAuthErrorCode::InvalidRequest,
-            &e.oauth_description(),
-        );
+        return par_error_response(OAuthErrorCode::InvalidRequest, &e.oauth_description());
     }
 
     // Validate redirect_uri against registered URIs
@@ -459,7 +432,6 @@ pub(crate) async fn par(
         .is_valid_redirect_uri(validated.redirect_uri())
     {
         return par_error_response(
-            StatusCode::BAD_REQUEST,
             OAuthErrorCode::InvalidRequest,
             "redirect_uri is not registered for this client",
         );
@@ -470,7 +442,6 @@ pub(crate) async fn par(
         && !authenticated_client.client.is_valid_resource_uri(resource)
     {
         return par_error_response(
-            StatusCode::BAD_REQUEST,
             OAuthErrorCode::InvalidTarget,
             "The requested resource is not registered for this client",
         );
@@ -490,7 +461,6 @@ pub(crate) async fn par(
         let is_match: bool = requested_jkt.as_bytes().ct_eq(proof.jkt.as_bytes()).into();
         if !is_match {
             return par_error_response(
-                StatusCode::BAD_REQUEST,
                 OAuthErrorCode::InvalidDpopProof,
                 "dpop_jkt does not match DPoP proof JWK thumbprint",
             );
@@ -510,7 +480,6 @@ pub(crate) async fn par(
             Some(m) => m,
             None => {
                 return par_error_response(
-                    StatusCode::BAD_REQUEST,
                     OAuthErrorCode::InvalidRequest,
                     &format!(
                         "Unsupported response_mode. Supported values: {}",
@@ -550,12 +519,10 @@ pub(crate) async fn par(
                 // 500 for a replay tempts them to retry-loop with a consumed JTI.
                 return match e {
                     ClientAuthError::InvalidCredentials => par_error_response(
-                        StatusCode::UNAUTHORIZED,
                         OAuthErrorCode::InvalidClient,
                         "Client authentication failed",
                     ),
                     _ => par_error_response(
-                        StatusCode::INTERNAL_SERVER_ERROR,
                         OAuthErrorCode::ServerError,
                         "Failed to complete client authentication",
                     ),
@@ -606,7 +573,6 @@ pub(crate) async fn par(
         Err(e) => {
             tracing::error!("Failed to create pushed authorization request: {}", e);
             par_error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
                 OAuthErrorCode::ServerError,
                 "Failed to store pushed authorization request",
             )
@@ -615,9 +581,15 @@ pub(crate) async fn par(
 }
 
 /// Build a PAR error response.
-fn par_error_response(status: StatusCode, error: OAuthErrorCode, description: &str) -> Response {
+/// Build an OAuth error response for the PAR endpoint.
+///
+/// The status comes from [`OAuthErrorCode::status_code`], not from the call
+/// site, so the two cannot disagree. Several sites pass a code extracted from
+/// a `ServiceError` rather than a literal, and those carry statuses other than
+/// 400 — `server_error` is a 500.
+fn par_error_response(error: OAuthErrorCode, description: &str) -> Response {
     (
-        status,
+        error.status_code(),
         Json(OAuthErrorResponse {
             error: error.as_str().to_string(),
             error_description: Some(description.to_string()),

--- a/crates/vouch-server/src/handlers/oidc/par.rs
+++ b/crates/vouch-server/src/handlers/oidc/par.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Pushed Authorization Request (PAR) endpoint handler (RFC 9126).
 
-use super::client_auth::{ClientAuthFields, complete_client_auth, extract_client_auth};
+use super::client_auth::{
+    ClientAuthFields, ClientAuthPresentation, complete_client_auth, extract_client_auth,
+    with_client_auth_challenge,
+};
 use crate::AppState;
 use crate::db::{self, CreateParParams, PAR_EXPIRES_IN};
 use crate::error::OAuthErrorCode;
@@ -181,10 +184,15 @@ pub(crate) async fn par(
     headers: HeaderMap,
     OAuthForm(params): OAuthForm<ParRequest>,
 ) -> Response {
+    // How the client presented credentials, for the RFC 6749 Section 5.2
+    // challenge every error response below may owe it.
+    let presentation = ClientAuthPresentation::of(&headers, &params);
+
     // RFC 9126 Section 2.1: request_uri MUST NOT be provided in a PAR request
     if params.request_uri.is_some() {
         return par_error_response(
             OAuthErrorCode::InvalidRequest,
+            presentation,
             "request_uri must not be provided in a pushed authorization request",
         );
     }
@@ -196,7 +204,11 @@ pub(crate) async fn par(
     if let Some(ref request_jwt) = params.request
         && let Err(e) = validate_request_object_header(request_jwt)
     {
-        return par_error_response(OAuthErrorCode::InvalidRequestObject, &e.oauth_description());
+        return par_error_response(
+            OAuthErrorCode::InvalidRequestObject,
+            presentation,
+            &e.oauth_description(),
+        );
     }
 
     // Extract and authenticate the client (required for PAR)
@@ -212,6 +224,7 @@ pub(crate) async fn par(
     }) else {
         return par_error_response(
             OAuthErrorCode::InvalidClient,
+            presentation,
             "Client authentication is required for pushed authorization requests",
         );
     };
@@ -235,6 +248,7 @@ pub(crate) async fn par(
         let Some(cert) = client_cert.0.as_ref() else {
             return par_error_response(
                 OAuthErrorCode::InvalidClient,
+                presentation,
                 "mTLS client certificate required",
             );
         };
@@ -270,7 +284,11 @@ pub(crate) async fn par(
         &authenticated_client.client,
         actual_method,
     ) {
-        return par_error_response(OAuthErrorCode::InvalidClient, &e.oauth_description());
+        return par_error_response(
+            OAuthErrorCode::InvalidClient,
+            presentation,
+            &e.oauth_description(),
+        );
     }
 
     // RFC 9101: Enforce require_signed_request_object for this client.
@@ -283,6 +301,7 @@ pub(crate) async fn par(
     {
         return par_error_response(
             OAuthErrorCode::InvalidRequest,
+            presentation,
             "This client requires a signed Request Object (RFC 9101)",
         );
     }
@@ -314,10 +333,14 @@ pub(crate) async fn par(
                 .into_response();
         }
         Err(e @ DpopError::Database(_)) => {
-            return par_error_response(OAuthErrorCode::ServerError, &e.to_string());
+            return par_error_response(OAuthErrorCode::ServerError, presentation, &e.to_string());
         }
         Err(e) => {
-            return par_error_response(OAuthErrorCode::InvalidDpopProof, &e.to_string());
+            return par_error_response(
+                OAuthErrorCode::InvalidDpopProof,
+                presentation,
+                &e.to_string(),
+            );
         }
     };
     let dpop_jkt = dpop_proof.as_ref().map(|p| p.jkt.as_str());
@@ -329,6 +352,7 @@ pub(crate) async fn par(
         if !is_match {
             return par_error_response(
                 OAuthErrorCode::InvalidDpopProof,
+                presentation,
                 "dpop_jkt parameter does not match DPoP proof JWK thumbprint",
             );
         }
@@ -352,7 +376,7 @@ pub(crate) async fn par(
                 Ok(params) => params,
                 Err(e) => {
                     let (error_code, description) = service_error_codes(&e);
-                    return par_error_response(error_code, &description);
+                    return par_error_response(error_code, presentation, &description);
                 }
             };
 
@@ -360,6 +384,7 @@ pub(crate) async fn par(
         if request_params.client_id != authenticated_client.client.client_id {
             return par_error_response(
                 OAuthErrorCode::InvalidRequestObject,
+                presentation,
                 "client_id in Request Object does not match authenticated client",
             );
         }
@@ -371,7 +396,7 @@ pub(crate) async fn par(
             Ok(v) => v,
             Err(e) => {
                 let (error_code, description) = service_error_codes(&e);
-                return par_error_response(error_code, &description);
+                return par_error_response(error_code, presentation, &description);
             }
         };
         (v, jar_rm)
@@ -383,6 +408,7 @@ pub(crate) async fn par(
                 None => {
                     return par_error_response(
                         OAuthErrorCode::InvalidRequest,
+                        presentation,
                         &format!(
                             "Unsupported prompt value. Supported values: {}",
                             crate::services::oidc::authorization::Prompt::supported_values()
@@ -415,7 +441,7 @@ pub(crate) async fn par(
             Ok(v) => v,
             Err(e) => {
                 let (error_code, description) = service_error_codes(&e);
-                return par_error_response(error_code, &description);
+                return par_error_response(error_code, presentation, &description);
             }
         };
         (v, None)
@@ -423,7 +449,11 @@ pub(crate) async fn par(
 
     // RFC 9700: PKCE required for public clients and Native/SPA types.
     if let Err(e) = require_pkce_for_client(&validated, &authenticated_client.client) {
-        return par_error_response(OAuthErrorCode::InvalidRequest, &e.oauth_description());
+        return par_error_response(
+            OAuthErrorCode::InvalidRequest,
+            presentation,
+            &e.oauth_description(),
+        );
     }
 
     // Validate redirect_uri against registered URIs
@@ -433,6 +463,7 @@ pub(crate) async fn par(
     {
         return par_error_response(
             OAuthErrorCode::InvalidRequest,
+            presentation,
             "redirect_uri is not registered for this client",
         );
     }
@@ -443,6 +474,7 @@ pub(crate) async fn par(
     {
         return par_error_response(
             OAuthErrorCode::InvalidTarget,
+            presentation,
             "The requested resource is not registered for this client",
         );
     }
@@ -462,6 +494,7 @@ pub(crate) async fn par(
         if !is_match {
             return par_error_response(
                 OAuthErrorCode::InvalidDpopProof,
+                presentation,
                 "dpop_jkt does not match DPoP proof JWK thumbprint",
             );
         }
@@ -481,6 +514,7 @@ pub(crate) async fn par(
             None => {
                 return par_error_response(
                     OAuthErrorCode::InvalidRequest,
+                    presentation,
                     &format!(
                         "Unsupported response_mode. Supported values: {}",
                         crate::db::documents::oauth::ResponseMode::supported_values()
@@ -520,10 +554,12 @@ pub(crate) async fn par(
                 return match e {
                     ClientAuthError::InvalidCredentials => par_error_response(
                         OAuthErrorCode::InvalidClient,
+                        presentation,
                         "Client authentication failed",
                     ),
                     _ => par_error_response(
                         OAuthErrorCode::ServerError,
+                        presentation,
                         "Failed to complete client authentication",
                     ),
                 };
@@ -574,21 +610,30 @@ pub(crate) async fn par(
             tracing::error!("Failed to create pushed authorization request: {}", e);
             par_error_response(
                 OAuthErrorCode::ServerError,
+                presentation,
                 "Failed to store pushed authorization request",
             )
         }
     }
 }
 
-/// Build a PAR error response.
 /// Build an OAuth error response for the PAR endpoint.
 ///
 /// The status comes from [`OAuthErrorCode::status_code`], not from the call
 /// site, so the two cannot disagree. Several sites pass a code extracted from
 /// a `ServiceError` rather than a literal, and those carry statuses other than
 /// 400 — `server_error` is a 500.
-fn par_error_response(error: OAuthErrorCode, description: &str) -> Response {
-    (
+///
+/// `presentation` is required for the same reason it is at the token endpoint:
+/// whether a failure owes the client a `WWW-Authenticate` challenge depends on
+/// how the client authenticated, so a caller has to supply it and
+/// [`with_client_auth_challenge`] decides whether it applies.
+fn par_error_response(
+    error: OAuthErrorCode,
+    presentation: ClientAuthPresentation,
+    description: &str,
+) -> Response {
+    let response = (
         error.status_code(),
         Json(OAuthErrorResponse {
             error: error.as_str().to_string(),
@@ -596,5 +641,7 @@ fn par_error_response(error: OAuthErrorCode, description: &str) -> Response {
             error_uri: None,
         }),
     )
-        .into_response()
+        .into_response();
+
+    with_client_auth_challenge(presentation, response)
 }

--- a/crates/vouch-server/src/handlers/oidc/tests/fido2_grant.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/fido2_grant.rs
@@ -112,8 +112,10 @@ async fn test_fido2_token_missing_assertion_rejected() {
 
 #[tokio::test]
 async fn test_fido2_token_missing_client_auth_rejected() {
-    // The FIDO2 grant requires private_key_jwt client authentication.
-    // A request with assertion but no client auth must return invalid_client.
+    // The FIDO2 grant requires private_key_jwt client authentication, so a
+    // request carrying an assertion but no client credentials is
+    // `invalid_client`. RFC 6749 Section 5.2 permits 401 for that code, and
+    // `OAuthErrorCode::status_code` is what decides it.
     let (app, _state) = test_app().await;
 
     let garbage_assertion = URL_SAFE_NO_PAD.encode(b"not-a-real-assertion");
@@ -131,7 +133,7 @@ async fn test_fido2_token_missing_client_auth_rejected() {
 
     assert_eq!(
         status,
-        StatusCode::BAD_REQUEST,
+        StatusCode::UNAUTHORIZED,
         "Missing client auth must be rejected: {body}"
     );
     let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc6749_token.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc6749_token.rs
@@ -818,6 +818,75 @@ async fn test_par_basic_auth_failure_challenges_with_basic() {
     );
 }
 
+// ── no credentials at all ────────────────────────────────────────────────
+//
+// RFC 6749 Section 5.2, `specs/rfc/rfc6749.txt:2490-2492`:
+//
+// > The authorization server MAY return an HTTP 401 (Unauthorized) status
+// > code to indicate which HTTP authentication schemes are supported.
+//
+// A MAY, so any of these endpoints could stay silent and still conform. They
+// answer alike instead, so a client discovering one learns the same thing at
+// all four. `Basic` is the only method that has an HTTP auth-scheme token;
+// the rest are discoverable through RFC 8414 metadata.
+
+/// Each endpoint requiring client authentication, and a body that reaches its
+/// client-auth check without credentials.
+fn no_credential_requests() -> Vec<(&'static str, &'static str)> {
+    vec![
+        (
+            "/oauth/token",
+            "grant_type=authorization_code&code=irrelevant\
+             &redirect_uri=https%3A%2F%2Fexample.com%2Fcallback",
+        ),
+        (
+            "/oauth/par",
+            "response_type=code&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback\
+             &code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM\
+             &code_challenge_method=S256",
+        ),
+        ("/oauth/revoke", "token=irrelevant"),
+        ("/oauth/introspect", "token=irrelevant"),
+    ]
+}
+
+#[tokio::test]
+async fn test_no_credentials_challenges_uniformly_across_endpoints() {
+    let (app, _state) = test_app().await;
+
+    for (path, body) in no_credential_requests() {
+        let response = http_post_form_full(&app, path, body, &[]).await;
+
+        assert_eq!(
+            response.status,
+            StatusCode::UNAUTHORIZED,
+            "{path} must reject a request carrying no client credentials: {}",
+            response.body
+        );
+        assert!(
+            www_authenticate(&response).starts_with("Basic"),
+            "{path} must advertise Basic when no credentials were presented, got: {:?}",
+            www_authenticate(&response)
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_introspect_no_credentials_keeps_resource_metadata_pointer() {
+    // Introspection is a protected resource, so its challenge also carries the
+    // RFC 9728 pointer. The uniform `Basic` must not displace it.
+    let (app, _state) = test_app().await;
+
+    let response = http_post_form_full(&app, "/oauth/introspect", "token=irrelevant", &[]).await;
+
+    assert_eq!(response.status, StatusCode::UNAUTHORIZED);
+    let challenge = www_authenticate(&response);
+    assert!(
+        challenge.contains("resource_metadata="),
+        "introspection must keep its RFC 9728 pointer, got: {challenge:?}"
+    );
+}
+
 // ========================================================================
 // RFC 6749 Section 3.2 — Token endpoint parameter rules
 // ========================================================================

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc6749_token.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc6749_token.rs
@@ -745,6 +745,43 @@ async fn test_token_malformed_basic_header_challenges_with_basic() {
 }
 
 #[tokio::test]
+async fn test_fido2_grant_basic_auth_failure_challenges_with_basic() {
+    // The fido2-assertion grant requires `private_key_jwt`, so a client that
+    // presents Basic credentials is rejected as `invalid_client`. It attempted
+    // header authentication, so the same MUST binds: 401 plus a challenge.
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "fido2-basic-challenge@example.com").await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+
+    let encoded = base64::engine::general_purpose::STANDARD
+        .encode(format!("{}:wrong-secret", client.client_id).as_bytes());
+    let auth = format!("Basic {encoded}");
+
+    let response = http_post_form_full(
+        &app,
+        "/oauth/token",
+        "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Afido2-assertion\
+         &assertion=aXJyZWxldmFudA",
+        &[("Authorization", &auth)],
+    )
+    .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::UNAUTHORIZED,
+        "a client that used the Authorization header must get 401: {}",
+        response.body
+    );
+    assert_eq!(
+        www_authenticate(&response),
+        "Basic",
+        "a 401 for a client that used the Authorization header MUST carry a \
+         matching WWW-Authenticate challenge"
+    );
+}
+
+#[tokio::test]
 async fn test_par_basic_auth_failure_challenges_with_basic() {
     // PAR reaches the failure through `complete_client_auth` rather than the
     // token endpoint's own path, so it needs its own coverage.

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -245,17 +245,19 @@ enum TokenRequestRejection {
 }
 
 impl TokenRequestRejection {
-    fn into_response(self) -> Response {
+    fn into_response(self, presentation: ClientAuthPresentation) -> Response {
         match self {
             Self::UnsupportedGrantType => {
                 let supported = OAuthGrantType::supported_wire_values().join(", ");
                 token_error_response(
                     OAuthErrorCode::UnsupportedGrantType,
+                    presentation,
                     &format!("Supported grant types: {supported}"),
                 )
             }
             Self::MissingParameter(name) => token_error_response(
                 OAuthErrorCode::InvalidRequest,
+                presentation,
                 &format!("Missing {name} parameter"),
             ),
         }
@@ -387,12 +389,18 @@ pub(crate) async fn token(
     headers: HeaderMap,
     OAuthForm(params): OAuthForm<TokenRequestForm>,
 ) -> Response {
+    // Classified once, up front: `parse` consumes the form, and every error
+    // response below needs it to decide whether RFC 6749 Section 5.2 owes the
+    // client a challenge.
+    let presentation = ClientAuthPresentation::of(&headers, &params);
+
     // Input length validation — reject oversized parameters early.
     if let Some(ref v) = params.code_verifier
         && !is_valid_pkce_verifier(v)
     {
         return token_error_response(
             OAuthErrorCode::InvalidRequest,
+            presentation,
             "code_verifier must be 43-128 characters and contain only [A-Za-z0-9\\-._~]",
         );
     }
@@ -401,6 +409,7 @@ pub(crate) async fn token(
     {
         return token_error_response(
             OAuthErrorCode::InvalidRequest,
+            presentation,
             &format!("redirect_uri exceeds maximum length of {MAX_TOKEN_REDIRECT_URI_LEN}"),
         );
     }
@@ -409,6 +418,7 @@ pub(crate) async fn token(
     {
         return token_error_response(
             OAuthErrorCode::InvalidRequest,
+            presentation,
             &format!("client_id exceeds maximum length of {MAX_TOKEN_CLIENT_ID_LEN}"),
         );
     }
@@ -417,6 +427,7 @@ pub(crate) async fn token(
     {
         return token_error_response(
             OAuthErrorCode::InvalidRequest,
+            presentation,
             &format!("scope exceeds maximum length of {MAX_TOKEN_SCOPE_LEN}"),
         );
     }
@@ -425,6 +436,7 @@ pub(crate) async fn token(
     {
         return token_error_response(
             OAuthErrorCode::InvalidRequest,
+            presentation,
             &format!("resource exceeds maximum length of {MAX_TOKEN_RESOURCE_LEN}"),
         );
     }
@@ -433,6 +445,7 @@ pub(crate) async fn token(
     {
         return token_error_response(
             OAuthErrorCode::InvalidRequest,
+            presentation,
             &format!("client_assertion exceeds maximum length of {MAX_ASSERTION_LEN}"),
         );
     }
@@ -441,6 +454,7 @@ pub(crate) async fn token(
     {
         return token_error_response(
             OAuthErrorCode::InvalidRequest,
+            presentation,
             &format!("assertion exceeds maximum length of {MAX_ASSERTION_LEN}"),
         );
     }
@@ -450,6 +464,7 @@ pub(crate) async fn token(
     {
         return token_error_response(
             OAuthErrorCode::InvalidAuthorizationDetails,
+            presentation,
             &format!("authorization_details exceeds maximum length of {MAX_ASSERTION_LEN}"),
         );
     }
@@ -458,7 +473,7 @@ pub(crate) async fn token(
     // grant did not carry.
     let TokenRequest { auth, grant } = match params.parse() {
         Ok(typed) => typed,
-        Err(rejection) => return rejection.into_response(),
+        Err(rejection) => return rejection.into_response(presentation),
     };
 
     match grant {
@@ -1235,6 +1250,27 @@ async fn handle_token_exchange_grant(
     }
 }
 
+/// `TokenRequestForm` carries the same client-authentication fields as
+/// [`ClientAuthParams`], and `parse` consumes the form — so classifying how
+/// the client authenticated has to happen on the form, before the split.
+impl ClientAuthFields for TokenRequestForm {
+    fn client_id(&self) -> Option<&str> {
+        self.client_id.as_deref()
+    }
+
+    fn client_secret(&self) -> Option<SecretString> {
+        self.client_secret.clone()
+    }
+
+    fn client_assertion(&self) -> Option<&str> {
+        self.client_assertion.as_ref().map(|s| s.expose_secret())
+    }
+
+    fn client_assertion_type(&self) -> Option<&str> {
+        self.client_assertion_type.as_deref()
+    }
+}
+
 /// Implement `ClientAuthFields` for `TokenRequest` to enable shared client
 /// authentication extraction.
 impl ClientAuthFields for ClientAuthParams {
@@ -1268,6 +1304,7 @@ async fn handle_fido2_assertion_grant(
     params: Fido2AssertionParams,
 ) -> Response {
     let assertion = params.assertion;
+    let presentation = ClientAuthPresentation::of(&headers, &auth);
 
     // Extract and authenticate client via private_key_jwt
     let client_auth = match extract_client_auth(&headers, &auth) {
@@ -1286,6 +1323,7 @@ async fn handle_fido2_assertion_grant(
         _ => {
             return token_error_response(
                 OAuthErrorCode::InvalidClient,
+                presentation,
                 "fido2-assertion grant requires private_key_jwt client authentication",
             );
         }
@@ -1491,14 +1529,37 @@ pub(crate) fn dpop_use_nonce_response(nonce: &str) -> Response {
 }
 
 /// Build an OAuth error response for parameter validation failures.
-fn token_error_response(code: OAuthErrorCode, description: &str) -> Response {
-    (
-        StatusCode::BAD_REQUEST,
+/// Build an OAuth error response for the token endpoint.
+///
+/// The status comes from [`OAuthErrorCode::status_code`] rather than the call
+/// site, so a code and a status cannot disagree. `presentation` is required
+/// rather than optional because the RFC 6749 Section 5.2 challenge obligation
+/// depends on how the client authenticated, which is request state the error
+/// code alone cannot carry:
+///
+/// > If the client attempted to authenticate via the "Authorization" request
+/// > header field, the authorization server MUST respond with an HTTP 401
+/// > (Unauthorized) status code and include the "WWW-Authenticate" response
+/// > header field matching the authentication scheme used by the client.
+///
+/// `specs/rfc/rfc6749.txt:2493-2497`. Taking it as a parameter means a caller
+/// cannot build a client-authentication failure that silently omits the
+/// challenge — the argument has to be supplied, and
+/// [`with_client_auth_challenge`] decides whether it applies.
+fn token_error_response(
+    code: OAuthErrorCode,
+    presentation: ClientAuthPresentation,
+    description: &str,
+) -> Response {
+    let response = (
+        code.status_code(),
         Json(OAuthErrorResponse {
             error: code.as_str().to_string(),
             error_description: Some(description.to_string()),
             error_uri: None,
         }),
     )
-        .into_response()
+        .into_response();
+
+    with_client_auth_challenge(presentation, response)
 }

--- a/crates/vouch-tests/tests/proptest.rs
+++ b/crates/vouch-tests/tests/proptest.rs
@@ -275,9 +275,7 @@ proptest! {
     }
 
     /// A credential ID outside 16..=1023 bytes never deserializes, in either
-    /// encoding. This is the bound that #1069 lost when it was a hand-written
-    /// check inside a handler; as a property of the type there is no call site
-    /// that can omit it.
+    /// encoding. The bound belongs to the type, so no call site can omit it.
     #[test]
     fn prop_out_of_range_encoded_is_rejected(
         short in prop::collection::vec(any::<u8>(), 0..16),


### PR DESCRIPTION
Closes #1046

## Bug

`token_error_response` (`handlers/oidc/token.rs`) accepted an `OAuthErrorCode`
and discarded it, answering 400 for every code. One call site passes
`invalid_client` — the fido2-assertion grant's arm for a client that did not
authenticate with `private_key_jwt`.

A client presenting `Authorization: Basic …` on that grant received **400 with
no `WWW-Authenticate`**. RFC 6749 §5.2, `specs/rfc/rfc6749.txt:2493-2497`:

> If the client attempted to authenticate via the "Authorization" request
> header field, the authorization server MUST respond with an HTTP 401
> (Unauthorized) status code and include the "WWW-Authenticate" response
> header field matching the authentication scheme used by the client.

Both halves of the MUST were missed. The challenge machinery from #1048 only
touches responses that are already 401, so a hardcoded 400 bypassed it.

Reproduced before fixing:

```
assertion `left == right` failed
  left: 400   right: 401
{"error":"invalid_client","error_description":"fido2-assertion grant requires
 private_key_jwt client authentication"}
```

## Fix

The status is derived from `OAuthErrorCode::status_code`, so a code and a
status cannot disagree. `token_error_response` additionally takes a
`ClientAuthPresentation` and routes through `with_client_auth_challenge`.

Making the presentation a required parameter is the structural half: a call
site cannot build a client-authentication failure that silently omits the
challenge, because the argument has to be supplied and the function decides
whether it applies. `TokenRequestForm` implements `ClientAuthFields` so the
classification happens before `parse` consumes the form.

`par_error_response` had the same shape — an explicit status passed beside a
code. Three of its call sites paired a code extracted from a `ServiceError`
with a hardcoded 400, so `server_error` reached the client as 400 rather than
500. It derives the status now and the parameter is gone.

## Behavior changes

- A client that used the Authorization header and fails client auth on the
  fido2-assertion grant gets 401 with `WWW-Authenticate: Basic`.
- `invalid_client` with no credentials at the token endpoint is 401 rather
  than 400. §5.2 permits 401 for that code ("The authorization server MAY
  return an HTTP 401"), and `OAuthErrorCode::status_code` already declared it;
  the 400 came from the discard. `test_fido2_token_missing_client_auth_rejected`
  is updated accordingly.
- PAR reports `server_error` as 500.

## Testing

- New `test_fido2_grant_basic_auth_failure_challenges_with_basic` in
  `rfc6749_token.rs`, alongside #1048's challenge tests. It fails on the parent
  commit with the output above and passes here.
- `cargo test --workspace --all-features` — all green.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` and
  `cargo fmt --all --check` clean.

## Not covered

`userinfo::oauth_error` keeps an explicit status. It is a protected resource
emitting RFC 6750 `Bearer` challenges rather than an RFC 6749 §5.2 client-auth
surface, so it is a different obligation and out of scope here.

#1049 — the remaining §5.2 question, whether endpoints should advertise
schemes when a client presents no credentials at all — follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
