### PR TITLE
ci: build AMIs for arm64 only and stop copying to EU regions

### DIFF
--- a/.github/workflows/ami-test.yml
+++ b/.github/workflows/ami-test.yml
@@ -19,10 +19,10 @@ on:
         description: 'Architecture to build and boot-test'
         required: true
         type: choice
-        default: x86_64
+        default: arm64
         options:
-          - x86_64
           - arm64
+          - x86_64
       keep_ami:
         description: 'Keep the test AMI and snapshot after verification'
         required: false

--- a/.github/workflows/ami.yml
+++ b/.github/workflows/ami.yml
@@ -114,8 +114,8 @@ jobs:
         id: regions
         run: |
           # Target regions to copy AMIs to (source region is us-east-1)
-          echo 'copy_regions=["us-west-2","eu-central-1","eu-west-3"]' >> "$GITHUB_OUTPUT"
-          echo 'all_regions=["us-east-1","us-west-2","eu-central-1","eu-west-3"]' >> "$GITHUB_OUTPUT"
+          echo 'copy_regions=["us-west-2"]' >> "$GITHUB_OUTPUT"
+          echo 'all_regions=["us-east-1","us-west-2"]' >> "$GITHUB_OUTPUT"
 
       - name: Set S3 paths
         id: s3
@@ -155,8 +155,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - arch: x86_64
-            instance_type: m5.xlarge
           - arch: arm64
             instance_type: m6g.xlarge
     outputs:
@@ -427,7 +425,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [x86_64, arm64]
+        arch: [arm64]
         region: ${{ fromJSON(needs.prepare.outputs.copy_regions) }}
 
     steps:
@@ -510,7 +508,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [x86_64, arm64]
+        arch: [arm64]
         region: ${{ fromJSON(needs.prepare.outputs.all_regions) }}
 
     steps:
@@ -604,7 +602,7 @@ jobs:
           EOF
 
           for region in $(echo "$ALL_REGIONS" | jq -r '.[]'); do
-            for arch in x86_64 arm64; do
+            for arch in arm64; do
               AMI_ID=$(aws ec2 describe-images \
                 --region "${region}" \
                 --filters "Name=name,Values=vouch-server-${VERSION}-${arch}" \
@@ -622,7 +620,7 @@ jobs:
           |--------------|--------------------|--------------------------|-----------------------|
           EOF
 
-          for arch in x86_64 arm64; do
+          for arch in arm64; do
             AMI_ID=$(aws ec2 describe-images \
               --region us-east-1 \
               --filters "Name=name,Values=vouch-server-${VERSION}-${arch}" \
@@ -662,7 +660,7 @@ jobs:
           # Launch instance with configuration
           aws ec2 run-instances \
             --image-id <AMI_ID> \
-            --instance-type t3.medium \
+            --instance-type m6g.large \
             --metadata-options 'HttpTokens=required,InstanceMetadataTags=enabled' \
             --tag-specifications 'ResourceType=instance,Tags=[{Key=VouchConfigParameter,Value=/vouch-server/config}]'
           ```
@@ -673,13 +671,12 @@ jobs:
 
           | Parameter | Description |
           |-----------|-------------|
-          | `/vouch-server/ami/x86_64/latest` | Latest x86_64 AMI ID |
           | `/vouch-server/ami/arm64/latest` | Latest arm64 AMI ID |
 
           ```bash
           # Query latest AMI in your region
           AMI_ID=$(aws ssm get-parameter \
-            --name "/vouch-server/ami/x86_64/latest" \
+            --name "/vouch-server/ami/arm64/latest" \
             --query 'Parameter.Value' --output text)
           ```
           EOF


### PR DESCRIPTION
## What this does

The AMI pipeline now builds `arm64` only and copies to `us-west-2` only.

Neither the EU copies nor the x86_64 images had a consumer. `modules/app/data.tf` in vouch-infra reads only `/vouch-server/ami/arm64/latest` — there is no x86_64 AMI reference anywhere in the Terraform — and the `app` module is `count = 0` in `eu-prod`, `ap-prod`, and `jp-prod`. Every release paid for an extra `m5.xlarge` builder instance and five unnecessary cross-region `copy-image` calls.

## Changes

**`.github/workflows/ami.yml`**

- `copy_regions` is `["us-west-2"]`; `all_regions` is `["us-east-1","us-west-2"]`. Both are `prepare` job outputs that the copy matrix, SSM matrix, and summary table consume via `fromJSON`, so this is the single place regions are defined.
- The `build-ami` matrix drops the `x86_64` / `m5.xlarge` leg.
- The `copy-ami` and `update-ssm-parameters` matrices become `arch: [arm64]`, and the two summary loops iterate `arm64`.
- The generated step summary listed an x86_64 SSM parameter that is no longer written, and its `run-instances` example used `t3.medium`. That type is x86_64-only and burstable, and burstable types fail NitroTPM `NV_DefineSpace`, so the example is now `m6g.large`.

Architecture stays a single-element matrix in all three jobs, and the `ami_id_x86_64` job output and its producer are retained, so re-enabling x86_64 is a matrix edit rather than a rewrite.

**`.github/workflows/ami-test.yml`**

Keeps both architectures — it is a manual-dispatch boot verification that does no region copies, no SSM writes, and deletes its own AMI, so an unused option costs nothing and gives a way to validate an x86_64 build before re-enabling it here. Only the default changes, from `x86_64` to `arm64`.

## Operational follow-up

Images already copied to `eu-central-1` and `eu-west-3`, and the x86_64 images in the US regions, are removed out of band. The cleanup Lambda in vouch-infra retains the newest images per architecture per region unconditionally, so those 42 AMIs and their 42 snapshots — 168 GiB of the 224 GiB currently provisioned — would never age out once builds stop. The six SSM parameters that would be left pointing at deregistered images go with them; the two US `arm64` parameters remain.

`environments/global/main.tf` in vouch-infra keeps all four regions in `ami_lifecycle_regions`. The Lambda no-ops on a region with no matching images, so this stays as a backstop.

## Note

If `environments/eu-prod/main.tf` is ever flipped from `count = 0` to `1`, `modules/app/data.tf` will fail at plan time looking up `/vouch-server/ami/arm64/latest` in `eu-central-1`. Re-enabling an EU deployment means restoring the EU entries in `copy_regions` / `all_regions` and running one release first.

## Verification

- `actionlint` and `zizmor` clean on both files; the full `prek` hook set passes.
- `rg` confirms no `x86_64`, `eu-central-1`, `eu-west-3`, or `m5.xlarge` remains in `ami.yml` outside the retained `ami_id_x86_64` output.
- The arm64 path is exercised end to end by dispatching **Test AMI Build**, which builds on `m6g.xlarge` and boot-verifies FIPS mode over the serial console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)