### PR TITLE
fix(server): reject empty-domain emails at the enrollment chokepoint

### DIFF
--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -751,6 +751,26 @@ pub(crate) async fn complete_enrollment_after_identity(
         .into_response();
     }
 
+    // The shape check above deliberately lets an empty domain (`foo@`)
+    // through because SCIM's create path has a downstream domain-ownership
+    // gate that rejects it with a specific error. Enrollment has no such
+    // always-on gate: its only domain check is the optional
+    // `allowed_domains` allowlist below, which is unset by default. Reject
+    // the empty domain here so open-enrollment mode cannot persist a user
+    // with `email = "foo@"` and a synthetic organization with `domain = ""`.
+    if crate::email::Email::domain_of(&identity.email).is_none_or(|d| d.is_empty()) {
+        tracing::warn!(
+            email = %redact_email(&identity.email),
+            "rejected IdP enrollment: upstream email has an empty domain"
+        );
+        return ErrorTemplate {
+            title: Tr::new("error-heading").to_string(),
+            message: Tr::new("enroll-error-invalid-email").to_string(),
+            back_url: None,
+        }
+        .into_response();
+    }
+
     // Check domain restriction.
     // For Google consumers (no `hd` claim), `identity.domain` is `None`,
     // so `email_domain` becomes "" and will never match an allowed domain.

--- a/crates/vouch-server/src/handlers/enroll/tests.rs
+++ b/crates/vouch-server/src/handlers/enroll/tests.rs
@@ -9,7 +9,7 @@
 use super::*;
 use crate::test_utils::{
     TestSessionSpec, create_test_authenticator, create_test_session_with, create_test_user,
-    http_delete_full, http_get_full, http_post_json, test_app, test_app_state,
+    http_delete_full, http_get_full, http_post_json, test_app, test_app_state, test_config,
 };
 use axum::http::StatusCode;
 use base64::Engine;
@@ -1996,6 +1996,66 @@ async fn test_enrollment_rejects_empty_local_part_email() {
     assert!(
         user.is_none(),
         "an email with no local part must not be persisted"
+    );
+}
+
+// RFC 5322 §3.4.1: addr-spec requires a non-empty domain. The shape check
+// lets `foo@` through by design (SCIM's downstream ownership gate rejects
+// it), so enrollment needs its own gate: with `allowed_domains` unset (the
+// default, open-enrollment mode), nothing else rejects an empty domain
+// before `enroll_user_with_org` persists it.
+#[tokio::test]
+async fn test_enrollment_open_mode_rejects_empty_domain_email() {
+    let state = test_app_state().await;
+    let mut config = test_config();
+    config.allowed_domains = None;
+    state.config.store(std::sync::Arc::new(config));
+    let (stored, claim) = seed_and_consume_oidc_state(&state, "bad-email-state-3", None).await;
+    let identity = IdentityResult {
+        email: "foo@".to_string(),
+        domain: Some(String::new()),
+        upstream: None,
+    };
+
+    let resp =
+        complete_enrollment_after_identity(&state, &stored, identity, claim, ClientInfo::default())
+            .await;
+    assert_eq!(resp.status(), StatusCode::OK, "error page renders as 200");
+
+    let user = crate::db::get_user_by_email(&state.store, "foo@")
+        .await
+        .expect("db query ok");
+    assert!(
+        user.is_none(),
+        "an empty-domain email must not be persisted in open-enrollment mode"
+    );
+}
+
+// RFC 5322 §3.4.1: a well-formed addr-spec passes in open-enrollment mode
+// too (the positive control pinning that the empty-domain gate does not
+// over-reject when `allowed_domains` is unset).
+#[tokio::test]
+async fn test_enrollment_open_mode_accepts_well_formed_email() {
+    let state = test_app_state().await;
+    let mut config = test_config();
+    config.allowed_domains = None;
+    state.config.store(std::sync::Arc::new(config));
+    let user = create_test_user(&state.store, "open-ok@example.com").await;
+    create_test_authenticator(&state.store, &user.id).await;
+    let (stored, claim) = seed_and_consume_oidc_state(&state, "good-email-state-2", None).await;
+    let identity = IdentityResult {
+        email: "open-ok@example.com".to_string(),
+        domain: Some("example.com".to_string()),
+        upstream: None,
+    };
+
+    let resp =
+        complete_enrollment_after_identity(&state, &stored, identity, claim, ClientInfo::default())
+            .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::SEE_OTHER,
+        "a valid email must proceed through enrollment in open-enrollment mode"
     );
 }
 


### PR DESCRIPTION
Fixes #1244

## Bug

`complete_enrollment_after_identity` (`handlers/enroll.rs`) — the single funnel both the OIDC and SAML callbacks feed — shape-checks the upstream IdP email with `Email::is_valid_address`, a helper that **by documented design** lets an empty-domain address (`foo@`) through: the SCIM create path it was written for has a downstream domain-ownership gate that rejects it with a distinct error. Enrollment has no equivalent always-on gate; its only domain check is the operator-configured `allowed_domains` allowlist, which is `None` by default. In open-enrollment mode a non-compliant IdP emitting `foo@` was persisted as a `User` row with `email = "foo@"` and a synthetic `Organization` with `domain = ""`.

Introduced in 79b86747 (#1222), which hardened local-part validation at this chokepoint but left domain-side validation asymmetric. Severity: defense-in-depth / input-validation gap — no authentication bypass or cross-org escalation; requires a misbehaving IdP plus unset `VOUCH_ALLOWED_DOMAINS`.

## Fix

Reject when `Email::domain_of(&identity.email)` is `None` or empty, after the shape check and before the optional allowlist. `is_valid_address` itself is unchanged, preserving SCIM's documented behavior and error semantics. The rejection renders the existing `enroll-error-invalid-email` page (no new i18n key).

## Testing

- `test_enrollment_open_mode_rejects_empty_domain_email` — `allowed_domains = None`, `email = "foo@"`: error page renders, nothing persisted. Verified RED without the fix (fails: user persisted) and GREEN with it.
- `test_enrollment_open_mode_accepts_well_formed_email` — positive control: open-enrollment mode still accepts a normal address.
- `cargo fmt --all --check`, `cargo clippy -p vouch-server --all-targets -- -D warnings`, full `handlers::enroll::tests` suite (39 tests) all pass.