### PR TITLE
refactor(test): drop the dpop_jti_id_for_test wrapper

### DIFF
--- a/crates/vouch-server/src/db/dpop.rs
+++ b/crates/vouch-server/src/db/dpop.rs
@@ -18,7 +18,7 @@ const MAX_JTI_LENGTH: usize = 256;
 /// DPoP JTIs are globally unique (RFC 9449 Section 11.1), unlike JWT
 /// assertion JTIs which are scoped per-client. The domain separator
 /// `"dpop_jti\0"` prevents cross-type ID collisions.
-fn deterministic_dpop_jti_id(jti: &str) -> String {
+pub(crate) fn deterministic_dpop_jti_id(jti: &str) -> String {
     use aws_lc_rs::digest::{self, SHA256};
 
     let mut ctx = digest::Context::new(&SHA256);
@@ -174,13 +174,4 @@ pub async fn delete_expired_dpop_nonces(store: &DocumentStore, _now: &str) -> Re
 /// Delete expired JTIs. Returns count deleted.
 pub async fn delete_expired_dpop_jtis(store: &DocumentStore, _now: &str) -> Result<u64> {
     store.delete_expired(DpopJtiDoc::DOC_TYPE).await
-}
-
-/// Test-only access to the deterministic JTI document ID, so integration tests
-/// can read back a `DpopJtiDoc` committed by [`check_and_store_dpop_jti`] and
-/// assert on its `expires_at` (e.g. that JTI retention covers the full
-/// skew-extended proof-validity window — RFC 9449 §4.3 step 11).
-#[cfg(test)]
-pub(crate) fn dpop_jti_id_for_test(jti: &str) -> String {
-    deterministic_dpop_jti_id(jti)
 }

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -24,7 +24,7 @@ mod credentials;
 mod device_auth;
 pub(crate) mod document_type;
 pub(crate) mod documents;
-mod dpop;
+pub(crate) mod dpop;
 pub(crate) mod dsql;
 mod enrollment;
 mod github;
@@ -166,10 +166,6 @@ pub use dpop::{
     DpopJtiClaim, check_and_store_dpop_jti, delete_expired_dpop_jtis, delete_expired_dpop_nonces,
     generate_dpop_nonce, validate_and_consume_dpop_nonce,
 };
-// Test-only access to the deterministic DPoP JTI document ID, so integration
-// tests can read back a committed JTI and assert on its retention window.
-#[cfg(test)]
-pub(crate) use dpop::dpop_jti_id_for_test;
 
 // Re-export credentials types and functions
 pub use credentials::{

--- a/crates/vouch-server/src/services/oidc/dpop.rs
+++ b/crates/vouch-server/src/services/oidc/dpop.rs
@@ -1674,7 +1674,7 @@ mod tests {
         let now_after = jiff::Timestamp::now().as_second();
 
         // Read the committed JTI back by its deterministic document ID.
-        let id = crate::db::dpop_jti_id_for_test(&validated.jti);
+        let id = crate::db::dpop::deterministic_dpop_jti_id(&validated.jti);
         let doc = store
             .get::<crate::db::documents::dpop::DpopJtiDoc>(&id)
             .await


### PR DESCRIPTION
Follow-up to #1250, which inlined the single-caller helpers the Detail fixes added but left one behind.

#1238 added `db::dpop_jti_id_for_test`, a one-line `#[cfg(test)]` wrapper around the private `deterministic_dpop_jti_id`, plus a matching `#[cfg(test)]` re-export in `db/mod.rs`, so `test_dpop_at_resource_jti_retention_covers_skew_window` in `services/oidc/dpop.rs` could read a committed `DpopJtiDoc` back by its document ID. It has exactly one caller and delegates to one expression, which is the thin-wrapper shape the repo convention inlines.

## Change

The wrapper existed only to bridge visibility, so expose the real function instead:

- `deterministic_dpop_jti_id` becomes `pub(crate)`.
- `db::dpop` becomes a `pub(crate)` module, as `par`, `pool`, `store`, and `documents` already are.
- The wrapper and its `db/mod.rs` re-export are deleted; the test calls `crate::db::dpop::deterministic_dpop_jti_id` directly.

## Kept, deliberately

`deterministic_dpop_jti_id` itself is not inlined into `check_and_store_dpop_jti`. It carries the `"dpop_jti\0"` domain-separator invariant and is cited by name from `challenge_states.rs`, so the name is the documentation.

No behavior change. `cargo fmt --all --check`, `cargo clippy -p vouch-server --all-targets --all-features -- -D warnings`, the 125 `dpop` lib tests, and `tests/arch_boundaries.rs` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014F1evkeCgFuBew4RrhSa1r

---
_Generated by [Claude Code](https://claude.ai/code/session_014F1evkeCgFuBew4RrhSa1r)_