### PR TITLE
fix(oidc): advertise Basic uniformly when no credentials are presented

### DIFF
--- a/crates/vouch-server/src/handlers/oidc/client_auth.rs
+++ b/crates/vouch-server/src/handlers/oidc/client_auth.rs
@@ -108,15 +108,30 @@ impl ClientAuthPresentation {
         }
     }
 
-    /// The `WWW-Authenticate` challenge matching the scheme the client used,
-    /// or `None` when the client did not use the `Authorization` header.
+    /// The `WWW-Authenticate` challenge this failure carries, if any.
+    ///
+    /// `Basic` is the only one of the six methods in
+    /// `token_endpoint_auth_methods_supported` that is an HTTP authentication
+    /// scheme. RFC 9110 Section 11.3 (`specs/rfc/rfc9110.txt:4921`) defines a
+    /// challenge as `auth-scheme [ 1*SP ( token68 / #auth-param ) ]`, and
+    /// `client_secret_post` and `private_key_jwt` travel in the request body
+    /// while the two mTLS methods live in the TLS layer — none has a scheme
+    /// token to name. Clients discover the full set through RFC 8414
+    /// `token_endpoint_auth_methods_supported`.
     fn challenge(self) -> Option<HeaderValue> {
         match self {
+            // RFC 6749 Section 5.2 mandates the challenge here.
             Self::AuthorizationHeader => Some(HeaderValue::from_static("Basic")),
-            // RFC 6749 Section 5.2 mandates a challenge only for header
-            // authentication. Advertising `Basic` to a client that used
-            // neither would name a scheme it did not attempt.
-            Self::RequestBody | Self::NoCredentials => None,
+            // The same section permits it for a caller that presented nothing:
+            // "The authorization server MAY return an HTTP 401 (Unauthorized)
+            // status code to indicate which HTTP authentication schemes are
+            // supported." Answering uniformly means a client discovering the
+            // endpoint gets the same hint wherever it knocks.
+            Self::NoCredentials => Some(HeaderValue::from_static("Basic")),
+            // A client that authenticated in the body did attempt a scheme,
+            // just not an HTTP one. Naming `Basic` would name a scheme it did
+            // not use, which is what the RFC's "matching" rules out.
+            Self::RequestBody => None,
         }
     }
 }

--- a/crates/vouch-server/src/handlers/oidc/introspect.rs
+++ b/crates/vouch-server/src/handlers/oidc/introspect.rs
@@ -23,7 +23,10 @@ use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use std::sync::Arc;
 
-use super::client_auth::{ClientAuthFields, complete_client_auth, extract_client_auth};
+use super::client_auth::{
+    ClientAuthFields, ClientAuthPresentation, complete_client_auth, extract_client_auth,
+    with_client_auth_challenge,
+};
 
 /// Token revocation request (RFC 7009 Section 2.1).
 ///
