### PR TITLE
fix(server): trust IdP sign-in for browser sessions

### DIFF
--- a/crates/vouch-server/i18n/en-US/vouch-server.ftl
+++ b/crates/vouch-server/i18n/en-US/vouch-server.ftl
@@ -279,7 +279,6 @@ login-terms = Terms of Service
 # text inside (login.html). Cannot merge without losing the link element.
 login-no-account-prefix = Don't have an account?
 login-enroll-now = Enroll now
-login-lost-key-link = Lost your security key? Manage your keys
 login-cert-test-login = Certification Test Login
 login-cert-test-deny = Certification Test Deny
 

--- a/crates/vouch-server/src/handlers/admin/members.rs
+++ b/crates/vouch-server/src/handlers/admin/members.rs
@@ -731,10 +731,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_bootstrap_admin_session_is_sent_to_assert_not_shown_the_page() {
-        // The page must not render controls its own POSTs would refuse. An
-        // unverified org admin is sent to /login to touch their key, the same
-        // answer the GitHub admin flows give.
+    async fn test_bootstrap_admin_session_sees_the_page() {
+        // The upstream IdP is the trust root for the browser: an org-admin
+        // session minted by IdP sign-in alone (no FIDO2 ceremony) reads the
+        // members page like any other signed-in admin.
         let (app, state) = test_app().await;
         let org = create_test_org(&state.store, "example.com").await;
         let admin = create_test_user_in_org(&state.store, "admin@example.com", &org.id, true).await;
@@ -755,26 +755,18 @@ mod tests {
             crate::test_utils::http_get_full(&app, "/admin", &[("Cookie", &admin_cookie(&token))])
                 .await;
 
-        assert!(
-            resp.status.is_redirection(),
-            "an unverified admin must be redirected, got {}",
-            resp.status
+        assert_eq!(
+            resp.status,
+            StatusCode::OK,
+            "a signed-in admin reads the page without a key ceremony"
         );
-        let location = resp
-            .headers
-            .get("location")
-            .expect("redirect location")
-            .to_str()
-            .expect("ascii location");
-        assert_eq!(location, "/login");
     }
 
     #[tokio::test]
-    async fn test_bootstrap_admin_session_cannot_promote() {
-        // The OrgAdmin extractor refuses an org-admin session minted by
-        // upstream IdP sign-in alone (no FIDO2 ceremony): granting persistent
-        // admin to another account is an org-wide write and takes the same
-        // bar as credential issuance.
+    async fn test_bootstrap_admin_session_can_promote() {
+        // Org-admin writes take IdP-backed sign-in, not a key ceremony: the
+        // browser trust root is the upstream IdP, and hardware proof gates
+        // credential issuance and key deletion instead.
         let (app, state) = test_app().await;
         let org = create_test_org(&state.store, "example.com").await;
         let admin = create_test_user_in_org(&state.store, "admin@example.com", &org.id, true).await;
@@ -804,19 +796,15 @@ mod tests {
 
         assert_eq!(
             status,
-            StatusCode::FORBIDDEN,
-            "an unverified session must not promote members: {body}"
-        );
-        assert!(
-            body.contains("hardware_required"),
-            "the refusal must name the missing proof: {body}"
+            StatusCode::SEE_OTHER,
+            "a signed-in admin promotes without a key ceremony: {body}"
         );
 
-        let unchanged = crate::db::get_user_by_id(&state.store, &target.id)
+        let promoted = crate::db::get_user_by_id(&state.store, &target.id)
             .await
             .expect("target lookup")
             .expect("target exists");
-        assert!(!unchanged.is_org_admin, "target must remain a member");
+        assert!(promoted.is_org_admin, "target must now be an admin");
     }
 
     #[tokio::test]

--- a/crates/vouch-server/src/handlers/admin/scim_tokens.rs
+++ b/crates/vouch-server/src/handlers/admin/scim_tokens.rs
@@ -338,9 +338,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn page_for_unverified_admin_redirects_to_login() {
-        // An admin session minted by upstream IdP sign-in alone (no FIDO2
-        // ceremony) is sent to assert before seeing token-management buttons.
+    async fn page_renders_for_unverified_admin() {
+        // The upstream IdP is the trust root for the browser: an admin
+        // session minted by IdP sign-in alone (no FIDO2 ceremony) reads the
+        // token-management page like any other signed-in admin.
         let (app, state) = test_app().await;
         let org = create_test_org(&state.store, "example.com").await;
         let admin = create_test_user_in_org(&state.store, "admin@example.com", &org.id, true).await;
@@ -360,8 +361,11 @@ mod tests {
 
         let resp = http_get_full(&app, "/admin/scim-tokens", &[("Cookie", &cookie)]).await;
 
-        assert!(resp.status.is_redirection(), "got {}", resp.status);
-        assert_eq!(location(&resp), "/login");
+        assert_eq!(
+            resp.status,
+            StatusCode::OK,
+            "a signed-in admin reads the page without a key ceremony"
+        );
     }
 
     #[tokio::test]

--- a/crates/vouch-server/src/handlers/api/org/scim_tokens/tests.rs
+++ b/crates/vouch-server/src/handlers/api/org/scim_tokens/tests.rs
@@ -324,10 +324,10 @@ async fn test_create_scim_token_cert_bound_token_with_wrong_cert_returns_401() {
 }
 
 #[tokio::test]
-async fn test_bootstrap_admin_session_cannot_mint_scim_token() {
-    // An org admin session minted by upstream IdP sign-in alone (no FIDO2
-    // ceremony) must not mint a SCIM token — a long-lived credential that
-    // would outlive any later step-up. Same bar as credential issuance.
+async fn test_bootstrap_admin_session_can_mint_scim_token() {
+    // Org-admin writes take IdP-backed sign-in, not a key ceremony: the
+    // upstream IdP is the trust root for admin surfaces, and hardware proof
+    // gates credential issuance and key deletion instead.
     let (app, state) = test_app().await;
     let org = create_test_org(&state.store, "example.com").await;
     let admin = create_test_user_in_org(&state.store, "admin@example.com", &org.id, true).await;
@@ -355,12 +355,12 @@ async fn test_bootstrap_admin_session_cannot_mint_scim_token() {
 
     assert_eq!(
         status,
-        StatusCode::FORBIDDEN,
-        "an unverified session must not mint SCIM tokens: {body}"
+        StatusCode::OK,
+        "a signed-in admin mints a SCIM token without a key ceremony: {body}"
     );
     assert!(
-        body.contains("hardware_required"),
-        "the refusal must name the missing proof: {body}"
+        body.contains("token"),
+        "the response must carry the minted token: {body}"
     );
 }
 

--- a/crates/vouch-server/src/handlers/applications/mod.rs
+++ b/crates/vouch-server/src/handlers/applications/mod.rs
@@ -183,10 +183,11 @@ mod tests {
         );
     }
 
-    /// Client secrets outlive the session that mints them, so the portal is
-    /// closed to a session that never ran a key ceremony.
+    /// The upstream IdP is the trust root for the browser: a session minted
+    /// by IdP sign-in alone (no FIDO2 ceremony) uses the applications portal
+    /// like any other signed-in session.
     #[tokio::test]
-    async fn bootstrap_session_cannot_reach_the_applications_portal() {
+    async fn bootstrap_session_uses_the_applications_portal() {
         let (app, state) = test_app().await;
         let user = create_test_user(&state.store, "bootstrap-apps@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
@@ -204,31 +205,23 @@ mod tests {
         let cookie = format!("__Host-vouch_session={token}");
 
         let resp = http_get_full(&app, "/applications", &[("Cookie", &cookie)]).await;
-        assert!(
-            resp.status.is_redirection(),
-            "an unverified session must be sent to assert, got {}",
-            resp.status
-        );
         assert_eq!(
-            resp.headers
-                .get("location")
-                .expect("redirect location")
-                .to_str()
-                .expect("ascii location"),
-            "/login"
+            resp.status,
+            axum::http::StatusCode::OK,
+            "a signed-in session reads the portal without a key ceremony"
         );
 
         let resp = crate::test_utils::http_post_form_full(
             &app,
             "/applications/new",
-            "name=evil&redirect_uris=https://evil.example.com/cb",
+            "name=portal-app&application_type=web&access_scope=personal&redirect_uris=https://app.example.com/cb",
             &[("Cookie", &cookie), ("Origin", "https://test.example.com")],
         )
         .await;
-        assert!(
-            resp.status.is_redirection(),
-            "an unverified session must not register an application, got {}",
-            resp.status
+        assert_eq!(
+            resp.status,
+            axum::http::StatusCode::OK,
+            "a signed-in session registers an application without a key ceremony"
         );
     }
 }

--- a/crates/vouch-server/src/handlers/applications/web.rs
+++ b/crates/vouch-server/src/handlers/applications/web.rs
@@ -24,7 +24,7 @@ use super::validate::{
     validate_update_format,
 };
 use super::{generate_client_secret, parse_redirect_uris, parse_resource_uris};
-use crate::handlers::extractors::AttestedSession;
+use crate::handlers::extractors::SignedInSession;
 use crate::handlers::hash_token;
 use crate::infra::i18n::Tr;
 
@@ -57,9 +57,9 @@ fn validation_error_response(err: &AppValidationError, back_url: String) -> Resp
 /// GET /applications
 pub(crate) async fn list_applications_page(
     State(state): State<Arc<AppState>>,
-    session: AttestedSession,
+    session: SignedInSession,
 ) -> Response {
-    let AttestedSession { auth } = session;
+    let SignedInSession { auth } = session;
 
     let user_id = auth.user_id.as_deref().unwrap_or_default();
     let applications = match db::get_oauth_clients_for_user(&state.store, user_id).await {
@@ -79,8 +79,8 @@ pub(crate) async fn list_applications_page(
 
 /// Show create application form.
 /// GET /applications/new
-pub(crate) async fn create_application_page(session: AttestedSession) -> Response {
-    let AttestedSession { auth } = session;
+pub(crate) async fn create_application_page(session: SignedInSession) -> Response {
+    let SignedInSession { auth } = session;
 
     let user_has_org = auth.has_org;
     ApplicationCreateTemplate { auth, user_has_org }.into_response()
@@ -90,10 +90,10 @@ pub(crate) async fn create_application_page(session: AttestedSession) -> Respons
 /// POST /applications/new
 pub(crate) async fn create_application_form(
     State(state): State<Arc<AppState>>,
-    session: AttestedSession,
+    session: SignedInSession,
     Form(form): Form<CreateApplicationForm>,
 ) -> Response {
-    let AttestedSession { auth } = session;
+    let SignedInSession { auth } = session;
 
     let user_id = auth.user_id.as_deref().unwrap_or_default();
 
@@ -251,10 +251,10 @@ pub(crate) async fn create_application_form(
 /// GET /applications/:id
 pub(crate) async fn detail_application_page(
     State(state): State<Arc<AppState>>,
-    session: AttestedSession,
+    session: SignedInSession,
     Path(app_id): Path<String>,
 ) -> Response {
-    let AttestedSession { auth } = session;
+    let SignedInSession { auth } = session;
 
     let user_id = auth.user_id.as_deref().unwrap_or_default();
 
@@ -333,11 +333,11 @@ pub(crate) async fn detail_application_page(
 /// POST /applications/:id
 pub(crate) async fn update_application_form(
     State(state): State<Arc<AppState>>,
-    session: AttestedSession,
+    session: SignedInSession,
     Path(app_id): Path<String>,
     Form(form): Form<UpdateApplicationForm>,
 ) -> Response {
-    let AttestedSession { auth } = session;
+    let SignedInSession { auth } = session;
 
     let user_id = auth.user_id.as_deref().unwrap_or_default();
 
@@ -481,10 +481,10 @@ pub(crate) async fn update_application_form(
 /// POST /applications/:id/delete
 pub(crate) async fn delete_application_form(
     State(state): State<Arc<AppState>>,
-    session: AttestedSession,
+    session: SignedInSession,
     Path(app_id): Path<String>,
 ) -> Response {
-    let AttestedSession { auth } = session;
+    let SignedInSession { auth } = session;
 
     let user_id = auth.user_id.as_deref().unwrap_or_default();
 
@@ -519,10 +519,10 @@ pub(crate) async fn delete_application_form(
 /// POST /applications/:id/secrets
 pub(crate) async fn add_secret_form(
     State(state): State<Arc<AppState>>,
-    session: AttestedSession,
+    session: SignedInSession,
     Path(app_id): Path<String>,
 ) -> Response {
-    let AttestedSession { auth } = session;
+    let SignedInSession { auth } = session;
 
     let user_id = auth.user_id.as_deref().unwrap_or_default();
 
@@ -616,10 +616,10 @@ pub(crate) async fn add_secret_form(
 /// POST /applications/:id/secrets/:secret_id/delete
 pub(crate) async fn delete_secret_form(
     State(state): State<Arc<AppState>>,
-    session: AttestedSession,
+    session: SignedInSession,
     Path((app_id, secret_id)): Path<(String, String)>,
 ) -> Response {
-    let AttestedSession { auth } = session;
+    let SignedInSession { auth } = session;
 
     let user_id = auth.user_id.as_deref().unwrap_or_default();
 

--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -353,35 +353,40 @@ pub(crate) async fn login_page(
     }) || device_auth_pending;
 
     if !requires_reauth {
-        // Leave /login only when the session would satisfy the gate
-        // /oauth/authorize itself applies. `auth.authenticated` is the wrong
-        // question here: an enrollment bootstrap session (upstream IdP
-        // sign-in, no FIDO2) holds a valid cookie but is not
-        // hardware-verified — deciding from it bounced such sessions to an
-        // endpoint that refuses them, consuming the single-use pending id on
-        // the way (#1168). Web sign-in routes returning users here precisely
-        // to assert, so a session the gate refuses gets the form: on
-        // NeedsAuth, and on a store failure too, where rendering the form
-        // needlessly costs one touch but redirecting could strand the flow.
-        let session_token = jar
-            .get(vouch_common::SESSION_COOKIE_NAME)
-            .map(|c| c.value());
-        let authorized = match check_session_for_authorization(&state, session_token).await {
-            Ok(AuthorizationSessionState::Authenticated { .. }) => true,
-            Ok(AuthorizationSessionState::NeedsAuth) => false,
-            Err(e) => {
-                tracing::error!("Session check failed at /login; rendering the form: {e}");
-                false
-            }
-        };
-        if authorized {
-            if let Some(ref pending_id) = query.pending_auth {
+        if let Some(ref pending_id) = query.pending_auth {
+            // Bounce back to /oauth/authorize only when the gate that endpoint
+            // applies would accept the session. `auth.authenticated` is the
+            // wrong question here: an enrollment bootstrap session (upstream
+            // IdP sign-in, no FIDO2) holds a valid cookie but is not
+            // hardware-verified, so deciding from it bounced the user to an
+            // endpoint that refuses the session — consuming the single-use
+            // pending id on the way (#1168). Asking the same predicate keeps
+            // the two endpoints from disagreeing. NeedsAuth falls through to
+            // the assertion form; so does a store failure, where rendering the
+            // form needlessly costs one touch but redirecting could strand
+            // the flow.
+            let session_token = jar
+                .get(vouch_common::SESSION_COOKIE_NAME)
+                .map(|c| c.value());
+            let authorized = match check_session_for_authorization(&state, session_token).await {
+                Ok(AuthorizationSessionState::Authenticated { .. }) => true,
+                Ok(AuthorizationSessionState::NeedsAuth) => false,
+                Err(e) => {
+                    tracing::error!("Session check failed at /login; rendering the form: {e}");
+                    false
+                }
+            };
+            if authorized {
                 return axum::response::Redirect::to(&format!(
                     "/oauth/authorize?pending_auth={}",
                     urlencoding::encode(pending_id)
                 ))
                 .into_response();
             }
+        } else if get_auth_context(&state, &jar).await.authenticated {
+            // Without a pending authorization a signed-in user has nothing to
+            // do here — IdP sign-in is the whole bar for the browser UI, so a
+            // bootstrap session goes home like any other.
             return axum::response::Redirect::to("/").into_response();
         }
     }
@@ -1101,11 +1106,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_login_page_shows_form_for_bootstrap_session_no_pending() {
-        // Web sign-in sends a returning user here with a bootstrap
-        // (NotVerified) session precisely to assert. Redirecting them to `/`
-        // because the cookie looks authenticated would skip the ceremony the
-        // redirect exists for.
+    async fn test_login_page_redirects_bootstrap_session_home_no_pending() {
+        // Without a pending authorization a signed-in user has nothing to do
+        // at /login: IdP sign-in is the whole bar for the browser UI, so a
+        // bootstrap (NotVerified) session goes home like a verified one.
         let (app, state) = crate::test_utils::test_app().await;
 
         let user =
@@ -1130,13 +1134,18 @@ mod tests {
         )
         .await;
 
-        assert_eq!(
-            resp.status,
-            axum::http::StatusCode::OK,
-            "an unverified session must get the assertion form, got {} with location {:?}",
-            resp.status,
-            resp.headers.get("location")
+        assert!(
+            resp.status.is_redirection(),
+            "a signed-in session skips the form, got {}",
+            resp.status
         );
+        let location = resp
+            .headers
+            .get("location")
+            .expect("redirect location")
+            .to_str()
+            .expect("ascii location");
+        assert_eq!(location, "/");
     }
 
     #[tokio::test]

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -977,13 +977,12 @@ pub(crate) async fn complete_enrollment_after_identity(
     let token = session_result.token;
     let token_hash = hash_token(token.expose_secret());
 
-    // The IdP sign-in authenticates the person, never the hardware, so any
-    // returning user — anyone with a key on record — is sent to /login to
-    // assert before their session is good for more than key management. A
-    // fresh enrollee has no key to assert with and goes to /enroll/keys to
-    // register one, which is itself a ceremony: browser_register_complete
-    // replaces this bootstrap session with a hardware-verified one.
-    let require_assertion = authenticator_id.is_some();
+    // Handle CLI-initiated device auth flow. Direct browser sign-ins carry
+    // no device_auth_id in the OIDC state (see direct_enroll_start).
+    //
+    // Either way the CLI is released by a key ceremony, never by the IdP
+    // sign-in alone, which authenticates the person rather than the hardware.
+    let mut require_assertion = false;
 
     if let Some(device_auth_id) = stored_state.device_auth_id.as_deref() {
         // Refuse before the key ceremony if the request the CLI is waiting on
@@ -1029,6 +1028,7 @@ pub(crate) async fn complete_enrollment_after_identity(
             }
             .into_response();
         }
+        require_assertion = authenticator_id.is_some();
     } else if authenticator_id.is_some() {
         // Returning user signing in directly via the website (upstream IdP,
         // no CLI). No FIDO2 assertion happened, so authenticator_id stays
@@ -1048,9 +1048,9 @@ pub(crate) async fn complete_enrollment_after_identity(
     // marked the row `consumed_at = Some(now)` (replay-blocking) and
     // `delete_expired_oidc_states` will reclaim the row at expiry.
 
-    // A returning user goes to the login page to assert with their key
-    // (whether or not a CLI is waiting); a first-time enrollee lands on the
-    // keys page to register one.
+    // A returning user with a CLI waiting goes to the login page to assert
+    // with their key; everyone else lands on the keys page, where a
+    // first-time enrollee registers one.
     let destination = if require_assertion {
         "/login"
     } else {
@@ -1134,7 +1134,6 @@ pub(crate) async fn enroll_keys_page(
                 user_email: Some(email),
                 has_org,
                 is_org_admin,
-                hardware_verified: token.hardware_verified,
             };
 
             // Consume any flash error set by a prior failed form POST (rename),

--- a/crates/vouch-server/src/handlers/enroll/tests.rs
+++ b/crates/vouch-server/src/handlers/enroll/tests.rs
@@ -543,9 +543,9 @@ async fn test_direct_web_signin_bootstrap_session_cannot_delete_keys() {
             .await;
     assert_eq!(resp.status(), StatusCode::SEE_OTHER);
 
-    // A returning user is sent to `/login` to assert; the exploit ignores
-    // the redirect and drives `/enroll/keys` directly with the issued
-    // cookie, which the bootstrap session still permits for key management.
+    // A direct web sign-in (no CLI waiting) lands on the keys page; the
+    // bootstrap session permits key management, and the exploit drives the
+    // DELETE endpoint with the issued cookie.
     let location = resp
         .headers()
         .get(header::LOCATION)
@@ -554,8 +554,8 @@ async fn test_direct_web_signin_bootstrap_session_cannot_delete_keys() {
         .expect("ascii location")
         .to_string();
     assert_eq!(
-        location, "/login",
-        "direct returning-user sign-in must redirect to /login to assert, got {location}"
+        location, "/enroll/keys",
+        "direct returning-user sign-in lands on the keys page, got {location}"
     );
 
     // Extract the session cookie value the handler just issued.

--- a/crates/vouch-server/src/handlers/extractors.rs
+++ b/crates/vouch-server/src/handlers/extractors.rs
@@ -319,25 +319,25 @@ impl FromRequestParts<Arc<AppState>> for OptionalClientCert {
     }
 }
 
-/// A signed-in user whose session is backed by a FIDO2 ceremony.
+/// A signed-in, active user answering a browser page.
 ///
-/// The default for any browser page offering a privileged action — the
-/// applications portal registers OAuth clients, minting secrets and setting
-/// redirect URIs, credentials that outlive the session creating them. Taking
-/// this type is what runs the check, so a new page gets the bar by asking for
-/// the type rather than by remembering a guard.
+/// The default extractor for browser pages: the upstream IdP is the trust
+/// root for the browser UI, so a session cookie from IdP sign-in is the whole
+/// bar — no key ceremony is required to read or use these pages. Hardware
+/// proof is demanded where credentials move instead: issuance
+/// ([`HardwareVerifiedToken`]) and key deletion ([`SteppedUpToken`]).
 ///
-/// It answers a person, not an API client: a session that has not asserted is
-/// sent to `/login` to touch a key, and one that is not signed in at all gets
-/// the unauthorized page. [`HardwareVerifiedToken`] is the same requirement
-/// for callers that read a JSON error instead, and [`AdminPage`] adds the
-/// org-admin role on top of this one.
-pub(crate) struct AttestedSession {
+/// It answers a person, not an API client: a request without a usable
+/// session is redirected to sign in. [`AdminPage`] adds the org-admin role
+/// on top of this one.
+///
+/// [`SteppedUpToken`]: crate::handlers::session::SteppedUpToken
+pub(crate) struct SignedInSession {
     /// Header/template context for the rendered page.
     pub(crate) auth: AuthContext,
 }
 
-impl FromRequestParts<Arc<AppState>> for AttestedSession {
+impl FromRequestParts<Arc<AppState>> for SignedInSession {
     type Rejection = axum::response::Response;
 
     async fn from_request_parts(
@@ -360,15 +360,6 @@ impl FromRequestParts<Arc<AppState>> for AttestedSession {
             return Err(sign_in());
         };
 
-        if !session.hardware_verified {
-            tracing::info!(
-                target: "security",
-                user_id = %session.sub,
-                "application registration requires an assertion: session is not hardware-verified"
-            );
-            return Err(axum::response::Redirect::to("/login").into_response());
-        }
-
         Ok(Self {
             auth: AuthContext {
                 authenticated: true,
@@ -376,7 +367,6 @@ impl FromRequestParts<Arc<AppState>> for AttestedSession {
                 user_email: Some(user.email),
                 has_org: user.org_id.is_some(),
                 is_org_admin: user.is_org_admin,
-                hardware_verified: session.hardware_verified,
             },
         })
     }
@@ -384,15 +374,14 @@ impl FromRequestParts<Arc<AppState>> for AttestedSession {
 
 /// An organization administrator viewing an admin page.
 ///
-/// Every admin page needs the same four facts — a signed-in user, the
-/// org-admin role, a session backed by a key ceremony, and the organization
-/// being administered — and each failure has its own destination. Taking
-/// this type is what runs those checks, so a new admin page cannot render
-/// privileged controls by forgetting them.
+/// Every admin page needs the same three facts — a signed-in user, the
+/// org-admin role, and the organization being administered — and each
+/// failure has its own destination. Taking this type is what runs those
+/// checks, so a new admin page cannot render privileged controls by
+/// forgetting them.
 ///
 /// Where [`OrgAdmin`] answers an API caller with 403, this redirects: a
-/// person reading a page needs somewhere to go, and an unverified session is
-/// sent to `/login` to assert rather than shown buttons that will refuse it.
+/// person reading a page needs somewhere to go.
 pub(crate) struct AdminPage {
     /// Header/template context for the rendered page.
     pub(crate) auth: AuthContext,
@@ -420,14 +409,6 @@ impl FromRequestParts<Arc<AppState>> for AdminPage {
         if !auth.is_org_admin {
             return Err(Redirect::to("/integrations").into_response());
         }
-        if !auth.hardware_verified {
-            tracing::info!(
-                target: "security",
-                path = %parts.uri.path(),
-                "admin page requires an assertion: session is not hardware-verified"
-            );
-            return Err(Redirect::to("/login").into_response());
-        }
         let Some(user_id) = auth.user_id.clone() else {
             return Err(Redirect::to("/enroll/start").into_response());
         };
@@ -452,12 +433,11 @@ impl FromRequestParts<Arc<AppState>> for AdminPage {
     }
 }
 
-/// An organization administrator holding a hardware-verified session.
+/// An organization administrator.
 ///
 /// The proof is the type: a handler that mutates org-wide state takes
-/// `OrgAdmin` in its signature and cannot run without the admin-role and
-/// key-ceremony checks in [`extract_org_admin`] — the same reasoning
-/// [`super::session::HardwareVerifiedToken`] applies to credential issuance.
+/// `OrgAdmin` in its signature and cannot run without the admin-role check
+/// in [`extract_org_admin`].
 pub(crate) struct OrgAdmin {
     /// The administrator's user record (active, org member, admin).
     pub(crate) user: db::User,

--- a/crates/vouch-server/src/handlers/github.rs
+++ b/crates/vouch-server/src/handlers/github.rs
@@ -374,18 +374,6 @@ pub(crate) async fn github_connect_page(
         Err(e) => return error_response(e),
     };
 
-    // Connecting the GitHub App mutates org-wide state; require a session
-    // backed by a key ceremony, the same bar as every other org-admin write.
-    // A bootstrap (IdP-only) session asserts at /login first.
-    if !session.hardware_verified {
-        tracing::warn!(
-            target: "security",
-            user_id = %user.id,
-            "Refusing GitHub admin action: session is not hardware-verified"
-        );
-        return Redirect::to("/login").into_response();
-    }
-
     // Get existing connected accounts
     let connected_accounts = service
         .get_org_installations(org_id)
@@ -437,7 +425,6 @@ pub(crate) async fn github_connect_page(
         user_email: Some(user.email),
         has_org: user.org_id.is_some(),
         is_org_admin: user.is_org_admin,
-        hardware_verified: session.hardware_verified,
     };
 
     GitHubConnectTemplate {
@@ -771,18 +758,6 @@ pub(crate) async fn github_reconnect(
         Ok(org_id) => org_id.to_string(),
         Err(e) => return error_response(e),
     };
-
-    // Connecting the GitHub App mutates org-wide state; require a session
-    // backed by a key ceremony, the same bar as every other org-admin write.
-    // A bootstrap (IdP-only) session asserts at /login first.
-    if !session.hardware_verified {
-        tracing::warn!(
-            target: "security",
-            user_id = %user.id,
-            "Refusing GitHub admin action: session is not hardware-verified"
-        );
-        return Redirect::to("/login").into_response();
-    }
 
     // Reconnect the installation
     match service

--- a/crates/vouch-server/src/handlers/integrations.rs
+++ b/crates/vouch-server/src/handlers/integrations.rs
@@ -8,7 +8,7 @@
 //! - EKS (via AWS IAM and EKS Access Entries)
 
 use crate::db;
-use crate::handlers::extractors::AttestedSession;
+use crate::handlers::extractors::SignedInSession;
 use crate::handlers::session::{AuthContext, extract_session_from_cookie};
 use crate::{AppState, impl_template_response};
 use askama::Template;
@@ -45,12 +45,9 @@ impl_template_response!(IntegrationsTemplate);
 pub(crate) async fn integrations_page(
     State(state): State<Arc<AppState>>,
     jar: CookieJar,
-    session: AttestedSession,
+    session: SignedInSession,
 ) -> Response {
-    // Every action on this page — connecting or managing the GitHub App —
-    // already requires a ceremony, so a session that has not asserted would
-    // read a status screen whose every button turns it away.
-    let AttestedSession { auth } = session;
+    let SignedInSession { auth } = session;
 
     // Check if GitHub App is configured on the server
     let github_configured = state.github_app.is_some();

--- a/crates/vouch-server/src/handlers/session.rs
+++ b/crates/vouch-server/src/handlers/session.rs
@@ -36,10 +36,6 @@ pub(crate) struct AuthContext {
     /// Whether the user is an organization admin.
     /// Used to show/hide org admin features like connecting GitHub.
     pub is_org_admin: bool,
-    /// Whether a FIDO2 ceremony backs this session. An enrollment bootstrap
-    /// session (upstream IdP sign-in, no assertion) is authenticated but not
-    /// verified, and pages that offer privileged actions gate on this.
-    pub hardware_verified: bool,
 }
 
 impl AuthContext {
@@ -52,7 +48,6 @@ impl AuthContext {
             user_email: None,
             has_org: false,
             is_org_admin: false,
-            hardware_verified: false,
         }
     }
 }
@@ -601,11 +596,9 @@ pub(crate) async fn load_active_user(
     Ok(user)
 }
 
-/// Extract authenticated user, their org_id, and the validated token.
+/// Extract authenticated user and their org_id.
 ///
-/// Returns `(user, org_id, token)` or an error if not authenticated or no
-/// org. The token is returned so callers can gate on its claims (e.g.
-/// `hardware_verified`) without a second extraction.
+/// Returns `(user, org_id)` or an error if not authenticated or no org.
 pub(crate) async fn extract_user_with_org(
     state: &AppState,
     headers: &axum::http::HeaderMap,
@@ -613,7 +606,7 @@ pub(crate) async fn extract_user_with_org(
     method: &str,
     uri: &str,
     client_cert: Option<&crate::services::oidc::mtls::ClientCertificate>,
-) -> Result<(db::User, String, ValidatedResourceToken), ServiceError> {
+) -> Result<(db::User, String), ServiceError> {
     let token = extract_resource_token(state, headers, jar, method, uri, client_cert).await?;
     let user = load_active_user(state, &token.sub).await?;
 
@@ -625,15 +618,16 @@ pub(crate) async fn extract_user_with_org(
         )
     })?;
 
-    Ok((user, org_id, token))
+    Ok((user, org_id))
 }
 
 /// Extract and validate an org admin from the access token.
 ///
-/// Returns the user and their org_id if they are an org admin holding a
-/// hardware-verified session. Reuses `extract_user_with_org` for token
-/// validation and the active-user lookup, then adds the admin-role and
-/// hardware checks.
+/// Returns the user and their org_id if they are an org admin. Reuses
+/// `extract_user_with_org` for token validation and the active-user lookup,
+/// then adds the admin-role check. No key ceremony is demanded: the upstream
+/// IdP is the trust root for the browser and admin surfaces, while hardware
+/// proof gates credential issuance and key deletion.
 pub(crate) async fn extract_org_admin(
     state: &AppState,
     headers: &axum::http::HeaderMap,
@@ -642,7 +636,7 @@ pub(crate) async fn extract_org_admin(
     uri: &str,
     client_cert: Option<&crate::services::oidc::mtls::ClientCertificate>,
 ) -> Result<(db::User, String), ServiceError> {
-    let (user, org_id, token) =
+    let (user, org_id) =
         extract_user_with_org(state, headers, jar, method, uri, client_cert).await?;
 
     if !user.is_org_admin {
@@ -650,26 +644,6 @@ pub(crate) async fn extract_org_admin(
             StatusCode::FORBIDDEN,
             "forbidden",
             "Organization admin access required",
-        ));
-    }
-
-    // Organization administration mutates org-wide state (SCIM tokens,
-    // policies, issuer keys, membership), so it takes the same bar as
-    // credential issuance: a session backed by a key ceremony. An enrollment
-    // bootstrap session authenticates the person via the upstream IdP, never
-    // the hardware. Web sign-in routes every returning user through an
-    // assertion, so only a session that skipped every ceremony is refused.
-    if !token.hardware_verified {
-        tracing::warn!(
-            target: "security",
-            user_id = %user.id,
-            path = %uri,
-            "Refusing org-admin action: session is not hardware-verified"
-        );
-        return Err(ServiceError::api(
-            StatusCode::FORBIDDEN,
-            "hardware_required",
-            "Organization admin actions require a security-key-verified session - sign in with your security key and try again",
         ));
     }
 
@@ -765,7 +739,6 @@ pub(crate) async fn get_resource_auth_context(state: &AppState, jar: &CookieJar)
         user_email,
         has_org,
         is_org_admin,
-        hardware_verified: decoded.hardware_verification().hardware_verified(),
     }
 }
 

--- a/crates/vouch-server/templates/login.html
+++ b/crates/vouch-server/templates/login.html
@@ -35,11 +35,6 @@
         <p class="text-gray-400 text-xs mt-6">
             {{ self.tr("login-no-account-prefix") }} <a href="/enroll/start" class="text-vouch-accent hover:text-vouch-accent-hover">{{ self.tr("login-enroll-now") }}</a>
         </p>
-        {% if auth.authenticated %}
-        <p class="text-gray-400 text-xs mt-2">
-            <a href="/enroll/keys" class="text-vouch-accent hover:text-vouch-accent-hover">{{ self.tr("login-lost-key-link") }}</a>
-        </p>
-        {% endif %}
     </div>
 </div>
 <div id="login-config" data-rp-id="{{ rp_id }}" {% if pending_auth.is_some() %}data-pending-auth="{{ pending_auth.as_ref().unwrap() }}"{% endif %} hidden></div>


### PR DESCRIPTION
Partially unwinds #1173: the browser UI now answers to a signed-in cookie session, with no hardware-attestation gate on pages or browser writes. Hardware proof still gates credential issuance (`HardwareVerifiedToken`) and key deletion (`SteppedUpToken`).

## Why

The browser ceremony gates added friction without changing the threat model. The self-service lost-key recovery path deliberately lets a bootstrap (IdP-only) session register a new key, and registration is itself a ceremony that yields a verified session — so an attacker holding the IdP account or a stolen cookie could always register their own key and walk through every gate. Meanwhile the gates produced real dead ends for legitimate users: privileged pages bounced bootstrap sessions to a `/login` assertion form, and a user who lost their only key could reach the keys page but nothing else.

The published threat model (vouch.sh/docs/threat-model) is silent on upstream-IdP credential compromise — it is neither a listed threat nor out-of-scope, and it does not model `/admin`, OAuth client registration, or browser sessions. This PR makes the working position explicit in code: the upstream IdP is the trust root for the browser UI; hardware proof gates credential issuance and key deletion.

## What changed

- `AttestedSession` becomes `SignedInSession`: a signed-in, active user is the whole bar for the applications portal (pages and form POSTs) and the integrations page.
- `AdminPage` and `extract_org_admin` (backing `OrgAdmin` and the `/api/v1/org/*` writes) drop their hardware checks; the GitHub connect/reconnect inline gates are removed.
- Returning users signing in through the website land on `/enroll/keys` with a working session; only the CLI device-auth flow still routes through `/login` to assert, because releasing the CLI issues credentials.
- `/login` with no pending authorization sends any signed-in session home; the "Lost your security key?" link is gone with the flow that needed it.
- `AuthContext.hardware_verified` had no readers left and is removed.
- Seven gate-pinning tests are flipped to pin the new model (e.g. `test_bootstrap_admin_session_can_promote`, `bootstrap_session_uses_the_applications_portal`).

## Kept from #1173

The #1168 check-before-spend fix and `/login`'s shared authorize predicate on the pending path (regression tests `rfc6749_authorize.rs` and `browser_login.rs` still pass), the same-origin CSRF middleware, the deactivated-account (`load_active_user`) fixes, and the `TestPendingAuthSpec` fixtures.

## Security note

This deliberately accepts that a hijacked IdP account can mint long-lived artifacts from the browser (SCIM tokens, OAuth client secrets, GitHub App connections) without touching hardware. Given the self-service recovery path above, the removed gates never prevented that — they only added a step using the attacker's own authenticator. The compensating control remains IdP-side: SCIM de-provisioning revokes access (threat-model assumption A6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)