### PR TITLE
chore(detail): add the four broad class rules

### DIFF
--- a/.claude/skills/detail-rules/references/asymmetric-input-validation-across-entry-points.md
+++ b/.claude/skills/detail-rules/references/asymmetric-input-validation-across-entry-points.md
@@ -1,0 +1,213 @@
+# Asymmetric Input Validation Across Entry Points
+
+Detect cases where a validation rule applied on one entry point (create, register, initial path) is missing, weaker, or incorrect on a paired entry point (update, PUT, PATCH, rename, alternate config source) that writes the same data.
+
+## What to look for
+
+### 1. Create/register enforces checks that update/rename/PUT omits
+
+When a create handler trims, rejects empty, checks non-empty lists, or enforces character limits — look for the matching update handler to confirm it applies the **same** checks to the same fields. Flag any update path that:
+
+- Persists a `name`, `display_name`, or label without calling `ResourceLabel::parse` (or equivalent trim + non-empty + `chars().count()` guard).
+- Accepts `redirect_uris: []` for a non-service OAuth client when create rejects it with `MissingRedirectUris`.
+- Accepts a field value (e.g. `access_scope`, `fapi_profile`, `client_name`) via `and_then(|s| s.parse().ok()).unwrap_or_default()` silently falling back to default instead of returning an error.
+
+Key example pattern (validate.rs): `validate_create_application` checks `input.redirect_uris.is_empty()` for non-service apps and errors; the paired `validate_update_format` did not — bug fixed by adding the check inside `validate_update_fapi`.
+
+### 2. Shared validator called with fewer checks on one path
+
+When a `validate_*` function or a closure has multiple mandatory checks — look for any call site that skips a check by:
+
+- Passing `None` instead of the required option, silently disabling a branch.
+- Using an older call signature that predates a new parameter.
+- Calling a sub-validator but not the full top-level one.
+
+Key example: `validate_prompt` logic was correct in the plain PAR path but the JAR path called `Prompt::parse(p)` without the rejection branch, so unsupported values silently became `None`.
+
+### 3. User-supplied values persisted without the full sanitization chain
+
+Flag any handler that stores a user-provided `String` field directly into the DB (via `db::create_*` or `db::update_*`) without first:
+
+- Trimming whitespace (`.trim()`)
+- Rejecting empty/whitespace-only (`.is_empty()` check after trim)
+- Enforcing a length bound in **characters** (`.chars().count()`, not `.len()`)
+- Rejecting NUL bytes (`\x00`) when the field is used as a DB index value
+
+Look for `req.name`, `req.description`, or similar raw fields threaded directly into persistence params. The correct pattern is `ResourceLabel::parse(&req.name)?`.
+
+### 4. Byte-based length checks with character-limit error messages
+
+Flag any length check of the form:
+```rust
+if name.len() > N {
+    return Err(... "must be between 1 and N characters" ...)
+}
+```
+`str::len()` returns **bytes**, not characters. The correct pattern uses `chars().count()`. A 100-character CJK string is 300 bytes and must pass a 100-char limit. Key handlers affected: `handlers/keys.rs` (rename), policy name, SCIM token description.
+
+### 5. Config values from alternate sources bypassing validation
+
+When one config path (env vars, CLI flags) calls a validator (e.g. `validate_provider_slug`), check that alternate config paths (S3, bootstrap overlay, IMDS-merged values) call the same validator or are funneled through a shared validation step. Also flag empty-string values from env that silently override a fallback chain:
+
+```rust
+std::env::var("AWS_REGION").ok()   // Ok("") becomes Some("") and blocks IMDS fallback
+```
+Should be:
+```rust
+std::env::var("AWS_REGION").ok().filter(|v| !v.is_empty())
+```
+
+### 6. `map_or` / `unwrap_or_default` swallowing parse errors on invalid enum values
+
+Flag patterns where an optional enum field from the request is parsed with `.ok()` and defaulted:
+```rust
+req.access_scope.as_ref().and_then(|s| s.parse().ok()).unwrap_or_default()
+```
+If the user supplies an unrecognized value (e.g., typo `"organizaton"`), this silently applies the default. It should instead return a `400 invalid_access_scope` error.
+
+## Violation examples
+
+**Create validates, update does not (redirect_uris)**
+```rust
+// CREATE — correctly rejects empty list for non-service apps
+if !matches!(app_type, OAuthClientType::Service) && input.redirect_uris.is_empty() {
+    return Err(AppValidationError::MissingRedirectUris);
+}
+
+// UPDATE (buggy) — only format-validates; empty list passes for non-service apps
+if let Some(uris) = input.redirect_uris {
+    validate_redirect_uris(uris).map_err(AppValidationError::InvalidRedirectUris)?;
+    // Missing: is_empty() guard for non-service apps
+}
+```
+
+**Unvalidated name stored directly**
+```rust
+// register_start (buggy): no trim, no empty check, no length check
+let reg_state = RegistrationState {
+    device_name: req.name,  // persisted verbatim
+    ...
+};
+```
+
+**Byte-based length check reported as character limit**
+```rust
+// handlers/keys.rs (buggy)
+let name = req.name.trim();
+if name.is_empty() || name.len() > 256 {  // .len() = bytes, not chars
+    return Err(ServiceError::api(
+        StatusCode::BAD_REQUEST,
+        "invalid_name",
+        "Key name must be between 1 and 256 characters",  // misleading
+    ));
+}
+```
+
+**Silent enum fallback on update**
+```rust
+// api.rs (buggy): update path; parse errors become None, then unwrap_or_default
+let access_scope = req
+    .access_scope
+    .as_ref()
+    .and_then(|s| s.parse::<AccessScope>().ok())  // swallows invalid values
+    .unwrap_or_default();
+```
+
+**S3 config bypasses slug validation**
+```rust
+// s3_config.rs (buggy): into_idp_config uses `id` directly
+IdpConfig::Oidc(OidcProviderConfig {
+    id,  // no validate_provider_slug() call; env-var path validates, S3 path does not
+    ...
+})
+```
+
+**JAR path omits prompt rejection that plain PAR enforces**
+```rust
+// jar.rs (buggy): None returned on unsupported values instead of erroring
+let parsed_prompt = match claims.prompt.as_deref() {
+    Some(p) => Prompt::parse(p),  // returns None for "select_account"; no rejection
+    None => None,
+};
+
+// par.rs (correct): same field, same endpoint, but plain path rejects invalid values
+let parsed_prompt = match params.prompt.as_deref() {
+    Some(p) => match Prompt::parse(p) {
+        Some(prompt) => Some(prompt),
+        None => return par_error_response(OAuthErrorCode::InvalidRequest, ...),
+    },
+    None => None,
+};
+```
+
+**Empty env var overrides fallback chain**
+```rust
+// config.rs (buggy): Ok("") becomes Some("") and blocks IMDS + SDK default chain
+let aws_region = args.aws_region
+    .or_else(|| std::env::var("AWS_DEFAULT_REGION").ok())  // "" is Some("")
+    .or_else(|| instance.map(|b| b.region.clone()));
+```
+
+## Correct patterns
+
+**Use `ResourceLabel::parse` for all user-assigned display labels**
+```rust
+// register_start, rename_key, create/update policy — correct pattern:
+let name = ResourceLabel::parse(&req.name).map_err(|e| match e {
+    ResourceLabelError::Empty => ServiceError::api(StatusCode::BAD_REQUEST, "invalid_name",
+        "Key name must be between 1 and 100 characters"),
+    ResourceLabelError::TooLong => ServiceError::api(StatusCode::BAD_REQUEST, "invalid_name",
+        "Key name must be between 1 and 100 characters"),
+})?;
+```
+
+**Validate enum fields explicitly; reject unknowns**
+```rust
+// create and update — correct:
+let access_scope = match input.access_scope {
+    None => AccessScope::default(),
+    Some(s) => s.parse::<AccessScope>()
+        .map_err(|_| AppValidationError::InvalidAccessScope)?,
+};
+```
+
+**Use `chars().count()` for character limits**
+```rust
+if trimmed.chars().count() > ResourceLabel::MAX_CHARS {
+    return Err(ResourceLabelError::TooLong);
+}
+```
+
+**Filter empty strings from env/config before they enter the option chain**
+```rust
+std::env::var("AWS_DEFAULT_REGION").ok().filter(|v| !v.is_empty())
+```
+
+**Validate all config sources at a shared post-merge step**
+```rust
+// config.rs — validate() called after all sources (env, S3) have been merged:
+for idp in &self.idps {
+    validate_provider_slug(idp.id())?;  // catches S3-sourced slugs too
+}
+```
+
+**One shared validator for equivalent paths (PAR plain vs. JAR)**
+Move parameter parsing out of each handler into a shared `validate_authorize_request` function, so plain form body, pushed request, and JAR all reach the same parse-and-reject logic.
+
+## Scope
+
+All files in these directories are in scope:
+
+- `crates/vouch-server/src/handlers/` — HTTP handlers for create, update, rename, register endpoints
+- `crates/vouch-server/src/handlers/applications/` — OAuth app create/update validation
+- `crates/vouch-server/src/handlers/keys.rs` — key register, rename
+- `crates/vouch-server/src/handlers/scim/` — SCIM user/group create and PATCH
+- `crates/vouch-server/src/handlers/oidc/` — PAR, JAR, dynamic client registration PUT
+- `crates/vouch-server/src/services/oidc/registration.rs` — RFC 7592 PUT
+- `crates/vouch-server/src/infra/s3_config.rs` — S3-sourced config merge
+- `crates/vouch-server/src/config.rs` — env var config parsing and post-merge validation
+- `crates/vouch-server/src/lib.rs` — AWS config resolution
+- `crates/vouch-cli/src/commands/` — CLI setup, credential, and register commands
+- `crates/vouch-common/src/` — shared validation types (`ResourceLabel`, `MAX_KEY_NAME_CHARS`)
+
+Not in scope: test files (`tests.rs`, `*_test.rs`), migration scripts, documentation.

