### PR TITLE
fix(server): keep mTLS client identity through RFC 7592 PUT

### DIFF
--- a/crates/vouch-server/src/db/documents/oauth.rs
+++ b/crates/vouch-server/src/db/documents/oauth.rs
@@ -402,19 +402,19 @@ pub struct OAuthClientDoc {
     /// that were created before RS256 support was added.
     #[serde(default)]
     pub id_token_signed_response_alg: JwsAlgorithm,
-    /// RFC 8705 Section 2.1.1: subject DN for tls_client_auth.
+    /// RFC 8705 Section 2.1.2: subject DN for tls_client_auth.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tls_client_auth_subject_dn: Option<String>,
-    /// RFC 8705 Section 2.1.1: SAN DNS name for tls_client_auth.
+    /// RFC 8705 Section 2.1.2: SAN DNS name for tls_client_auth.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tls_client_auth_san_dns: Option<String>,
-    /// RFC 8705 Section 2.1.1: SAN URI for tls_client_auth.
+    /// RFC 8705 Section 2.1.2: SAN URI for tls_client_auth.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tls_client_auth_san_uri: Option<String>,
-    /// RFC 8705 Section 2.1.1: SAN IP for tls_client_auth.
+    /// RFC 8705 Section 2.1.2: SAN IP for tls_client_auth.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tls_client_auth_san_ip: Option<String>,
-    /// RFC 8705 Section 2.1.1: SAN email for tls_client_auth.
+    /// RFC 8705 Section 2.1.2: SAN email for tls_client_auth.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tls_client_auth_san_email: Option<String>,
     /// RFC 8705 Section 3: certificate-bound access tokens.

--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -1639,15 +1639,15 @@ pub struct UpdateClientRegistrationParams<'a> {
     pub request_object_signing_alg: Option<JwsAlgorithm>,
     /// RFC 9101: Whether this client requires signed Request Objects.
     pub require_signed_request_object: Option<bool>,
-    /// RFC 8705 §2.1.1: subject DN for `tls_client_auth`.
+    /// RFC 8705 §2.1.2: subject DN for `tls_client_auth`.
     pub tls_client_auth_subject_dn: Option<&'a str>,
-    /// RFC 8705 §2.1.1: SAN DNS name for `tls_client_auth`.
+    /// RFC 8705 §2.1.2: SAN DNS name for `tls_client_auth`.
     pub tls_client_auth_san_dns: Option<&'a str>,
-    /// RFC 8705 §2.1.1: SAN URI for `tls_client_auth`.
+    /// RFC 8705 §2.1.2: SAN URI for `tls_client_auth`.
     pub tls_client_auth_san_uri: Option<&'a str>,
-    /// RFC 8705 §2.1.1: SAN IP for `tls_client_auth`.
+    /// RFC 8705 §2.1.2: SAN IP for `tls_client_auth`.
     pub tls_client_auth_san_ip: Option<&'a str>,
-    /// RFC 8705 §2.1.1: SAN email for `tls_client_auth`.
+    /// RFC 8705 §2.1.2: SAN email for `tls_client_auth`.
     pub tls_client_auth_san_email: Option<&'a str>,
 }
 

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7591.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7591.rs
@@ -1373,6 +1373,345 @@ async fn test_rfc7591_accepts_tls_client_auth_registration_without_jwks() {
     );
 }
 