@@ -166,8 +169,11 @@ pub(crate) async fn revoke(
     let (caller_client_id, pending_jti) = match complete_client_auth(&state, auth).await {
         Ok(Some(a)) => (a.client_id, a.pending_jti),
         Ok(None) => {
-            // No credentials provided → 401
-            return (StatusCode::UNAUTHORIZED, [("www-authenticate", "Basic")]).into_response();
+            // No credentials provided → 401 with the shared challenge.
+            return with_client_auth_challenge(
+                ClientAuthPresentation::of(&headers, &params),
+                StatusCode::UNAUTHORIZED.into_response(),
+            );
         }
         Err(response) => return response,
     };
@@ -222,8 +228,11 @@ pub(crate) async fn introspect(
     let (authenticated_client, pending_jti) = match complete_client_auth(&state, auth).await {
         Ok(Some(a)) => (a.client.client, a.pending_jti),
         Ok(None) => {
-            // No credentials provided → 401
-            return (StatusCode::UNAUTHORIZED, [("www-authenticate", "Basic")]).into_response();
+            // No credentials provided → 401 with the shared challenge.
+            return with_client_auth_challenge(
+                ClientAuthPresentation::of(&headers, &params),
+                StatusCode::UNAUTHORIZED.into_response(),
+            );
         }
         Err(response) => return response,
     };

--- a/crates/vouch-server/src/handlers/oidc/par.rs
+++ b/crates/vouch-server/src/handlers/oidc/par.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Pushed Authorization Request (PAR) endpoint handler (RFC 9126).
 
-use super::client_auth::{ClientAuthFields, complete_client_auth, extract_client_auth};
+use super::client_auth::{
+    ClientAuthFields, ClientAuthPresentation, complete_client_auth, extract_client_auth,
+    with_client_auth_challenge,
+};
 use crate::AppState;
 use crate::db::{self, CreateParParams, PAR_EXPIRES_IN};
 use crate::error::OAuthErrorCode;
@@ -181,10 +184,15 @@ pub(crate) async fn par(
     headers: HeaderMap,
     OAuthForm(params): OAuthForm<ParRequest>,
 ) -> Response {
+    // How the client presented credentials, for the RFC 6749 Section 5.2
+    // challenge every error response below may owe it.
+    let presentation = ClientAuthPresentation::of(&headers, &params);
+
     // RFC 9126 Section 2.1: request_uri MUST NOT be provided in a PAR request
     if params.request_uri.is_some() {
         return par_error_response(
             OAuthErrorCode::InvalidRequest,
+            presentation,
             "request_uri must not be provided in a pushed authorization request",
         );
     }
@@ -196,7 +204,11 @@ pub(crate) async fn par(
     if let Some(ref request_jwt) = params.request
         && let Err(e) = validate_request_object_header(request_jwt)
     {
-        return par_error_response(OAuthErrorCode::InvalidRequestObject, &e.oauth_description());
+        return par_error_response(
+            OAuthErrorCode::InvalidRequestObject,
+            presentation,
+            &e.oauth_description(),
+        );
     }
 
     // Extract and authenticate the client (required for PAR)
@@ -212,6 +224,7 @@ pub(crate) async fn par(
     }) else {
         return par_error_response(
             OAuthErrorCode::InvalidClient,
+            presentation,
             "Client authentication is required for pushed authorization requests",
         );
     };
@@ -235,6 +248,7 @@ pub(crate) async fn par(
         let Some(cert) = client_cert.0.as_ref() else {
             return par_error_response(
                 OAuthErrorCode::InvalidClient,
+                presentation,
                 "mTLS client certificate required",
             );
         };
@@ -270,7 +284,11 @@ pub(crate) async fn par(
         &authenticated_client.client,
         actual_method,
     ) {
-        return par_error_response(OAuthErrorCode::InvalidClient, &e.oauth_description());
+        return par_error_response(
+            OAuthErrorCode::InvalidClient,
+            presentation,
+            &e.oauth_description(),
+        );
     }
 
     // RFC 9101: Enforce require_signed_request_object for this client.
@@ -283,6 +301,7 @@ pub(crate) async fn par(
     {
         return par_error_response(
             OAuthErrorCode::InvalidRequest,
+            presentation,
             "This client requires a signed Request Object (RFC 9101)",
         );
     }
@@ -314,10 +333,14 @@ pub(crate) async fn par(
                 .into_response();
         }
         Err(e @ DpopError::Database(_)) => {
-            return par_error_response(OAuthErrorCode::ServerError, &e.to_string());
+            return par_error_response(OAuthErrorCode::ServerError, presentation, &e.to_string());
         }
         Err(e) => {
-            return par_error_response(OAuthErrorCode::InvalidDpopProof, &e.to_string());
+            return par_error_response(
+                OAuthErrorCode::InvalidDpopProof,
+                presentation,
+                &e.to_string(),
+            );
         }
     };
     let dpop_jkt = dpop_proof.as_ref().map(|p| p.jkt.as_str());
@@ -329,6 +352,7 @@ pub(crate) async fn par(
         if !is_match {
             return par_error_response(
                 OAuthErrorCode::InvalidDpopProof,
+                presentation,
                 "dpop_jkt parameter does not match DPoP proof JWK thumbprint",
             );
         }
@@ -352,7 +376,7 @@ pub(crate) async fn par(
                 Ok(params) => params,
                 Err(e) => {
                     let (error_code, description) = service_error_codes(&e);
-                    return par_error_response(error_code, &description);
+                    return par_error_response(error_code, presentation, &description);
                 }
             };
 
@@ -360,6 +384,7 @@ pub(crate) async fn par(
         if request_params.client_id != authenticated_client.client.client_id {
             return par_error_response(
                 OAuthErrorCode::InvalidRequestObject,
+                presentation,
                 "client_id in Request Object does not match authenticated client",
             );
         }
@@ -371,7 +396,7 @@ pub(crate) async fn par(
             Ok(v) => v,
             Err(e) => {
                 let (error_code, description) = service_error_codes(&e);
-                return par_error_response(error_code, &description);
+                return par_error_response(error_code, presentation, &description);
             }
         };
         (v, jar_rm)
@@ -383,6 +408,7 @@ pub(crate) async fn par(
                 None => {
                     return par_error_response(
                         OAuthErrorCode::InvalidRequest,
+                        presentation,
                         &format!(
                             "Unsupported prompt value. Supported values: {}",
                             crate::services::oidc::authorization::Prompt::supported_values()
@@ -415,7 +441,7 @@ pub(crate) async fn par(
             Ok(v) => v,
             Err(e) => {
                 let (error_code, description) = service_error_codes(&e);
-                return par_error_response(error_code, &description);
+                return par_error_response(error_code, presentation, &description);
             }
         };
         (v, None)
@@ -423,7 +449,11 @@ pub(crate) async fn par(
 
     // RFC 9700: PKCE required for public clients and Native/SPA types.
     if let Err(e) = require_pkce_for_client(&validated, &authenticated_client.client) {
-        return par_error_response(OAuthErrorCode::InvalidRequest, &e.oauth_description());
+        return par_error_response(
+            OAuthErrorCode::InvalidRequest,
+            presentation,
+            &e.oauth_description(),
+        );
     }
 
     // Validate redirect_uri against registered URIs
@@ -433,6 +463,7 @@ pub(crate) async fn par(
     {
         return par_error_response(
             OAuthErrorCode::InvalidRequest,
+            presentation,
             "redirect_uri is not registered for this client",
         );
     }
@@ -443,6 +474,7 @@ pub(crate) async fn par(
     {
         return par_error_response(
             OAuthErrorCode::InvalidTarget,
+            presentation,
             "The requested resource is not registered for this client",
         );
     }
@@ -462,6 +494,7 @@ pub(crate) async fn par(
         if !is_match {
             return par_error_response(
                 OAuthErrorCode::InvalidDpopProof,
+                presentation,
                 "dpop_jkt does not match DPoP proof JWK thumbprint",
             );
         }
@@ -481,6 +514,7 @@ pub(crate) async fn par(
             None => {
                 return par_error_response(
                     OAuthErrorCode::InvalidRequest,
+                    presentation,
                     &format!(
                         "Unsupported response_mode. Supported values: {}",
                         crate::db::documents::oauth::ResponseMode::supported_values()
@@ -520,10 +554,12 @@ pub(crate) async fn par(
                 return match e {
                     ClientAuthError::InvalidCredentials => par_error_response(
                         OAuthErrorCode::InvalidClient,
+                        presentation,
                         "Client authentication failed",
                     ),
                     _ => par_error_response(
                         OAuthErrorCode::ServerError,
+                        presentation,
                         "Failed to complete client authentication",
                     ),
                 };
@@ -574,21 +610,30 @@ pub(crate) async fn par(
             tracing::error!("Failed to create pushed authorization request: {}", e);
             par_error_response(
                 OAuthErrorCode::ServerError,
+                presentation,
                 "Failed to store pushed authorization request",
             )
         }
     }
 }
 
-/// Build a PAR error response.
 /// Build an OAuth error response for the PAR endpoint.
 ///
 /// The status comes from [`OAuthErrorCode::status_code`], not from the call
 /// site, so the two cannot disagree. Several sites pass a code extracted from
 /// a `ServiceError` rather than a literal, and those carry statuses other than
 /// 400 — `server_error` is a 500.
-fn par_error_response(error: OAuthErrorCode, description: &str) -> Response {
-    (
+///
+/// `presentation` is required for the same reason it is at the token endpoint:
+/// whether a failure owes the client a `WWW-Authenticate` challenge depends on
+/// how the client authenticated, so a caller has to supply it and
+/// [`with_client_auth_challenge`] decides whether it applies.
+fn par_error_response(
+    error: OAuthErrorCode,
+    presentation: ClientAuthPresentation,
+    description: &str,
+) -> Response {
+    let response = (
         error.status_code(),
         Json(OAuthErrorResponse {
             error: error.as_str().to_string(),
@@ -596,5 +641,7 @@ fn par_error_response(error: OAuthErrorCode, description: &str) -> Response {
             error_uri: None,
         }),
     )
-        .into_response()
+        .into_response();
+
+    with_client_auth_challenge(presentation, response)
 }

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc6749_token.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc6749_token.rs
@@ -818,6 +818,75 @@ async fn test_par_basic_auth_failure_challenges_with_basic() {
     );
 }
 
+// ── no credentials at all ────────────────────────────────────────────────
+//
+// RFC 6749 Section 5.2, `specs/rfc/rfc6749.txt:2490-2492`:
+//
+// > The authorization server MAY return an HTTP 401 (Unauthorized) status
+// > code to indicate which HTTP authentication schemes are supported.
+//
+// A MAY, so any of these endpoints could stay silent and still conform. They
+// answer alike instead, so a client discovering one learns the same thing at
+// all four. `Basic` is the only method that has an HTTP auth-scheme token;
+// the rest are discoverable through RFC 8414 metadata.
+
+/// Each endpoint requiring client authentication, and a body that reaches its
+/// client-auth check without credentials.
+fn no_credential_requests() -> Vec<(&'static str, &'static str)> {
+    vec![
+        (
+            "/oauth/token",
+            "grant_type=authorization_code&code=irrelevant\
+             &redirect_uri=https%3A%2F%2Fexample.com%2Fcallback",
+        ),
+        (
+            "/oauth/par",
+            "response_type=code&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback\
+             &code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM\
+             &code_challenge_method=S256",
+        ),
+        ("/oauth/revoke", "token=irrelevant"),
+        ("/oauth/introspect", "token=irrelevant"),
+    ]
+}
+
+#[tokio::test]
+async fn test_no_credentials_challenges_uniformly_across_endpoints() {
+    let (app, _state) = test_app().await;
+
+    for (path, body) in no_credential_requests() {
+        let response = http_post_form_full(&app, path, body, &[]).await;
+
+        assert_eq!(
+            response.status,
+            StatusCode::UNAUTHORIZED,
+            "{path} must reject a request carrying no client credentials: {}",
+            response.body
+        );
+        assert!(
+            www_authenticate(&response).starts_with("Basic"),
+            "{path} must advertise Basic when no credentials were presented, got: {:?}",
+            www_authenticate(&response)
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_introspect_no_credentials_keeps_resource_metadata_pointer() {
+    // Introspection is a protected resource, so its challenge also carries the
+    // RFC 9728 pointer. The uniform `Basic` must not displace it.
+    let (app, _state) = test_app().await;
+
+    let response = http_post_form_full(&app, "/oauth/introspect", "token=irrelevant", &[]).await;
+
+    assert_eq!(response.status, StatusCode::UNAUTHORIZED);
+    let challenge = www_authenticate(&response);
+    assert!(
+        challenge.contains("resource_metadata="),
+        "introspection must keep its RFC 9728 pointer, got: {challenge:?}"
+    );
+}
+
 // ========================================================================
 // RFC 6749 Section 3.2 — Token endpoint parameter rules
 // ========================================================================


### PR DESCRIPTION
Closes #1049

> **Stacked on #1079.** Base is `fix/1046-oauth-error-status`; GitHub will
> retarget to `main` once that merges, and the diff collapses to this change
> alone. `/oauth/token` cannot emit a challenge until #1079 routes its error
> responses through `with_client_auth_challenge`, which is why these are
> ordered.

## Problem

A caller reaching an OAuth endpoint with no client credentials got three
different answers:

| endpoint | before | after |
|---|---|---|
| `/oauth/token` | 401, no challenge | 401 `Basic` |
| `/oauth/par` | 401, no challenge | 401 `Basic` |
| `/oauth/revoke` | 401 `Basic` | 401 `Basic` |
| `/oauth/introspect` | 401 `Basic resource_metadata="…"` | unchanged |

The divergence followed from which handler built its own 401 rather than from
a decision about each endpoint.

## This was not a conformance defect

RFC 6749 §5.2, `specs/rfc/rfc6749.txt:2490-2492`:

> The authorization server MAY return an HTTP 401 (Unauthorized) status code
> to indicate which HTTP authentication schemes are supported.

**A MAY.** All four behaviors conformed; none was a violation. This is a
consistency decision, taken so a client discovering one endpoint learns the
same thing at the others. The neighbouring MUST — a matching challenge when
the client *attempted* header authentication — is a separate obligation,
handled by #1048 and #1079.

## Why only `Basic`

`Basic` is the only one of the six methods in
`token_endpoint_auth_methods_supported` that is an HTTP authentication scheme.
RFC 9110 §11.3, `specs/rfc/rfc9110.txt:4921`:

> `challenge = auth-scheme [ 1*SP ( token68 / #auth-param ) ]`

`client_secret_post` and `private_key_jwt` travel in the request body; the two
mTLS methods live in the TLS layer. None has a scheme token to name, and the
same section warns that "many clients fail to parse a challenge that contains
an unknown scheme". Clients discover the full set through RFC 8414
`token_endpoint_auth_methods_supported`, which is the mechanism for it.

## Changes

- `ClientAuthPresentation::NoCredentials` maps to the challenge instead of
  `None`. `RequestBody` still carries none: that client attempted a scheme,
  just not an HTTP one, so `Basic` would not *match* what it used.
- `par_error_response` takes a `ClientAuthPresentation`, the way
  `token_error_response` does after #1079, so PAR cannot build a
  client-authentication failure that omits the challenge. The compiler caught
  all 22 call sites.
- Revocation and introspection route through `with_client_auth_challenge`
  instead of each hardcoding `("www-authenticate", "Basic")`, leaving one place
  that decides what a challenge says. Introspection keeps its RFC 9728
  `resource_metadata` pointer.

## Testing

- `test_no_credentials_challenges_uniformly_across_endpoints` drives all four
  endpoints with no credentials and asserts 401 plus a `Basic` challenge. It
  failed on `/oauth/par` until `par_error_response` took the presentation.
- `test_introspect_no_credentials_keeps_resource_metadata_pointer` pins the
  RFC 9728 parameter so the uniform `Basic` cannot displace it.
- #1048's tests still pin that a body-authenticated client gets no challenge.
- `cargo test --workspace --all-features` green;
  `cargo clippy --workspace --all-targets --all-features -- -D warnings` and
  `cargo fmt --all --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
