### PR TITLE
fix(server): audit every committed change before the next fallible step

### DIFF
--- a/crates/vouch-server/src/handlers/api/applications.rs
+++ b/crates/vouch-server/src/handlers/api/applications.rs
@@ -719,6 +719,52 @@ pub(crate) async fn revoke_tokens_api(
             )
         })?;
 
+    // The secrets are revoked, which is durable whether or not the session
+    // sweeps below succeed. Audit exactly what committed: the event is
+    // written after the sweeps either way, with `details` naming a partial
+    // outcome, so a failed sweep cannot leave revoked secrets with no
+    // `TokenRevoked` event while the caller is told to retry.
+    let sessions_revoked = revoke_client_sessions(&state, &client).await;
+    db::record_oauth_event(
+        &state.audit,
+        &state.store,
+        &db::RecordOAuthEventParams {
+            oauth_client_id: &app_id,
+            event_type: OAuthEventType::TokenRevoked,
+            user_id: Some(&token.sub),
+            ip_address: None,
+            user_agent: None,
+            details: Some(if sessions_revoked.is_ok() {
+                "All tokens revoked"
+            } else {
+                "Client secrets revoked; session revocation failed, retry required"
+            }),
+            org_domain: db::RecordedOrgDomain::Unresolved,
+        },
+    )
+    .await;
+    sessions_revoked?;
+
+    tracing::info!(
+        "Revoked all tokens for OAuth application: {}",
+        client.client_id
+    );
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// Terminate every live session issued to or for an OAuth client, after its
+/// secrets have been revoked.
+///
+/// Fails closed: if either sweep fails, the caller must not report
+/// revocation success. Secrets are already revoked, but unexpired access
+/// tokens could still validate via DB-backed session lookup, so the caller
+/// must be told the revocation was incomplete (and retry) rather than see a
+/// 204.
+async fn revoke_client_sessions(
+    state: &AppState,
+    client: &db::OAuthClient,
+) -> Result<(), ServiceError> {
     // Terminate live M2M (client_credentials) sessions.
     //
     // Per RFC 9068 §2.2, client_credentials access tokens are persisted as
@@ -727,12 +773,6 @@ pub(crate) async fn revoke_tokens_api(
     // secrets is not enough on its own: the session cache may still serve
     // unexpired tokens until their TTL elapses. Deleting those sessions and
     // invalidating the cache is what closes the M2M half of revocation.
-    //
-    // Fail closed: if session deletion fails, do not report revocation
-    // success. Secrets are already revoked, but unexpired M2M access tokens
-    // could still validate via DB-backed session lookup, so the caller must
-    // be told the revocation was incomplete (and retry) rather than see a
-    // 204 + TokenRevoked.
     db::delete_sessions_for_user(&state.store, &client.client_id)
         .await
         .map_err(|e| {
@@ -764,9 +804,6 @@ pub(crate) async fn revoke_tokens_api(
     // deserialize `client_id` to `None` and so are not matched; they remain
     // valid until their `exp` (bounded by `session_hours`). New tokens minted
     // after this change are revocable on demand.
-    //
-    // Fail closed, as above: a failure here means some user-issued tokens for
-    // this client may still validate, so do not report revocation success.
     db::delete_sessions_for_oauth_client(&state.store, &client.client_id)
         .await
         .map_err(|e| {
@@ -781,29 +818,7 @@ pub(crate) async fn revoke_tokens_api(
             )
         })?;
     state.session_cache.invalidate_for_client(&client.client_id);
-
-    // Log the event
-    db::record_oauth_event(
-        &state.audit,
-        &state.store,
-        &db::RecordOAuthEventParams {
-            oauth_client_id: &app_id,
-            event_type: OAuthEventType::TokenRevoked,
-            user_id: Some(&token.sub),
-            ip_address: None,
-            user_agent: None,
-            details: Some("All tokens revoked"),
-            org_domain: db::RecordedOrgDomain::Unresolved,
-        },
-    )
-    .await;
-
-    tracing::info!(
-        "Revoked all tokens for OAuth application: {}",
-        client.client_id
-    );
-
-    Ok(StatusCode::NO_CONTENT)
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/vouch-server/src/handlers/scim/groups.rs
+++ b/crates/vouch-server/src/handlers/scim/groups.rs
@@ -232,6 +232,20 @@ pub(crate) async fn create_group(
         Err(e) => return create_scim_group_error_response(e),
     };
 
+    // Audit log — the group row is committed, so its audit row is written
+    // before the fallible member adds below: a rejected member must not
+    // leave a created group with no `create` event.
+    db::record_scim_audit(
+        &state.audit,
+        "create",
+        "Group",
+        &db_group.id,
+        Some(&auth.token_id),
+        Some(&serde_json::json!({"displayName": &db_group.display_name}).to_string()),
+        auth.org_domain.as_deref(),
+    )
+    .await;
+
     // Add members if provided
     if let Some(members) = &group.members {
         for member in members {
@@ -243,18 +257,6 @@ pub(crate) async fn create_group(
             }
         }
     }
-
-    // Audit log
-    db::record_scim_audit(
-        &state.audit,
-        "create",
-        "Group",
-        &db_group.id,
-        Some(&auth.token_id),
-        Some(&serde_json::json!({"displayName": &db_group.display_name}).to_string()),
-        auth.org_domain.as_deref(),
-    )
-    .await;
 
     let base_url = &state.config().base_url;
     let Ok(members) =
@@ -452,6 +454,31 @@ async fn apply_member_op(
 /// Modifies a Group resource using SCIM PATCH operations (add, replace,
 /// remove) applied against [`GROUP_ATTRIBUTES`], plus member management
 /// via the `members` path.
+/// Audit a group PATCH that failed after `applied` member operations had
+/// already committed. Membership changes are applied one at a time, so an
+/// error part-way through leaves real state behind; the audit row must
+/// reflect it even though the request fails. No-op when nothing committed.
+async fn record_partial_group_update(
+    state: &AppState,
+    auth: &super::ScimAuth,
+    group_id: &str,
+    applied: usize,
+) {
+    if applied == 0 {
+        return;
+    }
+    db::record_scim_audit(
+        &state.audit,
+        "update",
+        "Group",
+        group_id,
+        Some(&auth.token_id),
+        Some(&serde_json::json!({"partial": true, "memberOpsApplied": applied}).to_string()),
+        auth.org_domain.as_deref(),
+    )
+    .await;
+}
+
 pub(crate) async fn patch_group(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -522,10 +549,17 @@ pub(crate) async fn patch_group(
         }
     }
 
+    // Member operations commit one at a time, so a failure part-way leaves
+    // the earlier ones applied. Every error exit past the first applied
+    // operation audits what committed before returning, so a membership
+    // change never lands without an `update` event.
+    let mut applied_member_ops = 0usize;
     for (path, op) in member_ops {
         if let Err(response) = apply_member_op(&state.store, &id, &auth.org_id, path, op).await {
+            record_partial_group_update(&state, &auth, &id, applied_member_ops).await;
             return response;
         }
+        applied_member_ops = applied_member_ops.saturating_add(1);
     }
 
     // Update group in database
@@ -541,6 +575,7 @@ pub(crate) async fn patch_group(
         {
             Ok(true) => {}
             Ok(false) => {
+                record_partial_group_update(&state, &auth, &id, applied_member_ops).await;
                 return (
                     StatusCode::NOT_FOUND,
                     Json(ScimError::new(404, "Group not found")),
@@ -548,6 +583,7 @@ pub(crate) async fn patch_group(
                     .into_response();
             }
             Err(e) => {
+                record_partial_group_update(&state, &auth, &id, applied_member_ops).await;
                 if let Some(resp) = super::invalid_index_value_response(&e) {
                     return resp.into_response();
                 }

--- a/crates/vouch-server/src/handlers/scim/tests/groups.rs
+++ b/crates/vouch-server/src/handlers/scim/tests/groups.rs
@@ -1184,3 +1184,133 @@ async fn test_scim_create_and_delete_user_audit_events_never_carry_a_raw_email()
         );
     }
 }
+
+// ========================================================================
+// Audit ordering: a committed change must have its audit row even when a
+// later step of the same request fails (the class behind the missing
+// `Enrollment` event in CLI-initiated WebAuthn enrollment).
+// ========================================================================
+
+async fn scim_operation_events(state: &crate::AppState) -> Vec<serde_json::Value> {
+    state
+        .audit
+        .query_events(&crate::db::AuditEventFilter {
+            event_types: Some(vec!["scim_operation".to_string()]),
+            ..crate::db::AuditEventFilter::default()
+        })
+        .await
+        .expect("query audit events")
+        .into_iter()
+        .map(|e| serde_json::from_str(&e.data).expect("scim audit data is JSON"))
+        .collect()
+}
+
+#[tokio::test]
+async fn test_scim_create_group_audits_committed_group_when_member_add_fails() {
+    // The group row commits before members are added one at a time. A
+    // rejected member fails the request, but the group exists, so its
+    // `create` audit row must exist too.
+    let (app, state) = test_app().await;
+    let token = create_test_scim_token(&state.store, "test-create-audit-partial", "test-org").await;
+    let auth_header = format!("Bearer {token}");
+
+    let (status, body) = http_post_json(
+        &app,
+        "/scim/v2/Groups",
+        r#"{"schemas":["urn:ietf:params:scim:schemas:core:2.0:Group"],"displayName":"TeamAudit","members":[{"value":"bad\u0000member"}]}"#,
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert!(
+        !status.is_success(),
+        "a NUL-bearing member must fail the request, got {status}: {body}"
+    );
+
+    let events = scim_operation_events(&state).await;
+    let creates: Vec<_> = events
+        .iter()
+        .filter(|e| e["operation"] == "create" && e["resource_type"] == "Group")
+        .collect();
+    assert_eq!(
+        creates.len(),
+        1,
+        "the committed group must have its create audit row, got {events:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_scim_patch_group_audits_partially_applied_member_ops() {
+    // Member operations commit one at a time. When a later one fails, the
+    // earlier ones are already applied, so the request must leave an
+    // `update` audit row that says so.
+    let (app, state) = test_app().await;
+    let token = create_test_scim_token(&state.store, "test-patch-audit-partial", "test-org").await;
+    let auth_header = format!("Bearer {token}");
+
+    let (_, user_body) = http_post_json(
+        &app,
+        "/scim/v2/Users",
+        r#"{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],"userName":"partial-patch@test-org.example.com"}"#,
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    let user: serde_json::Value = serde_json::from_str(&user_body).expect("Valid JSON");
+    let user_id = user["id"].as_str().expect("user id");
+
+    let (status, body) = http_post_json(
+        &app,
+        "/scim/v2/Groups",
+        r#"{"schemas":["urn:ietf:params:scim:schemas:core:2.0:Group"],"displayName":"TeamPartial"}"#,
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{body}");
+    let created: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let group_id = created["id"].as_str().expect("group id");
+
+    // First op adds a real member (commits); second names an unknown one.
+    let patch_body = format!(
+        r#"{{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],"Operations":[{{"op":"add","path":"members","value":[{{"value":"{user_id}"}}]}},{{"op":"add","path":"members","value":[{{"value":"bad\u0000member"}}]}}]}}"#
+    );
+    let (status, body) = http_request(
+        &app,
+        "PATCH",
+        &format!("/scim/v2/Groups/{group_id}"),
+        Some(patch_body),
+        &[
+            ("Content-Type", "application/json"),
+            ("Authorization", &auth_header),
+        ],
+    )
+    .await;
+    assert!(
+        !status.is_success(),
+        "the NUL-bearing member must fail the request, got {status}: {body}"
+    );
+
+    // The first op really committed.
+    let (_, body) = http_get(
+        &app,
+        &format!("/scim/v2/Groups/{group_id}"),
+        &[("Authorization", &auth_header)],
+    )
+    .await;
+    let group: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert!(
+        group["members"]
+            .as_array()
+            .is_some_and(|m| m.iter().any(|m| m["value"] == user_id)),
+        "the first member op must have been applied: {group}"
+    );
+
+    let events = scim_operation_events(&state).await;
+    let partial = events.iter().find(|e| {
+        e["operation"] == "update" && e["resource_type"] == "Group" && e["resource_id"] == group_id
+    });
+    let details: serde_json::Value = partial
+        .and_then(|e| e["details"].as_str())
+        .map(|d| serde_json::from_str(d).expect("details JSON"))
+        .expect("the partially applied PATCH must leave an update audit row");
+    assert_eq!(details["partial"], true);
+    assert_eq!(details["memberOpsApplied"], 1);
+}

--- a/crates/vouch-server/src/handlers/scim/users.rs
+++ b/crates/vouch-server/src/handlers/scim/users.rs
@@ -498,6 +498,29 @@ pub(crate) async fn patch_user(
                 .into_response();
         }
         Err(crate::services::auth::DeactivationError::Persist(e)) => {
+            if patched.deactivated {
+                // `revoke_then_persist` already withdrew the user's sessions
+                // and SSH certificates; that committed change gets its audit
+                // row even though the `active = false` write then failed.
+                db::record_scim_audit(
+                    &state.audit,
+                    "update",
+                    "User",
+                    &id,
+                    Some(&auth.token_id),
+                    Some(
+                        &serde_json::json!({
+                            "active": patched.active,
+                            "deactivated": true,
+                            "accessRevoked": true,
+                            "persisted": false
+                        })
+                        .to_string(),
+                    ),
+                    auth.org_domain.as_deref(),
+                )
+                .await;
+            }
             if let Some(resp) = super::invalid_index_value_response(&e) {
                 return resp.into_response();
             }
@@ -619,6 +642,18 @@ pub(crate) async fn delete_user(
                 .into_response();
         }
         Err(e) => {
+            // Access was already revoked above; that committed change gets
+            // its audit row even though the delete itself failed.
+            db::record_scim_audit(
+                &state.audit,
+                "delete",
+                "User",
+                &id,
+                Some(&auth.token_id),
+                Some(&serde_json::json!({"accessRevoked": true, "deleted": false}).to_string()),
+                auth.org_domain.as_deref(),
+            )
+            .await;
             tracing::error!("Failed to delete user: {e}");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/vouch-server/src/services/oidc/fido2_grant.rs
+++ b/crates/vouch-server/src/services/oidc/fido2_grant.rs
@@ -319,9 +319,24 @@ pub(crate) async fn exchange_fido2_assertion(
         assertion_result.user_verified,
     );
 
+    // Validate authorization_details if provided (RFC 9396). Pure request
+    // validation, so it runs before the counter commit below: a malformed
+    // parameter is rejected with nothing durable changed and nothing that
+    // needs an audit row.
+    let validated_ad = params
+        .authorization_details
+        .map(AuthorizationDetails::parse)
+        .transpose()?;
+
+    let ad_value = validated_ad.as_ref().map(serde_json::Value::from);
+
     // Update counter in database
     // WebAuthn counter is u32; stored bit-identical as i32. Real authenticators never
     // approach 2^31 uses, and bitwise reinterpret preserves DB monotonicity comparisons.
+    //
+    // From here on every exit records an audit event (`LoginFailed` from
+    // the posture gate, `LoginSuccess` otherwise): the counter update is
+    // committed, and a verified ceremony must never vanish from AuthEvents.
     db::update_authenticator_counter(
         &state.store,
         &authenticator.id,
@@ -333,14 +348,6 @@ pub(crate) async fn exchange_fido2_assertion(
     // Capture client metadata for the audit events below.
     let client_ip = params.client_info.client_ip;
     let client_user_agent = params.client_info.user_agent.clone();
-
-    // Validate authorization_details if provided (RFC 9396)
-    let validated_ad = params
-        .authorization_details
-        .map(AuthorizationDetails::parse)
-        .transpose()?;
-
-    let ad_value = validated_ad.as_ref().map(serde_json::Value::from);
 
     // Evaluate device posture policies (if org has active policies).
     // The login audit event is written AFTER this gate: a policy-denied

--- a/crates/vouch-server/src/services/oidc/registration.rs
+++ b/crates/vouch-server/src/services/oidc/registration.rs
@@ -570,7 +570,27 @@ pub async fn register_client(
         ServiceError::Internal("Failed to create client".to_string())
     })?;
 
-    // 16. Generate client_secret for confidential clients
+    // 16. Record audit event — the client row is committed, so its audit row
+    // is written before the fallible secret-generation step below; a secret
+    // failure must not leave a registered client with no `ClientRegistered`
+    // event.
+    let base_url = &state.config().base_url;
+    db::record_oauth_event(
+        &state.audit,
+        &state.store,
+        &db::RecordOAuthEventParams {
+            oauth_client_id: &client.id,
+            event_type: OAuthEventType::ClientRegistered,
+            user_id: authenticated_user_id,
+            ip_address: None,
+            user_agent: None,
+            details: Some("RFC 7591 dynamic registration"),
+            org_domain: db::RecordedOrgDomain::Unresolved,
+        },
+    )
+    .await;
+
+    // 17. Generate client_secret for confidential clients
     let client_secret = if matches!(
         jwks_auth.auth_method,
         TokenEndpointAuthMethod::ClientSecretBasic | TokenEndpointAuthMethod::ClientSecretPost
@@ -593,23 +613,6 @@ pub async fn register_client(
     } else {
         None
     };
-
-    // 17. Record audit event
-    let base_url = &state.config().base_url;
-    db::record_oauth_event(
-        &state.audit,
-        &state.store,
-        &db::RecordOAuthEventParams {
-            oauth_client_id: &client.id,
-            event_type: OAuthEventType::ClientRegistered,
-            user_id: authenticated_user_id,
-            ip_address: None,
-            user_agent: None,
-            details: Some("RFC 7591 dynamic registration"),
-            org_domain: db::RecordedOrgDomain::Unresolved,
-        },
-    )
-    .await;
 
     // Derive client_id_issued_at from created_at
     let client_id_issued_at = client.created_at.as_second();

--- a/crates/vouch-server/src/services/oidc/token.rs
+++ b/crates/vouch-server/src/services/oidc/token.rs
@@ -397,32 +397,10 @@ pub(crate) async fn exchange_authorization_code(
     let access_token = session_result.token;
     let expires_in = session_result.expires_in;
 
-    // Extract the per-client ID token signing algorithm.
-    // Public/unauthenticated clients fall back to "RS256" per OIDC Core default.
-    let id_token_alg =
-        authenticated_client.map_or("RS256", |c| c.client.id_token_signed_response_alg.as_str());
-
-    // Generate ID token (with at_hash computed from the access token)
-    let id_token = generate_id_token(
-        state,
-        IdTokenParams {
-            client_id: &auth_code.client_id,
-            user_id: &auth_code.user_id,
-            email: &auth_code.email,
-            nonce: auth_code.nonce.as_deref(),
-            expires_in,
-            binding: params.binding,
-            scope: &auth_code.scope,
-            hardware_verification: HardwareVerification::Verified {
-                auth_time: auth_code.auth_time,
-            },
-            access_token: Some(access_token.expose_secret()),
-            id_token_alg,
-        },
-    )
-    .await?;
-
-    // Record usage event for registered clients
+    // Record usage event for registered clients. The session is committed,
+    // so this is written before the fallible ID-token signing below: a
+    // signing failure must not leave a persisted access token with no
+    // `TokenIssued` event.
     if let Some(auth_client) = authenticated_client {
         // The user-org half of `resolve_event_org_domain`'s "prefer user,
         // fall back to client" rule was already resolved above for the
@@ -455,6 +433,31 @@ pub(crate) async fn exchange_authorization_code(
         )
         .await;
     }
+
+    // Extract the per-client ID token signing algorithm.
+    // Public/unauthenticated clients fall back to "RS256" per OIDC Core default.
+    let id_token_alg =
+        authenticated_client.map_or("RS256", |c| c.client.id_token_signed_response_alg.as_str());
+
+    // Generate ID token (with at_hash computed from the access token)
+    let id_token = generate_id_token(
+        state,
+        IdTokenParams {
+            client_id: &auth_code.client_id,
+            user_id: &auth_code.user_id,
+            email: &auth_code.email,
+            nonce: auth_code.nonce.as_deref(),
+            expires_in,
+            binding: params.binding,
+            scope: &auth_code.scope,
+            hardware_verification: HardwareVerification::Verified {
+                auth_time: auth_code.auth_time,
+            },
+            access_token: Some(access_token.expose_secret()),
+            id_token_alg,
+        },
+    )
+    .await?;
 
     if let Some(proof) = params.binding.dpop_proof() {
         tracing::info!(


### PR DESCRIPTION
Follow-up to #1224 (Detail issue #1197), which fixed one instance of a pattern: a durable state change commits, a later step of the same request can fail, and the audit row for the committed change sits after that step, so the failure path leaves real state with no audit trail. #1224 merged before this class sweep was ready, so it lands here on its own.

## Same-class sites fixed

Each site now writes the audit row for what actually committed, before (or regardless of) the step that can fail:

- **RFC 7591 registration** (`services/oidc/registration.rs`): `ClientRegistered` is written right after the client row commits, before the fallible secret generation.
- **authorization_code grant** (`services/oidc/token.rs`): `TokenIssued` is written right after the session persists, before ID-token signing can fail.
- **`revoke_tokens_api`** (`handlers/api/applications.rs`): the two session sweeps move into `revoke_client_sessions`, and `TokenRevoked` is always written after them, with `details` naming a failed sweep, so revoked secrets never go unaudited while the caller is told to retry.
- **FIDO2 grant** (`services/oidc/fido2_grant.rs`): `authorization_details` is parsed before the counter commit, so a malformed parameter is rejected with nothing durable changed; past the commit every exit records `LoginFailed` or `LoginSuccess`.
- **SCIM group create** (`handlers/scim/groups.rs`): the `create` event is written before member adds.
- **SCIM group PATCH**: member operations commit one at a time, so an error after one or more have applied records an `update` event marking the partial application (`record_partial_group_update`).
- **SCIM user PATCH (deactivation) and DELETE** (`handlers/scim/users.rs`): a persist or delete failure after `revoke_user_access` committed records the revocation.

## Not changed (noted for follow-up)

These paths have no audit event at all on their failure branches rather than a misplaced one, so they are a different class: `handlers/device.rs` when a consumed device code is then refused (inactive user, org lookup, token mint), `handlers/enroll.rs` after the user row and session commit but the device-auth branch errors, and the web/API application create/delete handlers, which emit no OAuth events (only the RFC 7591/7592 paths do).

## Testing

- New: `test_scim_create_group_audits_committed_group_when_member_add_fails` and `test_scim_patch_group_audits_partially_applied_member_ops` (a NUL-bearing member id is the deterministic failure the index layer rejects).
- `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features -p vouch-server` (3610 lib tests), and the `spec_coverage`, `integration`, and `scim_org_isolation` targets of `vouch-tests` all pass.
- Not verified: failure injection for ID-token signing, secret generation, and session-sweep errors has no test seam, so those reorderings are covered by inspection and the unchanged happy-path suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VQ5Rx6HQkHekNNSaRsiR9

---
_Generated by [Claude Code](https://claude.ai/code/session_016VQ5Rx6HQkHekNNSaRsiR9)_