+#[tokio::test]
+async fn test_rfc7591_empty_optional_strings_are_not_stored() {
+    // An empty string is a third state next to "absent" and "set" that means
+    // nothing the two do not, so it is not persisted. These four fields have no
+    // validator to reject one, unlike logo_uri or application_type.
+    let (app, state) = test_app().await;
+    let auth = bearer_token_unique(&state, "empty-optional-strings").await;
+
+    let body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "client_name": "",
+        "scope": "",
+        "software_id": "",
+        "software_version": ""
+    });
+
+    let (status, resp) = http_post_json(
+        &app,
+        "/oauth/register",
+        &body.to_string(),
+        &[("Authorization", &auth)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "Registration failed: {resp}");
+
+    let json: serde_json::Value = serde_json::from_str(&resp).expect("Valid JSON");
+    let client_id = json["client_id"].as_str().expect("client_id");
+
+    let stored = crate::db::get_oauth_client_by_client_id(&state.store, client_id)
+        .await
+        .expect("lookup ok")
+        .expect("client exists");
+
+    // The name column is non-nullable, so an emptied client_name takes the same
+    // fallback an omitted one does.
+    assert_eq!(stored.name, "Unnamed Client");
+    assert_eq!(stored.software_id, None, "software_id is indexed");
+    assert_eq!(stored.software_version, None);
+
+    // `scope` lives in the cosmetic-metadata blob, where absent means no key.
+    let metadata = stored
+        .registration_metadata
+        .unwrap_or(serde_json::Value::Null);
+    assert!(
+        metadata.get("scope").is_none(),
+        "an empty scope must not be stored: {metadata}"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc7591_empty_arrays_are_not_stored() {
+    // Same reasoning as the empty strings: an empty list is not a different
+    // state from an absent one. `post_logout_redirect_uris` already did this.
+    let (app, state) = test_app().await;
+    let auth = bearer_token_unique(&state, "empty-arrays").await;
+
+    let body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "contacts": [],
+        "request_uris": [],
+        "post_logout_redirect_uris": []
+    });
+
+    let (status, resp) = http_post_json(
+        &app,
+        "/oauth/register",
+        &body.to_string(),
+        &[("Authorization", &auth)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "Registration failed: {resp}");
+
+    let json: serde_json::Value = serde_json::from_str(&resp).expect("Valid JSON");
+    let client_id = json["client_id"].as_str().expect("client_id");
+
+    let stored = crate::db::get_oauth_client_by_client_id(&state.store, client_id)
+        .await
+        .expect("lookup ok")
+        .expect("client exists");
+
+    assert_eq!(stored.request_uris, None);
+    assert_eq!(stored.post_logout_redirect_uris, None);
+    let metadata = stored
+        .registration_metadata
+        .unwrap_or(serde_json::Value::Null);
+    assert!(
+        metadata.get("contacts").is_none(),
+        "an empty contacts list must not be stored: {metadata}"
+    );
+}
+
+/// An empty-string member of an array is refused outright rather than dropped,
+/// because each of these fields has a validator that an empty value fails.
+#[tokio::test]
+async fn test_rfc7591_rejects_empty_array_members() {
+    for (field, value) in [
+        ("contacts", serde_json::json!(["", "", ""])),
+        ("contacts", serde_json::json!(["", "ok@example.com"])),
+        ("request_uris", serde_json::json!([""])),
+        ("grant_types", serde_json::json!([""])),
+    ] {
+        let (app, state) = test_app().await;
+        let auth = bearer_token_unique(&state, &format!("empty-member-{field}")).await;
+        let mut body = serde_json::json!({"redirect_uris": ["https://example.com/callback"]});
+        body[field] = value.clone();
+
+        let (status, resp) = http_post_json(
+            &app,
+            "/oauth/register",
+            &body.to_string(),
+            &[("Authorization", &auth)],
+        )
+        .await;
+
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "{field}={value} must be refused, got: {resp}"
+        );
+        let json: serde_json::Value = serde_json::from_str(&resp).expect("Valid JSON");
+        assert_eq!(json["error"], "invalid_client_metadata");
+    }
+}
+
+/// The five RFC 8705 §2.1.2 certificate-subject parameters, each of which must
+/// carry the empty-is-absent rule.
+const IDENTITY_FIELDS: [&str; 5] = [
+    "tls_client_auth_subject_dn",
+    "tls_client_auth_san_dns",
+    "tls_client_auth_san_email",
+    "tls_client_auth_san_uri",
+    "tls_client_auth_san_ip",
+];
+
+/// A legal value for each parameter, so a single-field registration is accepted.
+const IDENTITY_VALUES: [&str; 5] = [
+    "CN=test-client",
+    "client.example.com",
+    "client@example.com",
+    "https://client.example.com/",
+    "198.51.100.7",
+];
+
+/// Every one of the five parameters carries the empty-is-absent rule, not just
+/// the first. A missing `deserialize_with` on any of them would leave that
+/// field satisfying the one-field rule with an unmatchable empty subject.
+#[tokio::test]
+async fn test_rfc7591_empty_is_absent_for_every_identity_field() {
+    for field in IDENTITY_FIELDS {
+        let (app, state) = test_app().await;
+        let auth = bearer_token_unique(&state, &format!("empty-{field}")).await;
+        let mut body = serde_json::json!({
+            "redirect_uris": ["https://example.com/callback"],
+            "token_endpoint_auth_method": "tls_client_auth"
+        });
+        body[field] = serde_json::json!("");
+
+        let (status, resp) = http_post_json(
+            &app,
+            "/oauth/register",
+            &body.to_string(),
+            &[("Authorization", &auth)],
+        )
+        .await;
+
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "an empty {field} must not count as present, got: {resp}"
+        );
+    }
+}
+
+/// The converse: each parameter on its own is a complete registration, so the
+/// empty-is-absent rule has not started swallowing legitimate values.
+#[tokio::test]
+async fn test_rfc7591_each_identity_field_suffices_alone() {
+    for (field, value) in IDENTITY_FIELDS.iter().zip(IDENTITY_VALUES) {
+        let (app, state) = test_app().await;
+        let auth = bearer_token_unique(&state, &format!("single-{field}")).await;
+        let mut body = serde_json::json!({
+            "redirect_uris": ["https://example.com/callback"],
+            "token_endpoint_auth_method": "tls_client_auth"
+        });
+        body[*field] = serde_json::json!(value);
+
+        let (status, resp) = http_post_json(
+            &app,
+            "/oauth/register",
+            &body.to_string(),
+            &[("Authorization", &auth)],
+        )
+        .await;
+
+        assert_eq!(
+            status,
+            StatusCode::CREATED,
+            "{field}={value} alone must be accepted, got: {resp}"
+        );
+    }
+}
+
+/// A `tls_client_auth` registration naming no certificate subject at all is
+/// refused end-to-end, not just by the validator in isolation.
+#[tokio::test]
+async fn test_rfc7591_rejects_tls_client_auth_with_no_identity_field() {
+    let (app, state) = test_app().await;
+    let auth = bearer_token_unique(&state, "tls-client-auth-no-identity").await;
+
+    let body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "token_endpoint_auth_method": "tls_client_auth"
+    });
+
+    let (status, resp) = http_post_json(
+        &app,
+        "/oauth/register",
+        &body.to_string(),
+        &[("Authorization", &auth)],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "tls_client_auth without a certificate subject must be refused: {resp}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&resp).expect("Valid JSON");
+    assert_eq!(json["error"], "invalid_client_metadata");
+}
+
+/// The fields that deliberately do NOT read an empty value as absent, because
+/// each already has a validator that an empty value fails. Turning these into
+/// silent defaults would hide a client bug that is currently reported as
+/// `invalid_client_metadata`.
+#[tokio::test]
+async fn test_rfc7591_validated_fields_still_reject_empty_string() {
+    for field in [
+        "application_type",
+        "token_endpoint_auth_method",
+        "client_uri",
+        "logo_uri",
+        "tos_uri",
+        "policy_uri",
+        "jwks_uri",
+        "id_token_signed_response_alg",
+        "authorization_signed_response_alg",
+        "introspection_signed_response_alg",
+        "request_object_signing_alg",
+        "userinfo_signed_response_alg",
+    ] {
+        let (app, state) = test_app().await;
+        let auth = bearer_token_unique(&state, &format!("reject-empty-{field}")).await;
+        let mut body = serde_json::json!({"redirect_uris": ["https://example.com/callback"]});
+        body[field] = serde_json::json!("");
+
+        let (status, resp) = http_post_json(
+            &app,
+            "/oauth/register",
+            &body.to_string(),
+            &[("Authorization", &auth)],
+        )
+        .await;
+
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "an empty {field} must be reported, not defaulted, got: {resp}"
+        );
+        let json: serde_json::Value = serde_json::from_str(&resp).expect("Valid JSON");
+        assert_eq!(json["error"], "invalid_client_metadata", "field: {field}");
+    }
+}
+
+#[tokio::test]
+async fn test_rfc7591_rejects_tls_client_auth_with_two_identity_fields() {
+    // RFC 8705 §2.1.2: "A client using the "tls_client_auth" authentication
+    // method MUST use exactly one of the below metadata parameters to indicate
+    // the certificate subject value that the authorization server is to expect
+    // when authenticating the respective client."
+    let (app, state) = test_app().await;
+    let auth = bearer_token_unique(&state, "tls-client-auth-two-identities").await;
+
+    let body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "token_endpoint_auth_method": "tls_client_auth",
+        "tls_client_auth_subject_dn": "CN=test-client",
+        "tls_client_auth_san_dns": "client.example.com"
+    });
+
+    let (status, body) = http_post_json(
+        &app,
+        "/oauth/register",
+        &body.to_string(),
+        &[("Authorization", &auth)],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "two certificate-subject parameters must be rejected: {body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(json["error"], "invalid_client_metadata");
+}
+
+#[tokio::test]
+async fn test_rfc7591_rejects_tls_client_auth_with_empty_identity_field() {
+    // RFC 7591 says nothing about empty JSON string values, so this follows the
+    // RFC 6749 §3.1/§3.2 rule the form-encoded endpoints apply: an empty value
+    // reads as omitted. An empty subject would match no certificate, leaving a
+    // client that RFC 8705 §2.1.2's one-field rule exists to prevent.
+    let (app, state) = test_app().await;
+    let auth = bearer_token_unique(&state, "tls-client-auth-empty-identity").await;
+
+    let body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "token_endpoint_auth_method": "tls_client_auth",
+        "tls_client_auth_subject_dn": ""
+    });
+
+    let (status, body) = http_post_json(
+        &app,
+        "/oauth/register",
+        &body.to_string(),
+        &[("Authorization", &auth)],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "an empty certificate-subject parameter must not count as present: {body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(json["error"], "invalid_client_metadata");
+}
+
 // ========================================================================
 // JWKS write-path shape validation — a type-invalid member (e.g. a boolean
 // "alg") must be rejected at registration through the same typed

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7592.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7592.rs
@@ -1019,7 +1019,7 @@ async fn test_rfc7592_put_rejects_rs256_id_token_alg_for_fapi_client() {
 
 #[tokio::test]
 async fn test_rfc7592_put_updates_mtls_client_auth_fields() {
-    // RFC 8705 Section 2.1.1 certificate-matching metadata. Each has a
+    // RFC 8705 Section 2.1.2 certificate-matching metadata. Each has a
     // dedicated column, so RFC 7592 §2.2 replacement applies to all five.
     let (app, state) = test_app().await;
     let (client_id, token) = register_fully_specified_client(&app).await;
@@ -1066,7 +1066,7 @@ async fn test_rfc7592_put_updates_mtls_client_auth_fields() {
 
 #[tokio::test]
 async fn test_rfc7592_put_omitting_mtls_client_auth_fields_clears_them() {
-    // RFC 7592 §2.2 full replacement, applied to the RFC 8705 Section 2.1.1 fields.
+    // RFC 7592 §2.2 full replacement, applied to the RFC 8705 Section 2.1.2 fields.
     let (app, state) = test_app().await;
     let (client_id, token) = register_fully_specified_client(&app).await;
 
@@ -1086,6 +1086,198 @@ async fn test_rfc7592_put_omitting_mtls_client_auth_fields_clears_them() {
     assert_eq!(stored.tls_client_auth_san_uri, None);
     assert_eq!(stored.tls_client_auth_san_ip, None);
     assert_eq!(stored.tls_client_auth_san_email, None);
+}
+
+#[tokio::test]
+async fn test_rfc7592_put_empty_optional_strings_are_not_stored() {
+    // The empty-is-absent rule is in the shared `RegistrationRequest`, so it
+    // applies to the PUT body too: emptying these is the same request as
+    // omitting them, which RFC 7592 §2.2 replacement treats as a delete.
+    let (app, state) = test_app().await;
+    let (client_id, token) = register_fully_specified_client(&app).await;
+
+    let update_body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "client_name": "",
+        "software_id": "",
+        "software_version": "",
+        "scope": "",
+        "contacts": [],
+        "request_uris": []
+    });
+
+    let (status, body) = put_client_config(&app, &client_id, &token, &update_body).await;
+    assert_eq!(status, StatusCode::OK, "PUT failed: {body}");
+
+    let stored = crate::db::get_oauth_client_by_client_id(&state.store, &client_id)
+        .await
+        .expect("lookup ok")
+        .expect("client exists");
+
+    // The name column is non-nullable, so it takes the registration default.
+    assert_eq!(stored.name, "Unnamed Client");
+    assert_eq!(stored.software_id, None);
+    assert_eq!(stored.software_version, None);
+    assert_eq!(stored.request_uris, None);
+    let metadata = stored
+        .registration_metadata
+        .unwrap_or(serde_json::Value::Null);
+    assert!(
+        metadata.get("scope").is_none() && metadata.get("contacts").is_none(),
+        "empty scope/contacts must not be stored: {metadata}"
+    );
+}
+
+/// Register a `tls_client_auth` client carrying exactly one RFC 8705 §2.1.2
+/// certificate-subject parameter, returning its `client_id` and registration
+/// access token.
+///
+/// The five parameters are only load-bearing for this authentication method,
+/// so the full-replacement tests above — which register `client_secret_basic`
+/// — cannot exercise the rule that governs them.
+async fn register_mtls_client(app: &axum::Router) -> (String, String) {
+    let body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "client_name": "mTLS Client",
+        "token_endpoint_auth_method": "tls_client_auth",
+        "tls_client_auth_subject_dn": "CN=original.example.com"
+    });
+
+    let (status, body) = http_post_json(app, "/oauth/register", &body.to_string(), &[]).await;
+    assert_eq!(status, StatusCode::CREATED, "Registration failed: {body}");
+
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let client_id = json["client_id"].as_str().expect("client_id").to_string();
+    let token = json["registration_access_token"]
+        .as_str()
+        .expect("registration_access_token")
+        .to_string();
+
+    (client_id, token)
+}
+
+#[tokio::test]
+async fn test_rfc7592_put_refuses_to_clear_mtls_identity_of_tls_client_auth_client() {
+    // RFC 8705 §2.1.2: "A client using the "tls_client_auth" authentication
+    // method MUST use exactly one of the below metadata parameters to indicate
+    // the certificate subject value that the authorization server is to expect
+    // when authenticating the respective client."
+    //
+    // RFC 7592 §2.2 replacement would otherwise clear all five, leaving a
+    // client `verify_tls_client_auth` reads as CertificateNotRegistered.
+    let (app, state) = test_app().await;
+    let (client_id, token) = register_mtls_client(&app).await;
+
+    let update_body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "token_endpoint_auth_method": "tls_client_auth"
+    });
+
+    let (status, body) = put_client_config(&app, &client_id, &token, &update_body).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "clearing every identity field of a tls_client_auth client must be refused: {body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(json["error"].as_str(), Some("invalid_client_metadata"));
+
+    // A refused update must not have written anything.
+    let stored = crate::db::get_oauth_client_by_client_id(&state.store, &client_id)
+        .await
+        .expect("lookup ok")
+        .expect("client exists");
+    assert_eq!(
+        stored.tls_client_auth_subject_dn.as_deref(),
+        Some("CN=original.example.com"),
+        "the registered identity field must survive a refused PUT"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc7592_put_replaces_the_single_mtls_identity_of_tls_client_auth_client() {
+    // RFC 7592 §2.2 replacement still applies within the one-field rule: a PUT
+    // naming a different parameter moves the client onto it and clears the old.
+    let (app, state) = test_app().await;
+    let (client_id, token) = register_mtls_client(&app).await;
+
+    let update_body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "token_endpoint_auth_method": "tls_client_auth",
+        "tls_client_auth_san_dns": "rotated.example.com"
+    });
+
+    let (status, body) = put_client_config(&app, &client_id, &token, &update_body).await;
+    assert_eq!(status, StatusCode::OK, "PUT failed: {body}");
+
+    let stored = crate::db::get_oauth_client_by_client_id(&state.store, &client_id)
+        .await
+        .expect("lookup ok")
+        .expect("client exists");
+    assert_eq!(
+        stored.tls_client_auth_san_dns.as_deref(),
+        Some("rotated.example.com")
+    );
+    assert_eq!(stored.tls_client_auth_subject_dn, None);
+}
+
+#[tokio::test]
+async fn test_rfc7592_put_refuses_empty_mtls_identity_for_tls_client_auth_client() {
+    // An empty string is not a certificate subject anything can match, so it
+    // deserializes as absent and cannot satisfy RFC 8705 §2.1.2's one-field
+    // rule. Otherwise a PUT could blank the client's identity while passing.
+    let (app, state) = test_app().await;
+    let (client_id, token) = register_mtls_client(&app).await;
+
+    let update_body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "token_endpoint_auth_method": "tls_client_auth",
+        "tls_client_auth_subject_dn": ""
+    });
+
+    let (status, body) = put_client_config(&app, &client_id, &token, &update_body).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "an empty identity field must not satisfy the one-field rule: {body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(json["error"].as_str(), Some("invalid_client_metadata"));
+
+    let stored = crate::db::get_oauth_client_by_client_id(&state.store, &client_id)
+        .await
+        .expect("lookup ok")
+        .expect("client exists");
+    assert_eq!(
+        stored.tls_client_auth_subject_dn.as_deref(),
+        Some("CN=original.example.com"),
+        "the registered identity field must survive a refused PUT"
+    );
+}
+
+#[tokio::test]
+async fn test_rfc7592_put_refuses_multiple_mtls_identities_for_tls_client_auth_client() {
+    // RFC 8705 §2.1.2 requires exactly one. `verify_tls_client_auth` consults
+    // the parameters in a fixed precedence order and returns on the first one
+    // present, so a second would be silently ignored.
+    let (app, _state) = test_app().await;
+    let (client_id, token) = register_mtls_client(&app).await;
+
+    let update_body = serde_json::json!({
+        "redirect_uris": ["https://example.com/callback"],
+        "token_endpoint_auth_method": "tls_client_auth",
+        "tls_client_auth_subject_dn": "CN=rotated.example.com",
+        "tls_client_auth_san_dns": "rotated.example.com"
+    });
+
+    let (status, body) = put_client_config(&app, &client_id, &token, &update_body).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "two identity fields must be refused: {body}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(json["error"].as_str(), Some("invalid_client_metadata"));
 }
 
 #[tokio::test]

