### PR TITLE
refactor(test): build test sessions from TestSessionSpec (#1130)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,6 +297,21 @@ covered without hardware through the `CoseVerifier` seam
   doc lists every submodule's scope — put new db tests in the file whose scope matches,
   and add a new file (listed in that doc) when none does.
 
+**Build fixtures from the spec structs, never from hand-rolled parameter
+literals.** `test_utils.rs` has one factory per fixture kind, each taking a
+spec struct whose `Default` is the ordinary case, so a test spells out only the
+axis it is about:
+
+- Sessions → `create_test_session_with(&state, TestSessionSpec { .. })`. Vary
+  `auth_id`, `client_id`, `audience`, `binding` (`TestBinding`), and
+  `verification` (`TestVerification`).
+- OAuth clients → `create_test_client(&store, &user_id, TestClientSpec { .. })`.
+
+If a field the test needs is missing, add it to the spec — do not reach past
+the factory to `CreateOAuthTokenParams` / `CreateOAuthClientParams`. Those
+literals are spelled out once, inside the factory, so adding a field to either
+does not touch a single test.
+
 **Cite the requirement a test pins.** A test that verifies a normative
 statement names the spec and section in a comment above it or in its assertion
 message:

--- a/crates/vouch-server/src/handlers/admin/audit.rs
+++ b/crates/vouch-server/src/handlers/admin/audit.rs
@@ -503,7 +503,16 @@ mod tests {
         let user =
             create_test_user_in_org(&state.store, "regular@example.com", &org.id, false).await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let cookie = format!("{}={token}", vouch_common::SESSION_COOKIE_NAME);
 
         let (status, _body) = http_get(&app, "/admin/audit", &[("Cookie", &cookie)]).await;
@@ -518,7 +527,16 @@ mod tests {
         let (app, state) = test_app().await;
         let user = create_test_user(&state.store, "noorg@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let cookie = format!("{}={token}", vouch_common::SESSION_COOKIE_NAME);
 
         let (status, _body) = http_get(&app, "/admin/audit", &[("Cookie", &cookie)]).await;
@@ -534,7 +552,16 @@ mod tests {
         let org = create_test_org(&state.store, "example.com").await;
         let admin = create_test_user_in_org(&state.store, "admin@example.com", &org.id, true).await;
         let auth_id = create_test_authenticator(&state.store, &admin.id).await;
-        let token = create_test_session(&state, &admin.id, &admin.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &admin.id,
+                email: &admin.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let cookie = format!("{}={token}", vouch_common::SESSION_COOKIE_NAME);
 
         let (status, body) = http_get(&app, "/admin/audit", &[("Cookie", &cookie)]).await;
@@ -551,7 +578,16 @@ mod tests {
         let org = create_test_org(&state.store, "example.com").await;
         let admin = create_test_user_in_org(&state.store, "admin@example.com", &org.id, true).await;
         let auth_id = create_test_authenticator(&state.store, &admin.id).await;
-        let token = create_test_session(&state, &admin.id, &admin.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &admin.id,
+                email: &admin.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let cookie = format!("{}={token}", vouch_common::SESSION_COOKIE_NAME);
 
         let (status, _body) =
@@ -569,7 +605,16 @@ mod tests {
         let org = create_test_org(&state.store, "example.com").await;
         let admin = create_test_user_in_org(&state.store, "admin@example.com", &org.id, true).await;
         let auth_id = create_test_authenticator(&state.store, &admin.id).await;
-        let token = create_test_session(&state, &admin.id, &admin.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &admin.id,
+                email: &admin.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let cookie = format!("{}={token}", vouch_common::SESSION_COOKIE_NAME);
 
         // Unknown filters are treated as no filter — page still loads
@@ -597,7 +642,16 @@ mod tests {
         let admin =
             create_test_user_in_org(&state.store, "admin@corp.example.com", &org.id, true).await;
         let auth_id = create_test_authenticator(&state.store, &admin.id).await;
-        let token = create_test_session(&state, &admin.id, &admin.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &admin.id,
+                email: &admin.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let cookie = format!("{}={token}", vouch_common::SESSION_COOKIE_NAME);
 
         // Seed an audit event with a mixed-case email domain, as an IdP might
@@ -632,7 +686,16 @@ mod tests {
         let target =
             create_test_user_in_org(&state.store, "target@example.com", &org.id, false).await;
         let auth_id = create_test_authenticator(&state.store, &admin.id).await;
-        let token = create_test_session(&state, &admin.id, &admin.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &admin.id,
+                email: &admin.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let cookie = format!("{}={token}", vouch_common::SESSION_COOKIE_NAME);
 
         let data = serde_json::json!({ "target_user_id": target.id }).to_string();

--- a/crates/vouch-server/src/handlers/admin/audit_api.rs
+++ b/crates/vouch-server/src/handlers/admin/audit_api.rs
@@ -567,7 +567,16 @@ mod tests {
         let org = create_test_org(&state.store, "example.com").await;
         let admin = create_test_user_in_org(&state.store, "admin@example.com", &org.id, true).await;
         let auth_id = create_test_authenticator(&state.store, &admin.id).await;
-        let token = create_test_session(state, &admin.id, &admin.email, &auth_id).await;
+        let token = create_test_session_with(
+            state,
+            TestSessionSpec {
+                user_id: &admin.id,
+                email: &admin.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         (org.id, admin.id, token)
     }
 
@@ -663,7 +672,16 @@ mod tests {
         let member =
             create_test_user_in_org(&state.store, "member@example.com", &org.id, false).await;
         let auth_id = create_test_authenticator(&state.store, &member.id).await;
-        let token = create_test_session(&state, &member.id, &member.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &member.id,
+                email: &member.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let (status, _body) =
             http_get(&app, PATH, &[("Authorization", &format!("Bearer {token}"))]).await;

--- a/crates/vouch-server/src/handlers/admin/members.rs
+++ b/crates/vouch-server/src/handlers/admin/members.rs
@@ -561,7 +561,16 @@ mod tests {
         let org = create_test_org(&state.store, "example.com").await;
         let admin = create_test_user_in_org(&state.store, "admin@example.com", &org.id, true).await;
         let auth_id = create_test_authenticator(&state.store, &admin.id).await;
-        let token = create_test_session(state, &admin.id, &admin.email, &auth_id).await;
+        let token = create_test_session_with(
+            state,
+            TestSessionSpec {
+                user_id: &admin.id,
+                email: &admin.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let member =
             create_test_user_in_org(&state.store, "member@example.com", &org.id, false).await;
         (admin, token, member)
@@ -579,7 +588,16 @@ mod tests {
         let org = create_test_org(&state.store, "example.com").await;
         let admin = create_test_user_in_org(&state.store, "admin@example.com", &org.id, true).await;
         let auth_id = create_test_authenticator(&state.store, &admin.id).await;
-        let token = create_test_session(&state, &admin.id, &admin.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &admin.id,
+                email: &admin.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         // Deactivate the admin
         crate::db::update_user_active_status(&state.store, &admin.id, false)
@@ -603,7 +621,16 @@ mod tests {
         let org = create_test_org(&state.store, "example.com").await;
         let admin = create_test_user_in_org(&state.store, "admin@example.com", &org.id, true).await;
         let auth_id = create_test_authenticator(&state.store, &admin.id).await;
-        let token = create_test_session(&state, &admin.id, &admin.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &admin.id,
+                email: &admin.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         // Deactivate the user
         crate::db::update_user_active_status(&state.store, &admin.id, false)
@@ -696,7 +723,16 @@ mod tests {
         // Create a non-admin user with a session
         let user = create_test_user_in_org(&state.store, "user@example.com", &org.id, false).await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let cookie = admin_cookie(&token);
 
         let target =
@@ -725,7 +761,16 @@ mod tests {
         let org = create_test_org(&state.store, "example.com").await;
         let admin = create_test_user_in_org(&state.store, "admin@example.com", &org.id, true).await;
         let auth_id = create_test_authenticator(&state.store, &admin.id).await;
-        let token = create_test_session(&state, &admin.id, &admin.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &admin.id,
+                email: &admin.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let cookie = admin_cookie(&token);
 
         let (status, body) = http_post_form(
@@ -749,7 +794,16 @@ mod tests {
         let org = create_test_org(&state.store, "example.com").await;
         let admin = create_test_user_in_org(&state.store, "admin@example.com", &org.id, true).await;
         let auth_id = create_test_authenticator(&state.store, &admin.id).await;
-        let token = create_test_session(&state, &admin.id, &admin.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &admin.id,
+                email: &admin.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let cookie = admin_cookie(&token);
 
         let (status, body) = http_post_form(
@@ -773,7 +827,16 @@ mod tests {
         let org = create_test_org(&state.store, "example.com").await;
         let admin = create_test_user_in_org(&state.store, "admin@example.com", &org.id, true).await;
         let auth_id = create_test_authenticator(&state.store, &admin.id).await;
-        let token = create_test_session(&state, &admin.id, &admin.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &admin.id,
+                email: &admin.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let cookie = admin_cookie(&token);
 
         let (status, body) = http_post_form(
@@ -797,7 +860,16 @@ mod tests {
         let org = create_test_org(&state.store, "example.com").await;
         let admin = create_test_user_in_org(&state.store, "admin@example.com", &org.id, true).await;
         let auth_id = create_test_authenticator(&state.store, &admin.id).await;
-        let token = create_test_session(&state, &admin.id, &admin.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &admin.id,
+                email: &admin.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let cookie = admin_cookie(&token);
 
         let (status, body) = http_post_form(
@@ -825,7 +897,16 @@ mod tests {
 
         let admin = create_test_user_in_org(&state.store, "admin@org1.com", &org1.id, true).await;
         let auth_id = create_test_authenticator(&state.store, &admin.id).await;
-        let token = create_test_session(&state, &admin.id, &admin.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &admin.id,
+                email: &admin.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let cookie = admin_cookie(&token);
 
         let other_user =
@@ -907,7 +988,16 @@ mod tests {
         let admin =
             create_test_user_in_org(&state.store, "admin1@example.com", &org.id, true).await;
         let auth_id = create_test_authenticator(&state.store, &admin.id).await;
-        let token = create_test_session(&state, &admin.id, &admin.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &admin.id,
+                email: &admin.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let cookie = admin_cookie(&token);
 
         // Create another admin to demote
@@ -968,7 +1058,16 @@ mod tests {
         let org = create_test_org(&state.store, "example.com").await;
         let admin = create_test_user_in_org(&state.store, "admin@example.com", &org.id, true).await;
         let auth_id = create_test_authenticator(&state.store, &admin.id).await;
-        let token = create_test_session(&state, &admin.id, &admin.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &admin.id,
+                email: &admin.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let cookie = admin_cookie(&token);
         let target_email = "target@example.com";
         let target = create_test_user_in_org(&state.store, target_email, &org.id, false).await;

--- a/crates/vouch-server/src/handlers/admin/policies.rs
+++ b/crates/vouch-server/src/handlers/admin/policies.rs
@@ -864,7 +864,16 @@ mod tests {
         let org = create_test_org(&state.store, "example.com").await;
         let admin = create_test_user_in_org(&state.store, "admin@example.com", &org.id, true).await;
         let auth_id = create_test_authenticator(&state.store, &admin.id).await;
-        let token = create_test_session(state, &admin.id, &admin.email, &auth_id).await;
+        let token = create_test_session_with(
+            state,
+            TestSessionSpec {
+                user_id: &admin.id,
+                email: &admin.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         (admin, token)
     }
 
@@ -1219,7 +1228,16 @@ mod tests {
         let member =
             create_test_user_in_org(&state.store, "member@example.com", &org.id, false).await;
         let auth_id = create_test_authenticator(&state.store, &member.id).await;
-        let token = create_test_session(&state, &member.id, &member.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &member.id,
+                email: &member.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let auth = format!("Bearer {token}");
 
         let body = serde_json::json!({"policy_text": "forbid (principal, action == Vouch::Action::\"IssueToken\", resource) unless { context.device.os == \"macos\" };"});
@@ -1351,7 +1369,16 @@ mod tests {
         let member =
             create_test_user_in_org(&state.store, "member@example.com", &org.id, false).await;
         let auth_id = create_test_authenticator(&state.store, &member.id).await;
-        let token = create_test_session(&state, &member.id, &member.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &member.id,
+                email: &member.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let cookie = admin_cookie(&token);
 
         let (status, _body) = http_get(&app, "/admin/policies", &[("Cookie", &cookie)]).await;

--- a/crates/vouch-server/src/handlers/admin/scim_tokens.rs
+++ b/crates/vouch-server/src/handlers/admin/scim_tokens.rs
@@ -780,7 +780,16 @@ mod tests {
         let org = create_test_org(&state.store, "example.com").await;
         let admin = create_test_user_in_org(&state.store, "admin@example.com", &org.id, true).await;
         let auth_id = create_test_authenticator(&state.store, &admin.id).await;
-        let token = create_test_session(&state, &admin.id, &admin.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &admin.id,
+                email: &admin.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let auth_header = format!("Bearer {token}");
 
         let (status, body) = http_post_json(
@@ -816,7 +825,16 @@ mod tests {
         let org = create_test_org(&state.store, "example.com").await;
         let admin = create_test_user_in_org(&state.store, "admin@example.com", &org.id, true).await;
         let auth_id = create_test_authenticator(&state.store, &admin.id).await;
-        let token = create_test_session(&state, &admin.id, &admin.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &admin.id,
+                email: &admin.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let auth_header = format!("Bearer {token}");
 
         let (status, body) = http_post_json(
@@ -874,7 +892,16 @@ mod tests {
         let member =
             create_test_user_in_org(&state.store, "member@example.com", &org.id, false).await;
         let auth_id = create_test_authenticator(&state.store, &member.id).await;
-        let token = create_test_session(&state, &member.id, &member.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &member.id,
+                email: &member.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let auth_header = format!("Bearer {token}");
 
         let (status, _body) = http_post_json(
@@ -894,7 +921,16 @@ mod tests {
         let org = create_test_org(&state.store, "example.com").await;
         let admin = create_test_user_in_org(&state.store, "admin@example.com", &org.id, true).await;
         let auth_id = create_test_authenticator(&state.store, &admin.id).await;
-        let token = create_test_session(&state, &admin.id, &admin.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &admin.id,
+                email: &admin.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let auth_header = format!("Bearer {token}");
 
         // Create first token
@@ -942,7 +978,16 @@ mod tests {
         let org = create_test_org(&state.store, "example.com").await;
         let admin = create_test_user_in_org(&state.store, "admin@example.com", &org.id, true).await;
         let auth_id = create_test_authenticator(&state.store, &admin.id).await;
-        let token = create_test_session(&state, &admin.id, &admin.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &admin.id,
+                email: &admin.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let auth_header = format!("Bearer {token}");
 
         let (status, body) = http_get(
@@ -964,7 +1009,16 @@ mod tests {
         let org = create_test_org(&state.store, "example.com").await;
         let admin = create_test_user_in_org(&state.store, "admin@example.com", &org.id, true).await;
         let auth_id = create_test_authenticator(&state.store, &admin.id).await;
-        let token = create_test_session(&state, &admin.id, &admin.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &admin.id,
+                email: &admin.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let auth_header = format!("Bearer {token}");
 
         // Create a token
@@ -1037,7 +1091,16 @@ mod tests {
         let org = create_test_org(&state.store, "example.com").await;
         let admin = create_test_user_in_org(&state.store, "admin@example.com", &org.id, true).await;
         let auth_id = create_test_authenticator(&state.store, &admin.id).await;
-        let token = create_test_session(&state, &admin.id, &admin.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &admin.id,
+                email: &admin.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let auth_header = format!("Bearer {token}");
 
         // Create a token to delete
@@ -1077,7 +1140,16 @@ mod tests {
         let org = create_test_org(&state.store, "example.com").await;
         let admin = create_test_user_in_org(&state.store, "admin@example.com", &org.id, true).await;
         let auth_id = create_test_authenticator(&state.store, &admin.id).await;
-        let token = create_test_session(&state, &admin.id, &admin.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &admin.id,
+                email: &admin.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let auth_header = format!("Bearer {token}");
 
         let nonexistent_id = uuid::Uuid::now_v7();

--- a/crates/vouch-server/src/handlers/applications/api/tests.rs
+++ b/crates/vouch-server/src/handlers/applications/api/tests.rs
@@ -17,7 +17,16 @@ use crate::test_utils::*;
 async fn setup_user_with_app(state: &crate::AppState, email: &str) -> (String, String) {
     let user = create_test_user(&state.store, email).await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
     (client.app_id, token)
 }
@@ -179,7 +188,16 @@ async fn test_add_secret_wrong_owner() {
     // Authenticate as user2
     let user2 = create_test_user(&state.store, "other@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user2.id).await;
-    let token2 = create_test_session(&state, &user2.id, &user2.email, &auth_id).await;
+    let token2 = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user2.id,
+            email: &user2.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token2);
 
     let (status, _) = http_post_json(
@@ -197,7 +215,16 @@ async fn test_add_secret_nonexistent_app() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "noapp@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
 
     let bogus_id = uuid::Uuid::now_v7();
@@ -216,7 +243,16 @@ async fn test_add_secret_invalid_app_id() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "badid@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
 
     let (status, _) = http_post_json(
@@ -238,7 +274,16 @@ async fn test_add_secret_invalid_app_id() {
 async fn authed_user(state: &crate::AppState, email: &str) -> String {
     let user = create_test_user(&state.store, email).await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     bearer(&token)
 }
 
@@ -444,7 +489,16 @@ async fn test_list_secrets_wrong_owner() {
 
     let user2 = create_test_user(&state.store, "other2@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user2.id).await;
-    let token2 = create_test_session(&state, &user2.id, &user2.email, &auth_id).await;
+    let token2 = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user2.id,
+            email: &user2.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token2);
 
     let (status, _) = http_get(
@@ -567,7 +621,16 @@ async fn test_delete_secret_wrong_app() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "wrong-app@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
 
     // Create two apps
@@ -606,7 +669,16 @@ async fn test_delete_secret_wrong_owner() {
 
     let user2 = create_test_user(&state.store, "del-owner2@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user2.id).await;
-    let token2 = create_test_session(&state, &user2.id, &user2.email, &auth_id).await;
+    let token2 = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user2.id,
+            email: &user2.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token2);
 
     // Get secret ID from app (via db directly, since API would 404)
@@ -771,7 +843,16 @@ async fn test_list_applications_empty() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "list-empty@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
 
     let (status, body) = http_get(&app, "/api/v1/applications", &[("Authorization", &auth)]).await;
@@ -786,7 +867,16 @@ async fn test_list_applications_returns_created() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "list-created@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
 
     let client = create_test_oauth_client(&state.store, &user.id).await;
@@ -818,7 +908,16 @@ async fn test_create_application_succeeds() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "create-ok@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
 
     let (status, body) = http_post_json(
@@ -841,7 +940,16 @@ async fn test_create_application_returns_client_credentials() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "create-creds@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
 
     let (status, body) = http_post_json(
@@ -880,7 +988,16 @@ async fn test_create_spa_application_is_public_client() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "spa-public@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
 
     let (status, body) = http_post_json(
@@ -921,7 +1038,16 @@ async fn test_create_native_application_is_public_client() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "native-public@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
 
     let (status, body) = http_post_json(
@@ -958,7 +1084,16 @@ async fn test_create_web_application_is_confidential_client() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "web-confidential@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
 
     let (status, body) = http_post_json(
@@ -1004,7 +1139,16 @@ async fn test_create_application_rejects_deactivated_user() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "deactivated-create@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
 
     crate::db::update_user_active_status(&state.store, &user.id, false)
@@ -1030,7 +1174,16 @@ async fn test_create_application_rejects_empty_name() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "create-emptyname@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
 
     let (status, body) = http_post_json(
@@ -1051,7 +1204,16 @@ async fn test_create_application_rejects_http_redirect_uri() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "create-http-uri@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
 
     // http:// redirect URIs are not valid for web apps — only https:// or custom schemes
@@ -1077,7 +1239,16 @@ async fn test_get_application_by_id() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "get-app@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
@@ -1098,7 +1269,16 @@ async fn test_get_application_not_found() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "get-notfound@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
     let bogus_id = uuid::Uuid::now_v7();
 
@@ -1137,7 +1317,16 @@ async fn test_update_application_name() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "update-name@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
@@ -1164,7 +1353,16 @@ async fn test_update_application_rejects_deactivated_user() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "deactivated-update@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
@@ -1199,7 +1397,16 @@ async fn test_delete_application_succeeds() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "delete-ok@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
@@ -1226,7 +1433,16 @@ async fn test_delete_application_not_found() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "delete-notfound@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
     let bogus_id = uuid::Uuid::now_v7();
 
@@ -1282,7 +1498,16 @@ async fn test_revoke_tokens_not_found() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "revoke-notfound@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
     let bogus_id = uuid::Uuid::now_v7();
 
@@ -1317,18 +1542,30 @@ async fn test_revoke_tokens_clears_m2m_sessions() {
     // Owner user + their application
     let user = create_test_user(&state.store, "revoke-m2m@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let owner_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let owner_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&owner_token);
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
     // Mint a client_credentials session for the OAuth client.
     // Per RFC 9068 §2.2 the session's user_id is the client's client_id.
-    create_test_session_for_client(
+    create_test_session_with(
         &state,
-        &client.client_id,
-        &format!("{}@clients", client.client_id),
-        &auth_id,
-        &client.client_id,
+        TestSessionSpec {
+            user_id: &client.client_id,
+            email: &format!("{}@clients", client.client_id),
+            auth_id: Some(&auth_id),
+            client_id: Some(&client.client_id),
+            ..Default::default()
+        },
     )
     .await;
 
@@ -1363,7 +1600,16 @@ async fn test_update_application_should_reject_empty_redirect_uris() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "update-no-uris@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
@@ -1393,7 +1639,16 @@ async fn test_update_application_rejects_fapi_downgrade() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "fapi-downgrade@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
 
     let client = create_test_client(
@@ -1450,7 +1705,16 @@ async fn test_update_application_preserves_jwks_when_fapi_profile_absent() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "pkjwt-preserve@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
 
     let client = create_test_client(
@@ -1506,7 +1770,16 @@ async fn test_update_application_rejects_clearing_jwks_for_pkjwt_client() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "pkjwt-clear@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
 
     let client = create_test_client(
@@ -1558,7 +1831,16 @@ async fn test_update_application_should_reject_empty_name() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "update-empty-name@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
@@ -1584,7 +1866,16 @@ async fn test_update_application_absent_name_keeps_existing() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "update-no-name@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
@@ -1617,7 +1908,16 @@ async fn test_create_application_with_post_logout_redirect_uris() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "post-logout-create@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
 
     let payload = serde_json::json!({
@@ -1688,7 +1988,16 @@ async fn test_create_application_rejects_invalid_post_logout_redirect_uri() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "post-logout-invalid-create@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
 
     let payload = serde_json::json!({
@@ -1724,7 +2033,16 @@ async fn test_update_application_post_logout_redirect_uris_roundtrip() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "post-logout-update@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
@@ -1770,7 +2088,16 @@ async fn test_create_application_rejects_invalid_access_scope() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "bad-scope@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
 
     let (status, body) = http_post_json(
@@ -1814,7 +2141,16 @@ async fn test_create_application_rejects_invalid_fapi_profile() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "bad-fapi@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
 
     let (status, body) = http_post_json(
@@ -1856,7 +2192,16 @@ async fn test_create_application_accepts_valid_access_scope() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "good-scope@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
 
     let (status, body) = http_post_json(
@@ -1877,7 +2222,16 @@ async fn test_create_application_defaults_access_scope_to_personal() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "default-scope@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
 
     let (status, body) = http_post_json(
@@ -1898,7 +2252,16 @@ async fn test_update_application_rejects_invalid_access_scope() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "upd-bad-scope@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
@@ -1924,7 +2287,16 @@ async fn test_update_application_rejects_invalid_fapi_profile() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "upd-bad-fapi@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
@@ -2008,7 +2380,16 @@ async fn test_update_application_accepts_valid_access_scope() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "upd-good-scope@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
@@ -2034,7 +2415,16 @@ async fn test_update_application_absent_access_scope_preserves_existing() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "upd-keep-scope@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = bearer(&token);
 
     // Create with public scope, then PATCH without access_scope.

--- a/crates/vouch-server/src/handlers/applications/mod.rs
+++ b/crates/vouch-server/src/handlers/applications/mod.rs
@@ -179,7 +179,16 @@ mod tests {
         let state = test_app_state().await;
         let user = create_test_user(&state.store, "deactivated-web@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let jar = CookieJar::new().add(Cookie::new(vouch_common::SESSION_COOKIE_NAME, token));
 
         let auth = super::extract_auth_from_cookie(&state, &jar).await;

--- a/crates/vouch-server/src/handlers/applications/web.rs
+++ b/crates/vouch-server/src/handlers/applications/web.rs
@@ -827,7 +827,16 @@ mod tests {
         let (app, state) = test_app().await;
         let user = create_test_user(&state.store, "web-update-empty-name@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let session_token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let client = create_test_oauth_client(&state.store, &user.id).await;
 
         // Submit the web update form with an empty name.
@@ -875,7 +884,16 @@ mod tests {
         let (app, state) = test_app().await;
         let user = create_test_user(&state.store, "web-update-empty-uris@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let session_token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let client = create_test_oauth_client(&state.store, &user.id).await;
 
         // Submit with a valid name but blank redirect_uris textarea.
@@ -925,7 +943,16 @@ mod tests {
         let (app, state) = test_app().await;
         let user = create_test_user(&state.store, "web-update-fapi-exit@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let session_token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let client = create_test_client(
             &state.store,
             &user.id,

--- a/crates/vouch-server/src/handlers/auth.rs
+++ b/crates/vouch-server/src/handlers/auth.rs
@@ -200,7 +200,16 @@ mod tests {
         let (app, state) = test_app().await;
         let user = create_test_user(&state.store, "valid@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let auth_header = format!("Bearer {token}");
         let (status, body) =
@@ -220,7 +229,16 @@ mod tests {
         let (app, state) = test_app().await;
         let user = create_test_user(&state.store, "email-check@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let auth_header = format!("Bearer {token}");
         let (status, body) =

--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -918,8 +918,16 @@ mod tests {
         let user = crate::test_utils::create_test_user(&state.store, "reauth@example.com").await;
         let auth_id = crate::test_utils::create_test_authenticator(&state.store, &user.id).await;
         let client = crate::test_utils::create_test_oauth_client(&state.store, &user.id).await;
-        let session_token =
-            crate::test_utils::create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let session_token = crate::test_utils::create_test_session_with(
+            &state,
+            crate::test_utils::TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         // Create a pending auth with prompt=login
         let pending_id = crate::db::create_pending_oauth_authorization(
@@ -971,8 +979,16 @@ mod tests {
         let user = crate::test_utils::create_test_user(&state.store, "no-reauth@example.com").await;
         let auth_id = crate::test_utils::create_test_authenticator(&state.store, &user.id).await;
         let client = crate::test_utils::create_test_oauth_client(&state.store, &user.id).await;
-        let session_token =
-            crate::test_utils::create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let session_token = crate::test_utils::create_test_session_with(
+            &state,
+            crate::test_utils::TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         // Create a pending auth WITHOUT prompt=login
         let pending_id = crate::db::create_pending_oauth_authorization(
@@ -1036,8 +1052,16 @@ mod tests {
         let user =
             crate::test_utils::create_test_user(&state.store, "cli-assert@example.com").await;
         let auth_id = crate::test_utils::create_test_authenticator(&state.store, &user.id).await;
-        let session_token =
-            crate::test_utils::create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let session_token = crate::test_utils::create_test_session_with(
+            &state,
+            crate::test_utils::TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let expires: jiff::Timestamp = "2099-12-31T23:59:59Z".parse().expect("valid timestamp");
         let device_auth_id = crate::db::create_device_auth_request(

--- a/crates/vouch-server/src/handlers/credentials.rs
+++ b/crates/vouch-server/src/handlers/credentials.rs
@@ -1095,7 +1095,16 @@ mod tests {
 
         let user = create_test_user(&state.store, "user@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let (status, body) = http_get(
             &app,
@@ -1128,7 +1137,16 @@ mod tests {
 
         let user = create_test_user(&state.store, "norsa@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let (status, body) = http_get(
             &app,
@@ -1154,11 +1172,15 @@ mod tests {
 
         let user = create_test_user(&state.store, "bootstrap@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_bootstrap_session_with_authenticator(
+        let token = create_test_session_with(
             &state,
-            &user.id,
-            &user.email,
-            &auth_id,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                verification: TestVerification::NotVerified,
+                ..Default::default()
+            },
         )
         .await;
 
@@ -1182,7 +1204,16 @@ mod tests {
         let (app, state) = test_app().await;
 
         let user = create_test_user(&state.store, "newuser@example.com").await;
-        let token = create_test_bootstrap_session(&state, &user.id, &user.email).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                verification: TestVerification::NotVerified,
+                ..Default::default()
+            },
+        )
+        .await;
 
         let (status, body) = http_get(
             &app,
@@ -1206,7 +1237,16 @@ mod tests {
         let user =
             create_test_user_in_org(&state.store, "orguser@example.com", &org.id, false).await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let (status, body) = http_get(
             &app,
@@ -1241,7 +1281,16 @@ mod tests {
 
         let user = create_test_user(&state.store, "pinned@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let (status, body) = http_get(
             &app,
@@ -1269,7 +1318,16 @@ mod tests {
 
         let user = create_test_user(&state.store, "unpinned@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let (status, body) = http_get(
             &app,
@@ -1295,7 +1353,16 @@ mod tests {
 
         let user = create_test_user(&state.store, "badarn@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let (status, body) = http_get(
             &app,
@@ -1317,7 +1384,16 @@ mod tests {
 
         let user = create_test_user(&state.store, "userarn@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let (status, body) = http_get(
             &app,
@@ -1365,7 +1441,16 @@ mod tests {
 
         let user = create_test_user(&state.store, "ghstatus@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let (status, body) = http_get(
             &app,
@@ -1385,7 +1470,16 @@ mod tests {
 
         let user = create_test_user(&state.store, "ghnoorg@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let (status, body) = http_get(
             &app,
@@ -1414,7 +1508,16 @@ mod tests {
 
         let user = create_test_user(&state.store, "ghtoken@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let body = serde_json::json!({ "repositories": [] });
         let (status, resp_body) = http_post_json(
@@ -1457,7 +1560,16 @@ mod tests {
 
         let user = create_test_user(&state.store, "deactivated-aws@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         // Deactivate the user
         crate::db::update_user_active_status(&state.store, &user.id, false)
@@ -1483,7 +1595,16 @@ mod tests {
 
         let user = create_test_user(&state.store, "deactivated-gh@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         crate::db::update_user_active_status(&state.store, &user.id, false)
             .await

--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -1532,7 +1532,16 @@ mod tests {
 
         // Create a pre-existing OAuth session for the user. Its survival
         // after a race-loser AlreadyConsumed is the regression we test for.
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let token_hash = {
             use aws_lc_rs::digest::{self, SHA256};
             URL_SAFE_NO_PAD.encode(digest::digest(&SHA256, token.as_bytes()).as_ref())

--- a/crates/vouch-server/src/handlers/enroll/tests.rs
+++ b/crates/vouch-server/src/handlers/enroll/tests.rs
@@ -8,8 +8,8 @@
 
 use super::*;
 use crate::test_utils::{
-    create_test_authenticator, create_test_session, create_test_user, http_delete_full,
-    http_get_full, http_post_json, test_app, test_app_state,
+    TestSessionSpec, create_test_authenticator, create_test_session_with, create_test_user,
+    http_delete_full, http_get_full, http_post_json, test_app, test_app_state,
 };
 use axum::http::StatusCode;
 use base64::Engine;
@@ -1405,7 +1405,16 @@ async fn test_browser_register_start_refuses_deactivated_user() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "deactivated-start@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     crate::db::update_user_active_status(&state.store, &user.id, false)
         .await

--- a/crates/vouch-server/src/handlers/github.rs
+++ b/crates/vouch-server/src/handlers/github.rs
@@ -1039,7 +1039,16 @@ mod tests {
         let org = create_test_org(&state.store, domain).await;
         let user = create_test_user_in_org(&state.store, email, &org.id, true).await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let session_token = create_test_session(state, &user.id, email, &auth_id).await;
+        let session_token = create_test_session_with(
+            state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let token_hash = crate::crypto::hash_token(&session_token);
         (user.id, org.id, session_token, token_hash)
     }

--- a/crates/vouch-server/src/handlers/keys.rs
+++ b/crates/vouch-server/src/handlers/keys.rs
@@ -555,7 +555,16 @@ mod tests {
         let (app, state) = test_app().await;
         let user = create_test_user(&state.store, "list@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let (status, body) = http_get(
             &app,
@@ -574,7 +583,16 @@ mod tests {
         let (app, state) = test_app().await;
         let user = create_test_user(&state.store, "listkey@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let (status, body) = http_get(
             &app,
@@ -628,7 +646,16 @@ mod tests {
         let (app, state) = test_app().await;
         let user = create_test_user(&state.store, "start@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let (status, body) = http_post_json(
             &app,
@@ -669,7 +696,16 @@ mod tests {
         let (app, state) = test_app().await;
         let user = create_test_user(&state.store, "deactivated-register@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         crate::db::update_user_active_status(&state.store, &user.id, false)
             .await
@@ -726,7 +762,16 @@ mod tests {
         let (app, state) = test_app().await;
         let user = create_test_user(&state.store, email).await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let (state_jwt, exp) = make_reg_state(&state, &user).await;
 
         let body = serde_json::json!({
@@ -822,7 +867,16 @@ mod tests {
         // request must be signed (RFC 9421); the harness signs it transparently.
         let user = create_test_user(&state.store, "invalid-state@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         // All Raw fields deserialize as Vec<u8> (JSON arrays), and their length
         // bounds are applied there, so the binary fields must be in range for
@@ -861,7 +915,16 @@ mod tests {
         // request must be signed (RFC 9421); the harness signs it transparently.
         let user = create_test_user(&state.store, "replay-session@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         // Build a valid RegistrationState JWT with a far-future expiry.
         let signer = &state.state_signer;
@@ -926,7 +989,16 @@ mod tests {
         let (app, state) = test_app().await;
         let user = create_test_user(&state.store, "deactivated-complete@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let user_uuid = Uuid::parse_str(&user.id).expect("user id is a uuid");
 
         // Build a valid RegistrationState JWT for an (initially) active user.
@@ -988,7 +1060,16 @@ mod tests {
         let (app, state) = test_app().await;
         let user = create_test_user(&state.store, "active-complete@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         let user_uuid = Uuid::parse_str(&user.id).expect("user id is a uuid");
 
         let signer = &state.state_signer;
@@ -1047,7 +1128,16 @@ mod tests {
         let (app, state) = test_app().await;
         let user = create_test_user(&state.store, "rename@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let (status, _body) = http_request(
             &app,
@@ -1090,7 +1180,16 @@ mod tests {
         let (app, state) = test_app().await;
         let user = create_test_user(&state.store, "renamebaduuid@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let (status, body) = http_request(
             &app,
@@ -1114,7 +1213,16 @@ mod tests {
         let (app, state) = test_app().await;
         let user = create_test_user(&state.store, "renameempty@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let (status, body) = http_request(
             &app,
@@ -1138,7 +1246,16 @@ mod tests {
         let (app, state) = test_app().await;
         let user = create_test_user(&state.store, "renametoolong@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let long_name = "a".repeat(257);
         let body_str = format!(r#"{{"name":"{long_name}"}}"#);
@@ -1166,7 +1283,16 @@ mod tests {
         let (app, state) = test_app().await;
         let user = create_test_user(&state.store, "renamecjk@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         // 90 CJK characters = 270 UTF-8 bytes: within the 100-character limit
         // the handler and service share, so the rename succeeds end to end.
@@ -1200,7 +1326,16 @@ mod tests {
         let (app, state) = test_app().await;
         let user = create_test_user(&state.store, "renamecjklong@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         // 101 CJK characters = 303 bytes: one character over the cap.
         let name = "名".repeat(101);
@@ -1235,7 +1370,16 @@ mod tests {
         let (app, state) = test_app().await;
         let user = create_test_user(&state.store, "renamemidrange@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let name = "a".repeat(150);
         let body = serde_json::json!({ "name": name }).to_string();
@@ -1279,7 +1423,16 @@ mod tests {
         let (app, state) = test_app().await;
         let user = create_test_user(&state.store, "deletebaduuid@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let (status, body) = http_delete(
             &app,
@@ -1331,9 +1484,17 @@ mod tests {
         let _key_b = create_test_authenticator(&state.store, &user.id).await;
         // The browser's cookie is a bearer token; presenting it over the
         // Authorization header must not buy more than presenting it as a cookie.
-        let token =
-            create_test_bootstrap_session_with_authenticator(&state, &user.id, &user.email, &key_a)
-                .await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&key_a),
+                verification: TestVerification::NotVerified,
+                ..Default::default()
+            },
+        )
+        .await;
 
         let resp = http_delete_full(
             &app,
@@ -1361,8 +1522,19 @@ mod tests {
         let stale = jiff::Timestamp::now()
             .as_second()
             .saturating_sub(key_svc::KEY_DELETE_MAX_AGE_SECS.saturating_mul(10));
-        let token =
-            create_test_session_with_iat(&state, &user.id, &user.email, &key_a, stale).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&key_a),
+                verification: TestVerification::Verified {
+                    auth_time: Some(stale),
+                },
+                ..Default::default()
+            },
+        )
+        .await;
 
         let resp = http_delete_full(
             &app,
@@ -1386,11 +1558,17 @@ mod tests {
         let user = create_test_user(&state.store, "unverified-fresh@example.com").await;
         let key_a = create_test_authenticator(&state.store, &user.id).await;
         let _key_b = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session_unverified_with_fresh_auth_time(
+        let token = create_test_session_with(
             &state,
-            &user.id,
-            &user.email,
-            &key_a,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&key_a),
+                verification: TestVerification::NotVerifiedForgedAuthTime {
+                    auth_time: jiff::Timestamp::now().as_second(),
+                },
+                ..Default::default()
+            },
         )
         .await;
 
@@ -1418,7 +1596,16 @@ mod tests {
         let user = create_test_user(&state.store, "fresh-delete@example.com").await;
         let key_a = create_test_authenticator(&state.store, &user.id).await;
         let key_b = create_test_authenticator(&state.store, &user.id).await;
-        let token = create_test_session(&state, &user.id, &user.email, &key_a).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&key_a),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let (status, body) = http_delete(
             &app,

--- a/crates/vouch-server/src/handlers/oidc/logout.rs
+++ b/crates/vouch-server/src/handlers/oidc/logout.rs
@@ -516,9 +516,9 @@ mod tests {
     use super::*;
     use crate::services::oidc::token::IdTokenClaims;
     use crate::test_utils::{
-        TestClientSpec, create_test_authenticator, create_test_client, create_test_session,
-        create_test_user, http_get, http_post_form, test_app, test_app_state,
-        test_app_state_with_rsa_key,
+        TestClientSpec, TestSessionSpec, create_test_authenticator, create_test_client,
+        create_test_session_with, create_test_user, http_get, http_post_form, test_app,
+        test_app_state, test_app_state_with_rsa_key,
     };
 
     /// Build a minimal `IdTokenClaims` for signing in tests.
@@ -698,7 +698,16 @@ mod tests {
         // Create a user + session.
         let user = create_test_user(&state.store, "logout-redirect@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let session_token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         // Create an OAuth client with a registered post_logout_redirect_uri.
         let post_logout_uri = "https://rp.example.com/logged-out";
@@ -745,7 +754,16 @@ mod tests {
 
         let user = create_test_user(&state.store, "logout-inactive@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
-        let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+        let session_token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let post_logout_uri = "https://rp.example.com/logged-out";
         let client = create_test_client(

--- a/crates/vouch-server/src/handlers/oidc/tests/aud_enforcement.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/aud_enforcement.rs
@@ -20,13 +20,16 @@ async fn test_narrowed_token_accepted_at_named_resource() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let base_url = state.config().base_url.clone();
     let audience = format!("{base_url}/v1/keys");
-    let token = create_test_session_with_audience(
+    let token = create_test_session_with(
         &state,
-        &user.id,
-        &user.email,
-        &auth_id,
-        &base_url,
-        &audience,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            client_id: Some(&base_url),
+            audience: Some(&audience),
+            ..Default::default()
+        },
     )
     .await;
 
@@ -60,13 +63,16 @@ async fn test_narrowed_token_rejected_at_other_resource() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let base_url = state.config().base_url.clone();
     let audience = format!("{base_url}/api/v1/applications");
-    let token = create_test_session_with_audience(
+    let token = create_test_session_with(
         &state,
-        &user.id,
-        &user.email,
-        &auth_id,
-        &base_url,
-        &audience,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            client_id: Some(&base_url),
+            audience: Some(&audience),
+            ..Default::default()
+        },
     )
     .await;
 
@@ -119,13 +125,16 @@ async fn test_narrowed_token_covers_subpath_not_sibling() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let base_url = state.config().base_url.clone();
     let audience = format!("{base_url}/v1/keys");
-    let token = create_test_session_with_audience(
+    let token = create_test_session_with(
         &state,
-        &user.id,
-        &user.email,
-        &auth_id,
-        &base_url,
-        &audience,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            client_id: Some(&base_url),
+            audience: Some(&audience),
+            ..Default::default()
+        },
     )
     .await;
     let auth = format!("Bearer {token}");
@@ -171,13 +180,16 @@ async fn test_root_scoped_audience_accepted_everywhere() {
     // Trailing slash: differs from client_id byte-wise (so the enforcement
     // path runs) but still names the deployment root.
     let audience = format!("{base_url}/");
-    let token = create_test_session_with_audience(
+    let token = create_test_session_with(
         &state,
-        &user.id,
-        &user.email,
-        &auth_id,
-        &base_url,
-        &audience,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            client_id: Some(&base_url),
+            audience: Some(&audience),
+            ..Default::default()
+        },
     )
     .await;
     let auth = format!("Bearer {token}");
@@ -206,13 +218,16 @@ async fn test_external_audience_rejected_at_resource_endpoints() {
     let user = create_test_user(&state.store, "aud-external@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let base_url = state.config().base_url.clone();
-    let token = create_test_session_with_audience(
+    let token = create_test_session_with(
         &state,
-        &user.id,
-        &user.email,
-        &auth_id,
-        &base_url,
-        "https://api.example.com",
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            client_id: Some(&base_url),
+            audience: Some("https://api.example.com"),
+            ..Default::default()
+        },
     )
     .await;
     let auth = format!("Bearer {token}");
@@ -240,13 +255,16 @@ async fn test_logical_audience_rejected_at_resource_endpoints() {
     let user = create_test_user(&state.store, "aud-logical@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let base_url = state.config().base_url.clone();
-    let token = create_test_session_with_audience(
+    let token = create_test_session_with(
         &state,
-        &user.id,
-        &user.email,
-        &auth_id,
-        &base_url,
-        "kubernetes",
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            client_id: Some(&base_url),
+            audience: Some("kubernetes"),
+            ..Default::default()
+        },
     )
     .await;
 
@@ -274,13 +292,16 @@ async fn test_external_audience_exempt_at_userinfo_and_introspect() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
     // Bind to the registered client so the RFC 7662 cross-client check passes.
-    let token = create_test_session_with_audience(
+    let token = create_test_session_with(
         &state,
-        &user.id,
-        &user.email,
-        &auth_id,
-        &client.client_id,
-        "https://api.example.com",
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            client_id: Some(&client.client_id),
+            audience: Some("https://api.example.com"),
+            ..Default::default()
+        },
     )
     .await;
 
@@ -323,7 +344,16 @@ async fn test_default_audience_token_accepted_everywhere() {
 
     let user = create_test_user(&state.store, "aud-default@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = format!("Bearer {token}");
 
     let (status, body) = http_get(&app, "/v1/keys", &[("Authorization", &auth)]).await;
@@ -407,13 +437,16 @@ async fn test_cookie_only_path_rejects_narrowed_token() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let base_url = state.config().base_url.clone();
 
-    let narrowed = create_test_session_with_audience(
+    let narrowed = create_test_session_with(
         &state,
-        &user.id,
-        &user.email,
-        &auth_id,
-        &base_url,
-        &format!("{base_url}/v1/keys"),
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            client_id: Some(&base_url),
+            audience: Some(&format!("{base_url}/v1/keys")),
+            ..Default::default()
+        },
     )
     .await;
     let jar = CookieJar::new().add(Cookie::new(vouch_common::SESSION_COOKIE_NAME, narrowed));
@@ -423,13 +456,16 @@ async fn test_cookie_only_path_rejects_narrowed_token() {
         "narrowed token must be rejected on cookie-only paths"
     );
 
-    let root_scoped = create_test_session_with_audience(
+    let root_scoped = create_test_session_with(
         &state,
-        &user.id,
-        &user.email,
-        &auth_id,
-        &base_url,
-        &format!("{base_url}/"),
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            client_id: Some(&base_url),
+            audience: Some(&format!("{base_url}/")),
+            ..Default::default()
+        },
     )
     .await;
     let jar = CookieJar::new().add(Cookie::new(vouch_common::SESSION_COOKIE_NAME, root_scoped));

--- a/crates/vouch-server/src/handlers/oidc/tests/auth_flows.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/auth_flows.rs
@@ -23,7 +23,16 @@ async fn test_session_bound_to_authenticator() {
     let auth_a = create_test_authenticator(&state.store, &user.id).await;
     let auth_b = create_test_authenticator(&state.store, &user.id).await;
 
-    let token = create_test_session(&state, &user.id, &user.email, &auth_a).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_a),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let (status, body) = http_get(
         &app,
@@ -63,7 +72,16 @@ async fn test_session_valid_after_registering_new_key() {
     let user = create_test_user(&state.store, "bind-a2@example.com").await;
     let auth_a = create_test_authenticator(&state.store, &user.id).await;
 
-    let token = create_test_session(&state, &user.id, &user.email, &auth_a).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_a),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Verify session works
     let (status, _) = http_get(
@@ -104,8 +122,26 @@ async fn test_multiple_sessions_different_keys() {
     let auth_a = create_test_authenticator(&state.store, &user.id).await;
     let auth_b = create_test_authenticator(&state.store, &user.id).await;
 
-    let token_a = create_test_session(&state, &user.id, &user.email, &auth_a).await;
-    let token_b = create_test_session(&state, &user.id, &user.email, &auth_b).await;
+    let token_a = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_a),
+            ..Default::default()
+        },
+    )
+    .await;
+    let token_b = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_b),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let (status_a, _) = http_get(
         &app,
@@ -138,7 +174,16 @@ async fn test_delete_non_session_key_preserves_session() {
     let auth_a = create_test_authenticator(&state.store, &user.id).await;
     let auth_b = create_test_authenticator(&state.store, &user.id).await;
 
-    let token = create_test_session(&state, &user.id, &user.email, &auth_a).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_a),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Delete Key B (not the session key)
     let (status, body) = http_delete(
@@ -186,7 +231,16 @@ async fn test_delete_session_key_invalidates_session() {
     let auth_a = create_test_authenticator(&state.store, &user.id).await;
     let _auth_b = create_test_authenticator(&state.store, &user.id).await;
 
-    let token = create_test_session(&state, &user.id, &user.email, &auth_a).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_a),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Delete Key A (the session key) — this should succeed for the delete
     // itself but cascade-delete the session
@@ -233,10 +287,37 @@ async fn test_delete_key_revokes_all_sessions_for_that_key() {
     let auth_b = create_test_authenticator(&state.store, &user.id).await;
 
     // Create two sessions bound to Key A
-    let token_a1 = create_test_session(&state, &user.id, &user.email, &auth_a).await;
-    let token_a2 = create_test_session(&state, &user.id, &user.email, &auth_a).await;
+    let token_a1 = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_a),
+            ..Default::default()
+        },
+    )
+    .await;
+    let token_a2 = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_a),
+            ..Default::default()
+        },
+    )
+    .await;
     // One session bound to Key B (the "admin" session that performs the delete)
-    let token_b = create_test_session(&state, &user.id, &user.email, &auth_b).await;
+    let token_b = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_b),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Delete Key A using session bound to Key B
     let (status, body) = http_delete(
@@ -299,7 +380,16 @@ async fn test_cannot_delete_last_key() {
     let user = create_test_user(&state.store, "del-b4@example.com").await;
     let auth_a = create_test_authenticator(&state.store, &user.id).await;
 
-    let token = create_test_session(&state, &user.id, &user.email, &auth_a).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_a),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let (status, body) = http_delete(
         &app,
@@ -331,11 +421,47 @@ async fn test_delete_returns_revoked_session_count() {
     let auth_b = create_test_authenticator(&state.store, &user.id).await;
 
     // Create 3 sessions bound to Key A
-    let _t1 = create_test_session(&state, &user.id, &user.email, &auth_a).await;
-    let _t2 = create_test_session(&state, &user.id, &user.email, &auth_a).await;
-    let _t3 = create_test_session(&state, &user.id, &user.email, &auth_a).await;
+    let _t1 = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_a),
+            ..Default::default()
+        },
+    )
+    .await;
+    let _t2 = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_a),
+            ..Default::default()
+        },
+    )
+    .await;
+    let _t3 = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_a),
+            ..Default::default()
+        },
+    )
+    .await;
     // Use Key B to perform the delete
-    let token_b = create_test_session(&state, &user.id, &user.email, &auth_b).await;
+    let token_b = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_b),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let (status, body) = http_delete(
         &app,
@@ -368,8 +494,19 @@ async fn test_stale_session_cannot_delete_key() {
     let auth_b = create_test_authenticator(&state.store, &user.id).await;
 
     let stale_iat = jiff::Timestamp::now().as_second() - 600;
-    let token =
-        create_test_session_with_iat(&state, &user.id, &user.email, &auth_a, stale_iat).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_a),
+            verification: TestVerification::Verified {
+                auth_time: Some(stale_iat),
+            },
+            ..Default::default()
+        },
+    )
+    .await;
 
     let response = http_delete_full(
         &app,
@@ -410,7 +547,16 @@ async fn test_fresh_session_can_delete_key() {
     let auth_a = create_test_authenticator(&state.store, &user.id).await;
     let auth_b = create_test_authenticator(&state.store, &user.id).await;
 
-    let token = create_test_session(&state, &user.id, &user.email, &auth_a).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_a),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let (status, body) = http_delete(
         &app,
@@ -438,8 +584,19 @@ async fn test_boundary_exactly_at_max_age() {
     let auth_b = create_test_authenticator(&state.store, &user.id).await;
 
     let boundary_iat = jiff::Timestamp::now().as_second() - 59;
-    let token =
-        create_test_session_with_iat(&state, &user.id, &user.email, &auth_a, boundary_iat).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_a),
+            verification: TestVerification::Verified {
+                auth_time: Some(boundary_iat),
+            },
+            ..Default::default()
+        },
+    )
+    .await;
 
     let (status, body) = http_delete(
         &app,
@@ -464,8 +621,19 @@ async fn test_one_second_over_max_age() {
     let auth_b = create_test_authenticator(&state.store, &user.id).await;
 
     let over_iat = jiff::Timestamp::now().as_second() - 61;
-    let token =
-        create_test_session_with_iat(&state, &user.id, &user.email, &auth_a, over_iat).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_a),
+            verification: TestVerification::Verified {
+                auth_time: Some(over_iat),
+            },
+            ..Default::default()
+        },
+    )
+    .await;
 
     let response = http_delete_full(
         &app,
@@ -563,7 +731,16 @@ async fn test_revoke_kills_all_user_sessions() {
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
     let (token_a, _) = issue_oauth_access_token(&app, &state, &user, &auth_a, &client).await;
-    let token_b = create_test_session(&state, &user.id, &user.email, &auth_b).await;
+    let token_b = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_b),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Revoke token_a — should kill ALL sessions for the user
     let auth_header = client.basic_auth_header();
@@ -615,7 +792,16 @@ async fn test_register_then_delete_original_key() {
     let user = create_test_user(&state.store, "cross-e1@example.com").await;
     let auth_a = create_test_authenticator(&state.store, &user.id).await;
 
-    let token_a = create_test_session(&state, &user.id, &user.email, &auth_a).await;
+    let token_a = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_a),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // "Register" Key B
     let _auth_b = create_test_authenticator(&state.store, &user.id).await;
@@ -651,7 +837,16 @@ async fn test_delete_registered_key_preserves_original_session() {
     let user = create_test_user(&state.store, "cross-e2@example.com").await;
     let auth_a = create_test_authenticator(&state.store, &user.id).await;
 
-    let token_a = create_test_session(&state, &user.id, &user.email, &auth_a).await;
+    let token_a = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_a),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // "Register" Key B
     let auth_b = create_test_authenticator(&state.store, &user.id).await;
@@ -688,7 +883,16 @@ async fn test_delete_self_then_login_with_other_key() {
     let auth_a = create_test_authenticator(&state.store, &user.id).await;
     let auth_b = create_test_authenticator(&state.store, &user.id).await;
 
-    let token_a = create_test_session(&state, &user.id, &user.email, &auth_a).await;
+    let token_a = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_a),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Delete Key A (self-delete)
     let (status, _) = http_delete(
@@ -713,7 +917,16 @@ async fn test_delete_self_then_login_with_other_key() {
     );
 
     // Login with Key B
-    let token_b = create_test_session(&state, &user.id, &user.email, &auth_b).await;
+    let token_b = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_b),
+            ..Default::default()
+        },
+    )
+    .await;
     let (status, body) = http_get(
         &app,
         "/v1/keys",
@@ -742,7 +955,16 @@ async fn test_full_lifecycle() {
 
     let user = create_test_user(&state.store, "cross-e5@example.com").await;
     let auth_a = create_test_authenticator(&state.store, &user.id).await;
-    let token_a = create_test_session(&state, &user.id, &user.email, &auth_a).await;
+    let token_a = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_a),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Step 2: 1 key
     let (status, body) = http_get(
@@ -788,7 +1010,16 @@ async fn test_full_lifecycle() {
     assert_eq!(status, StatusCode::UNAUTHORIZED);
 
     // Step 7: New session with Key B
-    let token_b = create_test_session(&state, &user.id, &user.email, &auth_b).await;
+    let token_b = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_b),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Step 8: Only Key B remains
     let (status, body) = http_get(
@@ -821,7 +1052,16 @@ async fn test_token_revocation_vs_key_deletion() {
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
     let (token_a1, _) = issue_oauth_access_token(&app, &state, &user, &auth_a, &client).await;
-    let token_a2 = create_test_session(&state, &user.id, &user.email, &auth_a).await;
+    let token_a2 = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_a),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Revoke token_a1 — kills ALL sessions for the user
     let auth_header = client.basic_auth_header();
@@ -861,8 +1101,26 @@ async fn test_token_revocation_vs_key_deletion() {
 
     // Key deletion is a separate mechanism — create fresh sessions and
     // verify key deletion cascades to sessions for that key
-    let token_b = create_test_session(&state, &user.id, &user.email, &auth_b).await;
-    let token_a3 = create_test_session(&state, &user.id, &user.email, &auth_a).await;
+    let token_b = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_b),
+            ..Default::default()
+        },
+    )
+    .await;
+    let token_a3 = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_a),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Delete Key A via session bound to Key B
     let (status, _) = http_delete(
@@ -907,8 +1165,19 @@ async fn test_step_up_recovery() {
 
     // Stale session
     let stale_iat = jiff::Timestamp::now().as_second() - 600;
-    let stale_token =
-        create_test_session_with_iat(&state, &user.id, &user.email, &auth_a, stale_iat).await;
+    let stale_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_a),
+            verification: TestVerification::Verified {
+                auth_time: Some(stale_iat),
+            },
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Delete fails due to step-up
     let response = http_delete_full(
@@ -924,7 +1193,16 @@ async fn test_step_up_recovery() {
     );
 
     // Fresh re-login
-    let fresh_token = create_test_session(&state, &user.id, &user.email, &auth_a).await;
+    let fresh_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_a),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Delete now succeeds
     let (status, body) = http_delete(

--- a/crates/vouch-server/src/handlers/oidc/tests/e2e.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/e2e.rs
@@ -76,7 +76,16 @@ async fn test_oauth_token_works_at_management_endpoints() {
 
     let user = create_test_user(&state.store, "oauth-mgmt@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Call key listing endpoint with OAuth access token (should succeed)
     let (status, _body) = http_get(
@@ -215,10 +224,10 @@ async fn test_access_token_optional_scope_field() {
 // ========================================================================
 
 #[tokio::test]
-async fn test_create_test_session_for_client_produces_client_bound_token() {
-    // Verify the new create_test_session_for_client helper creates a token
-    // whose client_id claim matches the given client_id, not the server base_url.
-    // This is critical for introspection cross-client tests.
+async fn test_session_spec_client_id_produces_client_bound_token() {
+    // A `TestSessionSpec` naming a `client_id` must produce a token whose
+    // `client_id` claim is that client, not the server base_url. Introspection
+    // cross-client tests depend on it.
     use crate::services::auth::{DecodedToken, decode_token};
 
     let (_app, state) = test_app().await;
@@ -227,10 +236,17 @@ async fn test_create_test_session_for_client_produces_client_bound_token() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
-    // Use the helper — token's client_id must match client.client_id
-    let token =
-        create_test_session_for_client(&state, &user.id, &user.email, &auth_id, &client.client_id)
-            .await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            client_id: Some(&client.client_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let config = state.config();
     let decoded = decode_token(&token, &state.oidc_key, &config.base_url)
@@ -254,7 +270,16 @@ async fn test_unified_token_hardware_verified_claim_always_set() {
 
     let user = create_test_user(&state.store, "hw-verified@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let config = state.config();
     let decoded = decode_token(&token, &state.oidc_key, &config.base_url)
@@ -270,14 +295,23 @@ async fn test_unified_token_hardware_verified_claim_always_set() {
 #[tokio::test]
 async fn test_unified_token_typ_header_is_at_jwt() {
     // RFC 9068 Section 2.1 + Step 9 migration: the single surviving token type
-    // is ES256 with typ "at+jwt". Verify this is what create_test_session produces.
+    // is ES256 with typ "at+jwt". Verify this is what a default TestSessionSpec produces.
     use crate::crypto::jwt::JwtType;
 
     let (_app, state) = test_app().await;
 
     let user = create_test_user(&state.store, "typ-header@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Peek at the header without full validation
     let header = jsonwebtoken::decode_header(&token).expect("Valid JWT header");
@@ -302,7 +336,16 @@ async fn test_legacy_register_routes_removed() {
 
     let user = create_test_user(&state.store, "legacy-route@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = format!("Bearer {token}");
 
     // Legacy path: /v1/auth/register/start — must not exist
@@ -375,7 +418,16 @@ async fn test_decoded_token_enum_single_variant_destructuring() {
 
     let user = create_test_user(&state.store, "enum-destr@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let config = state.config();
     let decoded =

--- a/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/fapi2.rs
@@ -1477,7 +1477,16 @@ async fn test_fapi2_token_exchange_rejects_unbound_fapi_client() {
 
     let user = create_test_user(&state.store, "fapi2-exchange-unbound@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let subject_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let subject_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let (client, pkcs8_bytes) = create_fapi_test_client(&state.store, &user.id).await;
 
     let assertion = build_client_assertion(
@@ -1516,7 +1525,16 @@ async fn test_fapi2_token_exchange_with_dpop_issues_bound_token() {
 
     let user = create_test_user(&state.store, "fapi2-exchange-dpop@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let subject_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let subject_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let (client, pkcs8_bytes) = create_fapi_test_client(&state.store, &user.id).await;
 
     let (dpop_key, dpop_jwk) = generate_dpop_key_pair();

--- a/crates/vouch-server/src/handlers/oidc/tests/oidc_userinfo.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/oidc_userinfo.rs
@@ -51,7 +51,16 @@ async fn test_userinfo_returns_sub_claim() {
     // Create a test user and OAuth access token session (includes email scope)
     let user = create_test_user(&state.store, "userinfo@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let (status, body) = http_get(
         &app,
@@ -261,7 +270,16 @@ async fn test_userinfo_post_body_access_token() {
 
     let user = create_test_user(&state.store, "postbody@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let (status, body) = http_post_form(
         &app,
@@ -327,7 +345,16 @@ async fn test_userinfo_post_body_with_auth_header() {
 
     let user = create_test_user(&state.store, "authheader@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Authorization header takes precedence; body token is ignored
     let (status, body) = http_post_form(
@@ -357,9 +384,17 @@ async fn test_userinfo_plain_json_when_no_signed_alg_configured() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
     // Token bound to this client (client has no userinfo_signed_response_alg)
-    let token =
-        create_test_session_for_client(&state, &user.id, &user.email, &auth_id, &client.client_id)
-            .await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            client_id: Some(&client.client_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let response = http_request_full(
         &app,
@@ -410,9 +445,17 @@ async fn test_userinfo_signed_jwt_when_es256_configured() {
     let client_id_str = client.client_id;
 
     // Token bound to this client so client_id is populated in the access token
-    let token =
-        create_test_session_for_client(&state, &user.id, &user.email, &auth_id, &client_id_str)
-            .await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            client_id: Some(&client_id_str),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let response = http_request_full(
         &app,
@@ -500,9 +543,17 @@ async fn test_userinfo_rs256_without_rsa_key_returns_500() {
     .await
     .expect("Failed to set RS256 alg");
 
-    let token =
-        create_test_session_for_client(&state, &user.id, &user.email, &auth_id, &client.client_id)
-            .await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            client_id: Some(&client.client_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let response = http_request_full(
         &app,
@@ -561,9 +612,17 @@ async fn test_userinfo_unsupported_signing_algorithm_returns_500() {
     .await
     .expect("Failed to set PS256 alg");
 
-    let token =
-        create_test_session_for_client(&state, &user.id, &user.email, &auth_id, &client.client_id)
-            .await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            client_id: Some(&client.client_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let response = http_request_full(
         &app,
@@ -624,7 +683,16 @@ async fn test_userinfo_rejects_deactivated_user_with_live_session() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "userinfo-deactivated@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     crate::db::update_user_active_status(&state.store, &user.id, false)
         .await

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc6749_authorize.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc6749_authorize.rs
@@ -18,7 +18,16 @@ async fn test_rfc6749_authorize_authenticated_user_redirects_with_code() {
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
     // Create a valid session stored in the DB (cookie-based auth)
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Build a valid PKCE challenge
     let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
@@ -401,8 +410,16 @@ async fn test_rfc6749_authorize_access_denied_personal_scope() {
     // Create a different user who will try to authorize
     let other_user = create_test_user(&state.store, "authorize-other@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &other_user.id).await;
-    let session_token =
-        create_test_session(&state, &other_user.id, &other_user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &other_user.id,
+            email: &other_user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
     let challenge = sha256_base64url(verifier);
@@ -467,7 +484,16 @@ async fn test_rfc8707_authorize_invalid_resource_redirects_with_error() {
     )
     .await;
 
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
     let challenge = sha256_base64url(verifier);
@@ -592,7 +618,16 @@ async fn test_rfc6749_authorize_state_preserved_across_redirect() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
     let challenge = sha256_base64url(verifier);
@@ -702,7 +737,16 @@ async fn test_rfc6749_authorize_code_redirect_to_registered_uri_only() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
     let challenge = sha256_base64url(verifier);
@@ -874,7 +918,16 @@ async fn test_response_mode_form_post_returns_html_form() {
     let user = create_test_user(&state.store, "form-post-test@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
     let challenge = sha256_base64url(verifier);
@@ -1179,7 +1232,16 @@ async fn test_authorize_rejects_unrecognized_response_mode() {
     let user = create_test_user(&state.store, "bad-response-mode@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let challenge = sha256_base64url("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk");
 
@@ -1293,7 +1355,16 @@ async fn test_rfc6749_authorize_session_store_error_returns_server_error() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     state
         .session_cache
         .inject_fault(crate::crypto::hash_token(&session_token));
@@ -1351,7 +1422,16 @@ async fn test_rfc6749_authorize_session_store_error_does_not_redirect_to_login()
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     state
         .session_cache
         .inject_fault(crate::crypto::hash_token(&session_token));
@@ -1427,7 +1507,16 @@ async fn test_rfc6749_authorize_pending_auth_store_error_is_not_auth_failure() {
         .expect("login redirect must carry pending_auth");
 
     // Second leg: the user now has a session, but its lookup faults.
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     state
         .session_cache
         .inject_fault(crate::crypto::hash_token(&session_token));
@@ -1487,9 +1576,17 @@ async fn test_authorize_refuses_bootstrap_session_and_issues_no_code() {
     // its `authenticator_id`.
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
-    let session_token =
-        create_test_bootstrap_session_with_authenticator(&state, &user.id, &user.email, &auth_id)
-            .await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            verification: TestVerification::NotVerified,
+            ..Default::default()
+        },
+    )
+    .await;
 
     let response = http_get_full(
         &app,
@@ -1522,7 +1619,16 @@ async fn test_authorize_still_issues_a_code_for_a_verified_session() {
     let user = create_test_user(&state.store, "authorize-verified@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let response = http_get_full(
         &app,

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc6749_token.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc6749_token.rs
@@ -1033,7 +1033,16 @@ async fn test_rfc6749_code_replay_revocation_is_scoped_to_that_code() {
     let token_b = token_from_code(&app, &client, &code_b).await;
     // A session from a grant with no single-use code. It carries the server's
     // own audience, so `/v1/keys` is its probe.
-    let token_c = create_test_session(&state, &user.id, &user.email, &auth).await;
+    let token_c = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth),
+            ..Default::default()
+        },
+    )
+    .await;
 
     assert_eq!(
         userinfo_status(&app, &token_b).await,

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7515.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7515.rs
@@ -377,7 +377,16 @@ async fn test_rfc7515_crit_header_rejected_on_request_object() {
         },
     )
     .await;
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let critical = serde_json::json!({
         "alg": "ES256",

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7591.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7591.rs
@@ -17,7 +17,16 @@ use super::helpers::*;
 async fn bearer_token(app_state: &std::sync::Arc<crate::AppState>) -> String {
     let user = create_test_user(&app_state.store, "rfc7591-test@example.com").await;
     let auth_id = create_test_authenticator(&app_state.store, &user.id).await;
-    let token = create_test_session(app_state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        app_state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     format!("Bearer {token}")
 }
 
@@ -26,7 +35,16 @@ async fn bearer_token_unique(app_state: &std::sync::Arc<crate::AppState>, suffix
     let email = format!("rfc7591-{suffix}@example.com");
     let user = create_test_user(&app_state.store, &email).await;
     let auth_id = create_test_authenticator(&app_state.store, &user.id).await;
-    let token = create_test_session(app_state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        app_state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     format!("Bearer {token}")
 }
 
@@ -98,7 +116,16 @@ async fn test_rfc7591_register_rejects_expired_token() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "rfc7591-expired@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Delete the session to simulate revocation/expiry
     let token_hash = crate::crypto::hash_token(&token);
@@ -1678,8 +1705,17 @@ async fn test_rfc7591_mtls_bound_token_with_matching_cert_authenticates() {
 
     let cert_der = make_test_cert_der("rfc7591-mtls-match");
     let thumbprint = cert_thumbprint(&cert_der);
-    let token =
-        create_test_session_with_mtls(&state, &user.id, &user.email, &auth_id, &thumbprint).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            binding: TestBinding::Mtls(&thumbprint),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let body = serde_json::json!({
         "redirect_uris": ["https://example.com/callback"],
@@ -1724,8 +1760,17 @@ async fn test_rfc7591_mtls_bound_token_with_wrong_cert_rejected() {
 
     let cert_a_der = make_test_cert_der("rfc7591-bound-a");
     let thumbprint_a = cert_thumbprint(&cert_a_der);
-    let token =
-        create_test_session_with_mtls(&state, &user.id, &user.email, &auth_id, &thumbprint_a).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            binding: TestBinding::Mtls(&thumbprint_a),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Present a different certificate than the one the token is bound to.
     let cert_b_der = make_test_cert_der("rfc7591-presented-b");
@@ -1766,8 +1811,17 @@ async fn test_rfc7591_mtls_bound_token_without_cert_rejected() {
 
     let cert_der = make_test_cert_der("rfc7591-nocert");
     let thumbprint = cert_thumbprint(&cert_der);
-    let token =
-        create_test_session_with_mtls(&state, &user.id, &user.email, &auth_id, &thumbprint).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            binding: TestBinding::Mtls(&thumbprint),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let body = serde_json::json!({
         "redirect_uris": ["https://example.com/callback"],
@@ -1807,7 +1861,16 @@ async fn test_rfc7591_plain_token_with_cert_presented_still_works() {
 
     let user = create_test_user(&state.store, "rfc7591-plain-cert@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let cert_der = make_test_cert_der("rfc7591-plain");
     let body = serde_json::json!({
@@ -1858,7 +1921,17 @@ async fn test_rfc7591_dpop_bound_token_with_replayed_nonce() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let (key, jwk) = generate_dpop_key_pair();
     let jkt = dpop_jkt(&jwk);
-    let token = create_test_session_with_dpop(&state, &user.id, &user.email, &auth_id, &jkt).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            binding: TestBinding::Dpop(&jkt),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Generate and consume a nonce to simulate replay.
     let nonce = crate::db::generate_dpop_nonce(&state.store, 300)
@@ -1949,7 +2022,17 @@ async fn test_rfc7591_dpop_nonce_replay_retry_flow_succeeds() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let (key, jwk) = generate_dpop_key_pair();
     let jkt = dpop_jkt(&jwk);
-    let token = create_test_session_with_dpop(&state, &user.id, &user.email, &auth_id, &jkt).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            binding: TestBinding::Dpop(&jkt),
+            ..Default::default()
+        },
+    )
+    .await;
     let register_uri = format!("{}/oauth/register", state.config().base_url);
     let auth = format!("DPoP {token}");
 

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7662.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7662.rs
@@ -81,7 +81,16 @@ async fn test_introspect_revoked_token() {
     // Create user, OAuth client, and session
     let user = create_test_user(&state.store, "introspect-revoked@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
     let auth_header = client.basic_auth_header();
 
@@ -202,7 +211,16 @@ async fn test_rfc7662_response_content_type() {
 
     let user = create_test_user(&state.store, "introspect-ct@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
     let auth_header = client.basic_auth_header();
 

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc8628.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc8628.rs
@@ -194,7 +194,16 @@ async fn test_rfc8628_device_code_replay_revokes_only_that_code_s_token() {
         .to_string();
 
     // A session from a grant with no single-use code.
-    let token_c = create_test_session(&state, &user.id, &user.email, &auth).await;
+    let token_c = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let (status, body) = poll_device_token(&app, &device_code_a).await;
     assert_eq!(

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc8693.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc8693.rs
@@ -28,7 +28,16 @@ async fn test_token_exchange_valid_token_types() {
 
     let user = create_test_user(&state.store, "exchange-types@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
     let auth_header = client.basic_auth_header();
 
@@ -96,7 +105,16 @@ async fn test_token_exchange_successful() {
     // Create a valid subject token and client for authentication
     let user = create_test_user(&state.store, "exchange@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
     let auth_header = client.basic_auth_header();
 
@@ -157,7 +175,16 @@ async fn test_token_exchange_scope_downgrade() {
 
     let user = create_test_user(&state.store, "exchange-scope@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
     let auth_header = client.basic_auth_header();
 
@@ -253,7 +280,16 @@ async fn test_rfc8693_missing_subject_token_type() {
 
     let user = create_test_user(&state.store, "exchange-missing-type@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
     let auth_header = client.basic_auth_header();
 
@@ -283,7 +319,16 @@ async fn test_rfc8693_issued_token_type_in_response() {
 
     let user = create_test_user(&state.store, "exchange-issued-type@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
     let auth_header = client.basic_auth_header();
 
@@ -318,7 +363,16 @@ async fn test_rfc8693_unsupported_requested_token_type() {
 
     let user = create_test_user(&state.store, "exchange-bad-type@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
     let auth_header = client.basic_auth_header();
 
@@ -370,8 +424,16 @@ async fn test_rfc8693_delegation_depth_limit() {
         let actor_email = format!("actor-{}@example.com", i);
         let iter_actor = create_test_user(&state.store, &actor_email).await;
         let iter_actor_auth = create_test_authenticator(&state.store, &iter_actor.id).await;
-        let actor_token =
-            create_test_session(&state, &iter_actor.id, &iter_actor.email, &iter_actor_auth).await;
+        let actor_token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &iter_actor.id,
+                email: &iter_actor.email,
+                auth_id: Some(&iter_actor_auth),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let (status, body) = http_post_form(
             &app,
@@ -416,7 +478,16 @@ async fn test_rfc8693_client_auth_required_for_exchange() {
 
     let user = create_test_user(&state.store, "exchange-noauth@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Try token exchange without any client authentication
     let (status, body) = http_post_form(
@@ -768,7 +839,16 @@ async fn test_rfc8693_deactivated_subject_user_rejected() {
 
     let user = create_test_user(&state.store, "deactivated-exchange@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
     let auth_header = client.basic_auth_header();
 
@@ -814,7 +894,16 @@ async fn test_rfc8693_id_token_request_returns_clean_id_token() {
 
     let user = create_test_user(&state.store, "wif-basic@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
     let auth_header = client.basic_auth_header();
 
@@ -895,7 +984,16 @@ async fn test_rfc8693_id_token_audience_routing() {
 
     let user = create_test_user(&state.store, "wif-aud@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
     let auth_header = client.basic_auth_header();
 
@@ -936,7 +1034,16 @@ async fn test_rfc8693_id_token_default_audience_is_issuer() {
 
     let user = create_test_user(&state.store, "wif-default-aud@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
     let auth_header = client.basic_auth_header();
 
@@ -977,7 +1084,16 @@ async fn test_rfc8693_id_token_lifetime_capped_at_default() {
 
     let user = create_test_user(&state.store, "wif-ttl@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
     let auth_header = client.basic_auth_header();
 
@@ -1028,7 +1144,16 @@ async fn test_rfc8693_id_token_not_persisted_as_session() {
 
     let user = create_test_user(&state.store, "wif-nosession@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
     let auth_header = client.basic_auth_header();
 
@@ -1090,7 +1215,16 @@ async fn test_rfc8693_id_token_carries_hardware_aaguid() {
     )
     .await
     .expect("create authenticator with aaguid");
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
     let auth_header = client.basic_auth_header();
 
@@ -1150,7 +1284,16 @@ async fn test_rfc8693_id_token_uses_session_aaguid_after_rotation() {
     .expect("create original authenticator");
 
     // Session captures the original AAGUID.
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
     let auth_header = client.basic_auth_header();
 
@@ -1200,7 +1343,16 @@ async fn test_rfc8693_id_token_carries_hd_for_org_user() {
     let org = create_test_org(&state.store, "example.com").await;
     let user = create_test_user_in_org(&state.store, "hduser@example.com", &org.id, false).await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
     let auth_header = client.basic_auth_header();
 
@@ -1241,7 +1393,16 @@ async fn test_rfc8693_access_token_request_unaffected_by_id_token_branch() {
 
     let user = create_test_user(&state.store, "wif-regression@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
     let auth_header = client.basic_auth_header();
 
@@ -1292,7 +1453,16 @@ async fn test_rfc8693_id_token_deactivated_user_rejected() {
 
     let user = create_test_user(&state.store, "wif-deactivated@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
     let auth_header = client.basic_auth_header();
 
@@ -1329,8 +1499,16 @@ async fn test_rfc8693_id_token_rejects_non_hardware_verified_subject() {
     let (app, state) = test_app().await;
 
     let user = create_test_user(&state.store, "wif-bootstrap@example.com").await;
-    let token =
-        crate::test_utils::create_test_bootstrap_session(&state, &user.id, &user.email).await;
+    let token = crate::test_utils::create_test_session_with(
+        &state,
+        crate::test_utils::TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            verification: TestVerification::NotVerified,
+            ..Default::default()
+        },
+    )
+    .await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
     let auth_header = client.basic_auth_header();
 
@@ -1541,7 +1719,16 @@ async fn test_token_exchange_inherits_the_subject_s_authorization_code() {
             .to_string();
 
     // A session from a grant with no single-use code must survive the replay.
-    let unrelated = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let unrelated = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let (status, _) = http_post_form(
         &app,

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc8705.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc8705.rs
@@ -19,8 +19,17 @@ async fn test_userinfo_mtls_bound_token_without_cert_returns_401() {
     let cert_der = make_test_cert_der("client-a");
     let thumbprint = cert_thumbprint(&cert_der);
 
-    let token =
-        create_test_session_with_mtls(&state, &user.id, &user.email, &auth_id, &thumbprint).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            binding: TestBinding::Mtls(&thumbprint),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // No client certificate — should be rejected.
     let (status, body) = http_get_with_cert(
@@ -52,8 +61,17 @@ async fn test_userinfo_mtls_bound_token_with_wrong_cert_returns_401() {
     // Token is bound to cert A's thumbprint.
     let cert_a_der = make_test_cert_der("client-a");
     let thumbprint_a = cert_thumbprint(&cert_a_der);
-    let token =
-        create_test_session_with_mtls(&state, &user.id, &user.email, &auth_id, &thumbprint_a).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            binding: TestBinding::Mtls(&thumbprint_a),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Present cert B — a different certificate.
     let cert_b_der = make_test_cert_der("client-b");
@@ -86,8 +104,17 @@ async fn test_userinfo_mtls_bound_token_with_matching_cert_succeeds() {
     let cert_der = make_test_cert_der("client-match");
     let thumbprint = cert_thumbprint(&cert_der);
 
-    let token =
-        create_test_session_with_mtls(&state, &user.id, &user.email, &auth_id, &thumbprint).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            binding: TestBinding::Mtls(&thumbprint),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Present the correct certificate.
     let (status, body) = http_get_with_cert(
@@ -120,7 +147,16 @@ async fn test_userinfo_non_mtls_token_works_without_cert() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
 
     // Plain token — no cert binding.
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // No client certificate — should succeed because token is not cert-bound.
     let (status, body) = http_get_with_cert(
@@ -156,8 +192,17 @@ async fn test_rfc8705_cnf_claim_present_in_mtls_bound_token() {
     let cert_der = make_test_cert_der("client-cnf");
     let thumbprint = cert_thumbprint(&cert_der);
 
-    let token =
-        create_test_session_with_mtls(&state, &user.id, &user.email, &auth_id, &thumbprint).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            binding: TestBinding::Mtls(&thumbprint),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Decode the JWT and inspect the cnf claim
     let claims = decode_jwt_payload(&token);
@@ -673,8 +718,17 @@ async fn test_rfc8705_userinfo_mtls_bound_token_with_dpop_scheme_rejected() {
 
     let cert_der = make_test_cert_der("mtls-token-dpop-scheme");
     let thumbprint = cert_thumbprint(&cert_der);
-    let token =
-        create_test_session_with_mtls(&state, &user.id, &user.email, &auth_id, &thumbprint).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            binding: TestBinding::Mtls(&thumbprint),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // DPoP authorization scheme but no DPoP header.
     let (status, body) = http_get_with_cert(

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc8725.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc8725.rs
@@ -35,7 +35,16 @@ async fn test_rfc8725_cross_type_token_substitution() {
     // Valid OAuth access token (ES256, at+jwt) should work
     let user = create_test_user(&state.store, "cross-type@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let (status, _body) = http_get(
         &app,
@@ -193,7 +202,16 @@ async fn test_rfc8725_access_token_not_accepted_at_par_as_id_token() {
     let user = create_test_user(&state.store, "par-hint@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Submit an access token as id_token_hint to PAR endpoint
     // (the token is valid ES256 but the endpoint should not be confused)

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9101.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9101.rs
@@ -195,7 +195,16 @@ async fn test_rfc9101_authorize_with_valid_request_parameter_es256() {
     let user = create_test_user(&state.store, "jar-es256@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let (client, pkcs8_bytes) = create_test_jar_client(&state.store, &user.id).await;
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let issuer = &state.config().base_url;
     let request_jwt = build_request_object(&client.client_id, issuer, &pkcs8_bytes);
@@ -239,7 +248,16 @@ async fn test_rfc9101_authorize_request_object_with_pkce() {
     let user = create_test_user(&state.store, "jar-pkce@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let (client, pkcs8_bytes) = create_test_jar_client(&state.store, &user.id).await;
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let issuer = &state.config().base_url;
     let request_jwt = build_request_object(&client.client_id, issuer, &pkcs8_bytes);
@@ -639,7 +657,16 @@ async fn test_rfc9101_require_signed_request_object_rejects_plain_params() {
 
     let user = create_test_user(&state.store, "jar-required@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let (_pkcs8_bytes, jwk) = generate_es256_signing_key();
     let jwks_value = serde_json::json!({ "keys": [jwk] });
@@ -694,7 +721,16 @@ async fn test_rfc9101_require_signed_request_object_accepts_valid_jar() {
 
     let user = create_test_user(&state.store, "jar-reqok@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let (pkcs8_bytes, jwk) = generate_es256_signing_key();
     let jwks_value = serde_json::json!({ "keys": [jwk] });
@@ -979,7 +1015,16 @@ async fn test_rfc9101_client_signing_alg_es256_accepts_es256_jwt() {
 
     let user = create_test_user(&state.store, "jar-algok@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let (pkcs8_bytes, jwk) = generate_es256_signing_key();
     let jwks_value = serde_json::json!({ "keys": [jwk] });
@@ -1152,7 +1197,16 @@ async fn test_rfc9101_state_from_request_object_preserved_in_response() {
     let user = create_test_user(&state.store, "jar-state@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let (client, pkcs8_bytes) = create_test_jar_client(&state.store, &user.id).await;
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let now = jiff::Timestamp::now().as_second();
     let issuer = &state.config().base_url;
@@ -1345,7 +1399,16 @@ async fn test_rfc9101_fapi2_matching_query_params_accepted() {
     let user = create_test_user(&state.store, "jar-fapi-match@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let (client, pkcs8_bytes) = create_test_jar_client(&state.store, &user.id).await;
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let now = jiff::Timestamp::now().as_second();
     let issuer = &state.config().base_url;
@@ -2028,7 +2091,16 @@ async fn test_rfc9101_authorize_rejects_unsupported_prompt_in_request_object() {
     let user = create_test_user(&state.store, "jar-auth-badprompt@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let (client, pkcs8_bytes) = create_test_jar_client(&state.store, &user.id).await;
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let issuer = &state.config().base_url;
     let now = jiff::Timestamp::now().as_second();
@@ -2215,7 +2287,16 @@ async fn test_rfc9101_registration_rejects_pinned_alg_without_usable_key() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "jar-unusable-reg@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let body = serde_json::json!({
         "redirect_uris": ["https://example.com/callback"],
@@ -2251,7 +2332,16 @@ async fn test_rfc9101_registration_rejects_required_signing_without_any_key() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "jar-no-keys-reg@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let body = serde_json::json!({
         "redirect_uris": ["https://example.com/callback"],
@@ -2281,7 +2371,16 @@ async fn test_rfc9101_update_rejects_jwks_without_key_for_pinned_alg() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "jar-unusable-put@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let (client_id, reg_token, _pkcs8) =
         register_working_jar_client(&app, &state, &session_token, "JAR PUT App").await;
@@ -2314,7 +2413,16 @@ async fn test_rfc9101_update_accepts_jwks_with_key_for_pinned_alg() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "jar-rotate-put@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let (client_id, reg_token, _pkcs8) =
         register_working_jar_client(&app, &state, &session_token, "JAR Rotate App").await;
@@ -2346,7 +2454,16 @@ async fn test_rfc9101_admin_update_rejects_jwks_without_key_for_pinned_alg() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "jar-admin-patch@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let auth = format!("Bearer {session_token}");
 
     let (client_id, _reg_token, _pkcs8) =
@@ -2389,7 +2506,16 @@ async fn test_rfc9101_admin_update_form_rejects_jwks_without_key_for_pinned_alg(
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "jar-admin-form@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let (client_id, _reg_token, _pkcs8) =
         register_working_jar_client(&app, &state, &session_token, "Admin JAR Form App").await;

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
@@ -848,7 +848,16 @@ async fn test_rfc9126_authorize_resolves_request_uri() {
     let user = create_test_user(&state.store, "par-resolve@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let request_uri = create_par_request_with_prompt(&app, &client, Some("none")).await;
 
@@ -953,7 +962,16 @@ async fn test_rfc9126_request_uri_is_single_use() {
     let user = create_test_user(&state.store, "par-single@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let request_uri = create_par_request_with_prompt(&app, &client, Some("none")).await;
 
@@ -1014,7 +1032,16 @@ async fn test_rfc9126_request_uri_is_client_bound() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client_a = create_test_oauth_client(&state.store, &user.id).await;
     let client_b = create_test_oauth_client(&state.store, &user.id).await;
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Create PAR with client_a
     let request_uri = create_par_request(&app, &client_a).await;
@@ -1054,7 +1081,16 @@ async fn test_rfc9126_client_binding_failure_does_not_consume() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client_a = create_test_oauth_client(&state.store, &user.id).await;
     let client_b = create_test_oauth_client(&state.store, &user.id).await;
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let request_uri = create_par_request(&app, &client_a).await;
 
@@ -1104,7 +1140,16 @@ async fn test_rfc9126_authorize_rejects_expired_request_uri() {
     let user = create_test_user(&state.store, "par-expired@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
-    let _session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let _session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let request_uri = create_par_request_with_prompt(&app, &client, Some("none")).await;
 
@@ -1449,7 +1494,16 @@ async fn test_rfc9126_par_not_consumed_when_reauth_required() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
     // User has a valid session — but PAR flow always requires re-auth.
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Create PAR without prompt=none — will trigger re-auth under ReauthPolicy::Always.
     let request_uri = create_par_request(&app, &client).await;
@@ -1505,7 +1559,16 @@ async fn test_rfc9126_par_consumed_when_code_issued_after_login() {
     let user = create_test_user(&state.store, "par-deferred@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let request_uri = create_par_request(&app, &client).await;
     let cookie = format!("__Host-vouch_session={session_token}");
@@ -1594,7 +1657,16 @@ async fn test_rfc9126_par_reuse_succeeds_after_reauth_redirect() {
     let user = create_test_user(&state.store, "par-reauth-replay@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let request_uri = create_par_request(&app, &client).await;
 
@@ -3354,7 +3426,16 @@ async fn test_rfc9126_authorize_extends_par_ttl_and_survives_cleanup() {
 
     // Step 4: Complete the deferred flow — return to /oauth/authorize?pending_auth=<id>
     // with a valid session cookie. complete_pending_auth must consume the PAR and issue a code.
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
     let completion = http_get_full(
         &app,
         &format!(

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9207.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9207.rs
@@ -94,7 +94,16 @@ async fn test_rfc9207_authorize_response_includes_iss_parameter() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
     let challenge = sha256_base64url(verifier);

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9449.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9449.rs
@@ -377,7 +377,16 @@ async fn test_dpop_scheme_without_proof_rejected() {
 
     let user = create_test_user(&state.store, "dpop-noproof@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let response = http_get_full(
         &app,
@@ -1655,7 +1664,17 @@ async fn test_rfc9449_userinfo_multiple_dpop_headers_rejected() {
 
     let (dpop_key, dpop_jwk) = generate_dpop_key_pair();
     let jkt = dpop_jkt(&dpop_jwk);
-    let token = create_test_session_with_dpop(&state, &user.id, &user.email, &auth_id, &jkt).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            binding: TestBinding::Dpop(&jkt),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let userinfo_uri = format!("{}/oauth/userinfo", state.config().base_url);
     let proof_a = create_dpop_proof(
@@ -1715,7 +1734,17 @@ async fn test_rfc9449_userinfo_mtls_and_dpop_combined_succeeds() {
 
     let (dpop_key, dpop_jwk) = generate_dpop_key_pair();
     let jkt = dpop_jkt(&dpop_jwk);
-    let token = create_test_session_with_dpop(&state, &user.id, &user.email, &auth_id, &jkt).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            binding: TestBinding::Dpop(&jkt),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // mTLS cert is presented but the token is DPoP-bound (no x5t#S256 in cnf).
     let cert_der = make_test_cert_der("mtls-also-present");
@@ -1765,7 +1794,17 @@ async fn test_rfc9449_userinfo_dpop_bound_token_in_post_body_rejected() {
 
     let (_dpop_key, dpop_jwk) = generate_dpop_key_pair();
     let jkt = dpop_jkt(&dpop_jwk);
-    let token = create_test_session_with_dpop(&state, &user.id, &user.email, &auth_id, &jkt).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            binding: TestBinding::Dpop(&jkt),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let body_str = format!("access_token={}", urlencoding::encode(&token));
     let (status, body) = http_post_form(&app, "/oauth/userinfo", &body_str, &[]).await;

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9470.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9470.rs
@@ -21,7 +21,16 @@ async fn test_rfc9470_acr_values_aal3_accepted() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
     let challenge = sha256_base64url(verifier);
@@ -72,7 +81,16 @@ async fn test_rfc9470_acr_values_unsupported_returns_error() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
     let challenge = sha256_base64url(verifier);
@@ -137,7 +155,16 @@ async fn test_rfc9470_acr_values_multiple_with_aal3_accepted() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
     let challenge = sha256_base64url(verifier);
@@ -249,7 +276,16 @@ async fn test_rfc9470_max_age_one_does_not_reauth_a_fresh_session() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
     let challenge = sha256_base64url(verifier);
@@ -291,7 +327,16 @@ async fn test_rfc9470_max_age_zero_forces_reauth() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
     let challenge = sha256_base64url(verifier);
@@ -344,7 +389,16 @@ async fn test_rfc9470_max_age_large_value_allows_fresh_session() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
     let challenge = sha256_base64url(verifier);
@@ -396,7 +450,16 @@ async fn test_rfc9470_prompt_login_forces_reauth() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
     let challenge = sha256_base64url(verifier);
@@ -448,7 +511,16 @@ async fn test_rfc9470_prompt_none_with_valid_session_succeeds() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
     let challenge = sha256_base64url(verifier);
@@ -556,7 +628,16 @@ async fn test_rfc9470_prompt_none_with_max_age_zero_returns_login_required() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
-    let session_token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session_token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
     let challenge = sha256_base64url(verifier);
@@ -868,8 +949,19 @@ async fn test_rfc9470_key_delete_requires_step_up() {
 
     // Create a session with iat 10 minutes in the past (well beyond 60s max_age)
     let stale_iat = jiff::Timestamp::now().as_second() - 600;
-    let token =
-        create_test_session_with_iat(&state, &user.id, &user.email, &auth_id, stale_iat).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            verification: TestVerification::Verified {
+                auth_time: Some(stale_iat),
+            },
+            ..Default::default()
+        },
+    )
+    .await;
 
     let response = http_delete_full(
         &app,
@@ -932,7 +1024,16 @@ async fn test_rfc9470_key_delete_with_fresh_session_succeeds() {
     let auth_id2 = create_test_authenticator(&state.store, &user.id).await;
 
     // Fresh session — iat is now
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let (status, body) = http_delete(
         &app,
@@ -967,7 +1068,16 @@ async fn test_rfc9470_key_delete_self_deletion_after_step_up() {
     let _auth_id2 = create_test_authenticator(&state.store, &user.id).await;
 
     // Fresh session authenticated with auth_id
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Delete the same key used to authenticate
     let (status, body) = http_delete(
@@ -1018,7 +1128,16 @@ async fn test_rfc9470_max_age_zero_completes_after_reauth() {
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
     // Step 1: existing session triggers re-auth with max_age=0.
-    let old_session = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let old_session = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
     let challenge = sha256_base64url(verifier);
@@ -1066,7 +1185,16 @@ async fn test_rfc9470_max_age_zero_completes_after_reauth() {
         .into_owned();
 
     // Step 2: simulate post-login — create a brand-new fresh session.
-    let fresh_session = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let fresh_session = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Step 3: complete the pending authorization with the fresh session.
     let completion = http_get_full(
@@ -1123,7 +1251,16 @@ async fn test_rfc9470_max_age_completion_rejects_stale_session() {
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let client = create_test_oauth_client(&state.store, &user.id).await;
 
-    let session = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let session = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Age the session so it is at least 2 seconds old (well past max_age=1).
     tokio::time::sleep(std::time::Duration::from_secs(2)).await;

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9728.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9728.rs
@@ -847,8 +847,19 @@ async fn test_rfc9728_www_authenticate_preserves_step_up() {
     let auth_id2 = create_test_authenticator(&state.store, &user.id).await;
 
     let stale_iat = jiff::Timestamp::now().as_second() - 600;
-    let token =
-        create_test_session_with_iat(&state, &user.id, &user.email, &auth_id, stale_iat).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            verification: TestVerification::Verified {
+                auth_time: Some(stale_iat),
+            },
+            ..Default::default()
+        },
+    )
+    .await;
 
     let response = http_delete_full(
         &app,

--- a/crates/vouch-server/src/handlers/session/tests.rs
+++ b/crates/vouch-server/src/handlers/session/tests.rs
@@ -61,7 +61,16 @@ async fn test_cookie_session_normal_token_succeeds() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "cookie-ok@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session(&state, &user.id, &user.email, &auth_id).await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let cookie = format!("{}={token}", vouch_common::SESSION_COOKIE_NAME);
     let (status, _body) = http_get(&app, "/api/v1/applications", &[("Cookie", &cookie)]).await;
@@ -75,12 +84,15 @@ async fn test_cookie_session_dpop_bound_token_rejected() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "cookie-dpop@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session_with_dpop(
+    let token = create_test_session_with(
         &state,
-        &user.id,
-        &user.email,
-        &auth_id,
-        "fake-jkt-thumbprint",
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            binding: TestBinding::Dpop("fake-jkt-thumbprint"),
+            ..Default::default()
+        },
     )
     .await;
 
@@ -101,12 +113,15 @@ async fn test_bearer_dpop_bound_token_rejected() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "bearer-dpop@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session_with_dpop(
+    let token = create_test_session_with(
         &state,
-        &user.id,
-        &user.email,
-        &auth_id,
-        "fake-jkt-thumbprint",
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            binding: TestBinding::Dpop("fake-jkt-thumbprint"),
+            ..Default::default()
+        },
     )
     .await;
 
@@ -128,12 +143,17 @@ async fn test_mtls_bound_token_without_cert_rejected() {
     let (app, state) = test_app().await;
     let user = create_test_user(&state.store, "bearer-mtls@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
-    let token = create_test_session_with_mtls(
+    let token = create_test_session_with(
         &state,
-        &user.id,
-        &user.email,
-        &auth_id,
-        &crate::services::oidc::mtls::compute_cert_thumbprint(b"fake-cert-der"),
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            binding: TestBinding::Mtls(&crate::services::oidc::mtls::compute_cert_thumbprint(
+                b"fake-cert-der",
+            )),
+            ..Default::default()
+        },
     )
     .await;
 
@@ -161,9 +181,17 @@ async fn test_mtls_bound_token_with_matching_cert_succeeds() {
         crate::services::oidc::mtls::parse_client_certificate(&cert_der).expect("parse cert");
 
     // Issue a token bound to this cert's thumbprint
-    let token =
-        create_test_session_with_mtls(&state, &user.id, &user.email, &auth_id, &cert.thumbprint)
-            .await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            binding: TestBinding::Mtls(&cert.thumbprint),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Call extract_resource_token directly with the matching cert
     let mut headers = axum::http::HeaderMap::new();
@@ -207,9 +235,17 @@ async fn test_mtls_bound_token_with_wrong_cert_rejected() {
         crate::services::oidc::mtls::parse_client_certificate(&cert_b_der).expect("parse cert B");
 
     // Token is bound to cert_a's thumbprint
-    let token =
-        create_test_session_with_mtls(&state, &user.id, &user.email, &auth_id, &cert_a.thumbprint)
-            .await;
+    let token = create_test_session_with(
+        &state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            binding: TestBinding::Mtls(&cert_a.thumbprint),
+            ..Default::default()
+        },
+    )
+    .await;
 
     // Present cert_b (wrong cert)
     let mut headers = axum::http::HeaderMap::new();
@@ -251,12 +287,15 @@ async fn test_dpop_takes_precedence_over_mtls() {
 
     // Create a DPoP-bound token (jkt is set; mTLS thumbprint is not set via
     // create_oauth_access_token because dpop_jkt takes precedence)
-    let token = create_test_session_with_dpop(
+    let token = create_test_session_with(
         &state,
-        &user.id,
-        &user.email,
-        &auth_id,
-        "fake-dpop-jkt-thumbprint",
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            binding: TestBinding::Dpop("fake-dpop-jkt-thumbprint"),
+            ..Default::default()
+        },
     )
     .await;
 
@@ -369,7 +408,17 @@ async fn setup_dpop_resource_token(
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let (key, jwk) = generate_dpop_key_pair();
     let jkt = dpop_jkt(&jwk);
-    let token = create_test_session_with_dpop(state, &user.id, &user.email, &auth_id, &jkt).await;
+    let token = create_test_session_with(
+        state,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            binding: TestBinding::Dpop(&jkt),
+            ..Default::default()
+        },
+    )
+    .await;
     let resource_uri = format!("{}/api/v1/applications", state.config().base_url);
     (key, jwk, token, resource_uri)
 }

--- a/crates/vouch-server/src/test_utils.rs
+++ b/crates/vouch-server/src/test_utils.rs
@@ -372,8 +372,8 @@ static TEST_HTTPSIG: std::sync::LazyLock<TestHttpSig> = std::sync::LazyLock::new
 
 /// Register the first-party OAuth client used by test sessions.
 ///
-/// `create_test_session*` mint tokens whose `client_id` is the server
-/// `base_url`. The `/v1/*` routes now require an RFC 9421 signature, and the
+/// [`create_test_session_with`] mints tokens whose `client_id` is the server
+/// `base_url` unless the spec names one. The `/v1/*` routes require an RFC 9421 signature, and the
 /// server resolves the verifying key from the token client's registered JWKS.
 /// Registering a client keyed to `base_url` with the shared test signing key
 /// lets [`build_test_request`] transparently sign `/v1/*` requests so existing
@@ -891,46 +891,184 @@ async fn resolve_session_snapshot(
     (hardware_aaguid, org_domain)
 }
 
+/// How a test session's access token is bound to the party that may present
+/// it, named the way a fixture site knows it: by thumbprint.
+///
+/// The production `TokenBinding` takes a
+/// `ValidatedDpopProof` witness rather than a bare `jkt`, so a sender-constrained
+/// token cannot be minted from a string that never passed proof validation.
+/// [`create_test_session_with`] stands that witness up.
+pub enum TestBinding<'a> {
+    /// A bearer token: whoever holds it may present it.
+    Bearer,
+    /// RFC 9449 §6: `cnf.jkt` set to this JWK thumbprint.
+    Dpop(&'a str),
+    /// RFC 8705 §3.1: `cnf.x5t#S256` set to this certificate thumbprint.
+    Mtls(&'a crate::services::oidc::mtls::CertThumbprint),
+}
+
+/// The authentication assurance a test session's token claims.
+///
+/// The first two variants map onto `HardwareVerification` and travel the
+/// ordinary issuance path. The third does not — see its docs.
+pub enum TestVerification {
+    /// A FIDO2 assertion happened: `hardware_verified: true`, `amr: [hwk, pin,
+    /// user]`, `acr: aal3`. `auth_time` is when it happened; `None` models
+    /// verification inherited from another token (RFC 8693 token exchange runs
+    /// no ceremony of its own).
+    Verified {
+        /// When the assertion happened, in Unix seconds.
+        auth_time: Option<i64>,
+    },
+    /// No FIDO2 assertion: `hardware_verified: false`, no `auth_time`, no
+    /// `amr`/`acr`. The enrollment-bootstrap shape in `handlers/enroll.rs` —
+    /// a real user and a persisted session minted right after upstream IdP
+    /// sign-in.
+    NotVerified,
+    /// A token this deployment's issuer cannot produce: `hardware_verified`
+    /// false alongside an `auth_time` a freshness gate would read as recent
+    /// FIDO2. `HardwareVerification::NotVerified` has nowhere to put a
+    /// timestamp, so the combination is unrepresentable by design (issue
+    /// #1114) and this variant reaches it by mutating a minted token's claims
+    /// and re-signing.
+    ///
+    /// That is the point: it produces what an older server's token, or a
+    /// future regression, would put in front of the key handlers. Every claim
+    /// other than `auth_time` and `jti` is whatever the production issuer
+    /// produced, so a claim added later travels here automatically instead of
+    /// silently diverging.
+    ///
+    /// Leaves two session rows for the user: the base token's and the mutated
+    /// one's. [`create_test_session_with`] returns the mutated token.
+    NotVerifiedForgedAuthTime {
+        /// The `auth_time` to stamp on a session that ran no ceremony.
+        auth_time: i64,
+    },
+}
+
+/// Knobs that test-session fixture sites actually vary.
+///
+/// The canonical way to build a session; [`create_test_session_with`] is the
+/// only place a `CreateOAuthTokenParams` literal is spelled out for tests.
+/// `Default` supplies the ordinary hardware-verified bearer session, so a test
+/// names only the axis it is about:
+///
+/// ```rust,ignore
+/// let token = create_test_session_with(&state, TestSessionSpec {
+///     user_id: &user.id,
+///     email: &user.email,
+///     auth_id: Some(&auth_id),
+///     binding: TestBinding::Dpop(&jkt),
+///     ..Default::default()
+/// })
+/// .await;
+/// ```
+pub struct TestSessionSpec<'a> {
+    /// Subject of the token. Required — the default is empty and rejected.
+    pub user_id: &'a str,
+    /// Email claim and session-row email. Required — the default is empty and
+    /// rejected.
+    pub email: &'a str,
+    /// Authenticator establishing the session, recorded server-side on the
+    /// session row and used to resolve the `hardware_aaguid` snapshot.
+    /// Default: `None`, the shape of a session minted before any key exists.
+    pub auth_id: Option<&'a str>,
+    /// OAuth client the token is issued to. Default: `None`, meaning this
+    /// deployment's own `base_url` (first-party CLI/UI sessions).
+    pub client_id: Option<&'a str>,
+    /// RFC 8707 resource / RFC 8693 audience narrowing. Default: `None`,
+    /// meaning `aud == client_id`.
+    pub audience: Option<&'a str>,
+    /// Sender-constraining. Default: [`TestBinding::Bearer`].
+    pub binding: TestBinding<'a>,
+    /// Authentication assurance. Default: [`TestVerification::Verified`] with
+    /// `auth_time` now.
+    pub verification: TestVerification,
+}
+
+impl Default for TestSessionSpec<'_> {
+    fn default() -> Self {
+        Self {
+            user_id: "",
+            email: "",
+            auth_id: Option::None,
+            client_id: Option::None,
+            audience: Option::None,
+            binding: TestBinding::Bearer,
+            verification: TestVerification::Verified {
+                auth_time: Some(jiff::Timestamp::now().as_second()),
+            },
+        }
+    }
+}
+
 /// Create a test session with an OAuth access token stored in the database.
 ///
 /// Returns the raw access token string. Uses the real `create_oauth_access_token`
 /// service function with ES256 signing so the token validates through the full
-/// token validation pipeline.
-pub async fn create_test_session(
-    state: &AppState,
-    user_id: &str,
-    email: &str,
-    auth_id: &str,
-) -> String {
+/// token validation pipeline, and resolves the `hardware_aaguid` / `org_domain`
+/// snapshot the way production call sites do.
+pub async fn create_test_session_with(state: &AppState, spec: TestSessionSpec<'_>) -> String {
     use crate::services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenBinding,
-        TokenIssuanceProof, create_oauth_access_token,
+        ClientAuthProof, CreateOAuthTokenParams, GrantProof, HardwareVerification,
+        SenderConstraintProof, TokenBinding, TokenIssuanceProof, create_oauth_access_token,
     };
-    use crate::services::oidc::ScopeSet;
+    use crate::services::oidc::{ScopeSet, ValidatedDpopProof};
     use secrecy::ExposeSecret;
 
+    assert!(
+        !spec.user_id.is_empty() && !spec.email.is_empty(),
+        "TestSessionSpec requires user_id and email; struct-update syntax defaults them to empty"
+    );
+
     let (hardware_aaguid, org_domain) =
-        resolve_session_snapshot(state, user_id, Some(auth_id)).await;
+        resolve_session_snapshot(state, spec.user_id, spec.auth_id).await;
+
+    let config = state.config();
+    let client_id = spec.client_id.unwrap_or(&config.base_url);
+
+    // Fixtures name a DPoP binding by thumbprint, so stand up the witness the
+    // issuance path requires. Only reachable under `cfg(test)` /
+    // `feature = "test-utils"`.
+    let dpop_witness = match spec.binding {
+        TestBinding::Dpop(jkt) => Some(ValidatedDpopProof::for_testing(
+            jkt.to_string(),
+            format!("test-jti-{jkt}"),
+            Option::None,
+        )),
+        TestBinding::Bearer | TestBinding::Mtls(_) => Option::None,
+    };
+    let mtls_thumbprint = match spec.binding {
+        TestBinding::Mtls(thumbprint) => Some(thumbprint),
+        TestBinding::Bearer | TestBinding::Dpop(_) => Option::None,
+    };
+
+    let hardware_verification = match spec.verification {
+        TestVerification::Verified { auth_time } => HardwareVerification::Verified { auth_time },
+        // The forged variant mints an unverified token and mutates it below;
+        // the issuer has no way to stamp the `auth_time` it wants.
+        TestVerification::NotVerified | TestVerification::NotVerifiedForgedAuthTime { .. } => {
+            HardwareVerification::NotVerified
+        }
+    };
 
     let result = create_oauth_access_token(
         state,
         CreateOAuthTokenParams {
-            user_id,
-            email,
-            authenticator_id: Some(auth_id),
-            client_id: &state.config().base_url,
+            user_id: spec.user_id,
+            email: spec.email,
+            authenticator_id: spec.auth_id,
+            client_id,
             scope: Some(ScopeSet::all()),
-            binding: TokenBinding::Bearer,
-            act: None,
-            audience: None,
-            hardware_verification: crate::services::auth::HardwareVerification::Verified {
-                auth_time: Some(jiff::Timestamp::now().as_second()),
-            },
+            binding: TokenBinding::new(dpop_witness.as_ref(), mtls_thumbprint),
+            act: Option::None,
+            audience: spec.audience,
+            hardware_verification,
             session_purpose: crate::db::SessionPurpose::OAuthAccessToken,
-            authorization_details: None,
+            authorization_details: Option::None,
             hardware_aaguid: hardware_aaguid.as_deref(),
             org_domain: org_domain.as_deref(),
-            source_code_hash: None,
+            source_code_hash: Option::None,
         },
         TokenIssuanceProof {
             grant: GrantProof::TestingOnly,
@@ -943,475 +1081,67 @@ pub async fn create_test_session(
     .await
     .expect("Failed to create test session");
 
-    result.token.expose_secret().to_string()
-}
+    let token = result.token.expose_secret().to_string();
 
-/// Create a test session whose access token is narrowed to an explicit
-/// audience (RFC 8707 resource / RFC 8693 audience).
-///
-/// Mirrors [`create_test_session`] but passes `audience: Some(..)`, so the
-/// minted token has `aud != client_id` and exercises the audience-coverage
-/// enforcement in `extract_resource_token` without driving the full
-/// authorization-code flow. `client_id` is explicit so tests can bind the
-/// token to a registered OAuth client (e.g. for the introspection
-/// cross-client check); pass `&state.config().base_url` to mirror
-/// [`create_test_session`].
-pub async fn create_test_session_with_audience(
-    state: &AppState,
-    user_id: &str,
-    email: &str,
-    auth_id: &str,
-    client_id: &str,
-    audience: &str,
-) -> String {
-    use crate::services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenBinding,
-        TokenIssuanceProof, create_oauth_access_token,
+    let TestVerification::NotVerifiedForgedAuthTime { auth_time } = spec.verification else {
+        return token;
     };
-    use crate::services::oidc::ScopeSet;
-    use secrecy::ExposeSecret;
-
-    let (hardware_aaguid, org_domain) =
-        resolve_session_snapshot(state, user_id, Some(auth_id)).await;
-
-    let result = create_oauth_access_token(
-        state,
-        CreateOAuthTokenParams {
-            user_id,
-            email,
-            authenticator_id: Some(auth_id),
-            client_id,
-            scope: Some(ScopeSet::all()),
-            binding: TokenBinding::Bearer,
-            act: None,
-            audience: Some(audience),
-            hardware_verification: crate::services::auth::HardwareVerification::Verified {
-                auth_time: Some(jiff::Timestamp::now().as_second()),
-            },
-            session_purpose: crate::db::SessionPurpose::OAuthAccessToken,
-            authorization_details: None,
-            hardware_aaguid: hardware_aaguid.as_deref(),
-            org_domain: org_domain.as_deref(),
-            source_code_hash: None,
-        },
-        TokenIssuanceProof {
-            grant: GrantProof::TestingOnly,
-            client_auth: ClientAuthProof::NoAuth(
-                crate::services::auth::NoClientAuth::internal_endpoint(),
-            ),
-            sender_constraint: SenderConstraintProof::no_registered_client(),
-        },
-    )
-    .await
-    .expect("Failed to create audience-narrowed test session");
-
-    result.token.expose_secret().to_string()
+    forge_auth_time(state, &spec, &token, auth_time).await
 }
 
-/// Create a test session backed by a non-hardware-verified access token.
+/// Re-sign `base` with `auth_time` stamped onto claims the issuer produced
+/// without one, and persist a session row for the result.
 ///
-/// Mirrors the enrollment-bootstrap shape in `handlers/enroll.rs`: a real
-/// user, a persisted session, but `HardwareVerification::NotVerified` and
-/// `auth_time: None` (no FIDO2 authentication occurred; the session was
-/// minted right after upstream IdP sign-in). Used to verify that paths
-/// gated on hardware attestation reject these sessions (e.g., the RFC 8693
-/// ID-token fork), and that freshness-gated destructive operations fail
-/// closed instead of treating the IdP login time as recent FIDO2.
-pub async fn create_test_bootstrap_session(state: &AppState, user_id: &str, email: &str) -> String {
-    use crate::services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenBinding,
-        TokenIssuanceProof, create_oauth_access_token,
-    };
-    use crate::services::oidc::ScopeSet;
-    use secrecy::ExposeSecret;
-
-    let (_, org_domain) = resolve_session_snapshot(state, user_id, None).await;
-
-    let result = create_oauth_access_token(
-        state,
-        CreateOAuthTokenParams {
-            user_id,
-            email,
-            authenticator_id: None,
-            client_id: &state.config().base_url,
-            scope: Some(ScopeSet::all()),
-            binding: TokenBinding::Bearer,
-            act: None,
-            audience: None,
-            // `NotVerified` carries no `auth_time` — see `handlers/enroll.rs`.
-            hardware_verification: crate::services::auth::HardwareVerification::NotVerified,
-            session_purpose: crate::db::SessionPurpose::OAuthAccessToken,
-            authorization_details: None,
-            hardware_aaguid: None,
-            org_domain: org_domain.as_deref(),
-            source_code_hash: None,
-        },
-        TokenIssuanceProof {
-            grant: GrantProof::TestingOnly,
-            client_auth: ClientAuthProof::NoAuth(
-                crate::services::auth::NoClientAuth::internal_endpoint(),
-            ),
-            sender_constraint: SenderConstraintProof::no_registered_client(),
-        },
-    )
-    .await
-    .expect("Failed to create bootstrap test session");
-
-    result.token.expose_secret().to_string()
-}
-
-/// Like [`create_test_bootstrap_session`], but with an `authenticator_id`
-/// attached so the access token's `hardware_verified` claim is `false`
-/// while the session record still references a key.
-///
-/// This reproduces the #451 token-laundering scenario: a re-enrollment
-/// bootstrap session for a user who already has a registered security
-/// key has `authenticator_id = Some(_)` and `hardware_verified = false`.
-/// As in production, `auth_time` is `None` (no FIDO2 assertion happened on
-/// a direct browser sign-in), so the destructive-key freshness gate must
-/// reject this session. Hardware-gated handlers must reject it.
-pub async fn create_test_bootstrap_session_with_authenticator(
+/// Split out because it is the whole of
+/// [`TestVerification::NotVerifiedForgedAuthTime`]: derive from a real token,
+/// change the single field under test, leave everything else alone.
+async fn forge_auth_time(
     state: &AppState,
-    user_id: &str,
-    email: &str,
-    auth_id: &str,
-) -> String {
-    use crate::services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenBinding,
-        TokenIssuanceProof, create_oauth_access_token,
-    };
-    use crate::services::oidc::ScopeSet;
-    use secrecy::ExposeSecret;
-
-    let (hardware_aaguid, org_domain) =
-        resolve_session_snapshot(state, user_id, Some(auth_id)).await;
-
-    let result = create_oauth_access_token(
-        state,
-        CreateOAuthTokenParams {
-            user_id,
-            email,
-            authenticator_id: Some(auth_id),
-            client_id: &state.config().base_url,
-            scope: Some(ScopeSet::all()),
-            binding: TokenBinding::Bearer,
-            act: None,
-            audience: None,
-            // `NotVerified` carries no `auth_time` — see `handlers/enroll.rs`.
-            hardware_verification: crate::services::auth::HardwareVerification::NotVerified,
-            session_purpose: crate::db::SessionPurpose::OAuthAccessToken,
-            authorization_details: None,
-            hardware_aaguid: hardware_aaguid.as_deref(),
-            org_domain: org_domain.as_deref(),
-            source_code_hash: None,
-        },
-        TokenIssuanceProof {
-            grant: GrantProof::TestingOnly,
-            client_auth: ClientAuthProof::NoAuth(
-                crate::services::auth::NoClientAuth::internal_endpoint(),
-            ),
-            sender_constraint: SenderConstraintProof::no_registered_client(),
-        },
-    )
-    .await
-    .expect("Failed to create bootstrap test session with authenticator");
-
-    result.token.expose_secret().to_string()
-}
-
-/// Create a test session with a custom `iat`-equivalent auth_time.
-///
-/// Used for step-up authentication tests (RFC 9470) where the auth_time
-/// relative to now determines whether the operation is allowed.
-/// Mint an access token in the shape issue #1114 exploited: `auth_time` fresh,
-/// `hardware_verified` false.
-///
-/// `HardwareVerification` no longer lets that combination be constructed —
-/// `NotVerified` has nowhere to put a timestamp — so this cannot go through
-/// `create_oauth_access_token`. That is the point: it produces a token this
-/// deployment's issuer cannot mint, which is what an older server's token, or
-/// a future regression, would put in front of the key handlers.
-///
-/// Rather than restate `AccessTokenClaims`, it mints a real bootstrap token,
-/// decodes it, and changes the single field under test. Every other claim is
-/// whatever the production issuer produced, so a claim added later travels
-/// here automatically instead of silently diverging.
-///
-/// Leaves two session rows for the user: the base token's and this one's. The
-/// returned token is the mutated one.
-pub async fn create_test_session_unverified_with_fresh_auth_time(
-    state: &AppState,
-    user_id: &str,
-    email: &str,
-    auth_id: &str,
+    spec: &TestSessionSpec<'_>,
+    base: &str,
+    auth_time: i64,
 ) -> String {
     use crate::services::auth::{DecodedToken, decode_token};
 
-    let base =
-        create_test_bootstrap_session_with_authenticator(state, user_id, email, auth_id).await;
     let DecodedToken::AccessToken(mut claims) =
-        decode_token(&base, &state.oidc_key, &state.config().base_url)
-            .expect("the bootstrap token this deployment just minted must decode");
+        decode_token(base, &state.oidc_key, &state.config().base_url)
+            .expect("the token this deployment just minted must decode");
 
     assert!(
         !claims.hardware_verified,
         "the base token must be unverified for this fixture to mean anything"
     );
-    // The one deviation: a session that ran no ceremony, carrying the instant
-    // one would have been recorded at.
-    claims.auth_time = Some(jiff::Timestamp::now().as_second());
+    claims.auth_time = Some(auth_time);
     claims.jti = uuid::Uuid::now_v7().to_string();
 
     let token = state
         .oidc_key
         .sign_access_token_jwt(&claims)
         .await
-        .expect("Failed to sign the pre-fix-shaped access token");
+        .expect("Failed to sign the forged-auth_time access token");
 
     let (hardware_aaguid, org_domain) =
-        resolve_session_snapshot(state, user_id, Some(auth_id)).await;
+        resolve_session_snapshot(state, spec.user_id, spec.auth_id).await;
     let expires_at = jiff::Timestamp::from_second(claims.exp).expect("valid expiry");
     crate::db::create_session(
         &state.store,
         &crate::db::CreateSessionParams {
-            user_id,
-            user_email: email,
+            user_id: spec.user_id,
+            user_email: spec.email,
             token_hash: &crate::crypto::hash_token(&token),
-            authenticator_id: Some(auth_id),
+            authenticator_id: Option::None,
             expires_at,
             session_type: crate::db::SessionPurpose::OAuthAccessToken,
-            authorization_details: None,
+            authorization_details: Option::None,
             hardware_aaguid: hardware_aaguid.as_deref(),
             org_domain: org_domain.as_deref(),
-            source_code_hash: None,
+            source_code_hash: Option::None,
         },
     )
     .await
-    .expect("Failed to persist the pre-fix-shaped session");
+    .expect("Failed to persist the forged-auth_time session");
 
     token
-}
-
-pub async fn create_test_session_with_iat(
-    state: &AppState,
-    user_id: &str,
-    email: &str,
-    auth_id: &str,
-    iat: i64,
-) -> String {
-    use crate::services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenBinding,
-        TokenIssuanceProof, create_oauth_access_token,
-    };
-    use crate::services::oidc::ScopeSet;
-    use secrecy::ExposeSecret;
-
-    let (hardware_aaguid, org_domain) =
-        resolve_session_snapshot(state, user_id, Some(auth_id)).await;
-
-    let result = create_oauth_access_token(
-        state,
-        CreateOAuthTokenParams {
-            user_id,
-            email,
-            authenticator_id: Some(auth_id),
-            client_id: &state.config().base_url,
-            scope: Some(ScopeSet::all()),
-            binding: TokenBinding::Bearer,
-            act: None,
-            audience: None,
-            hardware_verification: crate::services::auth::HardwareVerification::Verified {
-                auth_time: Some(iat),
-            },
-            session_purpose: crate::db::SessionPurpose::OAuthAccessToken,
-            authorization_details: None,
-            hardware_aaguid: hardware_aaguid.as_deref(),
-            org_domain: org_domain.as_deref(),
-            source_code_hash: None,
-        },
-        TokenIssuanceProof {
-            grant: GrantProof::TestingOnly,
-            client_auth: ClientAuthProof::NoAuth(
-                crate::services::auth::NoClientAuth::internal_endpoint(),
-            ),
-            sender_constraint: SenderConstraintProof::no_registered_client(),
-        },
-    )
-    .await
-    .expect("Failed to create test session");
-
-    result.token.expose_secret().to_string()
-}
-
-/// Create a test session bound to a specific OAuth client.
-///
-/// Used for tests that require the token's `client_id` to match a specific
-/// OAuth client (e.g., introspection cross-client checks).
-pub async fn create_test_session_for_client(
-    state: &AppState,
-    user_id: &str,
-    email: &str,
-    auth_id: &str,
-    client_id: &str,
-) -> String {
-    use crate::services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenBinding,
-        TokenIssuanceProof, create_oauth_access_token,
-    };
-    use crate::services::oidc::ScopeSet;
-    use secrecy::ExposeSecret;
-
-    let (hardware_aaguid, org_domain) =
-        resolve_session_snapshot(state, user_id, Some(auth_id)).await;
-
-    let result = create_oauth_access_token(
-        state,
-        CreateOAuthTokenParams {
-            user_id,
-            email,
-            authenticator_id: Some(auth_id),
-            client_id,
-            scope: Some(ScopeSet::all()),
-            binding: TokenBinding::Bearer,
-            act: None,
-            audience: None,
-            hardware_verification: crate::services::auth::HardwareVerification::Verified {
-                auth_time: Some(jiff::Timestamp::now().as_second()),
-            },
-            session_purpose: crate::db::SessionPurpose::OAuthAccessToken,
-            authorization_details: None,
-            hardware_aaguid: hardware_aaguid.as_deref(),
-            org_domain: org_domain.as_deref(),
-            source_code_hash: None,
-        },
-        TokenIssuanceProof {
-            grant: GrantProof::TestingOnly,
-            client_auth: ClientAuthProof::NoAuth(
-                crate::services::auth::NoClientAuth::internal_endpoint(),
-            ),
-            sender_constraint: SenderConstraintProof::no_registered_client(),
-        },
-    )
-    .await
-    .expect("Failed to create test session");
-
-    result.token.expose_secret().to_string()
-}
-
-/// Create a test session with a DPoP binding (sender-constrained token).
-///
-/// The token will have a `cnf.jkt` claim, making it a sender-constrained
-/// token that requires DPoP proof for validation.
-pub async fn create_test_session_with_dpop(
-    state: &AppState,
-    user_id: &str,
-    email: &str,
-    auth_id: &str,
-    dpop_jkt: &str,
-) -> String {
-    use crate::services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenBinding,
-        TokenIssuanceProof, create_oauth_access_token,
-    };
-    use crate::services::oidc::{ScopeSet, ValidatedDpopProof};
-    use secrecy::ExposeSecret;
-
-    let (hardware_aaguid, org_domain) =
-        resolve_session_snapshot(state, user_id, Some(auth_id)).await;
-
-    // Fixtures name the binding by thumbprint, so stand up the witness the
-    // issuance path now requires. Only reachable under `cfg(test)` /
-    // `feature = "test-utils"`.
-    let dpop_proof =
-        ValidatedDpopProof::for_testing(dpop_jkt.to_string(), format!("test-jti-{dpop_jkt}"), None);
-
-    let result = create_oauth_access_token(
-        state,
-        CreateOAuthTokenParams {
-            user_id,
-            email,
-            authenticator_id: Some(auth_id),
-            client_id: &state.config().base_url,
-            scope: Some(ScopeSet::all()),
-            binding: TokenBinding::new(Some(&dpop_proof), None),
-            act: None,
-            audience: None,
-            hardware_verification: crate::services::auth::HardwareVerification::Verified {
-                auth_time: Some(jiff::Timestamp::now().as_second()),
-            },
-            session_purpose: crate::db::SessionPurpose::OAuthAccessToken,
-            authorization_details: None,
-            hardware_aaguid: hardware_aaguid.as_deref(),
-            org_domain: org_domain.as_deref(),
-            source_code_hash: None,
-        },
-        TokenIssuanceProof {
-            grant: GrantProof::TestingOnly,
-            client_auth: ClientAuthProof::NoAuth(
-                crate::services::auth::NoClientAuth::internal_endpoint(),
-            ),
-            sender_constraint: SenderConstraintProof::no_registered_client(),
-        },
-    )
-    .await
-    .expect("Failed to create DPoP-bound test session");
-
-    result.token.expose_secret().to_string()
-}
-
-/// Create an mTLS certificate-bound access token for testing.
-///
-/// The token includes `cnf.x5t#S256` set to `mtls_cert_thumbprint`, binding it to
-/// the certificate identified by that thumbprint per RFC 8705 Section 3.1.
-pub async fn create_test_session_with_mtls(
-    state: &AppState,
-    user_id: &str,
-    email: &str,
-    auth_id: &str,
-    mtls_cert_thumbprint: &crate::services::oidc::mtls::CertThumbprint,
-) -> String {
-    use crate::services::auth::{
-        ClientAuthProof, CreateOAuthTokenParams, GrantProof, SenderConstraintProof, TokenBinding,
-        TokenIssuanceProof, create_oauth_access_token,
-    };
-    use crate::services::oidc::ScopeSet;
-    use secrecy::ExposeSecret;
-
-    let (hardware_aaguid, org_domain) =
-        resolve_session_snapshot(state, user_id, Some(auth_id)).await;
-
-    let result = create_oauth_access_token(
-        state,
-        CreateOAuthTokenParams {
-            user_id,
-            email,
-            authenticator_id: Some(auth_id),
-            client_id: &state.config().base_url,
-            scope: Some(ScopeSet::all()),
-            binding: TokenBinding::new(None, Some(mtls_cert_thumbprint)),
-            act: None,
-            audience: None,
-            hardware_verification: crate::services::auth::HardwareVerification::Verified {
-                auth_time: Some(jiff::Timestamp::now().as_second()),
-            },
-            session_purpose: crate::db::SessionPurpose::OAuthAccessToken,
-            authorization_details: None,
-            hardware_aaguid: hardware_aaguid.as_deref(),
-            org_domain: org_domain.as_deref(),
-            source_code_hash: None,
-        },
-        TokenIssuanceProof {
-            grant: GrantProof::TestingOnly,
-            client_auth: ClientAuthProof::NoAuth(
-                crate::services::auth::NoClientAuth::internal_endpoint(),
-            ),
-            sender_constraint: SenderConstraintProof::no_registered_client(),
-        },
-    )
-    .await
-    .expect("Failed to create mTLS-bound test session");
-
-    result.token.expose_secret().to_string()
 }
 
 /// Create an organization API token for testing, bound to the given org,

--- a/crates/vouch-tests/src/harness.rs
+++ b/crates/vouch-tests/src/harness.rs
@@ -95,7 +95,16 @@ impl TestHarness {
         email: &str,
         auth_id: &str,
     ) -> Result<String> {
-        let token = test_utils::create_test_session(&self.state, user_id, email, auth_id).await;
+        let token = test_utils::create_test_session_with(
+            &self.state,
+            test_utils::TestSessionSpec {
+                user_id,
+                email,
+                auth_id: Some(auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
         Ok(token)
     }
 
@@ -111,12 +120,15 @@ impl TestHarness {
         auth_id: &str,
         client_id: &str,
     ) -> Result<String> {
-        let token = test_utils::create_test_session_for_client(
+        let token = test_utils::create_test_session_with(
             &self.state,
-            user_id,
-            email,
-            auth_id,
-            client_id,
+            test_utils::TestSessionSpec {
+                user_id,
+                email,
+                auth_id: Some(auth_id),
+                client_id: Some(client_id),
+                ..Default::default()
+            },
         )
         .await;
         Ok(token)
@@ -489,7 +501,16 @@ impl TestHarness {
     pub async fn create_expired_token(&self, user_id: &str, email: &str, auth_id: &str) -> String {
         use vouch_server::crypto::hash_token;
 
-        let token = test_utils::create_test_session(&self.state, user_id, email, auth_id).await;
+        let token = test_utils::create_test_session_with(
+            &self.state,
+            test_utils::TestSessionSpec {
+                user_id,
+                email,
+                auth_id: Some(auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
 
         let token_hash = hash_token(&token);
         db::delete_session_by_token_hash(&self.state.store, &token_hash)

--- a/crates/vouch-tests/tests/enroll_keys_api.rs
+++ b/crates/vouch-tests/tests/enroll_keys_api.rs
@@ -156,12 +156,17 @@ async fn delete_rejects_stale_session() {
     // KEY_DELETE_MAX_AGE_SECS is 60. A session with auth_time an hour in the
     // past must fail the freshness gate.
     let stale_iat = jiff::Timestamp::now().as_second() - 3600;
-    let token = test_utils::create_test_session_with_iat(
+    let token = test_utils::create_test_session_with(
         &harness.state,
-        &user.id,
-        &user.email,
-        &auth_id,
-        stale_iat,
+        test_utils::TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            verification: test_utils::TestVerification::Verified {
+                auth_time: Some(stale_iat),
+            },
+            ..Default::default()
+        },
     )
     .await;
 
@@ -286,11 +291,15 @@ async fn delete_rejects_bootstrap_session_without_fido2_auth_time() {
     // The helper mirrors the (fixed) production bootstrap session: a
     // returning user with an existing key gets `authenticator_id = Some(kept)`,
     // `hardware_verified = false`, and `auth_time = None`.
-    let token = test_utils::create_test_bootstrap_session_with_authenticator(
+    let token = test_utils::create_test_session_with(
         &harness.state,
-        &user.id,
-        &user.email,
-        &kept,
+        test_utils::TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&kept),
+            verification: test_utils::TestVerification::NotVerified,
+            ..Default::default()
+        },
     )
     .await;
 


### PR DESCRIPTION
Closes #1130.

## What this does

`crates/vouch-server/src/test_utils.rs` had nine session-minting helpers, eight of which spelled out a full `CreateOAuthTokenParams` literal. Each differed from its neighbours in one or two fields and repeated the remaining dozen, so adding a field to the params struct meant editing eight call sites with no reason to care.

They are replaced by one factory:

```rust
let token = create_test_session_with(&state, TestSessionSpec {
    user_id: &user.id,
    email: &user.email,
    auth_id: Some(&auth_id),
    binding: TestBinding::Dpop(&jkt),
    ..Default::default()
})
.await;
```

`TestSessionSpec::default()` is the ordinary hardware-verified bearer session, so a test spells out only the axis it is about. The axes are `auth_id`, `client_id`, `audience`, `binding` (`TestBinding::{Bearer, Dpop, Mtls}`), and `verification` (`TestVerification::{Verified, NotVerified, NotVerifiedForgedAuthTime}`). The `CreateOAuthTokenParams` literal now appears once, inside the factory.

This is the treatment `TestClientSpec` already gave `CreateOAuthClientParams`; sessions never got it.

## The impossible-token shape

`TestVerification::NotVerifiedForgedAuthTime` models what issue #1114 made unrepresentable: `hardware_verified: false` alongside an `auth_time` a freshness gate would read as recent FIDO2. `HardwareVerification::NotVerified` has nowhere to put a timestamp, so the issuer cannot mint it. The factory therefore mints a real unverified token, decodes it, changes `auth_time` and `jti`, re-signs, and persists a session row. Every other claim is whatever the production issuer produced, so a claim added later travels with the fixture instead of silently diverging.

Modelling it as a spec variant rather than a separate helper keeps the "which fixture do I want" decision in one place, while its docs make clear that it does not travel the ordinary issuance path.

## Required fields

`user_id` and `email` default to `""` — struct-update syntax on a borrowing struct offers no alternative. The factory asserts both are non-empty, so an omission fails with a clear message instead of minting a token for the empty subject.

## Migration

292 call sites across 39 files, rewritten mechanically and formatted with `cargo fmt`. `CLAUDE.md` gains a paragraph documenting the fixture convention for both `TestSessionSpec` and `TestClientSpec`, which previously existed only as unwritten practice.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --workspace --all-features` — 51 test binaries, 0 failures
- `cargo fmt --all --check` — clean
- `cargo doc` — no new warnings from the added items

Because a mechanical migration can silently weaken fixtures, the new factory was checked by breaking it three ways and confirming the suite catches each: the `NotVerified` mapping (5 tests fail), `auth_id` plumbing (37 fail), and the mTLS binding (7 fail). All three were restored before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)