### PR TITLE
fix(server): close RFC 8693 conformance gaps on token exchange

### DIFF
--- a/crates/vouch-server/src/handlers/oidc/tests/rfc8693.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc8693.rs
@@ -632,6 +632,84 @@ async fn test_rfc8693_requested_token_type_jwt_rejected() {
 }
 
 #[tokio::test]
+async fn test_rfc8693_resource_must_be_absolute_uri_without_fragment() {
+    // RFC 8693 §2.1: "The value of the 'resource' parameter MUST be an
+    // absolute URI, as specified by Section 4.3 of [RFC3986], that MAY
+    // include a query component and MUST NOT include a fragment component."
+    // RFC 8693 §2.2.2: "If the authorization server is unwilling or unable to
+    // issue a token for any target service indicated by the 'resource' or
+    // 'audience' parameters, the 'invalid_target' error code SHOULD be used
+    // in the error response."
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "exchange-resource-uri@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+
+    let (access_token, _) = issue_oauth_access_token(&app, &state, &user, &auth_id, &client).await;
+    let auth_header = client.basic_auth_header();
+
+    for invalid_resource in [
+        // Relative reference: not an absolute URI.
+        "not-a-valid-uri",
+        // Fragment component.
+        "https://api.example.com/v1#frag",
+    ] {
+        let (status, body) = http_post_form(
+            &app,
+            "/oauth/token",
+            &format!(
+                "grant_type=urn:ietf:params:oauth:grant-type:token-exchange\
+                 &subject_token={access_token}\
+                 &subject_token_type=urn:ietf:params:oauth:token-type:access_token\
+                 &resource={}",
+                urlencoding::encode(invalid_resource)
+            ),
+            &[("Authorization", &auth_header)],
+        )
+        .await;
+
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "resource={invalid_resource} must be rejected: {body}"
+        );
+        let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+        assert_eq!(
+            error["error"], "invalid_target",
+            "resource={invalid_resource} must report invalid_target: {body}"
+        );
+    }
+
+    // A query component is explicitly allowed ("MAY include a query
+    // component"), so this exchange must succeed.
+    let (status, body) = http_post_form(
+        &app,
+        "/oauth/token",
+        &format!(
+            "grant_type=urn:ietf:params:oauth:grant-type:token-exchange\
+             &subject_token={access_token}\
+             &subject_token_type=urn:ietf:params:oauth:token-type:access_token\
+             &resource={}",
+            urlencoding::encode("https://api.example.com/v1?tenant=acme")
+        ),
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "resource with a query component must be accepted: {body}"
+    );
+    let response: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert!(
+        response.get("access_token").is_some(),
+        "exchange must issue a token: {body}"
+    );
+}
+
+#[tokio::test]
 async fn test_rfc8693_actor_token_delegation_chain() {
     // RFC 8693 Section 2.1: Token exchange with actor token produces nested `act` claims.
     let (app, state) = test_app().await;

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc8693.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc8693.rs
@@ -1578,7 +1578,9 @@ async fn test_rfc8693_id_token_rejects_non_hardware_verified_subject() {
 
     assert_eq!(status, StatusCode::BAD_REQUEST);
     let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
-    assert_eq!(error["error"], "access_denied");
+    // RFC 8693 §2.2.2: a subject token "unacceptable based on policy" MUST
+    // yield the invalid_request error code.
+    assert_eq!(error["error"], "invalid_request");
 
     // Regression guard: the same subject token must still work for an
     // access-token exchange. The hardware gate is specific to ID-token

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc8693.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc8693.rs
@@ -585,6 +585,49 @@ async fn test_rfc8693_unsupported_requested_token_type_rejected() {
 }
 
 #[tokio::test]
+async fn test_rfc8693_requested_token_type_jwt_rejected() {
+    // RFC 8693 Section 2.1: `jwt` is accepted as a subject_token_type but is
+    // not a type this server issues, so requesting it is rejected rather than
+    // silently substituted with an access token (Section 2.2.1 requires
+    // `issued_token_type` to name what was actually issued).
+    let (app, state) = test_app().await;
+
+    let user = create_test_user(&state.store, "exchange-jwt-requested@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+
+    let (access_token, _) = issue_oauth_access_token(&app, &state, &user, &auth_id, &client).await;
+
+    let auth_header = client.basic_auth_header();
+    let (status, body) = http_post_form(
+        &app,
+        "/oauth/token",
+        &format!(
+            "grant_type=urn:ietf:params:oauth:grant-type:token-exchange\
+             &subject_token={access_token}\
+             &subject_token_type=urn:ietf:params:oauth:token-type:access_token\
+             &requested_token_type=urn:ietf:params:oauth:token-type:jwt"
+        ),
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "requested_token_type=jwt should be rejected: {body}"
+    );
+    let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(error["error"], "invalid_request");
+    assert!(
+        error["error_description"]
+            .as_str()
+            .is_some_and(|d| d.contains("Unsupported requested_token_type")),
+        "description should name the parameter: {body}"
+    );
+}
+
+#[tokio::test]
 async fn test_rfc8693_actor_token_delegation_chain() {
     // RFC 8693 Section 2.1: Token exchange with actor token produces nested `act` claims.
     let (app, state) = test_app().await;

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc8693.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc8693.rs
@@ -774,6 +774,61 @@ async fn test_rfc8693_actor_token_delegation_chain() {
 }
 
 #[tokio::test]
+async fn test_rfc8693_delegated_exchange_records_actor_user_id() {
+    // A delegated exchange (actor_token present) must record the actor's
+    // user id on the token_exchange audit row, so delegation is attributable
+    // to the acting party, not just visible in the issued JWT's `act` claim.
+    // The insert is best-effort in production (failures only log a warning);
+    // against the test store it always lands.
+    let (app, state) = test_app().await;
+
+    let grantor = create_test_user(&state.store, "audit-actor-grantor@example.com").await;
+    let grantor_auth = create_test_authenticator(&state.store, &grantor.id).await;
+    let client = create_test_oauth_client(&state.store, &grantor.id).await;
+
+    let grantee = create_test_user(&state.store, "audit-actor-grantee@example.com").await;
+    let grantee_auth = create_test_authenticator(&state.store, &grantee.id).await;
+
+    let (grantor_token, _) =
+        issue_oauth_access_token(&app, &state, &grantor, &grantor_auth, &client).await;
+    let (grantee_token, _) =
+        issue_oauth_access_token(&app, &state, &grantee, &grantee_auth, &client).await;
+
+    let auth_header = client.basic_auth_header();
+
+    let (status, body) = http_post_form(
+        &app,
+        "/oauth/token",
+        &format!(
+            "grant_type=urn:ietf:params:oauth:grant-type:token-exchange\
+             &subject_token={grantor_token}\
+             &subject_token_type=urn:ietf:params:oauth:token-type:access_token\
+             &actor_token={grantee_token}\
+             &actor_token_type=urn:ietf:params:oauth:token-type:access_token"
+        ),
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "delegated exchange should succeed: {body}"
+    );
+
+    let row = state
+        .store
+        .find_one::<crate::db::documents::oauth::TokenExchangeDoc>("actor_user_id", &grantee.id)
+        .await
+        .expect("query token_exchange by actor_user_id")
+        .expect("delegated exchange row must record actor_user_id");
+    assert_eq!(
+        row.data.subject_user_id, grantor.id,
+        "audit row must pair the actor with the delegating subject"
+    );
+    assert_eq!(row.data.actor_user_id.as_deref(), Some(grantee.id.as_str()));
+}
+
+#[tokio::test]
 async fn test_rfc8693_token_lifetime_capped_by_subject() {
     // RFC 8693 Section 2.2: Exchanged token lifetime should not exceed
     // the remaining lifetime of the subject token.

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc8693.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc8693.rs
@@ -77,7 +77,11 @@ async fn test_token_exchange_valid_token_types() {
 
 #[tokio::test]
 async fn test_token_exchange_invalid_subject_token() {
-    // RFC 8693: Invalid subject token returns invalid_grant
+    // RFC 8693 §2.2.2: "If the request itself is not valid or if either the
+    // 'subject_token' or 'actor_token' are invalid for any reason, or are
+    // unacceptable based on policy, the authorization server MUST construct
+    // an error response, as specified in Section 5.2 of [RFC6749]. The value
+    // of the 'error' parameter MUST be the 'invalid_request' error code."
     let (app, state) = test_app().await;
 
     let user = create_test_user(&state.store, "exchange-invalid@example.com").await;
@@ -94,7 +98,7 @@ async fn test_token_exchange_invalid_subject_token() {
 
     assert_eq!(status, StatusCode::BAD_REQUEST);
     let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
-    assert_eq!(error["error"], "invalid_grant");
+    assert_eq!(error["error"], "invalid_request");
 }
 
 #[tokio::test]
@@ -265,7 +269,7 @@ async fn test_rfc8693_missing_subject_token() {
     // RFC 6749 §5.2: invalid_request covers a request "missing a required
     // parameter". Pairing subject_token with subject_token_type is what makes
     // this reachable — an absent token used to reach the decoder as an empty
-    // string and come back as invalid_grant.
+    // string and be reported as an invalid token instead.
     assert_eq!(
         error["error"], "invalid_request",
         "Missing subject_token should be rejected as invalid_request, got: {}",
@@ -914,7 +918,9 @@ async fn test_rfc8693_deactivated_subject_user_rejected() {
 
     assert_eq!(status, StatusCode::BAD_REQUEST);
     let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
-    assert_eq!(error["error"], "invalid_grant");
+    // RFC 8693 §2.2.2: a subject token "unacceptable based on policy"
+    // (deactivated user) MUST yield the invalid_request error code.
+    assert_eq!(error["error"], "invalid_request");
 }
 
 // ========================================================================
@@ -1528,7 +1534,9 @@ async fn test_rfc8693_id_token_deactivated_user_rejected() {
 
     assert_eq!(status, StatusCode::BAD_REQUEST);
     let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
-    assert_eq!(error["error"], "invalid_grant");
+    // RFC 8693 §2.2.2: a subject token "unacceptable based on policy"
+    // (deactivated user) MUST yield the invalid_request error code.
+    assert_eq!(error["error"], "invalid_request");
 }
 
 #[tokio::test]
@@ -1643,7 +1651,7 @@ async fn test_rfc8693_id_token_rejects_actor_token() {
 //
 // When a token exchange carries an actor_token, the actor user's active
 // flag must be checked symmetrically with the subject user check. A
-// deactivated actor must produce invalid_grant, not a 200 with an act claim.
+// deactivated actor must produce an error, not a 200 with an act claim.
 // ========================================================================
 
 #[tokio::test]
@@ -1691,9 +1699,11 @@ async fn test_rfc8693_deactivated_actor_user_rejected() {
         "Deactivated actor must be rejected: {body}"
     );
     let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    // RFC 8693 §2.2.2: an actor token "unacceptable based on policy"
+    // (deactivated user) MUST yield the invalid_request error code.
     assert_eq!(
-        error["error"], "invalid_grant",
-        "Must return invalid_grant for deactivated actor: {body}"
+        error["error"], "invalid_request",
+        "Must return invalid_request for deactivated actor: {body}"
     );
     assert!(
         error["error_description"]
@@ -1813,7 +1823,7 @@ async fn test_token_exchange_inherits_the_subject_s_authorization_code() {
 // token lookup (issue #540 pattern).
 //
 // The actor session lookup must distinguish:
-//   * Ok(None) — session missing/revoked → `invalid_grant`
+//   * Ok(None) — session missing/revoked → `invalid_request` (RFC 8693 §2.2.2)
 //   * Err(_)   — store failure          → `ServiceError::Internal` (500)
 //
 // The `Ok(None)` arm is exercised here by issuing a real actor token and
@@ -1828,11 +1838,12 @@ async fn test_token_exchange_inherits_the_subject_s_authorization_code() {
 // ========================================================================
 
 /// A validly-decoded actor token whose backing session has been removed
-/// must produce `invalid_grant` ("Actor token session not found or
-/// revoked"), not a 500. Exercises the `Ok(None)` arm of the actor session
-/// lookup — the same call site whose `Err` handling the fix tightens.
+/// must produce `invalid_request` ("Actor token session not found or
+/// revoked") per RFC 8693 §2.2.2, not a 500. Exercises the `Ok(None)` arm
+/// of the actor session lookup — the same call site whose `Err` handling
+/// the fix tightens.
 #[tokio::test]
-async fn test_rfc8693_actor_session_not_found_returns_invalid_grant() {
+async fn test_rfc8693_actor_session_not_found_returns_invalid_request() {
     let (app, state) = test_app().await;
 
     // Subject (grantor) with a stored, valid access token.
@@ -1873,12 +1884,12 @@ async fn test_rfc8693_actor_session_not_found_returns_invalid_grant() {
     assert_eq!(
         status,
         StatusCode::BAD_REQUEST,
-        "missing actor session must return invalid_grant, got: {body}"
+        "missing actor session must return invalid_request, got: {body}"
     );
     let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
     assert_eq!(
-        error["error"], "invalid_grant",
-        "missing actor session must report invalid_grant: {body}"
+        error["error"], "invalid_request",
+        "missing actor session must report invalid_request: {body}"
     );
     assert!(
         error["error_description"]
@@ -1898,10 +1909,10 @@ async fn test_rfc8693_actor_session_not_found_returns_invalid_grant() {
 /// token hash fail with a store error while every other lookup uses the live,
 /// open pool.
 ///
-/// Against the pre-fix `!matches!(.., Ok(Some(_)))` code this returns
-/// `invalid_grant` (the bug); against the fixed `.map_err(Internal)?.ok_or_else(InvalidGrant)?`
-/// code it returns 500. This is the only test that discriminates the fix from
-/// the bug.
+/// Against the pre-fix `!matches!(.., Ok(Some(_)))` code this returns the
+/// OAuth error for a missing session (the bug); against the fixed
+/// `.map_err(Internal)?.ok_or_else(..)?` code it returns 500. This is the
+/// only test that discriminates the fix from the bug.
 #[tokio::test]
 async fn test_rfc8693_actor_session_store_error_returns_internal() {
     let (app, state) = test_app().await;
@@ -1941,10 +1952,14 @@ async fn test_rfc8693_actor_session_store_error_returns_internal() {
     assert_eq!(
         status,
         StatusCode::INTERNAL_SERVER_ERROR,
-        "store failure during actor session lookup must return 500, not \
-         invalid_grant; got: {body}"
+        "store failure during actor session lookup must return 500, not an \
+         OAuth token error; got: {body}"
     );
     let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_ne!(
+        error["error"], "invalid_request",
+        "DB error must not be reported as invalid_request: {body}"
+    );
     assert_ne!(
         error["error"], "invalid_grant",
         "DB error must not be reported as invalid_grant: {body}"

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -17,7 +17,7 @@ use crate::services::oidc::mtls::CertThumbprint;
 use crate::services::oidc::{
     ScopeSet,
     client_credentials::exchange_client_credentials,
-    exchange::{ActorToken, SubjectToken, TokenExchangeParams, TokenType, exchange_token},
+    exchange::{ActorToken, RequestedTokenType, SubjectToken, TokenExchangeParams, exchange_token},
     grant_type::{OAuthGrantType, ParseOAuthGrantTypeError},
     jwt_bearer::client_auth::{PendingJti, authenticate_client_jwt},
     token::{AuthCodeExchangeParams, exchange_authorization_code, validate_dpop_if_present},
@@ -1059,7 +1059,7 @@ struct ExchangeTokens<'a> {
     /// `actor_token` + `actor_token_type`, present together or not at all.
     actor: Option<ActorToken<'a>>,
     /// `requested_token_type`, OPTIONAL.
-    requested_token_type: Option<TokenType>,
+    requested_token_type: Option<RequestedTokenType>,
 }
 
 impl<'a> ExchangeTokens<'a> {
@@ -1071,22 +1071,15 @@ impl<'a> ExchangeTokens<'a> {
     /// server does not accept, or a token and type that did not arrive
     /// together.
     fn from_request(params: &'a TokenExchangeRequestParams) -> ServiceResult<Self> {
-        let requested_token_type = match params.requested_token_type.as_deref() {
-            Some(urn) => Some(TokenType::parse(urn).ok_or_else(|| {
-                ServiceError::oauth(
-                    OAuthErrorCode::InvalidRequest,
-                    "Unsupported requested_token_type",
-                )
-            })?),
-            None => None,
-        };
         Ok(Self {
             subject: SubjectToken::new(&params.subject_token, &params.subject_token_type)?,
             actor: ActorToken::from_params(
                 params.actor_token.as_ref(),
                 params.actor_token_type.as_deref(),
             )?,
-            requested_token_type,
+            requested_token_type: RequestedTokenType::from_param(
+                params.requested_token_type.as_deref(),
+            )?,
         })
     }
 }

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -1167,6 +1167,23 @@ async fn handle_token_exchange_grant(
         Err(e) => return e.into_oauth_response().into_response(),
     };
 
+    // RFC 8693 §2.1: "The value of the 'resource' parameter MUST be an
+    // absolute URI, as specified by Section 4.3 of [RFC3986], that MAY
+    // include a query component and MUST NOT include a fragment component."
+    // Validate only — the raw string stays the audience value below, because
+    // `ResourceUri::parse` normalizes (host-only URIs gain a trailing `/`)
+    // and the issued `aud` must equal what the client sent.
+    if let Some(res) = params.resource.as_deref()
+        && crate::services::oidc::ResourceUri::parse(res).is_err()
+    {
+        return ServiceError::oauth(
+            OAuthErrorCode::InvalidTarget,
+            "Invalid resource parameter: must be an absolute URI without a fragment",
+        )
+        .into_oauth_response()
+        .into_response();
+    }
+
     // RFC 8707: If resource is present, use it as audience (unless audience is explicitly set).
     // If both are present, they must match.
     let effective_audience = match (params.audience.as_deref(), params.resource.as_deref()) {

--- a/crates/vouch-server/src/services/oidc/exchange.rs
+++ b/crates/vouch-server/src/services/oidc/exchange.rs
@@ -367,7 +367,19 @@ pub(crate) async fn exchange_token(
             params.client_id,
             params.audience,
         )
-        .await?;
+        .await
+        // RFC 8693 §2.2.2: a subject token "unacceptable based on policy"
+        // MUST be reported with the invalid_request error code. The policy
+        // engine answers access_denied for every decision point (the login
+        // path keeps that code), so remap here, at the only exchange caller,
+        // preserving the policy name and remediation in the description.
+        .map_err(|e| match e {
+            ServiceError::OAuth {
+                code: OAuthErrorCode::AccessDenied,
+                description,
+            } => ServiceError::oauth(OAuthErrorCode::InvalidRequest, description),
+            other => other,
+        })?;
     }
 
     let subject_email = &subject_user.email;
@@ -492,8 +504,10 @@ pub(crate) async fn exchange_token(
     // gate the fork on the subject token's hardware verification level.
     if params.requested_token_type == Some(RequestedTokenType::IdToken) {
         if !subject_decoded.hardware_verification().hardware_verified() {
+            // RFC 8693 §2.2.2: a subject token "unacceptable based on policy"
+            // MUST be reported with the invalid_request error code.
             return Err(ServiceError::oauth(
-                OAuthErrorCode::AccessDenied,
+                OAuthErrorCode::InvalidRequest,
                 "ID token exchange requires a hardware-verified subject token",
             ));
         }

--- a/crates/vouch-server/src/services/oidc/exchange.rs
+++ b/crates/vouch-server/src/services/oidc/exchange.rs
@@ -308,8 +308,14 @@ pub(crate) async fn exchange_token(
     let subject_token = params.subject.token.expose_secret();
     let subject_decoded = decode_token(subject_token, &state.oidc_key, &config.base_url)
         .ok_or_else(|| {
+            // RFC 8693 §2.2.2: "If the request itself is not valid or if
+            // either the 'subject_token' or 'actor_token' are invalid for any
+            // reason, or are unacceptable based on policy, the authorization
+            // server MUST construct an error response, as specified in
+            // Section 5.2 of [RFC6749]. The value of the 'error' parameter
+            // MUST be the 'invalid_request' error code."
             ServiceError::oauth(
-                OAuthErrorCode::InvalidGrant,
+                OAuthErrorCode::InvalidRequest,
                 "Invalid or expired subject token",
             )
         })?;
@@ -323,7 +329,7 @@ pub(crate) async fn exchange_token(
         .map_err(|e| ServiceError::Internal(format!("Database error: {e}")))?
         .ok_or_else(|| {
             ServiceError::oauth(
-                OAuthErrorCode::InvalidGrant,
+                OAuthErrorCode::InvalidRequest,
                 "Subject token session not found",
             )
         })?;
@@ -335,12 +341,15 @@ pub(crate) async fn exchange_token(
         .await
         .map_err(|e| ServiceError::Internal(format!("Database error: {e}")))?
         .ok_or_else(|| {
-            ServiceError::oauth(OAuthErrorCode::InvalidGrant, "Subject token user not found")
+            ServiceError::oauth(
+                OAuthErrorCode::InvalidRequest,
+                "Subject token user not found",
+            )
         })?;
 
     if !subject_user.active {
         return Err(ServiceError::oauth(
-            OAuthErrorCode::InvalidGrant,
+            OAuthErrorCode::InvalidRequest,
             "User account is deactivated",
         ));
     }
@@ -370,7 +379,7 @@ pub(crate) async fn exchange_token(
         // Decode actor token (supports both HS256 and ES256)
         let actor_decoded = decode_token(actor_token, &state.oidc_key, &config.base_url)
             .ok_or_else(|| {
-                ServiceError::oauth(OAuthErrorCode::InvalidGrant, "Invalid actor token")
+                ServiceError::oauth(OAuthErrorCode::InvalidRequest, "Invalid actor token")
             })?;
 
         // Block self-delegation: actor and subject must be different users
@@ -390,7 +399,7 @@ pub(crate) async fn exchange_token(
             .map_err(|e| ServiceError::Internal(format!("Database error: {e}")))?
             .ok_or_else(|| {
                 ServiceError::oauth(
-                    OAuthErrorCode::InvalidGrant,
+                    OAuthErrorCode::InvalidRequest,
                     "Actor token session not found or revoked",
                 )
             })?;
@@ -401,11 +410,11 @@ pub(crate) async fn exchange_token(
             .await
             .map_err(|e| ServiceError::Internal(format!("Database error: {e}")))?
             .ok_or_else(|| {
-                ServiceError::oauth(OAuthErrorCode::InvalidGrant, "Actor token user not found")
+                ServiceError::oauth(OAuthErrorCode::InvalidRequest, "Actor token user not found")
             })?;
         if !actor_user.active {
             return Err(ServiceError::oauth(
-                OAuthErrorCode::InvalidGrant,
+                OAuthErrorCode::InvalidRequest,
                 "User account is deactivated",
             ));
         }

--- a/crates/vouch-server/src/services/oidc/exchange.rs
+++ b/crates/vouch-server/src/services/oidc/exchange.rs
@@ -385,7 +385,7 @@ pub(crate) async fn exchange_token(
     let subject_email = &subject_user.email;
 
     // Handle actor token if present (for delegation chains)
-    let actor_claim = if let Some(actor) = params.actor {
+    let (actor_claim, actor_user_id) = if let Some(actor) = params.actor {
         let actor_token = actor.token().expose_secret();
 
         // Decode actor token (supports both HS256 and ES256)
@@ -430,6 +430,7 @@ pub(crate) async fn exchange_token(
                 "User account is deactivated",
             ));
         }
+        let actor_user_id = actor_user.id.clone();
         let actor_email = actor_decoded
             .email()
             .map(str::to_string)
@@ -453,9 +454,9 @@ pub(crate) async fn exchange_token(
             ));
         }
 
-        Some(actor)
+        (Some(actor), Some(actor_user_id))
     } else {
-        None
+        (None, None)
     };
 
     // Calculate granted scope (intersection of requested and available).
@@ -620,7 +621,7 @@ pub(crate) async fn exchange_token(
         &db::InsertTokenExchangeParams {
             subject_user_id: &subject_session.user_id,
             subject_token_hash: &subject_token_hash,
-            actor_user_id: None,
+            actor_user_id: actor_user_id.as_deref(),
             issued_token_hash: &issued_token_hash,
             requested_audience: params.audience,
             granted_scope: scope_string.as_deref(),
@@ -766,6 +767,8 @@ async fn issue_id_token(
         &db::InsertTokenExchangeParams {
             subject_user_id: ctx.user_id,
             subject_token_hash: ctx.subject_token_hash,
+            // Always None: actor_token with requested_token_type=id_token is
+            // rejected before this path is reached.
             actor_user_id: None,
             issued_token_hash: &issued_token_hash,
             requested_audience: ctx.audience,

--- a/crates/vouch-server/src/services/oidc/exchange.rs
+++ b/crates/vouch-server/src/services/oidc/exchange.rs
@@ -164,6 +164,44 @@ impl<'a> ActorToken<'a> {
     }
 }
 
+/// RFC 8693 §2.1 `requested_token_type`: the subset of [`TokenType`] this
+/// server will issue. [`TokenType::Jwt`] has no variant because the server
+/// never issues a token it would label with the generic `jwt` URN — RFC 8693
+/// §2.2.1 requires `issued_token_type` to name what was actually issued, and
+/// every issued token is either an access token or an ID token. `jwt` remains
+/// a valid `subject_token_type` and `actor_token_type`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestedTokenType {
+    /// `requested_token_type=urn:ietf:params:oauth:token-type:access_token`.
+    AccessToken,
+    /// `requested_token_type=urn:ietf:params:oauth:token-type:id_token`.
+    IdToken,
+}
+
+impl RequestedTokenType {
+    /// Parse the OPTIONAL `requested_token_type` parameter, or `None` when
+    /// the request omits it (the issued type is then at the server's
+    /// discretion per RFC 8693 §2.1 — this server issues an access token).
+    ///
+    /// # Errors
+    ///
+    /// `invalid_request` when the declared type is one this server does not
+    /// issue.
+    pub fn from_param(urn: Option<&str>) -> ServiceResult<Option<Self>> {
+        let Some(urn) = urn else {
+            return Ok(None);
+        };
+        match TokenType::parse(urn) {
+            Some(TokenType::AccessToken) => Ok(Some(Self::AccessToken)),
+            Some(TokenType::IdToken) => Ok(Some(Self::IdToken)),
+            Some(TokenType::Jwt) | None => Err(ServiceError::oauth(
+                OAuthErrorCode::InvalidRequest,
+                "Unsupported requested_token_type",
+            )),
+        }
+    }
+}
+
 /// Default lifetime for an exchanged OIDC ID token
 /// (`requested_token_type=id_token`). Short because the token is presented
 /// immediately as a federation assertion (Kubernetes, Claude/OpenAI WIF) and
@@ -184,7 +222,7 @@ pub struct TokenExchangeParams<'a> {
     /// RFC 8693 Section 2.1: The requested scope for the new token (OPTIONAL).
     pub scope: Option<&'a str>,
     /// RFC 8693 Section 2.1: The desired type of the requested security token (OPTIONAL).
-    pub requested_token_type: Option<TokenType>,
+    pub requested_token_type: Option<RequestedTokenType>,
     /// OAuth client_id of the requesting client.
     pub client_id: &'a str,
     /// RFC 9449 §6 / RFC 8705 §3: how the issued token is bound. The DPoP
@@ -258,7 +296,7 @@ pub(crate) async fn exchange_token(
     // path issues a clean OIDC claim set and does not carry the `act` claim,
     // so honoring `actor_token` here would silently drop the delegation chain.
     // Refuse the combination explicitly rather than ignore the input.
-    if params.requested_token_type == Some(TokenType::IdToken) && params.actor.is_some() {
+    if params.requested_token_type == Some(RequestedTokenType::IdToken) && params.actor.is_some() {
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidRequest,
             "actor_token is not supported with requested_token_type=id_token",
@@ -443,7 +481,7 @@ pub(crate) async fn exchange_token(
     // upstream SSO but before FIDO2 registration) from minting a WIF
     // assertion that downstream relying parties trust as hardware-attested,
     // gate the fork on the subject token's hardware verification level.
-    if params.requested_token_type == Some(TokenType::IdToken) {
+    if params.requested_token_type == Some(RequestedTokenType::IdToken) {
         if !subject_decoded.hardware_verification().hardware_verified() {
             return Err(ServiceError::oauth(
                 OAuthErrorCode::AccessDenied,
@@ -905,6 +943,42 @@ mod tests {
             "access_token",
         ] {
             assert_eq!(TokenType::parse(urn), None, "{urn} must not parse");
+        }
+    }
+
+    #[test]
+    fn test_requested_token_type_accepts_issuable_types() {
+        assert_eq!(
+            RequestedTokenType::from_param(None).expect("absent param is valid"),
+            None
+        );
+        assert_eq!(
+            RequestedTokenType::from_param(Some(protocol::TOKEN_TYPE_ACCESS_TOKEN))
+                .expect("access_token is issuable"),
+            Some(RequestedTokenType::AccessToken)
+        );
+        assert_eq!(
+            RequestedTokenType::from_param(Some(protocol::TOKEN_TYPE_ID_TOKEN))
+                .expect("id_token is issuable"),
+            Some(RequestedTokenType::IdToken)
+        );
+    }
+
+    #[test]
+    fn test_requested_token_type_rejects_types_the_server_never_issues() {
+        // RFC 8693 §2.2.1: `issued_token_type` names what was actually issued,
+        // and this server only issues access tokens and ID tokens — so `jwt`
+        // is a valid subject/actor type but not a requested type.
+        for urn in [
+            protocol::TOKEN_TYPE_JWT,
+            "urn:ietf:params:oauth:token-type:saml2",
+            "urn:ietf:params:oauth:token-type:refresh_token",
+            "",
+        ] {
+            assert!(
+                RequestedTokenType::from_param(Some(urn)).is_err(),
+                "{urn} must be rejected as a requested_token_type"
+            );
         }
     }
 

--- a/crates/vouch-tests/tests/dogwood_temporal_e2e.rs
+++ b/crates/vouch-tests/tests/dogwood_temporal_e2e.rs
@@ -46,8 +46,22 @@ async fn seed_event(
         .expect("seed audit event");
 }
 
-/// Assert an OAuth error response is a policy denial.
-fn assert_access_denied(status: u16, json: &serde_json::Value, context: &str) {
+/// Assert an OAuth error response is a policy denial on the exchange grant.
+/// RFC 8693 §2.2.2: a subject token "unacceptable based on policy" MUST be
+/// reported with the `invalid_request` error code.
+fn assert_exchange_policy_denied(status: u16, json: &serde_json::Value, context: &str) {
+    assert_eq!(status, 400, "{context}: expected denial. Response: {json}");
+    assert_eq!(
+        json["error"].as_str().unwrap_or(""),
+        "invalid_request",
+        "{context}: expected invalid_request. Response: {json}"
+    );
+}
+
+/// Assert an OAuth error response is a policy denial on the FIDO2 assertion
+/// grant, which keeps `access_denied` (RFC 8693 §2.2.2 governs only the
+/// exchange grant).
+fn assert_login_policy_denied(status: u16, json: &serde_json::Value, context: &str) {
     assert_eq!(status, 400, "{context}: expected denial. Response: {json}");
     assert_eq!(
         json["error"].as_str().unwrap_or(""),
@@ -127,7 +141,7 @@ async fn test_exchange_step_up_denies_without_recent_login() {
     )
     .await;
     let (status, json) = do_exchange(&harness, &token, &auth).await;
-    assert_access_denied(status, &json, "exchange without any login history");
+    assert_exchange_policy_denied(status, &json, "exchange without any login history");
     assert!(
         json["error_description"]
             .as_str()
@@ -166,7 +180,7 @@ async fn test_exchange_step_up_denies_with_stale_login() {
     .await;
     seed_event(&harness, AuditEventKind::LoginSuccess, &user.id, 1800, "{}").await;
     let (status, json) = do_exchange(&harness, &token, &auth).await;
-    assert_access_denied(status, &json, "exchange with a 30-minute-old login");
+    assert_exchange_policy_denied(status, &json, "exchange with a 30-minute-old login");
 }
 
 /// Another user's fresh login must not satisfy this user's window
@@ -189,7 +203,7 @@ async fn test_exchange_step_up_ignores_other_users_logins() {
         .expect("other user");
     seed_event(&harness, AuditEventKind::LoginSuccess, &other.id, 60, "{}").await;
     let (status, json) = do_exchange(&harness, &token, &auth).await;
-    assert_access_denied(status, &json, "another principal's login must not count");
+    assert_exchange_policy_denied(status, &json, "another principal's login must not count");
 }
 
 // ── Token exchange: logout invalidates ───────────────────────────────────
@@ -206,7 +220,7 @@ async fn test_logout_invalidates_exchange_denies_after_logout() {
     seed_event(&harness, AuditEventKind::LoginSuccess, &user.id, 600, "{}").await;
     seed_event(&harness, AuditEventKind::Logout, &user.id, 300, "{}").await;
     let (status, json) = do_exchange(&harness, &token, &auth).await;
-    assert_access_denied(status, &json, "exchange after logout");
+    assert_exchange_policy_denied(status, &json, "exchange after logout");
 }
 
 /// logout → re-login → exchange is allowed again.
@@ -269,7 +283,7 @@ async fn test_exchange_ip_consistency_denies_different_ip() {
     )
     .await;
     let (status, json) = do_exchange(&harness, &token, &auth).await;
-    assert_access_denied(status, &json, "different-IP login must not satisfy the pin");
+    assert_exchange_policy_denied(status, &json, "different-IP login must not satisfy the pin");
 }
 
 // ── FIDO2 grant: aggregation policies ────────────────────────────────────
@@ -454,7 +468,7 @@ async fn test_failed_login_burst_denies_grant() {
         .await;
     }
     let (status, json) = fido2_grant(&harness, &device, &user.id, &client, &pkcs8).await;
-    assert_access_denied(status, &json, "5 failed logins in 10m");
+    assert_login_policy_denied(status, &json, "5 failed logins in 10m");
     assert!(
         json["error_description"]
             .as_str()
@@ -515,7 +529,7 @@ async fn test_issuance_rate_limit_denies_at_cap() {
         .await;
     }
     let (status, json) = fido2_grant(&harness, &device, &user.id, &client, &pkcs8).await;
-    assert_access_denied(status, &json, "10 issuances in 1h");
+    assert_login_policy_denied(status, &json, "10 issuances in 1h");
     assert!(
         json["error_description"]
             .as_str()

--- a/crates/vouch-tests/tests/integration.rs
+++ b/crates/vouch-tests/tests/integration.rs
@@ -1266,7 +1266,9 @@ mod token_exchange {
 
         assert_eq!(response.status, 400);
         let error: serde_json::Value = response.json().expect("Failed to parse error");
-        assert_eq!(error["error"], "invalid_grant");
+        // RFC 8693 §2.2.2: an invalid subject_token MUST be reported with the
+        // invalid_request error code.
+        assert_eq!(error["error"], "invalid_request");
     }
 
     /// Test that token exchange works with valid token.

--- a/docs/src/admin/policies.md
+++ b/docs/src/admin/policies.md
@@ -45,8 +45,11 @@ itself is a hardware authentication, so requiring a recent login there would alw
 > posture policies would reject at `vouch login`. Treat posture policies as a control on the CLI
 > credential path, not a fleet-wide device gate, until browser enrollment is covered.
 
-If any active policy fails, the token request is rejected with OAuth `access_denied` and a message
-naming the failed policy plus remediation guidance for the user's operating system:
+If any active policy fails, the token request is rejected with a message naming the failed policy
+plus remediation guidance for the user's operating system. The OAuth error code is `access_denied`
+on the login (FIDO2 assertion) grant and `invalid_request` on the RFC 8693 token-exchange grant —
+RFC 8693 §2.2.2 requires `invalid_request` for a subject token that is unacceptable based on
+policy:
 
 ```
 Device posture policy 'Disk Encryption' not satisfied. Enable FileVault in

--- a/specs/coverage-baseline.tsv
+++ b/specs/coverage-baseline.tsv
@@ -2052,9 +2052,6 @@ rfc8628#5.4#978bf787	SHOULD	To mitigate such an attack, it is RECOMMENDED to inf
 rfc8628#5.4#def2895d	SHOULD	The authorization server SHOULD display information about the device so that the user could notice if a software client was attempting to impersonate a hardware
 rfc8628#5.5#fc8dab50	SHOULD	Devices SHOULD take into account the operating environment when considering how to communicate the code to the user to reduce the chances it will be observed by
 rfc8628#5.7#08d60057	SHOULD	To mitigate an attack in which a malicious user can bootstrap their credentials on a device not in their control, it is RECOMMENDED that any chosen communicatio
-rfc8693#2.2.2#90069c53	MUST	If the request itself is not valid or if either the "subject_token" or "actor_token" are invalid for any reason, or are unacceptable based on policy, the author
-rfc8693#2.2.2#97677945	SHOULD	If the authorization server is unwilling or unable to issue a token for any target service indicated by the "resource" or "audience" parameters, the "invalid_ta
-rfc8693#2.2.2#9c878927	MUST	The value of the "error" parameter MUST be the "invalid_request" error code.
 rfc8693#4#5e0c0c44	MUST	For the purpose of applying access control policy, the consumer of a token MUST only consider the token's top-level claims and the party identified as the curre
 rfc8693#6#95614386	MUST	Tokens employed in the context of the functionality described herein may contain privacy-sensitive information and, to prevent disclosure of such information to
 rfc8693#6#e59b1faa	MUST	In cases where it is desirable to prevent disclosure of certain information to the client, the token MUST be encrypted to its intended recipient.


### PR DESCRIPTION
## What

Four conformance/hardening fixes on the RFC 8693 token-exchange grant, found while auditing Vouch's RFC 8693 support.

**Reject \`requested_token_type=jwt\`.** The generic \`jwt\` URN previously parsed and silently took the access-token path. RFC 8693 §2.2.1 requires \`issued_token_type\` to name what was actually issued, and this server only issues access tokens and ID tokens, so the issuable subset is now its own \`RequestedTokenType\` enum (same pattern as \`ActorToken\`) and \`jwt\` is rejected with \`invalid_request\`. It remains valid as a \`subject_token_type\` / \`actor_token_type\`.

**\`invalid_request\` for invalid and policy-denied tokens.** RFC 8693 §2.2.2: "If the request itself is not valid or if either the 'subject_token' or 'actor_token' are invalid for any reason, or are unacceptable based on policy, the authorization server MUST construct an error response, as specified in Section 5.2 of [RFC6749]. The value of the 'error' parameter MUST be the 'invalid_request' error code." All eight token-validity failures on this grant (decode, session lookup, user lookup, deactivated user — subject and actor) previously returned \`invalid_grant\`; org temporal-policy denials and the hardware-verified ID-token gate returned \`access_denied\`. All now return \`invalid_request\` on the exchange grant only — the policy engine is shared with the FIDO2 login grant, which keeps \`access_denied\`, so the remap happens at the exchange call site. Store failures still surface as 500. The three §2.2.2 rows leave \`specs/coverage-baseline.tsv\` now that tests cite the section.

**Validate \`resource\` as an absolute URI.** RFC 8693 §2.1: "The value of the 'resource' parameter MUST be an absolute URI, as specified by Section 4.3 of [RFC3986], that MAY include a query component and MUST NOT include a fragment component." The exchange grant only length-checked it. It now runs through the authorize path's \`ResourceUri\` validator (validate-only; the raw string remains the \`aud\` value) and rejects with \`invalid_target\` — RFC 8693 §2.2.2: "If the authorization server is unwilling or unable to issue a token for any target service indicated by the 'resource' or 'audience' parameters, the 'invalid_target' error code SHOULD be used in the error response."

**Record \`actor_user_id\` on delegated-exchange audit rows.** The \`token_exchange\` audit document has carried the field and a secondary index since it was introduced, but the service hardcoded \`None\`. Delegated exchanges are now attributable to the acting party.

Operator docs (\`docs/src/admin/policies.md\`) updated for the per-grant policy-denial error codes.

## Verification

- \`make fmt\`, \`make lint\` (zero warnings), \`make test\` (all crates pass), \`make test-integration\` (405 passed, 0 failed), \`prek run\` clean.
- \`cargo test -p vouch-tests --test spec_coverage\` passes with the pruned baseline.
- New tests: \`requested_token_type=jwt\` rejection (unit + e2e), resource URI rejection/acceptance loop, delegated-exchange audit row; existing rfc8693/dogwood/integration assertions updated to the new error codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)