### PR TITLE
perf(server): drop redundant org-domain lookups on OAuth grant paths

### DIFF
--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -139,16 +139,17 @@ pub(crate) use oauth::JwtAssertionJtiClaim;
 pub use oauth::{
     ClientKeys, ClientKeysError, CreateOAuthClientParams, JwkEntry, JwkSet, KeyType,
     MAX_ACTIVE_SECRETS, MAX_POST_LOGOUT_REDIRECT_URIS, OAuthClient, OAuthClientSecret,
-    OAuthEventType, OAuthUsageStats, RecordOAuthEventParams, RedirectUriError,
+    OAuthEventType, OAuthUsageStats, RecordOAuthEventParams, RecordedOrgDomain, RedirectUriError,
     UpdateClientRegistrationParams, UpdateOAuthClientParams, client_keys_to_stored,
     create_oauth_client, create_oauth_client_secret, delete_expired_jwt_assertion_jtis,
     delete_oauth_client, get_oauth_client_by_client_id, get_oauth_client_by_id,
     get_oauth_client_secret_by_id, get_oauth_client_secrets, get_oauth_clients_for_user,
     get_oauth_secret_by_hash, get_oauth_usage_stats, is_loopback_redirect_host,
     is_valid_post_logout_redirect_uri_str, parse_jwks_set, record_oauth_event,
-    revoke_all_oauth_client_secrets, revoke_oauth_client_secret, revoke_registration_access_token,
-    store_jwt_assertion_jti, update_oauth_client, update_oauth_client_last_used,
-    update_oauth_client_registration, validate_oauth_client_credentials, validate_redirect_uri,
+    resolve_event_org_domain, revoke_all_oauth_client_secrets, revoke_oauth_client_secret,
+    revoke_registration_access_token, store_jwt_assertion_jti, update_oauth_client,
+    update_oauth_client_last_used, update_oauth_client_registration,
+    validate_oauth_client_credentials, validate_redirect_uri,
 };
 
 // Re-export test-only OAuth client helpers

--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -1432,6 +1432,22 @@ impl OAuthEventType {
     }
 }
 
+/// An OAuth event's org domain, as known to the caller.
+///
+/// Forces every call site of [`record_oauth_event`] to state whether it
+/// already resolved the domain (per the same "prefer user, fall back to
+/// client" rule as [`resolve_oauth_event_org_domain`]) so the common grant
+/// paths — which already hold both the user and the client in scope — skip
+/// re-deriving it from the database.
+#[derive(Debug, Clone, Copy)]
+pub enum RecordedOrgDomain<'a> {
+    /// No precomputed info — do the full lookup (today's behavior).
+    Unresolved,
+    /// Caller already resolved this per the same "prefer user, fall back
+    /// to client" rule (see [`resolve_oauth_event_org_domain`]'s doc comment).
+    Known(Option<&'a str>),
+}
+
 /// Parameters for [`record_oauth_event`].
 pub struct RecordOAuthEventParams<'a> {
     pub oauth_client_id: &'a str,
@@ -1440,6 +1456,27 @@ pub struct RecordOAuthEventParams<'a> {
     pub ip_address: Option<std::net::IpAddr>,
     pub user_agent: Option<&'a str>,
     pub details: Option<&'a str>,
+    pub org_domain: RecordedOrgDomain<'a>,
+}
+
+/// Shared "prefer the acting user's org, else the client's own org" rule for
+/// an OAuth event's `email_domain`. Both inputs are already-resolved values —
+/// this makes no user or client lookups of its own, only the one conditional
+/// domain lookup when falling back to the client — so callers control
+/// whether the user/client rows get fetched at all.
+pub async fn resolve_event_org_domain(
+    store: &DocumentStore,
+    user_org_domain: Option<&str>,
+    client_org_id: Option<&str>,
+) -> Option<String> {
+    if let Some(domain) = user_org_domain {
+        return Some(domain.to_string());
+    }
+    let org_id = client_org_id?;
+    super::get_organization_domain(store, org_id)
+        .await
+        .ok()
+        .flatten()
 }
 
 /// Resolve the org domain to stamp on an OAuth event's `email_domain`.
@@ -1460,13 +1497,12 @@ async fn resolve_oauth_event_org_domain(
     {
         return Some(domain);
     }
-    if let Ok(Some(client)) = get_oauth_client_by_id(store, params.oauth_client_id).await
-        && let Some(org_id) = client.org_id
-        && let Ok(Some(domain)) = super::get_organization_domain(store, &org_id).await
-    {
-        return Some(domain);
-    }
-    None
+    let client_org_id = get_oauth_client_by_id(store, params.oauth_client_id)
+        .await
+        .ok()
+        .flatten()
+        .and_then(|c| c.org_id);
+    resolve_event_org_domain(store, None, client_org_id.as_deref()).await
 }
 
 /// Record an OAuth usage event via the audit store.