--- a/crates/vouch-server/src/services/oidc/mtls.rs
+++ b/crates/vouch-server/src/services/oidc/mtls.rs
@@ -4,7 +4,7 @@
 //! Provides:
 //! - Certificate DER parsing and field extraction
 //! - `x5t#S256` thumbprint computation (RFC 8705 Section 3.1)
-//! - `tls_client_auth` subject/SAN matching (RFC 8705 Section 2.1.1)
+//! - `tls_client_auth` subject/SAN matching (RFC 8705 Section 2.1.2)
 //! - `self_signed_tls_client_auth` JWKS x5c matching (RFC 8705 Section 2.2.2)
 
 use base64::Engine;
@@ -151,7 +151,7 @@ fn format_ip_bytes(bytes: &[u8]) -> String {
 }
 
 /// Verify `tls_client_auth` — match certificate against registered
-/// subject DN or SAN fields (RFC 8705 Section 2.1.1).
+/// subject DN or SAN fields (RFC 8705 Section 2.1.2).
 ///
 /// Exactly one of the `tls_client_auth_*` fields must match.
 pub(crate) fn verify_tls_client_auth(
@@ -327,7 +327,7 @@ mod tests {
     }
 
     // =========================================================================
-    // verify_tls_client_auth — all-None case (RFC 8705 Section 2.1.1)
+    // verify_tls_client_auth — all-None case (RFC 8705 Section 2.1.2)
     // =========================================================================
 
     /// When all expected identity fields are None, the certificate cannot be

--- a/crates/vouch-server/src/services/oidc/registration.rs
+++ b/crates/vouch-server/src/services/oidc/registration.rs
@@ -88,6 +88,7 @@ pub struct RegistrationRequest {
     /// RFC 7591 Section 2: Array of OAuth 2.0 response type strings.
     pub response_types: Option<Vec<String>>,
     /// RFC 7591 Section 2: Human-readable name of the client.
+    #[serde(default, deserialize_with = "empty_string_as_none")]
     pub client_name: Option<String>,
     /// RFC 7591 Section 2: URL of the client's home page.
     pub client_uri: Option<String>,
@@ -98,6 +99,7 @@ pub struct RegistrationRequest {
     /// RFC 7591 Section 2: URL of the client's privacy policy.
     pub policy_uri: Option<String>,
     /// RFC 7591 Section 2: Space-delimited scope string.
+    #[serde(default, deserialize_with = "empty_string_as_none")]
     pub scope: Option<String>,
     /// RFC 7591 Section 2: Array of contact email addresses.
     pub contacts: Option<Vec<String>>,
@@ -106,22 +108,29 @@ pub struct RegistrationRequest {
     /// RFC 7591 Section 2: URL for the client's JSON Web Key Set.
     pub jwks_uri: Option<String>,
     /// RFC 7591 Section 2: Unique identifier for the client software.
+    #[serde(default, deserialize_with = "empty_string_as_none")]
     pub software_id: Option<String>,
     /// RFC 7591 Section 2: Version of the client software.
+    #[serde(default, deserialize_with = "empty_string_as_none")]
     pub software_version: Option<String>,
     /// FAPI 2.0: Whether access tokens must be DPoP-bound.
     pub dpop_bound_access_tokens: Option<bool>,
     /// OIDC Core Section 3.1.3.7: ID token signing algorithm.
     pub id_token_signed_response_alg: Option<String>,
-    /// RFC 8705 Section 2.1.1: subject DN for tls_client_auth.
+    /// RFC 8705 Section 2.1.2: subject DN for tls_client_auth.
+    #[serde(default, deserialize_with = "empty_string_as_none")]
     pub tls_client_auth_subject_dn: Option<String>,
-    /// RFC 8705 Section 2.1.1: SAN DNS name for tls_client_auth.
+    /// RFC 8705 Section 2.1.2: SAN DNS name for tls_client_auth.
+    #[serde(default, deserialize_with = "empty_string_as_none")]
     pub tls_client_auth_san_dns: Option<String>,
-    /// RFC 8705 Section 2.1.1: SAN URI for tls_client_auth.
+    /// RFC 8705 Section 2.1.2: SAN URI for tls_client_auth.
+    #[serde(default, deserialize_with = "empty_string_as_none")]
     pub tls_client_auth_san_uri: Option<String>,
-    /// RFC 8705 Section 2.1.1: SAN IP for tls_client_auth.
+    /// RFC 8705 Section 2.1.2: SAN IP for tls_client_auth.
+    #[serde(default, deserialize_with = "empty_string_as_none")]
     pub tls_client_auth_san_ip: Option<String>,
-    /// RFC 8705 Section 2.1.1: SAN email for tls_client_auth.
+    /// RFC 8705 Section 2.1.2: SAN email for tls_client_auth.
+    #[serde(default, deserialize_with = "empty_string_as_none")]
     pub tls_client_auth_san_email: Option<String>,
     /// RFC 8705 Section 3: certificate-bound access tokens.
     pub tls_client_certificate_bound_access_tokens: Option<bool>,
@@ -144,6 +153,42 @@ pub struct RegistrationRequest {
     /// When present, only these URIs are accepted as `post_logout_redirect_uri` in
     /// the end-session request. Absent means no redirect-back after logout.
     pub post_logout_redirect_uris: Option<Vec<String>>,
+}
+
+/// Deserialize an optional string, reading an empty value as absent.
+///
+/// RFC 7591 is silent here: its JSON body has no counterpart to RFC 6749 §3.1
+/// and §3.2's "Parameters sent without a value MUST be treated as if they were
+/// omitted from the request", which
+/// [`crate::handlers::extractors::OAuthForm`] applies to the form-encoded
+/// endpoints. So the choice is ours, and it is made the same way: a stored
+/// empty string is a third state next to "absent" and "set" that means nothing
+/// the two do not, so the field is not stored at all.
+///
+/// Carried by the fields where an empty value would otherwise be persisted:
+/// the RFC 8705 §2.1.2 certificate-subject parameters, where an empty string
+/// matches no certificate and would satisfy the exactly-one rule with a value
+/// that still leaves the client unable to authenticate; and `client_name`,
+/// `scope`, `software_id`, and `software_version`, which have no validator to
+/// pass. An emptied `client_name` therefore takes the same
+/// `"Unnamed Client"` fallback an omitted one does, and the other three go to
+/// NULL — `software_id` is indexed, so this also keeps an empty key out of the
+/// index.
+///
+/// The remaining metadata fields keep serde's plain `Option<String>`, because
+/// an empty value there already reaches a validator that rejects it outright
+/// (an empty `logo_uri` is not a valid HTTPS URL, an empty `application_type`
+/// is not "native" or "web", an empty signing algorithm is not a supported
+/// one). Reading those as absent would turn an explicit
+/// `invalid_client_metadata` into a silent default and hide the client's bug.
+///
+/// A whitespace-only value stays present, matching the form-encoded rule that
+/// reads `%20` as a value rather than as nothing.
+fn empty_string_as_none<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::<String>::deserialize(deserializer)?.filter(|s| !s.is_empty()))
 }
 
 impl RegistrationRequest {
@@ -172,7 +217,12 @@ impl RegistrationRequest {
                 serde_json::Value::String(v.clone()),
             );
         }
-        if let Some(ref v) = self.contacts {
+        // An empty list carries nothing an absent key does not, so it is not
+        // stored. Individual empty members never reach here: an address without
+        // an `@` is refused by `validate_contacts_and_uris`.
+        if let Some(ref v) = self.contacts
+            && !v.is_empty()
+        {
             metadata.insert(
                 "contacts".to_string(),
                 serde_json::Value::Array(
@@ -971,6 +1021,11 @@ fn validate_request_object_signing(
 /// Returns the validated list, or `None` if the field is absent.
 fn validate_request_uris(uris: Option<&[String]>) -> Result<Option<Vec<String>>, ServiceError> {
     let Some(uris) = uris else { return Ok(None) };
+    // An empty allowlist is the same state as no allowlist, so it is not
+    // stored — as in `validate_post_logout_redirect_uris_registration`.
+    if uris.is_empty() {
+        return Ok(None);
+    }
     const MAX_REQUEST_URIS: usize = 10;
     if uris.len() > MAX_REQUEST_URIS {
         return Err(ServiceError::oauth(
@@ -1238,25 +1293,78 @@ fn validate_jwks_and_auth_method(
         ));
     }
 
-    // RFC 8705 Section 2.1.1: tls_client_auth requires at least one identity field
-    if auth_method == TokenEndpointAuthMethod::TlsClientAuth {
-        let has_identity = request.tls_client_auth_subject_dn.is_some()
-            || request.tls_client_auth_san_dns.is_some()
-            || request.tls_client_auth_san_email.is_some()
-            || request.tls_client_auth_san_uri.is_some()
-            || request.tls_client_auth_san_ip.is_some();
-        if !has_identity {
-            return Err(ServiceError::oauth(
-                OAuthErrorCode::InvalidClientMetadata,
-                "tls_client_auth requires at least one identity field \
-                 (tls_client_auth_subject_dn, tls_client_auth_san_dns, \
-                 tls_client_auth_san_email, tls_client_auth_san_uri, \
-                 or tls_client_auth_san_ip)",
-            ));
+    validate_tls_client_auth_identity(auth_method, request)?;
+
+    Ok(ValidatedJwksAuth { keys, auth_method })
+}
+
+/// Enforce the certificate-subject metadata rule on a `tls_client_auth` client.
+///
+/// RFC 8705 §2.1.2:
+///
+/// > A client using the "tls_client_auth" authentication method MUST use
+/// > exactly one of the below metadata parameters to indicate the certificate
+/// > subject value that the authorization server is to expect when
+/// > authenticating the respective client.
+///
+/// Zero is refused because `verify_tls_client_auth` reads an all-absent client
+/// as `CertificateNotRegistered`, so the client could never authenticate at the
+/// token endpoint. More than one is refused because that same function consults
+/// the parameters in a fixed precedence order and returns on the first one
+/// present, silently ignoring the rest.
+///
+/// Shared by initial registration and the RFC 7592 §2.2 PUT. The PUT is a full
+/// replacement — omitted fields are cleared — so without this check there it
+/// could move a working client into the exact state registration refuses.
+///
+/// Returns `Ok(())` for every other authentication method, which does not use
+/// these parameters.
+fn validate_tls_client_auth_identity(
+    auth_method: TokenEndpointAuthMethod,
+    request: &RegistrationRequest,
+) -> Result<(), ServiceError> {
+    if auth_method != TokenEndpointAuthMethod::TlsClientAuth {
+        return Ok(());
+    }
+
+    // Listed in the precedence order `verify_tls_client_auth` consults them.
+    let mut present: Vec<&str> = Vec::new();
+    for (name, value) in [
+        (
+            "tls_client_auth_subject_dn",
+            &request.tls_client_auth_subject_dn,
+        ),
+        ("tls_client_auth_san_dns", &request.tls_client_auth_san_dns),
+        (
+            "tls_client_auth_san_email",
+            &request.tls_client_auth_san_email,
+        ),
+        ("tls_client_auth_san_uri", &request.tls_client_auth_san_uri),
+        ("tls_client_auth_san_ip", &request.tls_client_auth_san_ip),
+    ] {
+        if value.is_some() {
+            present.push(name);
         }
     }
 
-    Ok(ValidatedJwksAuth { keys, auth_method })
+    match present.len() {
+        1 => Ok(()),
+        0 => Err(ServiceError::oauth(
+            OAuthErrorCode::InvalidClientMetadata,
+            "tls_client_auth requires exactly one identity field \
+             (tls_client_auth_subject_dn, tls_client_auth_san_dns, \
+             tls_client_auth_san_email, tls_client_auth_san_uri, \
+             or tls_client_auth_san_ip)",
+        )),
+        count => Err(ServiceError::oauth(
+            OAuthErrorCode::InvalidClientMetadata,
+            format!(
+                "tls_client_auth requires exactly one identity field, but {count} were \
+                 supplied: {}",
+                present.join(", ")
+            ),
+        )),
+    }
 }
 
 /// Validate HTTPS URI fields and contacts.
@@ -1639,6 +1747,12 @@ pub async fn update_client_configuration(
             "FAPI 2.0 requires a JWKS key usable with ES256, PS256, or EdDSA",
         ));
     }
+
+    // The five RFC 8705 §2.1.2 certificate-subject parameters are written as a
+    // full replacement below, so a PUT that omits them clears them. Checked
+    // against the client's registered (immutable) auth method, which is what
+    // decides whether the parameters are required at all.
+    validate_tls_client_auth_identity(client.token_endpoint_auth_method, &mutable_request)?;
 
     // Validate the signed-response algorithms with the same validators initial
     // registration uses. The client's FAPI profile is immutable

--- a/crates/vouch-server/src/services/oidc/registration/tests.rs
+++ b/crates/vouch-server/src/services/oidc/registration/tests.rs
@@ -1242,7 +1242,7 @@ fn test_validate_jwks_and_auth_method_unknown_auth_method_rejected() {
 }
 
 // =========================================================================
-// validate_jwks_and_auth_method — tls_client_auth (RFC 8705 Section 2.1.1)
+// validate_jwks_and_auth_method — tls_client_auth (RFC 8705 Section 2.1.2)
 // =========================================================================
 
 /// tls_client_auth with a subject_dn identity field is accepted.
@@ -1273,6 +1273,89 @@ fn test_validate_tls_client_auth_requires_identity_field() {
     assert_oauth_error(result, OAuthErrorCode::InvalidClientMetadata);
 }
 
+/// An empty certificate-subject parameter deserializes as absent, so it cannot
+/// satisfy the one-field rule.
+///
+/// RFC 7591 is silent on empty JSON string values; this mirrors the RFC 6749
+/// §3.1/§3.2 rule the form-encoded endpoints already apply.
+#[test]
+fn test_empty_identity_field_deserializes_as_absent() {
+    let json = serde_json::json!({
+        "tls_client_auth_subject_dn": "",
+        "tls_client_auth_san_dns": "client.example.com"
+    });
+    let req: RegistrationRequest =
+        serde_json::from_value(json).expect("an empty identity field must deserialize");
+
+    assert_eq!(req.tls_client_auth_subject_dn, None);
+    assert_eq!(
+        req.tls_client_auth_san_dns.as_deref(),
+        Some("client.example.com")
+    );
+}
+
+/// A whitespace-only value is a value, matching the form-encoded rule that
+/// reads `%20` as present rather than as nothing.
+#[test]
+fn test_whitespace_identity_field_deserializes_as_present() {
+    let json = serde_json::json!({"tls_client_auth_subject_dn": " "});
+    let req: RegistrationRequest =
+        serde_json::from_value(json).expect("a whitespace identity field must deserialize");
+
+    assert_eq!(req.tls_client_auth_subject_dn.as_deref(), Some(" "));
+}
+
+/// tls_client_auth whose only identity field is empty must be rejected: an
+/// empty subject matches no certificate, so accepting it would leave the client
+/// unable to authenticate.
+///
+/// Deserialized rather than built from a struct literal, because the
+/// empty-is-absent rule lives in the deserializer — the same place the
+/// form-encoded endpoints apply it — not in the validator.
+// RFC 8705 §2.1.2 requires exactly one certificate-subject parameter.
+#[test]
+fn test_validate_tls_client_auth_rejects_empty_identity_field() {
+    let json = serde_json::json!({"tls_client_auth_subject_dn": ""});
+    let mut req: RegistrationRequest = serde_json::from_value(json).expect("deserializes");
+
+    let result = validate_jwks_and_auth_method(&mut req, "tls_client_auth");
+    assert_oauth_error(result, OAuthErrorCode::InvalidClientMetadata);
+}
+
+/// tls_client_auth with two identity fields must be rejected with invalid_client_metadata.
+// RFC 8705 §2.1.2: "A client using the "tls_client_auth" authentication method
+// MUST use exactly one of the below metadata parameters to indicate the
+// certificate subject value that the authorization server is to expect when
+// authenticating the respective client."
+#[test]
+fn test_validate_tls_client_auth_rejects_multiple_identity_fields() {
+    let mut req = RegistrationRequest {
+        tls_client_auth_subject_dn: Some("CN=test-client".to_string()),
+        tls_client_auth_san_dns: Some("client.example.com".to_string()),
+        ..Default::default()
+    };
+    let result = validate_jwks_and_auth_method(&mut req, "tls_client_auth");
+    assert_oauth_error(result, OAuthErrorCode::InvalidClientMetadata);
+}
+
+/// The identity-field rule binds tls_client_auth only; another method may carry
+/// the parameters without them meaning anything.
+// RFC 8705 §2.1.2 scopes the parameters to "a client using the
+// "tls_client_auth" authentication method".
+#[test]
+fn test_validate_identity_fields_unconstrained_for_other_auth_methods() {
+    let mut req = RegistrationRequest {
+        tls_client_auth_subject_dn: Some("CN=test-client".to_string()),
+        tls_client_auth_san_dns: Some("client.example.com".to_string()),
+        ..Default::default()
+    };
+    let result = validate_jwks_and_auth_method(&mut req, "client_secret_basic");
+    assert!(
+        result.is_ok(),
+        "the one-field rule must not reach a non-mTLS client, got: {result:?}"
+    );
+}
+
 /// tls_client_auth with san_dns identity field is accepted.
 // RFC 8705 §2.1.2: tls_client_auth_san_dns identifies the certificate subject.
 #[test]
@@ -1288,7 +1371,7 @@ fn test_validate_tls_client_auth_with_san_dns_accepted() {
     );
 }
 
-/// tls_client_auth with san_email identity field is accepted (RFC 8705 Section 2.1.1).
+/// tls_client_auth with san_email identity field is accepted (RFC 8705 Section 2.1.2).
 // RFC 8705 §2.1.2: tls_client_auth_san_email identifies the certificate subject.
 #[test]
 fn test_validate_tls_client_auth_with_san_email() {
@@ -1304,7 +1387,7 @@ fn test_validate_tls_client_auth_with_san_email() {
     );
 }
 
-/// tls_client_auth with san_uri identity field is accepted (RFC 8705 Section 2.1.1).
+/// tls_client_auth with san_uri identity field is accepted (RFC 8705 Section 2.1.2).
 // RFC 8705 §2.1.2: tls_client_auth_san_uri identifies the certificate subject.
 #[test]
 fn test_validate_tls_client_auth_with_san_uri() {
@@ -1320,7 +1403,7 @@ fn test_validate_tls_client_auth_with_san_uri() {
     );
 }
 
-/// tls_client_auth with san_ip identity field is accepted (RFC 8705 Section 2.1.1).
+/// tls_client_auth with san_ip identity field is accepted (RFC 8705 Section 2.1.2).
 // RFC 8705 §2.1.2: tls_client_auth_san_ip identifies the certificate subject.
 #[test]
 fn test_validate_tls_client_auth_with_san_ip() {


### PR DESCRIPTION
## What this does

The RFC 7592 PUT client-configuration endpoint replaces every mutable client metadata field, but never checked that a `tls_client_auth` client keeps a certificate subject. A PUT omitting all five `tls_client_auth_*` parameters returned 200 and cleared them, leaving a client the token endpoint rejects with `invalid_client` — `verify_tls_client_auth` reads an all-absent client as `CertificateNotRegistered`. Initial registration refuses that same state.

`validate_tls_client_auth_identity` now holds the rule and both paths call it. On the PUT it is checked against the client's registered (immutable) `token_endpoint_auth_method`, which is what decides whether the parameters are required at all.

### Exactly one, not at least one

The guard requires exactly one parameter. RFC 8705 §2.1.2:

> A client using the "tls_client_auth" authentication method MUST use exactly one of the below metadata parameters to indicate the certificate subject value that the authorization server is to expect when authenticating the respective client.

Two or more were previously accepted. `verify_tls_client_auth` consults them in a fixed precedence order and returns on the first present, so any others were silently ignored.

**This is a behavior change for existing clients.** A client that registered two or more identity parameters is now refused on its next PUT with `invalid_client_metadata`. No test in the repo registered more than one, so nothing in CI depended on the old behavior.

### An empty string is not a supplied value

RFC 7591 is silent on empty JSON string values — it only ever says "omitted", and has no counterpart to the RFC 6749 §3.1/§3.2 rule that `OAuthForm` already applies to the form-encoded endpoints. So this is a judgment call, not a conformance requirement: a stored empty string is a third state next to "absent" and "set" that means nothing the two do not.

The rule lives in a `deserialize_with` on the request struct, so it applies to registration and the PUT alike. It carries on nine fields — the five identity parameters, where an empty string matches no certificate and would satisfy the one-field rule with a value that still leaves the client unable to authenticate; and `client_name`, `scope`, `software_id`, and `software_version`, which had no validator to reject one. An emptied `client_name` now takes the same `"Unnamed Client"` fallback an omitted one gets, and the other three go to NULL (`software_id` is indexed, so this also keeps an empty key out of the index).

The remaining twelve optional string fields deliberately keep serde's plain `Option<String>`, because an empty value there already reaches a validator that rejects it. Reading those as absent would turn an explicit `invalid_client_metadata` into a silent default and hide the client's bug. A whitespace-only value stays present, matching the form-encoded rule that reads `%20` as a value.

Empty `contacts` and `request_uris` lists are likewise no longer stored, matching `validate_post_logout_redirect_uris_registration`, which already had that guard. Empty members *within* those lists were already refused — `contacts` requires an `@`, `request_uris` requires HTTPS — and still are.

### Citations

Twenty RFC 8705 comments cited §2.1.1, which registers the `tls_client_auth` method value. The five certificate-subject parameters are defined in §2.1.2. The one reference that genuinely is about the method value keeps §2.1.1.

## Scope of the class

Every other registration-time validator already had a PUT counterpart — grant/response types, redirect URIs, contacts and URIs, the signed-response algorithms, request URIs, post-logout redirect URIs, the request-object commitment, JWKS mutual exclusion and shape, the `private_key_jwt`/self-signed key-material and `x5c` checks, and the FAPI algorithm check. The `tls_client_auth` identity guard was the only gap. The admin applications API cannot reach this state: `build_create_params` hardcodes all five parameters to `None` and never creates a `tls_client_auth` client, and its update params don't include those columns.

## Tests

18 new tests. Both directions are covered: every one of the five identity parameters is checked for the empty-is-absent rule *and* for sufficing alone, and a separate test pins that the twelve validated fields still reject `""` — so a future broad application of the deserializer fails loudly instead of silently converting twelve errors into defaults.

Verified the tests catch the defects by reintroducing each one:

- neutering the PUT guard failed both PUT identity tests
- removing `.filter(|s| !s.is_empty())` failed all four empty-value tests
- dropping the attribute from `tls_client_auth_san_ip` failed the per-field test, naming that field
- adding the attribute to `logo_uri` failed the non-application guard, naming that field

`make fmt`, `make lint` (zero warnings), `make test`, `make test-integration` all clean.

## Left out

`grant_types: []` and `response_types: []` are accepted and stored as empty arrays, registering a client that can use no flow at all. RFC 7591 §2 defaults an omitted `grant_types` to `["authorization_code"]`, so by the same empty-is-absent reasoning these arguably should too. Not included here: it changes what a client ends up able to do rather than only what is stored.

Fixes #1169

🤖 Generated with [Claude Code](https://claude.com/claude-code)
