### PR TITLE
perf(server): return Arc<Session> from the session cache

### DIFF
--- a/crates/vouch-server/src/db/sessions.rs
+++ b/crates/vouch-server/src/db/sessions.rs
@@ -7,8 +7,8 @@ use super::store::DocumentStore;
 use anyhow::Result;
 use jiff::Timestamp;
 use std::collections::HashMap;
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 // Re-export SessionPurpose from documents module
@@ -218,24 +218,23 @@ pub struct SessionCache {
 }
 
 struct CacheEntry {
-    value: Option<Session>,
+    /// Shared with every caller that got a hit; hits must stay a refcount
+    /// bump, never a deep copy. `Session` is plain immutable data — do not
+    /// reach for `Arc::make_mut`, which would either copy-on-write or mutate
+    /// the cached entry in place depending on the live refcount.
+    value: Option<Arc<Session>>,
     inserted_at: Instant,
 }
 
 /// Result of a cache probe, distinguishing a miss from a cached
 /// "no such session" answer (negative caching).
-#[expect(
-    clippy::large_enum_variant,
-    reason = "Hit is the common case on the auth hot path and is destructured \
-              immediately; boxing would add an allocation per lookup"
-)]
 enum CacheLookup {
     /// No fresh entry for this key — consult the database.
     Miss,
     /// Cached knowledge that the database has no session for this key.
     NegativeHit,
     /// Cached session.
-    Hit(Session),
+    Hit(Arc<Session>),
 }
 
 impl SessionCache {
@@ -265,7 +264,7 @@ impl SessionCache {
         &self,
         store: &DocumentStore,
         token_hash: &str,
-    ) -> Result<Option<Session>> {
+    ) -> Result<Option<Arc<Session>>> {
         // Test-only fault injection: the hash was registered via
         // [`Self::inject_fault`]; return a store-style `Err` so callers can
         // exercise their DB-error propagation path without a real outage.
@@ -283,7 +282,9 @@ impl SessionCache {
         // Snapshot generation before the async DB fetch so we can
         // detect invalidations that occurred during the await.
         let gen_before = self.generation.load(Ordering::SeqCst);
-        let result = get_session_by_token_hash(store, token_hash, Timestamp::now()).await?;
+        let result = get_session_by_token_hash(store, token_hash, Timestamp::now())
+            .await?
+            .map(Arc::new);
         self.insert_if_valid(token_hash.to_string(), result.clone(), gen_before);
         Ok(result)
     }
@@ -360,7 +361,7 @@ impl SessionCache {
     /// `expected_gen` was captured. The generation is re-checked under
     /// the lock so no invalidation can race between the check and the
     /// actual map write.
-    fn insert_if_valid(&self, key: String, value: Option<Session>, expected_gen: u64) {
+    fn insert_if_valid(&self, key: String, value: Option<Arc<Session>>, expected_gen: u64) {
         let Ok(mut map) = self.entries.lock() else {
             return;
         };
@@ -398,8 +399,8 @@ impl SessionCache {
 mod tests {
     use super::*;
 
-    fn fake_session(token_hash: &str) -> Session {
-        Session {
+    fn fake_session(token_hash: &str) -> Arc<Session> {
+        Arc::new(Session {
             id: "sess-1".to_string(),
             user_id: "user-1".to_string(),
             user_email: "test@example.com".to_string(),
@@ -412,7 +413,7 @@ mod tests {
             hardware_aaguid: None,
             org_domain: None,
             source_code_hash: None,
-        }
+        })
     }
 
     #[test]
@@ -425,6 +426,32 @@ mod tests {
             generation,
         );
         assert!(matches!(cache.get("hash-a"), CacheLookup::Hit(_)));
+    }
+
+    /// Two hits for the same key must return the same allocation — the point
+    /// of storing `Arc<Session>` is that a hit is a refcount bump, and a
+    /// reintroduced deep copy would pass every shape-only `matches!` test.
+    #[test]
+    fn cache_hit_shares_the_cached_allocation() {
+        let cache = SessionCache::new(100, 30);
+        let generation = cache.generation();
+        cache.insert_if_valid(
+            "hash-share".to_string(),
+            Some(fake_session("hash-share")),
+            generation,
+        );
+        let first = match cache.get("hash-share") {
+            CacheLookup::Hit(session) => Some(session),
+            CacheLookup::Miss | CacheLookup::NegativeHit => None,
+        };
+        let second = match cache.get("hash-share") {
+            CacheLookup::Hit(session) => Some(session),
+            CacheLookup::Miss | CacheLookup::NegativeHit => None,
+        };
+        assert!(
+            matches!((&first, &second), (Some(a), Some(b)) if Arc::ptr_eq(a, b)),
+            "both lookups must hit and share the cached allocation"
+        );
     }
 
     #[test]

--- a/crates/vouch-server/src/handlers/auth.rs
+++ b/crates/vouch-server/src/handlers/auth.rs
@@ -96,8 +96,11 @@ pub(crate) async fn status(
     }
 
     // Get authenticator name from server-side session record
-    let device_name = match session.and_then(|s| s.authenticator_id) {
-        Some(auth_id) => db::get_authenticator_by_id(&state.store, &auth_id)
+    let device_name = match session
+        .as_deref()
+        .and_then(|s| s.authenticator_id.as_deref())
+    {
+        Some(auth_id) => db::get_authenticator_by_id(&state.store, auth_id)
             .await
             .ok()
             .flatten()
@@ -166,7 +169,12 @@ pub(crate) async fn logout(
                             client: client_info,
                             ..Default::default()
                         };
-                        db::record_auth_event(&state.audit, params, Some(session.user_email)).await;
+                        db::record_auth_event(
+                            &state.audit,
+                            params,
+                            Some(session.user_email.clone()),
+                        )
+                        .await;
                     }
                 }
             }

--- a/crates/vouch-server/src/handlers/oidc/authorize.rs
+++ b/crates/vouch-server/src/handlers/oidc/authorize.rs
@@ -418,7 +418,6 @@ async fn check_session_and_authorize(
     match check_session_for_authorization(state, session_token).await {
         Ok(AuthorizationSessionState::Authenticated {
             user,
-            session: _,
             authenticator,
             auth_time: session_auth_time,
         }) => {
@@ -1219,7 +1218,6 @@ async fn handle_pending_auth(state: &Arc<AppState>, pending_id: &str, jar: &Cook
     match check_session_for_authorization(state, session_token).await {
         Ok(AuthorizationSessionState::Authenticated {
             user,
-            session: _,
             authenticator,
             auth_time: session_auth_time,
         }) => {

--- a/crates/vouch-server/src/handlers/oidc/logout.rs
+++ b/crates/vouch-server/src/handlers/oidc/logout.rs
@@ -493,7 +493,8 @@ async fn clear_user_session(
                         client: client_info,
                         ..Default::default()
                     };
-                    db::record_auth_event(&state.audit, params, Some(session.user_email)).await;
+                    db::record_auth_event(&state.audit, params, Some(session.user_email.clone()))
+                        .await;
                 }
             }
         }

--- a/crates/vouch-server/src/handlers/session.rs
+++ b/crates/vouch-server/src/handlers/session.rs
@@ -267,13 +267,13 @@ async fn extract_resource_token(
         client_id: access_claims.client_id,
         aud: access_claims.aud,
         scope: access_claims.scope,
-        authenticator_id: session.authenticator_id,
+        authenticator_id: session.authenticator_id.clone(),
         hardware_verified: access_claims.hardware_verified,
         auth_time: access_claims.auth_time,
         token_hash,
         dpop_source,
-        hardware_aaguid: session.hardware_aaguid,
-        org_domain: session.org_domain,
+        hardware_aaguid: session.hardware_aaguid.clone(),
+        org_domain: session.org_domain.clone(),
     })
 }
 

--- a/crates/vouch-server/src/services/oidc/authorization.rs
+++ b/crates/vouch-server/src/services/oidc/authorization.rs
@@ -8,7 +8,7 @@
 use crate::AppState;
 use crate::crypto::jwt::JwtType;
 use crate::db::{
-    AccessScope, Authenticator, OAuthClient, ParConsumptionProof, ResponseMode, Session,
+    AccessScope, Authenticator, OAuthClient, ParConsumptionProof, ResponseMode,
     TokenEndpointAuthMethod, User,
 };
 use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
@@ -519,8 +519,6 @@ pub enum AuthorizationSessionState {
     Authenticated {
         /// The authenticated user.
         user: Box<User>,
-        /// The session.
-        session: Box<Session>,
         /// The authenticator used.
         authenticator: Box<Authenticator>,
         /// When the session's FIDO2 ceremony happened, from the access
@@ -877,7 +875,6 @@ pub async fn check_session_for_authorization(
             };
             Ok(AuthorizationSessionState::Authenticated {
                 user: Box::new(validated.user),
-                session: Box::new(validated.session),
                 authenticator: Box::new(authenticator),
                 auth_time: validated.auth_time,
             })

--- a/crates/vouch-server/src/services/oidc/introspection.rs
+++ b/crates/vouch-server/src/services/oidc/introspection.rs
@@ -215,7 +215,7 @@ pub async fn introspect_token(
     }
 
     // RFC 9396: authorization_details from session (already a Value).
-    let authorization_details = session.authorization_details;
+    let authorization_details = session.authorization_details.clone();
 
     // RFC 7662 §2.2 `token_type`: derived from the confirmation claim the
     // token actually carries, by the same rule issuance used to advertise it.

--- a/crates/vouch-server/src/services/oidc/token.rs
+++ b/crates/vouch-server/src/services/oidc/token.rs
@@ -12,7 +12,7 @@ use super::scope::{OAuthScope, ScopeSet};
 use crate::AppState;
 use crate::assurance::{ACR_AAL3, AuthMethod, HardwareVerification};
 use crate::crypto::hash_token;
-use crate::db::{self, Authenticator, OAuthClient, Session, User};
+use crate::db::{self, Authenticator, OAuthClient, User};
 use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
 use crate::infra::jwks::JwksOrigin;
 use crate::redact_email;
@@ -1237,8 +1237,6 @@ pub async fn validate_dpop_if_present(
 pub struct OidcValidatedSession {
     /// The authenticated user.
     pub user: User,
-    /// The database session record.
-    pub session: Session,
     /// The authenticator used to create the session, if any.
     /// `None` for OIDC-only enrollment sessions that lack a hardware key.
     ///
@@ -1343,7 +1341,6 @@ pub async fn validate_session_token(
 
     Ok(Some(OidcValidatedSession {
         user,
-        session,
         authenticator,
         scope: decoded.scope().cloned(),
         client_id,


### PR DESCRIPTION
## Summary

`SessionCache::get` deep-cloned the whole `Session` on every hit — 4-8 string allocations plus a recursive clone of `authorization_details` (RFC 9396 rich authorization details, whose size the client influences) — inside the cache mutex on the auth path. The cache now stores `Arc<Session>`: a hit is a refcount bump, and the miss path wraps the DB result once at insert.

Two commits:

- **refactor(server): drop unread session field from authorization state** — `OidcValidatedSession.session` had one consumer, which boxed it into `AuthorizationSessionState::Authenticated.session`, a field every destructuring site discarded. The authorize path was cloning a session out of the cache only to box and drop it unread. Behavior-neutral.
- **perf(server): return Arc<Session> from the session cache** — `CacheEntry.value` and `CacheLookup::Hit` hold `Arc<Session>`; the cache method returns `Result<Option<Arc<Session>>>`. The `#[expect(clippy::large_enum_variant)]` on `CacheLookup` is deleted (with `Hit` at pointer size the lint no longer fires, and an unfulfilled expectation would fail `make lint`). Callers that moved fields out of the returned `Session` now clone just those fields; borrow-only callers are unchanged. A doc comment on `CacheEntry.value` warns off `Arc::make_mut`.

## Testing

- New `cache_hit_shares_the_cached_allocation` test asserts `Arc::ptr_eq` across two hits, so a deep copy cannot be silently reintroduced; verified by mutation (reintroducing the clone makes it fail).
- `make lint` clean (zero warnings), `make test` (all suites, 0 failures), `make test-integration` (28 suites, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)