### PR TITLE
fix(server): validate key and policy names through a ResourceLabel type

### DIFF
--- a/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
+++ b/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
@@ -399,6 +399,8 @@ login-err-invalid-client =
 
 ## register command
 
+register-err-name-empty = Name cannot be empty
+register-err-name-long = Name must be 100 characters or less
 register-starting = Registering additional { -yubikey } '{ $name }'...
 register-contacting-server = Contacting server...
 register-contact-ok = ok

--- a/crates/vouch-cli/src/commands/keys.rs
+++ b/crates/vouch-cli/src/commands/keys.rs
@@ -8,8 +8,8 @@ use inquire::{
     ui::{RenderConfig, Styled},
 };
 use vouch_common::{
-    DeleteKeyResponse, KeyInfo, ListKeysResponse, MAX_KEY_NAME_CHARS, RenameKeyRequest,
-    RenameKeyResponse,
+    DeleteKeyResponse, KeyInfo, ListKeysResponse, RenameKeyRequest, RenameKeyResponse,
+    ResourceLabel, ResourceLabelError,
 };
 
 use crate::client::VouchClient;
@@ -357,14 +357,13 @@ pub(crate) async fn remove(server: &str, key_id: &str, force: bool) -> Result<()
 pub(crate) async fn rename(server: &str, key_id: &str, new_name: &str) -> Result<()> {
     let client = VouchClient::new(server).await?;
 
-    // Validate name
-    let new_name = new_name.trim();
-    if new_name.is_empty() {
-        bail!(tr!("keys-err-name-empty"));
-    }
-    if new_name.chars().count() > MAX_KEY_NAME_CHARS {
-        bail!(tr!("keys-err-name-long"));
-    }
+    // Validate the name client-side before the round-trip; the server applies
+    // the same `ResourceLabel` contract authoritatively.
+    let new_name = match ResourceLabel::parse(new_name) {
+        Ok(name) => name,
+        Err(ResourceLabelError::Empty) => bail!(tr!("keys-err-name-empty")),
+        Err(ResourceLabelError::TooLong) => bail!(tr!("keys-err-name-long")),
+    };
 
     // First, verify the key exists
     let keys_response: ListKeysResponse = client.get_authenticated("/v1/keys").await?;
@@ -376,7 +375,7 @@ pub(crate) async fn rename(server: &str, key_id: &str, new_name: &str) -> Result
 
     // Rename the key
     let req = RenameKeyRequest {
-        name: new_name.to_string(),
+        name: new_name.into_string(),
     };
     let response: RenameKeyResponse = client
         .patch_authenticated(&format!("/v1/keys/{key_id}"), &req)

--- a/crates/vouch-cli/src/commands/register.rs
+++ b/crates/vouch-cli/src/commands/register.rs
@@ -8,9 +8,10 @@
 //! synchronous FIDO2 device operations run on separate threads. See the
 //! module-level docs in [`crate::fido2`] for why this separation is required.
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use vouch_common::{
     RegisterCompleteRequest, RegisterCompleteResponse, RegisterStartRequest, RegisterStartResponse,
+    ResourceLabel, ResourceLabelError,
 };
 
 use crate::client::VouchClient;
@@ -59,8 +60,15 @@ fn browser_register_fallback(server: &str) -> Result<()> {
 /// 2. All FIDO2 device work on a plain OS thread (wait, PIN, register)
 /// 3. Complete registration with the server (async)
 pub(crate) async fn run(server: &str, name: Option<&str>, timeout_secs: u64) -> Result<()> {
-    let name = name.unwrap_or("YubiKey");
-    tr_println!("register-starting", name = name);
+    // Validate the name before any hardware interaction or network round-trip,
+    // so input the server would reject does not cost a YubiKey PIN prompt. The
+    // default "YubiKey" always parses, so an omitted --name never bails.
+    let name = match ResourceLabel::parse(name.unwrap_or("YubiKey")) {
+        Ok(name) => name,
+        Err(ResourceLabelError::Empty) => bail!(tr!("register-err-name-empty")),
+        Err(ResourceLabelError::TooLong) => bail!(tr!("register-err-name-long")),
+    };
+    tr_println!("register-starting", name = name.as_str());
     println!();
 
     // Pre-flight: if Chrome is running on macOS, the CTAP-HID flow will fail

--- a/crates/vouch-common/src/api.rs
+++ b/crates/vouch-common/src/api.rs
@@ -413,13 +413,6 @@ pub struct DeleteKeyResponse {
     pub current_session_revoked: bool,
 }
 
-/// Maximum length of a security key name, in Unicode characters.
-///
-/// Counted in characters rather than UTF-8 bytes so the limit means the same
-/// thing for every script. The CLI, the JSON API handler, the key service, and
-/// the `maxlength` on the enrollment form all enforce or state this number.
-pub const MAX_KEY_NAME_CHARS: usize = 100;
-
 /// Request to rename a security key.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RenameKeyRequest {

--- a/crates/vouch-common/src/lib.rs
+++ b/crates/vouch-common/src/lib.rs
@@ -17,6 +17,7 @@ pub mod jwk;
 pub mod paths;
 pub mod posture;
 pub mod protocol;
+pub mod resource_label;
 pub(crate) mod url;
 
 #[cfg(test)]
@@ -41,13 +42,14 @@ pub use api::{
     BrowserRegisterStartResponse, CloudTokenResponse, DeleteKeyResponse, DeviceCodeRequest,
     DeviceCodeResponse, DeviceTokenRequest, DeviceTokenResponse, Fido2ChallengeResponse,
     GitHubAccountStatus, GitHubStatusResponse, GitHubTokenRequest, GitHubTokenResponse, KeyInfo,
-    ListKeysResponse, MAX_KEY_NAME_CHARS, OAuthError, RegisterCompleteRequest,
-    RegisterCompleteResponse, RegisterStartRequest, RegisterStartResponse, RenameKeyRequest,
-    RenameKeyResponse, SessionStatus, SshCaPublicKeyResponse, SshCertificateRequest,
-    SshCertificateResponse, serialize_opt_secret_string, serialize_secret_string,
+    ListKeysResponse, OAuthError, RegisterCompleteRequest, RegisterCompleteResponse,
+    RegisterStartRequest, RegisterStartResponse, RenameKeyRequest, RenameKeyResponse,
+    SessionStatus, SshCaPublicKeyResponse, SshCertificateRequest, SshCertificateResponse,
+    serialize_opt_secret_string, serialize_secret_string,
 };
 pub use cookie::{SessionCookie, clear_cookie, cookie_path, write_cookie};
 pub use error::ApiError;
+pub use resource_label::{ResourceLabel, ResourceLabelError};
 pub use url::{
     UrlSecurity, check_url_security, is_loopback_host, normalize_git_host, strip_default_https_port,
 };

--- a/crates/vouch-common/src/resource_label.rs
+++ b/crates/vouch-common/src/resource_label.rs
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! A validated display label for a resource a user owns.
+
+use serde::{Deserialize, Deserializer, Serialize};
+use std::fmt;
+
+/// A user-assigned display label for a resource the user owns — a security key
+/// or a custom device-posture policy.
+///
+/// A `ResourceLabel` is always trimmed of surrounding whitespace, non-empty,
+/// and at most [`ResourceLabel::MAX_CHARS`] Unicode characters (counted in
+/// characters, not UTF-8 bytes, so the limit means the same thing in every
+/// script). [`ResourceLabel::parse`] is the only constructor, so a value of
+/// this type is valid by construction: a handler cannot persist an unvalidated
+/// label, and an audit record that stores a `ResourceLabel` cannot capture the
+/// raw pre-trim input.
+///
+/// The wire request types stay `String` so the JSON API can return its own
+/// localized `invalid_name` error; handlers call [`ResourceLabel::parse`] and
+/// hand the parsed value to the persistence layer, which only accepts this
+/// type.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct ResourceLabel(String);
+
+/// Why a string was rejected as a [`ResourceLabel`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResourceLabelError {
+    /// The value was empty or contained only whitespace.
+    Empty,
+    /// The trimmed value exceeded [`ResourceLabel::MAX_CHARS`] characters.
+    TooLong,
+}
+
+impl ResourceLabel {
+    /// Maximum length, in Unicode characters, of the trimmed label.
+    pub const MAX_CHARS: usize = 100;
+
+    /// Trim surrounding whitespace, reject empty and over-length values, and
+    /// keep the trimmed form.
+    ///
+    /// # Errors
+    ///
+    /// - [`ResourceLabelError::Empty`] if `raw` is empty or all whitespace.
+    /// - [`ResourceLabelError::TooLong`] if the trimmed value exceeds
+    ///   [`Self::MAX_CHARS`] characters.
+    pub fn parse(raw: &str) -> Result<Self, ResourceLabelError> {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return Err(ResourceLabelError::Empty);
+        }
+        if trimmed.chars().count() > Self::MAX_CHARS {
+            return Err(ResourceLabelError::TooLong);
+        }
+        Ok(Self(trimmed.to_string()))
+    }
+
+    /// The validated, trimmed label.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consume into the inner `String`.
+    #[must_use]
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for ResourceLabel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// English by design: this text is for the `Error` trait, `serde`
+/// deserialization errors, and logs — never a browser. Every UI caller matches
+/// the [`ResourceLabelError`] variant and renders its own translated message
+/// (e.g. the `keys-error-name-*` Fluent keys); the server JSON handlers discard
+/// the error and return an exempt `error_description`.
+impl fmt::Display for ResourceLabelError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => f.write_str("label must not be empty"),
+            Self::TooLong => {
+                write!(
+                    f,
+                    "label must be at most {} characters",
+                    ResourceLabel::MAX_CHARS
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ResourceLabelError {}
+
+/// Validate on the way in so a `ResourceLabel` decoded from a signed state
+/// token (or any other serialized form) upholds the same invariant as one built
+/// through [`ResourceLabel::parse`].
+impl<'de> Deserialize<'de> for ResourceLabel {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        Self::parse(&raw).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test code: panic on assertion failure is acceptable"
+)]
+mod tests {
+    use super::{ResourceLabel, ResourceLabelError};
+
+    #[test]
+    fn parse_trims_surrounding_whitespace() {
+        let label = ResourceLabel::parse("  My Key  ").expect("valid");
+        assert_eq!(label.as_str(), "My Key");
+    }
+
+    #[test]
+    fn parse_rejects_empty() {
+        assert_eq!(ResourceLabel::parse(""), Err(ResourceLabelError::Empty));
+    }
+
+    #[test]
+    fn parse_rejects_whitespace_only() {
+        assert_eq!(ResourceLabel::parse("   "), Err(ResourceLabelError::Empty));
+    }
+
+    #[test]
+    fn parse_accepts_max_length() {
+        let name = "a".repeat(ResourceLabel::MAX_CHARS);
+        assert_eq!(ResourceLabel::parse(&name).expect("valid").as_str(), name);
+    }
+
+    #[test]
+    fn parse_rejects_over_max_length() {
+        let name = "a".repeat(ResourceLabel::MAX_CHARS + 1);
+        assert_eq!(
+            ResourceLabel::parse(&name),
+            Err(ResourceLabelError::TooLong)
+        );
+    }
+
+    #[test]
+    fn length_limit_counts_characters_not_bytes() {
+        // 100 CJK characters is 300 UTF-8 bytes but exactly MAX_CHARS characters,
+        // so a byte-based limit would wrongly reject it. (Regression guard for
+        // the char-not-byte contract this type centralizes.)
+        let cjk = "料".repeat(ResourceLabel::MAX_CHARS);
+        assert_eq!(cjk.len(), ResourceLabel::MAX_CHARS * 3);
+        assert!(ResourceLabel::parse(&cjk).is_ok());
+        let too_long = "料".repeat(ResourceLabel::MAX_CHARS + 1);
+        assert_eq!(
+            ResourceLabel::parse(&too_long),
+            Err(ResourceLabelError::TooLong)
+        );
+    }
+
+    #[test]
+    fn length_measured_after_trim() {
+        // MAX_CHARS real characters plus surrounding whitespace is still valid;
+        // the whitespace does not count toward the limit.
+        let padded = format!("  {}  ", "a".repeat(ResourceLabel::MAX_CHARS));
+        assert!(ResourceLabel::parse(&padded).is_ok());
+    }
+
+    #[test]
+    fn serializes_transparently_as_inner_string() {
+        let label = ResourceLabel::parse("My Key").expect("valid");
+        assert_eq!(
+            serde_json::to_string(&label).expect("serialize"),
+            "\"My Key\""
+        );
+    }
+
+    #[test]
+    fn deserialize_validates_and_trims() {
+        let label: ResourceLabel = serde_json::from_str("\"  My Key  \"").expect("valid");
+        assert_eq!(label.as_str(), "My Key");
+    }
+
+    #[test]
+    fn deserialize_rejects_empty() {
+        let err = serde_json::from_str::<ResourceLabel>("\"   \"").unwrap_err();
+        assert!(err.to_string().contains("must not be empty"));
+    }
+
+    #[test]
+    fn deserialize_rejects_over_length() {
+        let name = format!("\"{}\"", "a".repeat(ResourceLabel::MAX_CHARS + 1));
+        let err = serde_json::from_str::<ResourceLabel>(&name).unwrap_err();
+        assert!(err.to_string().contains("at most"));
+    }
+}

--- a/crates/vouch-server/src/handlers/admin/policies.rs
+++ b/crates/vouch-server/src/handlers/admin/policies.rs
@@ -17,6 +17,7 @@ use axum::response::{IntoResponse, Redirect, Response};
 use axum_extra::extract::cookie::CookieJar;
 use serde::Deserialize;
 use std::sync::Arc;
+use vouch_common::ResourceLabel;
 
 use crate::handlers::ValidPath;
 use crate::handlers::browser_login::validate_origin;
@@ -30,11 +31,6 @@ fn redirect_error(jar: CookieJar, msg: impl Into<String>) -> Response {
 
 /// Maximum number of custom policies per org (active + inactive).
 const MAX_CUSTOM_POLICIES: usize = 20;
-
-/// Maximum length of a policy name, in Unicode characters. Matches the
-/// `maxlength` the admin form advertises, which the browser counts in
-/// characters rather than UTF-8 bytes.
-const MAX_POLICY_NAME_CHARS: usize = 100;
 
 /// Maximum length of a policy description, in Unicode characters. Matches the
 /// `maxlength` the admin form advertises.
@@ -336,13 +332,12 @@ pub(crate) async fn create_custom_policy(
     validate_origin(&headers, &state.config().base_url)?;
 
     // Validate inputs before auth
-    let name = form.name.trim();
-    if name.is_empty() || name.chars().count() > MAX_POLICY_NAME_CHARS {
+    let Ok(name) = ResourceLabel::parse(&form.name) else {
         return Ok(redirect_error(
             jar,
             "Name must be between 1 and 100 characters",
         ));
-    }
+    };
 
     if form.policy_text.is_empty()
         || form.policy_text.chars().count() > posture::catalog::MAX_POLICY_TEXT_LEN
@@ -392,7 +387,7 @@ pub(crate) async fn create_custom_policy(
     let policy = db::create_custom_policy(
         &state.store,
         db::CreateCustomPolicyParams {
-            name,
+            name: name.as_str(),
             description: description.as_deref(),
             policy_text: &form.policy_text,
             org_id: &org_id,
@@ -444,13 +439,12 @@ pub(crate) async fn update_custom_policy(
 ) -> Result<Response, ServiceError> {
     validate_origin(&headers, &state.config().base_url)?;
 
-    let name = form.name.trim();
-    if name.is_empty() || name.chars().count() > MAX_POLICY_NAME_CHARS {
+    let Ok(name) = ResourceLabel::parse(&form.name) else {
         return Ok(redirect_error(
             jar,
             "Name must be between 1 and 100 characters",
         ));
-    }
+    };
 
     if form.policy_text.is_empty()
         || form.policy_text.chars().count() > posture::catalog::MAX_POLICY_TEXT_LEN
@@ -487,7 +481,7 @@ pub(crate) async fn update_custom_policy(
         &id,
         &org_id,
         db::UpdateCustomPolicyParams {
-            name: Some(name),
+            name: Some(name.as_str()),
             description: description
                 .as_deref()
                 .map_or(db::FieldUpdate::Clear, db::FieldUpdate::Set),
@@ -514,7 +508,9 @@ pub(crate) async fn update_custom_policy(
     let data = CustomPolicyAdminData {
         action: "custom_policy_updated".to_string(),
         policy_id: &id,
-        policy_name: Some(&form.name),
+        // Record the same trimmed name that was persisted, not the raw form
+        // input, so the audit row never names a value no policy row holds.
+        policy_name: Some(name.as_str()),
         admin_user_id: &admin.id,
         policy_text_hash: Some(policy_hash),
     };
@@ -849,11 +845,12 @@ pub(crate) async fn validate_policy_api(
     reason = "test code: panic on assertion failure is acceptable"
 )]
 mod tests {
-    use super::{MAX_POLICY_DESCRIPTION_CHARS, MAX_POLICY_NAME_CHARS, PolicyRow, posture};
+    use super::{MAX_POLICY_DESCRIPTION_CHARS, PolicyRow, posture};
     use crate::db;
     use crate::test_utils::*;
     use axum::http::StatusCode;
     use std::sync::Arc;
+    use vouch_common::ResourceLabel;
 
     fn admin_cookie(token: &str) -> String {
         format!("{}={token}", vouch_common::SESSION_COOKIE_NAME)
@@ -879,6 +876,74 @@ mod tests {
 
     /// Policy text that parses, for tests whose subject is a different field.
     const VALID_POLICY_TEXT: &str = "forbid (principal, action == Vouch::Action::\"IssueToken\", resource) unless { context.device.os == \"macos\" };";
+
+    #[tokio::test]
+    async fn test_update_custom_policy_audit_records_trimmed_name() {
+        // #1135: the update audit event must name the value actually persisted
+        // (trimmed), not the raw form input — otherwise it names a value no
+        // policy row holds. Parsing once into a ResourceLabel and using it for
+        // both the write and the audit is what keeps them from diverging.
+        let (app, state) = test_app().await;
+        let (admin, token) = setup_admin(&state).await;
+        let cookie = admin_cookie(&token);
+        let origin = "https://test.example.com";
+        let org_id = admin.org_id.clone().expect("admin has org");
+
+        let created = db::create_custom_policy(
+            &state.store,
+            db::CreateCustomPolicyParams {
+                name: "Original",
+                description: None,
+                policy_text: VALID_POLICY_TEXT,
+                org_id: &org_id,
+                builder_spec: None,
+            },
+        )
+        .await
+        .expect("create custom policy");
+
+        let form = format!(
+            "policy_name={}&policy_text={}",
+            urlencoding::encode(" My Policy "),
+            urlencoding::encode(VALID_POLICY_TEXT),
+        );
+        let (status, _body) = http_post_form(
+            &app,
+            &format!("/admin/policies/custom/{}", created.id),
+            &form,
+            &[("Cookie", &cookie), ("Origin", origin)],
+        )
+        .await;
+        assert_eq!(status, StatusCode::SEE_OTHER);
+
+        let stored = db::list_custom_policies(&state.store, &org_id)
+            .await
+            .expect("list")
+            .into_iter()
+            .find(|p| p.id == created.id)
+            .expect("still present");
+        assert_eq!(stored.name, "My Policy", "stored name is trimmed");
+
+        let filter = db::AuditEventFilter {
+            event_types: Some(vec![
+                db::AuditEventKind::AdminPolicyUpdate.as_str().to_string(),
+            ]),
+            user_id: Some(admin.id.clone()),
+            ..Default::default()
+        };
+        let events = state
+            .audit
+            .query_events(&filter)
+            .await
+            .expect("query audit events");
+        assert_eq!(events.len(), 1, "one update -> one audit event");
+        let v: serde_json::Value = serde_json::from_str(&events[0].data).expect("json");
+        assert_eq!(
+            v["policy_name"].as_str().expect("policy_name present"),
+            stored.name.as_str(),
+            "audit records the persisted (trimmed) name, not raw form.name",
+        );
+    }
 
     // ── Validation API — accepted input ──────────────────────────────────────
 
@@ -1513,7 +1578,7 @@ mod tests {
         // 90 CJK characters = 270 bytes; 400 CJK characters = 1200 bytes.
         let name = "名".repeat(90);
         let description = "説".repeat(400);
-        assert!(name.len() > MAX_POLICY_NAME_CHARS);
+        assert!(name.len() > ResourceLabel::MAX_CHARS);
         assert!(description.len() > MAX_POLICY_DESCRIPTION_CHARS);
 
         let form = format!(

--- a/crates/vouch-server/src/handlers/enroll_keys.rs
+++ b/crates/vouch-server/src/handlers/enroll_keys.rs
@@ -23,7 +23,7 @@ use axum::{
 use axum_extra::extract::cookie::CookieJar;
 use serde::Deserialize;
 use std::sync::Arc;
-use vouch_common::{DeleteKeyResponse, ListKeysResponse};
+use vouch_common::{DeleteKeyResponse, ListKeysResponse, ResourceLabel, ResourceLabelError};
 
 use super::session::{SteppedUpToken, extract_session_from_cookie};
 
@@ -68,15 +68,33 @@ pub(crate) async fn rename_key_form(
         Err(_) => return Redirect::to("/enroll/start").into_response(),
     };
 
-    match key_svc::rename_key(&state.store, &token.sub, &key_id, &form.name).await {
+    let name = match ResourceLabel::parse(&form.name) {
+        Ok(name) => name,
+        Err(err) => {
+            let message = match err {
+                ResourceLabelError::Empty => Tr::new("keys-error-name-empty").to_string(),
+                ResourceLabelError::TooLong => Tr::new("keys-error-name-too-long")
+                    .arg("max", ResourceLabel::MAX_CHARS.to_string())
+                    .to_string(),
+            };
+            let jar = crate::handlers::admin::flash::set_err_at(
+                jar,
+                &message,
+                crate::handlers::admin::flash::KEYS_PATH,
+            );
+            return (jar, Redirect::to("/enroll/keys")).into_response();
+        }
+    };
+
+    match key_svc::rename_key(&state.store, &token.sub, &key_id, &name).await {
         Ok(_) => Redirect::to("/enroll/keys").into_response(),
         Err(err) => {
             tracing::warn!(error = ?err, "rename_key_form: rename failed");
-            // A generic, user-safe message: the common failures (empty / too
-            // long) are also constrained by the form, and we must not surface
-            // internal error detail.
+            // Name-shape failures are handled above with specific messages; the
+            // remaining errors get a generic message that surfaces no internal
+            // detail.
             let message = Tr::new("keys-error-rename-failed")
-                .arg("max", vouch_common::MAX_KEY_NAME_CHARS.to_string())
+                .arg("max", ResourceLabel::MAX_CHARS.to_string())
                 .to_string();
             let jar = crate::handlers::admin::flash::set_err_at(
                 jar,

--- a/crates/vouch-server/src/handlers/keys.rs
+++ b/crates/vouch-server/src/handlers/keys.rs
@@ -19,7 +19,7 @@ use uuid::Uuid;
 use vouch_common::{
     DeleteKeyResponse, ListKeysResponse, Raw, RegisterCompleteRequest, RegisterCompleteResponse,
     RegisterStartRequest, RegisterStartResponse, RenameKeyRequest, RenameKeyResponse,
-    fido2_types::Challenge,
+    ResourceLabel, fido2_types::Challenge,
 };
 
 use super::extractors::ValidJson;
@@ -36,7 +36,7 @@ use crate::crypto::webauthn_verify;
 struct RegistrationState {
     user_id: Uuid,
     user_name: String,
-    device_name: String,
+    device_name: ResourceLabel,
     challenge: Challenge<Raw>,
     rp_id: String,
     /// RFC 8725 §3.11: Issued at time for expiration enforcement.
@@ -179,10 +179,20 @@ pub(crate) async fn register_start(
     let exp = now
         .checked_add(jiff::Span::new().minutes(5))
         .map_or(now.as_second().saturating_add(300), |t| t.as_second());
+    // Validate the user-supplied key name at the entry point. Storing it into
+    // a `ResourceLabel` field is what forces this parse; the rename path and
+    // the enrollment form apply the same 1..=100-character contract.
+    let device_name = ResourceLabel::parse(&req.name).map_err(|_| {
+        ServiceError::api(
+            StatusCode::BAD_REQUEST,
+            "invalid_name",
+            "Key name must be between 1 and 100 characters",
+        )
+    })?;
     let reg_state = RegistrationState {
         user_id,
         user_name: user.email.clone(),
-        device_name: req.name,
+        device_name,
         challenge: challenge.clone(),
         rp_id: state.config().rp_id.clone(),
         iat: now.as_second(),
@@ -343,7 +353,7 @@ pub(crate) async fn register_complete(
         &db::CreateAuthenticatorParams {
             user_id: &reg_state.user_id.to_string(),
             user_email: &reg_state.user_name,
-            name: &reg_state.device_name,
+            name: reg_state.device_name.as_str(),
             credential_id: &verified_cred_id,
             public_key: &verified_public_key,
             aaguid: aaguid.as_deref(),
@@ -408,16 +418,15 @@ pub(crate) async fn rename_key(
             "Key ID must be a valid UUID",
         ));
     }
-    let name = req.name.trim();
-    if name.is_empty() || name.chars().count() > vouch_common::MAX_KEY_NAME_CHARS {
-        return Err(ServiceError::api(
+    let name = ResourceLabel::parse(&req.name).map_err(|_| {
+        ServiceError::api(
             StatusCode::BAD_REQUEST,
             "invalid_name",
             "Key name must be between 1 and 100 characters",
-        ));
-    }
+        )
+    })?;
 
-    let message = key_svc::rename_key(&state.store, &token.sub, &key_id, name).await?;
+    let message = key_svc::rename_key(&state.store, &token.sub, &key_id, &name).await?;
 
     Ok(Json(RenameKeyResponse { message }))
 }
@@ -486,7 +495,7 @@ mod tests {
         let state = RegistrationState {
             user_id: Uuid::nil(),
             user_name: "test-user".to_string(),
-            device_name: "test-device".to_string(),
+            device_name: ResourceLabel::parse("test-device").expect("valid label"),
             challenge,
             rp_id: "test.example.com".to_string(),
             iat: 1_000_000_000,
@@ -500,7 +509,7 @@ mod tests {
 
         assert_eq!(decoded.user_id, Uuid::nil());
         assert_eq!(decoded.user_name, "test-user");
-        assert_eq!(decoded.device_name, "test-device");
+        assert_eq!(decoded.device_name.as_str(), "test-device");
         assert_eq!(decoded.rp_id, "test.example.com");
     }
 
@@ -512,7 +521,7 @@ mod tests {
         let state = RegistrationState {
             user_id: Uuid::nil(),
             user_name: "test".to_string(),
-            device_name: "dev".to_string(),
+            device_name: ResourceLabel::parse("dev").expect("valid label"),
             challenge: Challenge::from(vec![1u8; 32]),
             rp_id: "test.example.com".to_string(),
             iat: 1_000_000_000,
@@ -530,7 +539,7 @@ mod tests {
         let state = RegistrationState {
             user_id: Uuid::nil(),
             user_name: "test".to_string(),
-            device_name: "dev".to_string(),
+            device_name: ResourceLabel::parse("dev").expect("valid label"),
             challenge: Challenge::from(vec![1u8; 32]),
             rp_id: "test.example.com".to_string(),
             iat: 1_000_000_000,
@@ -725,6 +734,45 @@ mod tests {
         assert_eq!(error["message"], "User account is deactivated");
     }
 
+    #[tokio::test]
+    async fn test_register_start_rejects_invalid_name() {
+        // #1133: the CLI register path must enforce the same 1..=100-character
+        // key-name contract as rename; empty, whitespace-only, and over-long
+        // names are rejected before any state token is minted.
+        let (app, state) = test_app().await;
+        let user = create_test_user(&state.store, "register-name@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        let token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let over_long = "x".repeat(101);
+        for bad in ["", "   ", over_long.as_str()] {
+            let body = serde_json::json!({ "name": bad }).to_string();
+            let (status, resp) = http_post_json(
+                &app,
+                "/v1/keys/register/start",
+                &body,
+                &[("Authorization", &format!("Bearer {token}"))],
+            )
+            .await;
+            assert_eq!(
+                status,
+                StatusCode::BAD_REQUEST,
+                "name {bad:?} must be rejected"
+            );
+            let error: serde_json::Value = serde_json::from_str(&resp).expect("Valid JSON");
+            assert_eq!(error["code"], "invalid_name", "name {bad:?}");
+        }
+    }
+
     // ========================================================================
     // Register Complete — Negative
     // ========================================================================
@@ -739,7 +787,7 @@ mod tests {
         let reg_state = RegistrationState {
             user_id: Uuid::parse_str(&user.id).expect("user id is a uuid"),
             user_name: user.email.clone(),
-            device_name: "Test Device".to_string(),
+            device_name: ResourceLabel::parse("Test Device").expect("valid label"),
             challenge: Challenge::from(vec![7u8; 32]),
             rp_id: "localhost".to_string(),
             iat: now.as_second(),
@@ -936,7 +984,7 @@ mod tests {
         let reg_state = RegistrationState {
             user_id: Uuid::new_v4(),
             user_name: "replay-test@example.com".to_string(),
-            device_name: "Test Device".to_string(),
+            device_name: ResourceLabel::parse("Test Device").expect("valid label"),
             challenge,
             rp_id: "localhost".to_string(),
             iat: now.as_second(),
@@ -1011,7 +1059,7 @@ mod tests {
         let reg_state = RegistrationState {
             user_id: user_uuid,
             user_name: user.email.clone(),
-            device_name: "Test Device".to_string(),
+            device_name: ResourceLabel::parse("Test Device").expect("valid label"),
             challenge,
             rp_id: "localhost".to_string(),
             iat: now.as_second(),
@@ -1081,7 +1129,7 @@ mod tests {
         let reg_state = RegistrationState {
             user_id: user_uuid,
             user_name: user.email.clone(),
-            device_name: "Test Device".to_string(),
+            device_name: ResourceLabel::parse("Test Device").expect("valid label"),
             challenge,
             rp_id: "localhost".to_string(),
             iat: now.as_second(),

--- a/crates/vouch-server/src/services/keys.rs
+++ b/crates/vouch-server/src/services/keys.rs
@@ -11,7 +11,7 @@ use crate::db::documents::user::UserDoc;
 use crate::db::{self, store::DocumentStore};
 use crate::error::ServiceError;
 use crate::infra::i18n::Tr;
-use vouch_common::{KeyInfo, MAX_KEY_NAME_CHARS, lookup_device_model};
+use vouch_common::{KeyInfo, ResourceLabel, lookup_device_model};
 
 /// Maximum session age (in seconds) for destructive key operations.
 pub(crate) const KEY_DELETE_MAX_AGE_SECS: i64 = 60;
@@ -169,12 +169,14 @@ pub(crate) async fn list_keys_for_user(
 
 /// Rename a registered key.
 ///
-/// Validates ownership and name constraints before updating the key name.
+/// The new name arrives already validated as a [`ResourceLabel`] (trimmed,
+/// non-empty, within the length limit), so this function only checks the key id
+/// and ownership before updating.
 ///
 /// # Errors
 ///
 /// Returns:
-/// - `ServiceError::Validation` if the name is empty or too long.
+/// - `ServiceError::Validation` if `key_id` is not a valid UUID.
 /// - `ServiceError::NotFound` if the key does not exist *or* belongs to another
 ///   user. The two are deliberately indistinguishable: a 403 for someone else's
 ///   key would let any authenticated caller probe whether a given key id exists.
@@ -183,7 +185,7 @@ pub(crate) async fn rename_key(
     store: &DocumentStore,
     user_id: &str,
     key_id: &str,
-    new_name: &str,
+    new_name: &ResourceLabel,
 ) -> Result<String, ServiceError> {
     // Validate key_id is a UUID before DB lookup
     if uuid::Uuid::try_parse(key_id).is_err() {
@@ -192,20 +194,9 @@ pub(crate) async fn rename_key(
         ));
     }
 
-    // Validate name
-    let name = new_name.trim();
-    if name.is_empty() {
-        return Err(ServiceError::Validation(
-            Tr::new("keys-error-name-empty").to_string(),
-        ));
-    }
-    if name.chars().count() > MAX_KEY_NAME_CHARS {
-        return Err(ServiceError::Validation(
-            Tr::new("keys-error-name-too-long")
-                .arg("max", MAX_KEY_NAME_CHARS.to_string())
-                .to_string(),
-        ));
-    }
+    // The name is already trimmed and length-checked: `ResourceLabel` has no
+    // other constructor, so both callers had to validate before reaching here.
+    let name = new_name.as_str();
 
     // Get the authenticator to verify ownership
     let authenticator = db::get_authenticator_by_id(store, key_id)
@@ -449,12 +440,22 @@ mod tests {
         let owned_key = crate::test_utils::create_test_authenticator(&state.store, &owner.id).await;
         let absent_key = uuid::Uuid::now_v7().to_string();
 
-        let foreign = rename_key(&state.store, &caller.id, &owned_key, "renamed")
-            .await
-            .unwrap_err();
-        let missing = rename_key(&state.store, &caller.id, &absent_key, "renamed")
-            .await
-            .unwrap_err();
+        let foreign = rename_key(
+            &state.store,
+            &caller.id,
+            &owned_key,
+            &ResourceLabel::parse("renamed").unwrap(),
+        )
+        .await
+        .unwrap_err();
+        let missing = rename_key(
+            &state.store,
+            &caller.id,
+            &absent_key,
+            &ResourceLabel::parse("renamed").unwrap(),
+        )
+        .await
+        .unwrap_err();
 
         assert!(
             matches!(foreign, ServiceError::NotFound("Key")),


### PR DESCRIPTION
Closes #1133
Closes #1135

## Bugs

Two Detail findings that are the same class — a user-assigned display label validated inconsistently across entry points:

- **#1133** — the FIDO2 CLI register path (`register_start`) stored the user-supplied key name verbatim into the signed `RegistrationState`, with no trim / non-empty / length check, so empty, whitespace-only, and over-long names were accepted where the rename path rejects them.
- **#1135** — the custom-policy update audit recorded the raw, untrimmed `form.name` while the database stored the trimmed value, so the audit row named a value no policy row held.

## Fix: one type instead of scattered guards

Introduce `vouch_common::ResourceLabel` — a newtype whose only constructor (`parse`) trims, rejects empty, and enforces the 1..=100-character limit (counted in characters, not bytes). A field typed as `ResourceLabel` cannot hold an unvalidated value, so both bugs become unrepresentable rather than latent.

Threaded through the user-input entry points:

- **`register_start`** parses into a `ResourceLabel`-typed `RegistrationState.device_name`; the parse is now compile-forced, closing #1133.
- **custom-policy create/update** parse once and use the same `ResourceLabel` for both the DB write and the audit event, so they cannot diverge — closing #1135.
- **the rename service** now takes `&ResourceLabel`, removing the duplicate validation the JSON handler and the enrollment form each performed; each handler maps the parse error to its own audience (JSON `invalid_name`, or a translated flash / CLI message).
- **the CLI** `register` and `keys rename` commands validate before the network round-trip.

`MAX_KEY_NAME_CHARS` and the local `MAX_POLICY_NAME_CHARS` are collapsed into `ResourceLabel::MAX_CHARS` (single source).

### Scope note

`ResourceLabel` sits at the entry points that are exclusively user input. `CreateAuthenticatorParams.name` stays `&str` because it is shared with the browser-enrollment path, whose name is a server-derived device-model string (from the attestation AAGUID), not user input. SCIM group `displayName`, OAuth `client_name`, usernames, and policy descriptions have different rules and are out of scope.

### i18n

No new browser-facing English. The server JSON errors are exempt API strings (RFC 6749 §5.2 audience); the enrollment flash and CLI reuse existing/added Fluent keys (`keys-error-name-*`, `register-err-name-*`); the admin-policy flash keeps the file's existing (pre-existing, untranslated) strings. `ResourceLabelError`'s `Display` is documented as non-UI (Error trait / serde / logs only).

## Testing

- `ResourceLabel` unit tests (11): trim, empty, whitespace-only, max-length boundary, char-not-byte (100 CJK = 300 bytes accepted), trim-then-measure, transparent serialize, validating deserialize.
- **#1133 regression** (`test_register_start_rejects_invalid_name`): empty / whitespace / 101-char names → `400 invalid_name`. Mutation-checked: neutering `ResourceLabel::parse` fails it and 6 unit tests.
- **#1135 regression** (`test_update_custom_policy_audit_records_trimmed_name`): a whitespace-padded name through the real router → audit `policy_name` equals the stored trimmed name. Mutation-checked: reverting the audit source to `&form.name` fails it.
- Full gates green via the pre-push hook: `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features`, `cargo fmt --check`. Touched suites: keys (32), policies (30), services::keys (7), i18n completeness, vouch-cli (81), vouch-common resource_label (11).

Not verified: live WebAuthn register/rename with a physical YubiKey (no hardware harness); covered at the router/service level by the in-process tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)