### PR TITLE
refactor(server): await audit events and unify the audit write API

### DIFF
--- a/crates/vouch-server/src/db/audit.rs
+++ b/crates/vouch-server/src/db/audit.rs
@@ -11,8 +11,6 @@ use anyhow::{Context, Result};
 use jiff::Timestamp;
 use sea_query::{Expr, ExprTrait, Iden, Order, Query};
 
-use serde::Serialize;
-
 use super::documents::audit::{AuditData, CredentialAuditDetails, CredentialAuditEnvelope};
 use super::pool::Pool;
 use crate::crypto::document_crypto::DocumentCrypto;
@@ -93,7 +91,7 @@ macro_rules! audit_event_kinds {
     ($($(#[$attr:meta])* $variant:ident => $name:literal, $retention:ident, $group:ident;)+) => {
         /// Every audit event type the server writes.
         ///
-        /// This is the single registry: [`AuditStore::insert_event`] only
+        /// This is the single registry: [`AuditStore::record_event`] only
         /// accepts these kinds, the cleanup task derives retention from
         /// [`Self::retention`], and the operator documentation
         /// (`docs/src/admin/audit.md`) is generated from [`Self::group`] plus
@@ -323,89 +321,82 @@ impl AuditStore {
         Some(self.crypto.hmac_index(canonical.as_str()))
     }
 
-    /// Insert a new audit event with a typed `data` payload.
+    /// Record an audit event with a typed `data` payload; best-effort.
     ///
     /// `email` is masked to domain-only and HMAC-hashed for correlation.
     /// `data` must be one of the vetted payload structs in
     /// [`crate::db::documents::audit`] — [`AuditData`] is sealed there, so
     /// an ad hoc `serde_json::json!` literal cannot be passed.
     ///
-    /// # Errors
-    ///
-    /// Returns an error if serialization or the database write fails.
-    pub async fn insert_event<D: AuditData>(
+    /// An audit write must never fail the operation it records, so a
+    /// failed write is logged with the wire `event_type` and swallowed.
+    pub async fn record_event<D: AuditData>(
         &self,
         kind: AuditEventKind,
         user_id: Option<&str>,
         email: Option<&str>,
         data: &D,
-    ) -> Result<String> {
-        let data_json = serde_json::to_string(data).context("serialize audit data payload")?;
-        self.insert_event_json(kind, user_id, email, &data_json)
-            .await
-    }
-
-    /// Crate-internal raw-JSON insert path behind [`Self::insert_event`].
-    ///
-    /// `pub(super)` because only two write sites assemble their payload as
-    /// a `serde_json::Value`: `record_auth_event`'s geo-field merge in
-    /// `db/config.rs` and the flattened envelope in
-    /// [`Self::log_credential_event`]. Everything outside `db` must go
-    /// through a typed [`AuditData`] payload.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the database write fails.
-    pub(super) async fn insert_event_json(
-        &self,
-        kind: AuditEventKind,
-        user_id: Option<&str>,
-        email: Option<&str>,
-        data_json: &str,
-    ) -> Result<String> {
+    ) {
         let email_domain = email.and_then(crate::email::Email::domain_of);
         let email_hmac = email.and_then(|e| self.email_hmac(e));
-
-        self.insert_event_raw(
+        self.record_best_effort(
             kind,
             user_id,
             email_domain.as_deref(),
             email_hmac.as_deref(),
-            jiff::Timestamp::now(),
-            data_json,
+            data,
         )
-        .await
+        .await;
     }
 
-    /// Insert a new audit event with an explicit `email_domain`, bypassing
-    /// the email→domain derivation in [`Self::insert_event`].
+    /// Record an audit event with an explicit `org_domain`, bypassing the
+    /// email→domain derivation in [`Self::record_event`]; best-effort.
     ///
     /// Used by write sites that act on behalf of an organization rather
     /// than a specific user — SCIM operations, org-lifecycle cleanup
-    /// events — and so have no email to derive a domain from. Without
-    /// this, those events are written with a NULL `email_domain` and are
-    /// invisible to org-scoped audit reads.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if serialization or the database write fails.
-    pub async fn insert_event_with_domain<D: AuditData>(
+    /// events — and so have no email to derive a domain from: the org's
+    /// primary email domain is stamped into `email_domain` instead.
+    /// Without it, those events are written with a NULL `email_domain`
+    /// and are invisible to org-scoped audit reads.
+    pub async fn record_event_with_domain<D: AuditData>(
+        &self,
+        kind: AuditEventKind,
+        user_id: Option<&str>,
+        org_domain: Option<&str>,
+        data: &D,
+    ) {
+        self.record_best_effort(kind, user_id, org_domain, None, data)
+            .await;
+    }
+
+    /// Shared swallow-and-log behind [`Self::record_event`] and
+    /// [`Self::record_event_with_domain`] — the one place audit write
+    /// failures are formatted.
+    async fn record_best_effort<D: AuditData>(
         &self,
         kind: AuditEventKind,
         user_id: Option<&str>,
         email_domain: Option<&str>,
+        email_hmac: Option<&str>,
         data: &D,
-    ) -> Result<String> {
-        let data_json = serde_json::to_string(data).context("serialize audit data payload")?;
-        self.insert_event_raw(
-            kind,
-            user_id,
-            email_domain,
-            None,
-            jiff::Timestamp::now(),
-            &data_json,
-        )
-        .await
+    ) {
+        let result = match serde_json::to_string(data).context("serialize audit data payload") {
+            Ok(data_json) => self
+                .insert_event_raw(
+                    kind,
+                    user_id,
+                    email_domain,
+                    email_hmac,
+                    jiff::Timestamp::now(),
+                    &data_json,
+                )
+                .await
+                .map(|_| ()),
+            Err(e) => Err(e),
+        };
+        if let Err(e) = result {
+            tracing::warn!(error = %e, event_type = kind.as_str(), "failed to write audit event");
+        }
     }
 
     /// Insert an audit event with an explicit `created_at`.
@@ -448,7 +439,7 @@ impl AuditStore {
     }
 
     /// Test-only raw-JSON insert with the email→domain/HMAC derivation of
-    /// [`Self::insert_event`]. Tests legitimately seed arbitrary, legacy,
+    /// [`Self::record_event`]. Tests legitimately seed arbitrary, legacy,
     /// and malformed payloads that no vetted [`AuditData`] struct should
     /// ever describe.
     ///
@@ -463,12 +454,21 @@ impl AuditStore {
         email: Option<&str>,
         data_json: &str,
     ) -> Result<String> {
-        self.insert_event_json(kind, user_id, email, data_json)
-            .await
+        let email_domain = email.and_then(crate::email::Email::domain_of);
+        let email_hmac = email.and_then(|e| self.email_hmac(e));
+        self.insert_event_raw(
+            kind,
+            user_id,
+            email_domain.as_deref(),
+            email_hmac.as_deref(),
+            jiff::Timestamp::now(),
+            data_json,
+        )
+        .await
     }
 
-    /// Shared insert path for [`Self::insert_event`],
-    /// [`Self::insert_event_with_domain`], and (test-only)
+    /// Shared insert path for [`Self::record_event`],
+    /// [`Self::record_event_with_domain`], and (test-only)
     /// [`Self::insert_event_for_test`].
     async fn insert_event_raw(
         &self,
@@ -512,11 +512,7 @@ impl AuditStore {
 
     /// Log a credential-issuance audit event: the shared envelope flattened
     /// with the kind-specific details, written under the details' registry
-    /// kind ([`CredentialAuditDetails::KIND`]).
-    ///
-    /// Best-effort: audit writes must never fail the credential operation
-    /// that already succeeded, so failures are logged and swallowed here
-    /// instead of at every call site.
+    /// kind ([`CredentialAuditDetails::KIND`]); best-effort.
     pub async fn log_credential_event<D: CredentialAuditDetails>(
         &self,
         user_id: &str,
@@ -524,31 +520,12 @@ impl AuditStore {
         envelope: CredentialAuditEnvelope,
         details: &D,
     ) {
-        #[derive(serde::Serialize)]
-        struct Payload<'a, D: Serialize> {
-            #[serde(flatten)]
-            envelope: &'a CredentialAuditEnvelope,
-            #[serde(flatten)]
-            details: &'a D,
-        }
-
-        let result = match serde_json::to_string(&Payload {
+        let payload = crate::db::documents::audit::CredentialAuditPayload {
             envelope: &envelope,
             details,
-        }) {
-            Ok(data_json) => {
-                self.insert_event_json(D::KIND, Some(user_id), Some(user_email), &data_json)
-                    .await
-            }
-            Err(e) => Err(e.into()),
         };
-        if let Err(e) = result {
-            tracing::warn!(
-                error = %e,
-                event_type = D::KIND.as_str(),
-                "failed to write credential audit event"
-            );
-        }
+        self.record_event(D::KIND, Some(user_id), Some(user_email), &payload)
+            .await;
     }
 
     /// Query audit events with optional filters.
@@ -1087,11 +1064,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn insert_event_with_domain_stamps_domain_without_email() {
+    async fn record_event_with_domain_stamps_domain_without_email() {
         let audit = test_audit().await;
 
-        let id = audit
-            .insert_event_with_domain(
+        audit
+            .record_event_with_domain(
                 AuditEventKind::ScimOperation,
                 None,
                 Some("example.com"),
@@ -1103,9 +1080,7 @@ mod tests {
                     details: None,
                 },
             )
-            .await
-            .unwrap();
-        assert!(!id.is_empty());
+            .await;
 
         let events = audit
             .query_events(&AuditEventFilter::default())

--- a/crates/vouch-server/src/db/audit.rs
+++ b/crates/vouch-server/src/db/audit.rs
@@ -348,7 +348,7 @@ impl AuditStore {
     /// Crate-internal raw-JSON insert path behind [`Self::insert_event`].
     ///
     /// `pub(super)` because only two write sites assemble their payload as
-    /// a `serde_json::Value`: `insert_auth_event`'s geo-field merge in
+    /// a `serde_json::Value`: `record_auth_event`'s geo-field merge in
     /// `db/config.rs` and the flattened envelope in
     /// [`Self::log_credential_event`]. Everything outside `db` must go
     /// through a typed [`AuditData`] payload.

--- a/crates/vouch-server/src/db/config.rs
+++ b/crates/vouch-server/src/db/config.rs
@@ -105,42 +105,21 @@ pub struct ClientInfo {
 /// Record an authentication event via the audit store.
 ///
 /// Awaited so the row is committed before the response is sent, and
-/// best-effort: an audit write must never fail the operation it records,
-/// so failures are logged with the wire `event_type` string and swallowed.
+/// best-effort like every [`AuditStore`] write: failures are logged with
+/// the wire `event_type` and swallowed.
 pub async fn record_auth_event(audit: &AuditStore, params: AuthEventParams, email: Option<String>) {
-    let kind = params.event_type.kind();
-    let result = match serde_json::to_value(&params) {
-        Ok(mut value) => {
-            if let (Some(obj), Some(geo)) = (
-                value.as_object_mut(),
-                params.client.client_ip.and_then(crate::geo::lookup),
-            ) {
-                obj.insert(
-                    "country_code".to_string(),
-                    serde_json::Value::String(geo.country_code),
-                );
-                if let Some(asn) = geo.asn {
-                    obj.insert("asn".to_string(), serde_json::json!(asn));
-                }
-                if let Some(org) = geo.org_name {
-                    obj.insert("org_name".to_string(), serde_json::Value::String(org));
-                }
-            }
-            audit
-                .insert_event_json(
-                    kind,
-                    Some(&params.user_id),
-                    email.as_deref(),
-                    &value.to_string(),
-                )
-                .await
-                .map(|_| ())
-        }
-        Err(e) => Err(anyhow::anyhow!("Failed to serialize auth event: {e}")),
+    let data = crate::db::documents::audit::AuthEventData {
+        geo: crate::db::documents::audit::GeoFields::from_ip(params.client.client_ip),
+        params: &params,
     };
-    if let Err(e) = result {
-        tracing::warn!(error = %e, event_type = kind.as_str(), "failed to record audit event");
-    }
+    audit
+        .record_event(
+            params.event_type.kind(),
+            Some(&params.user_id),
+            email.as_deref(),
+            &data,
+        )
+        .await;
 }
 
 #[cfg(test)]

--- a/crates/vouch-server/src/db/config.rs
+++ b/crates/vouch-server/src/db/config.rs
@@ -7,7 +7,6 @@
 use std::net::IpAddr;
 
 use super::audit::{AuditEventKind, AuditStore};
-use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 // ============================================================================
@@ -103,56 +102,45 @@ pub struct ClientInfo {
     pub client_version: Option<String>,
 }
 
-/// Insert a new authentication event via the audit store.
+/// Record an authentication event via the audit store.
 ///
-/// Production code records events through [`spawn_audit_event`]; this is
-/// exposed to in-crate tests that need to await the write and inspect the
-/// returned event ID.
-pub(super) async fn insert_auth_event(
-    audit: &AuditStore,
-    params: &AuthEventParams,
-    email: Option<&str>,
-) -> Result<String> {
-    let mut value = serde_json::to_value(params)
-        .map_err(|e| anyhow::anyhow!("Failed to serialize auth event: {e}"))?;
-    if let (Some(obj), Some(geo)) = (
-        value.as_object_mut(),
-        params.client.client_ip.and_then(crate::geo::lookup),
-    ) {
-        obj.insert(
-            "country_code".to_string(),
-            serde_json::Value::String(geo.country_code),
-        );
-        if let Some(asn) = geo.asn {
-            obj.insert("asn".to_string(), serde_json::json!(asn));
+/// Awaited so the row is committed before the response is sent, and
+/// best-effort: an audit write must never fail the operation it records,
+/// so failures are logged with the wire `event_type` string and swallowed.
+pub async fn record_auth_event(audit: &AuditStore, params: AuthEventParams, email: Option<String>) {
+    let kind = params.event_type.kind();
+    let result = match serde_json::to_value(&params) {
+        Ok(mut value) => {
+            if let (Some(obj), Some(geo)) = (
+                value.as_object_mut(),
+                params.client.client_ip.and_then(crate::geo::lookup),
+            ) {
+                obj.insert(
+                    "country_code".to_string(),
+                    serde_json::Value::String(geo.country_code),
+                );
+                if let Some(asn) = geo.asn {
+                    obj.insert("asn".to_string(), serde_json::json!(asn));
+                }
+                if let Some(org) = geo.org_name {
+                    obj.insert("org_name".to_string(), serde_json::Value::String(org));
+                }
+            }
+            audit
+                .insert_event_json(
+                    kind,
+                    Some(&params.user_id),
+                    email.as_deref(),
+                    &value.to_string(),
+                )
+                .await
+                .map(|_| ())
         }
-        if let Some(org) = geo.org_name {
-            obj.insert("org_name".to_string(), serde_json::Value::String(org));
-        }
+        Err(e) => Err(anyhow::anyhow!("Failed to serialize auth event: {e}")),
+    };
+    if let Err(e) = result {
+        tracing::warn!(error = %e, event_type = kind.as_str(), "failed to record audit event");
     }
-    let data_json = value.to_string();
-    audit
-        .insert_event_json(
-            params.event_type.kind(),
-            Some(&params.user_id),
-            email,
-            &data_json,
-        )
-        .await
-}
-
-/// Record an authentication event without blocking the caller.
-///
-/// Spawns a detached task so credential flows never wait on (or fail with)
-/// the audit write; failures are logged with the event type so dropped
-/// records are visible in one consistent format.
-pub fn spawn_audit_event(audit: &AuditStore, params: AuthEventParams, email: Option<String>) {
-    let audit = audit.clone();
-    tokio::spawn(async move {
-        if let Err(e) = insert_auth_event(&audit, &params, email.as_deref()).await {
-            tracing::warn!(error = %e, event_type = ?params.event_type, "failed to record audit event");
-        }
-    });
 }
 
 #[cfg(test)]
@@ -260,7 +248,7 @@ mod tests {
                     .then(|| "invalid assertion".to_string()),
                 ..AuthEventParams::default()
             };
-            insert_auth_event(&state.audit, &params, Some("test@example.com")).await?;
+            record_auth_event(&state.audit, params, Some("test@example.com".to_string())).await;
         }
 
         let before = jiff::Timestamp::now()

--- a/crates/vouch-server/src/db/documents/audit.rs
+++ b/crates/vouch-server/src/db/documents/audit.rs
@@ -3,7 +3,7 @@
 //!
 //! These are serialized to JSON and stored in the unencrypted audit table.
 //! They are NOT `DocumentType` implementations — they're the typed payload
-//! behind [`AuditData`] that `AuditStore::insert_event` serializes.
+//! behind [`AuditData`] that `AuditStore::record_event` serializes.
 //!
 //! Every payload the audit write API accepts is a named struct in this
 //! file: [`AuditData`] is sealed by a module-private supertrait, so an ad
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::db::audit::AuditEventKind;
+use crate::db::config::AuthEventParams;
 
 /// Seal for [`AuditData`]. Private to this module on purpose: a new payload
 /// type must be added here, not implemented ad hoc elsewhere in the crate.
@@ -218,7 +219,46 @@ impl_audit_data!(
     PolicyDenialData<'_>,
     OAuthUsageData,
     ScimAuditData,
+    AuthEventData<'_>,
 );
+
+/// Geolocation of the caller's IP, flattened into audit payloads.
+///
+/// Keys are omitted when the lookup produced nothing, matching the rows
+/// written before this shared struct existed.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct GeoFields {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub country_code: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub asn: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub org_name: Option<String>,
+}
+
+impl GeoFields {
+    /// Geo fields for the caller's IP; all-`None` when the IP is absent,
+    /// non-global, or not in the GeoIP database.
+    #[must_use]
+    pub fn from_ip(ip: Option<std::net::IpAddr>) -> Self {
+        let (country_code, asn, org_name) = crate::geo::audit_fields(ip);
+        Self {
+            country_code,
+            asn,
+            org_name,
+        }
+    }
+}
+
+/// The stored payload of an authentication event:
+/// [`AuthEventParams`] flattened with the geolocation of the client IP.
+#[derive(Debug, Serialize)]
+pub(crate) struct AuthEventData<'a> {
+    #[serde(flatten)]
+    pub params: &'a AuthEventParams,
+    #[serde(flatten)]
+    pub geo: GeoFields,
+}
 
 /// Data payload for OAuth usage audit events.
 #[derive(Debug, Serialize, Deserialize)]
@@ -228,12 +268,8 @@ pub(crate) struct OAuthUsageData {
     #[serde(alias = "ip_address")]
     pub client_ip: Option<String>,
     pub user_agent: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub country_code: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub asn: Option<u32>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub org_name: Option<String>,
+    #[serde(flatten)]
+    pub geo: GeoFields,
 }
 
 /// Data payload for SCIM operation audit events.
@@ -264,12 +300,8 @@ pub struct CredentialAuditEnvelope {
     #[serde(alias = "ip_address")]
     pub client_ip: Option<String>,
     pub user_agent: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub country_code: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub asn: Option<u32>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub org_name: Option<String>,
+    #[serde(flatten)]
+    pub geo: GeoFields,
 }
 
 impl CredentialAuditEnvelope {
@@ -281,10 +313,24 @@ impl CredentialAuditEnvelope {
     pub fn with_client(mut self, ip: Option<std::net::IpAddr>, user_agent: Option<String>) -> Self {
         self.client_ip = ip.map(|a| a.to_string());
         self.user_agent = user_agent;
-        (self.country_code, self.asn, self.org_name) = crate::geo::audit_fields(ip);
+        self.geo = GeoFields::from_ip(ip);
         self
     }
 }
+
+/// The stored payload of a credential audit event: the shared envelope
+/// flattened with the kind-specific details, one flat JSON object per
+/// event.
+#[derive(Serialize)]
+pub(crate) struct CredentialAuditPayload<'a, D: CredentialAuditDetails> {
+    #[serde(flatten)]
+    pub envelope: &'a CredentialAuditEnvelope,
+    #[serde(flatten)]
+    pub details: &'a D,
+}
+
+impl<D: CredentialAuditDetails> sealed::Sealed for CredentialAuditPayload<'_, D> {}
+impl<D: CredentialAuditDetails> AuditData for CredentialAuditPayload<'_, D> {}
 
 /// Domain-specific fields of a credential audit event, tied at compile time
 /// to the registry kind they are written under — a payload cannot be stored
@@ -374,9 +420,9 @@ mod tests {
             "country_code": "US"
         }"#;
         let data: OAuthUsageData = serde_json::from_str(json).unwrap();
-        assert_eq!(data.country_code.as_deref(), Some("US"));
-        assert!(data.asn.is_none());
-        assert!(data.org_name.is_none());
+        assert_eq!(data.geo.country_code.as_deref(), Some("US"));
+        assert!(data.geo.asn.is_none());
+        assert!(data.geo.org_name.is_none());
     }
 
     #[test]
@@ -386,14 +432,16 @@ mod tests {
             details: None,
             client_ip: Some("8.8.8.8".to_string()),
             user_agent: None,
-            country_code: Some("US".to_string()),
-            asn: Some(15169),
-            org_name: Some("GOOGLE".to_string()),
+            geo: GeoFields {
+                country_code: Some("US".to_string()),
+                asn: Some(15169),
+                org_name: Some("GOOGLE".to_string()),
+            },
         };
         let json = serde_json::to_string(&data).unwrap();
         let back: OAuthUsageData = serde_json::from_str(&json).unwrap();
-        assert_eq!(back.asn, Some(15169));
-        assert_eq!(back.org_name.as_deref(), Some("GOOGLE"));
+        assert_eq!(back.geo.asn, Some(15169));
+        assert_eq!(back.geo.org_name.as_deref(), Some("GOOGLE"));
     }
 
     #[test]
@@ -403,9 +451,7 @@ mod tests {
             details: None,
             client_ip: None,
             user_agent: None,
-            country_code: None,
-            asn: None,
-            org_name: None,
+            geo: GeoFields::default(),
         };
         let json = serde_json::to_string(&data).unwrap();
         assert!(!json.contains("\"asn\""));
@@ -417,8 +463,8 @@ mod tests {
         let json = r#"{"event_type":"token_issued","success":true}"#;
         let data: CredentialAuditEnvelope = serde_json::from_str(json).unwrap();
         assert_eq!(data.event_type, "token_issued");
-        assert!(data.asn.is_none());
-        assert!(data.org_name.is_none());
+        assert!(data.geo.asn.is_none());
+        assert!(data.geo.org_name.is_none());
     }
 
     #[test]
@@ -434,15 +480,18 @@ mod tests {
         let data = CredentialAuditEnvelope {
             event_type: "token_issued".to_string(),
             agent: Some("claude-code".to_string()),
-            asn: Some(3320),
-            org_name: Some("DTAG".to_string()),
+            geo: GeoFields {
+                asn: Some(3320),
+                org_name: Some("DTAG".to_string()),
+                ..GeoFields::default()
+            },
             ..CredentialAuditEnvelope::default()
         };
         let json = serde_json::to_string(&data).unwrap();
         let back: CredentialAuditEnvelope = serde_json::from_str(&json).unwrap();
         assert_eq!(back.agent.as_deref(), Some("claude-code"));
-        assert_eq!(back.asn, Some(3320));
-        assert_eq!(back.org_name.as_deref(), Some("DTAG"));
+        assert_eq!(back.geo.asn, Some(3320));
+        assert_eq!(back.geo.org_name.as_deref(), Some("DTAG"));
     }
 
     /// Every typed payload must serialize to the exact JSON shape of the
@@ -783,6 +832,100 @@ mod tests {
         for (typed, literal) in cases {
             assert_eq!(typed, literal);
         }
+    }
+
+    /// The sealed auth-event and credential payloads must serialize to the
+    /// exact JSON shape the raw-JSON paths they replaced used to write
+    /// (Value equality — key order is irrelevant, every reader parses).
+    #[test]
+    fn test_auth_and_credential_payloads_match_stored_row_shapes() {
+        use crate::db::config::{AuthEventType, ClientInfo};
+        use serde_json::json;
+
+        // Without geo: identical to serde_json::to_value(AuthEventParams),
+        // ClientInfo flattened, client_id/idp_issuer omitted when None.
+        let params = AuthEventParams {
+            user_id: "u1".to_string(),
+            event_type: AuthEventType::LoginFailed,
+            authenticator_id: Some("auth-1".to_string()),
+            client: ClientInfo {
+                client_ip: Some("192.0.2.7".parse().unwrap()),
+                user_agent: Some("vouch-cli/1.0".to_string()),
+                ..ClientInfo::default()
+            },
+            success: false,
+            failure_reason: Some("invalid assertion".to_string()),
+            client_id: None,
+            idp_issuer: None,
+        };
+        let typed = serde_json::to_value(AuthEventData {
+            params: &params,
+            geo: GeoFields::default(),
+        })
+        .unwrap();
+        assert_eq!(
+            typed,
+            json!({
+                "user_id": "u1",
+                "authenticator_id": "auth-1",
+                "client_ip": "192.0.2.7",
+                "user_agent": "vouch-cli/1.0",
+                "client_hostname": null,
+                "client_os": null,
+                "client_arch": null,
+                "client_version": null,
+                "success": false,
+                "failure_reason": "invalid assertion",
+            })
+        );
+
+        // With geo: the fields are flattened alongside, present only when
+        // the lookup produced them.
+        let typed = serde_json::to_value(AuthEventData {
+            params: &params,
+            geo: GeoFields {
+                country_code: Some("US".to_string()),
+                asn: Some(15169),
+                org_name: Some("GOOGLE".to_string()),
+            },
+        })
+        .unwrap();
+        assert_eq!(typed.get("country_code"), Some(&json!("US")));
+        assert_eq!(typed.get("asn"), Some(&json!(15169)));
+        assert_eq!(typed.get("org_name"), Some(&json!("GOOGLE")));
+
+        // Credential payload: envelope + details flattened into one flat
+        // object.
+        let envelope = CredentialAuditEnvelope {
+            event_type: "certificate_issued".to_string(),
+            success: true,
+            ..CredentialAuditEnvelope::default()
+        };
+        let details = SshCredentialDetails {
+            serial: 42,
+            principals: vec!["dev".to_string()],
+            cert_expires_at: None,
+        };
+        let typed = serde_json::to_value(CredentialAuditPayload {
+            envelope: &envelope,
+            details: &details,
+        })
+        .unwrap();
+        assert_eq!(
+            typed,
+            json!({
+                "event_type": "certificate_issued",
+                "org_id": null,
+                "authenticator_id": null,
+                "agent": null,
+                "success": true,
+                "client_ip": null,
+                "user_agent": null,
+                "serial": 42,
+                "principals": ["dev"],
+                "cert_expires_at": null,
+            })
+        );
     }
 
     #[test]

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -118,7 +118,7 @@ pub use scim::{
     ScimScopeSet, ScimToken, ScimUserRecord, add_scim_group_member, create_scim_group,
     create_scim_token, create_scim_user, delete_expired_scim_tokens, delete_scim_group,
     delete_scim_token, get_scim_group, get_scim_group_members, get_scim_token_by_hash,
-    get_scim_user, insert_scim_audit, list_scim_groups, list_scim_tokens, list_scim_users,
+    get_scim_user, list_scim_groups, list_scim_tokens, list_scim_users, record_scim_audit,
     remove_scim_group_member, replace_scim_group_members, update_scim_group,
     update_scim_token_last_used, update_scim_user,
 };

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -110,7 +110,7 @@ pub(crate) use device_auth::{DeviceCodeClaim, OidcStateClaim, get_device_auth_by
 pub use audit::{AuditEvent, AuditEventFilter, AuditEventGroup, AuditEventKind, Retention};
 
 // Re-export config and auth event types and functions
-pub use config::{AuthEventParams, AuthEventType, ClientInfo, spawn_audit_event};
+pub use config::{AuthEventParams, AuthEventType, ClientInfo, record_auth_event};
 
 // Re-export SCIM types and functions
 pub use scim::{

--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -1521,35 +1521,25 @@ pub async fn record_oauth_event(
     store: &DocumentStore,
     params: &RecordOAuthEventParams<'_>,
 ) {
-    let (country_code, asn, org_name) = crate::geo::audit_fields(params.ip_address);
     let data = OAuthUsageData {
         oauth_client_id: params.oauth_client_id.to_string(),
         details: params.details.map(String::from),
         client_ip: params.ip_address.map(|ip| ip.to_string()),
         user_agent: params.user_agent.map(String::from),
-        country_code,
-        asn,
-        org_name,
+        geo: crate::db::documents::audit::GeoFields::from_ip(params.ip_address),
     };
     let org_domain = match params.org_domain {
         RecordedOrgDomain::Known(domain) => domain.map(String::from),
         RecordedOrgDomain::Unresolved => resolve_oauth_event_org_domain(store, params).await,
     };
-    let result = audit
-        .insert_event_with_domain(
+    audit
+        .record_event_with_domain(
             params.event_type.kind(),
             params.user_id,
             org_domain.as_deref(),
             &data,
         )
         .await;
-    if let Err(e) = result {
-        tracing::warn!(
-            error = %e,
-            event_type = params.event_type.kind().as_str(),
-            "failed to record OAuth event"
-        );
-    }
 }
 
 /// OAuth usage statistics.

--- a/crates/vouch-server/src/db/scim.rs
+++ b/crates/vouch-server/src/db/scim.rs
@@ -364,14 +364,14 @@ pub async fn delete_expired_scim_tokens(store: &DocumentStore) -> Result<u64> {
 // SCIM Audit → AuditStore
 // ============================================================================
 
-/// Insert SCIM audit log entry via AuditStore.
+/// Record a SCIM audit log entry via AuditStore; best-effort.
 ///
 /// `org_domain` is the acting organization's primary email domain
 /// ([`ScimAuth::org_domain`]). SCIM operations have no user/email of their
 /// own, so without it the event is written with a NULL `email_domain` and
 /// is invisible to org-scoped audit reads (`/admin/audit`,
 /// `GET /api/v1/org/audit-events`).
-pub async fn insert_scim_audit(
+pub async fn record_scim_audit(
     audit: &AuditStore,
     operation: &str,
     resource_type: &str,
@@ -379,7 +379,7 @@ pub async fn insert_scim_audit(
     actor_token_id: Option<&str>,
     details: Option<&str>,
     org_domain: Option<&str>,
-) -> Result<String> {
+) {
     let data = ScimAuditData {
         operation: operation.to_string(),
         resource_type: resource_type.to_string(),
@@ -388,8 +388,8 @@ pub async fn insert_scim_audit(
         details: details.map(String::from),
     };
     audit
-        .insert_event_with_domain(AuditEventKind::ScimOperation, None, org_domain, &data)
-        .await
+        .record_event_with_domain(AuditEventKind::ScimOperation, None, org_domain, &data)
+        .await;
 }
 
 // ============================================================================

--- a/crates/vouch-server/src/db/tests/audit_events.rs
+++ b/crates/vouch-server/src/db/tests/audit_events.rs
@@ -21,10 +21,10 @@ async fn test_auth_event_logging() {
         .await
         .expect("Failed to create user");
 
-    // Log successful login (insert_auth_event now uses AuditStore)
-    let event_id = config::insert_auth_event(
+    // Log successful login (record_auth_event writes via AuditStore)
+    config::record_auth_event(
         &audit,
-        &AuthEventParams {
+        AuthEventParams {
             user_id: user_id.clone(),
             event_type: AuthEventType::LoginSuccess,
             authenticator_id: Some("auth-123".to_string()),
@@ -36,17 +36,14 @@ async fn test_auth_event_logging() {
             success: true,
             ..Default::default()
         },
-        Some("events@example.com"),
+        Some("events@example.com".to_string()),
     )
-    .await
-    .expect("Failed to insert auth event");
-
-    assert!(!event_id.is_empty());
+    .await;
 
     // Log failed login
-    config::insert_auth_event(
+    config::record_auth_event(
         &audit,
-        &AuthEventParams {
+        AuthEventParams {
             user_id: user_id.clone(),
             event_type: AuthEventType::LoginFailed,
             client: ClientInfo {
@@ -57,10 +54,23 @@ async fn test_auth_event_logging() {
             failure_reason: Some("Invalid credential".to_string()),
             ..Default::default()
         },
-        Some("events@example.com"),
+        Some("events@example.com".to_string()),
     )
-    .await
-    .expect("Failed to insert auth event");
+    .await;
+
+    // The write is best-effort (failures are swallowed), so assert both
+    // rows landed by querying them back.
+    for expected in ["login_success", "login_failed"] {
+        let events = audit
+            .query_events(&AuditEventFilter {
+                event_types: Some(vec![expected.to_string()]),
+                user_id: Some(user_id.clone()),
+                ..AuditEventFilter::default()
+            })
+            .await
+            .expect("query events");
+        assert_eq!(events.len(), 1, "expected one {expected} event");
+    }
 }
 
 #[tokio::test]
@@ -78,19 +88,18 @@ async fn test_key_and_device_auth_events_round_trip_and_expire() {
         AuthEventType::DeviceAuthApproved,
     ];
     for event_type in variants {
-        config::insert_auth_event(
+        config::record_auth_event(
             &audit,
-            &AuthEventParams {
+            AuthEventParams {
                 user_id: user_id.clone(),
                 event_type,
                 authenticator_id: Some("auth-123".to_string()),
                 success: true,
                 ..Default::default()
             },
-            Some("key-events@example.com"),
+            Some("key-events@example.com".to_string()),
         )
-        .await
-        .expect("Failed to insert auth event");
+        .await;
     }
 
     // Each variant is queryable under its expected event_type string.

--- a/crates/vouch-server/src/db/tests/scim_users.rs
+++ b/crates/vouch-server/src/db/tests/scim_users.rs
@@ -470,8 +470,7 @@ async fn test_scim_session_invalidation_on_deactivation() {
 async fn test_scim_audit_logging() {
     let (_store, audit) = test_db().await;
 
-    // Insert audit log (insert_scim_audit now uses AuditStore directly)
-    let audit_id = insert_scim_audit(
+    record_scim_audit(
         &audit,
         "CREATE",
         "User",
@@ -480,16 +479,20 @@ async fn test_scim_audit_logging() {
         Some("Created user via SCIM"),
         Some("example.com"),
     )
-    .await
-    .expect("Failed to insert audit log");
+    .await;
 
-    assert!(!audit_id.is_empty());
+    // Record another audit log without token or org domain (None is valid)
+    record_scim_audit(&audit, "DELETE", "User", "user-789", None, None, None).await;
 
-    // Insert another audit log without token or org domain (None is valid)
-    let audit_id2 = insert_scim_audit(&audit, "DELETE", "User", "user-789", None, None, None)
+    // The write is best-effort (failures are swallowed), so assert both
+    // rows landed by querying them back.
+    let events = audit
+        .query_events(&AuditEventFilter {
+            event_types: Some(vec!["scim_operation".to_string()]),
+            ..AuditEventFilter::default()
+        })
         .await
-        .expect("Failed to insert audit log");
-
-    assert!(!audit_id2.is_empty());
-    assert_ne!(audit_id, audit_id2);
+        .expect("query audit events");
+    assert_eq!(events.len(), 2, "both SCIM audit rows must be stored");
+    assert_ne!(events[0].id, events[1].id);
 }

--- a/crates/vouch-server/src/handlers/admin/domains.rs
+++ b/crates/vouch-server/src/handlers/admin/domains.rs
@@ -196,18 +196,15 @@ pub(crate) async fn admin_add_domain(
                 admin_user_id: &admin.id,
                 method: None,
             };
-            if let Err(e) = state
+            state
                 .audit
-                .insert_event(
+                .record_event(
                     db::AuditEventKind::OrgDomainAdded,
                     Some(&admin.id),
                     Some(&admin.email),
                     &data,
                 )
-                .await
-            {
-                tracing::warn!(error = %e, "failed to write org_domain_added audit event");
-            }
+                .await;
             tracing::info!(
                 admin_email = %admin.email,
                 org_id = %org_id,
@@ -360,18 +357,15 @@ pub(crate) async fn admin_verify_domain(
                 admin_user_id: &admin.id,
                 method: Some("dns_txt"),
             };
-            if let Err(e) = state
+            state
                 .audit
-                .insert_event(
+                .record_event(
                     db::AuditEventKind::OrgDomainVerified,
                     Some(&admin.id),
                     Some(&admin.email),
                     &data,
                 )
-                .await
-            {
-                tracing::warn!(error = %e, "failed to write org_domain_verified audit event");
-            }
+                .await;
             tracing::info!(
                 admin_email = %admin.email,
                 org_id = %org_id,
@@ -439,18 +433,15 @@ pub(crate) async fn admin_remove_domain(
                 revocation_errored: errored,
                 released_subdomain: summary.released_subdomain.clone(),
             };
-            if let Err(e) = state
+            state
                 .audit
-                .insert_event(
+                .record_event(
                     db::AuditEventKind::OrgDomainRemoved,
                     Some(&admin.id),
                     Some(&admin.email),
                     &data,
                 )
-                .await
-            {
-                tracing::warn!(error = %e, "failed to write org_domain_removed audit event");
-            }
+                .await;
             tracing::info!(
                 admin_email = %admin.email,
                 org_id = %org_id,

--- a/crates/vouch-server/src/handlers/admin/members.rs
+++ b/crates/vouch-server/src/handlers/admin/members.rs
@@ -129,18 +129,15 @@ pub(crate) async fn promote_member(
         admin_user_id: &admin.id,
         keys_revoked: None,
     };
-    if let Err(e) = state
+    state
         .audit
-        .insert_event(
+        .record_event(
             db::AuditEventKind::AdminPromote,
             Some(&admin.id),
             Some(&target.email),
             &data,
         )
-        .await
-    {
-        tracing::warn!(error = %e, "failed to write admin_promote audit event");
-    }
+        .await;
 
     tracing::info!(
         "Admin {} promoted {} to org admin",
@@ -179,18 +176,15 @@ pub(crate) async fn demote_member(
         admin_user_id: &admin.id,
         keys_revoked: None,
     };
-    if let Err(e) = state
+    state
         .audit
-        .insert_event(
+        .record_event(
             db::AuditEventKind::AdminDemote,
             Some(&admin.id),
             Some(&target.email),
             &data,
         )
-        .await
-    {
-        tracing::warn!(error = %e, "failed to write admin_demote audit event");
-    }
+        .await;
 
     tracing::info!(
         "Admin {} demoted {} from org admin",
@@ -244,18 +238,15 @@ pub(crate) async fn deactivate_member(
         admin_user_id: &admin.id,
         keys_revoked: None,
     };
-    if let Err(e) = state
+    state
         .audit
-        .insert_event(
+        .record_event(
             db::AuditEventKind::AdminDeactivate,
             Some(&admin.id),
             Some(&target.email),
             &data,
         )
-        .await
-    {
-        tracing::warn!(error = %e, "failed to write admin_deactivate audit event");
-    }
+        .await;
 
     tracing::info!("Admin {} deactivated user {}", admin.email, target.email);
 
@@ -281,18 +272,15 @@ pub(crate) async fn activate_member(
         admin_user_id: &admin.id,
         keys_revoked: None,
     };
-    if let Err(e) = state
+    state
         .audit
-        .insert_event(
+        .record_event(
             db::AuditEventKind::AdminActivate,
             Some(&admin.id),
             Some(&target.email),
             &data,
         )
-        .await
-    {
-        tracing::warn!(error = %e, "failed to write admin_activate audit event");
-    }
+        .await;
 
     tracing::info!("Admin {} reactivated user {}", admin.email, target.email);
 
@@ -352,18 +340,15 @@ pub(crate) async fn revoke_member_credentials(
         admin_user_id: &admin.id,
         keys_revoked: Some(key_count),
     };
-    if let Err(e) = state
+    state
         .audit
-        .insert_event(
+        .record_event(
             db::AuditEventKind::AdminRevokeCredentials,
             Some(&admin.id),
             Some(&target.email),
             &data,
         )
-        .await
-    {
-        tracing::warn!(error = %e, "failed to write admin_revoke_credentials audit event");
-    }
+        .await;
 
     tracing::info!(
         "Admin {} revoked {} credentials for user {}",
@@ -421,18 +406,15 @@ pub(crate) async fn remove_member(
         admin_user_id: &admin.id,
         keys_revoked: None,
     };
-    if let Err(e) = state
+    state
         .audit
-        .insert_event(
+        .record_event(
             db::AuditEventKind::AdminRemoveUser,
             Some(&admin.id),
             Some(&target_email),
             &data,
         )
-        .await
-    {
-        tracing::warn!(error = %e, "failed to write admin_remove_user audit event");
-    }
+        .await;
 
     tracing::info!(
         "Admin {} removed user {} from organization",

--- a/crates/vouch-server/src/handlers/admin/policies.rs
+++ b/crates/vouch-server/src/handlers/admin/policies.rs
@@ -231,18 +231,15 @@ pub(crate) async fn toggle_preconfigured_policy(
         slug: &slug,
         admin_user_id: &admin.id,
     };
-    if let Err(e) = state
+    state
         .audit
-        .insert_event(
+        .record_event(
             db::AuditEventKind::AdminPolicyToggle,
             Some(&admin.id),
             Some(&admin.email),
             &data,
         )
-        .await
-    {
-        tracing::warn!(error = %e, "failed to write admin_policy_toggle audit event");
-    }
+        .await;
 
     tracing::info!(
         "Admin {} {} preconfigured policy '{}'",
@@ -385,18 +382,15 @@ pub(crate) async fn create_custom_policy(
         admin_user_id: &admin.id,
         policy_text_hash: Some(policy_hash),
     };
-    if let Err(e) = state
+    state
         .audit
-        .insert_event(
+        .record_event(
             db::AuditEventKind::AdminPolicyCreate,
             Some(&admin.id),
             Some(&admin.email),
             &data,
         )
-        .await
-    {
-        tracing::warn!(error = %e, "failed to write admin_policy_create audit event");
-    }
+        .await;
 
     tracing::info!(
         "Admin {} created custom policy '{}'",
@@ -492,18 +486,15 @@ pub(crate) async fn update_custom_policy(
         admin_user_id: &admin.id,
         policy_text_hash: Some(policy_hash),
     };
-    if let Err(e) = state
+    state
         .audit
-        .insert_event(
+        .record_event(
             db::AuditEventKind::AdminPolicyUpdate,
             Some(&admin.id),
             Some(&admin.email),
             &data,
         )
-        .await
-    {
-        tracing::warn!(error = %e, "failed to write admin_policy_update audit event");
-    }
+        .await;
 
     tracing::info!("Admin {} updated custom policy '{}'", admin.email, id);
 
@@ -540,18 +531,15 @@ pub(crate) async fn delete_custom_policy(
         admin_user_id: &admin.id,
         policy_text_hash: None,
     };
-    if let Err(e) = state
+    state
         .audit
-        .insert_event(
+        .record_event(
             db::AuditEventKind::AdminPolicyDelete,
             Some(&admin.id),
             Some(&admin.email),
             &data,
         )
-        .await
-    {
-        tracing::warn!(error = %e, "failed to write admin_policy_delete audit event");
-    }
+        .await;
 
     tracing::info!("Admin {} deleted custom policy '{}'", admin.email, id);
 
@@ -650,18 +638,15 @@ pub(crate) async fn toggle_custom_policy(
         admin_user_id: &admin.id,
         policy_text_hash: Some(policy_hash),
     };
-    if let Err(e) = state
+    state
         .audit
-        .insert_event(
+        .record_event(
             db::AuditEventKind::AdminPolicyToggle,
             Some(&admin.id),
             Some(&admin.email),
             &data,
         )
-        .await
-    {
-        tracing::warn!(error = %e, "failed to write admin_policy_toggle audit event");
-    }
+        .await;
 
     tracing::info!(
         "Admin {} {} custom policy '{}'",

--- a/crates/vouch-server/src/handlers/admin/scim_tokens.rs
+++ b/crates/vouch-server/src/handlers/admin/scim_tokens.rs
@@ -187,18 +187,15 @@ pub(crate) async fn admin_create_scim_token(
         token_id: &token_id,
         admin_user_id: &admin.id,
     };
-    if let Err(e) = state
+    state
         .audit
-        .insert_event(
+        .record_event(
             db::AuditEventKind::AdminCreateScimToken,
             Some(&admin.id),
             Some(&admin.email),
             &data,
         )
-        .await
-    {
-        tracing::warn!(error = %e, "failed to write admin_create_scim_token audit event");
-    }
+        .await;
 
     tracing::info!(
         "Admin {} created SCIM token {} for org {}",
@@ -258,18 +255,15 @@ pub(crate) async fn admin_revoke_scim_token(
         token_id: &token_id,
         admin_user_id: &admin.id,
     };
-    if let Err(e) = state
+    state
         .audit
-        .insert_event(
+        .record_event(
             db::AuditEventKind::AdminRevokeScimToken,
             Some(&admin.id),
             Some(&admin.email),
             &data,
         )
-        .await
-    {
-        tracing::warn!(error = %e, "failed to write admin_revoke_scim_token audit event");
-    }
+        .await;
 
     tracing::info!(
         "Admin {} revoked SCIM token {} for org {}",

--- a/crates/vouch-server/src/handlers/admin/subdomain.rs
+++ b/crates/vouch-server/src/handlers/admin/subdomain.rs
@@ -325,18 +325,15 @@ pub(crate) async fn admin_claim_subdomain(
         issuer: issuer.as_deref(),
         admin_user_id: &admin.id,
     };
-    if let Err(e) = state
+    state
         .audit
-        .insert_event(
+        .record_event(
             db::AuditEventKind::OrgSubdomainClaimed,
             Some(&admin.id),
             Some(&admin.email),
             &data,
         )
-        .await
-    {
-        tracing::warn!(error = %e, "failed to write org_subdomain_claimed audit event");
-    }
+        .await;
 
     tracing::info!(
         admin_email = %admin.email,
@@ -397,18 +394,15 @@ pub(crate) async fn admin_release_subdomain(
         label: &released,
         admin_user_id: &admin.id,
     };
-    if let Err(e) = state
+    state
         .audit
-        .insert_event(
+        .record_event(
             db::AuditEventKind::OrgSubdomainReleased,
             Some(&admin.id),
             Some(&admin.email),
             &data,
         )
-        .await
-    {
-        tracing::warn!(error = %e, "failed to write org_subdomain_released audit event");
-    }
+        .await;
 
     tracing::info!(
         admin_email = %admin.email,

--- a/crates/vouch-server/src/handlers/api/org/audit.rs
+++ b/crates/vouch-server/src/handlers/api/org/audit.rs
@@ -34,11 +34,11 @@ const DEFAULT_PAGE_SIZE: u64 = 500;
 const MAX_PAGE_SIZE: u64 = 1000;
 
 /// Events with `created_at` newer than `now - LAG_WINDOW_SECONDS` are never
-/// returned. Auth events are written from detached tasks (see
-/// `db/config.rs`), so commit order can trail id order by a few seconds
-/// under load; a naive high-water-mark poller would otherwise miss events
+/// returned. Every audit write is awaited before its request responds, but
+/// concurrent requests can still commit in a different order than they
+/// minted ids; a naive high-water-mark poller would otherwise miss events
 /// that commit late. This window — documented as the delivery guarantee in
-/// `docs/src/admin/audit.md` — is comfortably larger than that lag.
+/// `docs/src/admin/audit.md` — is comfortably larger than that skew.
 const LAG_WINDOW_SECONDS: i64 = 30;
 
 /// Byte budget for a single NDJSON response body. Keeps responses well

--- a/crates/vouch-server/src/handlers/api/org/scim_tokens.rs
+++ b/crates/vouch-server/src/handlers/api/org/scim_tokens.rs
@@ -139,18 +139,15 @@ pub(crate) async fn create_scim_token(
         token_id: &token_id,
         admin_user_id: &user.id,
     };
-    if let Err(e) = state
+    state
         .audit
-        .insert_event(
+        .record_event(
             db::AuditEventKind::AdminCreateScimToken,
             Some(&user.id),
             Some(&user.email),
             &data,
         )
-        .await
-    {
-        tracing::warn!(error = %e, "failed to write admin_create_scim_token audit event");
-    }
+        .await;
 
     tracing::info!("Created SCIM token: {} for org: {}", token_id, org_id);
 
@@ -215,18 +212,15 @@ pub(crate) async fn delete_scim_token(
         token_id: &token_id,
         admin_user_id: &user.id,
     };
-    if let Err(e) = state
+    state
         .audit
-        .insert_event(
+        .record_event(
             db::AuditEventKind::AdminDeleteScimToken,
             Some(&user.id),
             Some(&user.email),
             &data,
         )
-        .await
-    {
-        tracing::warn!(error = %e, "failed to write admin_delete_scim_token audit event");
-    }
+        .await;
 
     tracing::info!("Deleted SCIM token: {}", token_id);
 

--- a/crates/vouch-server/src/handlers/auth.rs
+++ b/crates/vouch-server/src/handlers/auth.rs
@@ -157,7 +157,7 @@ pub(crate) async fn logout(
                     state.session_cache.invalidate(&token_hash);
                     tracing::info!("Session deleted during logout");
 
-                    // Fire-and-forget logout audit event
+                    // Best-effort logout audit event
                     if let Some(session) = session_info {
                         let params = db::AuthEventParams {
                             user_id: session.user_id.clone(),
@@ -166,7 +166,7 @@ pub(crate) async fn logout(
                             client: client_info,
                             ..Default::default()
                         };
-                        db::spawn_audit_event(&state.audit, params, Some(session.user_email));
+                        db::record_auth_event(&state.audit, params, Some(session.user_email)).await;
                     }
                 }
             }

--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -523,6 +523,29 @@ pub(crate) async fn browser_login_start(
     }))
 }
 
+/// Record a failed browser-login attempt. The email feeds the audit row's
+/// `email_domain`/`email_hmac` columns (never stored raw); without it the
+/// event is invisible to org-scoped audit queries, which filter on domain.
+async fn log_login_failure(
+    audit: &db::audit::AuditStore,
+    client: ClientInfo,
+    user_id: &str,
+    email: Option<&str>,
+    authenticator_id: Option<&str>,
+    reason: &str,
+) {
+    let params = AuthEventParams {
+        user_id: user_id.to_string(),
+        event_type: AuthEventType::LoginFailed,
+        authenticator_id: authenticator_id.map(String::from),
+        success: false,
+        failure_reason: Some(reason.to_string()),
+        client,
+        ..AuthEventParams::default()
+    };
+    db::record_auth_event(audit, params, email.map(String::from)).await;
+}
+
 /// POST /login/webauthn/complete
 ///
 /// Verify WebAuthn assertion and create session.
@@ -576,26 +599,9 @@ pub(crate) async fn browser_login_complete(
         expires_at: _,
     } = checked;
 
-    // Helper to log failed login attempts. The email feeds the audit row's
-    // `email_domain`/`email_hmac` columns (never stored raw); without it the
-    // event is invisible to org-scoped audit queries, which filter on domain.
-    let log_failure =
-        |user_id: &str, email: Option<&str>, authenticator_id: Option<&str>, reason: &str| {
-            let params = AuthEventParams {
-                user_id: user_id.to_string(),
-                event_type: AuthEventType::LoginFailed,
-                authenticator_id: authenticator_id.map(String::from),
-                success: false,
-                failure_reason: Some(reason.to_string()),
-                client: client_info.clone(),
-                ..AuthEventParams::default()
-            };
-            db::spawn_audit_event(&state.audit, params, email.map(String::from));
-        };
-
     // Look up authenticator and verify ownership (single JOIN query)
     use crate::services::auth::{AuthenticatorLookupParams, lookup_and_verify_authenticator};
-    let lookup_result = lookup_and_verify_authenticator(
+    let lookup_result = match lookup_and_verify_authenticator(
         &state,
         AuthenticatorLookupParams {
             credential_id: req.credential_id.as_bytes(),
@@ -603,23 +609,34 @@ pub(crate) async fn browser_login_complete(
         },
     )
     .await
-    .map_err(|e| {
-        let reason = match &e {
-            crate::error::ServiceError::NotFound(entity) => {
-                format!("{entity}_not_found")
-            }
-            crate::error::ServiceError::Forbidden(_) => "user_mismatch".to_string(),
-            _ => "lookup_error".to_string(),
-        };
-        // Credential lookup failed — no user row was loaded, so no email.
-        log_failure(&user_id.to_string(), None, None, &reason);
-        // Return generic error to prevent credential enumeration
-        ServiceError::api(
-            StatusCode::UNAUTHORIZED,
-            "auth_failed",
-            Tr::new("login-error-auth-failed").to_string(),
-        )
-    })?;
+    {
+        Ok(result) => result,
+        Err(e) => {
+            let reason = match &e {
+                crate::error::ServiceError::NotFound(entity) => {
+                    format!("{entity}_not_found")
+                }
+                crate::error::ServiceError::Forbidden(_) => "user_mismatch".to_string(),
+                _ => "lookup_error".to_string(),
+            };
+            // Credential lookup failed — no user row was loaded, so no email.
+            log_login_failure(
+                &state.audit,
+                client_info.clone(),
+                &user_id.to_string(),
+                None,
+                None,
+                &reason,
+            )
+            .await;
+            // Return generic error to prevent credential enumeration
+            return Err(ServiceError::api(
+                StatusCode::UNAUTHORIZED,
+                "auth_failed",
+                Tr::new("login-error-auth-failed").to_string(),
+            ));
+        }
+    };
 
     let authenticator = lookup_result.authenticator;
     let user = lookup_result.user;
@@ -629,7 +646,7 @@ pub(crate) async fn browser_login_complete(
     let stored_counter = u32::try_from(authenticator.counter).unwrap_or(0);
 
     use crate::services::auth::{LoginAssertionParams, verify_login_assertion};
-    let verification_result = verify_login_assertion(LoginAssertionParams {
+    let verification_result = match verify_login_assertion(LoginAssertionParams {
         authenticator_data: req.authenticator_data.into_bytes(),
         client_data_json: req.client_data_json.into_bytes(),
         signature: req.signature.into_bytes(),
@@ -644,19 +661,25 @@ pub(crate) async fn browser_login_complete(
         origin_policy: state.config().as_ref().into(),
     })
     .await
-    .map_err(|e| {
-        log_failure(
-            &user.id,
-            Some(&user.email),
-            Some(&authenticator.id),
-            &e.to_string(),
-        );
-        ServiceError::api(
-            StatusCode::UNAUTHORIZED,
-            "auth_failed",
-            Tr::new("login-error-auth-failed").to_string(),
-        )
-    })?;
+    {
+        Ok(result) => result,
+        Err(e) => {
+            log_login_failure(
+                &state.audit,
+                client_info.clone(),
+                &user.id,
+                Some(&user.email),
+                Some(&authenticator.id),
+                &e.to_string(),
+            )
+            .await;
+            return Err(ServiceError::api(
+                StatusCode::UNAUTHORIZED,
+                "auth_failed",
+                Tr::new("login-error-auth-failed").to_string(),
+            ));
+        }
+    };
 
     tracing::info!(
         "Browser WebAuthn assertion verified for user {}: counter={}, uv={}",
@@ -706,7 +729,7 @@ pub(crate) async fn browser_login_complete(
                 )
             })?;
 
-            db::spawn_audit_event(
+            db::record_auth_event(
                 &state.audit,
                 AuthEventParams {
                     user_id: user.id.clone(),
@@ -717,7 +740,8 @@ pub(crate) async fn browser_login_complete(
                     ..AuthEventParams::default()
                 },
                 Some(user.email.clone()),
-            );
+            )
+            .await;
         } else {
             tracing::warn!(
                 target: "security",
@@ -787,7 +811,7 @@ pub(crate) async fn browser_login_complete(
     })?;
     let token = session_result.token;
 
-    // Log successful login event (fire-and-forget, consistent with failure path)
+    // Log successful login event (consistent with failure path)
     let auth_event_params = AuthEventParams {
         user_id: user.id.clone(),
         event_type: AuthEventType::LoginSuccess,
@@ -796,7 +820,7 @@ pub(crate) async fn browser_login_complete(
         client: client_info,
         ..AuthEventParams::default()
     };
-    db::spawn_audit_event(&state.audit, auth_event_params, Some(user.email.clone()));
+    db::record_auth_event(&state.audit, auth_event_params, Some(user.email.clone())).await;
 
     crate::infra::metrics::record_auth_event("browser_login_success");
 
@@ -1656,25 +1680,19 @@ mod tests {
             "invalid signature must fail authentication: {resp_body}"
         );
 
-        // The audit event is spawned fire-and-forget; poll briefly.
+        // The audit event is awaited before the response, so it is
+        // visible immediately.
         let filter = crate::db::AuditEventFilter {
             event_types: Some(vec!["login_failed".to_string()]),
             email_domains: Some(vec!["example.com".to_string()]),
             user_id: Some(user.id.clone()),
             ..crate::db::AuditEventFilter::default()
         };
-        let mut events = Vec::new();
-        for _ in 0..100 {
-            events = state
-                .audit
-                .query_events(&filter)
-                .await
-                .expect("query audit events");
-            if !events.is_empty() {
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        }
+        let events = state
+            .audit
+            .query_events(&filter)
+            .await
+            .expect("query audit events");
         assert_eq!(
             events.len(),
             1,

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -1382,39 +1382,35 @@ pub(crate) async fn browser_register_complete(
     // state JWT cannot be replayed within the 5-minute validity window.
     // The witness is threaded into TokenIssuanceProof below — the only
     // path to `GrantProof::EnrollmentComplete`.
-    let registration_claim = match key_svc::consume_registration_state(&state.store, &checked)
-        .await?
-    {
-        key_svc::RegistrationStateConsumed::Won(claim) => claim,
-        key_svc::RegistrationStateConsumed::Replay => {
-            tracing::warn!(
-                user_id = %checked.reg_state.user_id,
-                "browser registration state replay rejected"
-            );
-            let audit_data = crate::db::documents::audit::RegistrationReplayData {
-                flow: "browser_register",
-                success: false,
-                error_code: "state_already_used",
-            };
-            if let Err(e) = state
-                .audit
-                .insert_event(
-                    db::AuditEventKind::KeyRegistrationReplay,
-                    Some(&checked.reg_state.user_id.to_string()),
-                    Some(&checked.reg_state.user_email),
-                    &audit_data,
-                )
-                .await
-            {
-                tracing::warn!(error = %e, "failed to write key_registration_replay audit event");
+    let registration_claim =
+        match key_svc::consume_registration_state(&state.store, &checked).await? {
+            key_svc::RegistrationStateConsumed::Won(claim) => claim,
+            key_svc::RegistrationStateConsumed::Replay => {
+                tracing::warn!(
+                    user_id = %checked.reg_state.user_id,
+                    "browser registration state replay rejected"
+                );
+                let audit_data = crate::db::documents::audit::RegistrationReplayData {
+                    flow: "browser_register",
+                    success: false,
+                    error_code: "state_already_used",
+                };
+                state
+                    .audit
+                    .record_event(
+                        db::AuditEventKind::KeyRegistrationReplay,
+                        Some(&checked.reg_state.user_id.to_string()),
+                        Some(&checked.reg_state.user_email),
+                        &audit_data,
+                    )
+                    .await;
+                return Err(ServiceError::api(
+                    StatusCode::BAD_REQUEST,
+                    "state_already_used",
+                    Tr::new("enroll-error-registration-link-used").to_string(),
+                ));
             }
-            return Err(ServiceError::api(
-                StatusCode::BAD_REQUEST,
-                "state_already_used",
-                Tr::new("enroll-error-registration-link-used").to_string(),
-            ));
-        }
-    };
+        };
 
     let RegistrationCompletion {
         req,

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -797,7 +797,7 @@ pub(crate) async fn complete_enrollment_after_identity(
                 client: client_info,
                 ..Default::default()
             };
-            db::spawn_audit_event(&state.audit, event, Some(identity.email.clone()));
+            db::record_auth_event(&state.audit, event, Some(identity.email.clone())).await;
             return ErrorTemplate {
                 title: Tr::new("enroll-error-identity-conflict-title").to_string(),
                 message: Tr::new("enroll-error-identity-conflict").to_string(),
@@ -823,7 +823,7 @@ pub(crate) async fn complete_enrollment_after_identity(
                 client: client_info,
                 ..Default::default()
             };
-            db::spawn_audit_event(&state.audit, event, Some(email));
+            db::record_auth_event(&state.audit, event, Some(email)).await;
             return ErrorTemplate {
                 title: Tr::new("enroll-error-account-deactivated-title").to_string(),
                 message: Tr::new("enroll-error-account-deactivated").to_string(),
@@ -867,7 +867,7 @@ pub(crate) async fn complete_enrollment_after_identity(
             client: client_info.clone(),
             ..Default::default()
         };
-        db::spawn_audit_event(&state.audit, event, Some(user.email.clone()));
+        db::record_auth_event(&state.audit, event, Some(user.email.clone())).await;
     }
 
     // Create session for this user (using session cookie instead of enrollment cookie)
@@ -1041,7 +1041,7 @@ pub(crate) async fn complete_enrollment_after_identity(
             client: client_info,
             ..Default::default()
         };
-        db::spawn_audit_event(&state.audit, event, Some(user.email.clone()));
+        db::record_auth_event(&state.audit, event, Some(user.email.clone())).await;
     }
 
     // No explicit state delete here — `try_consume_oidc_state` already
@@ -1556,10 +1556,10 @@ pub(crate) async fn browser_register_complete(
             client: client_info.clone(),
             ..Default::default()
         };
-        db::spawn_audit_event(&state.audit, event, Some(reg_state.user_email.clone()));
+        db::record_auth_event(&state.audit, event, Some(reg_state.user_email.clone())).await;
     }
 
-    // Log enrollment event (fire-and-forget)
+    // Log enrollment event
     let auth_event_params = AuthEventParams {
         user_id: reg_state.user_id.to_string(),
         event_type: AuthEventType::Enrollment,
@@ -1568,11 +1568,12 @@ pub(crate) async fn browser_register_complete(
         client: client_info,
         ..AuthEventParams::default()
     };
-    db::spawn_audit_event(
+    db::record_auth_event(
         &state.audit,
         auth_event_params,
         Some(reg_state.user_email.clone()),
-    );
+    )
+    .await;
 
     crate::infra::metrics::record_auth_event("enrollment");
 

--- a/crates/vouch-server/src/handlers/enroll/tests.rs
+++ b/crates/vouch-server/src/handlers/enroll/tests.rs
@@ -427,31 +427,23 @@ async fn seed_and_consume_oidc_state(
         .expect("consume oidc state")
 }
 
-/// Poll the audit store for events of `event_type` for the user. Audit
-/// writes are spawned on a detached task, so the first read can race
-/// the write; retry briefly before returning whatever was found.
-async fn wait_for_audit_events(
+/// Query the audit store for events of `event_type` for the user. Audit
+/// writes are awaited before the handler responds, so the rows are
+/// visible immediately.
+async fn audit_events_for(
     state: &AppState,
     event_type: &str,
     user_id: &str,
 ) -> Vec<crate::db::AuditEvent> {
-    let mut events = Vec::new();
-    for _ in 0..40 {
-        events = state
-            .audit
-            .query_events(&crate::db::AuditEventFilter {
-                event_types: Some(vec![event_type.to_string()]),
-                user_id: Some(user_id.to_string()),
-                ..Default::default()
-            })
-            .await
-            .expect("query audit events");
-        if !events.is_empty() {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    }
-    events
+    state
+        .audit
+        .query_events(&crate::db::AuditEventFilter {
+            event_types: Some(vec![event_type.to_string()]),
+            user_id: Some(user_id.to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("query audit events")
 }
 
 #[tokio::test]
@@ -480,7 +472,7 @@ async fn test_direct_web_signin_returning_user_logs_login_success_with_ip() {
         complete_enrollment_after_identity(&state, &stored, identity, claim, client_info).await;
     assert_eq!(resp.status(), StatusCode::SEE_OTHER);
 
-    let events = wait_for_audit_events(&state, "login_success", &user.id).await;
+    let events = audit_events_for(&state, "login_success", &user.id).await;
     assert_eq!(events.len(), 1, "one direct sign-in -> one login_success");
     let event = events.first().expect("login_success event");
     let data: serde_json::Value = serde_json::from_str(&event.data).expect("event data JSON");
@@ -770,7 +762,7 @@ async fn test_identity_conflict_renders_error_and_audits() {
         "a refused login must not set a session cookie"
     );
 
-    let events = wait_for_audit_events(&state, "identity_bind_refused", &victim.id).await;
+    let events = audit_events_for(&state, "identity_bind_refused", &victim.id).await;
     assert_eq!(events.len(), 1, "one refusal -> one audit event");
     let event = events.first().expect("identity_bind_refused event");
     let data: serde_json::Value = serde_json::from_str(&event.data).expect("event data JSON");
@@ -827,7 +819,7 @@ async fn test_non_durable_login_refused_once_issuer_is_bound() {
         "a refused login must not set a session cookie"
     );
 
-    let events = wait_for_audit_events(&state, "identity_bind_refused", &victim.id).await;
+    let events = audit_events_for(&state, "identity_bind_refused", &victim.id).await;
     assert_eq!(events.len(), 1, "one refusal -> one audit event");
     let event = events.first().expect("identity_bind_refused event");
     let data: serde_json::Value = serde_json::from_str(&event.data).expect("event data JSON");
@@ -859,7 +851,7 @@ async fn test_lazy_bind_emits_identity_bound_event() {
             .await;
     assert_eq!(resp.status(), StatusCode::SEE_OTHER);
 
-    let events = wait_for_audit_events(&state, "identity_bound", &user.id).await;
+    let events = audit_events_for(&state, "identity_bound", &user.id).await;
     assert_eq!(events.len(), 1, "first IdP login -> one identity_bound");
     let event = events.first().expect("identity_bound event");
     let data: serde_json::Value = serde_json::from_str(&event.data).expect("event data JSON");
@@ -948,9 +940,8 @@ async fn test_direct_web_enrollment_new_user_emits_no_login_event() {
         "fresh enrollee must be sent to register a first key, got {location}"
     );
 
-    // Audit writes are spawned; give the runtime a moment before
-    // asserting absence.
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    // Audit writes are awaited before the handler responds, so absence
+    // here is conclusive.
     let events = state
         .audit
         .query_events(&crate::db::AuditEventFilter::default())

--- a/crates/vouch-server/src/handlers/enroll_keys.rs
+++ b/crates/vouch-server/src/handlers/enroll_keys.rs
@@ -133,7 +133,7 @@ pub(crate) async fn delete_key(
         client: client_info,
         ..Default::default()
     };
-    db::spawn_audit_event(&state.audit, event, token.email.clone());
+    db::record_auth_event(&state.audit, event, token.email.clone()).await;
 
     Ok(Json(DeleteKeyResponse {
         message: format!("Key '{}' has been deleted", key_name),

--- a/crates/vouch-server/src/handlers/keys.rs
+++ b/crates/vouch-server/src/handlers/keys.rs
@@ -375,7 +375,7 @@ pub(crate) async fn register_complete(
         client: client_info,
         ..Default::default()
     };
-    db::spawn_audit_event(&state.audit, event, Some(reg_state.user_name.clone()));
+    db::record_auth_event(&state.audit, event, Some(reg_state.user_name.clone())).await;
 
     Ok(Json(RegisterCompleteResponse {
         device_id: Uuid::parse_str(&device_id).map_err(|e| {
@@ -467,7 +467,7 @@ pub(crate) async fn delete_key(
         client: client_info,
         ..Default::default()
     };
-    db::spawn_audit_event(&state.audit, event, token.email.clone());
+    db::record_auth_event(&state.audit, event, token.email.clone()).await;
 
     Ok(Json(DeleteKeyResponse {
         message: format!("Key '{}' has been deleted", key_name),

--- a/crates/vouch-server/src/handlers/keys.rs
+++ b/crates/vouch-server/src/handlers/keys.rs
@@ -263,18 +263,15 @@ pub(crate) async fn register_complete(
                 success: false,
                 error_code: "state_already_used",
             };
-            if let Err(e) = state
+            state
                 .audit
-                .insert_event(
+                .record_event(
                     db::AuditEventKind::KeyRegistrationReplay,
                     Some(&checked.reg_state.user_id.to_string()),
                     Some(&checked.reg_state.user_name),
                     &audit_data,
                 )
-                .await
-            {
-                tracing::warn!(error = %e, "failed to write key_registration_replay audit event");
-            }
+                .await;
             return Err(ServiceError::api(
                 StatusCode::BAD_REQUEST,
                 "state_already_used",

--- a/crates/vouch-server/src/handlers/oidc/logout.rs
+++ b/crates/vouch-server/src/handlers/oidc/logout.rs
@@ -493,7 +493,7 @@ async fn clear_user_session(
                         client: client_info,
                         ..Default::default()
                     };
-                    db::spawn_audit_event(&state.audit, params, Some(session.user_email));
+                    db::record_auth_event(&state.audit, params, Some(session.user_email)).await;
                 }
             }
         }

--- a/crates/vouch-server/src/handlers/scim/groups.rs
+++ b/crates/vouch-server/src/handlers/scim/groups.rs
@@ -99,7 +99,7 @@ pub(crate) async fn list_groups(
     }
 
     // Audit log
-    if let Err(e) = db::insert_scim_audit(
+    db::record_scim_audit(
         &state.audit,
         "list",
         "Group",
@@ -108,10 +108,7 @@ pub(crate) async fn list_groups(
         Some(&format!("{{\"count\": {}}}", resources.len())),
         auth.org_domain.as_deref(),
     )
-    .await
-    {
-        tracing::warn!("Failed to record SCIM audit: {e}");
-    }
+    .await;
 
     Json(ScimListResponse {
         schemas: vec![urn::LIST_RESPONSE.to_string()],
@@ -248,7 +245,7 @@ pub(crate) async fn create_group(
     }
 
     // Audit log
-    if let Err(e) = db::insert_scim_audit(
+    db::record_scim_audit(
         &state.audit,
         "create",
         "Group",
@@ -257,10 +254,7 @@ pub(crate) async fn create_group(
         Some(&serde_json::json!({"displayName": &db_group.display_name}).to_string()),
         auth.org_domain.as_deref(),
     )
-    .await
-    {
-        tracing::warn!("Failed to record SCIM audit: {e}");
-    }
+    .await;
 
     let base_url = &state.config().base_url;
     let Ok(members) =
@@ -568,7 +562,7 @@ pub(crate) async fn patch_group(
     }
 
     // Audit log
-    if let Err(e) = db::insert_scim_audit(
+    db::record_scim_audit(
         &state.audit,
         "update",
         "Group",
@@ -577,10 +571,7 @@ pub(crate) async fn patch_group(
         None,
         auth.org_domain.as_deref(),
     )
-    .await
-    {
-        tracing::warn!("Failed to record SCIM audit: {e}");
-    }
+    .await;
 
     // Return updated group
     let updated = match db::get_scim_group(&state.store, &id, &auth.org_id).await {
@@ -657,7 +648,7 @@ pub(crate) async fn delete_group(
     }
 
     // Audit log
-    if let Err(e) = db::insert_scim_audit(
+    db::record_scim_audit(
         &state.audit,
         "delete",
         "Group",
@@ -666,10 +657,7 @@ pub(crate) async fn delete_group(
         Some(&serde_json::json!({"displayName": &group.display_name}).to_string()),
         auth.org_domain.as_deref(),
     )
-    .await
-    {
-        tracing::warn!("Failed to record SCIM audit: {e}");
-    }
+    .await;
 
     StatusCode::NO_CONTENT.into_response()
 }

--- a/crates/vouch-server/src/handlers/scim/users.rs
+++ b/crates/vouch-server/src/handlers/scim/users.rs
@@ -95,7 +95,7 @@ pub(crate) async fn list_users(
         .collect();
 
     // Audit log
-    if let Err(e) = db::insert_scim_audit(
+    db::record_scim_audit(
         &state.audit,
         "list",
         "User",
@@ -104,10 +104,7 @@ pub(crate) async fn list_users(
         Some(&format!("{{\"count\": {}}}", resources.len())),
         auth.org_domain.as_deref(),
     )
-    .await
-    {
-        tracing::warn!("Failed to record SCIM audit: {e}");
-    }
+    .await;
 
     Json(ScimListResponse {
         schemas: vec![urn::LIST_RESPONSE.to_string()],
@@ -270,7 +267,7 @@ pub(crate) async fn create_user(
     };
 
     // Audit log
-    if let Err(e) = db::insert_scim_audit(
+    db::record_scim_audit(
         &state.audit,
         "create",
         "User",
@@ -279,10 +276,7 @@ pub(crate) async fn create_user(
         None,
         auth.org_domain.as_deref(),
     )
-    .await
-    {
-        tracing::warn!("Failed to record SCIM audit: {e}");
-    }
+    .await;
 
     let base_url = &state.config().base_url;
     let scim_user = db_user_to_scim(base_url, db_user);
@@ -512,7 +506,7 @@ pub(crate) async fn patch_user(
     }
 
     // Audit log
-    if let Err(e) = db::insert_scim_audit(
+    db::record_scim_audit(
         &state.audit,
         "update",
         "User",
@@ -524,10 +518,7 @@ pub(crate) async fn patch_user(
         ),
         auth.org_domain.as_deref(),
     )
-    .await
-    {
-        tracing::warn!("Failed to record SCIM audit: {e}");
-    }
+    .await;
 
     // Return updated user
     let updated = match db::get_scim_user(&state.store, &id, &auth.org_id).await {
@@ -633,7 +624,7 @@ pub(crate) async fn delete_user(
     }
 
     // Audit log
-    if let Err(e) = db::insert_scim_audit(
+    db::record_scim_audit(
         &state.audit,
         "delete",
         "User",
@@ -642,10 +633,7 @@ pub(crate) async fn delete_user(
         None,
         auth.org_domain.as_deref(),
     )
-    .await
-    {
-        tracing::warn!("Failed to record SCIM audit: {e}");
-    }
+    .await;
 
     StatusCode::NO_CONTENT.into_response()
 }

--- a/crates/vouch-server/src/infra/cleanup.rs
+++ b/crates/vouch-server/src/infra/cleanup.rs
@@ -308,17 +308,14 @@ async fn gc_stale_additional_domains(
                 None
             }
         };
-        if let Err(e) = audit
-            .insert_event_with_domain(
+        audit
+            .record_event_with_domain(
                 db::AuditEventKind::OrgDomainExpired,
                 None,
                 org_domain.as_deref(),
                 &data,
             )
-            .await
-        {
-            tracing::warn!(error = %e, "failed to write org_domain_expired audit event");
-        }
+            .await;
     }
     Ok(())
 }
@@ -434,17 +431,14 @@ async fn recheck_one(store: &DocumentStore, audit: &AuditStore, rec: db::Verifie
                 org_id: &rec.org_id,
                 reason: "consecutive_dns_recheck_failures",
             };
-            if let Err(e) = audit
-                .insert_event_with_domain(
+            audit
+                .record_event_with_domain(
                     db::AuditEventKind::OrgDomainUnverified,
                     None,
                     org_domain.as_deref(),
                     &data,
                 )
-                .await
-            {
-                tracing::warn!(error = %e, "failed to write org_domain_unverified audit event");
-            }
+                .await;
             if let Some(label) = released_subdomain {
                 let data = OrgSubdomainCleanupData {
                     action: "release_subdomain",
@@ -452,20 +446,14 @@ async fn recheck_one(store: &DocumentStore, audit: &AuditStore, rec: db::Verifie
                     org_id: &rec.org_id,
                     reason: "backing_domain_unverified",
                 };
-                if let Err(e) = audit
-                    .insert_event_with_domain(
+                audit
+                    .record_event_with_domain(
                         db::AuditEventKind::OrgSubdomainReleased,
                         None,
                         org_domain.as_deref(),
                         &data,
                     )
-                    .await
-                {
-                    tracing::warn!(
-                        error = %e,
-                        "failed to write org_subdomain_released audit event"
-                    );
-                }
+                    .await;
             }
         }
         Ok(_) => {}

--- a/crates/vouch-server/src/services/oidc/fido2_grant.rs
+++ b/crates/vouch-server/src/services/oidc/fido2_grant.rs
@@ -270,7 +270,7 @@ pub(crate) async fn exchange_fido2_assertion(
     // Cloned for the failure audit event below, since the success path moves
     // `params.client_info` when it records the LoginSuccess event.
     let failure_client_info = params.client_info.clone();
-    let assertion_result = verify_login_assertion(LoginAssertionParams {
+    let assertion_result = match verify_login_assertion(LoginAssertionParams {
         authenticator_data: payload.authenticator_data.into_bytes(),
         client_data_json: payload.client_data_json.into_bytes(),
         signature: payload.signature.into_bytes(),
@@ -285,26 +285,32 @@ pub(crate) async fn exchange_fido2_assertion(
         origin_policy: state.config().as_ref().into(),
     })
     .await
-    .map_err(|e| {
-        tracing::warn!(
-            "FIDO2 assertion grant: assertion verification failed for user {}: {e}",
-            user_id
-        );
-        // A failed assertion — including clone detection (counter regression)
-        // — is a high-signal security event. Record it in the audit trail with
-        // the credential and user IDs and the failure reason.
-        let failure_event = AuthEventParams {
-            user_id: user.id.clone(),
-            event_type: AuthEventType::LoginFailed,
-            authenticator_id: Some(authenticator.id.clone()),
-            success: false,
-            failure_reason: Some(e.to_string()),
-            client: failure_client_info,
-            ..AuthEventParams::default()
-        };
-        db::spawn_audit_event(&state.audit, failure_event, Some(user.email.clone()));
-        ServiceError::oauth(OAuthErrorCode::InvalidGrant, "Authentication failed")
-    })?;
+    {
+        Ok(result) => result,
+        Err(e) => {
+            tracing::warn!(
+                "FIDO2 assertion grant: assertion verification failed for user {}: {e}",
+                user_id
+            );
+            // A failed assertion — including clone detection (counter regression)
+            // — is a high-signal security event. Record it in the audit trail with
+            // the credential and user IDs and the failure reason.
+            let failure_event = AuthEventParams {
+                user_id: user.id.clone(),
+                event_type: AuthEventType::LoginFailed,
+                authenticator_id: Some(authenticator.id.clone()),
+                success: false,
+                failure_reason: Some(e.to_string()),
+                client: failure_client_info,
+                ..AuthEventParams::default()
+            };
+            db::record_auth_event(&state.audit, failure_event, Some(user.email.clone())).await;
+            return Err(ServiceError::oauth(
+                OAuthErrorCode::InvalidGrant,
+                "Authentication failed",
+            ));
+        }
+    };
 
     tracing::info!(
         "FIDO2 assertion grant: verified for user {}, counter={}, uv={}",
@@ -362,11 +368,11 @@ pub(crate) async fn exchange_fido2_assertion(
             client: params.client_info,
             ..AuthEventParams::default()
         };
-        db::spawn_audit_event(&state.audit, failed_event, Some(user.email.clone()));
+        db::record_auth_event(&state.audit, failed_event, Some(user.email.clone())).await;
         return Err(denied);
     }
 
-    // Log the successful auth event (fire-and-forget)
+    // Log the successful auth event
     let auth_event_params = AuthEventParams {
         user_id: user.id.clone(),
         event_type: AuthEventType::LoginSuccess,
@@ -375,7 +381,7 @@ pub(crate) async fn exchange_fido2_assertion(
         client: params.client_info,
         ..AuthEventParams::default()
     };
-    db::spawn_audit_event(&state.audit, auth_event_params, Some(user.email.clone()));
+    db::record_auth_event(&state.audit, auth_event_params, Some(user.email.clone())).await;
 
     // Create OAuth access token
     let scope = params.scope.map_or_else(ScopeSet::all, ScopeSet::parse);

--- a/crates/vouch-server/src/services/oidc/introspection.rs
+++ b/crates/vouch-server/src/services/oidc/introspection.rs
@@ -323,7 +323,7 @@ pub async fn revoke_token(
     };
 
     if revoked {
-        // Fire-and-forget logout audit event
+        // Best-effort logout audit event
         if let Some(ref user_id) = sub {
             let params = db::AuthEventParams {
                 user_id: user_id.clone(),
@@ -332,7 +332,7 @@ pub async fn revoke_token(
                 client: client_info,
                 ..Default::default()
             };
-            db::spawn_audit_event(&state.audit, params, email.clone());
+            db::record_auth_event(&state.audit, params, email.clone()).await;
         }
 
         return RevocationResult {

--- a/crates/vouch-server/src/services/oidc/org_keys/rotation.rs
+++ b/crates/vouch-server/src/services/oidc/org_keys/rotation.rs
@@ -12,7 +12,6 @@ use jiff::{Span, Timestamp};
 use super::{KeyMaterial, ensure_key, generate_key_material, state_priority};
 use crate::AppState;
 use crate::crypto::alg::JwsAlgorithm;
-use crate::db::audit::AuditStore;
 use crate::db::documents::organization::{OrgSigningKeyDoc, OrganizationDoc, SigningKeyState};
 use crate::db::store::StoreTransaction;
 use crate::db::{self};
@@ -135,22 +134,6 @@ pub enum RevokeOutcome {
 pub struct Operator<'a> {
     pub user_id: Option<&'a str>,
     pub email: Option<&'a str>,
-}
-
-/// Insert an audit event, logging (never propagating) failures — audit writes
-/// must not abort a key operation that already committed.
-async fn audit_best_effort<D: db::AuditData>(
-    audit: &AuditStore,
-    kind: db::AuditEventKind,
-    operator: Operator<'_>,
-    data: &D,
-) {
-    if let Err(e) = audit
-        .insert_event(kind, operator.user_id, operator.email, data)
-        .await
-    {
-        tracing::warn!(error = %e, event_type = kind.as_str(), "failed to write audit event");
-    }
 }
 
 /// The instant a key staged at `staged_at` has been published long enough for
@@ -425,19 +408,21 @@ pub async fn rotate_org_keys(
     if let RotateOutcome::Rotated { es256, rs256 } = &outcome {
         state.org_keys_cache.invalidate(org_id);
         for (alg, kids) in [(JwsAlgorithm::Es256, es256), (JwsAlgorithm::Rs256, rs256)] {
-            audit_best_effort(
-                &state.audit,
-                db::AuditEventKind::OrgIssuerKeyRotated,
-                operator,
-                &db::documents::audit::OrgIssuerKeyRotationData {
-                    action: "rotate_org_issuer_key",
-                    org_id,
-                    alg: alg.as_str(),
-                    old_kid: &kids.old_kid,
-                    new_kid: &kids.new_kid,
-                },
-            )
-            .await;
+            state
+                .audit
+                .record_event(
+                    db::AuditEventKind::OrgIssuerKeyRotated,
+                    operator.user_id,
+                    operator.email,
+                    &db::documents::audit::OrgIssuerKeyRotationData {
+                        action: "rotate_org_issuer_key",
+                        org_id,
+                        alg: alg.as_str(),
+                        old_kid: &kids.old_kid,
+                        new_kid: &kids.new_kid,
+                    },
+                )
+                .await;
         }
         tracing::info!(org_id, "rotated org issuer keys");
     }
@@ -537,18 +522,20 @@ pub async fn revoke_org_previous_keys(
             (JwsAlgorithm::Rs256, rs256_kid),
         ] {
             let Some(kid) = kid else { continue };
-            audit_best_effort(
-                &state.audit,
-                db::AuditEventKind::OrgIssuerKeyRevoked,
-                operator,
-                &db::documents::audit::OrgIssuerKeyRevocationData {
-                    action: "revoke_org_issuer_key",
-                    org_id,
-                    alg: alg.as_str(),
-                    kid,
-                },
-            )
-            .await;
+            state
+                .audit
+                .record_event(
+                    db::AuditEventKind::OrgIssuerKeyRevoked,
+                    operator.user_id,
+                    operator.email,
+                    &db::documents::audit::OrgIssuerKeyRevocationData {
+                        action: "revoke_org_issuer_key",
+                        org_id,
+                        alg: alg.as_str(),
+                        kid,
+                    },
+                )
+                .await;
         }
         tracing::info!(org_id, "revoked previous org issuer keys");
     }
@@ -686,19 +673,21 @@ pub async fn emergency_rotate_org_keys(
         (JwsAlgorithm::Es256, &old_es256_kid, &es256.current.kid),
         (JwsAlgorithm::Rs256, &old_rs256_kid, &rs256.current.kid),
     ] {
-        audit_best_effort(
-            &state.audit,
-            db::AuditEventKind::OrgIssuerKeyEmergencyRotation,
-            operator,
-            &db::documents::audit::OrgIssuerKeyRotationData {
-                action: "emergency_rotate_org_issuer_key",
-                org_id,
-                alg: alg.as_str(),
-                old_kid,
-                new_kid,
-            },
-        )
-        .await;
+        state
+            .audit
+            .record_event(
+                db::AuditEventKind::OrgIssuerKeyEmergencyRotation,
+                operator.user_id,
+                operator.email,
+                &db::documents::audit::OrgIssuerKeyRotationData {
+                    action: "emergency_rotate_org_issuer_key",
+                    org_id,
+                    alg: alg.as_str(),
+                    old_kid,
+                    new_kid,
+                },
+            )
+            .await;
     }
 
     tracing::warn!(org_id, "emergency org issuer key rotation completed");

--- a/crates/vouch-server/src/services/policy/mod.rs
+++ b/crates/vouch-server/src/services/policy/mod.rs
@@ -461,9 +461,9 @@ async fn record_denial(
         policy,
         org_id,
     };
-    if let Err(e) = state
+    state
         .audit
-        .insert_event(
+        .record_event(
             db::AuditEventKind::PolicyDenied,
             Some(user_id),
             // The email sets `email_domain`, which is how the org audit
@@ -472,10 +472,7 @@ async fn record_denial(
             Some(user_email),
             &data,
         )
-        .await
-    {
-        tracing::warn!(error = %e, "failed to write policy_denied audit event");
-    }
+        .await;
 }
 
 /// The metrics label and audit policy identifier for a deny decision.

--- a/crates/vouch-server/src/services/policy/tests.rs
+++ b/crates/vouch-server/src/services/policy/tests.rs
@@ -1392,9 +1392,7 @@ fn test_ingestion_reads_the_keys_writers_serialize() {
         details: None,
         client_ip: Some("10.1.2.3".to_string()),
         user_agent: None,
-        country_code: None,
-        asn: None,
-        org_name: None,
+        geo: crate::db::documents::audit::GeoFields::default(),
     })
     .unwrap();
     let row = crate::db::audit::AuditEvent {

--- a/crates/vouch-tests/tests/fido2_posture_e2e.rs
+++ b/crates/vouch-tests/tests/fido2_posture_e2e.rs
@@ -8,7 +8,6 @@
 //! end-to-end through the policy gate in `fido2_grant.rs`.
 
 #![expect(
-    clippy::unwrap_used,
     clippy::expect_used,
     clippy::panic,
     clippy::indexing_slicing,
@@ -503,6 +502,30 @@ async fn test_fido2_grant_records_token_issued_audit_event() {
         "the audit payload must carry the grant type: {}",
         rows[0].data
     );
+
+    // Both audit writes are awaited in flow order, so the UUIDv7 ids must
+    // show the login before the token it authorized.
+    let login_rows = harness
+        .state
+        .audit
+        .query_events(&db::AuditEventFilter {
+            event_types: Some(vec!["login_success".to_string()]),
+            user_id: Some(user.id.clone()),
+            ..Default::default()
+        })
+        .await
+        .expect("query audit events");
+    assert_eq!(
+        login_rows.len(),
+        1,
+        "the grant must record one login_success"
+    );
+    assert!(
+        login_rows[0].id < rows[0].id,
+        "login_success ({}) must precede oauth_token_issued ({})",
+        login_rows[0].id,
+        rows[0].id
+    );
 }
 
 /// A successful FIDO2 grant for an org member stamps the org's domain into
@@ -653,7 +676,7 @@ async fn test_posture_denied_grant_records_login_failed_not_success() {
     .await;
     assert_eq!(status, 400, "grant must be denied: {json}");
 
-    // The audit write is spawned; poll briefly for it to land.
+    // The audit write is awaited before the grant responds.
     let query = |kind: &'static str| {
         let audit = harness.state.audit.clone();
         let user_id = user.id.clone();
@@ -668,14 +691,7 @@ async fn test_posture_denied_grant_records_login_failed_not_success() {
                 .expect("query audit events")
         }
     };
-    let mut failed_rows = Vec::new();
-    for _ in 0..40 {
-        failed_rows = query("login_failed").await;
-        if !failed_rows.is_empty() {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    }
+    let failed_rows = query("login_failed").await;
     assert_eq!(
         failed_rows.len(),
         1,
@@ -693,25 +709,22 @@ async fn test_posture_denied_grant_records_login_failed_not_success() {
     );
 }
 
-/// it should be visible immediately, but we poll briefly for safety.
-async fn poll_policy_denied_audit(harness: &TestHarness, user_id: &str) -> db::AuditEvent {
-    for _ in 0..40 {
-        let rows = harness
-            .state
-            .audit
-            .query_events(&db::AuditEventFilter {
-                event_types: Some(vec!["policy_denied".to_string()]),
-                user_id: Some(user_id.to_string()),
-                ..Default::default()
-            })
-            .await
-            .expect("query audit events");
-        if !rows.is_empty() {
-            return rows.into_iter().next().unwrap();
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    }
-    panic!("no policy_denied audit event found for user {user_id}");
+/// Fetch the `policy_denied` audit event for the user; the write is
+/// awaited by the policy gate, so it is visible immediately.
+async fn policy_denied_audit(harness: &TestHarness, user_id: &str) -> db::AuditEvent {
+    let rows = harness
+        .state
+        .audit
+        .query_events(&db::AuditEventFilter {
+            event_types: Some(vec!["policy_denied".to_string()]),
+            user_id: Some(user_id.to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("query audit events");
+    rows.into_iter()
+        .next()
+        .unwrap_or_else(|| panic!("no policy_denied audit event found for user {user_id}"))
 }
 
 /// A custom posture policy deny through the full HTTP router must record the
@@ -796,7 +809,7 @@ async fn custom_policy_denial_records_name_in_audit_and_error() {
     );
 
     // Step 4: Verify the audit record carries the actual policy name.
-    let audit_row = poll_policy_denied_audit(&harness, &user.id).await;
+    let audit_row = policy_denied_audit(&harness, &user.id).await;
     let audit_data: serde_json::Value =
         serde_json::from_str(&audit_row.data).expect("audit data is valid JSON");
     assert_eq!(
@@ -889,7 +902,7 @@ async fn preconfigured_policy_denial_records_slug_in_audit_and_metrics() {
     );
 
     // Verify the audit record carries the slug.
-    let audit_row = poll_policy_denied_audit(&harness, &user.id).await;
+    let audit_row = policy_denied_audit(&harness, &user.id).await;
     let audit_data: serde_json::Value =
         serde_json::from_str(&audit_row.data).expect("audit data is valid JSON");
     assert_eq!(

--- a/docs/src/admin/audit.md
+++ b/docs/src/admin/audit.md
@@ -203,10 +203,11 @@ org-scoped.
 ### Cursor semantics and delivery guarantee
 
 `next_cursor` is present whenever there may be more matching events; pass it back as `after`
-(or `before`, if you're walking backward) to continue. IDs are UUID v7 (time-ordered), but
-authentication events are written from detached background tasks, so **commit order can trail
-ID order by a few seconds under load** — a naive high-water-mark poller that just tracks "the
-highest ID seen" can miss events that commit late.
+(or `before`, if you're walking backward) to continue. IDs are UUID v7 (time-ordered) and
+every event is written before the request that caused it receives its response, but
+concurrent requests can still commit in a different order than they minted IDs — a naive
+high-water-mark poller that just tracks "the highest ID seen" can miss an event that commits
+a moment after a higher ID from an overlapping request.
 
 The API's delivery guarantee instead of ID ordering: **an event is never returned with
 `created_at` newer than `now - 30s`**, regardless of the `until` you pass. A poller that
@@ -215,13 +216,12 @@ requests `after=<last cursor>` no more often than every 30 seconds, and persists
 window. Because pages can be byte-capped (see NDJSON below), always follow `next_cursor` until a
 page comes back without one rather than assuming one poll drains everything new.
 
-This guarantee assumes an audit write actually commits within the window. `created_at` is
-stamped when the event is minted, not when it commits, so a detached write task delayed past
-30 seconds (executor saturation, a DSQL OCC retry storm) — or one that fails outright — is not
-currently surfaced by any metric; the event would land later than the poller expects, or not at
-all. Size your polling interval with margin above 30 seconds if your environment is prone to
-write-path contention, and treat this as a best-effort guarantee under normal operating
-conditions rather than a hard real-time bound.
+An event's ID and `created_at` are stamped together immediately before its insert, and the
+insert completes before the response is sent, so a committed event's timestamp trails its
+commit only by the write itself. Audit writes are best-effort, however: a write that fails
+outright is logged server-side and not retried, so the event is absent rather than late —
+treat the guarantee as best-effort under write-path failure rather than a hard real-time
+bound.
 
 ### NDJSON
 


### PR DESCRIPTION
Closes #1181.

## What changed

**Auth audit events are awaited, not spawned.** `spawn_audit_event` + `insert_auth_event` are merged into one awaited, best-effort `record_auth_event`; all 18 call sites await it. The detached spawn dropped events in flight at shutdown, let the audit log show a token issued before the login that authorized it (`fido2_grant.rs` spawned `LoginSuccess` then awaited `TokenIssued`), and forced the operator docs to document a weakened delivery guarantee. Awaiting sends the same number of DB requests; the row commits before the response is sent. The five test polling/sleep loops that existed only to race the detached write are deleted, and a new assertion pins `login_success` < `oauth_token_issued` by UUIDv7 id.

**One write API, one failure shape.** `AuditStore::insert_event` / `insert_event_with_domain` become best-effort `record_event` / `record_event_with_domain`: they return `()` and swallow-and-log in one place, with the wire `event_type` string as a structured field (the spawned path previously logged the Debug enum, which cannot be joined to the stored row). This deletes ~32 hand-written swallow blocks across handlers, the SCIM handlers' unstructured variant, and the local `audit_best_effort` helper in issuer-key rotation. `insert_scim_audit` becomes best-effort `record_scim_audit`. No production caller used the returned event id.

**The `AuditData` seal is now complete.** The two payload shapes that lived outside `db/documents/audit.rs` move behind the seal: `AuthEventData` (auth events, replacing raw `serde_json::to_value` + a manual geo merge) and `CredentialAuditPayload` (the credential envelope/details flatten). The `(country_code, asn, org_name)` triple, previously spelled out four times, is one flattened `GeoFields` struct with a `from_ip` constructor. Stored JSON shapes are unchanged and pinned by new shape tests against literal row values.

**Docs.** `docs/src/admin/audit.md`'s delivery-guarantee section no longer describes detached background tasks, and the incorrect claim that `created_at` is stamped "when the event is minted, not when it commits" is fixed (id and timestamp are stamped together immediately before the insert). The matching `LAG_WINDOW_SECONDS` comment is updated; the 30-second pull-API guarantee itself is unchanged.

## Verification

- `make fmt`, `make lint` (clippy `-D warnings`), `make test` (51 suites), `make test-integration`, `prek run` — all green on both commits.
- `rg 'spawn_audit_event|insert_auth_event|audit_best_effort'` over `crates/` returns nothing; no polling/sleep loops remain in the audit tests (issue acceptance criterion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)