### PR TITLE
fix(agent): register signal handlers before the listeners bind

### DIFF
--- a/crates/vouch-agent/src/main.rs
+++ b/crates/vouch-agent/src/main.rs
@@ -10,6 +10,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 use clap::Parser;
 use std::process::ExitCode;
 use std::sync::Arc;
+use tokio::signal::unix::{SignalKind, signal};
 use tracing::{error, info, warn};
 use tracing_subscriber::EnvFilter;
 use vouch_agent::daemon;
@@ -206,28 +207,53 @@ async fn run_agent_server(enable_ssh_agent: bool) -> ExitCode {
     // Spawn session expiry monitor (background task)
     tokio::spawn(vouch_agent::expiry_monitor::run(Arc::clone(&state)));
 
-    // Spawn the signal handler as a separate task so the server futures are
-    // not dropped before they can observe the shutdown signal.  When SIGTERM
-    // or Ctrl+C arrives the handler sends `true` on the watch channel; both
-    // servers poll `shutdown.changed()` in their accept loops and exit
-    // cleanly instead of being cancelled mid-request.
+    // Arm the signal handlers here, before either listener binds its socket
+    // and before the waiter task below is first polled.
+    //
+    // `signal()` is what replaces a signal's disposition; until it returns,
+    // SIGTERM and SIGINT keep the default disposition, which is to terminate
+    // the process. Registering inside the spawned task left a window between
+    // the socket appearing and the task's first poll in which a SIGTERM killed
+    // the agent outright — no drain, and `cleanup()` never ran, so the socket
+    // and PID file were left behind. A stale PID file makes the next
+    // `vouch-agent` start refuse with "already running".
+    //
+    // Waiting still happens in a spawned task so the server futures are not
+    // dropped before they observe the shutdown signal. That is safe because
+    // `Signal` buffers: a signal delivered between registration and the first
+    // `recv()` is still delivered to the stream.
+    //
+    // SIGINT is registered directly rather than through `tokio::signal::ctrl_c`,
+    // which registers on first poll and so reintroduces the same window.
+    let mut sigterm = match signal(SignalKind::terminate()) {
+        Ok(stream) => stream,
+        Err(e) => {
+            error!("Failed to register the SIGTERM handler: {e}");
+            cleanup();
+            return ExitCode::FAILURE;
+        }
+    };
+    let mut sigint = match signal(SignalKind::interrupt()) {
+        Ok(stream) => stream,
+        Err(e) => {
+            error!("Failed to register the SIGINT handler: {e}");
+            cleanup();
+            return ExitCode::FAILURE;
+        }
+    };
+
+    // A registration failure is fatal rather than degraded: an agent that
+    // cannot catch SIGTERM cannot shut down cleanly, and the stale PID file it
+    // leaves behind blocks the next start. The previous code fell through to
+    // `pending()`, so the failure was invisible until a shutdown went wrong.
     let shutdown_tx_for_signal = shutdown_tx.clone();
     tokio::spawn(async move {
-        let sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate());
         tokio::select! {
-            result = tokio::signal::ctrl_c() => {
-                match result {
-                    Ok(()) => info!("Received Ctrl+C, initiating graceful shutdown"),
-                    Err(e) => warn!("Failed to listen for Ctrl+C: {e}"),
-                }
-            }
-            Some(()) = async {
-                match sigterm {
-                    Ok(mut s) => s.recv().await,
-                    Err(_) => std::future::pending().await,
-                }
-            } => {
+            _ = sigterm.recv() => {
                 info!("Received SIGTERM, initiating graceful shutdown");
+            }
+            _ = sigint.recv() => {
+                info!("Received Ctrl+C, initiating graceful shutdown");
             }
         }
         let _signaled = shutdown_tx_for_signal.send(true);

--- a/crates/vouch-agent/tests/graceful_shutdown.rs
+++ b/crates/vouch-agent/tests/graceful_shutdown.rs
@@ -163,6 +163,26 @@ fn wait_for_exit(child: &mut Child) -> ExitStatus {
     }
 }
 
+/// Wait for a path to disappear, polling every 10 ms (max ~5 s).
+///
+/// `cleanup()` runs before the agent's `main` returns, so by the time
+/// [`wait_for_exit`] observes the exit the file is already gone on every
+/// platform seen so far. Polling rather than sleeping a fixed interval keeps
+/// the assertion from depending on that: a slower filesystem costs a few more
+/// iterations instead of a spurious failure.
+fn wait_for_removal(path: &std::path::Path) -> bool {
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if !path.exists() {
+            return true;
+        }
+        if std::time::Instant::now() > deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
 /// The agent exits cleanly (status 0) when it receives SIGTERM.
 #[tokio::test]
 async fn agent_exits_cleanly_on_sigterm() {
@@ -254,11 +274,10 @@ async fn socket_removed_on_shutdown() {
     let status = wait_for_exit(&mut agent.child);
     assert!(status.success(), "agent should exit with status 0");
 
-    // Give the OS a moment to finalise file removal.
-    tokio::time::sleep(Duration::from_millis(100)).await;
     assert!(
-        !socket.exists(),
-        "socket should be removed after graceful shutdown"
+        wait_for_removal(&socket),
+        "socket at {} should be removed after graceful shutdown",
+        socket.display()
     );
 }
 
@@ -281,9 +300,43 @@ async fn pid_file_removed_on_shutdown() {
     let status = wait_for_exit(&mut agent.child);
     assert!(status.success(), "agent should exit with status 0");
 
-    tokio::time::sleep(Duration::from_millis(100)).await;
     assert!(
-        !pid_file.exists(),
-        "PID file should be removed after graceful shutdown"
+        wait_for_removal(&pid_file),
+        "PID file at {} should be removed after graceful shutdown",
+        pid_file.display()
+    );
+}
+
+/// SIGINT cleans up the same files SIGTERM does.
+///
+/// Both signals are registered eagerly through `signal()` before either
+/// listener binds, so the cleanup guarantee must not depend on which one
+/// arrives. This test signals as soon as the socket exists, with no request
+/// round-trip first: that is the narrowest window between the socket appearing
+/// and the handler being armed, and the one a lazily-registered handler lost.
+#[tokio::test]
+async fn sigint_removes_socket_and_pid_file() {
+    let mut agent = spawn_agent();
+    let socket = wait_for_socket(&agent).await;
+    let pid_file = agent._dirs.cache.path().join("vouch").join("agent.pid");
+    assert!(
+        pid_file.exists(),
+        "PID file should exist at {} while the agent is running",
+        pid_file.display()
+    );
+
+    send_sigint(&agent.child);
+    let status = wait_for_exit(&mut agent.child);
+    assert!(status.success(), "agent should exit with status 0");
+
+    assert!(
+        wait_for_removal(&socket),
+        "socket at {} should be removed after SIGINT shutdown",
+        socket.display()
+    );
+    assert!(
+        wait_for_removal(&pid_file),
+        "PID file at {} should be removed after SIGINT shutdown",
+        pid_file.display()
     );
 }


### PR DESCRIPTION
Fixes the red `Unit Tests (macos)` job on `main` (`pid_file_removed_on_shutdown`, cd588b8d). The failure is a real agent bug, not a flaky test.

## The defect

`run_agent_server` created the SIGTERM stream *inside* the spawned waiter task, and reached `tokio::signal::ctrl_c()` only when that task was first polled. Both listeners start in the same `tokio::join!`, so nothing ordered the registration against the IPC socket appearing on disk.

`signal()` is what replaces a signal's disposition. Until it returns, SIGTERM and SIGINT keep the default disposition — terminate the process. A signal delivered in that window killed the agent outright: no drain, and `cleanup()` never ran, so the socket and PID file were left behind. Per the existing test's own doc comment, a stale PID file makes the next `vouch-agent` start refuse with "already running".

This is user-facing, not just a test artifact: a service manager that starts the agent and sends SIGTERM promptly hits the same window.

## Why macOS, and why only those two tests

The two file-cleanup tests signal as soon as the socket exists — the narrowest window. The tests that complete a ping round-trip first were wide enough to hide it. The macOS runner's scheduling made the narrow case lose.

## Evidence

Delaying the waiter task's first poll by 500 ms reproduces it on Linux:

| | pre-fix | post-fix |
|---|---|---|
| suite with waiter delayed 500 ms | **6 of 6 fail** | 6 of 6 pass |
| suite unmodified, 25 consecutive runs | passes (window too narrow on Linux) | passes |

The fix holds under the same delay because `Signal` buffers a signal delivered between registration and the first `recv()`.

## The change

- Register both streams synchronously in `run_agent_server`, before either listener binds and before the waiter is spawned. Waiting still happens in a spawned task so the server futures are not dropped before they observe the shutdown signal.
- SIGINT is registered directly rather than through `tokio::signal::ctrl_c`, which registers on first poll and reintroduces the same window.
- A registration failure is now fatal rather than degraded. The previous code fell through to `std::future::pending()`, so the failure was invisible until a shutdown went wrong.

## Tests

- The two fixed `sleep(100ms)`-then-assert cleanup checks become `wait_for_removal`, a bounded poll. `cleanup()` runs before `main` returns, so the file is already gone by the time `wait_for_exit` observes the exit; polling keeps the assertion from depending on that.
- Adds `sigint_removes_socket_and_pid_file`. SIGINT had exit-status coverage but no cleanup coverage, and this change moves it off `ctrl_c()`.

## Gates

`make fmt`, `make lint` (clean), `cargo test -p vouch-agent` — 85 + 6 + 1 passing, 0 failures.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7tK4Db3QTUWPc3SnCpiAV)_