### PR TITLE
refactor(test): inline the single-purpose helpers the Detail fixes added

### DIFF
--- a/crates/vouch-server/src/handlers/api/applications.rs
+++ b/crates/vouch-server/src/handlers/api/applications.rs
@@ -724,7 +724,69 @@ pub(crate) async fn revoke_tokens_api(
     // written after the sweeps either way, with `details` naming a partial
     // outcome, so a failed sweep cannot leave revoked secrets with no
     // `TokenRevoked` event while the caller is told to retry.
-    let sessions_revoked = revoke_client_sessions(&state, &client).await;
+    //
+    // The sweeps fail closed: if either fails, revocation is not reported as
+    // successful. Secrets are already revoked, but unexpired access tokens
+    // could still validate via DB-backed session lookup, so the caller must
+    // be told the revocation was incomplete (and retry) rather than see a
+    // 204.
+    let sessions_revoked: Result<(), ServiceError> = async {
+        // Terminate live M2M (client_credentials) sessions.
+        //
+        // Per RFC 9068 §2.2, client_credentials access tokens are persisted as
+        // sessions whose `user_id` equals the OAuth client's `client_id`, so this
+        // delete reaches exactly the M2M sessions for this client. Revoking
+        // secrets is not enough on its own: the session cache may still serve
+        // unexpired tokens until their TTL elapses. Deleting those sessions and
+        // invalidating the cache is what closes the M2M half of revocation.
+        db::delete_sessions_for_user(&state.store, &client.client_id)
+            .await
+            .map_err(|e| {
+                tracing::error!(
+                    "Failed to delete M2M sessions for {}: {e}",
+                    client.client_id
+                );
+                ServiceError::api(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "db_error",
+                    "Internal database error",
+                )
+            })?;
+        state.session_cache.invalidate_for_user(&client.client_id);
+
+        // Terminate user-issued access-token sessions minted for this client.
+        //
+        // `authorization_code`, `device_code`, RFC 8693 `token_exchange`, and
+        // FIDO2-assertion grants all persist sessions under the *real resource
+        // owner's* `user_id` (not the client's), so the M2M delete above — which
+        // filters by `user_id == client_id` — cannot reach them. Those sessions
+        // carry the issuing client's id on the `client_id` index (stamped by
+        // `create_oauth_access_token` from the RFC 9068 `client_id` claim), so a
+        // client-scoped delete is what "revoke all tokens for an application"
+        // must cover. Without it the tokens keep validating at resource
+        // endpoints until their `exp`.
+        //
+        // Pre-migration sessions issued before the `client_id` index existed
+        // deserialize `client_id` to `None` and so are not matched; they remain
+        // valid until their `exp` (bounded by `session_hours`). New tokens minted
+        // after this change are revocable on demand.
+        db::delete_sessions_for_oauth_client(&state.store, &client.client_id)
+            .await
+            .map_err(|e| {
+                tracing::error!(
+                    "Failed to delete user-issued sessions for client {}: {e}",
+                    client.client_id
+                );
+                ServiceError::api(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "db_error",
+                    "Internal database error",
+                )
+            })?;
+        state.session_cache.invalidate_for_client(&client.client_id);
+        Ok(())
+    }
+    .await;
     db::record_oauth_event(
         &state.audit,
         &state.store,
@@ -751,74 +813,6 @@ pub(crate) async fn revoke_tokens_api(
     );
 
     Ok(StatusCode::NO_CONTENT)
-}
-
-/// Terminate every live session issued to or for an OAuth client, after its
-/// secrets have been revoked.
-///
-/// Fails closed: if either sweep fails, the caller must not report
-/// revocation success. Secrets are already revoked, but unexpired access
-/// tokens could still validate via DB-backed session lookup, so the caller
-/// must be told the revocation was incomplete (and retry) rather than see a
-/// 204.
-async fn revoke_client_sessions(
-    state: &AppState,
-    client: &db::OAuthClient,
-) -> Result<(), ServiceError> {
-    // Terminate live M2M (client_credentials) sessions.
-    //
-    // Per RFC 9068 §2.2, client_credentials access tokens are persisted as
-    // sessions whose `user_id` equals the OAuth client's `client_id`, so this
-    // delete reaches exactly the M2M sessions for this client. Revoking
-    // secrets is not enough on its own: the session cache may still serve
-    // unexpired tokens until their TTL elapses. Deleting those sessions and
-    // invalidating the cache is what closes the M2M half of revocation.
-    db::delete_sessions_for_user(&state.store, &client.client_id)
-        .await
-        .map_err(|e| {
-            tracing::error!(
-                "Failed to delete M2M sessions for {}: {e}",
-                client.client_id
-            );
-            ServiceError::api(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "db_error",
-                "Internal database error",
-            )
-        })?;
-    state.session_cache.invalidate_for_user(&client.client_id);
-
-    // Terminate user-issued access-token sessions minted for this client.
-    //
-    // `authorization_code`, `device_code`, RFC 8693 `token_exchange`, and
-    // FIDO2-assertion grants all persist sessions under the *real resource
-    // owner's* `user_id` (not the client's), so the M2M delete above — which
-    // filters by `user_id == client_id` — cannot reach them. Those sessions
-    // carry the issuing client's id on the `client_id` index (stamped by
-    // `create_oauth_access_token` from the RFC 9068 `client_id` claim), so a
-    // client-scoped delete is what "revoke all tokens for an application"
-    // must cover. Without it the tokens keep validating at resource
-    // endpoints until their `exp`.
-    //
-    // Pre-migration sessions issued before the `client_id` index existed
-    // deserialize `client_id` to `None` and so are not matched; they remain
-    // valid until their `exp` (bounded by `session_hours`). New tokens minted
-    // after this change are revocable on demand.
-    db::delete_sessions_for_oauth_client(&state.store, &client.client_id)
-        .await
-        .map_err(|e| {
-            tracing::error!(
-                "Failed to delete user-issued sessions for client {}: {e}",
-                client.client_id
-            );
-            ServiceError::api(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "db_error",
-                "Internal database error",
-            )
-        })?;
-    state.session_cache.invalidate_for_client(&client.client_id);
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/vouch-server/src/handlers/api/applications/tests.rs
+++ b/crates/vouch-server/src/handlers/api/applications/tests.rs
@@ -2756,15 +2756,13 @@ async fn test_update_application_absent_access_scope_preserves_existing() {
 // secret row. Mirrors the web-handler regression coverage above.
 // ========================================================================
 
-async fn setup_user_with_fapi_app(
-    state: &crate::AppState,
-    email: &str,
-    auth_method: crate::db::TokenEndpointAuthMethod,
-) -> (String, String) {
-    let user = create_test_user(&state.store, email).await;
+#[tokio::test]
+async fn test_add_secret_rejects_mtls_fapi_client() {
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "api-mtls-fapi-secret@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let token = create_test_session_with(
-        state,
+        &state,
         TestSessionSpec {
             user_id: &user.id,
             email: &user.email,
@@ -2777,7 +2775,7 @@ async fn setup_user_with_fapi_app(
         &state.store,
         &user.id,
         TestClientSpec {
-            token_endpoint_auth_method: Some(auth_method),
+            token_endpoint_auth_method: Some(crate::db::TokenEndpointAuthMethod::TlsClientAuth),
             tls_client_auth_subject_dn: Some("CN=test.example.com".to_string()),
             jwks: TestJwks::Shared,
             dpop_bound_access_tokens: true,
@@ -2787,18 +2785,7 @@ async fn setup_user_with_fapi_app(
         },
     )
     .await;
-    (client.app_id, token)
-}
-
-#[tokio::test]
-async fn test_add_secret_rejects_mtls_fapi_client() {
-    let (app, state) = test_app().await;
-    let (app_id, token) = setup_user_with_fapi_app(
-        &state,
-        "api-mtls-fapi-secret@example.com",
-        crate::db::TokenEndpointAuthMethod::TlsClientAuth,
-    )
-    .await;
+    let app_id = client.app_id;
     let auth = bearer(&token);
 
     let (status, body) = http_post_json(
@@ -2825,12 +2812,35 @@ async fn test_add_secret_rejects_mtls_fapi_client() {
 #[tokio::test]
 async fn test_add_secret_rejects_self_signed_mtls_fapi_client() {
     let (app, state) = test_app().await;
-    let (app_id, token) = setup_user_with_fapi_app(
+    let user = create_test_user(&state.store, "api-self-signed-mtls-fapi-secret@example.com").await;
+    let auth_id = create_test_authenticator(&state.store, &user.id).await;
+    let token = create_test_session_with(
         &state,
-        "api-self-signed-mtls-fapi-secret@example.com",
-        crate::db::TokenEndpointAuthMethod::SelfSignedTlsClientAuth,
+        TestSessionSpec {
+            user_id: &user.id,
+            email: &user.email,
+            auth_id: Some(&auth_id),
+            ..Default::default()
+        },
     )
     .await;
+    let client = create_test_client(
+        &state.store,
+        &user.id,
+        TestClientSpec {
+            token_endpoint_auth_method: Some(
+                crate::db::TokenEndpointAuthMethod::SelfSignedTlsClientAuth,
+            ),
+            tls_client_auth_subject_dn: Some("CN=test.example.com".to_string()),
+            jwks: TestJwks::Shared,
+            dpop_bound_access_tokens: true,
+            fapi_profile: Some(crate::db::FapiProfile::Fapi2Security),
+            with_secret: false,
+            ..Default::default()
+        },
+    )
+    .await;
+    let app_id = client.app_id;
     let auth = bearer(&token);
 
     let (status, body) = http_post_json(
@@ -2912,14 +2922,16 @@ async fn test_add_secret_rejects_private_key_jwt_fapi_client() {
 // "last active secret" floor previously pinned it forever.
 // ========================================================================
 
-async fn setup_user_with_fapi_app_and_secret(
-    state: &crate::AppState,
-    email: &str,
-) -> (String, String) {
-    let user = create_test_user(&state.store, email).await;
+// FAPI 2.0 Security Profile §5.3.2.1 item 6: mTLS-FAPI clients authenticate
+// only via mutual TLS, so a FAPI client's last (unusable) secret must be
+// deletable.
+#[tokio::test]
+async fn test_delete_last_secret_allowed_for_fapi_client() {
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "api-fapi-del-last@example.com").await;
     let auth_id = create_test_authenticator(&state.store, &user.id).await;
     let token = create_test_session_with(
-        state,
+        &state,
         TestSessionSpec {
             user_id: &user.id,
             email: &user.email,
@@ -2937,22 +2949,12 @@ async fn setup_user_with_fapi_app_and_secret(
             jwks: TestJwks::Shared,
             dpop_bound_access_tokens: true,
             fapi_profile: Some(crate::db::FapiProfile::Fapi2Security),
-            with_secret: true, // simulates a pre-guard mTLS-FAPI client with a dead secret row
+            with_secret: true, // a pre-guard mTLS-FAPI client with a dead secret row
             ..Default::default()
         },
     )
     .await;
-    (client.app_id, token)
-}
-
-// FAPI 2.0 Security Profile §5.3.2.1 item 6: mTLS-FAPI clients authenticate
-// only via mutual TLS, so a FAPI client's last (unusable) secret must be
-// deletable.
-#[tokio::test]
-async fn test_delete_last_secret_allowed_for_fapi_client() {
-    let (app, state) = test_app().await;
-    let (app_id, token) =
-        setup_user_with_fapi_app_and_secret(&state, "api-fapi-del-last@example.com").await;
+    let app_id = client.app_id;
     let auth = bearer(&token);
 
     let (_, body) = http_get(

--- a/crates/vouch-server/src/handlers/applications/web.rs
+++ b/crates/vouch-server/src/handlers/applications/web.rs
@@ -1196,17 +1196,18 @@ mod tests {
     // `vouch_...` secret the token endpoint can never accept.
     // ========================================================================
 
-    async fn mint_secret_mtls_fapi_client(
-        email: &str,
-        auth_method: crate::db::TokenEndpointAuthMethod,
-    ) -> (
-        axum::Router,
-        std::sync::Arc<crate::AppState>,
-        String,
-        crate::test_utils::TestOAuthClient,
-    ) {
+    // Regression for #214: an mTLS-FAPI (`tls_client_auth`) client must NOT
+    // be able to mint a client secret via direct POST. Previously the narrow
+    // `== PrivateKeyJwt` guard let it through and rendered a plaintext
+    // `SecretAddedTemplate` while persisting a dead secret row.
+    //
+    // `error_page` and `SecretAddedTemplate` both render as HTTP 200 HTML
+    // (the `impl_template_into_response!` macro sets no status), so the
+    // guard is verified by response content + persisted rows, not by status.
+    #[tokio::test]
+    async fn test_web_add_secret_mints_unusable_secret_for_mtls_fapi_client() {
         let (app, state) = test_app().await;
-        let user = create_test_user(&state.store, email).await;
+        let user = create_test_user(&state.store, "mtls-fapi-secret@example.com").await;
         let auth_id = create_test_authenticator(&state.store, &user.id).await;
         let session_token = create_test_session_with(
             &state,
@@ -1222,7 +1223,7 @@ mod tests {
             &state.store,
             &user.id,
             TestClientSpec {
-                token_endpoint_auth_method: Some(auth_method),
+                token_endpoint_auth_method: Some(crate::db::TokenEndpointAuthMethod::TlsClientAuth),
                 tls_client_auth_subject_dn: Some("CN=test.example.com".to_string()),
                 jwks: TestJwks::Shared,
                 dpop_bound_access_tokens: true,
@@ -1230,24 +1231,6 @@ mod tests {
                 with_secret: false,
                 ..Default::default()
             },
-        )
-        .await;
-        (app, state, session_token, client)
-    }
-
-    // Regression for #214: an mTLS-FAPI (`tls_client_auth`) client must NOT
-    // be able to mint a client secret via direct POST. Previously the narrow
-    // `== PrivateKeyJwt` guard let it through and rendered a plaintext
-    // `SecretAddedTemplate` while persisting a dead secret row.
-    //
-    // `error_page` and `SecretAddedTemplate` both render as HTTP 200 HTML
-    // (the `impl_template_into_response!` macro sets no status), so the
-    // guard is verified by response content + persisted rows, not by status.
-    #[tokio::test]
-    async fn test_web_add_secret_mints_unusable_secret_for_mtls_fapi_client() {
-        let (app, state, session_token, client) = mint_secret_mtls_fapi_client(
-            "mtls-fapi-secret@example.com",
-            crate::db::TokenEndpointAuthMethod::TlsClientAuth,
         )
         .await;
 
@@ -1282,9 +1265,33 @@ mod tests {
     // other FAPI auth method #214 made reachable; it must be blocked too.
     #[tokio::test]
     async fn test_web_add_secret_rejects_self_signed_mtls_fapi_client() {
-        let (app, state, session_token, client) = mint_secret_mtls_fapi_client(
-            "self-signed-mtls-fapi-secret@example.com",
-            crate::db::TokenEndpointAuthMethod::SelfSignedTlsClientAuth,
+        let (app, state) = test_app().await;
+        let user = create_test_user(&state.store, "self-signed-mtls-fapi-secret@example.com").await;
+        let auth_id = create_test_authenticator(&state.store, &user.id).await;
+        let session_token = create_test_session_with(
+            &state,
+            TestSessionSpec {
+                user_id: &user.id,
+                email: &user.email,
+                auth_id: Some(&auth_id),
+                ..Default::default()
+            },
+        )
+        .await;
+        let client = create_test_client(
+            &state.store,
+            &user.id,
+            TestClientSpec {
+                token_endpoint_auth_method: Some(
+                    crate::db::TokenEndpointAuthMethod::SelfSignedTlsClientAuth,
+                ),
+                tls_client_auth_subject_dn: Some("CN=test.example.com".to_string()),
+                jwks: TestJwks::Shared,
+                dpop_bound_access_tokens: true,
+                fapi_profile: Some(crate::db::FapiProfile::Fapi2Security),
+                with_secret: false,
+                ..Default::default()
+            },
         )
         .await;
 

--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -1797,31 +1797,13 @@ mod tests {
     // never vanishes from the audit log. The full handler path needs a real
     // signed assertion, so these tests exercise the extracted tail directly.
 
-    async fn login_audit_events(
-        state: &AppState,
-        event_type: &str,
-        user_id: &str,
-    ) -> Vec<crate::db::AuditEvent> {
-        state
-            .audit
-            .query_events(&crate::db::AuditEventFilter {
-                event_types: Some(vec![event_type.to_string()]),
-                user_id: Some(user_id.to_string()),
-                ..Default::default()
-            })
-            .await
-            .expect("query audit events")
-    }
-
-    async fn finalize_login_fixture(
-        state: &AppState,
-        email: &str,
-    ) -> (
-        crate::db::User,
-        crate::db::Authenticator,
-        db::ChallengeStateClaim,
-    ) {
-        let user = crate::test_utils::create_test_user(&state.store, email).await;
+    #[tokio::test]
+    async fn finalize_login_session_records_login_success_on_happy_path() {
+        // Positive: the tail succeeds — LoginSuccess is recorded, LoginFailed
+        // is not, and a session cookie is issued.
+        let state = crate::test_utils::test_app_state().await;
+        let user =
+            crate::test_utils::create_test_user(&state.store, "finalize-ok@example.com").await;
         let auth_id = crate::test_utils::create_test_authenticator(&state.store, &user.id).await;
         let authenticator = crate::db::get_authenticator_by_id(&state.store, &auth_id)
             .await
@@ -1832,21 +1814,11 @@ mod tests {
             .expect("valid expiry");
         let claim = crate::db::consume_challenge_state_for_test(
             &state.store,
-            &format!("test-state-jwt-{email}"),
+            "test-state-jwt-finalize-ok@example.com",
             expires_at,
         )
         .await
         .expect("consume challenge state");
-        (user, authenticator, claim)
-    }
-
-    #[tokio::test]
-    async fn finalize_login_session_records_login_success_on_happy_path() {
-        // Positive: the tail succeeds — LoginSuccess is recorded, LoginFailed
-        // is not, and a session cookie is issued.
-        let state = crate::test_utils::test_app_state().await;
-        let (user, authenticator, claim) =
-            finalize_login_fixture(&state, "finalize-ok@example.com").await;
 
         let response = finalize_login_session(
             &state,
@@ -1867,9 +1839,25 @@ mod tests {
         .expect("happy path must succeed");
         assert_eq!(response.status(), StatusCode::OK);
 
-        let successes = login_audit_events(&state, "login_success", &user.id).await;
+        let successes = state
+            .audit
+            .query_events(&crate::db::AuditEventFilter {
+                event_types: Some(vec!["login_success".to_string()]),
+                user_id: Some(user.id.clone()),
+                ..Default::default()
+            })
+            .await
+            .expect("query audit events");
         assert_eq!(successes.len(), 1, "LoginSuccess must be recorded");
-        let failures = login_audit_events(&state, "login_failed", &user.id).await;
+        let failures = state
+            .audit
+            .query_events(&crate::db::AuditEventFilter {
+                event_types: Some(vec!["login_failed".to_string()]),
+                user_id: Some(user.id.clone()),
+                ..Default::default()
+            })
+            .await
+            .expect("query audit events");
         assert!(failures.is_empty(), "no LoginFailed on the happy path");
     }
 
@@ -1882,8 +1870,23 @@ mod tests {
         // does not exist, so `authorize_device_auth` fails after the counter
         // commit — the cleanup-swept-row trigger from production.
         let state = crate::test_utils::test_app_state().await;
-        let (user, authenticator, claim) =
-            finalize_login_fixture(&state, "finalize-fail@example.com").await;
+        let user =
+            crate::test_utils::create_test_user(&state.store, "finalize-fail@example.com").await;
+        let auth_id = crate::test_utils::create_test_authenticator(&state.store, &user.id).await;
+        let authenticator = crate::db::get_authenticator_by_id(&state.store, &auth_id)
+            .await
+            .expect("read authenticator")
+            .expect("authenticator present");
+        let expires_at = Timestamp::now()
+            .checked_add(Span::new().minutes(5))
+            .expect("valid expiry");
+        let claim = crate::db::consume_challenge_state_for_test(
+            &state.store,
+            "test-state-jwt-finalize-fail@example.com",
+            expires_at,
+        )
+        .await
+        .expect("consume challenge state");
 
         let session_token = "finalize-fail-session-token";
         let expires_at = Timestamp::now()
@@ -1927,7 +1930,15 @@ mod tests {
 
         // THE BUG FIX: the failure leaves a LoginFailed audit trace instead
         // of no AuthEvents row at all.
-        let failures = login_audit_events(&state, "login_failed", &user.id).await;
+        let failures = state
+            .audit
+            .query_events(&crate::db::AuditEventFilter {
+                event_types: Some(vec!["login_failed".to_string()]),
+                user_id: Some(user.id.clone()),
+                ..Default::default()
+            })
+            .await
+            .expect("query audit events");
         assert_eq!(
             failures.len(),
             1,
@@ -1941,7 +1952,15 @@ mod tests {
                 .is_some_and(|r| r.starts_with("post_verification")),
             "failure_reason must identify the post-verification stage"
         );
-        let successes = login_audit_events(&state, "login_success", &user.id).await;
+        let successes = state
+            .audit
+            .query_events(&crate::db::AuditEventFilter {
+                event_types: Some(vec!["login_success".to_string()]),
+                user_id: Some(user.id.clone()),
+                ..Default::default()
+            })
+            .await
+            .expect("query audit events");
         assert!(
             successes.is_empty(),
             "no LoginSuccess may be recorded when session creation did not complete"

--- a/crates/vouch-server/src/handlers/enroll/tests.rs
+++ b/crates/vouch-server/src/handlers/enroll/tests.rs
@@ -1950,46 +1950,6 @@ async fn test_enrollment_complete_foreign_origin_leaves_state_unconsumed() {
 // so these tests exercise the extracted tail directly — the same tail the
 // handler runs after `create_authenticator` commits.
 
-/// Build a `BrowserRegistrationState` for a real user, carrying the given
-/// `device_auth_id`. The `webauthn_state` field is real (it cannot be built
-/// any other way) but the tail under test does not consume it.
-async fn build_browser_reg_state(
-    state: &AppState,
-    user: &crate::db::User,
-    device_auth_id: String,
-) -> BrowserRegistrationState {
-    let user_uuid = Uuid::parse_str(&user.id).expect("user id is a uuid");
-    let (_ccr, webauthn_state) = state
-        .webauthn
-        .start_passkey_registration(user_uuid, &user.email, &user.email, None)
-        .expect("start_passkey_registration");
-    let now = jiff::Timestamp::now();
-    BrowserRegistrationState {
-        device_auth_id,
-        user_id: user_uuid,
-        user_email: user.email.clone(),
-        webauthn_state,
-        iat: now.as_second(),
-        exp: now.as_second() + 300,
-    }
-}
-
-/// Query the audit store for `device_auth_approved` events for a user.
-async fn device_auth_approved_events_for(
-    state: &AppState,
-    user_id: &str,
-) -> Vec<crate::db::AuditEvent> {
-    state
-        .audit
-        .query_events(&crate::db::AuditEventFilter {
-            event_types: Some(vec!["device_auth_approved".to_string()]),
-            user_id: Some(user_id.to_string()),
-            ..Default::default()
-        })
-        .await
-        .expect("query device_auth_approved events")
-}
-
 #[tokio::test]
 async fn finalize_enrollment_audit_records_enrollment_when_device_auth_release_fails() {
     // Regression: `authorize_device_auth` returns Err after `create_authenticator`
@@ -2003,8 +1963,20 @@ async fn finalize_enrollment_audit_records_enrollment_when_device_auth_release_f
     // Stand-in for the authenticator `create_authenticator` already committed.
     let authenticator_id = create_test_authenticator(&state.store, &user.id).await;
 
-    let reg_state =
-        build_browser_reg_state(&state, &user, "reclaimed-device-auth".to_string()).await;
+    let user_uuid = Uuid::parse_str(&user.id).expect("user id is a uuid");
+    let (_ccr, webauthn_state) = state
+        .webauthn
+        .start_passkey_registration(user_uuid, &user.email, &user.email, None)
+        .expect("start_passkey_registration");
+    let now = jiff::Timestamp::now();
+    let reg_state = BrowserRegistrationState {
+        device_auth_id: "reclaimed-device-auth".to_string(),
+        user_id: user_uuid,
+        user_email: user.email.clone(),
+        webauthn_state,
+        iat: now.as_second(),
+        exp: now.as_second() + 300,
+    };
     let now = jiff::Timestamp::now();
     let result = finalize_enrollment_audit_and_device_auth(
         &state,
@@ -2042,7 +2014,15 @@ async fn finalize_enrollment_audit_records_enrollment_when_device_auth_release_f
     );
 
     // The DeviceAuthApproved event must NOT be recorded — the release failed.
-    let approval_events = device_auth_approved_events_for(&state, &user.id).await;
+    let approval_events = state
+        .audit
+        .query_events(&crate::db::AuditEventFilter {
+            event_types: Some(vec!["device_auth_approved".to_string()]),
+            user_id: Some(user.id.clone()),
+            ..Default::default()
+        })
+        .await
+        .expect("query device_auth_approved events");
     assert!(
         approval_events.is_empty(),
         "no DeviceAuthApproved event may be recorded when authorize_device_auth fails"
@@ -2072,7 +2052,20 @@ async fn finalize_enrollment_audit_records_both_events_when_cli_release_succeeds
     .await
     .expect("seed pending device auth request");
 
-    let reg_state = build_browser_reg_state(&state, &user, device_auth_id).await;
+    let user_uuid = Uuid::parse_str(&user.id).expect("user id is a uuid");
+    let (_ccr, webauthn_state) = state
+        .webauthn
+        .start_passkey_registration(user_uuid, &user.email, &user.email, None)
+        .expect("start_passkey_registration");
+    let now = jiff::Timestamp::now();
+    let reg_state = BrowserRegistrationState {
+        device_auth_id,
+        user_id: user_uuid,
+        user_email: user.email.clone(),
+        webauthn_state,
+        iat: now.as_second(),
+        exp: now.as_second() + 300,
+    };
     let now = jiff::Timestamp::now();
     let result = finalize_enrollment_audit_and_device_auth(
         &state,
@@ -2090,7 +2083,15 @@ async fn finalize_enrollment_audit_records_both_events_when_cli_release_succeeds
         1,
         "Enrollment audit event must be recorded on the happy path"
     );
-    let approval_events = device_auth_approved_events_for(&state, &user.id).await;
+    let approval_events = state
+        .audit
+        .query_events(&crate::db::AuditEventFilter {
+            event_types: Some(vec!["device_auth_approved".to_string()]),
+            user_id: Some(user.id.clone()),
+            ..Default::default()
+        })
+        .await
+        .expect("query device_auth_approved events");
     assert_eq!(
         approval_events.len(),
         1,
@@ -2122,7 +2123,20 @@ async fn finalize_enrollment_audit_records_only_enrollment_for_direct_browser_fl
     let user = create_test_user(&state.store, "direct@example.com").await;
     let authenticator_id = create_test_authenticator(&state.store, &user.id).await;
 
-    let reg_state = build_browser_reg_state(&state, &user, String::new()).await;
+    let user_uuid = Uuid::parse_str(&user.id).expect("user id is a uuid");
+    let (_ccr, webauthn_state) = state
+        .webauthn
+        .start_passkey_registration(user_uuid, &user.email, &user.email, None)
+        .expect("start_passkey_registration");
+    let now = jiff::Timestamp::now();
+    let reg_state = BrowserRegistrationState {
+        device_auth_id: String::new(),
+        user_id: user_uuid,
+        user_email: user.email.clone(),
+        webauthn_state,
+        iat: now.as_second(),
+        exp: now.as_second() + 300,
+    };
     let now = jiff::Timestamp::now();
     let result = finalize_enrollment_audit_and_device_auth(
         &state,
@@ -2143,7 +2157,15 @@ async fn finalize_enrollment_audit_records_only_enrollment_for_direct_browser_fl
         1,
         "Enrollment audit event must be recorded for the direct browser flow"
     );
-    let approval_events = device_auth_approved_events_for(&state, &user.id).await;
+    let approval_events = state
+        .audit
+        .query_events(&crate::db::AuditEventFilter {
+            event_types: Some(vec!["device_auth_approved".to_string()]),
+            user_id: Some(user.id.clone()),
+            ..Default::default()
+        })
+        .await
+        .expect("query device_auth_approved events");
     assert!(
         approval_events.is_empty(),
         "no DeviceAuthApproved event may be recorded for the direct browser flow"

--- a/crates/vouch-server/src/handlers/scim/tests/groups.rs
+++ b/crates/vouch-server/src/handlers/scim/tests/groups.rs
@@ -1191,20 +1191,6 @@ async fn test_scim_create_and_delete_user_audit_events_never_carry_a_raw_email()
 // `Enrollment` event in CLI-initiated WebAuthn enrollment).
 // ========================================================================
 
-async fn scim_operation_events(state: &crate::AppState) -> Vec<serde_json::Value> {
-    state
-        .audit
-        .query_events(&crate::db::AuditEventFilter {
-            event_types: Some(vec!["scim_operation".to_string()]),
-            ..crate::db::AuditEventFilter::default()
-        })
-        .await
-        .expect("query audit events")
-        .into_iter()
-        .map(|e| serde_json::from_str(&e.data).expect("scim audit data is JSON"))
-        .collect()
-}
-
 #[tokio::test]
 async fn test_scim_create_group_audits_committed_group_when_member_add_fails() {
     // The group row commits before members are added one at a time. A
@@ -1226,7 +1212,17 @@ async fn test_scim_create_group_audits_committed_group_when_member_add_fails() {
         "a NUL-bearing member must fail the request, got {status}: {body}"
     );
 
-    let events = scim_operation_events(&state).await;
+    let events: Vec<serde_json::Value> = state
+        .audit
+        .query_events(&crate::db::AuditEventFilter {
+            event_types: Some(vec!["scim_operation".to_string()]),
+            ..crate::db::AuditEventFilter::default()
+        })
+        .await
+        .expect("query audit events")
+        .into_iter()
+        .map(|e| serde_json::from_str(&e.data).expect("scim audit data is JSON"))
+        .collect();
     let creates: Vec<_> = events
         .iter()
         .filter(|e| e["operation"] == "create" && e["resource_type"] == "Group")
@@ -1303,7 +1299,17 @@ async fn test_scim_patch_group_audits_partially_applied_member_ops() {
         "the first member op must have been applied: {group}"
     );
 
-    let events = scim_operation_events(&state).await;
+    let events: Vec<serde_json::Value> = state
+        .audit
+        .query_events(&crate::db::AuditEventFilter {
+            event_types: Some(vec!["scim_operation".to_string()]),
+            ..crate::db::AuditEventFilter::default()
+        })
+        .await
+        .expect("query audit events")
+        .into_iter()
+        .map(|e| serde_json::from_str(&e.data).expect("scim audit data is JSON"))
+        .collect();
     let partial = events.iter().find(|e| {
         e["operation"] == "update" && e["resource_type"] == "Group" && e["resource_id"] == group_id
     });


### PR DESCRIPTION
The five Detail fixes merged today (#1236, #1218, #1224, #1234, #1249's parent) each wrapped one call or one fixture in a local helper at the site they touched. Each had one or two callers and wrapped a single shared factory or query, which the repo convention inlines: fixtures come from the `test_utils` factories at the call site, and a helper needs several callers and a substantial step of its own.

## Inlined

- `handlers/api/applications/tests.rs`: `setup_user_with_fapi_app` (2 callers) and `setup_user_with_fapi_app_and_secret` (1 caller), both a `create_test_user` + `create_test_authenticator` + `create_test_session_with` + `create_test_client` sequence.
- `handlers/applications/web.rs`: `mint_secret_mtls_fapi_client` (2 callers), the same sequence plus `test_app`.
- `handlers/browser_login.rs` tests: `login_audit_events` (4 callers, one `query_events` call) and `finalize_login_fixture` (2 callers).
- `handlers/enroll/tests.rs`: `build_browser_reg_state` (3 callers, one struct literal) and `device_auth_approved_events_for` (3 callers, one `query_events` call).
- `handlers/scim/tests/groups.rs`: `scim_operation_events` (2 callers, one `query_events` call).
- `handlers/api/applications.rs`: the production `revoke_client_sessions` (1 caller) is back inline in `revoke_tokens_api` as the block whose result the `TokenRevoked` audit row reports.

## Kept, deliberately

- `finalize_login_session` / `finalize_login_session_inner` in `browser_login.rs`: folding them puts the function over the 150-line clippy limit, and the test that pins the `LoginFailed` guarantee drives the outer function directly. It is a substantial named step, not a one-line wrapper.
- `record_partial_group_update` in `scim/groups.rs`: three callers, twelve lines with an early return.
- `forge_short_lived_access_token` in `test_utils.rs`: one caller today, but it is a real fixture (re-signs a token and rewrites the session row) mirroring the existing `forge_auth_time`.

No behavior change. `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all-features -p vouch-server` (3627 lib tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VQ5Rx6HQkHekNNSaRsiR9

---
_Generated by [Claude Code](https://claude.ai/code/session_016VQ5Rx6HQkHekNNSaRsiR9)_