--- a/.claude/skills/detail-rules/references/complete-and-ordered-deactivation-revocation.md
+++ b/.claude/skills/detail-rules/references/complete-and-ordered-deactivation-revocation.md
@@ -1,0 +1,204 @@
+# Complete and Ordered Deactivation and Revocation
+
+Detects handlers or services that deactivate, delete, or revoke user access without closing every live credential path, or that commit the state change before revocation instead of revoking first.
+
+## What to look for
+
+### 1. Persist-before-revoke ordering (critical)
+
+Any path that calls `db::update_user_active_status(..., false)`, `db::delete_user`, or `db::update_scim_user` with a deactivation before calling `revoke_user_access` / `revoke_then_persist` is wrong. The correct helper in this codebase is `services::auth::revoke_then_persist`, which runs revocation atomically first and only persists `active=false` if revocation succeeds.
+
+**Smell**: `update_user_active_status(..., false)` or `update_scim_user` appears above, or is awaited before, `revoke_user_access` / `revoke_then_persist`.
+
+**Correct ordering**: `revoke_then_persist(&state, &user_id, reason, by, || persist_fn())`.
+
+### 2. Missing `user.active` check on credential-issuing or token-accepting paths
+
+Any handler or service that issues or accepts credentials without reading `user.active` after the session/authenticator lookup is a bypass. Paths that must re-check `user.active` immediately after loading the user row:
+
+- **FIDO2 assertion grant** (`services/oidc/fido2_grant.rs`): enforced inside `lookup_and_verify_authenticator` via `if !user.active { return Err(Forbidden) }`.
+- **JWT bearer grant** (`services/auth.rs` / `exchange_jwt_bearer_grant`): must load user and check `user.active`.
+- **Token exchange actor path** (`services/oidc/exchange.rs`): subject user checked at line ~303, actor user checked at line ~368 — both must be present.
+- **Device flow** (`handlers/device.rs`): must check user loaded for org_domain lookup.
+- **Authorization code exchange** (`services/oidc/token.rs`): must check authenticator still exists.
+- **OIDC introspection** (`services/oidc/introspection.rs`): must return `inactive()` when `!user.active` — skip for `M2MAccessToken` session types.
+- **CLI key registration complete** (`handlers/keys.rs`): must check `account.active` before registering.
+- **SSO/OIDC enrollment** (`db/enrollment.rs → resolve_user`): must return `EnrollUserError::Deactivated` before any identity-binding side effect.
+- **Kubernetes/AWS/GitHub credential minting** (`services/integrations/`): must check `user.active`.
+
+### 3. Revocation scope is too narrow (missing a credential type)
+
+`revoke_user_access` must cover all three: sessions, SSH certificates, and the GitHub refresh token. Omitting any one leaves live credentials after deactivation.
+
+- Sessions: `db::delete_sessions_for_user` + `session_cache.invalidate_for_user`.
+- SSH certificates: `db::revoke_user_credentials` (calls `revoke_all_ssh_certificates_for_user` using the issued-cert records' real numeric serials, not synthetic `user:{id}` strings).
+- GitHub refresh token: cleared inside `revoke_user_credentials`.
+
+**Smell**: Code that calls only `delete_sessions_for_user` (or only SSH revocation) without the other two, or a `revoke_all_ssh_certificates_for_user` that inserts a synthetic serial like `"user:{user_id}"` that never matches a real SSH certificate serial.
+
+### 4. Revocation scope is too broad (missing ownership check)
+
+`/oauth/revoke` (RFC 7009) must refuse cross-client and cross-user revocation. The ownership check is:
+
+```rust
+if caller_client_id != claims.client_id {
+    return RevocationResult { revoked: false, .. };
+}
+```
+
+Any call to `delete_sessions_for_user` that proceeds without first verifying the token belongs to `caller_client_id` violates RFC 7009 §2.1.
+
+Similarly, auth-code replay revocation must call `delete_sessions_for_code_replay(code_hash)` (revoke only sessions linked to the replayed code's `source_code_hash`) rather than `delete_sessions_for_user` (revoke all sessions), to avoid unintended logout-as-DoS.
+
+### 5. JTI not committed at revocation/introspection endpoints
+
+`private_key_jwt` client authentication at `/oauth/revoke` and `/oauth/introspect` must commit the JTI claim. A `PendingJti` dropped without calling `commit_jti` means the same JWT assertion can be replayed indefinitely.
+
+### 6. Malformed SCIM `active` values silently coercing to `true`
+
+SCIM PATCH `active` attribute must be a `bool`. Non-boolean values (e.g., the JSON string `"false"`) must return `400 invalidValue`, not be silently coerced. A coercion to `true` reactivates a deactivated user on a malformed request.
+
+### 7. Session-cache invalidation after partial DB delete
+
+`delete_sessions_for_code_replay` iterates per-session deletes; a mid-loop DB failure must still return the hashes of already-deleted sessions (on the `Ok` arm or equivalent) so the caller's session cache evicts them. An `Err` arm that discards already-deleted hashes leaves stale cache entries valid for up to the cache TTL.
+
+## Violation examples
+
+**Persist-before-revoke (admin deactivation — pre-fix)**
+```rust
+// WRONG: active=false commits before revocation runs
+let updated = db::update_user_active_status(&state.store, &target_id, false).await?;
+crate::services::auth::revoke_user_access(&state, &target_id, "...", &admin.id).await?;
+```
+
+**Persist-before-revoke (SCIM patch_user — pre-fix)**
+```rust
+// WRONG: update_scim_user persists active=false, revoke_user_access called after
+db::update_scim_user(&state.store, &id, &auth.org_id, ..., patched.active).await?;
+crate::services::auth::revoke_user_access(&state, &id, "...", "scim").await?;
+```
+
+**SSH revocation serial mismatch (pre-fix)**
+```rust
+// WRONG: synthetic serial never matches a real 64-bit SSH cert serial
+store.insert(&SshRevokedCertDoc {
+    serial: format!("user:{user_id}"),  // can never match issued certs
+    ..
+}).await?;
+```
+
+**Missing `user.active` check in device flow (pre-fix)**
+```rust
+// WRONG: only loads user for org_domain, never checks active
+let org_domain = match db::get_user_by_id(&state.store, &user_id).await? {
+    Some(u) => match u.org_id { Some(org_id) => ..., None => None },
+    None => None,
+};
+// issues token without checking u.active
+```
+
+**Cross-client revocation — missing ownership check (pre-fix)**
+```rust
+// WRONG: revokes all sessions for the token's sub, regardless of caller_client_id
+if let Some(ref user_id) = sub {
+    db::delete_sessions_for_user(&state.store, user_id).await?;
+}
+```
+
+**Auth-code replay revokes all sessions instead of code-scoped ones (pre-fix)**
+```rust
+// WRONG: revokes ALL user sessions on replay detection
+db::delete_sessions_for_user(&state.store, &user_id).await?;
+// should be:
+// db::delete_sessions_for_code_replay(&state.store, &code_hash).await?;
+```
+
+## Correct patterns
+
+**Deactivation ordering via `revoke_then_persist`**
+```rust
+let updated = crate::services::auth::revoke_then_persist(
+    &state,
+    &target_id,
+    "User deactivated by admin",
+    &admin.id,
+    || db::update_user_active_status(&state.store, &target_id, false),
+)
+.await
+.map_err(|e| match e {
+    DeactivationError::Revoke(err) => err,
+    DeactivationError::Persist(err) => ServiceError::from(err),
+})?;
+```
+
+**`user.active` check in FIDO2 / lookup paths**
+```rust
+// Inside lookup_and_verify_authenticator:
+if !user.active {
+    return Err(ServiceError::Forbidden("user_deactivated"));
+}
+```
+
+**`user.active` check in introspection (non-M2M tokens)**
+```rust
+if session.session_type != db::SessionPurpose::M2MAccessToken {
+    let user_active = db::get_user_by_id(&state.store, &session.user_id)
+        .await
+        .map_err(|e| ServiceError::Internal(...))?
+        .is_some_and(|u| u.active);
+    if !user_active {
+        return Ok(IntrospectionResult::inactive());
+    }
+}
+```
+
+**Token-exchange actor check**
+```rust
+let actor_user = db::get_user_by_id(&state.store, actor_decoded.sub()).await?
+    .ok_or_else(|| ServiceError::oauth(InvalidGrant, "Actor not found"))?;
+if !actor_user.active {
+    return Err(ServiceError::oauth(InvalidGrant, "Actor account is deactivated"));
+}
+```
+
+**RFC 7009 ownership check before revocation**
+```rust
+if let Some(DecodedToken::AccessToken(ref claims)) = decoded
+    && caller_client_id != claims.client_id
+{
+    return RevocationResult { revoked: false, user_email: None };
+}
+```
+
+**SSH revocation using real issued-cert serials**
+```rust
+// revoke_all_ssh_certificates_for_user looks up SshIssuedCertDoc by user_id,
+// then inserts one SshRevokedCertDoc per real numeric serial from those records.
+let issued = store.find_all::<SshIssuedCertDoc>("user_id", user_id).await?;
+for cert in &issued {
+    store.insert(&SshRevokedCertDoc { serial: cert.data.serial.clone(), .. }).await?;
+}
+```
+
+## Scope
+
+All files under `crates/vouch-server/src/` in these directories:
+
+- `handlers/admin/members.rs` — deactivate_member, remove_member
+- `handlers/scim/users.rs` — patch_user (deactivation branch), delete_user
+- `handlers/scim/mod.rs` — SCIM active-value parsing
+- `handlers/device.rs` — device_token (approved branch)
+- `handlers/keys.rs` — register_complete
+- `handlers/applications/mod.rs` — revoke_tokens_api
+- `handlers/oidc/introspect.rs` — JTI commit after private_key_jwt auth
+- `services/auth.rs` — revoke_user_access, revoke_then_persist, exchange_jwt_bearer_grant
+- `services/oidc/token.rs` — exchange_authorization_code (authenticator existence check)
+- `services/oidc/fido2_grant.rs` — exchange_fido2_assertion
+- `services/oidc/exchange.rs` — exchange_token (subject and actor active checks)
+- `services/oidc/introspection.rs` — introspect_token, revoke_token
+- `services/oidc/authorization.rs` — replay revocation scope
+- `services/oidc/registration.rs` — misdirected-token revocation ownership
+- `services/integrations/kubernetes.rs`, `aws.rs`, `github/` — credential minting
+- `db/enrollment.rs` — enroll_user_with_org (SSO deactivation gate)
+- `db/credentials.rs` — revoke_all_ssh_certificates_for_user (serial matching)
+- `db/sessions.rs` — delete_sessions_for_code_replay (partial-failure cache sync)

--- a/.claude/skills/detail-rules/references/no-infrastructure-faults-as-client-errors.md
+++ b/.claude/skills/detail-rules/references/no-infrastructure-faults-as-client-errors.md
@@ -1,0 +1,224 @@
+# No Infrastructure Faults as Client Errors
+
+Infrastructure or transient backend failures must never be reported to the caller as a client-side error code, and a partial write failure must never be reported as success.
+
+## What to look for
+
+### 1. DB/store error mapped to a client-fault error code
+
+Any `Err(...)` arm that converts a database, store, cache, or network failure into a 4xx OAuth error code or a SCIM client error is a violation:
+
+- `invalid_dpop_proof` / `InvalidDpopProof` — valid only for proof defects, never for a JTI or nonce persistence failure
+- `invalid_grant` — valid for missing/revoked sessions; a `db::get_session_by_token_hash` that returns `Err(e)` must become `ServiceError::Internal`, not `ServiceError::oauth(InvalidGrant, …)`
+- `invalid_client` — valid for credential mismatches; a JWKS cache lookup failure for an inline-JWKS client must not produce `ClientAuthError::InvalidCredentials`
+- `409 Conflict` / SCIM `"uniqueness"` — valid for actual uniqueness violations; a serialization timeout or OCC-retry exhaustion must produce `500 INTERNAL_SERVER_ERROR`
+- `404 Not Found` — a DB `Err(e)` must not be collapsed into `Ok(None)` and silently treated as "not found"
+
+Pattern to search for: catch-all `Err(e) =>` or `Err(_) =>` arms inside DB call results that emit `invalid_dpop_proof`, `invalid_grant`, `invalid_client`, `409`, or log-and-return-Ok.
+
+### 2. Infrastructure error swallowed; partial write reported as success
+
+An `if let Err(e) = db_call() { tracing::warn!(...) }` (without `return`) or a `let Ok(…) = db_call() else { continue }` that silently discards a write failure, then proceeds to return `200 OK` / `201 Created`, is a violation. Every write that materially changes state must propagate its error.
+
+Pattern to search for:
+- `if let Err(e) = db::add_scim_group_member(…) { tracing::warn!(…) }` with no early `return`
+- `let Ok(Some(user)) = db::get_user_by_id(…) else { /* skip */ }` after a rotation that already invalidated the old token
+- `matches!(…, Ok(Some(_)))` used to collapse `Err(e)` and `Ok(None)` into the same client-error branch
+
+### 3. Catch-all `_` or `Err(e)` that collapses a distinct backend-fault variant
+
+Error enums in this codebase use separate variants for client faults vs. infrastructure faults. Collapsing a `Database(…)` or `Internal(…)` variant into the same arm as `AlreadyConsumed` or `InvalidInput` is a violation.
+
+Pattern to search for:
+- `Err(e) => return Err(SomeClientError(format!("… {e}")))` as a catch-all after specific client-fault arms
+- A `ClaimError::Database` arm mapped to `DpopError::InvalidFormat` (correct is `DpopError::Database`)
+- A `ServiceError::Internal` case falling through `into_oauth_response` — acceptable only if the catch-all maps it to `500 server_error`, not to a 4xx
+
+### 4. Missing-auth vs. bad-auth conflation in RFC 6750 responses
+
+RFC 6750 §3.1: a request that *lacks* credentials entirely must get a bare `WWW-Authenticate: Bearer` (no `error=`). A request that *carries* an invalid token gets `error="invalid_token"`. Emitting `error="invalid_token"` for a missing Authorization header is a violation.
+
+### 5. Retryable DB errors incorrectly classified as non-retryable (or vice versa)
+
+`is_retryable_code` in `db/pool.rs` matches SQLSTATE strings verbatim. Any logic that masks, truncates, or bitwise-ANDs a numeric string before matching can cause a Postgres SQLSTATE (e.g. `"22021"`, `"42501"`) to alias a SQLite retryable primary code (`"5"`, `"6"`). The correct approach is explicit enumeration of the small, stable set of retryable codes.
+
+## Violation examples
+
+**DB error mapped to `invalid_dpop_proof` (400):**
+```rust
+// Catch-all collapses DB failure into client-proof error
+Err(e) => return Err(DpopError::InvalidFormat(format!("JTI check failed: {e}"))),
+// and nonce path:
+Err(e) => return Err(DpopError::InvalidFormat(format!("nonce validation failed: {e}"))),
+```
+
+**Actor session DB error mapped to `invalid_grant`:**
+```rust
+// !matches! collapses Err(db_error) and Ok(None) into the same InvalidGrant arm
+if !matches!(
+    state.session_cache.get_session_by_token_hash(&state.store, &hash).await,
+    Ok(Some(_))
+) {
+    return Err(ServiceError::oauth(OAuthErrorCode::InvalidGrant, "Actor token session not found or revoked"));
+}
+```
+
+**Infrastructure error swallowed; PATCH returns 200 with stale membership:**
+```rust
+if let Err(e) = db::add_scim_group_member(db, group_id, org_id, user_id).await {
+    tracing::warn!("Failed to add member: {e}");
+    // Ok(()) returned — PATCH continues and handler returns 200 OK with stale data
+}
+```
+
+**Group create returns `409 Conflict` for all non-uniqueness DB errors:**
+```rust
+Err(e) => {
+    let detail = if e.to_string().contains("UNIQUE") { "Group already exists" } else { "Failed to create group" };
+    return (StatusCode::CONFLICT, Json(ScimError::new(409, detail).with_type("uniqueness"))).into_response();
+}
+```
+
+**Wrong OAuth error code: `invalid_client` instead of `invalid_token` for bearer-token failure:**
+```rust
+Err(_) => {
+    return ServiceError::oauth(OAuthErrorCode::InvalidClient, "Invalid Bearer token")
+        .into_oauth_response().into_response();
+}
+```
+
+**Missing-auth emits `error="invalid_token"` in WWW-Authenticate (RFC 6750 §3.1 violation):**
+```rust
+fn missing_token_response() -> Response {
+    (StatusCode::UNAUTHORIZED,
+     [("www-authenticate", bearer_challenge(OAuthErrorCode::InvalidToken.as_str(), "Bearer token required"))],
+     Json(json!({"error": "invalid_token"}))).into_response()
+}
+```
+
+**GitHub refresh-token rotation: DB error swallowed, invalidated token permanently lost:**
+```rust
+if let Some(new_refresh_token) = &token_response.refresh_token
+    && let Ok(Some(user)) = db::get_user_by_id(self.store, user_id).await  // Err swallowed
+    && let (Some(github_id), Some(github_login)) = (user.github_id, &user.github_login)
+{
+    // Best-effort rotation — "the next refresh will retry" (incorrect: old token was already invalidated)
+}
+```
+
+**JWKS cache lookup unconditionally gates inline-JWKS client authentication:**
+```rust
+// Loads cache even for inline-JWKS clients; DB error becomes 401 InvalidCredentials
+let jwks_cache = crate::db::get_jwks_cache(&state.store, &client.id)
+    .await
+    .map_err(|_| ClientAuthError::InvalidCredentials)?;
+```
+
+**SQLSTATE masking produces false-positive retries:**
+```rust
+let primary = numeric & 0xFF;   // Postgres "42501" → 5 → collides with SQLITE_BUSY
+let primary_str = primary.to_string();
+RETRYABLE_SQL_STATES.contains(&primary_str.as_str())
+```
+
+## Correct patterns
+
+**DB error in DPoP mapped to `DpopError::Database` (500), not `InvalidFormat` (400):**
+```rust
+Err(db::claim::ClaimError::AlreadyConsumed) => return Err(DpopError::ReplayDetected),
+Err(db::claim::ClaimError::InvalidInput(msg)) => return Err(DpopError::InvalidFormat(msg)),
+Err(db::claim::ClaimError::Database(msg)) => {
+    return Err(DpopError::Database(format!("JTI check failed: {msg}")));
+}
+```
+
+**Actor session lookup: Err propagated as Internal, Ok(None) as InvalidGrant:**
+```rust
+let _actor_session = state.session_cache
+    .get_session_by_token_hash(&state.store, &actor_token_hash)
+    .await
+    .map_err(|e| ServiceError::Internal(format!("Database error: {e}")))?
+    .ok_or_else(|| ServiceError::oauth(OAuthErrorCode::InvalidGrant, "Actor token session not found or revoked"))?;
+```
+
+**Group member write failure returns 500, not swallowed:**
+```rust
+if let Err(e) = db::add_scim_group_member(db, group_id, org_id, user_id).await {
+    return Err(member_op_error_response(e));
+}
+```
+
+**Group create infrastructure error returns 500:**
+```rust
+pub(super) fn create_scim_group_error_response(err: anyhow::Error) -> Response {
+    if let Some(resp) = super::invalid_index_value_response(&err) {
+        return resp.into_response();
+    }
+    tracing::error!("Failed to create group: {err}");
+    (StatusCode::INTERNAL_SERVER_ERROR, Json(ScimError::new(500, "Failed to create group"))).into_response()
+}
+```
+
+**Missing-auth response has no error code; invalid-token response does:**
+```rust
+// Missing auth — RFC 6750 §3.1: bare Bearer, no error= parameter, no body
+fn missing_token_response() -> Response {
+    (StatusCode::UNAUTHORIZED, [(WWW_AUTHENTICATE, bearer_challenge(&[]))]).into_response()
+}
+// Invalid token — error= included
+fn into_registration_response(err: ServiceError) -> Response { ... /* error="invalid_token" */ }
+```
+
+**GitHub rotation propagates DB errors instead of swallowing them:**
+```rust
+let user = db::get_user_by_id(self.store, user_id)
+    .await
+    .map_err(GitHubError::Database)?          // propagate
+    .ok_or(GitHubError::UserNotFound)?;
+db::update_user_github_identity(self.store, user_id, github_id, github_login, Some(new_refresh_token.expose_secret()))
+    .await
+    .map_err(GitHubError::Database)?;         // propagate
+```
+
+**JWKS cache skipped for inline-JWKS clients:**
+```rust
+let jwks_cache = if client.jwks_uri.is_some() {
+    crate::db::get_jwks_cache(&state.store, &client.id).await.ok().flatten()
+} else {
+    None  // inline JWKS: skip DB lookup entirely
+};
+```
+
+**SQLSTATE retryable check uses verbatim list, no masking:**
+```rust
+const RETRYABLE_SQL_STATES: &[&str] = &["40001", "OC000", "OC001", "5", "6", "261", "517", "773", "262", "518"];
+fn is_retryable_code(code: &str) -> bool {
+    RETRYABLE_SQL_STATES.contains(&code)
+}
+```
+
+**`ServiceError::from_db_contention` separates retryable from non-retryable DB errors:**
+```rust
+pub(crate) fn from_db_contention(err: anyhow::Error, msg: &'static str) -> Self {
+    tracing::error!("{msg}: {err}");
+    if crate::db::pool::is_retryable_db_error(&err) {
+        Self::OccConflict
+    } else {
+        Self::Internal(msg.to_string())
+    }
+}
+```
+
+## Scope
+
+All files under `crates/vouch-server/src/`:
+
+- `handlers/oidc/` — token, PAR, register, introspect, authorize, par endpoints
+- `handlers/scim/` — users, groups, mod (SCIM CRUD and auth)
+- `services/oidc/` — dpop, exchange, jwt_bearer/client_auth, registration
+- `services/integrations/github/oauth.rs`
+- `db/` — dpop, oauth, scim, pool (error classification and retry logic)
+- `infra/jwks.rs`
+- `error.rs` — `ServiceError::into_oauth_response` catch-all mapping
+
+Out of scope: CLI crates, test-only code, and infrastructure that never returns a client-facing HTTP response.

--- a/.claude/skills/detail-rules/references/optimistic-concurrency-required.md
+++ b/.claude/skills/detail-rules/references/optimistic-concurrency-required.md
@@ -1,0 +1,216 @@
+# Optimistic Concurrency Required for Shared-Document Mutations
+
+Concurrent mutation of the same document, or enforcement of a cross-row invariant, must use optimistic concurrency (`store.modify` / `compare_and_update` with a version bump and a bounded retry via `with_dsql_retry!`), never a blind `store.get()`-then-`store.update()` or a check-then-write TOCTOU pattern.
+
+## What to look for
+
+### 1. Blind get-then-update (lost-update race)
+
+A call to `store.get::<T>()` or `find_one::<T>()` followed by `store.update()` on the same document ID, outside a `store.modify` closure, in any path reachable from concurrent HTTP requests, webhooks, or background tasks.
+
+The blind write clobbers every field the concurrent writer changed, silently discarding the other update. Security-sensitive fields — `is_org_admin`, `active`, signature `counter` — are the highest-risk targets.
+
+**Pattern to flag:**
+```rust
+let doc = store.get::<FooDoc>(id).await?;  // READ (version captured but ignored)
+let mut data = doc.data;
+data.some_field = new_value;               // MODIFY
+store.update(id, &data).await?;            // BLIND WRITE — loses concurrent changes
+```
+
+### 2. Count-cap / floor / uniqueness guards outside a version-bumped transaction
+
+Any read-then-insert or count-then-insert pattern where the counted document type and the inserted document live on different rows and no shared row is version-bumped inside the same transaction:
+
+- SCIM token count cap (`MAX_SCIM_TOKENS = 2`) checked outside the insert transaction
+- OAuth secret cap (≤ `MAX_ACTIVE_SECRETS`) or floor (≥ 1) checked before `store.insert()`
+- Authenticator count-before-delete check (`count_before <= 1`) performed without serializing on the user doc's version
+- Organization admin uniqueness — "first enrollee wins admin" — without a `compare_and_update` on the org row
+- Domain ownership uniqueness (additional domain verification) without a shared claim slot
+- SCIM group membership duplicate check (`find_by_indexes` then `insert`) outside a single transaction
+- JTI replay protection via `find_by_indexes` then `insert` instead of a deterministic document ID
+
+The fix pattern is to **version-bump a shared serialization-point document** (e.g., the `OrganizationDoc` for org-scoped invariants, the `UserDoc` for per-user invariants) inside the same transaction, so concurrent writers collide on the CAS and the loser re-reads and re-checks.
+
+### 3. Derived value computed outside the `modify` closure
+
+A value derived from the document's current state (e.g., the merged repository list, the applied-flag `AtomicBool`, a successor user ID) must be re-computed inside the `store.modify` closure. If it is computed before calling `modify`, an OCC retry re-runs the closure with stale input, producing wrong output.
+
+**Pattern to flag:**
+```rust
+let merged = compute_delta(&current_repos, added, removed);  // OUTSIDE closure — stale on retry
+store.modify::<Doc, _>(&id, |data| {
+    data.repositories = Some(merged.clone());  // BUG: merged is stale if CAS races
+}).await?;
+```
+
+### 4. Unchecked `Ok(false)` / `Ok(None)` from OCC operations in callers
+
+When `store.modify`, `compare_and_update`, or a higher-level function that wraps them returns `Ok(false)` / `Ok(None)` to signal "document not found" or "OCC conflict not won", callers that silently discard the signal (e.g., `if let Err(e) = ...`) will treat a failed update as a success and log spurious audit events, redirect the user to a success page, or skip required error handling.
+
+### 5. Cross-row invariant enforced only by a pre-flight read (not by a shared write)
+
+Under PostgreSQL READ COMMITTED, two concurrent transactions can each observe a predicate result that the other's uncommitted write would change. A count, find-by-index, or membership check does not create a write-write conflict. The only reliable serialization point is a `compare_and_update` on a row both writers must update.
+
+## Violation examples
+
+**Blind get-then-update (authenticator name / GitHub fields):**
+```rust
+// update_authenticator_name — before fix (commit c63387dd)
+if let Some(doc) = store.get::<AuthenticatorDoc>(authenticator_id).await? {
+    let mut data = doc.data;
+    data.name = name.to_string();
+    store.update(authenticator_id, &data).await?;  // clobbers concurrent counter update
+    Ok(true)
+} else {
+    Ok(false)
+}
+```
+
+**Count-then-insert TOCTOU (SCIM token cap — before fix):**
+```rust
+let active = db::count_active_scim_tokens(&state.store, &org_id).await?;  // separate tx
+if active >= MAX_SCIM_TOKENS {
+    return Err(...);
+}
+let token_id = db::create_scim_token(&state.store, ...).await?;  // another tx — race window
+```
+
+**Count-then-delete TOCTOU (last-key floor — before fix):**
+```rust
+let key_count = db::count_authenticators_for_user(store, user_id).await?;
+if key_count <= 1 {
+    return Err(ServiceError::api(400, "last_key", "..."));
+}
+// No tx boundary or version bump — two concurrent deletes can both pass the check
+db::delete_authenticator(store, key_id).await?;
+```
+
+**JTI replay via check-then-insert (JWT bearer — before fix):**
+```rust
+let existing = store
+    .find_by_indexes::<JwtAssertionJtiDoc>(&[("jti", jti), ("client_id", client_id)])
+    .await?;
+if !existing.is_empty() { return Ok(false); }
+store.insert(&doc).await?;  // no UNIQUE constraint on (jti, client_id) — both inserts succeed
+```
+
+**Delta computed outside modify closure (GitHub repos — before fix, commit 5dfdf31e):**
+```rust
+// delta read before entering the modify closure
+let merged = compute_merged(&current_repos, added, removed);
+store.modify::<GitHubInstallationDoc, _>(&doc_id, |data| {
+    data.repositories = Some(merged.clone());  // stale if OCC retried
+}).await?;
+```
+
+**Stale applied-flag not reset between OCC retries (commit c63387dd):**
+```rust
+// AtomicBool set inside closure on first attempt, never reset at top of closure
+let applied = AtomicBool::new(false);
+store.modify::<FooDoc, _>(id, |data| {
+    if data.org_id != expected_org { return; }  // bails without setting applied
+    applied.store(true, Ordering::Release);
+    data.field = new_value;
+}).await?;
+// If first attempt set applied=true then lost the CAS, and second attempt bails
+// (org changed), applied stays true — caller reports success for a no-op.
+```
+
+**Ignoring Ok(false) / Ok(None) from OCC (policies handler — before fix):**
+```rust
+db::update_custom_policy(&state.store, &id, &org_id, params)
+    .await
+    .map_err(|e| ServiceError::Internal(format!("Failed to toggle policy: {e}")))?;
+// Ok(None) silently discarded — audit event logged for a policy that wasn't toggled
+```
+
+## Correct patterns
+
+**Use `store.modify` for single-document field mutations:**
+```rust
+// update_authenticator_counter — correct
+store
+    .modify::<AuthenticatorDoc, _>(authenticator_id, |data| {
+        data.counter = std::cmp::max(data.counter, counter);  // max, not assignment
+    })
+    .await?;
+
+// update_user_admin_status — correct
+store
+    .modify::<UserDoc, _>(user_id, |data| {
+        data.is_org_admin = is_admin;
+    })
+    .await
+```
+
+**Version-bump a shared row for cross-row cap/floor invariants:**
+```rust
+// create_scim_token — correct (scim.rs)
+crate::with_dsql_retry!(async {
+    let mut tx = store.begin().await?;
+    let org_doc = tx.get::<OrganizationDoc>(&org_id).await?.ok_or(...)?;
+    let active = tx.find_all::<ScimTokenDoc>("org_id", &org_id).await?
+        .iter().filter(|d| !d.is_expired()).count();
+    if active >= MAX_SCIM_TOKENS { return Err(terminal_error); }
+    tx.insert(&doc).await?;
+    // Bump org version — concurrent creator that committed changes this version,
+    // so compare_and_update returns Ok(false) and the block re-runs.
+    if !tx.compare_and_update::<OrganizationDoc>(&org_id, org_doc.version, &org_doc.data).await? {
+        return Err(ServiceError::OccConflict);
+    }
+    tx.commit().await?;
+    Ok(inserted_id)
+})
+```
+
+**Compute derived values inside the closure:**
+```rust
+// update_github_installation_repos_delta — correct
+store.modify::<GitHubInstallationDoc, _>(&doc_id, |data| {
+    let repos = data.repositories.get_or_insert_default();
+    for repo in &added_owned { if !repos.contains(repo) { repos.push(repo.clone()); } }
+    repos.retain(|r| !removed_owned.contains(r));
+    repos.sort();
+}).await?;
+```
+
+**Use deterministic document ID for insert-once uniqueness:**
+```rust
+// enrollment org creation — correct
+fn deterministic_org_id(domain: &str) -> String { /* SHA-256 of domain */ }
+// Concurrent inserts collide on the primary key; the loser gets a unique-violation
+// and re-fetches rather than inserting a duplicate.
+```
+
+**Check and handle `Ok(false)` / `Ok(None)` from OCC functions:**
+```rust
+// toggle_custom_policy — correct
+let updated = db::update_custom_policy(&state.store, &id, &org_id, params)
+    .await
+    .map_err(|e| ServiceError::Internal(format!("{e}")))?;
+if updated.is_none() {
+    return Err(ServiceError::NotFound("Policy"));
+}
+// Only log audit event after confirming the update happened.
+```
+
+**Reset applied-flag at the top of the modify closure:**
+```rust
+let applied = AtomicBool::new(false);
+store.modify::<FooDoc, _>(id, |data| {
+    applied.store(false, Ordering::Release);  // reset first on every retry
+    if data.org_id != expected_org { return; }
+    applied.store(true, Ordering::Release);
+    data.field = new_value;
+}).await?;
+```
+
+## Scope
+
+All files in:
+- `crates/vouch-server/src/db/` — document-layer mutation functions
+- `crates/vouch-server/src/services/` — business-logic services (keys, enrollment, OIDC grants, GitHub integrations)
+- `crates/vouch-server/src/handlers/` — HTTP request handlers that call db functions directly or enforce counts
+
+Exclude `#[cfg(test)]` blocks and files under `src/db/tests/`, `src/db/store/tests.rs`, and files whose only `store.update` calls are inside `test_helpers` modules — these are intentional fault-injection fixtures.


### PR DESCRIPTION
Pulls the four class-level Detail rules generated from the 192-bug corpus into `.claude/skills/detail-rules/references/`, so the repo captures the rules Detail now enforces.

These replace the pattern of weekly one-off findings with four broad classes, each seeded from the real bug instances:

| Rule | Class | Seed bugs |
|---|---|---|
| `complete-and-ordered-deactivation-revocation` | deactivation must revoke-before-persist, re-check `user.active` on every credential path, and scope revocation correctly | 20 (#245→#1136) |
| `asymmetric-input-validation-across-entry-points` | validation enforced on one path but missing/weaker on a sibling path | 42 |
| `optimistic-concurrency-required` | blind read-modify-write / check-then-write instead of `store.modify` OCC | 30 |
| `no-infrastructure-faults-as-client-errors` | transient/infra failure mapped to a 4xx or reported as success | 15 |

Follow-up to #1153 (which synced the existing hosted rules). The 12 narrow/redundant hosted rules still can't be deleted via the CLI or app — that needs a Detail support request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)