### PR TITLE
refactor(server): share the recency check via a RecencyWindow type

### DIFF
--- a/crates/vouch-server/src/services/keys.rs
+++ b/crates/vouch-server/src/services/keys.rs
@@ -103,38 +103,29 @@ pub(crate) fn require_recent_hardware_verification(
     require_fresh_timestamp(token.auth_time.unwrap_or(0), KEY_DELETE_MAX_AGE_SECS)
 }
 
-/// Require the given issued-at or auth timestamp to be within `max_age_secs` seconds
-/// of the server's current wall clock and not in the future.
+/// Require the given issued-at or auth timestamp to be within `max_age_secs`
+/// seconds of the server's current wall clock and not in the future.
 ///
-/// Returns `ServiceError::StepUpRequired` if the timestamp is too old *or* is in
-/// the future relative to `now`. Used by delete key operations to enforce
-/// recency of authentication.
-///
-/// `i64::saturating_sub` returns the true signed difference for in-range inputs
-/// (it saturates only at `i64::MIN`/`i64::MAX`, not at `0`), so a future
-/// `issued_at` yields a *negative* `session_age`. The lone `session_age >
-/// max_age_secs` check would admit that as "age 0" fresh — which is wrong for a
-/// freshness gate, where a ceremony dated after `now` is impossible and must
-/// fail closed, mirroring the `unwrap_or(0)` epoch fallback the caller already
-/// applies for an absent timestamp.
+/// A step-up ceremony dated after now is impossible, so no clock skew is
+/// tolerated: both a too-old and a future-dated timestamp fail closed (issue
+/// #1144). The bounds check is the [`crate::services::RecencyWindow`] shared
+/// with the DPoP proof-age gate.
 ///
 /// # Errors
 ///
 /// Returns `ServiceError::StepUpRequired` when `issued_at` is older than