@@ -1489,7 +1525,10 @@ pub async fn record_oauth_event(
         asn,
         org_name,
     };
-    let org_domain = resolve_oauth_event_org_domain(store, params).await;
+    let org_domain = match params.org_domain {
+        RecordedOrgDomain::Known(domain) => domain.map(String::from),
+        RecordedOrgDomain::Unresolved => resolve_oauth_event_org_domain(store, params).await,
+    };
     let result = audit
         .insert_event_with_domain(
             params.event_type.kind(),
@@ -2611,6 +2650,7 @@ mod tests {
                     ip_address: None,
                     user_agent: None,
                     details: Some("coverage test"),
+                    org_domain: RecordedOrgDomain::Unresolved,
                 },
             )
             .await;
@@ -2646,5 +2686,220 @@ mod tests {
                 event_type.kind().as_str()
             );
         }
+    }
+
+    // ========================================================================
+    // RecordedOrgDomain Parity
+    // ========================================================================
+    //
+    // A caller passing `RecordedOrgDomain::Known` must produce the exact same
+    // `email_domain` that `Unresolved` (the original full-lookup path) would
+    // have produced — the whole point of the hint is to skip redundant reads,
+    // not to change what gets audited.
+
+    // Records one event and returns the `email_domain` it was stamped with.
+    // Events are ordered newest-first (see `AuditEventFilter::before_id`
+    // doc comment); every caller below uses a distinct `user_id` per call, so
+    // the first row matching `user_id` is unambiguously the one just inserted.
+    async fn stamped_email_domain(
+        audit: &AuditStore,
+        store: &DocumentStore,
+        oauth_client_id: &str,
+        user_id: &str,
+        org_domain: RecordedOrgDomain<'_>,
+    ) -> Option<String> {
+        record_oauth_event(
+            audit,
+            store,
+            &RecordOAuthEventParams {
+                oauth_client_id,
+                event_type: OAuthEventType::TokenIssued,
+                user_id: Some(user_id),
+                ip_address: None,
+                user_agent: None,
+                details: None,
+                org_domain,
+            },
+        )
+        .await;
+        let events = audit
+            .query_events(&AuditEventFilter {
+                user_id: Some(user_id.to_string()),
+                ..AuditEventFilter::default()
+            })
+            .await
+            .expect("query oauth audit events");
+        events
+            .first()
+            .expect("event was just inserted for this user_id")
+            .email_domain
+            .clone()
+    }
+
+    #[tokio::test]
+    async fn test_known_domain_matches_unresolved_user_with_org() {
+        let store = test_store().await;
+        let audit = AuditStore::new(store.pool().clone(), store.crypto().clone());
+        let org = crate::test_utils::create_test_org(&store, "user-org.example").await;
+        let user_a = crate::test_utils::create_test_user_in_org(
+            &store,
+            "member-a@user-org.example",
+            &org.id,
+            false,
+        )
+        .await;
+        let user_b = crate::test_utils::create_test_user_in_org(
+            &store,
+            "member-b@user-org.example",
+            &org.id,
+            false,
+        )
+        .await;
+        let (client, _secret, _hash) = create_client_and_secret(&store).await;
+
+        let unresolved = stamped_email_domain(
+            &audit,
+            &store,
+            &client.id,
+            &user_a.id,
+            RecordedOrgDomain::Unresolved,
+        )
+        .await;
+        let known = stamped_email_domain(
+            &audit,
+            &store,
+            &client.id,
+            &user_b.id,
+            RecordedOrgDomain::Known(Some("user-org.example")),
+        )
+        .await;
+
+        assert_eq!(unresolved.as_deref(), Some("user-org.example"));
+        assert_eq!(known, unresolved);
+    }
+
+    #[tokio::test]
+    async fn test_known_domain_matches_unresolved_personal_user_no_org_client() {
+        let store = test_store().await;
+        let audit = AuditStore::new(store.pool().clone(), store.crypto().clone());
+        let user_a = crate::test_utils::create_test_user(&store, "solo-a@personal.example").await;
+        let user_b = crate::test_utils::create_test_user(&store, "solo-b@personal.example").await;
+        let (client, _secret, _hash) = create_client_and_secret(&store).await;
+
+        let unresolved = stamped_email_domain(
+            &audit,
+            &store,
+            &client.id,
+            &user_a.id,
+            RecordedOrgDomain::Unresolved,
+        )
+        .await;
+        let known = stamped_email_domain(
+            &audit,
+            &store,
+            &client.id,
+            &user_b.id,
+            RecordedOrgDomain::Known(None),
+        )
+        .await;
+
+        assert_eq!(unresolved, None);
+        assert_eq!(known, unresolved);
+    }
+
+    // Parity edge case: a personal user (no org) authenticating against an
+    // org-owned client. `resolve_oauth_event_org_domain` falls through the
+    // user check (no org) to the client's own `org_id`. A caller passing
+    // `Known` must replicate that fallback itself rather than pass `None`.
+    #[tokio::test]
+    async fn test_known_domain_matches_unresolved_personal_user_on_org_owned_client() {
+        let store = test_store().await;
+        let audit = AuditStore::new(store.pool().clone(), store.crypto().clone());
+        let org = crate::test_utils::create_test_org(&store, "org-owned.example").await;
+        let user_a = crate::test_utils::create_test_user(&store, "solo-a@personal.example").await;
+        let user_b = crate::test_utils::create_test_user(&store, "solo-b@personal.example").await;
+        let client = crate::test_utils::create_test_client(
+            &store,
+            &user_a.id,
+            crate::test_utils::TestClientSpec {
+                org_id: Some(org.id.clone()),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let unresolved = stamped_email_domain(
+            &audit,
+            &store,
+            &client.app_id,
+            &user_a.id,
+            RecordedOrgDomain::Unresolved,
+        )
+        .await;
+
+        // Hot-path formula: the user has no org, so fall back to the
+        // client's own org_id (already in scope for every real call site).
+        let client_org_domain = crate::db::get_organization_domain(&store, &org.id)
+            .await
+            .expect("lookup org domain")
+            .expect("org has a domain");
+        let known = stamped_email_domain(
+            &audit,
+            &store,
+            &client.app_id,
+            &user_b.id,
+            RecordedOrgDomain::Known(Some(&client_org_domain)),
+        )
+        .await;
+
+        assert_eq!(unresolved.as_deref(), Some("org-owned.example"));
+        assert_eq!(known, unresolved);
+    }
+
+    // Distinguishes the two `RecordedOrgDomain` arms: the parity tests above
+    // pass a `Known` value equal to what `Unresolved` would resolve, which
+    // would also pass if `Known` were silently ignored. This asserts `Known`
+    // is honored verbatim even when it disagrees with the full resolution —
+    // the only assertion that actually pins the hint is being used.
+    #[tokio::test]
+    async fn test_known_domain_is_honored_even_when_it_differs_from_full_resolution() {
+        let store = test_store().await;
+        let audit = AuditStore::new(store.pool().clone(), store.crypto().clone());
+        let org = crate::test_utils::create_test_org(&store, "real-org.example").await;
+        let user_a = crate::test_utils::create_test_user_in_org(
+            &store,
+            "member-a@real-org.example",
+            &org.id,
+            false,
+        )
+        .await;
+        let user_b = crate::test_utils::create_test_user_in_org(
+            &store,
+            "member-b@real-org.example",
+            &org.id,
+            false,
+        )
+        .await;
+        let (client, _secret, _hash) = create_client_and_secret(&store).await;
+
+        let unresolved = stamped_email_domain(
+            &audit,
+            &store,
+            &client.id,
+            &user_a.id,
+            RecordedOrgDomain::Unresolved,
+        )
+        .await;
+        assert_eq!(unresolved.as_deref(), Some("real-org.example"));
+
+        let known = stamped_email_domain(
+            &audit,
+            &store,
+            &client.id,
+            &user_b.id,
+            RecordedOrgDomain::Known(Some("sentinel.example")),
+        )
+        .await;
+        assert_eq!(known.as_deref(), Some("sentinel.example"));
     }
 }

--- a/crates/vouch-server/src/db/tests/cascade_delete.rs
+++ b/crates/vouch-server/src/db/tests/cascade_delete.rs
@@ -255,6 +255,7 @@ async fn test_oauth_client_cascade_delete() {
             ip_address: None,
             user_agent: None,
             details: None,
+            org_domain: RecordedOrgDomain::Unresolved,
         },
     )
     .await;

