### PR TITLE
fix(server): revoke credentials before persisting user deactivation

### DIFF
--- a/crates/vouch-server/src/handlers/admin/members.rs
+++ b/crates/vouch-server/src/handlers/admin/members.rs
@@ -274,21 +274,25 @@ pub(crate) async fn deactivate_member(
         ));
     }
 
-    let updated = db::update_user_active_status(&state.store, &target_id, false).await?;
-    if !updated {
-        return Err(member_gone());
-    }
-
-    // Sessions, SSH certificates, and the GitHub refresh token all go, or the
-    // request fails — reporting a deactivation that left credentials live
-    // would tell the admin access is gone when it is not.
-    crate::services::auth::revoke_user_access(
+    // Revoke sessions, SSH certificates, and the GitHub refresh token BEFORE
+    // the active=false write commits. If the write landed first and revocation
+    // then failed, the member would be left inactive with live SSH certificates
+    // (#1116); revoking first leaves them active and retryable on failure.
+    let updated = crate::services::auth::revoke_then_persist(
         &state,
         &target_id,
         "User deactivated by admin",
         &admin.id,
+        || db::update_user_active_status(&state.store, &target_id, false),
     )
-    .await?;
+    .await
+    .map_err(|e| match e {
+        crate::services::auth::DeactivationError::Revoke(err) => err,
+        crate::services::auth::DeactivationError::Persist(err) => ServiceError::from(err),
+    })?;
+    if !updated {
+        return Err(member_gone());
+    }
 
     let data = AdminMemberActionData {
         action: "deactivate",

--- a/crates/vouch-server/src/handlers/scim/tests/users.rs
+++ b/crates/vouch-server/src/handlers/scim/tests/users.rs
@@ -244,6 +244,70 @@ async fn test_rfc7644_patch_user_deactivate() {
 }
 
 #[tokio::test]
+async fn test_patch_user_deactivate_revokes_ssh_certificates() {
+    // #1116: SCIM deactivation must revoke previously-issued SSH certificates,
+    // not merely flip active=false. `revoke_then_persist` runs revocation
+    // before the active=false write commits.
+    let (app, state) = test_app().await;
+    let token = create_test_scim_token(&state.store, "test-patch-revoke", "test-org").await;
+    let auth_header = format!("Bearer {token}");
+
+    let (status, body) = http_post_json(
+        &app,
+        "/scim/v2/Users",
+        r#"{"schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"], "userName": "revoke-cert@test-org.example.com", "active": true}"#,
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let created: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let user_id = created["id"].as_str().expect("user id").to_string();
+
+    let expires_at = jiff::Timestamp::now()
+        .checked_add(jiff::Span::new().hours(8))
+        .expect("future timestamp");
+    crate::db::record_ssh_certificate_issuance(
+        &state.store,
+        42_000_003,
+        &user_id,
+        "revoke-cert@test-org.example.com",
+        &["user".to_string()],
+        expires_at,
+    )
+    .await
+    .expect("record issuance");
+    assert!(
+        crate::db::get_revoked_ssh_certificates(&state.store)
+            .await
+            .expect("list revoked")
+            .is_empty(),
+        "setup: no revocations yet"
+    );
+
+    let (status, _body) = http_request(
+        &app,
+        "PATCH",
+        &format!("/scim/v2/Users/{user_id}"),
+        Some(r#"{"schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"], "Operations": [{"op": "replace", "path": "active", "value": false}]}"#.to_string()),
+        &[
+            ("Authorization", &auth_header),
+            ("Content-Type", "application/json"),
+        ],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let revoked = crate::db::get_revoked_ssh_certificates(&state.store)
+        .await
+        .expect("list revoked");
+    assert_eq!(
+        revoked.len(),
+        1,
+        "SCIM deactivation must revoke the user's SSH certificate"
+    );
+}
+
+#[tokio::test]
 async fn test_patch_user_active_string_rejected() {
     // PATCH with `"active": "false"` (string, not bool) must return 400
     // invalidValue per RFC 7643 §2.2 — it must never be coerced to a

--- a/crates/vouch-server/src/handlers/scim/users.rs
+++ b/crates/vouch-server/src/handlers/scim/users.rs
@@ -449,17 +449,40 @@ pub(crate) async fn patch_user(
         }
     }
 
-    // Update user in database
-    match db::update_scim_user(
-        &state.store,
-        &id,
-        &auth.org_id,
-        patched.name.as_deref(),
-        patched.external_id.as_deref(),
-        patched.active,
-    )
-    .await
-    {
+    // A deactivation must revoke live credentials BEFORE the active=false write
+    // commits: if the write landed first and revocation then failed, the user
+    // would be left inactive with live SSH certificates, and the deactivation
+    // transition gate would never re-fire revocation on retry (#1116). A
+    // non-deactivating PATCH just persists its field changes.
+    let persist = || {
+        db::update_scim_user(
+            &state.store,
+            &id,
+            &auth.org_id,
+            patched.name.as_deref(),
+            patched.external_id.as_deref(),
+            patched.active,
+        )
+    };
+    let result = if patched.deactivated {
+        tracing::info!(
+            "User {} deactivated via SCIM: revoking sessions and SSH certificates before persisting",
+            id
+        );
+        crate::services::auth::revoke_then_persist(
+            &state,
+            &id,
+            "User deactivated via SCIM",
+            "scim",
+            persist,
+        )
+        .await
+    } else {
+        persist()
+            .await
+            .map_err(crate::services::auth::DeactivationError::Persist)
+    };
+    match result {
         Ok(true) => {}
         Ok(false) => {
             return (
@@ -468,7 +491,14 @@ pub(crate) async fn patch_user(
             )
                 .into_response();
         }
-        Err(e) => {
+        Err(crate::services::auth::DeactivationError::Revoke(_)) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ScimError::new(500, "Failed to revoke user access")),
+            )
+                .into_response();
+        }
+        Err(crate::services::auth::DeactivationError::Persist(e)) => {
             if let Some(resp) = super::invalid_index_value_response(&e) {
                 return resp.into_response();
             }
@@ -476,29 +506,6 @@ pub(crate) async fn patch_user(
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ScimError::new(500, "Failed to update user")),
-            )
-                .into_response();
-        }
-    }
-
-    // If user was deactivated, invalidate all their sessions and revoke SSH certificates
-    if patched.deactivated {
-        tracing::info!(
-            "User {} deactivated via SCIM, invalidating sessions and revoking SSH certificates",
-            id
-        );
-        if crate::services::auth::revoke_user_access(
-            &state,
-            &id,
-            "User deactivated via SCIM",
-            "scim",
-        )
-        .await
-        .is_err()
-        {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ScimError::new(500, "Failed to revoke user access")),
             )
                 .into_response();
         }

--- a/crates/vouch-server/src/services/auth.rs
+++ b/crates/vouch-server/src/services/auth.rs
@@ -1140,6 +1140,51 @@ pub(crate) async fn revoke_user_access(
     Ok(())
 }
 
+/// Which step of [`revoke_then_persist`] failed.
+pub(crate) enum DeactivationError<E> {
+    /// [`revoke_user_access`] failed; the caller's state change was **not**
+    /// persisted, so the user is left active and the operation is safe to retry.
+    Revoke(ServiceError),
+    /// Revocation succeeded but persisting the state change failed afterward.
+    Persist(E),
+}
+
+/// Revoke a user's live credentials, then persist a deactivation — in that
+/// order, and only persisting if revocation succeeded.
+///
+/// Deactivating a user must withdraw sessions and certificates **before** the
+/// `active = false` write commits. If the write landed first and revocation
+/// then failed, the user would be marked inactive while previously-issued SSH
+/// certificates stayed valid until they expire — and, on the SCIM path, the
+/// deactivation transition gate would not fire again on retry, so no retry
+/// would re-attempt revocation (issue #1116). Revoking first means a revocation
+/// failure leaves the user active and recoverable by an IdP or admin retry.
+///
+/// `persist` runs exactly when [`revoke_user_access`] returns `Ok`; a caller
+/// therefore cannot persist the state change ahead of revocation.
+///
+/// # Errors
+///
+/// Returns [`DeactivationError::Revoke`] if revocation fails (in which case
+/// `persist` does not run), or [`DeactivationError::Persist`] if the state
+/// change fails after a successful revocation.
+pub(crate) async fn revoke_then_persist<T, E, F, Fut>(
+    state: &AppState,
+    user_id: &str,
+    reason: &str,
+    revoked_by: &str,
+    persist: F,
+) -> Result<T, DeactivationError<E>>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<T, E>>,
+{
+    revoke_user_access(state, user_id, reason, revoked_by)
+        .await
+        .map_err(DeactivationError::Revoke)?;
+    persist().await.map_err(DeactivationError::Persist)
+}
+
 #[cfg(test)]
 #[expect(
     clippy::unwrap_used,
@@ -1149,7 +1194,56 @@ pub(crate) async fn revoke_user_access(
 )]
 mod tests {
     use super::*;
-    use crate::test_utils::{TEST_ISSUER, make_test_access_token, make_test_oidc_key};
+    use crate::test_utils::{
+        TEST_ISSUER, create_test_user, make_test_access_token, make_test_oidc_key, test_app,
+    };
+
+    #[tokio::test]
+    async fn revoke_then_persist_revokes_before_running_persist() {
+        // #1116: `revoke_then_persist` must withdraw the user's live
+        // credentials before the caller's persist step runs, so a deactivation
+        // is never committed while credentials are still valid. The persist
+        // closure observes an already-revoked certificate.
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let (_app, state) = test_app().await;
+        let user = create_test_user(&state.store, "revoke-order@example.com").await;
+
+        let expires_at = jiff::Timestamp::now()
+            .checked_add(jiff::Span::new().hours(8))
+            .expect("future timestamp");
+        crate::db::record_ssh_certificate_issuance(
+            &state.store,
+            42_000_002,
+            &user.id,
+            &user.email,
+            &["user".to_string()],
+            expires_at,
+        )
+        .await
+        .expect("record issuance");
+
+        let revoked_at_persist = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&revoked_at_persist);
+        let state_ref = &state;
+        let outcome: Result<(), ()> =
+            revoke_then_persist(&state, &user.id, "test", "test", || async {
+                let revoked = crate::db::get_revoked_ssh_certificates(&state_ref.store)
+                    .await
+                    .expect("list revoked");
+                flag.store(!revoked.is_empty(), Ordering::SeqCst);
+                Ok::<(), ()>(())
+            })
+            .await
+            .map_err(|_| ());
+
+        assert!(outcome.is_ok(), "revocation and persist both succeed");
+        assert!(
+            revoked_at_persist.load(Ordering::SeqCst),
+            "the certificate must already be revoked when persist runs"
+        );
+    }
 
     #[tokio::test]
     async fn test_decode_token_routes_es256_to_access_token() {


### PR DESCRIPTION
Closes #1116
Supersedes #1126 (fixes both deactivation sites, not just the SCIM one)

## Bug

Deactivating a user committed `active=false` **before** revoking their sessions and SSH certificates. If revocation then failed, the user was left inactive while previously-issued SSH certificates stayed valid until expiry. On the SCIM path this was worse: revocation is gated on the `active: true → false` transition, so once the failed attempt left the user `active=false`, an IdP retry never re-entered revocation. Both write sites had the order backwards:

- `patch_user` (SCIM) — `update_scim_user` then `revoke_user_access` (the reported #1116).
- `deactivate_member` (admin) — `update_user_active_status(false)` then `revoke_user_access` (the same sibling bug, verified in main).

## Fix

`services::auth::revoke_then_persist` revokes first and runs the caller's persist step **only if revocation succeeded**, returning a two-variant `DeactivationError` so each handler renders its own response (SCIM JSON vs `ServiceError`). Both sites route through it. A revocation failure now leaves the user active and recoverable by an IdP or admin retry — strictly safer than inactive-with-live-credentials.

### Why an ordering helper and not one transaction

Revocation is *already* multiple committed transactions and cannot be wrapped in one: `delete_sessions_for_user` → `delete_by_index` chunks deletions into 500-doc batches, each its own commit, to stay within Aurora DSQL's ~3,000-statement-per-transaction limit (the constraint behind #1145/#1148); cert revocation is similar; and revocation also evicts the in-memory `SessionCache`, which no DB transaction can roll back. Bundling it all into one transaction would cap how many sessions/certs a user could have and still be deactivatable — reintroducing the #1145 failure mode. `revoke_user_access` is therefore designed to be idempotent and retryable rather than atomic; given non-atomicity is forced, revoke-first is the safe order.

## Testing

- `revoke_then_persist_revokes_before_running_persist` (services::auth) — the persist closure observes an already-revoked certificate, proving revocation completes first. Mutation-checked: reversing the helper's two statements fails it.
- `test_patch_user_deactivate_revokes_ssh_certificates` (SCIM) — a PATCH deactivation through the real router revokes the user's issued SSH cert.
- Existing `test_deactivate_member_revokes_ssh_certificates` (admin) and the SCIM/admin deactivation suites pass unchanged.
- Full gate green via the pre-push hook: `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features`, `cargo fmt --check`.

Not versioned: a production reproduction of a mid-revocation failure (no fault seam for `delete_by_index`/cert revocation). The failure-skip is a structural guarantee of the helper (`revoke().await?; persist()`), and the success-ordering is pinned by the mutation-checked test above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)