-/// `max_age_secs` or is later than `now` (a future-dated timestamp).
+/// `max_age_secs` or is later than now (a future-dated timestamp).
 pub(crate) fn require_fresh_timestamp(
     issued_at: i64,
     max_age_secs: i64,
 ) -> Result<(), ServiceError> {
-    let now = jiff::Timestamp::now().as_second();
-    let session_age = now.saturating_sub(issued_at);
-    if session_age < 0 || session_age > max_age_secs {
-        return Err(ServiceError::StepUpRequired {
-            acr_values: Some(crate::services::auth::ACR_AAL3.to_string()),
-            max_age: Some(u64::try_from(max_age_secs).unwrap_or(60)),
-        });
+    if crate::services::RecencyWindow::no_skew(max_age_secs).accepts(issued_at) {
+        return Ok(());
     }
-    Ok(())
+    Err(ServiceError::StepUpRequired {
+        acr_values: Some(crate::services::auth::ACR_AAL3.to_string()),
+        max_age: Some(u64::try_from(max_age_secs).unwrap_or(60)),
+    })
 }
 
 /// List all registered keys for a user.

--- a/crates/vouch-server/src/services/mod.rs
+++ b/crates/vouch-server/src/services/mod.rs
@@ -53,3 +53,106 @@ pub(crate) mod policy;
 
 // Protocol modules will be added here as they are implemented:
 // pub mod scim;
+
+/// A time window for judging whether a timestamp is recent enough to accept.
+///
+/// A timestamp is accepted when its age (`now - issued_at`, in seconds) falls
+/// within `[-clock_skew_secs, max_age_secs]`. The two ends are independent:
+///
+/// * `max_age_secs` is the validity *lifetime* — how long after `issued_at` the
+///   timestamp stays acceptable.
+/// * `clock_skew_secs` is the tolerance for a client clock running *ahead* of
+///   ours; a timestamp up to this far in the future is still accepted. Callers
+///   for which a future timestamp is impossible use [`RecencyWindow::no_skew`],
+///   so a future-dated value fails closed (issue #1144).
+///
+/// The bound is checked with saturating arithmetic, so an impossible timestamp
+/// (age below `-clock_skew_secs`, e.g. from a regressed server clock) is
+/// rejected rather than read as age-0 fresh.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RecencyWindow {
+    max_age_secs: i64,
+    clock_skew_secs: i64,
+}
+
+impl RecencyWindow {
+    /// A window that tolerates no clock skew: a timestamp dated after `now` is
+    /// rejected. For gates where a future-dated event is impossible (the
+    /// key-deletion step-up).
+    pub(crate) fn no_skew(max_age_secs: i64) -> Self {
+        Self {
+            max_age_secs,
+            clock_skew_secs: 0,
+        }
+    }
+
+    /// A window that accepts timestamps up to `clock_skew_secs` in the future,
+    /// forgiving a client clock ahead of ours (DPoP proofs allow this per
+    /// RFC 9449).
+    pub(crate) fn with_skew(max_age_secs: i64, clock_skew_secs: i64) -> Self {
+        Self {
+            max_age_secs,
+            clock_skew_secs,
+        }
+    }
+
+    /// Whether `issued_at` (Unix seconds) is within the window relative to the
+    /// current wall clock.
+    pub(crate) fn accepts(&self, issued_at: i64) -> bool {
+        self.accepts_at(jiff::Timestamp::now().as_second(), issued_at)
+    }
+
+    /// Whether `issued_at` is within the window relative to an explicit `now` —
+    /// for callers that have already stamped the time once (the DPoP validation
+    /// snapshots it at the request entry point) or for deterministic tests.
+    pub(crate) fn accepts_at(&self, now: i64, issued_at: i64) -> bool {
+        let age = now.saturating_sub(issued_at);
+        // `age >= -clock_skew_secs`, written without negating so
+        // `arithmetic_side_effects` is satisfied.
+        age.saturating_add(self.clock_skew_secs) >= 0 && age <= self.max_age_secs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RecencyWindow;
+
+    const MAX_AGE: i64 = 60;
+    const NOW: i64 = 1_000_000;
+
+    #[test]
+    fn accepts_recent_and_current() {
+        assert!(
+            RecencyWindow::no_skew(MAX_AGE).accepts_at(NOW, NOW),
+            "age 0"
+        );
+        assert!(RecencyWindow::no_skew(MAX_AGE).accepts_at(NOW, NOW - 30));
+    }
+
+    #[test]
+    fn max_age_boundary_is_inclusive() {
+        assert!(RecencyWindow::no_skew(MAX_AGE).accepts_at(NOW, NOW - 60));
+        assert!(!RecencyWindow::no_skew(MAX_AGE).accepts_at(NOW, NOW - 61));
+    }
+
+    // #1144: with no skew tolerated, a future-dated timestamp yields a negative
+    // age and must fail closed rather than read as age-0 fresh.
+    #[test]
+    fn no_skew_rejects_any_future_timestamp() {
+        assert!(!RecencyWindow::no_skew(MAX_AGE).accepts_at(NOW, NOW + 1));
+        assert!(!RecencyWindow::no_skew(MAX_AGE).accepts_at(NOW, NOW + 3600));
+    }
+
+    #[test]
+    fn skew_is_tolerated_up_to_its_bound() {
+        // Mirrors the DPoP 60s clock-skew allowance (RFC 9449).
+        assert!(RecencyWindow::with_skew(MAX_AGE, 60).accepts_at(NOW, NOW + 60));
+        assert!(!RecencyWindow::with_skew(MAX_AGE, 60).accepts_at(NOW, NOW + 61));
+    }
+
+    #[test]
+    fn saturating_arithmetic_does_not_overflow_at_bounds() {
+        assert!(!RecencyWindow::no_skew(MAX_AGE).accepts_at(i64::MAX, i64::MIN));
+        assert!(!RecencyWindow::no_skew(MAX_AGE).accepts_at(i64::MIN, i64::MAX));
+    }
+}

--- a/crates/vouch-server/src/services/oidc/dpop.rs
+++ b/crates/vouch-server/src/services/oidc/dpop.rs
@@ -339,13 +339,10 @@ pub fn validate_dpop_claims(
         return Err(DpopError::UriMismatch);
     }
 
-    // Check timestamp (not too old, not in future)
-    let age = now.saturating_sub(claims.iat);
-    if age < -60 {
-        // Allow 60 seconds clock skew into future
-        return Err(DpopError::Expired);
-    }
-    if age > max_age_seconds {
+    // Not too old, and not more than 60 seconds into the future — RFC 9449
+    // permits limited clock skew. Same bounds check the key-deletion step-up
+    // gate uses (there with no skew); `now` was stamped once at the entry point.
+    if !crate::services::RecencyWindow::with_skew(max_age_seconds, 60).accepts_at(now, claims.iat) {
         return Err(DpopError::Expired);
     }
 


### PR DESCRIPTION
## Why

Two server-side gates independently answered "is this timestamp recent enough?": `require_fresh_timestamp` (the key-deletion step-up gate, `services/keys.rs`) and the DPoP proof-age check (`services/oidc/dpop.rs`). They re-derived the same bounds arithmetic, and the key-deletion path had once gotten the future-timestamp bound wrong (#1144, fixed in #1147). This single-sources the check so a future divergence can't reappear on only one of them.

## What

`services::RecencyWindow`, a small value type both call:

- `max_age_secs` — the validity *lifetime* (how long after `issued_at` the timestamp stays acceptable).
- `clock_skew_secs` — the allowance for a client clock running *ahead* of ours. These are independent, asymmetric bounds (window `[-clock_skew_secs, max_age_secs]` on the age axis), not a symmetric ±: key deletion is `[0, 60]` (no future tolerated), DPoP is `[-60, max_age]` (60s skew against a 60s/300s lifetime).

```rust
// keys.rs — a future-dated step-up is impossible, so no skew; reads the clock
RecencyWindow::no_skew(max_age_secs).accepts(issued_at)

// dpop.rs — 60s clock skew (RFC 9449); uses the `now` DPoP already stamps once at entry
RecencyWindow::with_skew(max_age_seconds, 60).accepts_at(now, claims.iat)
```

`accepts()` reads the wall clock so most callers never pass `now`; `accepts_at(now, …)` takes a caller-stamped `now` for the DPoP path (which snapshots time once at its entry point for deterministic boundary tests). The bound uses saturating arithmetic, so an impossible timestamp (age below `-clock_skew_secs`, e.g. a regressed server clock) fails closed rather than reading as age-0 fresh — the #1144 failure mode.

Lives in `vouch-server` (`services/mod.rs`, the shared parent of both callers), not `vouch-common`: only this crate uses it, and the CLI/agent time logic is absolute-expiry (`now < expires_at`), a different check.

## Behavior

No behavior change — a pure refactor. The key-deletion freshness tests (`services::keys`, including the #1144 future/epoch/boundary cases) and the DPoP boundary vectors (issue #661) pass unchanged, plus 5 new unit tests on `RecencyWindow` itself.

Verified green via the pre-push hook: `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features`, `cargo fmt --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)