--- a/crates/vouch-server/src/db/tests/oauth_clients.rs
+++ b/crates/vouch-server/src/db/tests/oauth_clients.rs
@@ -492,6 +492,7 @@ async fn test_oauth_usage_recording() {
             ip_address: None,
             user_agent: None,
             details: None,
+            org_domain: RecordedOrgDomain::Unresolved,
         },
     )
     .await;
@@ -505,6 +506,7 @@ async fn test_oauth_usage_recording() {
             ip_address: None,
             user_agent: None,
             details: None,
+            org_domain: RecordedOrgDomain::Unresolved,
         },
     )
     .await;
@@ -518,6 +520,7 @@ async fn test_oauth_usage_recording() {
             ip_address: None,
             user_agent: None,
             details: None,
+            org_domain: RecordedOrgDomain::Unresolved,
         },
     )
     .await;

--- a/crates/vouch-server/src/handlers/api/applications.rs
+++ b/crates/vouch-server/src/handlers/api/applications.rs
@@ -497,6 +497,7 @@ pub(crate) async fn add_secret_api(
             ip_address: None,
             user_agent: None,
             details: Some("Secret added"),
+            org_domain: db::RecordedOrgDomain::Unresolved,
         },
     )
     .await;
@@ -668,6 +669,7 @@ pub(crate) async fn delete_secret_api(
             ip_address: None,
             user_agent: None,
             details: Some("Secret revoked"),
+            org_domain: db::RecordedOrgDomain::Unresolved,
         },
     )
     .await;
