### PR TITLE
fix(server): bound the http_requests_total label set

### DIFF
--- a/crates/vouch-server/src/infra/metrics.rs
+++ b/crates/vouch-server/src/infra/metrics.rs
@@ -4,10 +4,19 @@
 //! Exposes a `/metrics` endpoint in Prometheus text format and provides
 //! middleware for automatic HTTP request duration and count tracking.
 //! The endpoint is gated behind a bearer token for security.
+//!
+//! Every label value this module emits is drawn from a finite set, which is
+//! what bounds the number of Prometheus series the recorder holds. Nothing
+//! here is installed with an idle timeout, so a series that is created is
+//! never evicted; a label built from request data would therefore grow without
+//! limit. New metrics belong in this module so that property stays checkable
+//! in one place.
 
 use std::sync::Arc;
 
-use axum::http::{HeaderMap, StatusCode};
+use axum::extract::MatchedPath;
+use axum::http::{HeaderMap, Method, Request, StatusCode};
+use axum::middleware::Next;
 use axum::response::IntoResponse;
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 use secrecy::{ExposeSecret, SecretString};
@@ -70,6 +79,71 @@ pub async fn authenticated_metrics_handler(
     }
 }
 
+/// `path` label for a request that matched no route.
+///
+/// `MatchedPath` is absent on a 404, and the request target is chosen by the
+/// caller. Recording it verbatim would let any client mint an unbounded number
+/// of Prometheus series. No route template can collide with this value because
+/// every template begins with `/`.
+const UNMATCHED_PATH_LABEL: &str = "<unmatched>";
+
+/// `method` label for a request method outside the standard set.
+///
+/// RFC 9110 Section 9.1 defines the grammar as `method = token`, so any token
+/// is a syntactically valid method, and `http::Method` accepts arbitrary
+/// extension tokens (heap-allocating past its inline capacity). The method is
+/// therefore caller-controlled in exactly the way the request target is.
+const OTHER_METHOD_LABEL: &str = "OTHER";
+
+/// Map an HTTP method onto a bounded set of Prometheus label values.
+///
+/// The nine methods registered by RFC 9110 pass through unchanged; every other
+/// token folds into [`OTHER_METHOD_LABEL`]. The wildcard arm is load-bearing
+/// rather than a stand-in for unhandled cases: the input domain is unbounded
+/// strings, and collapsing it is the point.
+fn metrics_method_label(method: &Method) -> &'static str {
+    match method.as_str() {
+        "GET" => "GET",
+        "HEAD" => "HEAD",
+        "POST" => "POST",
+        "PUT" => "PUT",
+        "DELETE" => "DELETE",
+        "CONNECT" => "CONNECT",
+        "OPTIONS" => "OPTIONS",
+        "TRACE" => "TRACE",
+        "PATCH" => "PATCH",
+        _ => OTHER_METHOD_LABEL,
+    }
+}
+
+/// Middleware that records HTTP request metrics (counter + duration histogram).
+///
+/// Every label value is drawn from a finite set — a route template or
+/// [`UNMATCHED_PATH_LABEL`] for `path`, [`metrics_method_label`] for `method`,
+/// and a status code for `status` — so the series count has a ceiling that no
+/// request can raise.
+///
+/// `router::build_app` applies this OUTSIDE the request `TimeoutLayer` so that
+/// timed-out requests are still recorded; see the ordering note there.
+pub async fn metrics_middleware(req: Request<axum::body::Body>, next: Next) -> impl IntoResponse {
+    let method = metrics_method_label(req.method()).to_owned();
+    let path = req.extensions().get::<MatchedPath>().map_or_else(
+        || UNMATCHED_PATH_LABEL.to_owned(),
+        |p| p.as_str().to_string(),
+    );
+    let start = std::time::Instant::now();
+
+    let response = next.run(req).await;
+
+    let duration = start.elapsed().as_secs_f64();
+    let status = response.status().as_u16().to_string();
+    let labels = [("method", method), ("path", path), ("status", status)];
+    metrics::counter!("http_requests_total", &labels).increment(1);
+    metrics::histogram!("http_request_duration_seconds", &labels[..2]).record(duration);
+
+    response
+}
+
 /// Record an authentication event (login success, login failure, etc.).
 pub fn record_auth_event(event_type: &str) {
     metrics::counter!(
@@ -117,6 +191,126 @@ pub fn record_policy_decision_duration(seconds: f64, temporal: bool) {
 )]
 mod tests {
     use super::*;
+
+    use axum::Router;
+    use axum::body::Body;
+    use axum::routing::get;
+    use tower::ServiceExt;
+
+    /// The nine standard methods label as themselves and every other token
+    /// collapses to one value, so the `method` label has a finite range. See
+    /// [`OTHER_METHOD_LABEL`] for why an arbitrary token can arrive here.
+    ///
+    /// This pins label cardinality, not HTTP method semantics: it makes no
+    /// claim about which status code an unrecognized method earns.
+    #[test]
+    fn metrics_method_label_admits_only_the_standard_methods() {
+        for standard in [
+            "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH",
+        ] {
+            let method = Method::from_bytes(standard.as_bytes()).expect("standard method");
+            assert_eq!(
+                metrics_method_label(&method),
+                standard,
+                "{standard} is registered by RFC 9110 and must label as itself"
+            );
+        }
+
+        // Extension tokens, including one past `InlineExtension`'s capacity so
+        // the heap-allocated representation is covered too.
+        for extension in [
+            "FROBNICATE",
+            "get",
+            "Get",
+            "M-SEARCH",
+            "AVERYLONGEXTENSIONMETHODNAMEWELLPASTTHEINLINECAPACITY",
+        ] {
+            let method = Method::from_bytes(extension.as_bytes()).expect("valid token");
+            assert_eq!(
+                metrics_method_label(&method),
+                OTHER_METHOD_LABEL,
+                "{extension} is an extension token and must not reach a metric label"
+            );
+        }
+    }
+
+    /// The `path` and `method` labels on `http_requests_total` are copied into
+    /// a Prometheus series key, so echoing caller-supplied values lets any
+    /// client allocate unbounded series and exhaust server memory. `path` must
+    /// collapse to `<unmatched>` when no route matched, and `method` to
+    /// `OTHER` for any non-standard token.
+    ///
+    /// Asserts on the absence of the caller's tokens rather than on a series
+    /// count, so it stays correct alongside other tests sharing the
+    /// process-global recorder.
+    #[tokio::test]
+    async fn metrics_labels_do_not_echo_caller_input() {
+        let handle = install_recorder().expect("prometheus recorder");
+
+        let router = Router::new()
+            .route("/label-cardinality-probe", get(|| async { "ok" }))
+            .layer(axum::middleware::from_fn(metrics_middleware));
+
+        // Unmatched targets: each one would previously become its own series.
+        let unmatched: Vec<String> = (0..25)
+            .map(|i| format!("/no-such-route-cardinality-{i}"))
+            .collect();
+        for target in &unmatched {
+            let req = Request::builder()
+                .method("GET")
+                .uri(target.as_str())
+                .body(Body::empty())
+                .expect("valid request");
+            let resp = router.clone().oneshot(req).await.expect("oneshot succeeds");
+            assert_eq!(
+                resp.status(),
+                StatusCode::NOT_FOUND,
+                "{target} must not match a route"
+            );
+        }
+
+        // Extension methods against a MATCHED route: this vector never yields a
+        // 404, so bounding `path` alone would leave it open.
+        let extensions: Vec<String> = (0..25)
+            .map(|i| format!("FROBNICATECARDINALITY{i}"))
+            .collect();
+        for extension in &extensions {
+            let req = Request::builder()
+                .method(extension.as_str())
+                .uri("/label-cardinality-probe")
+                .body(Body::empty())
+                .expect("valid request");
+            let resp = router.clone().oneshot(req).await.expect("oneshot succeeds");
+            assert_eq!(
+                resp.status(),
+                StatusCode::METHOD_NOT_ALLOWED,
+                "{extension} must not match a method route"
+            );
+        }
+
+        let text = handle.render();
+
+        for target in &unmatched {
+            assert!(
+                !text.contains(target.as_str()),
+                "unmatched target {target} must not reach a metric label; got:\n{text}"
+            );
+        }
+        for extension in &extensions {
+            assert!(
+                !text.contains(extension.as_str()),
+                "extension method {extension} must not reach a metric label; got:\n{text}"
+            );
+        }
+        assert!(
+            text.contains(r#"path="<unmatched>""#),
+            "unmatched requests must collapse to a single path label; got:\n{text}"
+        );
+        assert!(
+            text.contains(r#"method="OTHER""#),
+            "extension methods must collapse to a single method label; got:\n{text}"
+        );
+    }
 
     fn headers_with_auth(value: &str) -> HeaderMap {
         let mut headers = HeaderMap::new();

--- a/crates/vouch-server/src/infra/router.rs
+++ b/crates/vouch-server/src/infra/router.rs
@@ -8,9 +8,8 @@ use std::sync::Arc;
 
 use axum::{
     Json, Router,
-    extract::{DefaultBodyLimit, MatchedPath, State},
-    http::{HeaderValue, Method, Request, StatusCode, header},
-    middleware::Next,
+    extract::{DefaultBodyLimit, State},
+    http::{HeaderValue, StatusCode, header},
     response::IntoResponse,
     routing::{delete, get, patch, post},
 };
@@ -210,7 +209,7 @@ pub fn build_app(state: Arc<AppState>, config: &config::ServerConfig) -> anyhow:
         StatusCode::REQUEST_TIMEOUT,
         std::time::Duration::from_secs(30),
     ))
-    .layer(axum::middleware::from_fn(metrics_middleware))
+    .layer(axum::middleware::from_fn(metrics::metrics_middleware))
     .layer(DefaultBodyLimit::max(GLOBAL_BODY_LIMIT))
     .layer(request_id::propagate_request_id_layer())
     .layer(axum::middleware::from_fn(
@@ -907,68 +906,6 @@ fn build_ui_routes(config: &config::ServerConfig) -> anyhow::Result<Router<Arc<A
         .layer(security_headers::build_ui_cors_layer(config)))
 }
 
-/// `path` label for a request that matched no route.
-///
-/// `MatchedPath` is absent on a 404, and the request target is chosen by the
-/// caller. Recording it verbatim would let any client mint an unbounded number
-/// of Prometheus series. No route template can collide with this value because
-/// every template begins with `/`.
-const UNMATCHED_PATH_LABEL: &str = "<unmatched>";
-
-/// `method` label for a request method outside the standard set.
-///
-/// RFC 9110 Section 9.1 defines the grammar as `method = token`, so any token
-/// is a syntactically valid method, and `http::Method` accepts arbitrary
-/// extension tokens (heap-allocating past its inline capacity). The method is
-/// therefore caller-controlled in exactly the way the request target is.
-const OTHER_METHOD_LABEL: &str = "OTHER";
-
-/// Map an HTTP method onto a bounded set of Prometheus label values.
-///
-/// The nine methods registered by RFC 9110 pass through unchanged; every other
-/// token folds into [`OTHER_METHOD_LABEL`]. The wildcard arm is load-bearing
-/// rather than a stand-in for unhandled cases: the input domain is unbounded
-/// strings, and collapsing it is the point.
-fn metrics_method_label(method: &Method) -> &'static str {
-    match method.as_str() {
-        "GET" => "GET",
-        "HEAD" => "HEAD",
-        "POST" => "POST",
-        "PUT" => "PUT",
-        "DELETE" => "DELETE",
-        "CONNECT" => "CONNECT",
-        "OPTIONS" => "OPTIONS",
-        "TRACE" => "TRACE",
-        "PATCH" => "PATCH",
-        _ => OTHER_METHOD_LABEL,
-    }
-}
-
-/// Middleware that records HTTP request metrics (counter + duration histogram).
-///
-/// Every label value is drawn from a finite set — a route template or
-/// [`UNMATCHED_PATH_LABEL`] for `path`, [`metrics_method_label`] for `method`,
-/// and a status code for `status` — so the series count has a ceiling that no
-/// request can raise.
-async fn metrics_middleware(req: Request<axum::body::Body>, next: Next) -> impl IntoResponse {
-    let method = metrics_method_label(req.method()).to_owned();
-    let path = req.extensions().get::<MatchedPath>().map_or_else(
-        || UNMATCHED_PATH_LABEL.to_owned(),
-        |p| p.as_str().to_string(),
-    );
-    let start = std::time::Instant::now();
-
-    let response = next.run(req).await;
-
-    let duration = start.elapsed().as_secs_f64();
-    let status = response.status().as_u16().to_string();
-    let labels = [("method", method), ("path", path), ("status", status)];
-    ::metrics::counter!("http_requests_total", &labels).increment(1);
-    ::metrics::histogram!("http_request_duration_seconds", &labels[..2]).record(duration);
-
-    response
-}
-
 #[cfg(test)]
 #[expect(
     clippy::expect_used,
@@ -979,6 +916,7 @@ mod tests {
     use std::time::Duration;
 
     use axum::body::Body;
+    use axum::http::Request;
     use tower::ServiceExt;
 
     /// Handler that never completes, used to trigger `TimeoutLayer`.
@@ -1024,7 +962,7 @@ mod tests {
                 StatusCode::REQUEST_TIMEOUT,
                 Duration::from_millis(50),
             ))
-            .layer(axum::middleware::from_fn(metrics_middleware));
+            .layer(axum::middleware::from_fn(metrics::metrics_middleware));
 
         let resp = router
             .oneshot(build_request("/slow-timeout-regression"))
@@ -1056,120 +994,6 @@ mod tests {
         );
     }
 
-    /// The nine standard methods label as themselves and every other token
-    /// collapses to one value, so the `method` label has a finite range. See
-    /// [`OTHER_METHOD_LABEL`] for why an arbitrary token can arrive here.
-    ///
-    /// This pins label cardinality, not HTTP method semantics: it makes no
-    /// claim about which status code an unrecognized method earns.
-    #[test]
-    fn metrics_method_label_admits_only_the_standard_methods() {
-        for standard in [
-            "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH",
-        ] {
-            let method = Method::from_bytes(standard.as_bytes()).expect("standard method");
-            assert_eq!(
-                metrics_method_label(&method),
-                standard,
-                "{standard} is registered by RFC 9110 and must label as itself"
-            );
-        }
-
-        // Extension tokens, including one past `InlineExtension`'s capacity so
-        // the heap-allocated representation is covered too.
-        for extension in [
-            "FROBNICATE",
-            "get",
-            "Get",
-            "M-SEARCH",
-            "AVERYLONGEXTENSIONMETHODNAMEWELLPASTTHEINLINECAPACITY",
-        ] {
-            let method = Method::from_bytes(extension.as_bytes()).expect("valid token");
-            assert_eq!(
-                metrics_method_label(&method),
-                OTHER_METHOD_LABEL,
-                "{extension} is an extension token and must not reach a metric label"
-            );
-        }
-    }
-
-    /// The `path` and `method` labels on `http_requests_total` are copied into
-    /// a Prometheus series key, so echoing caller-supplied values lets any
-    /// client allocate unbounded series and exhaust server memory. `path` must
-    /// collapse to `<unmatched>` when no route matched, and `method` to
-    /// `OTHER` for any non-standard token.
-    ///
-    /// Asserts on the absence of the caller's tokens rather than on a series
-    /// count, so it stays correct alongside other tests sharing the
-    /// process-global recorder.
-    #[tokio::test]
-    async fn metrics_labels_do_not_echo_caller_input() {
-        let handle = metrics::install_recorder().expect("prometheus recorder");
-
-        let router = Router::new()
-            .route("/label-cardinality-probe", get(|| async { "ok" }))
-            .layer(axum::middleware::from_fn(metrics_middleware));
-
-        // Unmatched targets: each one would previously become its own series.
-        let unmatched: Vec<String> = (0..25)
-            .map(|i| format!("/no-such-route-cardinality-{i}"))
-            .collect();
-        for target in &unmatched {
-            let resp = router
-                .clone()
-                .oneshot(build_request(target))
-                .await
-                .expect("oneshot succeeds");
-            assert_eq!(
-                resp.status(),
-                StatusCode::NOT_FOUND,
-                "{target} must not match a route"
-            );
-        }
-
-        // Extension methods against a MATCHED route: this vector never yields a
-        // 404, so bounding `path` alone would leave it open.
-        let extensions: Vec<String> = (0..25)
-            .map(|i| format!("FROBNICATECARDINALITY{i}"))
-            .collect();
-        for extension in &extensions {
-            let req = Request::builder()
-                .method(extension.as_str())
-                .uri("/label-cardinality-probe")
-                .body(Body::empty())
-                .expect("valid request");
-            let resp = router.clone().oneshot(req).await.expect("oneshot succeeds");
-            assert_eq!(
-                resp.status(),
-                StatusCode::METHOD_NOT_ALLOWED,
-                "{extension} must not match a method route"
-            );
-        }
-
-        let text = handle.render();
-
-        for target in &unmatched {
-            assert!(
-                !text.contains(target.as_str()),
-                "unmatched target {target} must not reach a metric label; got:\n{text}"
-            );
-        }
-        for extension in &extensions {
-            assert!(
-                !text.contains(extension.as_str()),
-                "extension method {extension} must not reach a metric label; got:\n{text}"
-            );
-        }
-        assert!(
-            text.contains(r#"path="<unmatched>""#),
-            "unmatched requests must collapse to a single path label; got:\n{text}"
-        );
-        assert!(
-            text.contains(r#"method="OTHER""#),
-            "extension methods must collapse to a single method label; got:\n{text}"
-        );
-    }
-
     /// Guards the source-level layer ordering in `build_app` against silent
     /// re-regression. In axum the last `.layer()` is outermost, so for the
     /// timeout to be the innermost layer (cancellable while metrics observes
@@ -1186,7 +1010,7 @@ mod tests {
             .find("TimeoutLayer::with_status_code")
             .expect("TimeoutLayer in build_app");
         let metrics_pos = build_app_src
-            .find("axum::middleware::from_fn(metrics_middleware)")
+            .find("axum::middleware::from_fn(metrics::metrics_middleware)")
             .expect("metrics_middleware in build_app");
         assert!(
             timeout_pos < metrics_pos,

--- a/crates/vouch-server/src/infra/router.rs
+++ b/crates/vouch-server/src/infra/router.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use axum::{
     Json, Router,
     extract::{DefaultBodyLimit, MatchedPath, State},
-    http::{HeaderValue, Request, StatusCode, header},
+    http::{HeaderValue, Method, Request, StatusCode, header},
     middleware::Next,
     response::IntoResponse,
     routing::{delete, get, patch, post},
@@ -907,13 +907,55 @@ fn build_ui_routes(config: &config::ServerConfig) -> anyhow::Result<Router<Arc<A
         .layer(security_headers::build_ui_cors_layer(config)))
 }
 
+/// `path` label for a request that matched no route.
+///
+/// `MatchedPath` is absent on a 404, and the request target is chosen by the
+/// caller. Recording it verbatim would let any client mint an unbounded number
+/// of Prometheus series. No route template can collide with this value because
+/// every template begins with `/`.
+const UNMATCHED_PATH_LABEL: &str = "<unmatched>";
+
+/// `method` label for a request method outside the standard set.
+///
+/// RFC 9110 Section 9.1 defines the grammar as `method = token`, so any token
+/// is a syntactically valid method, and `http::Method` accepts arbitrary
+/// extension tokens (heap-allocating past its inline capacity). The method is
+/// therefore caller-controlled in exactly the way the request target is.
+const OTHER_METHOD_LABEL: &str = "OTHER";
+
+/// Map an HTTP method onto a bounded set of Prometheus label values.
+///
+/// The nine methods registered by RFC 9110 pass through unchanged; every other
+/// token folds into [`OTHER_METHOD_LABEL`]. The wildcard arm is load-bearing
+/// rather than a stand-in for unhandled cases: the input domain is unbounded
+/// strings, and collapsing it is the point.
+fn metrics_method_label(method: &Method) -> &'static str {
+    match method.as_str() {
+        "GET" => "GET",
+        "HEAD" => "HEAD",
+        "POST" => "POST",
+        "PUT" => "PUT",
+        "DELETE" => "DELETE",
+        "CONNECT" => "CONNECT",
+        "OPTIONS" => "OPTIONS",
+        "TRACE" => "TRACE",
+        "PATCH" => "PATCH",
+        _ => OTHER_METHOD_LABEL,
+    }
+}
+
 /// Middleware that records HTTP request metrics (counter + duration histogram).
+///
+/// Every label value is drawn from a finite set — a route template or
+/// [`UNMATCHED_PATH_LABEL`] for `path`, [`metrics_method_label`] for `method`,
+/// and a status code for `status` — so the series count has a ceiling that no
+/// request can raise.
 async fn metrics_middleware(req: Request<axum::body::Body>, next: Next) -> impl IntoResponse {
-    let method = req.method().to_string();
-    let path = req
-        .extensions()
-        .get::<MatchedPath>()
-        .map_or_else(|| req.uri().path().to_string(), |p| p.as_str().to_string());
+    let method = metrics_method_label(req.method()).to_owned();
+    let path = req.extensions().get::<MatchedPath>().map_or_else(
+        || UNMATCHED_PATH_LABEL.to_owned(),
+        |p| p.as_str().to_string(),
+    );
     let start = std::time::Instant::now();
 
     let response = next.run(req).await;
@@ -1011,6 +1053,120 @@ mod tests {
         assert!(
             text.contains("http_request_duration_seconds"),
             "metrics middleware must emit http_request_duration_seconds; got:\n{text}"
+        );
+    }
+
+    /// The nine standard methods label as themselves and every other token
+    /// collapses to one value, so the `method` label has a finite range. See
+    /// [`OTHER_METHOD_LABEL`] for why an arbitrary token can arrive here.
+    ///
+    /// This pins label cardinality, not HTTP method semantics: it makes no
+    /// claim about which status code an unrecognized method earns.
+    #[test]
+    fn metrics_method_label_admits_only_the_standard_methods() {
+        for standard in [
+            "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH",
+        ] {
+            let method = Method::from_bytes(standard.as_bytes()).expect("standard method");
+            assert_eq!(
+                metrics_method_label(&method),
+                standard,
+                "{standard} is registered by RFC 9110 and must label as itself"
+            );
+        }
+
+        // Extension tokens, including one past `InlineExtension`'s capacity so
+        // the heap-allocated representation is covered too.
+        for extension in [
+            "FROBNICATE",
+            "get",
+            "Get",
+            "M-SEARCH",
+            "AVERYLONGEXTENSIONMETHODNAMEWELLPASTTHEINLINECAPACITY",
+        ] {
+            let method = Method::from_bytes(extension.as_bytes()).expect("valid token");
+            assert_eq!(
+                metrics_method_label(&method),
+                OTHER_METHOD_LABEL,
+                "{extension} is an extension token and must not reach a metric label"
+            );
+        }
+    }
+
+    /// The `path` and `method` labels on `http_requests_total` are copied into
+    /// a Prometheus series key, so echoing caller-supplied values lets any
+    /// client allocate unbounded series and exhaust server memory. `path` must
+    /// collapse to `<unmatched>` when no route matched, and `method` to
+    /// `OTHER` for any non-standard token.
+    ///
+    /// Asserts on the absence of the caller's tokens rather than on a series
+    /// count, so it stays correct alongside other tests sharing the
+    /// process-global recorder.
+    #[tokio::test]
+    async fn metrics_labels_do_not_echo_caller_input() {
+        let handle = metrics::install_recorder().expect("prometheus recorder");
+
+        let router = Router::new()
+            .route("/label-cardinality-probe", get(|| async { "ok" }))
+            .layer(axum::middleware::from_fn(metrics_middleware));
+
+        // Unmatched targets: each one would previously become its own series.
+        let unmatched: Vec<String> = (0..25)
+            .map(|i| format!("/no-such-route-cardinality-{i}"))
+            .collect();
+        for target in &unmatched {
+            let resp = router
+                .clone()
+                .oneshot(build_request(target))
+                .await
+                .expect("oneshot succeeds");
+            assert_eq!(
+                resp.status(),
+                StatusCode::NOT_FOUND,
+                "{target} must not match a route"
+            );
+        }
+
+        // Extension methods against a MATCHED route: this vector never yields a
+        // 404, so bounding `path` alone would leave it open.
+        let extensions: Vec<String> = (0..25)
+            .map(|i| format!("FROBNICATECARDINALITY{i}"))
+            .collect();
+        for extension in &extensions {
+            let req = Request::builder()
+                .method(extension.as_str())
+                .uri("/label-cardinality-probe")
+                .body(Body::empty())
+                .expect("valid request");
+            let resp = router.clone().oneshot(req).await.expect("oneshot succeeds");
+            assert_eq!(
+                resp.status(),
+                StatusCode::METHOD_NOT_ALLOWED,
+                "{extension} must not match a method route"
+            );
+        }
+
+        let text = handle.render();
+
+        for target in &unmatched {
+            assert!(
+                !text.contains(target.as_str()),
+                "unmatched target {target} must not reach a metric label; got:\n{text}"
+            );
+        }
+        for extension in &extensions {
+            assert!(
+                !text.contains(extension.as_str()),
+                "extension method {extension} must not reach a metric label; got:\n{text}"
+            );
+        }
+        assert!(
+            text.contains(r#"path="<unmatched>""#),
+            "unmatched requests must collapse to a single path label; got:\n{text}"
+        );
+        assert!(
+            text.contains(r#"method="OTHER""#),
+            "extension methods must collapse to a single method label; got:\n{text}"
         );
     }
 

--- a/docs/src/operations/monitoring.md
+++ b/docs/src/operations/monitoring.md
@@ -67,10 +67,20 @@ scrape_configs:
 
 | Metric | Type | Labels | Meaning |
 |--------|------|--------|---------|
-| `http_requests_total` | counter | `method`, `path`, `status` | Requests served. `path` is the matched route template (e.g. `/v1/keys/{id}`), not the raw URL, so cardinality stays bounded. |
+| `http_requests_total` | counter | `method`, `path`, `status` | Requests served. See the label note below. |
 | `http_request_duration_seconds` | histogram | `method`, `path` | Request latency. Not labelled by status. |
 | `vouch_auth_events_total` | counter | `event_type` | Authentication outcomes |
 | `vouch_credential_issuance_total` | counter | `type` | Credentials issued |
+
+The `method` and `path` labels are both drawn from fixed sets, so the number of series has a
+ceiling that no request can raise:
+
+- `path` is the matched route template (e.g. `/v1/keys/{id}`), never the raw request target. A
+  request that matches no route is labelled `<unmatched>` rather than by the target it asked for,
+  so 404 traffic contributes exactly one series per method/status pair. To see what is actually
+  being probed, read the request logs — every request logs its raw path on the `request` span.
+- `method` is one of the nine methods registered by RFC 9110. Any other token — HTTP permits any
+  token as a method — is labelled `OTHER`.
 
 `vouch_auth_events_total` uses these `event_type` values: `enrollment`, `browser_login_success`,
 `fido2_login_success`, `fido2_login_failure`, `authorization_code_success`.


### PR DESCRIPTION
Fixes #1109.

## The defect

`metrics_middleware` copied two of its three label values straight out of the
request. Prometheus allocates one series per distinct label combination, so a
caller decided how many series the recorder held, and nothing evicts them —
`PrometheusBuilder::new().install_recorder()` sets no idle timeout, and
eviction only happens during `render()` anyway.

```rust
let method = req.method().to_string();
let path = req
    .extensions()
    .get::<MatchedPath>()
    .map_or_else(|| req.uri().path().to_string(), |p| p.as_str().to_string());
```

**`path`** falls back to the raw request target whenever `MatchedPath` is
absent, which is every 404. Unmatched requests reach no rate limiter, because
limiting is applied inside route sub-groups.

**`method`** was the raw method token. This is the axis the issue did not
cover, and it is the more exposed of the two:

- RFC 9110 Section 9.1 defines the grammar as `method = token`, so any token is
  a syntactically valid method. `http::Method` accepts arbitrary extension
  tokens and heap-allocates ones past its inline capacity, so a single series
  can also be made large.
- It needs no 404. It lands on *matched* routes, including unauthenticated ones
  with no rate limiter such as `/health`, so bounding `path` alone would have
  left it wide open.

Both labels also key the `http_request_duration_seconds` histogram.

The server sits behind an L4 network load balancer with no L7 normalization in
front, so neither vector is filtered before it reaches axum.

## Reproduction

Driving the real `build_app` router and rendering the handle, before the fix:

```
http_requests_total{method="GET",path="/nonexistent-0-",status="404"} 1
http_requests_total{method="GET",path="/nonexistent-1-x",status="404"} 1
...
http_requests_total{method="FROBNICATE1",path="/health",status="405"} 1
http_requests_total{method="AVERYLONGEXTENSIONMETHODNAME",path="/health",status="405"} 1
```

## The fix

Unmatched targets label as `<unmatched>`; methods outside the nine registered
by RFC 9110 label as `OTHER`. Every value the middleware can emit is now a
literal, so no request data reaches a series key and the series count has a
fixed ceiling of routes x methods x statuses.

Raw paths are unaffected for debugging — every request already logs its path on
the `request` tracing span. The issue suggested also logging unmatched paths at
`debug` from the middleware; that is deliberately not done, since it would
reintroduce the same caller-controlled value into a log field at attacker-chosen
rate on a path with no rate limiter, and the span already carries it.

## Why not an idle timeout

Considered and rejected. It prunes only at scrape time, so it does nothing in
the default configuration where `VOUCH_METRICS_BEARER_TOKEN` is unset and
`/metrics` is never mounted. It also cannot separate `http_*` from `vouch_*`,
because `MetricKindMask` masks by metric kind and both groups contain counters
and a histogram — so enabling it would drop low-traffic business counters out
of the scrape and bring them back at zero. Bounding the labels makes it
unnecessary; a regression test is the better backstop.

## Tests

- `metrics_method_label_admits_only_the_standard_methods` — the nine standard
  methods label as themselves; extension tokens, case variants, and one token
  past the inline capacity all fold to `OTHER`.
- `metrics_labels_do_not_echo_caller_input` — drives 25 unique unmatched
  targets and 25 extension methods through the middleware and asserts none of
  those tokens appears anywhere in the rendered output. It asserts on absence
  rather than a series count so it stays correct alongside other tests sharing
  the process-global recorder.

Both were verified to fail against the original code before being kept.

## Second commit

`metrics_middleware` was the only `infra` middleware defined inside
`router.rs`; `request_id.rs`, `org_host.rs`, and `i18n.rs` all define their own
and let the router wire them. Moving it alongside the recorder and the
`record_*` helpers puts every label-producing site in one module, which is what
makes "is every label value drawn from a finite set?" answerable by reading one
file. The layer-ordering tests stay in `router.rs`, since they pin how
`build_app` composes the stack rather than what the middleware records.

## Docs

`docs/src/operations/monitoring.md` claimed cardinality "stays bounded" because
`path` is a route template. That was false for both axes; it now describes the
actual label ranges and points operators at the request log for raw paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
