### PR TITLE
docs(oidc): cite RFC 9449 §11.1 for JTI retention, not §4.3 step 11

### DIFF
--- a/crates/vouch-server/src/db/dpop.rs
+++ b/crates/vouch-server/src/db/dpop.rs
@@ -138,7 +138,7 @@ impl DpopJtiClaim {
 /// get a *different* `now` (separated from this one by the `await` on the
 /// insert). That dual-stamp lets the freshness window's upper bound drift
 /// past the replay record's `expires_at`, reopening a replay gap (RFC 9449
-/// §4.3 step 11). Production callers that share a `now` with a freshness
+/// §11.1). Production callers that share a `now` with a freshness
 /// check MUST use [`check_and_store_dpop_jti_at_second`] instead, passing
 /// the single caller-stamped instant. This overload remains for tests and
 /// callers that do not also enforce a freshness window against the row.
@@ -173,7 +173,7 @@ pub async fn check_and_store_dpop_jti(
 /// elapsed — should pass `now.as_second() + 1` (pre-rounded up by the
 /// caller) rather than `now.as_second()`. That keeps the row alive until
 /// the first second at which the freshness check would reject the proof,
-/// fully satisfying RFC 9449 §4.3 step 11.
+/// fully covering the RFC 9449 §11.1 acceptance window.
 ///
 /// Returns the same [`DpopJtiClaim`] witness / error mapping as
 /// [`check_and_store_dpop_jti`].

--- a/crates/vouch-server/src/db/tests/jti_replay.rs
+++ b/crates/vouch-server/src/db/tests/jti_replay.rs
@@ -301,7 +301,7 @@ async fn test_delete_expired_dpop_jtis() {
 // of the existing row's `expires_at`, so an expired-but-present row still
 // blocks replay until `delete_expired` physically removes it. After cleanup
 // the same `jti` can be committed again. This is the DB half of the RFC 9449
-// §4.3 step 11 replay defense; the cross-layer invariant — that the retention
+// §11.1 replay defense; the cross-layer invariant — that the retention
 // `validate_dpop_common` passes covers the skew-extended proof-validity
 // window so cleanup never reopens a replay gap — lives in
 // `services/oidc/dpop.rs::tests` (the `services` layer can import both

--- a/crates/vouch-server/src/services/oidc/dpop.rs
+++ b/crates/vouch-server/src/services/oidc/dpop.rs
@@ -30,9 +30,13 @@ const NONCE_VALIDITY_SECONDS: i64 = 300;
 /// [`validate_dpop_claims`] accepts a proof while `now - iat` falls in
 /// `[-PROOF_SKEW_SECONDS, max_age]`, so the freshness window extends
 /// `PROOF_SKEW_SECONDS` past `max_age` when a client clock runs ahead of the
-/// server. RFC 9449 §4.3 step 11 says the server "SHOULD retain the `jti`
-/// value for at least the length of time the DPoP proof JWT would be
-/// considered valid", so the replay record must outlive that whole window.
+/// server. RFC 9449 §11.1: "In the context of the target URI, servers can
+/// store the jti value of each DPoP proof for the time window in which the
+/// respective DPoP proof JWT would be accepted". The strength is permissive
+/// ("can" — the spec mandates no retention duration); making the replay
+/// record outlive the whole acceptance window is this server's design
+/// choice so the single-use check holds for every instant a proof is
+/// accepted.
 ///
 /// [`validate_dpop_common`] therefore commits the JTI for
 /// `config_max_age + PROOF_SKEW_SECONDS`. Retaining for only `config_max_age`
@@ -321,7 +325,7 @@ pub struct DpopClaimsValidation<'a> {
     /// boundary checks). The freshness check and the JTI `expires_at` MUST
     /// share this single instant — restamping `now` between the two lets
     /// the freshness window's upper bound drift past the replay record's
-    /// `expires_at` and reopens a replay gap (RFC 9449 §4.3 step 11).
+    /// `expires_at` and reopens a replay gap (RFC 9449 §11.1).
     pub now: i64,
     pub expected_method: &'a str,
     pub accepted_uris: &'a [String],
@@ -372,7 +376,7 @@ pub fn validate_dpop_claims(
     // rounds the JTI's `expires_at` up to the next integer second
     // (`floor(now) + 1 + max_age + skew`), so the replay record outlives
     // every second at which this floor-truncated freshness check would
-    // still accept the proof (RFC 9449 §4.3 step 11).
+    // still accept the proof (RFC 9449 §11.1's acceptance window).
     if !crate::services::RecencyWindow::with_skew(max_age_seconds, PROOF_SKEW_SECONDS)
         .accepts_at(now, claims.iat)
     {
@@ -531,7 +535,7 @@ async fn validate_dpop_common(
     // bound could land Δ past the JTI's `expires_at`, and `as_second()`
     // floor-truncation added up to one more second of slack — together
     // reopening a residual `Δ + 1` replay window between JTI cleanup and
-    // proof staleness (RFC 9449 §4.3 step 11). Passing the same `now` into
+    // proof staleness (RFC 9449 §11.1). Passing the same `now` into
     // `check_and_store_dpop_jti_at_second` and `validate_dpop_claims`
     // eliminates the Δ; the `+1` round-up below covers the floor-slack.
     let now = Timestamp::now();
@@ -541,8 +545,10 @@ async fn validate_dpop_common(
     // below, so the "this JTI was committed by this request" guarantee is
     // carried by the returned value for as long as it lives.
     //
-    // RFC 9449 §4.3 step 11: retain the JTI for at least as long as the proof
-    // is considered valid. `validate_dpop_claims` accepts an `iat` up to
+    // RFC 9449 §11.1: servers "can store the jti value of each DPoP proof
+    // for the time window in which the respective DPoP proof JWT would be
+    // accepted" — this server retains the JTI for that whole window so the
+    // single-use check holds. `validate_dpop_claims` accepts an `iat` up to
     // `PROOF_SKEW_SECONDS` into the future and uses `now.as_second()`
     // (floor-truncated), so a forward-skewed proof with `iat =
     // floor(now) + skew` stays freshness-accepted until the first second
@@ -1420,7 +1426,7 @@ mod tests {
     }
 
     // ========================================================================
-    // RFC 9449 §4.3 step 11 — JTI retention vs. the resource-endpoint replay
+    // RFC 9449 §11.1 — JTI retention vs. the resource-endpoint replay
     // window (integration guard for `validate_dpop_common`).
     //
     // `validate_dpop_common` must commit the JTI for `config_max_age +
@@ -1459,7 +1465,7 @@ mod tests {
     }
 
     // ========================================================================
-    // RFC 9449 §4.3 step 11 — JTI retention vs. the proof-validity window
+    // RFC 9449 §11.1 — JTI retention vs. the proof-validity window
     // (deterministic, no signatures).
     //
     // These two tests live in the `services` layer (not `db/tests/jti_replay.rs`)
@@ -1693,7 +1699,7 @@ mod tests {
 
     /// `validate_dpop_at_resource` must commit the JTI such that the replay
     /// record outlives every second at which the freshness check would still
-    /// accept the proof (RFC 9449 §4.3 step 11). After the fix,
+    /// accept the proof (RFC 9449 §11.1). After the fix,
     /// `validate_dpop_common` stamps `now` once, rounds up to
     /// `floor(now) + 1`, and commits `expires_at = floor(now) + 1 +
     /// max_age + skew`. The freshness check (using `floor(now)`,

--- a/specs/coverage-baseline.tsv
+++ b/specs/coverage-baseline.tsv
@@ -2647,7 +2647,6 @@ rfc9421#6.4.1#af4dfdc9	MUST	MUST be one of the values "Request", "Response", or 
 rfc9421#6.4.1#c1ab9b58	MUST	The name MUST be unique within the context of the registry.
 rfc9421#6.5.1#b52445d6	MUST	The name MUST be an ASCII string that conforms to the key ABNF rule defined in Section 3.1.2 of [STRUCTURED-FIELDS] and SHOULD NOT exceed 20 characters in lengt
 rfc9421#6.5.1#c1ab9b58	MUST	The name MUST be unique within the context of the registry.
-rfc9449#11.1#98fa6e38	MUST	To limit this, servers MUST only accept DPoP proofs for a limited time after their creation (preferably only for a relatively brief period on the order of secon
 rfc9449#11.2#9b6c65b3	SHOULD NOT	Deployments that do not utilize the nonce mechanism SHOULD NOT issue long-lived DPoP constrained access tokens, preferring instead to use short-lived access tok
 rfc9449#11.3#39a4c7a6	MUST NOT	A server MUST NOT accept any DPoP proofs without the nonce claim when a DPoP nonce has been provided to the client.
 rfc9449#11.5#03c4af6f	MUST	Servers accepting signed DPoP proof JWTs MUST verify that the typ field is dpop+jwt in the headers of the JWTs to ensure that adversaries cannot use JWTs create


### PR DESCRIPTION
## What

Comments-only correction of a fabricated spec citation in the DPoP JTI-retention code.

The comments in `services/oidc/dpop.rs` (and two doc comments in `db/dpop.rs`, one test banner in `db/tests/jti_replay.rs`) attributed to **RFC 9449 §4.3 step 11** the sentence:

> SHOULD retain the `jti` value for at least the length of time the DPoP proof JWT would be considered valid

That sentence does not exist anywhere in RFC 9449 — "retain" has zero occurrences in the spec text (`specs/rfc/rfc9449.txt`, sha256-verified against `specs/manifest.tsv`). §4.3 step 11 is actually the iat-freshness check. The real basis for JTI retention is **§11.1 (DPoP Proof Replay)**, and it is permissive:

> In the context of the target URI, servers can store the jti value of each DPoP proof for the time window in which the respective DPoP proof JWT would be accepted

This PR quotes §11.1 verbatim at the two sites that carried the invented quote, notes explicitly that retaining the record for the whole acceptance window is this server's design choice (the spec mandates no retention duration), and repoints the remaining §4.3-step-11 references that meant §11.1. The retention logic itself is unchanged — the invariants the comments describe were already correct; only their attribution was wrong.

`specs/coverage-baseline.tsv` prunes one entry: the verbatim §11.1 quote now counts as citing a previously-uncited statement, and the ratchet is shrink-only.

## Verification

- `make fmt` and `make lint` clean
- `cargo test -p vouch-tests --test spec_coverage` passes after the baseline prune
- `cargo test -p vouch-server --lib dpop`: 126 passed, 0 failed
- No residual "step 11" or "SHOULD retain" references outside WebAuthn §7.2 (a different spec, legitimate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)