@@ -761,6 +763,7 @@ pub(crate) async fn revoke_tokens_api(
             ip_address: None,
             user_agent: None,
             details: Some("All tokens revoked"),
+            org_domain: db::RecordedOrgDomain::Unresolved,
         },
     )
     .await;

--- a/crates/vouch-server/src/handlers/applications/web.rs
+++ b/crates/vouch-server/src/handlers/applications/web.rs
@@ -594,6 +594,7 @@ pub(crate) async fn add_secret_form(
             ip_address: None,
             user_agent: None,
             details: Some("Secret added"),
+            org_domain: db::RecordedOrgDomain::Unresolved,
         },
     )
     .await;
@@ -701,6 +702,7 @@ pub(crate) async fn delete_secret_form(
             ip_address: None,
             user_agent: None,
             details: Some("Secret revoked"),
+            org_domain: db::RecordedOrgDomain::Unresolved,
         },
     )
     .await;

--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -574,11 +574,25 @@ pub(crate) async fn device_token(
             // Usage stats correlate on the client's doc id, so resolve it for
             // registered clients; the built-in CLI flow (base_url fallback)
             // keeps the raw identifier.
-            let audit_client_id =
-                match db::get_oauth_client_by_client_id(&state.store, &client_id).await {
-                    Ok(Some(c)) => c.id,
-                    _ => client_id.clone(),
-                };
+            let audit_client = db::get_oauth_client_by_client_id(&state.store, &client_id)
+                .await
+                .ok()
+                .flatten();
+            let audit_client_id = audit_client
+                .as_ref()
+                .map_or_else(|| client_id.clone(), |c| c.id.clone());
+            // The user-org half of `resolve_event_org_domain`'s "prefer
+            // user, fall back to client" rule was already resolved above for
+            // the session claims, so it's reused here rather than
+            // re-derived; the client-org fallback still runs its own lookup
+            // when the user has no org, using the client already in scope
+            // instead of re-fetching it by id.
+            let audit_org_domain = db::resolve_event_org_domain(
+                &state.store,
+                org_domain.as_deref(),
+                audit_client.as_ref().and_then(|c| c.org_id.as_deref()),
+            )
+            .await;
             db::record_oauth_event(
                 &state.audit,
                 &state.store,
@@ -589,6 +603,7 @@ pub(crate) async fn device_token(
                     ip_address: client_info.client_ip,
                     user_agent: client_info.user_agent.as_deref(),
                     details: Some("grant_type=device_code"),
+                    org_domain: db::RecordedOrgDomain::Known(audit_org_domain.as_deref()),
                 },
             )
             .await;

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -1367,7 +1367,7 @@ pub(crate) async fn browser_register_complete(
         .map_err(|e| {
             ServiceError::api(StatusCode::INTERNAL_SERVER_ERROR, "db_error", e.to_string())
         })?;
-    if let Some(account) = account
+    if let Some(ref account) = account
         && !account.active
     {
         return Err(ServiceError::Forbidden("user_deactivated"));
@@ -1591,7 +1591,10 @@ pub(crate) async fn browser_register_complete(
     let enroll_client_id = state.config().base_url.clone();
     let user_id_str = reg_state.user_id.to_string();
 
-    // Snapshot org domain for federation claims tied to this session. Fail
+    // Snapshot org domain for federation claims tied to this session, reusing
+    // the same `account` read that gated activation above rather than a
+    // second `get_user_by_id` — so the snapshot reflects the user's org as of
+    // the start of this ceremony, not as of just before token issuance. Fail
     // closed: the snapshot is captured exactly once, so silently dropping a
     // transient DB error would permanently degrade this session's `hd` claim.
     let snapshot_error = |err: anyhow::Error| {
@@ -1602,16 +1605,10 @@ pub(crate) async fn browser_register_complete(
             Tr::new("enroll-error-browser-session-create-failed").to_string(),
         )
     };
-    let org_domain = match db::get_user_by_id(&state.store, &user_id_str)
-        .await
-        .map_err(snapshot_error)?
-    {
-        Some(u) => match u.org_id {
-            Some(org_id) => db::get_organization_domain(&state.store, &org_id)
-                .await
-                .map_err(snapshot_error)?,
-            None => None,
-        },
+    let org_domain = match account.as_ref().and_then(|u| u.org_id.clone()) {
+        Some(org_id) => db::get_organization_domain(&state.store, &org_id)
+            .await
+            .map_err(snapshot_error)?,
         None => None,
     };
 

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7592.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7592.rs
@@ -1713,6 +1713,58 @@ async fn test_rfc7592_delete_client_already_deleted() {
     );
 }
 
+/// Deleting an org-owned client whose owning user has no org of their own
+/// must still attribute the `ClientDeleted` audit event to the client's org.
+///
+/// Regression test: the client doc is deleted before the audit event is
+/// recorded, so a naive client-org lookup by `client_id` would always miss
+/// (the row is already gone). `delete_client_configuration` resolves the
+/// fallback from the already-in-scope `client.org_id` instead.
+#[tokio::test]
+async fn test_rfc7592_delete_client_attributes_org_domain_when_owner_has_no_org() {
+    let (app, state) = test_app().await;
+
+    let org = create_test_org(&state.store, "org-owned-deleted.example").await;
+    let owner = create_test_user(&state.store, "solo-owner@personal.example").await;
+
+    let plaintext_token = "test-rfc7592-delete-org-attribution-token";
+    let client = create_test_client(
+        &state.store,
+        &owner.id,
+        TestClientSpec {
+            org_id: Some(org.id.clone()),
+            registration_access_token_hash: Some(crate::crypto::hash_token(plaintext_token)),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let (status, _body) = http_delete(
+        &app,
+        &format!("/oauth/register/{}", client.client_id),
+        &[("Authorization", &format!("Bearer {plaintext_token}"))],
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    let events = state
+        .audit
+        .query_events(&db::AuditEventFilter {
+            event_types: Some(vec!["oauth_client_deleted".to_string()]),
+            user_id: Some(owner.id.clone()),
+            ..Default::default()
+        })
+        .await
+        .expect("query audit events");
+    assert_eq!(events.len(), 1, "delete must write exactly one audit event");
+    assert_eq!(
+        events[0].email_domain.as_deref(),
+        Some("org-owned-deleted.example"),
+        "the client's own org must be attributed even though the owning user has no org \
+         and the client doc is already deleted by the time the event is recorded"
+    );
+}
+
 // =========================================================================
 // PUT /oauth/register/:client_id — userinfo_signed_response_alg + request_uris
 // =========================================================================

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -988,6 +988,16 @@ async fn handle_client_credentials_grant(
     .await
     {
         Ok(result) => {
+            // Client-credentials grants have no user subject, so the event's
+            // default resolution would fall straight through to the
+            // client-org branch — the client is already in scope here, so
+            // skip that redundant re-lookup.
+            let audit_org_domain = crate::db::resolve_event_org_domain(
+                &state.store,
+                None,
+                authenticated_client.client.org_id.as_deref(),
+            )
+            .await;
             // Record audit event
             crate::db::record_oauth_event(
                 &state.audit,
@@ -999,6 +1009,7 @@ async fn handle_client_credentials_grant(
                     ip_address: client_info.client_ip,
                     user_agent: client_info.user_agent.as_deref(),
                     details: Some("grant_type=client_credentials"),
+                    org_domain: crate::db::RecordedOrgDomain::Known(audit_org_domain.as_deref()),
                 },
             )
             .await;

--- a/crates/vouch-server/src/services/oidc/fido2_grant.rs
+++ b/crates/vouch-server/src/services/oidc/fido2_grant.rs
@@ -425,6 +425,17 @@ pub(crate) async fn exchange_fido2_assertion(
     .await?;
 
     // Every access-token grant records an oauth_token_issued audit row.
+    // The user-org half of `resolve_event_org_domain`'s "prefer user, fall
+    // back to client" rule was already resolved above for the session
+    // claims, so it's reused here rather than re-derived; the client-org
+    // fallback still runs its own lookup when the user has no org, using the
+    // client already in scope instead of re-fetching it by id.
+    let audit_org_domain = db::resolve_event_org_domain(
+        &state.store,
+        org_domain.as_deref(),
+        params.client.client.org_id.as_deref(),
+    )
+    .await;
     db::record_oauth_event(
         &state.audit,
         &state.store,
@@ -435,6 +446,7 @@ pub(crate) async fn exchange_fido2_assertion(
             ip_address: client_ip,
             user_agent: client_user_agent.as_deref(),
             details: Some("grant_type=fido2-assertion"),
+            org_domain: db::RecordedOrgDomain::Known(audit_org_domain.as_deref()),
         },
     )
     .await;

--- a/crates/vouch-server/src/services/oidc/registration.rs
+++ b/crates/vouch-server/src/services/oidc/registration.rs
@@ -606,6 +606,7 @@ pub async fn register_client(
             ip_address: None,
             user_agent: None,
             details: Some("RFC 7591 dynamic registration"),
+            org_domain: db::RecordedOrgDomain::Unresolved,
         },
     )
     .await;
@@ -1606,6 +1607,28 @@ pub async fn delete_client_configuration(
             ServiceError::Internal("Failed to delete client".to_string())
         })?;
 
+    // The client doc is already deleted above, so `Unresolved`'s client-org
+    // fallback (a lookup by `client.id`) would always miss. `client.org_id`
+    // is still in scope from before the delete, so resolve the fallback
+    // ourselves instead of losing the org attribution on every org-owned
+    // client whose owning user has no org of their own.
+    let user_org_domain = if let Some(user_id) = client.user_id.as_deref()
+        && let Ok(Some(user)) = db::get_user_by_id(&state.store, user_id).await
+        && let Some(org_id) = user.org_id
+    {
+        db::get_organization_domain(&state.store, &org_id)
+            .await
+            .ok()
+            .flatten()
+    } else {
+        None
+    };
+    let audit_org_domain = db::resolve_event_org_domain(
+        &state.store,
+        user_org_domain.as_deref(),
+        client.org_id.as_deref(),
+    )
+    .await;
     db::record_oauth_event(
         &state.audit,
         &state.store,
@@ -1616,6 +1639,7 @@ pub async fn delete_client_configuration(
             ip_address: None,
             user_agent: None,
             details: Some("RFC 7592 client configuration DELETE"),
+            org_domain: db::RecordedOrgDomain::Known(audit_org_domain.as_deref()),
         },
     )
     .await;
@@ -1869,6 +1893,7 @@ pub async fn update_client_configuration(
             ip_address: None,
             user_agent: None,
             details: Some("RFC 7592 client configuration PUT"),
+            org_domain: db::RecordedOrgDomain::Unresolved,
         },
     )
     .await;

--- a/crates/vouch-server/src/services/oidc/token.rs
+++ b/crates/vouch-server/src/services/oidc/token.rs
@@ -417,6 +417,18 @@ pub(crate) async fn exchange_authorization_code(
 
     // Record usage event for registered clients
     if let Some(auth_client) = authenticated_client {
+        // The user-org half of `resolve_event_org_domain`'s "prefer user,
+        // fall back to client" rule was already resolved above for the
+        // session claims, so it's reused here rather than re-derived; the
+        // client-org fallback still runs its own lookup when the user has no
+        // org, using the client already in scope instead of re-fetching it
+        // by id.
+        let audit_org_domain = db::resolve_event_org_domain(
+            &state.store,
+            org_domain.as_deref(),
+            auth_client.client.org_id.as_deref(),
+        )
+        .await;
         db::record_oauth_event(
             &state.audit,
             &state.store,
@@ -431,6 +443,7 @@ pub(crate) async fn exchange_authorization_code(
                     .dpop_proof()
                     .map(|p| format!("dpop_jkt={}", p.jkt))
                     .as_deref(),
+                org_domain: db::RecordedOrgDomain::Known(audit_org_domain.as_deref()),
             },
         )
         .await;

--- a/crates/vouch-server/src/test_utils.rs
+++ b/crates/vouch-server/src/test_utils.rs
@@ -1396,6 +1396,12 @@ pub struct TestClientSpec {
     pub require_signed_request_object: Option<bool>,
     /// Registered post-logout redirect URIs (RP-Initiated Logout). Default: empty.
     pub post_logout_redirect_uris: Vec<String>,
+    /// RFC 7592 registration access token hash. Default: `None` (no RFC 7592
+    /// management access — `lookup_and_verify_registration_token` treats a
+    /// client with no stored hash as `invalid_token`). Set this to exercise
+    /// the RFC 7592 GET/PUT/DELETE endpoints against a client built through
+    /// this factory rather than through `/oauth/register`.
+    pub registration_access_token_hash: Option<String>,
 }
 
 impl Default for TestClientSpec {
@@ -1424,6 +1430,7 @@ impl Default for TestClientSpec {
             request_object_signing_alg: Option::None,
             require_signed_request_object: Option::None,
             post_logout_redirect_uris: vec![],
+            registration_access_token_hash: Option::None,
         }
     }
 }
@@ -1497,7 +1504,7 @@ pub async fn create_test_client(
             software_id: Option::None,
             software_version: Option::None,
             registration_source: RegistrationSource::Manual,
-            registration_access_token_hash: Option::None,
+            registration_access_token_hash: spec.registration_access_token_hash.as_deref(),
             registration_metadata: Option::None,
             id_token_signed_response_alg: spec.id_token_signed_response_alg,
             tls_client_auth_subject_dn: spec.tls_client_auth_subject_dn.as_deref(),

--- a/crates/vouch-tests/tests/fido2_posture_e2e.rs
+++ b/crates/vouch-tests/tests/fido2_posture_e2e.rs
@@ -201,6 +201,23 @@ async fn exchange_fido2_assertion(
     (status, json)
 }
 
+/// Return the `oauth_token_issued` audit event(s) for `user_id`.
+///
+/// `record_oauth_event` is awaited before `/oauth/token` returns its
+/// response, so the row is already visible by the time the caller queries.
+async fn token_issued_events(harness: &TestHarness, user_id: &str) -> Vec<db::AuditEvent> {
+    harness
+        .state
+        .audit
+        .query_events(&db::AuditEventFilter {
+            event_types: Some(vec!["oauth_token_issued".to_string()]),
+            user_id: Some(user_id.to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("query audit events")
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────
 
 /// Windows 11 24H2 with OsRecency active must successfully obtain a token.
@@ -475,16 +492,7 @@ async fn test_fido2_grant_records_token_issued_audit_event() {
     .await;
     assert_eq!(status, 200, "FIDO2 grant must succeed: {json}");
 
-    let rows = harness
-        .state
-        .audit
-        .query_events(&db::AuditEventFilter {
-            event_types: Some(vec!["oauth_token_issued".to_string()]),
-            user_id: Some(user.id.clone()),
-            ..Default::default()
-        })
-        .await
-        .expect("query audit events");
+    let rows = token_issued_events(&harness, &user.id).await;
     assert_eq!(
         rows.len(),
         1,
@@ -494,6 +502,52 @@ async fn test_fido2_grant_records_token_issued_audit_event() {
         rows[0].data.contains("fido2-assertion"),
         "the audit payload must carry the grant type: {}",
         rows[0].data
+    );
+}
+
+/// A successful FIDO2 grant for an org member stamps the org's domain into
+/// the `oauth_token_issued` event's `email_domain` — the hot-path formula
+/// (`fido2_grant.rs`) must reproduce what the full lookup would have done.
+#[tokio::test]
+async fn test_fido2_grant_records_org_email_domain_on_token_issued_event() {
+    let harness = TestHarness::new().await;
+    let org = harness
+        .create_org("login-audit.example.com")
+        .await
+        .expect("Failed to create org");
+    let user = harness
+        .create_user_in_org("member@login-audit.example.com", &org.id, false)
+        .await
+        .expect("Failed to create user");
+
+    let device = IntegrationMockDevice::new();
+    let _auth_id = register_mock_device_in_db(&harness, &user.id, &user.email, &device).await;
+    let (client, pkcs8) = create_jwt_client(&harness, &user.id).await;
+    let (challenge, state) = get_challenge(&harness).await;
+
+    let (status, json) = exchange_fido2_assertion(AssertionExchange {
+        harness: &harness,
+        device: &device,
+        challenge: &challenge,
+        state_jwt: &state,
+        user_id: &user.id,
+        client: &client,
+        pkcs8: &pkcs8,
+        authorization_details: None,
+    })
+    .await;
+    assert_eq!(status, 200, "FIDO2 grant must succeed: {json}");
+
+    let rows = token_issued_events(&harness, &user.id).await;
+    assert_eq!(
+        rows.len(),
+        1,
+        "the grant must write exactly one oauth_token_issued row"
+    );
+    assert_eq!(
+        rows[0].email_domain.as_deref(),
+        Some("login-audit.example.com"),
+        "org member login must stamp the org's domain onto the audit event"
     );
 }
 

--- a/crates/vouch-tests/tests/integration.rs
+++ b/crates/vouch-tests/tests/integration.rs
@@ -578,6 +578,76 @@ mod device_flow {
         assert_eq!(resp["token_type"], "Bearer");
     }
 
+    /// A device-poll success for an org member stamps the org's domain into
+    /// the `oauth_token_issued` event's `email_domain` — the hot-path
+    /// formula in `handlers/device.rs` must reproduce what the full lookup
+    /// would have done.
+    #[tokio::test]
+    async fn test_device_token_poll_success_records_org_email_domain() {
+        let harness = TestHarness::new().await;
+
+        let org = harness
+            .create_org("device-poll-org.example.com")
+            .await
+            .expect("Failed to create org");
+        let user = harness
+            .create_user_in_org(
+                "device-poll-member@device-poll-org.example.com",
+                &org.id,
+                false,
+            )
+            .await
+            .expect("Failed to create user");
+        let auth_id = harness
+            .create_authenticator(&user.id)
+            .await
+            .expect("Failed to create auth");
+
+        let response = harness
+            .post_form("/oauth/device", "scope=openid")
+            .await
+            .expect("Failed to post device code");
+        let resp: serde_json::Value = response.json().expect("Failed to parse response");
+        let device_code = resp["device_code"].as_str().expect("device_code");
+        let user_code = resp["user_code"].as_str().expect("user_code");
+
+        harness
+            .authorize_device_code(user_code, &user.id, &user.email, &auth_id)
+            .await
+            .expect("Failed to authorize device code");
+
+        let poll_body = format!(
+            "grant_type=urn:ietf:params:oauth:grant-type:device_code&device_code={}",
+            device_code
+        );
+        let response = harness
+            .post_form("/oauth/token", &poll_body)
+            .await
+            .expect("Failed to poll token");
+        assert_eq!(response.status, 200);
+
+        let rows = harness
+            .state
+            .audit
+            .query_events(&vouch_server::db::AuditEventFilter {
+                event_types: Some(vec!["oauth_token_issued".to_string()]),
+                user_id: Some(user.id.clone()),
+                ..Default::default()
+            })
+            .await
+            .expect("query audit events");
+        assert_eq!(
+            rows.len(),
+            1,
+            "the poll success must write exactly one oauth_token_issued row"
+        );
+        assert_eq!(
+            rows[0].email_domain.as_deref(),
+            Some("device-poll-org.example.com"),
+            "org member device-poll success must stamp the org's domain onto the audit event"
+        );
+    }
+
     /// Test that verification interval is respected.
     #[tokio::test]
     async fn test_device_code_interval_field() {


### PR DESCRIPTION
Closes #1175.

## What this changes

`record_oauth_event`'s org-domain resolution re-fetched data every hot caller already had in memory. This PR adds `RecordedOrgDomain` (`Unresolved | Known`) as a **required** field on `RecordOAuthEventParams`, so the compiler forces every call site to state whether it already resolved the domain. The four grant sites pass `Known` computed from in-scope data via a new shared `resolve_event_org_domain` helper (the single home of the "prefer user org, else client org" rule); the seven admin/registration sites keep today's full lookup via `Unresolved`.

Also fixed in the same class:

- `browser_register_complete` loaded the same user twice (deactivation check, then org-domain snapshot); it now borrows the ceremony-start read.
- `delete_client_configuration` recorded its event after deleting the client row, so the client-org fallback always resolved `None`; it now passes `Known` from the in-scope client. Regression test included.

## Round-trip counts (synchronous; fire-and-forget audit writes excluded)

| Path | Before | After |
|---|---|---|
| `vouch login` (challenge + token) | ~9 | ~7 |
| device-code poll, successful completion | +2 wasted | +0 |
| authorization_code grant | +2 wasted | +0 |
| client_credentials grant | +1 wasted | +0 |
| `POST /v1/credentials/aws/token` | ~3 | unchanged |
| browser register complete | 2× user load | 1× |

## Assessment (issue's expected outcome)

**Login (`/oauth/fido2/challenge` + `/oauth/token`):** every remaining query is load-bearing — DPoP nonce write; client lookup (authentication); challenge-state consume + authenticator lookup (replay protection, already concurrent under `try_join!`); counter update (clone detection); session-claim org-domain lookup (deliberate at-creation snapshot); token/session writes. The only redundancy was the audit event's re-derivation of user + org domain, removed here.

**`/v1/credentials/aws/token`:** confirmed tight, no changes. The session lookup is absorbed by `session_cache`; `load_active_user` is an intentionally fresh read (the deactivation gate — serving it from any cache would let a deactivated user coast); `get_organization` feeds issuer/key resolution (`org.subdomain`/`org.id`) and is a single necessary call.

**`session_cache` question:** nothing further can move into it without weakening a check — every candidate is either already cached (session), deliberately fresh (active-user gate), or already eliminated by this PR.

**Considered and rejected: async audit writes.** A fire-and-forget conversion of `record_oauth_event` was implemented and then reverted during review: it sends the same number of DB requests (the DSQL cost metric), only moves latency, and permanently taxes every audit-verifying test with drain machinery. The awaited write stays.

**Considered, deferred to a stacked PR: `UserDoc.org_domain` memoization.** `OrganizationDoc.domain` (primary) and `UserDoc.org_id` are both write-once under current code, so caching the domain on the user doc is memoization of an immutable mapping, not staleness-prone caching. Both production `org_id` writers already hold the org doc in scope; the field is a serde-default addition (no SQL migration). It saves one more round trip per org-user login/device-poll/auth-code grant. Lands separately, stacked on this branch. Not applicable to the AWS path (never reads the domain) or the OAuth client's `org_id` (mutable via RFC 7592 PUT — must not be cached).

## Verification

- `make lint` clean; `make fmt` applied; internal-label sweep clean
- `cargo test -p vouch-server --all-features`: 3475 passed / 0 failed (includes 3 parity tests, a sentinel test pinning that `Known` is honored, org-affiliated login and device-poll tests asserting the recorded `email_domain`, and the RFC 7592 delete regression test — each verified load-bearing by breaking the code under test)
- `cargo test --package vouch-tests`: all suites green; full `make test` exit 0
- Reviewer independently re-ran all gates and approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
