### PR TITLE
chore(detail): sync hosted Detail rules into the repo

### DIFF
--- a/.claude/skills/detail-rules/references/aws-credential-cache-key-missing-agent-source.md
+++ b/.claude/skills/detail-rules/references/aws-credential-cache-key-missing-agent-source.md
@@ -139,24 +139,17 @@ let data = cache::get_or_fetch(&cache_key, "EKS token", || async {
 **Correct CodeArtifact pattern** (`codeartifact.rs`):
 
 ```rust
-// Resolve the role BEFORE the cache lookup: `target.profile` is only the
-// configured anchor and is None when the account has to be inferred, so the
-// resolved role ARN — not the optional profile — is what disambiguates
-// accounts in the key.
-let role_arn =
-    resolve_vouch_profile(target.profile.as_deref(), ProfileOverride::Profile)?.role_arn;
-
 let agent_source = crate::commands::credential::aws::detect_agent_source();
-let cache_key = build_cache_key(target, &role_arn, agent_source.as_deref());
+let cache_key = build_cache_key(domain, domain_owner, region, agent_source.as_deref());
 
 let agent = agent_source;
 let data = cache::get_or_fetch(&cache_key, "CodeArtifact token", || async {
-    let token = fetch_token(server, target, &role_arn, agent.as_deref()).await?;
+    let token = fetch_token(server, domain, domain_owner, region, agent.as_deref()).await?;
     ...
 })
 ```
 
-Where `build_cache_key` produces `codeartifact:{domain}:{domain_owner}:{region}:{role_arn}` plus `:agent:{src}` when an agent is present. The resolved role ARN is part of the key (not the optional `target.profile`) so two invocations that resolve to different accounts never share an entry.
+Where `build_cache_key` produces `codeartifact:{domain}:{domain_owner}:{region}:agent:{src}` when an agent is present.
 
 ## Scope
 

--- a/.claude/skills/detail-rules/references/dpop-token-type-matches-binding.md
+++ b/.claude/skills/detail-rules/references/dpop-token-type-matches-binding.md
@@ -1,57 +1,88 @@
 # DPoP Token Type Must Match Sender Constraint Binding
 
-The `token_type` in an OAuth token response must be derived from the same value the issued token's `cnf` claim was derived from — never hardcoded and never recomputed in parallel. `create_oauth_access_token` already derives it from `params.binding.token_type()` and returns it as `CreateSessionResult::token_type`, so grant handlers take it from there rather than spelling the derivation themselves. For an access token the value is `DPoP` when `cnf.jkt` is set (RFC 9449 §5) and `Bearer` otherwise, including mTLS-bound tokens (`cnf.x5t#S256`, RFC 8705 defines no distinct token type).
+Token endpoint handlers must compute `token_type` from whether a DPoP proof was validated and threaded into the issued token (`cnf.jkt`), never hardcode it. When `dpop_jkt` is `Some`, the response must advertise `token_type: "DPoP"`; when it is `None`, it must advertise `token_type: "Bearer"` (RFC 9449 Section 5).
 
 ## What to look for
 
 Examine every code path that constructs a token response struct (`TokenResponse`, `TokenExchangeResponse`, `DeviceTokenResponse`, or any custom struct with a `token_type: String` field) in the token handlers and grant services:
 
-1. **Hardcoded `"Bearer"` (or `"DPoP"`) at a grant site.** Any call site that sets `token_type: "Bearer".to_string()` (or `"DPoP"`) instead of `session_result.token_type.to_string()` after calling `create_oauth_access_token` is a violation — the response is no longer tied to the `cnf` claim the issuance pipeline stamped.
+1. **Hardcoded `"Bearer"` when a DPoP proof may have been validated.** Any call site that sets `token_type: "Bearer".to_string()` (or `"Bearer".to_owned()`) while the surrounding code also holds a `dpop_proof`, `dpop_jkt`, or `dpop_jkt: Option<&str>` binding is a violation — the code minted a `cnf.jkt`-bound token but lied to the client about it.
 
-2. **Inconsistency between `CreateOAuthTokenParams::binding` and the returned `token_type`.** If `binding: TokenBinding::Dpop(_)` was passed to `create_oauth_access_token` (so `cnf.jkt` will be embedded in the JWT) but the constructed response carries anything other than `"DPoP"`, the response is wrong. The same goes for `TokenBinding::Bearer` / `TokenBinding::MutualTls(_)` producing anything other than `"Bearer"`.
+2. **Inconsistency between `CreateOAuthTokenParams::dpop_jkt` and the returned `token_type`.** If `dpop_jkt: Some(...)` is passed to `create_oauth_access_token` (meaning `cnf.jkt` will be embedded in the JWT), but the constructed response carries `token_type: "Bearer"`, the response is wrong.
 
-3. **Recomputing `token_type` from the proof/binding instead of using `session_result.token_type`.** Spelling `let token_type = if dpop_proof.is_some() { "DPoP" } else { "Bearer" };` (or `if dpop_jkt.is_some()`) at a grant site is a violation — it duplicates the derivation that lives behind `params.binding.token_type()` / `CnfClaim::token_type`, and the two can drift. Grant handlers that take `CreateSessionResult` and reach the response without referencing `session_result.token_type` are suspect.
+3. **Missing conditional before setting `token_type`.** The correct pattern is always:
+   ```rust
+   let token_type = if dpop_jkt.is_some() { "DPoP" } else { "Bearer" };
+   ```
+   or equivalently testing `dpop_proof.is_some()`. A grant handler that reaches token issuance without this conditional is suspect.
 
 The grants to check in this codebase:
-- `crates/vouch-server/src/handlers/device.rs` — `device_token`
+- `crates/vouch-server/src/handlers/device.rs` — `device_token` (the site of the confirmed bug)
 - `crates/vouch-server/src/services/oidc/token.rs` — `exchange_authorization_code`
 - `crates/vouch-server/src/services/oidc/client_credentials.rs` — `exchange_client_credentials`
 - `crates/vouch-server/src/services/oidc/exchange.rs` — `exchange_token` (access-token path)
 - `crates/vouch-server/src/services/oidc/fido2_grant.rs` — `exchange_fido2_assertion`
 
-Note: the ID-token path in `exchange.rs` (`issue_id_token`) legitimately returns `token_type: "N_A"` (`protocol::TOKEN_TYPE_NOT_APPLICABLE`), not `"Bearer"` — RFC 8693 §2.2.1 mandates `N_A` because the issued token is not usable as an access token. Do not flag it.
+Note: the ID-token path in `exchange.rs` (`issue_id_token`) legitimately returns `"Bearer"` because no DPoP-bound access token is issued there; do not flag it.
 
 ## Violation examples
 
-**Recomputing token_type after issuance already derived it**
+**Device flow hardcodes Bearer after threading dpop_jkt into the token (confirmed bug, `handlers/device.rs`)**
 ```rust
-// create_oauth_access_token already derives `token_type` from `params.binding`;
-// it is returned on session_result.token_type and that is the whole point.
-let token_type = if dpop_proof.is_some() {
-    "DPoP"
-} else {
-    "Bearer"
-};
+// dpop_jkt is derived from the validated DPoP proof above and passed to
+// create_oauth_access_token — the token carries cnf.jkt — but the response says Bearer.
+let session_result = create_oauth_access_token(
+    &state,
+    CreateOAuthTokenParams {
+        dpop_jkt: dpop_jkt.as_deref(), // Some("...") when DPoP proof was present
+        // ...
+    },
+    proof,
+).await?;
+
+Ok(Json(DeviceTokenResponse {
+    access_token: token.expose_secret().to_string(),
+    token_type: "Bearer".to_string(), // BUG: hardcoded; should be "DPoP" when dpop_jkt is Some
+    expires_in,
+    email: user_email,
+}))
+```
+
+**Generic pattern — hardcoded Bearer after DPoP validation**
+```rust
+// dpop_proof is Some(...) — token will be cnf.jkt-bound
+let dpop_jkt = dpop_proof.as_ref().map(|p| p.jkt.clone());
+// ... create_oauth_access_token called with dpop_jkt: dpop_jkt.as_deref() ...
 Ok(TokenResponse {
-    access_token: session_result.token.clone(),
-    token_type: token_type.to_string(), // VIOLATION — use session_result.token_type
-    expires_in: session_result.expires_in,
+    access_token: result.access_token,
+    token_type: "Bearer".to_string(), // VIOLATION
+    expires_in: result.expires_in,
 })
 ```
 
 ## Correct patterns
 
-**Take `token_type` from `CreateSessionResult` (used in `client_credentials.rs`, `exchange.rs`, `fido2_grant.rs`, `token.rs`, `device.rs`)**
+**Compute token_type from dpop_jkt (used in `client_credentials.rs`, `exchange.rs`, `fido2_grant.rs`, `token.rs`)**
 ```rust
+// RFC 9449 Section 5: token_type is "DPoP" when the token is sender-constrained
+let token_type = if bindings.dpop_jkt.is_some() {
+    "DPoP"
+} else {
+    "Bearer"
+};
 Ok(SomeResult {
-    access_token: session_result.token.clone(),
-    token_type: session_result.token_type.to_string(),
-    expires_in: session_result.expires_in,
-    // ...
+    access_token: ...,
+    token_type: token_type.to_string(),
+    expires_in: ...,
 })
 ```
 
-`session_result.token_type` is set inside `create_oauth_access_token` from `params.binding.token_type()` — the same `TokenBinding` whose `cnf()` was stamped into the JWT — so the advertisement cannot disagree with the confirmation the token carries.
+**Equivalent form using the proof object directly**
+```rust
+let token_type = if dpop_proof.is_some() { "DPoP" } else { "Bearer" };
+```
+
+Both forms are correct as long as the variable tested (`dpop_jkt` or `dpop_proof`) is the same binding that was passed to `create_oauth_access_token` as `dpop_jkt`.
 
 ## Scope
 

--- a/.claude/skills/detail-rules/references/oauth-infrastructure-error-misclassification.md
+++ b/.claude/skills/detail-rules/references/oauth-infrastructure-error-misclassification.md
@@ -16,17 +16,15 @@ A `DpopError` match arm uses a catch-all `Err(e)` that maps all variants — inc
 
 Key signal: a `match validate_dpop_*` or `match DpopError` that lacks an explicit `Err(e @ DpopError::Database(_))` arm before `Err(e)`.
 
-### Pattern 3: Silently returning `{"active": false}` on a server-side error
+### Pattern 3: Silently returning `{"active": false}` on signing failure
 
-`IntrospectionResult::inactive()` is the correct response only for expired/unknown tokens. Returning it from any error path — JWT signing failure after a successful introspection, or a DB error from the introspection service itself — misrepresents the token state and gives operators no signal of failure. Server-side failures must surface as HTTP 500 `server_error`.
+After a successful introspection result, if JWT signing fails, a handler that falls back to `Json(IntrospectionResult::inactive())` misrepresents a valid token as inactive. Signing failures must surface as HTTP 500 `server_error`.
 
-Key signals: a `match sign_introspection_jwt(...)` (previously `wrap_introspection_jwt`) whose `Err` arm produces `IntrospectionResult::inactive()` or any `active: false` response; or `svc_introspect(...).await` whose `Err` arm (or `.ok()` / `.unwrap_or(...)` collapse) yields `IntrospectionResult::inactive()`.
+Key signal: a `match sign_introspection_jwt(...)` (previously `wrap_introspection_jwt`) whose `Err` arm produces `IntrospectionResult::inactive()` or any `active: false` response.
 
 ### Pattern 4: Catch-all mapping `ClaimError::Database` to a 4xx
 
 `ClaimError` has three variants: `AlreadyConsumed` (→ 4xx), `InvalidInput` (→ 4xx), and `Database` (→ 500). A catch-all `Err(e)` arm after only `AlreadyConsumed` will silently map `Database` to the same 4xx as `InvalidInput`. Each `ClaimError` match must either handle all three variants explicitly or use `Database` as an intermediate arm before the catch-all.
-
-A related service-layer variant: producing the wrong `DpopError` variant in the first place. Mapping a `ClaimError::Database` (or any DB error) to `DpopError::InvalidFormat` in `services/oidc/dpop.rs` guarantees the handler classifies it as a 400 even with correct handler-side matching. DB errors must be raised as `DpopError::Database(_)` at the point of production.
 
 ### Pattern 5: Using `into_response()` instead of `into_oauth_response()` for OAuth endpoints
 
@@ -97,23 +95,6 @@ if let Err(e) = commit_jti(&state, pending_jti).await {
     .into_oauth_response()
     .into_response();
 }
-```
-
-**DB error from introspection service returning `{"active": false}` (issue #540)**
-
-```rust
-// VIOLATION: Err discarded, DB failure reported as inactive token
-let result = match svc_introspect(&state, ...).await {
-    Ok(r) => r,
-    Err(_) => IntrospectionResult::inactive(),
-};
-```
-
-**DPoP DB failure raised as `InvalidFormat` in the service layer (issue #427)**
-
-```rust
-// VIOLATION in dpop.rs: DB error → InvalidFormat → 400 in handler
-Err(e) => return Err(DpopError::InvalidFormat(format!("JTI check failed: {e}"))),
 ```
 
 **`into_response()` instead of `into_oauth_response()` on an OAuth endpoint (fixed in 91a00b3)**
@@ -201,23 +182,13 @@ Err(e) => {
 }
 ```
 
-**`DpopError::Database` variant raised explicitly in the service layer:**
-
-```rust
-Err(db::claim::ClaimError::Database(msg)) => {
-    return Err(DpopError::Database(format!("JTI check failed: {msg}")));
-}
-```
-
 ## Scope
 
 All files under:
 
-- `crates/vouch-server/src/handlers/oidc/` — primary scope: `token.rs`, `par.rs`, `userinfo.rs`, `introspect.rs`, `authorize.rs`, `logout.rs`, and any future handler files in this directory
+- `crates/vouch-server/src/handlers/oidc/` — primary scope: `token.rs`, `par.rs`, `userinfo.rs`, `introspect.rs`, `authorize.rs`
 - `crates/vouch-server/src/handlers/session.rs` — DPoP validation on the session resource-auth path
-- `crates/vouch-server/src/services/oidc/dpop.rs` — `DpopError` variant routing, and where variants are produced from `ClaimError`
-- `crates/vouch-server/src/services/oidc/introspection.rs` — where `IntrospectionResult::inactive()` is constructed
-- `crates/vouch-server/src/services/oidc/token.rs` — `ClientAuthError::into_service_error` and `commit_jti`
-- `crates/vouch-server/src/db/claim.rs` — `ClaimError` definition (verify `Database` variant remains distinct)
+- `crates/vouch-server/src/services/oidc/dpop.rs` — `DpopError` variant routing
+- `crates/vouch-server/src/services/oidc/token.rs` — `ClientAuthError::into_service_error`
 
 Out of scope: non-OAuth HTTP API handlers, CLI code, agent code.

--- a/.claude/skills/detail-rules/references/prefer-store-modify-over-blind-store-update.md
+++ b/.claude/skills/detail-rules/references/prefer-store-modify-over-blind-store-update.md
@@ -1,0 +1,237 @@
+# Prefer store.modify Over Blind store.update
+
+Detect blind read-modify-write patterns where `store.get()` + `store.update()` is used instead of `store.modify()` for documents that can be concurrently mutated, causing lost-update races that silently clobber concurrent writes.
+
+## What to look for
+
+Any non-test async function in `crates/vouch-server/src/db/` that:
+
+1. **Calls `store.get::<T>(id)` (or `store.find_one`)**, captures the returned document, mutates one or more fields of `doc.data`, then calls **`store.update(id, &data)`** — without going through `store.modify()`. This is the canonical blind read-modify-write.
+
+2. **Computes derived state outside a `store.modify` closure** and then writes it back. Examples:
+   - A delta merge (add/remove items from a `Vec` field) done before calling `update_github_installation_repos`, so two concurrent callers each read a stale list and lose the other's changes.
+   - A candidate removal set built from a paginated snapshot, then applied inside a `retain()` without re-checking whether entries have since transitioned state (e.g., `Pending → Verified`).
+
+3. **Uses `AtomicBool` to signal success from a `store.modify` closure but does not reset it at the top of the closure body.** Each OCC retry re-invokes the closure; if a prior attempt set the flag and then lost the version race, the flag stays set and a subsequent retry that bails early (e.g., org-scope check fails) reports success instead of skipping.
+
+The rule does **not** apply to:
+- `store.update_last_used_at()` — updates only a metadata timestamp, no semantic fields.
+- `store.update_by_index()` — bulk index-targeted writes with their own semantics.
+- `tx.update()` — writes inside an explicit `StoreTransaction`; atomicity is handled by the transaction.
+- `#[cfg(test)]` blocks — test helpers may use blind writes to set up fixture state.
+- Documents that are never mutated concurrently (e.g., write-once records like `DpopJtiDoc`). Use judgment; prefer `store.modify()` when in doubt.
+- `set_preconfigured_active` (posture_policies.rs): uses a full-replace pattern with caller-controlled `active_slugs`; the caller is authoritative for the entire field.
+
+## Violation examples
+
+**Pattern 1 — Direct field update (users.rs, fixed in fd75771)**
+
+```rust
+// VIOLATION: blind get + update; a concurrent admin-status change is lost
+pub async fn update_user_admin_status(
+    store: &DocumentStore,
+    user_id: &str,
+    is_admin: bool,
+) -> Result<bool> {
+    if let Some(doc) = store.get::<UserDoc>(user_id).await? {
+        let mut data = doc.data;
+        data.is_org_admin = is_admin;
+        store.update(user_id, &data).await?;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+```
+
+**Pattern 2 — Counter regression (authenticators.rs, fixed in fd75771)**
+
+```rust
+// VIOLATION: two concurrent counter updates can regress the WebAuthn counter
+pub async fn update_authenticator_counter(
+    store: &DocumentStore,
+    authenticator_id: &str,
+    counter: i32,
+) -> Result<()> {
+    if let Some(doc) = store.get::<AuthenticatorDoc>(authenticator_id).await? {
+        let mut data = doc.data;
+        data.counter = counter;   // overwrites; does not take max()
+        store.update(authenticator_id, &data).await?;
+    }
+    Ok(())
+}
+```
+
+**Pattern 3 — find_one + update on webhook events (github.rs, fixed in c63387d)**
+
+```rust
+// VIOLATION: two concurrent suspend/unsuspend webhooks can clobber each other
+pub async fn suspend_github_installation(
+    store: &DocumentStore,
+    installation_id: i64,
+) -> Result<bool> {
+    let doc = store
+        .find_one::<GitHubInstallationDoc>("installation_id", &installation_id.to_string())
+        .await?;
+    if let Some(doc) = doc {
+        let mut data = doc.data;
+        data.suspended_at = Some(Timestamp::now());
+        store.update(&doc.id, &data).await?;
+        return Ok(true);
+    }
+    Ok(false)
+}
+```
+
+**Pattern 4 — Delta merge outside the modify closure (github.rs, fixed in 5dfdf31)**
+
+```rust
+// VIOLATION: merge runs before store.modify, so two concurrent delta webhooks
+// each read a stale repo list and lose each other's additions/removals
+pub async fn update_github_installation_repos_delta(...) -> Result<bool> {
+    let installation = get_github_installation_by_installation_id(store, installation_id).await?;
+    let Some(installation) = installation else { return Ok(false); };
+
+    let mut repos: Vec<String> = installation.repositories.unwrap_or_default();
+    for repo in added { if !repos.contains(repo) { repos.push(repo.clone()); } }
+    repos.retain(|r| !removed.contains(r));
+    repos.sort();
+
+    // update_github_installation_repos calls store.modify, but the merge
+    // already happened on stale data — the modify window does not re-merge
+    update_github_installation_repos(store, installation_id, &repos).await
+}
+```
+
+**Pattern 5 — AtomicBool not reset between OCC retries (scim.rs / posture_policies.rs, fixed in c63387d)**
+
+```rust
+// VIOLATION: applied flag not reset at top of closure; if attempt N sets it
+// then loses the version race, attempt N+1 that bails early still reports success
+let applied = std::sync::atomic::AtomicBool::new(false);
+let found = store
+    .modify::<UserDoc, _>(user_id, |data| {
+        // BUG: missing `applied.store(false, ...)` reset here
+        if data.org_id.as_deref() == Some(org_id) {
+            data.name = name.map(String::from);
+            applied.store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+    })
+    .await?;
+```
+
+**Pattern 6 — State check using snapshot data inside modify closure (organizations.rs, fixed in d9fccba)**
+
+```rust
+// VIOLATION: domains_to_drop was built from a paginated snapshot; by the time
+// the modify closure runs, an entry may have flipped Pending → Verified and
+// must be preserved, but the old code blindly retains/removes based on the
+// stale snapshot name set without re-checking current state
+let domains_to_drop: HashSet<String> = to_remove.iter().map(|(d, _)| d.clone()).collect();
+store.modify::<OrganizationDoc, _>(&org.id, |doc| {
+    doc.additional_domains
+        .retain(|ad| !domains_to_drop.contains(&ad.domain));  // never re-checks state
+})
+```
+
+## Correct patterns
+
+**Pattern 1 fix — `store.modify` for single-field updates**
+
+```rust
+pub async fn update_user_admin_status(
+    store: &DocumentStore,
+    user_id: &str,
+    is_admin: bool,
+) -> Result<bool> {
+    store
+        .modify::<UserDoc, _>(user_id, |data| {
+            data.is_org_admin = is_admin;
+        })
+        .await
+}
+```
+
+**Pattern 2 fix — monotonic counter via `max()` inside modify**
+
+```rust
+store
+    .modify::<AuthenticatorDoc, _>(authenticator_id, |data| {
+        data.counter = std::cmp::max(data.counter, counter);
+    })
+    .await?;
+```
+
+**Pattern 3 fix — resolve doc ID, then modify**
+
+```rust
+let Some(doc_id) = resolve_installation_doc_id(store, installation_id).await? else {
+    return Ok(false);
+};
+store
+    .modify::<GitHubInstallationDoc, _>(&doc_id, |data| {
+        data.suspended_at = Some(Timestamp::now());
+    })
+    .await
+```
+
+**Pattern 4 fix — delta merge inside the modify closure**
+
+```rust
+let Some(doc_id) = resolve_installation_doc_id(store, installation_id).await? else {
+    return Ok(false);
+};
+let added_owned = added.to_vec();
+let removed_owned = removed.to_vec();
+store
+    .modify::<GitHubInstallationDoc, _>(&doc_id, |data| {
+        let repos = data.repositories.get_or_insert_default();
+        for repo in &added_owned {
+            if !repos.contains(repo) { repos.push(repo.clone()); }
+        }
+        repos.retain(|r| !removed_owned.contains(r));
+        repos.sort();
+    })
+    .await
+```
+
+**Pattern 5 fix — reset AtomicBool at top of every closure invocation**
+
+```rust
+let applied = std::sync::atomic::AtomicBool::new(false);
+store
+    .modify::<UserDoc, _>(user_id, |data| {
+        applied.store(false, std::sync::atomic::Ordering::Relaxed); // reset first
+        if data.org_id.as_deref() == Some(org_id) {
+            data.name = name.map(String::from);
+            applied.store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+    })
+    .await?;
+```
+
+**Pattern 6 fix — re-check live state inside the modify closure**
+
+```rust
+store.modify::<OrganizationDoc, _>(&org.id, |doc| {
+    doc.additional_domains.retain(|ad| {
+        // Never remove a Verified entry, even if it was Pending in the snapshot
+        if matches!(ad.state, AdditionalDomainState::Verified { .. }) {
+            return true;
+        }
+        !drop_candidates.contains_key(&ad.domain)
+    });
+})
+```
+
+## Scope
+
+Check all non-test Rust source files under:
+
+- `crates/vouch-server/src/db/` (including subdirectories such as `organizations/`)
+- `crates/vouch-server/src/services/`
+- `crates/vouch-server/src/handlers/`
+
+Focus on async functions that interact with a `DocumentStore` (`store: &DocumentStore` or `state.store`). The highest-risk document types — those touched by multiple concurrent request paths — are: `UserDoc`, `AuthenticatorDoc`, `GitHubInstallationDoc`, `ScimGroupDoc`, `CustomPosturePolicyDoc`, `OrganizationDoc`, and `OAuthClientDoc`.
+
+Skip `#[cfg(test)]` modules: test helpers legitimately use blind writes to inject fixture state without racing other writers.

--- a/.claude/skills/detail-rules/references/service-error-variant-coverage-across-converters.md
+++ b/.claude/skills/detail-rules/references/service-error-variant-coverage-across-converters.md
@@ -127,36 +127,27 @@ pub fn into_oauth_response(self) -> (StatusCode, Json<OAuthErrorResponse>) {
 }
 ```
 
-**When a wrapper helper needs headers, pre-extract them before calling `into_oauth_response` and reattach after response construction:**
+**When a wrapper helper needs headers, handle the variant before calling `into_oauth_response`:**
 
 ```rust
 fn into_registration_response(err: crate::error::ServiceError) -> Response {
-    // Pre-extract headers — into_oauth_response's tuple return type cannot convey them.
-    let extra_headers = match &err {
-        ServiceError::ApiWithHeaders { headers, .. } => Some(headers.clone()),
-        _ => None,
-    };
-
-    let (status, json) = err.into_oauth_response();
-    let mut response = if status == StatusCode::UNAUTHORIZED {
-        // ... build WWW-Authenticate challenge (RFC 6750 §3.1) ...
-        (status, [(WWW_AUTHENTICATE, www_auth)], json).into_response()
-    } else {
-        (status, json).into_response()
-    };
-
-    // Reattach headers (e.g., DPoP-Nonce) AFTER response construction so the
-    // 401 WWW-Authenticate wrapping still runs for ApiWithHeaders 401s.
-    if let Some(headers) = extra_headers {
+    // Pre-extract ApiWithHeaders before into_oauth_response loses the headers
+    if let ServiceError::ApiWithHeaders { status, code, message, headers } = err {
+        let oauth_body = Json(OAuthErrorResponse {
+            error: code,
+            error_description: Some(message),
+            error_uri: None,
+        });
+        let mut response = (status, oauth_body).into_response();
         for (name, value) in headers {
             response.headers_mut().append(name, value);
         }
+        return response;
     }
-    response
+    let (status, json) = err.into_oauth_response();
+    // ... rest of 401 WWW-Authenticate wrapping
 }
 ```
-
-Do NOT early-return on `ApiWithHeaders` before the 401 path — that would skip the `WWW-Authenticate` header that RFC 6750 §3.1 requires on every 401, including `use_dpop_nonce` challenges.
 
 ## Scope
 

--- a/.claude/skills/detail-rules/references/transient-failure-mapped-to-client-error.md
+++ b/.claude/skills/detail-rules/references/transient-failure-mapped-to-client-error.md
@@ -1,0 +1,185 @@
+# Transient-Failure Mapped to Client Error
+
+Detect error-handling paths where a transient database or server-side failure is mapped to a client-facing 4xx error code or a semantically misleading success response (such as `invalid_client`, `invalid_dpop_proof`, or `{"active": false}`), masking infrastructure failures as permanent client errors and hiding them from operators.
+
+## What to look for
+
+### 1. Catch-all `Err(_)` or `_ =>` swallowing `DpopError::Database`, `ClaimError::Database`, or `ClientAuthError::DatabaseError`
+
+In this repo, `DpopError`, `ClaimError`, and `ClientAuthError` each have a `Database(String)` / `DatabaseError(String)` variant that must be routed to HTTP 500 (`server_error`). A catch-all arm that covers all remaining variants after handling the expected cases will silently absorb `Database` errors and return a 4xx instead.
+
+**Pattern to flag:** A `match` on one of these error enums that uses a catch-all `Err(e) =>` or `_ =>` arm emitting `invalid_dpop_proof`, `invalid_client`, a 4xx status code, or `IntrospectionResult::inactive()`, **without** a prior explicit arm for `DpopError::Database(_)`, `ClaimError::Database(_)`, or `ClientAuthError::DatabaseError(_)`.
+
+### 2. `.ok()` or `.ok().flatten()` collapsing a DB `Result` into `None`
+
+Using `.ok()` on a `Result<Option<T>, DbError>` discards a database error, making a connectivity failure indistinguishable from "not found". When the resulting `None` triggers an `invalid_client` or similar response, infrastructure failures are misrepresented as client errors.
+
+**Pattern to flag:** `store_call().await.ok().flatten().filter(|x| x.active)` or similar, feeding into an `invalid_client` response when `None`.
+
+### 3. Returning `{"active": false}` on a server-side error
+
+`IntrospectionResult::inactive()` is the correct response for expired/unknown tokens. Returning it from an error path (signing failure, DB error) misrepresents a validated active token as inactive and gives operators no signal of failure.
+
+**Pattern to flag:** A `match jwt_signing_result { Err(_) => Json(IntrospectionResult::inactive()) }` or `Err(_) => IntrospectionResult::inactive()` where the error is a server failure, not a logical token state.
+
+### 4. DB errors from `commit_jti` mapped to `invalid_client`
+
+`commit_jti` can fail with either `ClientAuthError::InvalidCredentials` (JTI replay — a real client error) or `ClientAuthError::DatabaseError` (transient). A flat mapping of all `commit_jti` failures to `OAuthErrorCode::InvalidClient` hides connectivity failures.
+
+**Pattern to flag:** `let Err(e) = commit_jti(...).await { return ServiceError::oauth(OAuthErrorCode::InvalidClient, ...) }` with no discrimination by error variant.
+
+### 5. DB lookup errors collapsed with "not found" into `invalid_client`
+
+`db::get_oauth_client_by_client_id(...).await.ok().flatten().filter(|oc| oc.active)` maps DB errors, unknown clients, AND inactive clients all to `None`, so a connectivity failure looks like an unknown client and returns `invalid_client`.
+
+## Violation examples
+
+**Catch-all DPoP handler returning `invalid_dpop_proof` on DB error (issue #427):**
+```rust
+// BEFORE (violation): DpopError::Database swallowed by catch-all
+match validate_dpop_if_present(...).await {
+    Err(DpopError::UseNonce(nonce)) => return dpop_use_nonce_response(&nonce),
+    Err(e) => {
+        return ServiceError::oauth(OAuthErrorCode::InvalidDpopProof, e.to_string())
+            .into_oauth_response()
+            .into_response();
+    }
+}
+```
+
+**JWT signing failure returning `{"active": false}` instead of 500 (issue #396):**
+```rust
+// BEFORE (violation): signing error returns inactive token, not 500
+match wrap_introspection_jwt(&result, &issuer, &client_id, &state.oidc_key).await {
+    Ok(jwt) => (StatusCode::OK, ..., jwt).into_response(),
+    Err(_) => Json(IntrospectionResult::inactive()).into_response(),
+}
+```
+
+**DB error from introspection service returning `{"active": false}` (issue #540):**
+```rust
+// BEFORE (violation): .ok() discards DB error, returns inactive
+let result = match svc_introspect(&state, ...).await {
+    Ok(r) => r,
+    Err(_) => IntrospectionResult::inactive(),
+};
+```
+
+**`commit_jti` failure mapped to `invalid_client` regardless of cause (issue fixed in ea1e4a3):**
+```rust
+// BEFORE (violation): all commit_jti failures -> invalid_client, including DB errors
+if let Err(e) = commit_jti(&state, pending_jti).await {
+    return ServiceError::oauth(OAuthErrorCode::InvalidClient, "Client authentication failed")
+        .into_oauth_response()
+        .into_response();
+}
+```
+
+**Client lookup collapsing DB error with "not found" (issue fixed in c63387d):**
+```rust
+// BEFORE (violation): DB error + None + inactive all yield invalid_client
+match db::get_oauth_client_by_client_id(&state.store, &c.client_id)
+    .await
+    .ok()
+    .flatten()
+    .filter(|oc| oc.active)
+{
+    Some(client) => client,
+    None => return Err(ServiceError::oauth(OAuthErrorCode::InvalidClient, "Unknown client_id")
+        .into_oauth_response().into_response()),
+}
+```
+
+**DPoP nonce/JTI DB failure mapped to `invalid_dpop_proof` via `InvalidFormat` (issue #427):**
+```rust
+// BEFORE (violation in dpop.rs service layer): DB error -> InvalidFormat -> 400 in handler
+Err(e) => return Err(DpopError::InvalidFormat(format!("JTI check failed: {e}"))),
+```
+
+## Correct patterns
+
+**Explicit `Database` arm routes to 500:**
+```rust
+match validate_dpop_if_present(...).await {
+    Err(DpopError::UseNonce(nonce)) => return dpop_use_nonce_response(&nonce),
+    Err(e @ DpopError::Database(_)) => {
+        return ServiceError::oauth(OAuthErrorCode::ServerError, e.to_string())
+            .into_oauth_response()
+            .into_response();
+    }
+    Err(e) => {
+        return ServiceError::oauth(OAuthErrorCode::InvalidDpopProof, e.to_string())
+            .into_oauth_response()
+            .into_response();
+    }
+}
+```
+
+**JWT signing failure returns 500 `server_error`, never `{"active": false}`:**
+```rust
+fn jwt_introspect_response(jwt_result: Result<String, ServiceError>) -> Response {
+    match jwt_result {
+        Ok(jwt) => (StatusCode::OK, ..., jwt).into_response(),
+        Err(e) => {
+            tracing::error!("Failed to sign introspection JWT: {e}");
+            introspect_error_response(e) // routes through into_oauth_response -> server_error
+        }
+    }
+}
+```
+
+**DB introspection failure propagated as 500:**
+```rust
+let result = match svc_introspect(&state, ...).await {
+    Ok(r) => r,
+    Err(e) => {
+        tracing::error!("Introspection failed: {e}");
+        return introspect_error_response(e);
+    }
+};
+```
+
+**`commit_jti` failure discriminated by variant:**
+```rust
+if let Err(e) = commit_jti(&state, pending_jti).await {
+    // ClientAuthError::into_service_error() maps DatabaseError -> Internal -> 500
+    // and InvalidCredentials -> InvalidClient -> 401
+    return e.into_service_error().into_oauth_response().into_response();
+}
+```
+
+**Client lookup separates DB error from "not found":**
+```rust
+let db_result = db::get_oauth_client_by_client_id(&state.store, &c.client_id)
+    .await
+    .map_err(|e| {
+        tracing::error!("DB error looking up OAuth client: {e}");
+        ServiceError::Internal("Database error".to_string())
+            .into_oauth_response().into_response()
+    })?;
+match db_result.filter(|oc| oc.active) {
+    Some(client) => client,
+    None => return Err(ServiceError::oauth(OAuthErrorCode::InvalidClient, "Unknown client_id")
+        .into_oauth_response().into_response()),
+}
+```
+
+**`DpopError::Database` variant raised explicitly in service layer:**
+```rust
+Err(db::claim::ClaimError::Database(msg)) => {
+    return Err(DpopError::Database(format!("JTI check failed: {msg}")));
+}
+```
+
+## Scope
+
+Check all files under:
+
+- `crates/vouch-server/src/handlers/oidc/` — `token.rs`, `par.rs`, `userinfo.rs`, `introspect.rs`, `authorize.rs`, `logout.rs`, and any future handler files in this directory
+- `crates/vouch-server/src/handlers/session.rs` — DPoP validation on the resource-auth path
+- `crates/vouch-server/src/services/oidc/dpop.rs` — where `DpopError` variants are produced from `ClaimError`
+- `crates/vouch-server/src/services/oidc/introspection.rs` — where `IntrospectionResult::inactive()` is constructed
+- `crates/vouch-server/src/services/oidc/token.rs` — `ClientAuthError` and `commit_jti`
+- `crates/vouch-server/src/db/claim.rs` — `ClaimError` definition (verify `Database` variant remains distinct)
+
+The key error types to track: `DpopError`, `ClaimError`, `ClientAuthError`, and `ServiceError`. The key incorrect output signals are: `OAuthErrorCode::InvalidClient`, `OAuthErrorCode::InvalidDpopProof`, `IntrospectionResult::inactive()`, and any HTTP 4xx returned from a match arm that handles a `Database`/`DatabaseError` variant.

--- a/.claude/skills/detail-rules/references/use-store-modify-for-concurrent-updates.md
+++ b/.claude/skills/detail-rules/references/use-store-modify-for-concurrent-updates.md
@@ -24,10 +24,6 @@ This pattern is a blind read-modify-write: the `get` reads a snapshot, the calle
 
 3. **`find_one` + `store.update` on the same document**: using `store.find_one` to resolve a document then calling `store.update` on it has the same race as `get` + `update`.
 
-4. **`AtomicBool` success flag not reset at the top of a `store.modify` closure**: each OCC retry re-invokes the closure; if a prior attempt set the flag and then lost the version race, the flag stays set and a subsequent retry that bails early (e.g., org-scope check fails) reports success instead of skipping.
-
-5. **State check using stale snapshot data inside the closure**: a candidate set built from a paginated snapshot before `store.modify`, then applied inside the closure (e.g., via `retain()`) without re-checking whether entries have since transitioned state (e.g., `Pending → Verified`). The membership test runs against fresh data, but the decision was made against stale data.
-
 **What is safe (not a violation):**
 
 - `store.get()` used purely to read a document for the caller to return/display (no write follows).
@@ -36,10 +32,6 @@ This pattern is a blind read-modify-write: the `get` reads a snapshot, the calle
 - `store.update()` inside test helper functions under `#[cfg(test)]` or `mod test_helpers` — these are test scaffolding, not production paths.
 - `store.update_by_index()` — this is a bulk updater with internal batching, not a single document read-modify-write.
 - `compare_and_update()` called with a freshly-read version — this is the OCC mechanism itself.
-- `store.update_last_used_at()` — updates only a metadata timestamp, no semantic fields.
-- `tx.update()` — writes inside an explicit `StoreTransaction`; atomicity is handled by the transaction.
-- Documents that are never mutated concurrently (e.g., write-once records like `DpopJtiDoc`). Use judgment; prefer `store.modify()` when in doubt.
-- `set_preconfigured_active` (posture_policies.rs): uses a full-replace pattern with caller-controlled `active_slugs`; the caller is authoritative for the entire field.
 
 **Document types at highest risk** (all have concurrent writers):
 - `UserDoc` — admin status and active flag mutated by org admin + SCIM
@@ -118,37 +110,6 @@ repos.retain(|r| !removed.contains(r));
 update_github_installation_repos(store, installation_id, &repos).await
 ```
 
-**AtomicBool not reset between OCC retries (scim.rs / posture_policies.rs, fixed in c63387d)**
-
-```rust
-// VIOLATION: applied flag not reset at top of closure; if attempt N sets it
-// then loses the version race, attempt N+1 that bails early still reports success
-let applied = std::sync::atomic::AtomicBool::new(false);
-let found = store
-    .modify::<UserDoc, _>(user_id, |data| {
-        // BUG: missing `applied.store(false, ...)` reset here
-        if data.org_id.as_deref() == Some(org_id) {
-            data.name = name.map(String::from);
-            applied.store(true, std::sync::atomic::Ordering::Relaxed);
-        }
-    })
-    .await?;
-```
-
-**State check using snapshot data inside modify closure (organizations.rs, fixed in d9fccba)**
-
-```rust
-// VIOLATION: domains_to_drop was built from a paginated snapshot; by the time
-// the modify closure runs, an entry may have flipped Pending → Verified and
-// must be preserved, but the code blindly removes based on the stale snapshot
-// name set without re-checking current state
-let domains_to_drop: HashSet<String> = to_remove.iter().map(|(d, _)| d.clone()).collect();
-store.modify::<OrganizationDoc, _>(&org.id, |doc| {
-    doc.additional_domains
-        .retain(|ad| !domains_to_drop.contains(&ad.domain));  // never re-checks state
-})
-```
-
 ## Correct patterns
 
 **Use `store.modify` — only touch the target fields**
@@ -209,25 +170,11 @@ let found = store
 Ok(found && applied.load(std::sync::atomic::Ordering::Relaxed))
 ```
 
-**Re-check live state inside the modify closure**
-
-```rust
-store.modify::<OrganizationDoc, _>(&org.id, |doc| {
-    doc.additional_domains.retain(|ad| {
-        // Never remove a Verified entry, even if it was Pending in the snapshot
-        if matches!(ad.state, AdditionalDomainState::Verified { .. }) {
-            return true;
-        }
-        !drop_candidates.contains_key(&ad.domain)
-    });
-})
-```
-
 ## Scope
 
 **In scope** — all production database functions in:
 - `crates/vouch-server/src/db/*.rs` (users.rs, authenticators.rs, github.rs, scim.rs, posture_policies.rs, oauth.rs, organizations/mod.rs, organizations/domains.rs, organizations/issuer.rs, enrollment.rs, device_auth.rs, credentials.rs)
-- `crates/vouch-server/src/services/*.rs` and `crates/vouch-server/src/handlers/` if they call `store.get` + `store.update` directly
+- `crates/vouch-server/src/services/*.rs` if they call `store.get` + `store.update` directly
 
 **Out of scope:**
 - `crates/vouch-server/src/db/store.rs` itself (the implementation)


### PR DESCRIPTION
Captures Detail's 12 server-side rules as the repo's local copies under `.claude/skills/detail-rules/references/`, so the checked-in set matches what Detail actually enforces.

## Why

The local rule files had drifted from Detail's hosted rules (5 of them differed, some by dozens of lines), and two hosted rules had no local copy at all. Edits to the local files only feed the manual `detail-rules` scan skill — they never reach Detail's autonomous bug-filing, which runs off the hosted rules. Pulling the hosted rules down makes the repo an honest mirror of what Detail runs.

## What

`detail rules pull` for all 12 hosted rules into `.claude/skills/`:
- Updated 5 drifted files to the hosted content: `aws-credential-cache-key-missing-agent-source`, `dpop-token-type-matches-binding`, `oauth-infrastructure-error-misclassification`, `service-error-variant-coverage-across-converters`, `use-store-modify-for-concurrent-updates`.
- Added the 2 hosted rules that were missing locally: `prefer-store-modify-over-blind-store-update`, `transient-failure-mapped-to-client-error`.
- `SKILL.md` regenerated by the pull.
- `cap-outbound-response-bodies` is kept — it's a local-only rule that was never hosted (from PR #1117).

## Not in this PR

Four broad class rules are being created on Detail from the 192-bug corpus (deactivation/revocation, input-validation consistency, OCC/concurrency, infra-error misclassification) to replace the weekly one-off findings with class-level ones. Those build server-side; a follow-up will `pull` them here once complete. Deleting the narrow/redundant hosted rules needs Detail support (no delete in the CLI or app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)