### PR TITLE
refactor(server): stamp one ArrivalTime per request for time comparisons

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,6 +1,20 @@
 # Clippy configuration for the vouch workspace.
 # See: https://doc.rust-lang.org/clippy/configuration.html
 
+# Request-path time comparisons in vouch-server read one instant per request
+# (`vouch_server::arrival::ArrivalTime`) rather than stamping their own clock,
+# so two comparisons serving one decision cannot observe different instants.
+#
+# The lint LEVEL is `allow` workspace-wide (see `[workspace.lints.clippy]` in
+# Cargo.toml) and raised to `warn` only in vouch-server's crate roots: the CLI
+# and agent have no request to anchor to. Within vouch-server, ambient stamping
+# is still right in four places, each carrying an `#[expect]` that names which:
+# the arrival middleware, OCC retry closures, db row stamping, and background
+# tasks.
+disallowed-methods = [
+    { path = "jiff::Timestamp::now", reason = "request-path comparisons take `crate::arrival::ArrivalTime`; see `arrival.rs` for the sanctioned ambient-stamping cases" },
+]
+
 # Allow breaking the exported API (we're pre-1.0)
 avoid-breaking-exported-api = false
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,24 @@ When TLS is configured, a separate HTTP→HTTPS redirect router runs on port 80 
 
 **AppState** holds: `Pool` (db), `ArcSwap<ServerConfig>` (lock-free config reload), `Webauthn`, optional `SshCa`, optional `GitHubApp`, `DpopState`, and `OidcSigningKey`.
 
+**Request-scoped time** (`crates/vouch-server/src/arrival.rs`): `arrival_layer`
+is the outermost middleware in `build_app`; it stamps one `ArrivalTime` per
+request, and handlers take it as a `FromRequestParts` extractor and pass it
+down. Every time comparison that decides a request — JWT and Request Object
+temporal claims, DPoP freshness, session expiry, the RFC 8693 lifetime cap,
+OIDC `max_age`, SAML `Conditions`, policy history windows — reads that one
+instant, so two comparisons serving one decision cannot observe different
+clocks. `ArrivalTime` has no public constructor outside tests, so taking one is
+evidence the value came from the middleware.
+
+Ambient `Timestamp::now()` is still correct in four places, and a
+`disallowed_methods` entry in `.clippy.toml` (level raised to `warn` only in
+vouch-server's crate roots) forces each to say which it is via `#[expect]`:
+the arrival middleware itself; optimistic-concurrency retry closures, which
+need a fresh per-attempt reading rather than a stale captured one; `created_at`
+/ `expires_at` row stamping and artifact minting (id_token, JARM, auth-code and
+state-token expiries); and background tasks, which serve no request.
+
 **Services layer** (`crates/vouch-server/src/services/`): Business logic called by handlers — `oidc/` (authorization, token issuance, DPoP, discovery, JWKS, token exchange, per-org issuer keys + operator rotation), `integrations/` (AWS, GitHub App/OAuth/webhooks), `auth.rs` (WebAuthn verification).
 
 **Layer boundaries** (enforced by `crates/vouch-server/tests/arch_boundaries.rs`): the contract is direction-only. Handlers may call both services and db — calling db directly is legal and common; services may call db, infra primitives (ssrf, dns, metrics, csp), and crypto; db and infra may call only crypto; crypto imports no other layer. Lower layers never import upward. A type shared across layers lives in the lowest layer that consumes it, or in a crate-root shared module (`config.rs`, `geo.rs`, …). Deliberate deviations (e.g. `infra/router.rs` mounting handler routes) are listed with reasons in the test's `EXCEPTIONS` table; the stale-exception check means the list can only shrink.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ unused_lifetimes = "warn"
 single_use_lifetimes = "warn"
 
 [workspace.lints.clippy]
+# Configured in `.clippy.toml`, enabled only in vouch-server's crate roots.
+disallowed_methods = "allow"
+
 # Panic-prevention lints
 # See: https://blog.reverberate.org/2025/02/03/no-panic-rust.html
 # See: https://github.com/trailofbits/claude-code-config/blob/main/claude-md-template.md#rust

--- a/crates/vouch-server/src/arrival.rs
+++ b/crates/vouch-server/src/arrival.rs
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! The instant a request arrived, stamped once and passed down explicitly.
+//!
+//! Every time comparison serving a single request decision reads the same
+//! instant: [`arrival_layer`] stamps it at the outermost layer of the router
+//! and handlers receive it through the [`ArrivalTime`] extractor. Without a
+//! shared origin, two comparisons belonging to one decision observe instants
+//! separated by however long the awaits between them took, and the gap is a
+//! window — an exchanged token outliving its subject by the inter-read delta,
+//! or a replay record retired while its proof is still fresh.
+//!
+//! Construction is private to this module, so an `ArrivalTime` parameter is
+//! evidence that the value came from the middleware rather than from a fresh
+//! `Timestamp::now()` at the call site — the same witness pattern as
+//! [`crate::crypto::webauthn_verify::AuthTime`].
+//!
+//! # Which clock a comparison uses
+//!
+//! - Request-scoped validation (JWT and Request Object temporal claims, DPoP
+//!   freshness, the RFC 8693 lifetime cap, session expiry) → `ArrivalTime`.
+//! - Optimistic-concurrency commit preconditions → the per-attempt clock
+//!   [`crate::db::store::DocumentStore::transition`] hands its closure. An
+//!   arrival stamp there would grow stale across retries and redeem an
+//!   artifact that expired mid-loop.
+//! - Durable artifacts derived from a claim (DPoP JTI retention) → anchored on
+//!   the claim, no clock at all.
+//! - Background tasks and `created_at`-style stamping → ambient
+//!   `Timestamp::now()`.
+
+use axum::extract::FromRequestParts;
+use axum::extract::Request;
+use axum::middleware::Next;
+use axum::response::Response;
+use http::StatusCode;
+use jiff::Timestamp;
+
+/// The instant a request arrived at the server.
+///
+/// The inner value is stamped only by [`arrival_layer`], and there is no
+/// public constructor, so a function taking one is reading the clock of the
+/// request it is serving rather than its own.
+#[derive(Debug, Clone, Copy)]
+pub struct ArrivalTime(Timestamp);
+
+impl ArrivalTime {
+    /// Stamp the current instant. Private: the arrival middleware is the only
+    /// production path to an `ArrivalTime`.
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "the arrival middleware is the one sanctioned request-path stamp"
+    )]
+    fn stamp() -> Self {
+        Self(Timestamp::now())
+    }
+
+    /// The arrival instant, at full precision.
+    #[must_use]
+    pub fn timestamp(self) -> Timestamp {
+        self.0
+    }
+
+    /// The arrival instant truncated to Unix seconds, for comparison against
+    /// JWT `exp` / `nbf` / `iat` claims.
+    #[must_use]
+    pub fn as_second(self) -> i64 {
+        self.0.as_second()
+    }
+
+    /// Build an `ArrivalTime` for a specific instant, for tests that drive a
+    /// service function directly instead of through the router.
+    #[cfg(any(test, feature = "test-utils"))]
+    #[must_use]
+    pub fn for_test(at: Timestamp) -> Self {
+        Self(at)
+    }
+
+    /// Build an `ArrivalTime` from Unix seconds, for boundary tests written
+    /// against integer-second claim values.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `unix_seconds` is outside jiff's representable range.
+    #[cfg(any(test, feature = "test-utils"))]
+    #[must_use]
+    #[expect(
+        clippy::expect_used,
+        reason = "test-only constructor; an out-of-range literal is a test bug"
+    )]
+    pub fn for_test_second(unix_seconds: i64) -> Self {
+        Self(Timestamp::from_second(unix_seconds).expect("test timestamp in range"))
+    }
+}
+
+/// Stamp the arrival instant into request extensions.
+///
+/// Mounted as the outermost layer in [`crate::infra::router::build_app`], so
+/// the stamp is taken before any other middleware can await.
+pub async fn arrival_layer(mut request: Request, next: Next) -> Response {
+    request.extensions_mut().insert(ArrivalTime::stamp());
+    next.run(request).await
+}
+
+/// Generic over router state, and rejecting with a bare [`StatusCode`], so
+/// this module depends on nothing above it — `db` and `services` take an
+/// `ArrivalTime` without importing handler or error types.
+impl<S: Send + Sync> FromRequestParts<S> for ArrivalTime {
+    type Rejection = StatusCode;
+
+    async fn from_request_parts(
+        parts: &mut http::request::Parts,
+        _state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        parts.extensions.get::<Self>().copied().ok_or_else(|| {
+            tracing::error!(
+                "arrival_layer is not mounted on this router; request-scoped \
+                 time comparisons have no origin"
+            );
+            StatusCode::INTERNAL_SERVER_ERROR
+        })
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "test-only panics on impossible states"
+)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{http_get, test_app_state};
+    use axum::Router;
+    use axum::routing::get;
+
+    /// Echo the arrival instant the extractor produced, so a test can compare
+    /// it against the wall clock the request was made at.
+    async fn echo_arrival(arrival: ArrivalTime) -> String {
+        arrival.as_second().to_string()
+    }
+
+    #[tokio::test]
+    async fn mounted_layer_supplies_the_request_instant() {
+        let state = test_app_state().await;
+        let app = Router::new()
+            .route("/t", get(echo_arrival))
+            .layer(axum::middleware::from_fn(arrival_layer))
+            .with_state(state);
+
+        let before = Timestamp::now().as_second();
+        let (status, body) = http_get(&app, "/t", &[]).await;
+        let after = Timestamp::now().as_second();
+
+        assert_eq!(status, 200);
+        let stamped: i64 = body.parse().expect("handler echoed an integer second");
+        assert!(
+            (before..=after).contains(&stamped),
+            "arrival {stamped} must fall inside the request's wall-clock window {before}..={after}"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_layer_fails_closed() {
+        let state = test_app_state().await;
+        // Deliberately no `arrival_layer`. A router that forgot to mount it
+        // must fail rather than silently substitute a fresh clock reading —
+        // the whole point of the witness is that its absence is visible.
+        let app = Router::new()
+            .route("/t", get(echo_arrival))
+            .with_state(state);
+
+        let (status, _body) = http_get(&app, "/t", &[]).await;
+        assert_eq!(status, 500);
+    }
+
+    #[tokio::test]
+    async fn each_request_carries_its_own_stamp() {
+        let state = test_app_state().await;
+        let app = Router::new()
+            .route("/t", get(echo_arrival))
+            .layer(axum::middleware::from_fn(arrival_layer))
+            .with_state(state);
+
+        let (_, first) = http_get(&app, "/t", &[]).await;
+        // A second past the first request's stamp, so the comparison does not
+        // depend on sub-second clock granularity (Windows resolves ~15ms).
+        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+        let (_, second) = http_get(&app, "/t", &[]).await;
+
+        let first: i64 = first.parse().unwrap();
+        let second: i64 = second.parse().unwrap();
+        assert!(
+            second > first,
+            "the layer must stamp per request, not once per process: {first} then {second}"
+        );
+    }
+}

--- a/crates/vouch-server/src/crypto/jwt.rs
+++ b/crates/vouch-server/src/crypto/jwt.rs
@@ -176,6 +176,10 @@ impl StateTokenSigner {
     }
 
     /// Decode and verify a state token JWT.
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "KMS state-token validation happens below the layer ArrivalTime lives in"
+    )]
     pub async fn decode_state_token<T: DeserializeOwned>(
         &self,
         token: &str,

--- a/crates/vouch-server/src/crypto/jwt.rs
+++ b/crates/vouch-server/src/crypto/jwt.rs
@@ -175,22 +175,23 @@ impl StateTokenSigner {
         }
     }
 
-    /// Decode and verify a state token JWT.
-    #[expect(
-        clippy::disallowed_methods,
-        reason = "KMS state-token validation happens below the layer ArrivalTime lives in"
-    )]
+    /// Decode and verify a state token JWT, judging `exp` against `now`.
+    ///
+    /// `now` is Unix seconds — the crypto layer takes the primitive rather
+    /// than [`crate::arrival::ArrivalTime`], which lives above it. Callers on
+    /// the request path pass the request's arrival instant, so this check and
+    /// whatever the caller does with the decoded state read one clock.
     pub async fn decode_state_token<T: DeserializeOwned>(
         &self,
         token: &str,
         jwt_type: JwtType,
+        now: i64,
     ) -> Result<T, StateTokenError> {
         match self {
             Self::Local { secret } => {
-                decode_state_token(token, jwt_type, secret).map_err(StateTokenError::Jwt)
+                decode_state_token(token, jwt_type, secret, now).map_err(StateTokenError::Jwt)
             }
             Self::Kms { kms_client, key_id } => {
-                let now = jiff::Timestamp::now().as_second();
                 kms_decode(kms_client, key_id, token, jwt_type, now).await
             }
         }
@@ -702,22 +703,33 @@ pub(crate) fn encode_state_token<T: Serialize>(
     )
 }
 
-/// Decode a short-lived state token, validating the `typ` header.
+/// Decode a short-lived state token, validating the `typ` header and `exp`.
 ///
-/// This is a generic helper for the state token types. It decodes with
-/// default validation (only `exp` check), then validates that the `typ`
-/// header matches the expected [`JwtType`].
+/// This is a generic helper for the state token types. It verifies the
+/// signature, validates that the `typ` header matches the expected
+/// [`JwtType`], and rejects a token whose `exp` has passed at `now`.
+///
+/// `exp` is checked here rather than by `jsonwebtoken` so the instant is the
+/// caller's, not `SystemTime::now()` read inside the library: a state token
+/// accepted here and then acted on against a second clock reading is the
+/// two-clock gap [`crate::arrival::ArrivalTime`] exists to close. `exp` stays
+/// mandatory, matching both `jsonwebtoken`'s `validate_exp` behavior and the
+/// KMS branch in [`kms_decode`].
+///
+/// There is no leeway: state tokens are server-issued and server-validated, so
+/// clock skew is zero. A grace period would allow replaying an expired token
+/// after its single-use marker has been cleaned up.
 pub(crate) fn decode_state_token<T: DeserializeOwned>(
     token: &str,
     jwt_type: JwtType,
     secret: &[u8],
+    now: i64,
 ) -> Result<T, jsonwebtoken::errors::Error> {
     let validation = Validation {
-        // No leeway: state tokens are server-issued and server-validated on the
-        // same clock, so clock skew is zero. A 60s grace would allow replaying an
-        // expired token after its DB single-use marker is already cleaned up.
         leeway: 0,
         required_spec_claims: HashSet::new(),
+        // `exp` is validated below against the caller's `now`.
+        validate_exp: false,
         // Skip aud validation — callers that need it (e.g. AuthorizationCode)
         // validate iss/aud manually after decode.
         validate_aud: false,
@@ -730,7 +742,26 @@ pub(crate) fn decode_state_token<T: DeserializeOwned>(
             jsonwebtoken::errors::ErrorKind::InvalidToken,
         ));
     }
+    let exp = state_token_exp(token).ok_or_else(|| {
+        jsonwebtoken::errors::Error::from(jsonwebtoken::errors::ErrorKind::ExpiredSignature)
+    })?;
+    if now > exp {
+        return Err(jsonwebtoken::errors::Error::from(
+            jsonwebtoken::errors::ErrorKind::ExpiredSignature,
+        ));
+    }
     Ok(data.claims)
+}
+
+/// The `exp` claim of a compact JWS whose signature has already been verified.
+///
+/// `None` when the payload does not decode, is not a JSON object, or carries
+/// no integer `exp` — every one of which the caller treats as expired.
+fn state_token_exp(token: &str) -> Option<i64> {
+    let payload_b64 = token.split('.').nth(1)?;
+    let payload = decode_segment(payload_b64)?;
+    let raw: serde_json::Value = serde_json::from_slice(&payload).ok()?;
+    raw.get("exp")?.as_i64()
 }
 
 #[cfg(test)]
@@ -745,6 +776,10 @@ mod tests {
     use crate::test_utils::{
         TEST_ISSUER, TEST_JWT_SECRET, make_test_access_token, make_test_oidc_key,
     };
+
+    /// A fixed instant between the test fixtures' `iat` (1_000_000_000) and
+    /// `exp` (9_999_999_999), so state-token decoding is deterministic.
+    const TEST_NOW: i64 = 1_500_000_000;
 
     fn make_ctx(key: &OidcSigningKey) -> TokenValidationContext<'_> {
         TokenValidationContext::new(key, TEST_ISSUER)
@@ -919,6 +954,85 @@ mod tests {
     }
 
     #[test]
+    fn state_token_expiry_is_judged_against_the_caller_clock() {
+        // `exp` is checked against the `now` the caller supplies, not against
+        // `SystemTime::now()` read inside `jsonwebtoken`. A caller whose clock
+        // is the request's arrival instant therefore gets the same answer here
+        // as from every other time comparison serving that request.
+        let state = TestState {
+            data: "hello".to_string(),
+            iat: 1_000_000_000,
+            exp: 1_000_000_060,
+        };
+        let token = encode_state_token(&state, JwtType::RegistrationState, TEST_JWT_SECRET)
+            .expect("encode");
+
+        // One second before expiry: accepted.
+        let fresh: Result<TestState, _> = decode_state_token(
+            &token,
+            JwtType::RegistrationState,
+            TEST_JWT_SECRET,
+            1_000_000_059,
+        );
+        assert!(fresh.is_ok(), "a token one second from expiry must decode");
+
+        // At expiry: still accepted — the rule is `now > exp`, matching the
+        // KMS branch in `kms_decode`.
+        let boundary: Result<TestState, _> = decode_state_token(
+            &token,
+            JwtType::RegistrationState,
+            TEST_JWT_SECRET,
+            1_000_000_060,
+        );
+        assert!(boundary.is_ok(), "exp == now is not yet expired");
+
+        // One second past expiry: rejected, with no leeway.
+        let stale: Result<TestState, _> = decode_state_token(
+            &token,
+            JwtType::RegistrationState,
+            TEST_JWT_SECRET,
+            1_000_000_061,
+        );
+        assert!(
+            matches!(
+                stale.expect_err("expired token must be rejected").kind(),
+                jsonwebtoken::errors::ErrorKind::ExpiredSignature
+            ),
+            "an expired state token must be reported as ExpiredSignature"
+        );
+    }
+
+    #[test]
+    fn state_token_without_exp_is_rejected() {
+        // `exp` stays mandatory now that `jsonwebtoken` no longer enforces it:
+        // a token with no expiry would otherwise be replayable forever.
+        #[derive(serde::Serialize, serde::Deserialize)]
+        struct NoExp {
+            data: String,
+        }
+
+        let token = encode_state_token(
+            &NoExp {
+                data: "hello".to_string(),
+            },
+            JwtType::RegistrationState,
+            TEST_JWT_SECRET,
+        )
+        .expect("encode");
+
+        let result: Result<NoExp, _> = decode_state_token(
+            &token,
+            JwtType::RegistrationState,
+            TEST_JWT_SECRET,
+            TEST_NOW,
+        );
+        assert!(
+            result.is_err(),
+            "a state token carrying no exp claim must be rejected"
+        );
+    }
+
+    #[test]
     fn test_state_token_roundtrip() {
         let state = TestState {
             data: "hello".to_string(),
@@ -927,9 +1041,13 @@ mod tests {
         };
         let token = encode_state_token(&state, JwtType::RegistrationState, TEST_JWT_SECRET)
             .expect("encode");
-        let decoded: TestState =
-            decode_state_token(&token, JwtType::RegistrationState, TEST_JWT_SECRET)
-                .expect("decode");
+        let decoded: TestState = decode_state_token(
+            &token,
+            JwtType::RegistrationState,
+            TEST_JWT_SECRET,
+            TEST_NOW,
+        )
+        .expect("decode");
         assert_eq!(decoded, state);
     }
 
@@ -943,8 +1061,12 @@ mod tests {
         // Encode as RegistrationState, decode as BrowserRegistrationState (different typ)
         let token = encode_state_token(&state, JwtType::RegistrationState, TEST_JWT_SECRET)
             .expect("encode");
-        let result: Result<TestState, _> =
-            decode_state_token(&token, JwtType::BrowserRegistrationState, TEST_JWT_SECRET);
+        let result: Result<TestState, _> = decode_state_token(
+            &token,
+            JwtType::BrowserRegistrationState,
+            TEST_JWT_SECRET,
+            TEST_NOW,
+        );
         assert!(result.is_err(), "Wrong type should be rejected");
     }
 
@@ -958,7 +1080,7 @@ mod tests {
         let token =
             encode_state_token(&state, JwtType::GitHubState, TEST_JWT_SECRET).expect("encode");
         let result: Result<TestState, _> =
-            decode_state_token(&token, JwtType::GitHubState, b"wrong-secret");
+            decode_state_token(&token, JwtType::GitHubState, b"wrong-secret", TEST_NOW);
         assert!(result.is_err(), "Wrong secret should be rejected");
     }
 
@@ -980,7 +1102,7 @@ mod tests {
             .await
             .expect("encode");
         let decoded: TestState = signer
-            .decode_state_token(&token, JwtType::Fido2ChallengeState)
+            .decode_state_token(&token, JwtType::Fido2ChallengeState, TEST_NOW)
             .await
             .expect("decode");
         assert_eq!(decoded, state);
@@ -1000,7 +1122,7 @@ mod tests {
             .await
             .expect("encode");
         let result: Result<TestState, _> = signer
-            .decode_state_token(&token, JwtType::RegistrationState)
+            .decode_state_token(&token, JwtType::RegistrationState, TEST_NOW)
             .await;
         assert!(result.is_err(), "Wrong type should be rejected");
     }
@@ -1021,7 +1143,7 @@ mod tests {
             .await
             .expect("encode");
         let result: Result<TestState, _> = signer_b
-            .decode_state_token(&token, JwtType::AuthorizationCode)
+            .decode_state_token(&token, JwtType::AuthorizationCode, TEST_NOW)
             .await;
         assert!(result.is_err(), "Wrong secret should be rejected");
     }
@@ -1050,7 +1172,7 @@ mod tests {
                 .await
                 .expect("encode");
             let decoded: TestState = signer
-                .decode_state_token(&token, jwt_type)
+                .decode_state_token(&token, jwt_type, TEST_NOW)
                 .await
                 .expect("decode");
             assert_eq!(decoded, state, "Roundtrip failed for {:?}", jwt_type);
@@ -1071,7 +1193,7 @@ mod tests {
             .await
             .expect("encode");
         let result: Result<TestState, _> = signer
-            .decode_state_token(&token, JwtType::RegistrationState)
+            .decode_state_token(&token, JwtType::RegistrationState, TEST_NOW)
             .await;
         assert!(result.is_err(), "Expired token should be rejected");
     }
@@ -1090,23 +1212,22 @@ mod tests {
         assert_eq!(format!("{validation}"), "bad");
     }
 
-    /// Regression for #536: `decode_state_token` must reject tokens a few
-    /// seconds past `exp` with zero leeway. `exp` sits 5s in the past, inside
-    /// jsonwebtoken's default 60s leeway window, so reverting `leeway = 0` to
-    /// the default would *accept* this token and fail the test. A 1970 `exp`
-    /// cannot distinguish `leeway = 0` from the default — this one can.
+    /// Regression for #536: `decode_state_token` must reject a token a few
+    /// seconds past `exp`, with no grace period. `exp` sits 5s before the
+    /// `now` passed in — well inside the 60s window a leniently-configured
+    /// decoder would forgive, which a 1970 `exp` could not distinguish.
     #[test]
     fn test_state_token_recently_expired_rejected_no_leeway() {
-        let now = jiff::Timestamp::now().as_second();
+        let now = 1_700_000_000;
         let state = TestState {
             data: "replay-attempt".to_string(),
             iat: now - 3600,
-            exp: now - 5, // inside the default 60s leeway window, but past exp
+            exp: now - 5,
         };
         let token = encode_state_token(&state, JwtType::Fido2ChallengeState, TEST_JWT_SECRET)
             .expect("encode");
         let result: Result<TestState, _> =
-            decode_state_token(&token, JwtType::Fido2ChallengeState, TEST_JWT_SECRET);
+            decode_state_token(&token, JwtType::Fido2ChallengeState, TEST_JWT_SECRET, now);
         assert!(
             result.is_err(),
             "State token 5s past exp must be rejected with zero leeway"
@@ -1294,8 +1415,12 @@ mod tests {
             &serde_json::json!({ "sub": "attacker", "exp": 9_999_999_999i64 }),
         );
 
-        let decoded =
-            decode_state_token::<StateClaims>(&token, JwtType::RegistrationState, TEST_JWT_SECRET);
+        let decoded = decode_state_token::<StateClaims>(
+            &token,
+            JwtType::RegistrationState,
+            TEST_JWT_SECRET,
+            TEST_NOW,
+        );
         assert!(
             decoded.is_err(),
             "an Unsecured JWS must never be accepted as a state token"

--- a/crates/vouch-server/src/crypto/webauthn_verify.rs
+++ b/crates/vouch-server/src/crypto/webauthn_verify.rs
@@ -209,6 +209,10 @@ pub struct AuthTime(i64);
 impl AuthTime {
     /// Stamp the current instant. Private: every public path to an
     /// `AuthTime` runs through a completed ceremony.
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "stamps the instant a ceremony completed, not a comparison"
+    )]
     fn stamp() -> Self {
         Self(jiff::Timestamp::now().as_second())
     }

--- a/crates/vouch-server/src/db/dpop.rs
+++ b/crates/vouch-server/src/db/dpop.rs
@@ -92,7 +92,8 @@ pub async fn validate_and_consume_dpop_nonce(
 
 /// Witness that a DPoP JTI (RFC 9449 §11.1) was atomically committed by
 /// this caller. Construction is private to this module — the only path
-/// to an instance is a successful return from [`check_and_store_dpop_jti`],
+/// to an instance is a successful return from
+/// [`check_and_store_dpop_jti_at_second`],
 /// whose atomic INSERT on the deterministic PRIMARY KEY guarantees that
 /// at most one concurrent caller's insert commits.
 ///
@@ -109,7 +110,7 @@ pub struct DpopJtiClaim {
 
 impl DpopJtiClaim {
     /// Test-only constructor. Production code must obtain a claim via
-    /// [`check_and_store_dpop_jti`].
+    /// [`check_and_store_dpop_jti_at_second`].
     ///
     /// Gated on `test-utils` as well as `test` because
     /// `ValidatedDpopProof::for_testing` needs it to build a witness for
@@ -133,37 +134,17 @@ impl DpopJtiClaim {
 /// `ClaimError::InvalidInput` (client error → 401, not a 500 that would
 /// prompt retry).
 ///
-/// **Clock injection.** This overload stamps `Timestamp::now()` internally,
-/// so callers that also validate a freshness claim against the wall clock
-/// get a *different* `now` (separated from this one by the `await` on the
-/// insert). That dual-stamp lets the freshness window's upper bound drift
-/// past the replay record's `expires_at`, reopening a replay gap (RFC 9449
-/// §11.1). Production callers that share a `now` with a freshness
-/// check MUST use [`check_and_store_dpop_jti_at_second`] instead, passing
-/// the single caller-stamped instant. This overload remains for tests and
-/// callers that do not also enforce a freshness window against the row.
-pub async fn check_and_store_dpop_jti(
-    store: &DocumentStore,
-    jti: &str,
-    validity_seconds: i64,
-) -> std::result::Result<DpopJtiClaim, ClaimError> {
-    let now = Timestamp::now();
-    let expires_at = now
-        .checked_add(validity_seconds.seconds())
-        .map_err(|e| ClaimError::Database(format!("DPoP JTI expiry overflow: {e}")))?;
-    store_dpop_jti_with_expiry(store, jti, expires_at).await
-}
-
-/// Clock-injectable twin of [`check_and_store_dpop_jti`] that derives the
-/// row's `expires_at` from a caller-provided `now_second` (Unix seconds).
+/// The row's `expires_at` is derived from the caller-provided `now_second`
+/// (Unix seconds): `expires_at = Timestamp::from_second(now_second) +
+/// validity_seconds`.
 ///
-/// `expires_at = Timestamp::from_second(now_second) + validity_seconds`.
 /// Callers that also run a freshness check (e.g.
-/// `services::oidc::dpop::validate_dpop_common`) stamp a single `now` at
-/// their entry point and pass it here *and* to the freshness check, so the
-/// replay record and the freshness window share one reference instant —
-/// the dual-stamp `Δ` gap that `check_and_store_dpop_jti` would otherwise
-/// reintroduce cannot arise.
+/// `services::oidc::dpop::validate_dpop_common`) pass the request's arrival
+/// instant here *and* to the freshness check, so the replay record and the
+/// freshness window share one reference instant. Reading a second clock for
+/// either one lets the freshness window's upper bound drift past the record's
+/// `expires_at`, reopening a replay gap (RFC 9449 §11.1) — which is why there
+/// is no ambient-clock overload.
 ///
 /// `now_second` is in **integer seconds** (the `as_second()` granularity
 /// the freshness check uses). Callers that need to cover the
@@ -174,9 +155,6 @@ pub async fn check_and_store_dpop_jti(
 /// caller) rather than `now.as_second()`. That keeps the row alive until
 /// the first second at which the freshness check would reject the proof,
 /// fully covering the RFC 9449 §11.1 acceptance window.
-///
-/// Returns the same [`DpopJtiClaim`] witness / error mapping as
-/// [`check_and_store_dpop_jti`].
 pub async fn check_and_store_dpop_jti_at_second(
     store: &DocumentStore,
     jti: &str,
@@ -191,10 +169,8 @@ pub async fn check_and_store_dpop_jti_at_second(
 
 /// Validate `jti` and atomically insert a row expiring at `expires_at`.
 ///
-/// Shared body of [`check_and_store_dpop_jti`] and
-/// [`check_and_store_dpop_jti_at_second`]; the only difference between the
-/// two public overloads is how `expires_at` is computed (internal
-/// `Timestamp::now()` vs. a caller-provided integer-second instant).
+/// The insert body behind [`check_and_store_dpop_jti_at_second`], kept
+/// separate so the expiry arithmetic and the storage step stay legible.
 async fn store_dpop_jti_with_expiry(
     store: &DocumentStore,
     jti: &str,

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -225,9 +225,8 @@ pub use jwks_cache::{
 
 // Re-export DPoP types and functions (RFC 9449)
 pub use dpop::{
-    DpopJtiClaim, check_and_store_dpop_jti, check_and_store_dpop_jti_at_second,
-    delete_expired_dpop_jtis, delete_expired_dpop_nonces, generate_dpop_nonce,
-    validate_and_consume_dpop_nonce,
+    DpopJtiClaim, check_and_store_dpop_jti_at_second, delete_expired_dpop_jtis,
+    delete_expired_dpop_nonces, generate_dpop_nonce, validate_and_consume_dpop_nonce,
 };
 
 // Re-export credentials types and functions

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -14,30 +14,92 @@
 //! - `sqlite` (default): Uses SQLite for development and testing
 //! - `postgres`: Uses PostgreSQL/Aurora DSQL for production
 
+// The db layer stamps the timestamps it writes — `created_at`, `expires_at`,
+// `last_used_at` — and re-reads the clock inside optimistic-concurrency retry
+// closures, which need a fresh reading per attempt rather than a stale captured
+// one. Neither is a request-path comparison, so the modules doing it carry an
+// expectation for `disallowed_methods`. A comparison that decides a request
+// takes `crate::arrival::ArrivalTime` instead; see `arrival.rs`.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
+)]
 pub(crate) mod audit;
 mod authenticators;
+#[expect(
+    clippy::disallowed_methods,
+    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
+)]
 mod authorization_codes;
 mod challenge_states;
 pub(crate) mod claim;
 mod config;
+#[expect(
+    clippy::disallowed_methods,
+    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
+)]
 mod credentials;
+#[expect(
+    clippy::disallowed_methods,
+    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
+)]
 mod device_auth;
 pub(crate) mod document_type;
+#[expect(
+    clippy::disallowed_methods,
+    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
+)]
 pub(crate) mod documents;
+#[expect(
+    clippy::disallowed_methods,
+    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
+)]
 pub(crate) mod dpop;
 pub(crate) mod dsql;
 mod enrollment;
+#[expect(
+    clippy::disallowed_methods,
+    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
+)]
 mod github;
+#[expect(
+    clippy::disallowed_methods,
+    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
+)]
 mod jwks_cache;
 pub(crate) mod migrations;
+#[expect(
+    clippy::disallowed_methods,
+    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
+)]
 mod oauth;
+#[expect(
+    clippy::disallowed_methods,
+    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
+)]
 mod organizations;
+#[expect(
+    clippy::disallowed_methods,
+    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
+)]
 pub(crate) mod par;
+#[expect(
+    clippy::disallowed_methods,
+    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
+)]
 mod pending_oauth;
 pub(crate) mod pool;
 mod posture_policies;
+#[expect(
+    clippy::disallowed_methods,
+    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
+)]
 mod scim;
 mod sessions;
+#[expect(
+    clippy::disallowed_methods,
+    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
+)]
 pub(crate) mod store;
 mod users;
 

--- a/crates/vouch-server/src/db/sessions.rs
+++ b/crates/vouch-server/src/db/sessions.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Session database operations.
 
+use crate::arrival::ArrivalTime;
+
 use super::document_type::{Document, DocumentType};
 use super::documents::session::SessionDoc;
 use super::store::DocumentStore;
@@ -300,10 +302,15 @@ impl SessionCache {
     }
 
     /// Get a cached session by token hash, or fetch from DB on miss.
+    ///
+    /// `arrival` is the instant the session's `expires_at` is judged against,
+    /// so a request that authenticates here and then makes a second
+    /// time-sensitive decision downstream measures both from one clock.
     pub async fn get_session_by_token_hash(
         &self,
         store: &DocumentStore,
         token_hash: &str,
+        arrival: ArrivalTime,
     ) -> Result<Option<Arc<Session>>> {
         // Test-only fault injection: the hash was registered via
         // [`Self::inject_fault`]; return a store-style `Err` so callers can
@@ -322,7 +329,7 @@ impl SessionCache {
         // Snapshot generation before the async DB fetch so we can
         // detect invalidations that occurred during the await.
         let gen_before = self.generation.load(Ordering::SeqCst);
-        let result = get_session_by_token_hash(store, token_hash, Timestamp::now())
+        let result = get_session_by_token_hash(store, token_hash, arrival.timestamp())
             .await?
             .map(Arc::new);
         self.insert_if_valid(token_hash.to_string(), result.clone(), gen_before);

--- a/crates/vouch-server/src/db/tests/cascade_delete.rs
+++ b/crates/vouch-server/src/db/tests/cascade_delete.rs
@@ -8,6 +8,7 @@
 
 use super::*;
 use crate::crypto::alg::JwsAlgorithm;
+use crate::test_utils::test_arrival;
 
 // ========================================================================
 // Cascade Delete Tests
@@ -771,7 +772,7 @@ async fn test_delete_client_partial_failure_evicts_committed_m2m_from_cache() {
     let cache = SessionCache::new(100, 30);
     assert!(
         cache
-            .get_session_by_token_hash(&store, "m2m-hash")
+            .get_session_by_token_hash(&store, "m2m-hash", test_arrival())
             .await
             .expect("cache lookup m2m")
             .is_some(),
@@ -779,7 +780,7 @@ async fn test_delete_client_partial_failure_evicts_committed_m2m_from_cache() {
     );
     assert!(
         cache
-            .get_session_by_token_hash(&store, "user-hash")
+            .get_session_by_token_hash(&store, "user-hash", test_arrival())
             .await
             .expect("cache lookup user")
             .is_some(),
@@ -840,7 +841,7 @@ async fn test_delete_client_partial_failure_evicts_committed_m2m_from_cache() {
     // the TTL.
     assert!(
         cache
-            .get_session_by_token_hash(&store, "m2m-hash")
+            .get_session_by_token_hash(&store, "m2m-hash", test_arrival())
             .await
             .expect("cache re-lookup m2m")
             .is_none(),
@@ -855,7 +856,7 @@ async fn test_delete_client_partial_failure_evicts_committed_m2m_from_cache() {
     // still in the DB, so serving it is correct, not a stale `Hit`.
     assert!(
         cache
-            .get_session_by_token_hash(&store, "user-hash")
+            .get_session_by_token_hash(&store, "user-hash", test_arrival())
             .await
             .expect("cache re-lookup user")
             .is_some(),
@@ -907,14 +908,14 @@ async fn test_delete_client_first_delete_failure_changes_nothing() {
     let cache = SessionCache::new(100, 30);
     assert!(
         cache
-            .get_session_by_token_hash(&store, "m2m-f")
+            .get_session_by_token_hash(&store, "m2m-f", test_arrival())
             .await
             .expect("warm m2m")
             .is_some()
     );
     assert!(
         cache
-            .get_session_by_token_hash(&store, "user-f")
+            .get_session_by_token_hash(&store, "user-f", test_arrival())
             .await
             .expect("warm user")
             .is_some()
@@ -953,7 +954,7 @@ async fn test_delete_client_first_delete_failure_changes_nothing() {
     // a retry of the chokepoint starts from a clean state.
     assert!(
         cache
-            .get_session_by_token_hash(&store, "m2m-f")
+            .get_session_by_token_hash(&store, "m2m-f", test_arrival())
             .await
             .expect("cache m2m")
             .is_some(),
@@ -961,7 +962,7 @@ async fn test_delete_client_first_delete_failure_changes_nothing() {
     );
     assert!(
         cache
-            .get_session_by_token_hash(&store, "user-f")
+            .get_session_by_token_hash(&store, "user-f", test_arrival())
             .await
             .expect("cache user")
             .is_some(),

--- a/crates/vouch-server/src/db/tests/jti_replay.rs
+++ b/crates/vouch-server/src/db/tests/jti_replay.rs
@@ -180,21 +180,37 @@ async fn test_dpop_jti_replay_prevention() {
     let (store, _audit) = test_db().await;
 
     // First use returns the witness
-    let _claim = check_and_store_dpop_jti(&store, "dpop-jti-1", 600)
-        .await
-        .expect("First use of a JTI should be accepted");
+    let _claim = check_and_store_dpop_jti_at_second(
+        &store,
+        "dpop-jti-1",
+        jiff::Timestamp::now().as_second(),
+        600,
+    )
+    .await
+    .expect("First use of a JTI should be accepted");
 
     // Replay returns AlreadyConsumed
-    let replayed = check_and_store_dpop_jti(&store, "dpop-jti-1", 600).await;
+    let replayed = check_and_store_dpop_jti_at_second(
+        &store,
+        "dpop-jti-1",
+        jiff::Timestamp::now().as_second(),
+        600,
+    )
+    .await;
     assert!(
         matches!(replayed, Err(ClaimError::AlreadyConsumed)),
         "Replay of same JTI should be AlreadyConsumed, got: {replayed:?}"
     );
 
     // Different JTI succeeds
-    let _different = check_and_store_dpop_jti(&store, "dpop-jti-2", 600)
-        .await
-        .expect("Different JTI should be accepted");
+    let _different = check_and_store_dpop_jti_at_second(
+        &store,
+        "dpop-jti-2",
+        jiff::Timestamp::now().as_second(),
+        600,
+    )
+    .await
+    .expect("Different JTI should be accepted");
 }
 
 #[tokio::test]
@@ -202,7 +218,9 @@ async fn test_dpop_jti_empty() {
     use crate::db::claim::ClaimError;
     let (store, _audit) = test_db().await;
 
-    let result = check_and_store_dpop_jti(&store, "", 600).await;
+    let result =
+        check_and_store_dpop_jti_at_second(&store, "", jiff::Timestamp::now().as_second(), 600)
+            .await;
     assert!(
         matches!(result, Err(ClaimError::InvalidInput(_))),
         "Empty JTI must return InvalidInput, got: {result:?}"
@@ -215,7 +233,13 @@ async fn test_dpop_jti_too_long() {
     let (store, _audit) = test_db().await;
 
     let long_jti = "x".repeat(257);
-    let result = check_and_store_dpop_jti(&store, &long_jti, 600).await;
+    let result = check_and_store_dpop_jti_at_second(
+        &store,
+        &long_jti,
+        jiff::Timestamp::now().as_second(),
+        600,
+    )
+    .await;
     assert!(
         matches!(result, Err(ClaimError::InvalidInput(_))),
         "JTI exceeding max length must return InvalidInput, got: {result:?}"
@@ -228,11 +252,22 @@ async fn test_dpop_jti_at_max_length() {
     let (store, _audit) = test_db().await;
 
     let max_jti = "d".repeat(256);
-    let _stored = check_and_store_dpop_jti(&store, &max_jti, 600)
-        .await
-        .expect("JTI at max length should be accepted");
+    let _stored = check_and_store_dpop_jti_at_second(
+        &store,
+        &max_jti,
+        jiff::Timestamp::now().as_second(),
+        600,
+    )
+    .await
+    .expect("JTI at max length should be accepted");
 
-    let replayed = check_and_store_dpop_jti(&store, &max_jti, 600).await;
+    let replayed = check_and_store_dpop_jti_at_second(
+        &store,
+        &max_jti,
+        jiff::Timestamp::now().as_second(),
+        600,
+    )
+    .await;
     assert!(
         matches!(replayed, Err(ClaimError::AlreadyConsumed)),
         "Replay of max-length JTI should be AlreadyConsumed, got: {replayed:?}"
@@ -250,7 +285,13 @@ async fn test_dpop_jti_concurrent_insert_rejects_duplicates() {
     for _ in 0..num_tasks {
         let s = Arc::clone(&store);
         handles.push(tokio::spawn(async move {
-            check_and_store_dpop_jti(&s, "same-jti", 600).await
+            check_and_store_dpop_jti_at_second(
+                &s,
+                "same-jti",
+                jiff::Timestamp::now().as_second(),
+                600,
+            )
+            .await
         }));
     }
 
@@ -275,9 +316,14 @@ async fn test_delete_expired_dpop_jtis() {
     // Insert one with past expiry (validity_seconds=0 won't work since
     // it computes from now; instead insert directly with short validity
     // and rely on the fact that we can test cleanup.)
-    let _valid = check_and_store_dpop_jti(&store, "valid-dpop-jti", 3600)
-        .await
-        .expect("insert valid");
+    let _valid = check_and_store_dpop_jti_at_second(
+        &store,
+        "valid-dpop-jti",
+        jiff::Timestamp::now().as_second(),
+        3600,
+    )
+    .await
+    .expect("insert valid");
 
     // Cleanup should not delete the valid one
     let deleted = delete_expired_dpop_jtis(&store, "")
@@ -287,7 +333,13 @@ async fn test_delete_expired_dpop_jtis() {
 
     // The valid one should still block replay
     use crate::db::claim::ClaimError;
-    let result = check_and_store_dpop_jti(&store, "valid-dpop-jti", 3600).await;
+    let result = check_and_store_dpop_jti_at_second(
+        &store,
+        "valid-dpop-jti",
+        jiff::Timestamp::now().as_second(),
+        3600,
+    )
+    .await;
     assert!(
         matches!(result, Err(ClaimError::AlreadyConsumed)),
         "Valid JTI should still block replay, got: {result:?}"
@@ -319,12 +371,23 @@ async fn test_dpop_jti_replay_succeeds_after_cleanup() {
 
     // Commit with a negative validity → `expires_at` in the past, simulating
     // that the retention window has already elapsed.
-    let _claim = check_and_store_dpop_jti(&store, "replay-after-cleanup", -300)
-        .await
-        .expect("first use commits the JTI");
+    let _claim = check_and_store_dpop_jti_at_second(
+        &store,
+        "replay-after-cleanup",
+        jiff::Timestamp::now().as_second(),
+        -300,
+    )
+    .await
+    .expect("first use commits the JTI");
 
     // Expired-but-present row still blocks replay (PRIMARY KEY collision).
-    let blocked = check_and_store_dpop_jti(&store, "replay-after-cleanup", 600).await;
+    let blocked = check_and_store_dpop_jti_at_second(
+        &store,
+        "replay-after-cleanup",
+        jiff::Timestamp::now().as_second(),
+        600,
+    )
+    .await;
     assert!(
         matches!(blocked, Err(ClaimError::AlreadyConsumed)),
         "expired-but-present JTI row must still block replay until cleanup: got {blocked:?}"
@@ -344,7 +407,13 @@ async fn test_dpop_jti_replay_succeeds_after_cleanup() {
     // once the row is gone, only the retention duration controls whether a
     // replay is possible. See `services/oidc/dpop.rs::tests` for the
     // call-site guard that the retention outlives the proof-validity window.
-    let replayed = check_and_store_dpop_jti(&store, "replay-after-cleanup", 600).await;
+    let replayed = check_and_store_dpop_jti_at_second(
+        &store,
+        "replay-after-cleanup",
+        jiff::Timestamp::now().as_second(),
+        600,
+    )
+    .await;
     assert!(
         replayed.is_ok(),
         "after cleanup the replay insert succeeds (DB primitive): got {replayed:?}"
@@ -353,7 +422,7 @@ async fn test_dpop_jti_replay_succeeds_after_cleanup() {
 
 // ------------------------------------------------------------------------
 // Sanity: a not-yet-expired JTI is NOT removed by cleanup and keeps
-// blocking replay. The retention passed to `check_and_store_dpop_jti`
+// blocking replay. The retention passed to `check_and_store_dpop_jti_at_second`
 // controls how long the row lives; cleanup only deletes rows whose
 // `expires_at < now`. This complements `test_dpop_jti_replay_succeeds_after_cleanup`
 // (the expired case) and `test_delete_expired_dpop_jtis` (the valid case),
@@ -368,9 +437,14 @@ async fn test_dpop_jti_within_retention_survives_cleanup_and_blocks_replay() {
 
     // A positive retention the fix's caller would pass (e.g. max_age + skew).
     let retention: i64 = 360;
-    let _claim = check_and_store_dpop_jti(&store, "within-retention", retention)
-        .await
-        .expect("first use commits the JTI");
+    let _claim = check_and_store_dpop_jti_at_second(
+        &store,
+        "within-retention",
+        jiff::Timestamp::now().as_second(),
+        retention,
+    )
+    .await
+    .expect("first use commits the JTI");
 
     // Cleanup of not-yet-expired rows is a no-op.
     let deleted = delete_expired_dpop_jtis(&store, "")
@@ -382,7 +456,13 @@ async fn test_dpop_jti_within_retention_survives_cleanup_and_blocks_replay() {
     );
 
     // Replay is still blocked while the row is present.
-    let blocked = check_and_store_dpop_jti(&store, "within-retention", retention).await;
+    let blocked = check_and_store_dpop_jti_at_second(
+        &store,
+        "within-retention",
+        jiff::Timestamp::now().as_second(),
+        retention,
+    )
+    .await;
     assert!(
         matches!(blocked, Err(ClaimError::AlreadyConsumed)),
         "JTI within its retention window must block replay: got {blocked:?}"

--- a/crates/vouch-server/src/db/tests/users_and_sessions.rs
+++ b/crates/vouch-server/src/db/tests/users_and_sessions.rs
@@ -7,6 +7,7 @@
 )]
 
 use super::*;
+use crate::test_utils::test_arrival;
 
 #[tokio::test]
 async fn test_upsert_and_get_user() {
@@ -456,7 +457,7 @@ async fn test_replay_revocation_partial_failure_still_invalidates_committed_dele
     let cache = SessionCache::new(100, 30);
     assert!(
         cache
-            .get_session_by_token_hash(&store, "hash-p1")
+            .get_session_by_token_hash(&store, "hash-p1", test_arrival())
             .await
             .expect("cache lookup p1")
             .is_some(),
@@ -464,7 +465,7 @@ async fn test_replay_revocation_partial_failure_still_invalidates_committed_dele
     );
     assert!(
         cache
-            .get_session_by_token_hash(&store, "hash-p2")
+            .get_session_by_token_hash(&store, "hash-p2", test_arrival())
             .await
             .expect("cache lookup p2")
             .is_some(),
@@ -525,7 +526,7 @@ async fn test_replay_revocation_partial_failure_still_invalidates_committed_dele
     // lookup would return `Some` from the stale `Hit` (the bug).
     assert!(
         cache
-            .get_session_by_token_hash(&store, committed_hash)
+            .get_session_by_token_hash(&store, committed_hash, test_arrival())
             .await
             .expect("cache re-lookup committed")
             .is_none(),
@@ -535,7 +536,7 @@ async fn test_replay_revocation_partial_failure_still_invalidates_committed_dele
     // The session whose delete failed stays cached — it is still a valid row.
     assert!(
         cache
-            .get_session_by_token_hash(&store, surviving_hash)
+            .get_session_by_token_hash(&store, surviving_hash, test_arrival())
             .await
             .expect("cache re-lookup surviving")
             .is_some(),

--- a/crates/vouch-server/src/handlers/admin/mod.rs
+++ b/crates/vouch-server/src/handlers/admin/mod.rs
@@ -71,6 +71,10 @@ pub(crate) fn generate_scim_token() -> Result<GeneratedScimToken, ServiceError> 
 /// Compute token expiration from a number of days.
 ///
 /// `jiff::Timestamp` only supports time-based units, so we convert days to hours.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "mints a token expiry from an operator-supplied duration"
+)]
 pub(crate) fn compute_token_expiry(days: i64) -> Result<Timestamp, ServiceError> {
     let hours = days.checked_mul(24).ok_or_else(|| {
         ServiceError::api(

--- a/crates/vouch-server/src/handlers/admin/policies.rs
+++ b/crates/vouch-server/src/handlers/admin/policies.rs
@@ -2,6 +2,7 @@
 //! Device posture policies — browser UI handlers.
 
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::db;
 use crate::db::documents::audit::{CustomPolicyAdminData, PreconfiguredPolicyToggleData};
 use crate::error::ServiceError;
@@ -176,6 +177,7 @@ pub(crate) async fn toggle_preconfigured_policy(
     headers: HeaderMap,
     jar: CookieJar,
     ValidPath(slug): ValidPath<String>,
+    arrival: ArrivalTime,
 ) -> Result<Response, ServiceError> {
     if !posture::is_valid_preconfigured_slug(&slug) {
         return Err(ServiceError::api(
@@ -185,8 +187,16 @@ pub(crate) async fn toggle_preconfigured_policy(
         ));
     }
 
-    let (admin, org_id) =
-        extract_org_admin(&state, &headers, &jar, method.as_str(), uri.path(), None).await?;
+    let (admin, org_id) = extract_org_admin(
+        &state,
+        &headers,
+        &jar,
+        method.as_str(),
+        uri.path(),
+        None,
+        arrival,
+    )
+    .await?;
 
     // Single read of active slugs — fixes TOCTOU from old handler
     let mut active_slugs = db::get_active_preconfigured_slugs(&state.store, &org_id)
@@ -301,6 +311,7 @@ fn verified_builder_spec(form: &CustomPolicyForm) -> Option<&str> {
 
 /// POST /admin/policies/custom — Create a new custom policy.
 pub(crate) async fn create_custom_policy(
+    arrival: ArrivalTime,
     method: Method,
     uri: OriginalUri,
     State(state): State<Arc<AppState>>,
@@ -339,8 +350,16 @@ pub(crate) async fn create_custom_policy(
 
     // Authenticate before parsing: policy text is attacker-influenced
     // input, so only an authenticated org admin may reach the parser.
-    let (admin, org_id) =
-        extract_org_admin(&state, &headers, &jar, method.as_str(), uri.path(), None).await?;
+    let (admin, org_id) = extract_org_admin(
+        &state,
+        &headers,
+        &jar,
+        method.as_str(),
+        uri.path(),
+        None,
+        arrival,
+    )
+    .await?;
 
     if let Err(e) = posture::validate_policy_text(&form.policy_text) {
         return Ok(redirect_error(jar, format!("Invalid policy: {e}")));
@@ -402,7 +421,12 @@ pub(crate) async fn create_custom_policy(
 }
 
 /// POST /admin/policies/custom/{id} — Update a custom policy.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "axum extractors, one per request input; they cannot be bundled"
+)]
 pub(crate) async fn update_custom_policy(
+    arrival: ArrivalTime,
     method: Method,
     uri: OriginalUri,
     State(state): State<Arc<AppState>>,
@@ -439,8 +463,16 @@ pub(crate) async fn update_custom_policy(
         ));
     }
 
-    let (admin, org_id) =
-        extract_org_admin(&state, &headers, &jar, method.as_str(), uri.path(), None).await?;
+    let (admin, org_id) = extract_org_admin(
+        &state,
+        &headers,
+        &jar,
+        method.as_str(),
+        uri.path(),
+        None,
+        arrival,
+    )
+    .await?;
 
     if let Err(e) = posture::validate_policy_text(&form.policy_text) {
         return Ok(redirect_error(jar, format!("Invalid policy: {e}")));

--- a/crates/vouch-server/src/handlers/admin/scim_tokens.rs
+++ b/crates/vouch-server/src/handlers/admin/scim_tokens.rs
@@ -2,6 +2,7 @@
 //! SCIM token management — browser UI handlers.
 
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::db;
 use crate::db::CreateScimTokenParams;
 use crate::db::documents::audit::ScimTokenAdminData;
@@ -122,6 +123,7 @@ pub(crate) async fn admin_scim_tokens_page(
 
 /// POST /admin/scim-tokens — Create a new SCIM token (UI form).
 pub(crate) async fn admin_create_scim_token(
+    arrival: ArrivalTime,
     method: Method,
     uri: OriginalUri,
     State(state): State<Arc<AppState>>,
@@ -146,8 +148,16 @@ pub(crate) async fn admin_create_scim_token(
         ));
     }
 
-    let (admin, org_id) =
-        extract_org_admin(&state, &headers, &jar, method.as_str(), uri.path(), None).await?;
+    let (admin, org_id) = extract_org_admin(
+        &state,
+        &headers,
+        &jar,
+        method.as_str(),
+        uri.path(),
+        None,
+        arrival,
+    )
+    .await?;
 
     let generated = generate_scim_token()?;
     let expires_at = Some(compute_token_expiry(form.expires_in_days)?);
@@ -219,7 +229,7 @@ pub(crate) async fn admin_create_scim_token(
         })
         .collect();
 
-    let auth = get_resource_auth_context(&state, &jar).await;
+    let auth = get_resource_auth_context(&state, &jar, arrival).await;
 
     Ok(AdminScimTokensTemplate {
         auth,

--- a/crates/vouch-server/src/handlers/api/applications.rs
+++ b/crates/vouch-server/src/handlers/api/applications.rs
@@ -6,6 +6,7 @@
 //! the request/response types and validation rules both surfaces share.
 
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::db::{self, AccessScope, OAuthEventType, UpdateOAuthClientParams};
 use axum::{Json, extract::State, http::StatusCode};
 use std::sync::Arc;
@@ -538,6 +539,7 @@ pub(crate) async fn add_secret_api(
 /// List secrets for an application (API).
 /// GET /api/v1/applications/:id/secrets
 pub(crate) async fn list_secrets_api(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     AuthenticatedToken(token): AuthenticatedToken,
     ValidPath(app_id): ValidPath<ValidUuid>,
@@ -564,7 +566,7 @@ pub(crate) async fn list_secrets_api(
         ));
     }
 
-    let now = jiff::Timestamp::now();
+    let now = arrival.timestamp();
     let secrets = db::get_oauth_client_secrets(&state.store, &app_id)
         .await
         .map_err(|e| {
@@ -595,6 +597,7 @@ pub(crate) async fn list_secrets_api(
 /// Delete (revoke) a secret (API).
 /// DELETE /api/v1/applications/:id/secrets/:secret_id
 pub(crate) async fn delete_secret_api(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     AuthenticatedToken(token): AuthenticatedToken,
     ValidPath((app_id, secret_id)): ValidPath<(ValidUuid, ValidUuid)>,
@@ -631,7 +634,7 @@ pub(crate) async fn delete_secret_api(
         ));
     }
 
-    let now = jiff::Timestamp::now();
+    let now = arrival.timestamp();
     let all_secrets = db::get_oauth_client_secrets(&state.store, &app_id)
         .await
         .map_err(|e| {

--- a/crates/vouch-server/src/handlers/api/org/audit.rs
+++ b/crates/vouch-server/src/handlers/api/org/audit.rs
@@ -9,6 +9,7 @@
 //! browser-facing endpoint. See `docs/src/admin/audit.md` for the full
 //! contract (cursor semantics, delivery guarantee, filters).
 
+use crate::arrival::ArrivalTime;
 use std::sync::Arc;
 
 use aws_lc_rs::digest::{self, SHA256};
@@ -141,6 +142,7 @@ async fn authenticate(
     jar: &CookieJar,
     method: &str,
     uri: &str,
+    arrival: ArrivalTime,
 ) -> Result<AuditApiAuth, ServiceError> {
     let Some(auth_header) = headers
         .get(header::AUTHORIZATION)
@@ -213,7 +215,7 @@ async fn authenticate(
         ));
     }
 
-    let (user, org_id) = extract_org_admin(state, headers, jar, method, uri, None).await?;
+    let (user, org_id) = extract_org_admin(state, headers, jar, method, uri, None, arrival).await?;
     Ok(AuditApiAuth::OrgAdmin {
         org_id,
         user_id: user.id,
@@ -341,6 +343,7 @@ fn build_ndjson_body(
 
 /// GET /api/v1/org/audit-events
 pub(crate) async fn audit_events(
+    arrival: ArrivalTime,
     method: Method,
     uri: OriginalUri,
     State(state): State<Arc<AppState>>,
@@ -348,7 +351,7 @@ pub(crate) async fn audit_events(
     jar: CookieJar,
     Query(query): Query<AuditEventsQuery>,
 ) -> Result<Response, ServiceError> {
-    let auth = authenticate(&state, &headers, &jar, method.as_str(), uri.path()).await?;
+    let auth = authenticate(&state, &headers, &jar, method.as_str(), uri.path(), arrival).await?;
 
     let event_types = query
         .event_type
@@ -366,7 +369,8 @@ pub(crate) async fn audit_events(
         .map(|s| parse_timestamp_param("until", s))
         .transpose()?;
 
-    let lag_cutoff = Timestamp::now()
+    let lag_cutoff = arrival
+        .timestamp()
         .checked_sub(Span::new().seconds(LAG_WINDOW_SECONDS))
         .map_err(|e| {
             tracing::error!(error = %e, "failed to compute audit API lag window");

--- a/crates/vouch-server/src/handlers/api/org/scim_tokens.rs
+++ b/crates/vouch-server/src/handlers/api/org/scim_tokens.rs
@@ -3,6 +3,7 @@
 //! `DELETE /api/v1/org/scim-tokens/{id}`.
 
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::db;
 use crate::db::CreateScimTokenParams;
 use crate::db::documents::audit::ScimTokenAdminData;
@@ -78,7 +79,12 @@ pub(crate) struct ListScimTokensResponse {
 
 /// Create a new SCIM token.
 /// POST /api/v1/org/scim-tokens
+#[expect(
+    clippy::too_many_arguments,
+    reason = "axum extractors, one per request input; they cannot be bundled"
+)]
 pub(crate) async fn create_scim_token(
+    arrival: ArrivalTime,
     method: Method,
     uri: OriginalUri,
     State(state): State<Arc<AppState>>,
@@ -113,6 +119,7 @@ pub(crate) async fn create_scim_token(
         method.as_str(),
         uri.path(),
         client_cert.0.as_ref(),
+        arrival,
     )
     .await?;
 

--- a/crates/vouch-server/src/handlers/applications/web.rs
+++ b/crates/vouch-server/src/handlers/applications/web.rs
@@ -5,6 +5,7 @@
 //! self-service application management portal.
 
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::db::{self, AccessScope, UpdateOAuthClientParams};
 use axum::{
     Form,
@@ -250,6 +251,7 @@ pub(crate) async fn create_application_form(
 /// Show application details.
 /// GET /applications/:id
 pub(crate) async fn detail_application_page(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     session: SignedInSession,
     Path(app_id): Path<String>,
@@ -286,7 +288,7 @@ pub(crate) async fn detail_application_page(
     };
 
     // Get secrets metadata
-    let now = jiff::Timestamp::now();
+    let now = arrival.timestamp();
     let all_secrets = db::get_oauth_client_secrets(&state.store, &app_id)
         .await
         .unwrap_or_default();
@@ -628,6 +630,7 @@ pub(crate) async fn add_secret_form(
 /// Delete (revoke) a secret.
 /// POST /applications/:id/secrets/:secret_id/delete
 pub(crate) async fn delete_secret_form(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     session: SignedInSession,
     Path((app_id, secret_id)): Path<(String, String)>,
@@ -666,7 +669,7 @@ pub(crate) async fn delete_secret_form(
         );
     }
 
-    let now = jiff::Timestamp::now();
+    let now = arrival.timestamp();
     let all_secrets = db::get_oauth_client_secrets(&state.store, &app_id)
         .await
         .unwrap_or_default();

--- a/crates/vouch-server/src/handlers/auth.rs
+++ b/crates/vouch-server/src/handlers/auth.rs
@@ -2,6 +2,7 @@
 //! Authentication handlers for session management.
 
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::db;
 use crate::error::ServiceError;
 use crate::services::auth::AccessTokenClaims;
@@ -13,7 +14,6 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use axum_extra::extract::cookie::CookieJar;
-use jiff::Timestamp;
 use std::sync::Arc;
 use vouch_common::{SessionStatus, protocol};
 
@@ -25,6 +25,7 @@ use crate::db::ClientInfo;
 /// Accepts an OAuth access token (Bearer or DPoP scheme) and returns
 /// authenticated status, email, expiration, and device name.
 pub(crate) async fn status(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
 ) -> Result<Json<SessionStatus>, ServiceError> {
@@ -84,7 +85,7 @@ pub(crate) async fn status(
     let token_hash = hash_token(token);
     let session = state
         .session_cache
-        .get_session_by_token_hash(&state.store, &token_hash)
+        .get_session_by_token_hash(&state.store, &token_hash, arrival)
         .await?;
 
     if session.is_none() {
@@ -109,7 +110,7 @@ pub(crate) async fn status(
         None => None,
     };
 
-    Ok(Json(build_status(&access_claims, device_name)))
+    Ok(Json(build_status(&access_claims, device_name, arrival)))
 }
 
 /// Build the [`SessionStatus`] for the success path of [`status`].
@@ -121,8 +122,12 @@ pub(crate) async fn status(
 /// decision: it is `None` whenever `authenticated == false`. `device_name`
 /// carries no "if authenticated" qualifier in the contract and is returned
 /// unconditionally.
-fn build_status(access_claims: &AccessTokenClaims, device_name: Option<String>) -> SessionStatus {
-    let now = Timestamp::now().as_second();
+fn build_status(
+    access_claims: &AccessTokenClaims,
+    device_name: Option<String>,
+    arrival: ArrivalTime,
+) -> SessionStatus {
+    let now = arrival.as_second();
     let expires_in = if access_claims.exp > now {
         u64::try_from(access_claims.exp.saturating_sub(now)).ok()
     } else {
@@ -145,6 +150,7 @@ fn build_status(access_claims: &AccessTokenClaims, device_name: Option<String>) 
 /// Handle sign-out (clears session cookie).
 /// POST /logout
 pub(crate) async fn logout(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     client_info: ClientInfo,
     jar: CookieJar,
@@ -159,7 +165,7 @@ pub(crate) async fn logout(
         // Look up session before deletion to capture user info for audit
         let session_info = match state
             .session_cache
-            .get_session_by_token_hash(&state.store, &token_hash)
+            .get_session_by_token_hash(&state.store, &token_hash, arrival)
             .await
         {
             Ok(info) => info,
@@ -218,6 +224,7 @@ pub(crate) async fn logout(
     reason = "test code: panic on assertion failure is acceptable"
 )]
 mod tests {
+    use crate::arrival::ArrivalTime;
     use crate::test_utils::*;
     use axum::http::StatusCode;
 
@@ -342,11 +349,14 @@ mod tests {
         }
     }
 
+    /// A fixed instant, so a test about the `exp == now` edge compares against
+    /// exactly the second it constructed its claims from.
+    const FIXED: i64 = 1_800_000_000;
+
     #[test]
     fn build_status_email_is_none_at_exp_boundary() {
-        let now = jiff::Timestamp::now().as_second();
-        let claims = claims_with_exp(now, Some("user@example.com"));
-        let status = super::build_status(&claims, None);
+        let claims = claims_with_exp(FIXED, Some("user@example.com"));
+        let status = super::build_status(&claims, None, ArrivalTime::for_test_second(FIXED));
         // `exp == now` is the sharp edge of the strict `exp > now` re-check:
         // jsonwebtoken accepts it, but the server's authoritative rule rejects
         // it, so `authenticated == false` and `email` must be `None`.
@@ -361,9 +371,8 @@ mod tests {
 
     #[test]
     fn build_status_email_is_some_when_authenticated() {
-        let now = jiff::Timestamp::now().as_second();
-        let claims = claims_with_exp(now.saturating_add(3600), Some("user@example.com"));
-        let status = super::build_status(&claims, None);
+        let claims = claims_with_exp(FIXED.saturating_add(3600), Some("user@example.com"));
+        let status = super::build_status(&claims, None, ArrivalTime::for_test_second(FIXED));
         assert!(status.authenticated);
         assert_eq!(status.email.as_deref(), Some("user@example.com"));
         assert!(status.expires_in_seconds.unwrap_or(0) > 0);
@@ -371,18 +380,18 @@ mod tests {
 
     #[test]
     fn build_status_device_name_returned_regardless_of_auth() {
-        let now = jiff::Timestamp::now().as_second();
-
         let live = super::build_status(
-            &claims_with_exp(now.saturating_add(3600), Some("user@example.com")),
+            &claims_with_exp(FIXED.saturating_add(3600), Some("user@example.com")),
             Some("YubiKey 5C".to_string()),
+            ArrivalTime::for_test_second(FIXED),
         );
         assert!(live.authenticated);
         assert_eq!(live.device_name.as_deref(), Some("YubiKey 5C"));
 
         let expired = super::build_status(
-            &claims_with_exp(now.saturating_sub(3600), Some("user@example.com")),
+            &claims_with_exp(FIXED.saturating_sub(3600), Some("user@example.com")),
             Some("YubiKey 5C".to_string()),
+            ArrivalTime::for_test_second(FIXED),
         );
         // `device_name` is documented without an "if authenticated" qualifier,
         // so it is returned unconditionally — do not gate it on `authenticated`.

--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -141,11 +141,13 @@ impl BrowserAuthenticationState {
     async fn decode(
         token: &str,
         signer: &crate::crypto::jwt::StateTokenSigner,
+        arrival: ArrivalTime,
     ) -> Result<Self, crate::crypto::jwt::StateTokenError> {
         signer
             .decode_state_token(
                 token,
                 crate::crypto::jwt::JwtType::BrowserAuthenticationState,
+                arrival.as_second(),
             )
             .await
     }
@@ -233,7 +235,7 @@ impl LoginCompletion {
         })?;
 
         let auth_state =
-            BrowserAuthenticationState::decode(req.state.as_str(), &state.state_signer)
+            BrowserAuthenticationState::decode(req.state.as_str(), &state.state_signer, arrival)
                 .await
                 .map_err(|e| {
                     ServiceError::api(StatusCode::BAD_REQUEST, "invalid_state", e.to_string())
@@ -981,7 +983,7 @@ mod tests {
         };
 
         let encoded = state.encode(&signer).await.expect("Failed to encode state");
-        let decoded = BrowserAuthenticationState::decode(&encoded, &signer)
+        let decoded = BrowserAuthenticationState::decode(&encoded, &signer, test_arrival())
             .await
             .expect("Failed to decode state");
 
@@ -1530,7 +1532,8 @@ mod tests {
         };
 
         let encoded = state.encode(&signer).await.expect("Failed to encode state");
-        let result = BrowserAuthenticationState::decode(&encoded, &wrong_signer).await;
+        let result =
+            BrowserAuthenticationState::decode(&encoded, &wrong_signer, test_arrival()).await;
 
         assert!(result.is_err());
     }

--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -20,6 +20,7 @@
 //! - Session binding to authenticator
 
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::assurance::HardwareVerification;
 use crate::crypto::generate_challenge;
 use crate::crypto::hash_token;
@@ -203,6 +204,7 @@ impl LoginCompletion {
     async fn validate(
         req: BrowserLoginCompleteRequest,
         state: &AppState,
+        arrival: ArrivalTime,
     ) -> Result<Self, ServiceError> {
         let client_data = ClientDataProof::verify(
             &req.client_data_json,
@@ -237,7 +239,7 @@ impl LoginCompletion {
                     ServiceError::api(StatusCode::BAD_REQUEST, "invalid_state", e.to_string())
                 })?;
 
-        let now = Timestamp::now().as_second();
+        let now = arrival.as_second();
         if now > auth_state.exp {
             return Err(ServiceError::api(
                 StatusCode::BAD_REQUEST,
@@ -247,7 +249,7 @@ impl LoginCompletion {
         }
 
         let expires_at =
-            Timestamp::from_second(auth_state.exp).unwrap_or_else(|_| Timestamp::now());
+            Timestamp::from_second(auth_state.exp).unwrap_or_else(|_| arrival.timestamp());
 
         Ok(Self {
             req,
@@ -301,6 +303,7 @@ async fn pending_device_auth(
 }
 
 pub(crate) async fn login_page(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     axum::extract::Query(query): axum::extract::Query<LoginQuery>,
     jar: CookieJar,
@@ -369,14 +372,15 @@ pub(crate) async fn login_page(
             let session_token = jar
                 .get(vouch_common::SESSION_COOKIE_NAME)
                 .map(|c| c.value());
-            let authorized = match check_session_for_authorization(&state, session_token).await {
-                Ok(AuthorizationSessionState::Authenticated { .. }) => true,
-                Ok(AuthorizationSessionState::NeedsAuth) => false,
-                Err(e) => {
-                    tracing::error!("Session check failed at /login; rendering the form: {e}");
-                    false
-                }
-            };
+            let authorized =
+                match check_session_for_authorization(&state, session_token, arrival).await {
+                    Ok(AuthorizationSessionState::Authenticated { .. }) => true,
+                    Ok(AuthorizationSessionState::NeedsAuth) => false,
+                    Err(e) => {
+                        tracing::error!("Session check failed at /login; rendering the form: {e}");
+                        false
+                    }
+                };
             if authorized {
                 return axum::response::Redirect::to(&format!(
                     "/oauth/authorize?pending_auth={}",
@@ -384,7 +388,7 @@ pub(crate) async fn login_page(
                 ))
                 .into_response();
             }
-        } else if get_auth_context(&state, &jar).await.authenticated {
+        } else if get_auth_context(&state, &jar, arrival).await.authenticated {
             // Without a pending authorization a signed-in user has nothing to
             // do here — IdP sign-in is the whole bar for the browser UI, so a
             // bootstrap session goes home like any other.
@@ -451,7 +455,7 @@ pub(crate) async fn login_page(
     // Only the rendered form needs the header context, and building it costs
     // a session and a user lookup that the session gate above already did.
     // Reaching this point means the form is being shown.
-    let auth = get_auth_context(&state, &jar).await;
+    let auth = get_auth_context(&state, &jar, arrival).await;
 
     LoginTemplate {
         pending_auth: query.pending_auth,
@@ -471,6 +475,10 @@ pub(crate) async fn login_page(
 ///
 /// Generate a WebAuthn authentication challenge.
 /// Uses discoverable credentials (passkeys) so the authenticator identifies the user.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "mints a challenge state token's expiry"
+)]
 pub(crate) async fn browser_login_start(
     State(state): State<Arc<AppState>>,
     Json(req): Json<BrowserLoginStartRequest>,
@@ -557,6 +565,7 @@ async fn log_login_failure(
 /// request as an argument, so a malformed request cannot invalidate the state
 /// token it carries and lock the user out of the flow.
 pub(crate) async fn browser_login_complete(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     client_info: ClientInfo,
     jar: CookieJar,
@@ -564,7 +573,7 @@ pub(crate) async fn browser_login_complete(
 ) -> Result<Response, ServiceError> {
     tracing::info!("Browser login complete (discoverable credential flow)");
 
-    let checked = LoginCompletion::validate(req, &state).await?;
+    let checked = LoginCompletion::validate(req, &state, arrival).await?;
 
     // Mark the authentication state JWT consumed before any side effects.
     // The returned `ChallengeStateClaim` witness is the structural proof
@@ -702,6 +711,7 @@ pub(crate) async fn browser_login_complete(
             pending_auth: auth_state.pending_auth,
             client_info,
         },
+        arrival,
     )
     .await
 }
@@ -735,13 +745,14 @@ struct LoginSessionParams<'a> {
 async fn finalize_login_session(
     state: &AppState,
     params: LoginSessionParams<'_>,
+    arrival: ArrivalTime,
 ) -> Result<Response, ServiceError> {
     let user_id = params.user.id.clone();
     let user_email = params.user.email.clone();
     let authenticator_id = params.authenticator.id.clone();
     let client_info = params.client_info.clone();
 
-    let result = finalize_login_session_inner(state, params).await;
+    let result = finalize_login_session_inner(state, params, arrival).await;
 
     if let Err(ref e) = result {
         // The assertion verified and the counter update may already have
@@ -765,6 +776,7 @@ async fn finalize_login_session(
 async fn finalize_login_session_inner(
     state: &AppState,
     params: LoginSessionParams<'_>,
+    arrival: ArrivalTime,
 ) -> Result<Response, ServiceError> {
     let LoginSessionParams {
         jar,
@@ -884,6 +896,7 @@ async fn finalize_login_session_inner(
             ),
             sender_constraint: SenderConstraintProof::no_registered_client(),
         },
+        arrival,
     )
     .await
     .map_err(|e| {
@@ -953,6 +966,7 @@ mod tests {
         reason = "test code: panic on assertion failure is acceptable"
     )]
     use super::*;
+    use crate::test_utils::test_arrival;
 
     #[tokio::test]
     async fn test_browser_auth_state_encode_decode() {
@@ -1834,6 +1848,7 @@ mod tests {
                 pending_auth: None,
                 client_info: ClientInfo::default(),
             },
+            test_arrival(),
         )
         .await
         .expect("happy path must succeed");
@@ -1921,6 +1936,7 @@ mod tests {
                 pending_auth: None,
                 client_info: ClientInfo::default(),
             },
+            test_arrival(),
         )
         .await;
         assert!(

--- a/crates/vouch-server/src/handlers/certification.rs
+++ b/crates/vouch-server/src/handlers/certification.rs
@@ -14,6 +14,7 @@
 //! HTTPS with self-signed certs; the safeguards are operational discipline and
 //! the loud startup warnings.
 
+use crate::arrival::ArrivalTime;
 use crate::assurance::HardwareVerification;
 use std::sync::Arc;
 
@@ -76,7 +77,12 @@ impl std::fmt::Debug for CompleteLoginQuery {
 /// - `403` — HMAC validation failed
 /// - `404` — no pending authorization found for the given ID
 /// - `500` — internal error
+#[expect(
+    clippy::disallowed_methods,
+    reason = "records the synthetic ceremony instant for the conformance bypass"
+)]
 pub(crate) async fn complete_login(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     Query(query): Query<CompleteLoginQuery>,
 ) -> Response {
@@ -192,6 +198,7 @@ pub(crate) async fn complete_login(
             ),
             sender_constraint: SenderConstraintProof::no_registered_client(),
         },
+        arrival,
     )
     .await
     {

--- a/crates/vouch-server/src/handlers/credentials.rs
+++ b/crates/vouch-server/src/handlers/credentials.rs
@@ -2,6 +2,7 @@
 //! Credential issuance handlers (SSH certificates, AWS tokens, GitHub tokens, etc.).
 
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::db::{
     self, AwsCredentialDetails, CredentialAuditEnvelope, GitHubCredentialDetails,
     SshCredentialDetails,
@@ -31,6 +32,10 @@ use crate::services::auth::ValidatedResourceToken;
 ///
 /// Requires Bearer token authentication. Signs the provided SSH public key
 /// as a user certificate with principals extracted from the user's email.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "records the issued certificate's expiry for revocation tracking"
+)]
 pub(crate) async fn issue_ssh_certificate(
     State(state): State<Arc<AppState>>,
     client_info: ClientInfo,
@@ -228,6 +233,10 @@ pub(crate) struct SshKrlResponse {
 ///
 /// This endpoint does not require authentication to allow SSH servers
 /// to check revocation status without needing credentials.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "reports when the KRL was generated"
+)]
 pub(crate) async fn get_ssh_krl(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<SshKrlResponse>, ServiceError> {
@@ -258,6 +267,10 @@ pub(crate) async fn get_ssh_krl(
 /// GET /v1/credentials/ssh/krl/:serial
 ///
 /// Returns whether the certificate with the given serial is revoked.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "reports when the revocation check ran"
+)]
 pub(crate) async fn check_ssh_revocation(
     State(state): State<Arc<AppState>>,
     axum::extract::Path(serial): axum::extract::Path<String>,
@@ -464,6 +477,10 @@ fn validate_pinned_role(role_arn: &str) -> Result<(), ServiceError> {
 /// When the DPoP proof includes a `source` custom claim (e.g., "claude-code"),
 /// the issued token includes AI-specific session tags (`vouch:AccessType=AI`,
 /// `vouch:Agent=<agent>`) for CloudTrail differentiation and IAM condition keys.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "reports the issued token's expiry to the caller"
+)]
 pub(crate) async fn get_aws_token(
     State(state): State<Arc<AppState>>,
     Query(params): Query<AwsTokenParams>,
@@ -610,6 +627,7 @@ pub(crate) async fn get_github_status(
     reason = "sequential GitHub installation token validation and issuance"
 )]
 pub(crate) async fn get_github_token(
+    arrival: ArrivalTime,
     client_info: ClientInfo,
     State(state): State<Arc<AppState>>,
     HardwareVerifiedToken(token): HardwareVerifiedToken,
@@ -756,9 +774,9 @@ pub(crate) async fn get_github_token(
             "Failed to parse token expires_at '{}': {e}",
             gh_token.expires_at
         );
-        Timestamp::now()
+        arrival.timestamp()
     });
-    let now = Timestamp::now();
+    let now = arrival.timestamp();
     let expires_in = expires_at
         .as_second()
         .saturating_sub(now.as_second())

--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -2,6 +2,7 @@
 //! Device Authorization Grant handlers (RFC 8628).
 
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::db::{self, DeviceAuthState};
 use crate::handlers::extractors::{OAuthForm, OptionalClientCert};
 use crate::services::auth::{
@@ -85,6 +86,7 @@ fn hash_device_code(code: &str) -> String {
 ///
 /// RFC 8628 Section 3.1: The client makes a request using
 /// [`protocol::CONTENT_TYPE_FORM_URLENCODED`] format.
+#[expect(clippy::disallowed_methods, reason = "mints the device code's expiry")]
 pub(crate) async fn device_code(
     State(state): State<Arc<AppState>>,
     OAuthForm(req): OAuthForm<DeviceCodeRequest>,
@@ -240,6 +242,7 @@ pub(crate) async fn device_token(
     client_cert: OptionalClientCert,
     headers: HeaderMap,
     device_code: &str,
+    arrival: ArrivalTime,
 ) -> Result<Json<DeviceTokenResponse>, Response> {
     // Validate device_code format before hashing and DB lookup.
     // Generated codes are 32 random bytes base64url-encoded (43 chars).
@@ -265,7 +268,7 @@ pub(crate) async fn device_token(
         .ok_or_else(|| oauth_error(StatusCode::BAD_REQUEST, OAuthError::invalid_grant()))?;
 
     // Check if expired
-    let now = Timestamp::now();
+    let now = arrival.timestamp();
 
     if now > request.expires_at {
         return Err(oauth_error(
@@ -322,31 +325,38 @@ pub(crate) async fn device_token(
             let dpop_header = headers
                 .get(protocol::HEADER_DPOP)
                 .and_then(|v| v.to_str().ok());
-            let dpop_proof =
-                match validate_dpop_if_present(&state, dpop_header, "POST", "/oauth/token").await {
-                    Ok(proof) => proof,
-                    Err(DpopError::UseNonce(nonce)) => {
-                        return Err(dpop_use_nonce_response(&nonce));
-                    }
-                    Err(e @ DpopError::Database(_)) => {
-                        return Err(oauth_error(
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            OAuthError {
-                                error: OAuthErrorCode::ServerError.as_str().to_string(),
-                                error_description: Some(e.to_string()),
-                            },
-                        ));
-                    }
-                    Err(e) => {
-                        return Err(oauth_error(
-                            StatusCode::BAD_REQUEST,
-                            OAuthError {
-                                error: OAuthErrorCode::InvalidDpopProof.as_str().to_string(),
-                                error_description: Some(e.to_string()),
-                            },
-                        ));
-                    }
-                };
+            let dpop_proof = match validate_dpop_if_present(
+                &state,
+                dpop_header,
+                "POST",
+                "/oauth/token",
+                arrival,
+            )
+            .await
+            {
+                Ok(proof) => proof,
+                Err(DpopError::UseNonce(nonce)) => {
+                    return Err(dpop_use_nonce_response(&nonce));
+                }
+                Err(e @ DpopError::Database(_)) => {
+                    return Err(oauth_error(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        OAuthError {
+                            error: OAuthErrorCode::ServerError.as_str().to_string(),
+                            error_description: Some(e.to_string()),
+                        },
+                    ));
+                }
+                Err(e) => {
+                    return Err(oauth_error(
+                        StatusCode::BAD_REQUEST,
+                        OAuthError {
+                            error: OAuthErrorCode::InvalidDpopProof.as_str().to_string(),
+                            error_description: Some(e.to_string()),
+                        },
+                    ));
+                }
+            };
             let has_mtls_cert = client_cert.0.is_some();
 
             // Look up the registered OAuth client to enforce FAPI 2.0
@@ -604,6 +614,7 @@ pub(crate) async fn device_token(
                     ),
                     sender_constraint,
                 },
+                arrival,
             )
             .await
             .map_err(|e| {

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -227,9 +227,14 @@ impl BrowserRegistrationState {
     async fn decode(
         token: &str,
         signer: &crate::crypto::jwt::StateTokenSigner,
+        arrival: ArrivalTime,
     ) -> Result<Self, crate::crypto::jwt::StateTokenError> {
         signer
-            .decode_state_token(token, crate::crypto::jwt::JwtType::BrowserRegistrationState)
+            .decode_state_token(
+                token,
+                crate::crypto::jwt::JwtType::BrowserRegistrationState,
+                arrival.as_second(),
+            )
             .await
     }
 }
@@ -282,13 +287,10 @@ impl RegistrationCompletion {
     /// Returns a 400 `ServiceError` for client data that is not JSON or names
     /// the wrong ceremony type or origin, or a state token that fails to
     /// decode.
-    #[expect(
-        clippy::disallowed_methods,
-        reason = "fallback expiry for a state token whose exp will not parse"
-    )]
     async fn validate(
         req: BrowserRegisterCompleteRequest,
         state: &AppState,
+        arrival: ArrivalTime,
     ) -> Result<Self, ServiceError> {
         let expected_origin = state.config().base_url.clone();
         let client_data = ClientDataProof::verify(
@@ -313,13 +315,15 @@ impl RegistrationCompletion {
             ServiceError::api(StatusCode::BAD_REQUEST, "invalid_client_data", message)
         })?;
 
-        let reg_state = BrowserRegistrationState::decode(req.state.as_str(), &state.state_signer)
-            .await
-            .map_err(|e| {
-                ServiceError::api(StatusCode::BAD_REQUEST, "invalid_state", e.to_string())
-            })?;
+        let reg_state =
+            BrowserRegistrationState::decode(req.state.as_str(), &state.state_signer, arrival)
+                .await
+                .map_err(|e| {
+                    ServiceError::api(StatusCode::BAD_REQUEST, "invalid_state", e.to_string())
+                })?;
 
-        let expires_at = Timestamp::from_second(reg_state.exp).unwrap_or_else(|_| Timestamp::now());
+        let expires_at =
+            Timestamp::from_second(reg_state.exp).unwrap_or_else(|_| arrival.timestamp());
 
         Ok(Self {
             req,
@@ -1445,7 +1449,7 @@ pub(crate) async fn browser_register_complete(
     client_info: ClientInfo,
     ValidJson(req): ValidJson<BrowserRegisterCompleteRequest>,
 ) -> Result<impl IntoResponse, ServiceError> {
-    let checked = RegistrationCompletion::validate(req, &state).await?;
+    let checked = RegistrationCompletion::validate(req, &state, arrival).await?;
 
     // Bind the caller to the state JWT's user_id. `browser_register_start`
     // minted the state from the session cookie's `sub`; completion must

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -2,6 +2,7 @@
 //! Enrollment handlers for browser-based device authorization flow.
 
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::assurance::HardwareVerification;
 use crate::crypto::webauthn_verify::AuthTime;
 use crate::db::ClientInfo;
@@ -281,6 +282,10 @@ impl RegistrationCompletion {
     /// Returns a 400 `ServiceError` for client data that is not JSON or names
     /// the wrong ceremony type or origin, or a state token that fails to
     /// decode.
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "fallback expiry for a state token whose exp will not parse"
+    )]
     async fn validate(
         req: BrowserRegisterCompleteRequest,
         state: &AppState,
@@ -355,6 +360,7 @@ pub(crate) async fn device_verify_page(
 /// Handle device code submission.
 /// POST /device
 pub(crate) async fn device_verify_submit(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     Form(form): Form<UserCodeForm>,
 ) -> Response {
@@ -392,7 +398,7 @@ pub(crate) async fn device_verify_submit(
     };
 
     // Check if expired
-    let now = Timestamp::now();
+    let now = arrival.timestamp();
     if now > request.expires_at {
         return DeviceVerifyTemplate {
             error: Some("This code has expired. Please request a new one.".to_string()),
@@ -524,6 +530,7 @@ pub(crate) async fn device_verify_submit(
     reason = "axum handler; OIDC callback orchestrates IdP exchange and enrollment"
 )]
 pub(crate) async fn oidc_callback(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     client_info: ClientInfo,
     Query(params): Query<OidcCallbackParams>,
@@ -717,6 +724,7 @@ pub(crate) async fn oidc_callback(
         identity,
         oidc_state_claim,
         client_info,
+        arrival,
     )
     .await
 }
@@ -731,6 +739,7 @@ pub(crate) async fn complete_enrollment_after_identity(
     identity: IdentityResult,
     oidc_state_claim: db::OidcStateClaim,
     client_info: ClientInfo,
+    arrival: ArrivalTime,
 ) -> Response {
     // Shape-check the upstream-supplied email before it becomes the primary
     // identifier (same `Email::is_valid_address` rule the SCIM create path
@@ -918,8 +927,11 @@ pub(crate) async fn complete_enrollment_after_identity(
         db::record_auth_event(&state.audit, event, Some(user.email.clone())).await;
     }
 
-    // Create session for this user (using session cookie instead of enrollment cookie)
-    let now = Timestamp::now();
+    // Create session for this user (using session cookie instead of enrollment
+    // cookie). Measured from arrival, the same instant the access token minted
+    // below derives its `exp` from, so the cookie session and the token it
+    // carries cannot expire at different times.
+    let now = arrival.timestamp();
     let session_hours = i64::try_from(state.config().session_hours).unwrap_or(8);
     let duration = Span::new().hours(session_hours);
     let expires = match now.checked_add(duration) {
@@ -1009,6 +1021,7 @@ pub(crate) async fn complete_enrollment_after_identity(
             ),
             sender_constraint: SenderConstraintProof::no_registered_client(),
         },
+        arrival,
     )
     .await
     {
@@ -1149,13 +1162,14 @@ async fn load_keys_for_display(
 /// GET /enroll/keys
 /// Authentication is via session cookie (set by oidc_callback).
 pub(crate) async fn enroll_keys_page(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     jar: CookieJar,
 ) -> Response {
     tracing::debug!("enroll_keys_page: checking for session cookie");
 
     // Get session from cookie
-    match extract_session_from_cookie(&state, &jar).await {
+    match extract_session_from_cookie(&state, &jar, arrival).await {
         Ok(token) => {
             let email = token.email.clone().unwrap_or_default();
             tracing::debug!(
@@ -1220,12 +1234,17 @@ pub(crate) async fn enroll_keys_page(
 /// Start browser-based `WebAuthn` registration.
 /// POST /enroll/webauthn/start
 /// Authentication is via session cookie (set by oidc_callback).
+#[expect(
+    clippy::disallowed_methods,
+    reason = "mints a registration state token's expiry"
+)]
 pub(crate) async fn browser_register_start(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     jar: CookieJar,
 ) -> Result<Json<BrowserRegisterStartResponse>, ServiceError> {
     // Get session from cookie
-    let token = extract_session_from_cookie(&state, &jar)
+    let token = extract_session_from_cookie(&state, &jar, arrival)
         .await
         .map_err(|_| {
             ServiceError::api(
@@ -1420,6 +1439,7 @@ pub(crate) async fn browser_register_start(
     reason = "axum handler; FIDO2 registration completion: attestation, db, session"
 )]
 pub(crate) async fn browser_register_complete(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     jar: CookieJar,
     client_info: ClientInfo,
@@ -1433,7 +1453,7 @@ pub(crate) async fn browser_register_complete(
     // caller is rejected here, *before* the single-use consume, so the
     // legitimate holder can still complete the enrollment with the same
     // state token.
-    let session = extract_session_from_cookie(&state, &jar).await?;
+    let session = extract_session_from_cookie(&state, &jar, arrival).await?;
     if session.sub != checked.reg_state.user_id.to_string() {
         tracing::warn!(
             caller_sub = %session.sub,
@@ -1675,6 +1695,7 @@ pub(crate) async fn browser_register_complete(
             ),
             sender_constraint: SenderConstraintProof::no_registered_client(),
         },
+        arrival,
     )
     .await
     .map_err(|e| {
@@ -1802,6 +1823,10 @@ pub(crate) struct DirectEnrollQuery {
 /// This initiates OIDC authentication directly from the browser,
 /// without requiring the CLI to create a device authorization request.
 /// After successful enrollment, the user can download the CLI and login.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "stamps the enrollment audit record"
+)]
 pub(crate) async fn direct_enroll_start(
     State(state): State<Arc<AppState>>,
     Query(query): Query<DirectEnrollQuery>,

--- a/crates/vouch-server/src/handlers/enroll/tests.rs
+++ b/crates/vouch-server/src/handlers/enroll/tests.rs
@@ -7,6 +7,7 @@
 )]
 
 use super::*;
+use crate::test_utils::test_arrival;
 use crate::test_utils::{
     TestSessionSpec, create_test_authenticator, create_test_session_with, create_test_user,
     http_delete_full, http_get_full, http_post_json, test_app, test_app_state, test_config,
@@ -791,6 +792,7 @@ async fn test_enrollment_allowed_domains_distinct_from_invalid_domain_gate() {
         identity_in,
         claim_in,
         ClientInfo::default(),
+        test_arrival(),
     )
     .await;
     assert_eq!(
@@ -815,6 +817,7 @@ async fn test_enrollment_allowed_domains_distinct_from_invalid_domain_gate() {
         identity_out,
         claim_out,
         ClientInfo::default(),
+        test_arrival(),
     )
     .await;
     assert_eq!(
@@ -855,6 +858,7 @@ async fn test_enrollment_allowed_domains_distinct_from_invalid_domain_gate() {
         identity_ws,
         claim_ws,
         ClientInfo::default(),
+        test_arrival(),
     )
     .await;
     assert_eq!(
@@ -941,8 +945,15 @@ async fn test_direct_web_signin_returning_user_logs_login_success_with_ip() {
         upstream: None,
     };
 
-    let resp =
-        complete_enrollment_after_identity(&state, &stored, identity, claim, client_info).await;
+    let resp = complete_enrollment_after_identity(
+        &state,
+        &stored,
+        identity,
+        claim,
+        client_info,
+        test_arrival(),
+    )
+    .await;
     assert_eq!(resp.status(), StatusCode::SEE_OTHER);
 
     let events = audit_events_for(&state, "login_success", &user.id).await;
@@ -1003,9 +1014,15 @@ async fn test_direct_web_signin_bootstrap_session_cannot_delete_keys() {
         upstream: None,
     };
 
-    let resp =
-        complete_enrollment_after_identity(&state, &stored, identity, claim, ClientInfo::default())
-            .await;
+    let resp = complete_enrollment_after_identity(
+        &state,
+        &stored,
+        identity,
+        claim,
+        ClientInfo::default(),
+        test_arrival(),
+    )
+    .await;
     assert_eq!(resp.status(), StatusCode::SEE_OTHER);
 
     // A direct web sign-in (no CLI waiting) lands on the keys page; the
@@ -1140,9 +1157,15 @@ async fn test_cli_enroll_returning_user_requires_assertion_before_approval() {
         upstream: None,
     };
 
-    let resp =
-        complete_enrollment_after_identity(&state, &stored, identity, claim, ClientInfo::default())
-            .await;
+    let resp = complete_enrollment_after_identity(
+        &state,
+        &stored,
+        identity,
+        claim,
+        ClientInfo::default(),
+        test_arrival(),
+    )
+    .await;
 
     assert_eq!(resp.status(), StatusCode::SEE_OTHER);
     let location = resp
@@ -1224,9 +1247,15 @@ async fn test_identity_conflict_renders_error_and_audits() {
         }),
     };
 
-    let resp =
-        complete_enrollment_after_identity(&state, &stored, identity, claim, ClientInfo::default())
-            .await;
+    let resp = complete_enrollment_after_identity(
+        &state,
+        &stored,
+        identity,
+        claim,
+        ClientInfo::default(),
+        test_arrival(),
+    )
+    .await;
 
     // Error page renders 200 OK, and crucially carries no session cookie.
     assert_eq!(resp.status(), StatusCode::OK);
@@ -1282,9 +1311,15 @@ async fn test_non_durable_login_refused_once_issuer_is_bound() {
         }),
     };
 
-    let resp =
-        complete_enrollment_after_identity(&state, &stored, identity, claim, ClientInfo::default())
-            .await;
+    let resp = complete_enrollment_after_identity(
+        &state,
+        &stored,
+        identity,
+        claim,
+        ClientInfo::default(),
+        test_arrival(),
+    )
+    .await;
 
     assert_eq!(resp.status(), StatusCode::OK);
     assert!(
@@ -1319,9 +1354,15 @@ async fn test_lazy_bind_emits_identity_bound_event() {
         }),
     };
 
-    let resp =
-        complete_enrollment_after_identity(&state, &stored, identity, claim, ClientInfo::default())
-            .await;
+    let resp = complete_enrollment_after_identity(
+        &state,
+        &stored,
+        identity,
+        claim,
+        ClientInfo::default(),
+        test_arrival(),
+    )
+    .await;
     assert_eq!(resp.status(), StatusCode::SEE_OTHER);
 
     let events = audit_events_for(&state, "identity_bound", &user.id).await;
@@ -1353,9 +1394,15 @@ async fn test_cli_device_auth_failure_renders_error_instead_of_redirect() {
         upstream: None,
     };
 
-    let resp =
-        complete_enrollment_after_identity(&state, &stored, identity, claim, ClientInfo::default())
-            .await;
+    let resp = complete_enrollment_after_identity(
+        &state,
+        &stored,
+        identity,
+        claim,
+        ClientInfo::default(),
+        test_arrival(),
+    )
+    .await;
 
     assert_ne!(
         resp.status(),
@@ -1395,9 +1442,15 @@ async fn test_direct_web_enrollment_new_user_emits_no_login_event() {
         domain: Some(test_domain("example.com")),
         upstream: None,
     };
-    let resp =
-        complete_enrollment_after_identity(&state, &stored, identity, claim, ClientInfo::default())
-            .await;
+    let resp = complete_enrollment_after_identity(
+        &state,
+        &stored,
+        identity,
+        claim,
+        ClientInfo::default(),
+        test_arrival(),
+    )
+    .await;
     assert_eq!(resp.status(), StatusCode::SEE_OTHER);
 
     // A fresh enrollee has no key to assert with: they must reach the keys
@@ -2638,9 +2691,15 @@ async fn test_enrollment_rejects_display_name_wrapped_email() {
         upstream: None,
     };
 
-    let resp =
-        complete_enrollment_after_identity(&state, &stored, identity, claim, ClientInfo::default())
-            .await;
+    let resp = complete_enrollment_after_identity(
+        &state,
+        &stored,
+        identity,
+        claim,
+        ClientInfo::default(),
+        test_arrival(),
+    )
+    .await;
     assert_eq!(resp.status(), StatusCode::OK, "error page renders as 200");
 
     let user = crate::db::get_user_by_email(&state.store, "alice example <alice@example.com>")
@@ -2663,9 +2722,15 @@ async fn test_enrollment_rejects_empty_local_part_email() {
         upstream: None,
     };
 
-    let resp =
-        complete_enrollment_after_identity(&state, &stored, identity, claim, ClientInfo::default())
-            .await;
+    let resp = complete_enrollment_after_identity(
+        &state,
+        &stored,
+        identity,
+        claim,
+        ClientInfo::default(),
+        test_arrival(),
+    )
+    .await;
     assert_eq!(resp.status(), StatusCode::OK, "error page renders as 200");
 
     let user = crate::db::get_user_by_email(&state.store, "@example.com")
@@ -2695,9 +2760,15 @@ async fn test_enrollment_open_mode_rejects_empty_domain_email() {
         upstream: None,
     };
 
-    let resp =
-        complete_enrollment_after_identity(&state, &stored, identity, claim, ClientInfo::default())
-            .await;
+    let resp = complete_enrollment_after_identity(
+        &state,
+        &stored,
+        identity,
+        claim,
+        ClientInfo::default(),
+        test_arrival(),
+    )
+    .await;
     assert_eq!(resp.status(), StatusCode::OK, "error page renders as 200");
 
     let user = crate::db::get_user_by_email(&state.store, "foo@")
@@ -2736,9 +2807,15 @@ async fn test_enrollment_open_mode_rejects_whitespace_domain_email() {
         upstream: None,
     };
 
-    let resp =
-        complete_enrollment_after_identity(&state, &stored, identity, claim, ClientInfo::default())
-            .await;
+    let resp = complete_enrollment_after_identity(
+        &state,
+        &stored,
+        identity,
+        claim,
+        ClientInfo::default(),
+        test_arrival(),
+    )
+    .await;
     assert_eq!(
         resp.status(),
         StatusCode::OK,
@@ -2771,9 +2848,15 @@ async fn test_enrollment_open_mode_rejects_tab_in_domain_email() {
         upstream: None,
     };
 
-    let resp =
-        complete_enrollment_after_identity(&state, &stored, identity, claim, ClientInfo::default())
-            .await;
+    let resp = complete_enrollment_after_identity(
+        &state,
+        &stored,
+        identity,
+        claim,
+        ClientInfo::default(),
+        test_arrival(),
+    )
+    .await;
     assert_eq!(
         resp.status(),
         StatusCode::OK,
@@ -2807,9 +2890,15 @@ async fn test_enrollment_open_mode_accepts_well_formed_email() {
         upstream: None,
     };
 
-    let resp =
-        complete_enrollment_after_identity(&state, &stored, identity, claim, ClientInfo::default())
-            .await;
+    let resp = complete_enrollment_after_identity(
+        &state,
+        &stored,
+        identity,
+        claim,
+        ClientInfo::default(),
+        test_arrival(),
+    )
+    .await;
     assert_eq!(
         resp.status(),
         StatusCode::SEE_OTHER,
@@ -2831,9 +2920,15 @@ async fn test_enrollment_accepts_well_formed_email() {
         upstream: None,
     };
 
-    let resp =
-        complete_enrollment_after_identity(&state, &stored, identity, claim, ClientInfo::default())
-            .await;
+    let resp = complete_enrollment_after_identity(
+        &state,
+        &stored,
+        identity,
+        claim,
+        ClientInfo::default(),
+        test_arrival(),
+    )
+    .await;
     assert_eq!(
         resp.status(),
         StatusCode::SEE_OTHER,
@@ -2881,9 +2976,15 @@ async fn test_enrollment_open_mode_accepts_divergent_identity_domain() {
         upstream: None,
     };
 
-    let resp =
-        complete_enrollment_after_identity(&state, &stored, identity, claim, ClientInfo::default())
-            .await;
+    let resp = complete_enrollment_after_identity(
+        &state,
+        &stored,
+        identity,
+        claim,
+        ClientInfo::default(),
+        test_arrival(),
+    )
+    .await;
     assert_eq!(
         resp.status(),
         StatusCode::SEE_OTHER,
@@ -2927,9 +3028,15 @@ async fn test_enrollment_open_mode_gates_email_domain_without_asserted_domain() 
         domain: None,
         upstream: None,
     };
-    let resp =
-        complete_enrollment_after_identity(&state, &stored, identity, claim, ClientInfo::default())
-            .await;
+    let resp = complete_enrollment_after_identity(
+        &state,
+        &stored,
+        identity,
+        claim,
+        ClientInfo::default(),
+        test_arrival(),
+    )
+    .await;
     assert_eq!(
         resp.status(),
         StatusCode::SEE_OTHER,
@@ -2950,6 +3057,7 @@ async fn test_enrollment_open_mode_gates_email_domain_without_asserted_domain() 
         identity_ws,
         claim_ws,
         ClientInfo::default(),
+        test_arrival(),
     )
     .await;
     assert_eq!(

--- a/crates/vouch-server/src/handlers/enroll_keys.rs
+++ b/crates/vouch-server/src/handlers/enroll_keys.rs
@@ -11,6 +11,7 @@
 //! handler, which is worse than the asymmetry.
 
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::db;
 use crate::error::ServiceError;
 use crate::infra::i18n::Tr;
@@ -31,10 +32,11 @@ use super::session::{SteppedUpToken, extract_session_from_cookie};
 /// GET /enroll/keys/api
 /// Authentication is via session cookie.
 pub(crate) async fn list_keys(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     jar: CookieJar,
 ) -> Result<Json<ListKeysResponse>, ServiceError> {
-    let token = extract_session_from_cookie(&state, &jar).await?;
+    let token = extract_session_from_cookie(&state, &jar, arrival).await?;
 
     let keys =
         key_svc::list_keys_for_user(&state.store, &token.sub, token.authenticator_id.as_deref())
@@ -58,12 +60,13 @@ pub(crate) struct RenameKeyForm {
 /// the list — surfacing any error via a flash message rather than returning a
 /// raw JSON error body. Authentication is via session cookie.
 pub(crate) async fn rename_key_form(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     jar: CookieJar,
     Path(key_id): Path<String>,
     Form(form): Form<RenameKeyForm>,
 ) -> Response {
-    let token = match extract_session_from_cookie(&state, &jar).await {
+    let token = match extract_session_from_cookie(&state, &jar, arrival).await {
         Ok(token) => token,
         Err(_) => return Redirect::to("/enroll/start").into_response(),
     };

--- a/crates/vouch-server/src/handlers/extractors.rs
+++ b/crates/vouch-server/src/handlers/extractors.rs
@@ -11,6 +11,7 @@ use http::request::Parts;
 use serde::Deserialize;
 
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::db;
 use crate::db::ClientInfo;
 use crate::error::ServiceError;
@@ -349,7 +350,11 @@ impl FromRequestParts<Arc<AppState>> for SignedInSession {
         let jar = CookieJar::from_headers(&parts.headers);
         let sign_in = || axum::response::Redirect::to("/enroll/start").into_response();
 
-        let Ok(session) = crate::handlers::session::extract_session_from_cookie(state, &jar).await
+        let Ok(arrival) = ArrivalTime::from_request_parts(parts, state).await else {
+            return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response());
+        };
+        let Ok(session) =
+            crate::handlers::session::extract_session_from_cookie(state, &jar, arrival).await
         else {
             return Err(sign_in());
         };
@@ -401,7 +406,10 @@ impl FromRequestParts<Arc<AppState>> for AdminPage {
         use axum::response::{IntoResponse, Redirect};
 
         let jar = CookieJar::from_headers(&parts.headers);
-        let auth = get_resource_auth_context(state, &jar).await;
+        let Ok(arrival) = ArrivalTime::from_request_parts(parts, state).await else {
+            return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response());
+        };
+        let auth = get_resource_auth_context(state, &jar, arrival).await;
 
         if !auth.authenticated {
             return Err(Redirect::to("/enroll/start").into_response());
@@ -460,6 +468,9 @@ impl axum::extract::FromRequestParts<Arc<AppState>> for OrgAdmin {
             .await
             .unwrap_or_else(|infallible| match infallible {});
         let jar = CookieJar::from_headers(&parts.headers);
+        let arrival = ArrivalTime::from_request_parts(parts, state)
+            .await
+            .map_err(|_| ServiceError::Internal("Request arrival time unavailable".to_string()))?;
         let (user, org_id) = extract_org_admin(
             state,
             &parts.headers,
@@ -467,6 +478,7 @@ impl axum::extract::FromRequestParts<Arc<AppState>> for OrgAdmin {
             parts.method.as_str(),
             uri.path(),
             client_cert.0.as_ref(),
+            arrival,
         )
         .await?;
         Ok(Self { user, org_id })

--- a/crates/vouch-server/src/handlers/github.rs
+++ b/crates/vouch-server/src/handlers/github.rs
@@ -9,6 +9,7 @@
 //! - POST /github/reconnect - Reconnect an existing GitHub installation
 //! - GET /github/success - Success page after connection
 
+use crate::arrival::ArrivalTime;
 use crate::error::ServiceError;
 use crate::handlers::session::{
     AuthContext, extract_session_from_cookie, get_auth_context, load_active_user,
@@ -158,6 +159,10 @@ impl GitHubStateToken {
         Self::new(org_id, user_id, session_binding, GitHubStateFlowType::Link)
     }
 
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "mints the GitHub state token's iat"
+    )]
     fn new(
         org_id: &str,
         user_id: &str,
@@ -331,6 +336,7 @@ pub(crate) async fn github_webhook(
 /// Also handles redirects from GitHub after app installation if the GitHub App's
 /// "Setup URL" points here instead of `/github/callback`.
 pub(crate) async fn github_connect_page(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     jar: CookieJar,
     Query(params): Query<GitHubConnectParams>,
@@ -354,7 +360,7 @@ pub(crate) async fn github_connect_page(
     }
 
     // Extract session from cookie (browser UI)
-    let session = match extract_session_from_cookie(&state, &jar).await {
+    let session = match extract_session_from_cookie(&state, &jar, arrival).await {
         Ok(s) => s,
         Err(_) => {
             return Redirect::to("/enroll/start").into_response();
@@ -450,17 +456,18 @@ pub(crate) async fn github_connect_page(
 /// Both flows require an authenticated session cookie that matches the session
 /// which originally minted the state token (RFC 6819 §5.3.5 CSRF defense).
 pub(crate) async fn github_callback(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     jar: CookieJar,
     Query(params): Query<GitHubCallbackParams>,
 ) -> Response {
     // Detect callback type by presence of `code` parameter
     if let Some(code) = &params.code {
-        return handle_oauth_callback(&state, &jar, code, params.state.as_deref()).await;
+        return handle_oauth_callback(&state, &jar, code, params.state.as_deref(), arrival).await;
     }
 
     // Otherwise, handle as installation callback
-    handle_installation_callback(&state, &jar, &params).await
+    handle_installation_callback(&state, &jar, &params, arrival).await
 }
 
 /// Validate the callback session against the state token.
@@ -481,8 +488,9 @@ async fn validate_callback_session(
     jar: &CookieJar,
     token: &GitHubStateToken,
     flow_label: &'static str,
+    arrival: ArrivalTime,
 ) -> Result<crate::services::auth::ValidatedResourceToken, Response> {
-    let session = match extract_session_from_cookie(state, jar).await {
+    let session = match extract_session_from_cookie(state, jar, arrival).await {
         Ok(s) => s,
         Err(_) => {
             tracing::warn!(
@@ -525,6 +533,7 @@ async fn handle_oauth_callback(
     jar: &CookieJar,
     code: &str,
     state_param: Option<&str>,
+    arrival: ArrivalTime,
 ) -> Response {
     // Verify state parameter
     let state_token = match state_param {
@@ -547,7 +556,7 @@ async fn handle_oauth_callback(
     }
 
     // CSRF defense: bind the callback to the cookie session.
-    let session = match validate_callback_session(state, jar, &token, "oauth_link").await {
+    let session = match validate_callback_session(state, jar, &token, "oauth_link", arrival).await {
         Ok(s) => s,
         Err(resp) => return resp,
     };
@@ -588,6 +597,7 @@ async fn handle_installation_callback(
     state: &Arc<AppState>,
     jar: &CookieJar,
     params: &GitHubCallbackParams,
+    arrival: ArrivalTime,
 ) -> Response {
     // Verify required parameters
     let installation_id = match params.installation_id {
@@ -616,7 +626,7 @@ async fn handle_installation_callback(
     }
 
     // CSRF defense: bind the callback to the cookie session.
-    let session = match validate_callback_session(state, jar, &token, "install").await {
+    let session = match validate_callback_session(state, jar, &token, "install", arrival).await {
         Ok(s) => s,
         Err(resp) => return resp,
     };
@@ -674,6 +684,7 @@ async fn handle_installation_callback(
 
 /// GET /github/link - Redirect user to GitHub OAuth to link their GitHub account.
 pub(crate) async fn github_link_start(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     jar: CookieJar,
 ) -> Response {
@@ -686,7 +697,7 @@ pub(crate) async fn github_link_start(
     }
 
     // Extract session from cookie
-    let session = match extract_session_from_cookie(&state, &jar).await {
+    let session = match extract_session_from_cookie(&state, &jar, arrival).await {
         Ok(s) => s,
         Err(_) => {
             return Redirect::to("/enroll/start").into_response();
@@ -737,6 +748,7 @@ pub(crate) async fn github_link_start(
 /// This allows an org admin to link an existing GitHub installation (that they
 /// have access to via `/user/installations`) to their Vouch organization.
 pub(crate) async fn github_reconnect(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     jar: CookieJar,
     Form(form): Form<GitHubReconnectForm>,
@@ -750,7 +762,7 @@ pub(crate) async fn github_reconnect(
     }
 
     // Extract session from cookie
-    let session = match extract_session_from_cookie(&state, &jar).await {
+    let session = match extract_session_from_cookie(&state, &jar, arrival).await {
         Ok(s) => s,
         Err(_) => {
             return Redirect::to("/enroll/start").into_response();
@@ -797,11 +809,12 @@ pub(crate) async fn github_reconnect(
 
 /// GET /github/success - Show success page after GitHub connection.
 pub(crate) async fn github_success_page(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     jar: CookieJar,
     Query(params): Query<GitHubSuccessParams>,
 ) -> impl IntoResponse {
-    let auth = get_auth_context(&state, &jar).await;
+    let auth = get_auth_context(&state, &jar, arrival).await;
 
     GitHubSuccessTemplate {
         org_name: state.config().get_org_display_name().to_string(),
@@ -1290,7 +1303,7 @@ mod tests {
         // peer would: a first lookup hits the DB and inserts the session.
         let seeded = state
             .session_cache
-            .get_session_by_token_hash(&state.store, &session_hash)
+            .get_session_by_token_hash(&state.store, &session_hash, test_arrival())
             .await
             .expect("seed lookup succeeds");
         assert!(seeded.is_some(), "session row must exist before seeding");
@@ -1351,7 +1364,7 @@ mod tests {
 
         let seeded = state
             .session_cache
-            .get_session_by_token_hash(&state.store, &session_hash)
+            .get_session_by_token_hash(&state.store, &session_hash, test_arrival())
             .await
             .expect("seed lookup succeeds");
         assert!(seeded.is_some(), "session row must exist before seeding");

--- a/crates/vouch-server/src/handlers/github.rs
+++ b/crates/vouch-server/src/handlers/github.rs
@@ -196,9 +196,14 @@ impl GitHubStateToken {
     async fn decode(
         token: &str,
         signer: &crate::crypto::jwt::StateTokenSigner,
+        arrival: ArrivalTime,
     ) -> Result<Self, crate::crypto::jwt::StateTokenError> {
         signer
-            .decode_state_token(token, crate::crypto::jwt::JwtType::GitHubState)
+            .decode_state_token(
+                token,
+                crate::crypto::jwt::JwtType::GitHubState,
+                arrival.as_second(),
+            )
             .await
     }
 }
@@ -542,7 +547,7 @@ async fn handle_oauth_callback(
     };
 
     // Decode and validate state token
-    let token = match GitHubStateToken::decode(state_token, &state.state_signer).await {
+    let token = match GitHubStateToken::decode(state_token, &state.state_signer, arrival).await {
         Ok(t) => t,
         Err(e) => {
             tracing::warn!("Invalid state token: {}", e);
@@ -613,7 +618,7 @@ async fn handle_installation_callback(
     };
 
     // Decode and validate state token
-    let token = match GitHubStateToken::decode(state_token, &state.state_signer).await {
+    let token = match GitHubStateToken::decode(state_token, &state.state_signer, arrival).await {
         Ok(t) => t,
         Err(e) => {
             tracing::warn!("Invalid state token: {}", e);
@@ -841,7 +846,7 @@ mod tests {
             .expect("create token");
 
         let encoded = token.encode(&signer).await.expect("encode");
-        let decoded = GitHubStateToken::decode(&encoded, &signer)
+        let decoded = GitHubStateToken::decode(&encoded, &signer, test_arrival())
             .await
             .expect("decode");
 
@@ -858,7 +863,7 @@ mod tests {
             .expect("create token");
 
         let encoded = token.encode(&signer).await.expect("encode");
-        let decoded = GitHubStateToken::decode(&encoded, &signer)
+        let decoded = GitHubStateToken::decode(&encoded, &signer, test_arrival())
             .await
             .expect("decode");
 
@@ -877,7 +882,7 @@ mod tests {
             .expect("create token");
 
         let encoded = token.encode(&signer_a).await.expect("encode");
-        let result = GitHubStateToken::decode(&encoded, &signer_b).await;
+        let result = GitHubStateToken::decode(&encoded, &signer_b, test_arrival()).await;
         assert!(result.is_err(), "Wrong secret should be rejected");
     }
 
@@ -891,7 +896,11 @@ mod tests {
 
         // Try decoding with wrong JwtType via the raw signer
         let result: Result<GitHubStateToken, _> = signer
-            .decode_state_token(&encoded, JwtType::RegistrationState)
+            .decode_state_token(
+                &encoded,
+                JwtType::RegistrationState,
+                test_arrival().as_second(),
+            )
             .await;
         assert!(result.is_err(), "Wrong JWT type should be rejected");
     }

--- a/crates/vouch-server/src/handlers/home.rs
+++ b/crates/vouch-server/src/handlers/home.rs
@@ -6,6 +6,7 @@
 //! If the user is already authenticated, it shows a "Manage Security Keys"
 //! button instead.
 
+use crate::arrival::ArrivalTime;
 use crate::handlers::session::{AuthContext, get_auth_context};
 use crate::{AppState, impl_template_response};
 use askama::Template;
@@ -63,10 +64,11 @@ impl_template_response!(HomeTemplate);
 /// Home page showing enrollment instructions.
 /// GET /
 pub(crate) async fn home_page(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     jar: CookieJar,
 ) -> impl IntoResponse {
-    let auth = get_auth_context(&state, &jar).await;
+    let auth = get_auth_context(&state, &jar, arrival).await;
 
     let has_downloads = state.config().cli_download_macos.is_some()
         || state.config().cli_download_linux.is_some()

--- a/crates/vouch-server/src/handlers/install.rs
+++ b/crates/vouch-server/src/handlers/install.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Install page handler.
 
+use crate::arrival::ArrivalTime;
 use crate::handlers::session::{AuthContext, get_auth_context};
 use crate::{AppState, impl_template_response};
 use askama::Template;
@@ -27,10 +28,11 @@ impl_template_response!(InstallTemplate);
 /// Install page - CLI installation and enrollment instructions.
 /// GET /install
 pub(crate) async fn install_page(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     jar: CookieJar,
 ) -> impl IntoResponse {
-    let auth = get_auth_context(&state, &jar).await;
+    let auth = get_auth_context(&state, &jar, arrival).await;
 
     let has_downloads = state.config().cli_download_macos.is_some()
         || state.config().cli_download_linux.is_some()

--- a/crates/vouch-server/src/handlers/integrations.rs
+++ b/crates/vouch-server/src/handlers/integrations.rs
@@ -7,6 +7,7 @@
 //! - SSH (per-user, CLI setup)
 //! - EKS (via AWS IAM and EKS Access Entries)
 
+use crate::arrival::ArrivalTime;
 use crate::db;
 use crate::handlers::extractors::SignedInSession;
 use crate::handlers::session::{AuthContext, extract_session_from_cookie};
@@ -43,6 +44,7 @@ impl_template_response!(IntegrationsTemplate);
 
 /// GET /integrations - Show integrations page.
 pub(crate) async fn integrations_page(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     jar: CookieJar,
     session: SignedInSession,
@@ -57,7 +59,7 @@ pub(crate) async fn integrations_page(
 
     // Fetch session + user once for org-scoped lookups
     let org_context = if auth.has_org {
-        match extract_session_from_cookie(&state, &jar).await {
+        match extract_session_from_cookie(&state, &jar, arrival).await {
             Ok(session) => match db::get_user_by_id(&state.store, &session.sub).await {
                 Ok(Some(user)) => user.org_id.clone().map(|org_id| (user, org_id)),
                 Ok(None) => {

--- a/crates/vouch-server/src/handlers/keys.rs
+++ b/crates/vouch-server/src/handlers/keys.rs
@@ -2,6 +2,7 @@
 //! Key management handlers for listing, renaming, removing, and registering security keys.
 
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::db::{self};
 use crate::error::ServiceError;
 use crate::redact_email;
@@ -60,9 +61,14 @@ impl RegistrationState {
     async fn decode(
         token: &str,
         signer: &crate::crypto::jwt::StateTokenSigner,
+        arrival: ArrivalTime,
     ) -> Result<Self, crate::crypto::jwt::StateTokenError> {
         signer
-            .decode_state_token(token, crate::crypto::jwt::JwtType::RegistrationState)
+            .decode_state_token(
+                token,
+                crate::crypto::jwt::JwtType::RegistrationState,
+                arrival.as_second(),
+            )
             .await
     }
 }
@@ -101,21 +107,19 @@ impl RegistrationCompletion {
     /// # Errors
     ///
     /// Returns a 400 `ServiceError` if the state token fails to decode.
-    #[expect(
-        clippy::disallowed_methods,
-        reason = "fallback expiry for a state token whose exp will not parse"
-    )]
     async fn validate(
         req: RegisterCompleteRequest,
         state: &AppState,
+        arrival: ArrivalTime,
     ) -> Result<Self, ServiceError> {
-        let reg_state = RegistrationState::decode(req.state.as_str(), &state.state_signer)
+        let reg_state = RegistrationState::decode(req.state.as_str(), &state.state_signer, arrival)
             .await
             .map_err(|e| {
                 ServiceError::api(StatusCode::BAD_REQUEST, "invalid_state", e.to_string())
             })?;
 
-        let expires_at = Timestamp::from_second(reg_state.exp).unwrap_or_else(|_| Timestamp::now());
+        let expires_at =
+            Timestamp::from_second(reg_state.exp).unwrap_or_else(|_| arrival.timestamp());
 
         Ok(Self {
             req,
@@ -240,6 +244,7 @@ pub(crate) async fn register_start(
 /// with an attacker-controlled YubiKey and enroll a credential on a victim
 /// account by satisfying only the open RFC 7591 client-level signature gate.
 pub(crate) async fn register_complete(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     AuthenticatedToken(token): AuthenticatedToken,
     client_info: db::ClientInfo,
@@ -247,7 +252,7 @@ pub(crate) async fn register_complete(
 ) -> Result<Json<RegisterCompleteResponse>, ServiceError> {
     tracing::info!("Registration complete");
 
-    let checked = RegistrationCompletion::validate(req, &state).await?;
+    let checked = RegistrationCompletion::validate(req, &state, arrival).await?;
 
     // Bind the caller to the state JWT's user_id. `register_start` minted
     // the state from `token.sub`; completion must assert the same principal
@@ -549,7 +554,7 @@ mod tests {
         };
 
         let token = state.encode(&signer).await.expect("encode");
-        let decoded = RegistrationState::decode(&token, &signer)
+        let decoded = RegistrationState::decode(&token, &signer, test_arrival())
             .await
             .expect("decode");
 
@@ -575,7 +580,7 @@ mod tests {
         };
 
         let token = state.encode(&signer_a).await.expect("encode");
-        let result = RegistrationState::decode(&token, &signer_b).await;
+        let result = RegistrationState::decode(&token, &signer_b, test_arrival()).await;
         assert!(result.is_err(), "Wrong secret should be rejected");
     }
 
@@ -596,7 +601,11 @@ mod tests {
 
         // Try decoding with a different JwtType via the raw signer
         let result: Result<RegistrationState, _> = signer
-            .decode_state_token(&token, JwtType::BrowserRegistrationState)
+            .decode_state_token(
+                &token,
+                JwtType::BrowserRegistrationState,
+                test_arrival().as_second(),
+            )
             .await;
         assert!(result.is_err(), "Wrong JWT type should be rejected");
     }

--- a/crates/vouch-server/src/handlers/keys.rs
+++ b/crates/vouch-server/src/handlers/keys.rs
@@ -101,6 +101,10 @@ impl RegistrationCompletion {
     /// # Errors
     ///
     /// Returns a 400 `ServiceError` if the state token fails to decode.
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "fallback expiry for a state token whose exp will not parse"
+    )]
     async fn validate(
         req: RegisterCompleteRequest,
         state: &AppState,
@@ -137,6 +141,10 @@ impl RegistrationCompletion {
 ///
 /// Key *deletion* is gated, because it is destructive and has no recovery
 /// argument — see `SteppedUpToken`.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "mints a registration state token's expiry"
+)]
 pub(crate) async fn register_start(
     State(state): State<Arc<AppState>>,
     AuthenticatedToken(token): AuthenticatedToken,

--- a/crates/vouch-server/src/handlers/legal.rs
+++ b/crates/vouch-server/src/handlers/legal.rs
@@ -26,6 +26,10 @@ pub(crate) async fn terms_page() -> Redirect {
 /// `Host` header — the header is attacker-controlled behind the L4
 /// passthrough listener. `Expires` rolls 30 days ahead of each request so
 /// a long-lived deployment can never serve a stale value.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "mints the security.txt Expires field"
+)]
 pub(crate) async fn security_txt(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let config = state.config.load();
     let now = jiff::Timestamp::now();

--- a/crates/vouch-server/src/handlers/oidc/authorize.rs
+++ b/crates/vouch-server/src/handlers/oidc/authorize.rs
@@ -11,6 +11,7 @@ use super::{
     build_redirect_url_with_params,
 };
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::assurance::ACR_AAL3;
 use crate::db::ResponseMode;
 use crate::db::{self, Authenticator, CreatePendingOAuthParams, OAuthClient, User};
@@ -410,12 +411,13 @@ async fn check_session_and_authorize(
     jar: &CookieJar,
     reauth_policy: ReauthPolicy,
     par_to_consume: Option<db::ParRef<'_>>,
+    arrival: ArrivalTime,
 ) -> Response {
     let session_token = jar
         .get(vouch_common::SESSION_COOKIE_NAME)
         .map(|c| c.value());
 
-    match check_session_for_authorization(state, session_token).await {
+    match check_session_for_authorization(state, session_token, arrival).await {
         Ok(AuthorizationSessionState::Authenticated {
             user,
             authenticator,
@@ -431,6 +433,7 @@ async fn check_session_and_authorize(
                 reauth_policy,
                 par_to_consume,
                 resolved.response_mode,
+                arrival,
             )
             .await
         }
@@ -506,18 +509,24 @@ async fn check_session_and_authorize(
 /// - RFC 9207: Includes `iss` parameter in response
 /// - RFC 9700: Follows OAuth 2.0 Security BCP
 pub(crate) async fn authorize(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     OAuthQuery(params): OAuthQuery<AuthorizeQuery>,
     jar: CookieJar,
 ) -> Response {
-    authorize_inner(state, params, jar).await
+    authorize_inner(state, params, jar, arrival).await
 }
 
 /// Shared authorization logic for both GET and POST.
-async fn authorize_inner(state: Arc<AppState>, params: AuthorizeQuery, jar: CookieJar) -> Response {
+async fn authorize_inner(
+    state: Arc<AppState>,
+    params: AuthorizeQuery,
+    jar: CookieJar,
+    arrival: ArrivalTime,
+) -> Response {
     // Check if we're returning from login with a pending auth
     if let Some(pending_id) = &params.pending_auth {
-        return handle_pending_auth(&state, pending_id, &jar).await;
+        return handle_pending_auth(&state, pending_id, &jar, arrival).await;
     }
 
     // RFC 9101 + RFC 9126: Mutual exclusion — cannot provide both request and request_uri
@@ -540,7 +549,7 @@ async fn authorize_inner(state: Arc<AppState>, params: AuthorizeQuery, jar: Cook
             .into_response();
         }
 
-        return handle_jar_request(&state, request_jwt, &client_id, &params, jar).await;
+        return handle_jar_request(&state, request_jwt, &client_id, &params, jar, arrival).await;
     }
 
     // RFC 9126 / OIDC Core Section 6.2: If request_uri is present, dispatch by scheme.
@@ -576,13 +585,22 @@ async fn authorize_inner(state: Arc<AppState>, params: AuthorizeQuery, jar: Cook
                         .unwrap_or(ResponseMode::Query),
                 },
                 jar,
+                arrival,
             )
             .await;
         }
 
         if request_uri.starts_with("https://") {
             // OIDC Core Section 6.2: HTTPS URL — fetch the Request Object JWT.
-            return handle_request_uri_fetch(&state, request_uri, &client_id, &params, jar).await;
+            return handle_request_uri_fetch(
+                &state,
+                request_uri,
+                &client_id,
+                &params,
+                jar,
+                arrival,
+            )
+            .await;
         }
 
         // Neither a PAR URN nor an HTTPS URL.
@@ -594,7 +612,7 @@ async fn authorize_inner(state: Arc<AppState>, params: AuthorizeQuery, jar: Cook
     }
 
     // Normal direct authorization request.
-    handle_direct_request(&state, params, jar).await
+    handle_direct_request(&state, params, jar, arrival).await
 }
 
 /// POST /oauth/authorize
@@ -603,11 +621,12 @@ async fn authorize_inner(state: Arc<AppState>, params: AuthorizeQuery, jar: Cook
 /// Accepts `application/x-www-form-urlencoded` parameters and delegates
 /// to the same logic as the GET handler.
 pub(crate) async fn authorize_post(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     jar: CookieJar,
     OAuthForm(params): OAuthForm<AuthorizeQuery>,
 ) -> Response {
-    authorize_inner(state, params, jar).await
+    authorize_inner(state, params, jar, arrival).await
 }
 
 // ---------------------------------------------------------------------------
@@ -623,6 +642,7 @@ async fn handle_direct_request(
     state: &Arc<AppState>,
     params: AuthorizeQuery,
     jar: CookieJar,
+    arrival: ArrivalTime,
 ) -> Response {
     let client_id = params.client_id.clone().unwrap_or_default();
     if client_id.is_empty() {
@@ -696,6 +716,7 @@ async fn handle_direct_request(
         &jar,
         ReauthPolicy::OnDemand,
         None,
+        arrival,
     )
     .await
 }
@@ -711,6 +732,7 @@ async fn handle_jar_request(
     client_id: &str,
     query: &AuthorizeQuery,
     jar: CookieJar,
+    arrival: ArrivalTime,
 ) -> Response {
     // Phase A step 1: client lookup + active check (errors → page).
     let oauth_client = match lookup_and_check_active(state, client_id).await {
@@ -730,6 +752,7 @@ async fn handle_jar_request(
         request_jwt,
         &oauth_client,
         Some(&query_hints),
+        arrival,
     )
     .await
     {
@@ -810,6 +833,7 @@ async fn handle_jar_request(
         &jar,
         ReauthPolicy::OnDemand,
         None,
+        arrival,
     )
     .await
 }
@@ -901,6 +925,7 @@ async fn handle_par_request(
     state: &Arc<AppState>,
     ctx: ParRequestContext<'_>,
     jar: CookieJar,
+    arrival: ArrivalTime,
 ) -> Response {
     // FAPI 2.0 Section 5.3.2.2 Note 3: Look up the PAR without consuming it.
     let par = match lookup_par(state, ctx).await {
@@ -988,6 +1013,7 @@ async fn handle_par_request(
             client_id: ctx.client_id,
             mode: db::ParConsumptionMode::EnforceExpiry,
         }),
+        arrival,
     )
     .await
 }
@@ -1004,10 +1030,11 @@ async fn handle_request_uri_fetch(
     client_id: &str,
     query: &AuthorizeQuery,
     jar: CookieJar,
+    arrival: ArrivalTime,
 ) -> Response {
     // Phase A steps 1-6: lookup + FAPI + allowlist + fetch + validate + redirect_uri.
     let (resolved, request_params) =
-        match fetch_and_resolve_request_uri(state, request_uri, client_id, query).await {
+        match fetch_and_resolve_request_uri(state, request_uri, client_id, query, arrival).await {
             Ok(pair) => pair,
             Err(resp) => return resp,
         };
@@ -1048,6 +1075,7 @@ async fn handle_request_uri_fetch(
         &jar,
         ReauthPolicy::OnDemand,
         None,
+        arrival,
     )
     .await
 }
@@ -1068,6 +1096,7 @@ async fn fetch_and_resolve_request_uri(
     request_uri: &str,
     client_id: &str,
     query: &AuthorizeQuery,
+    arrival: ArrivalTime,
 ) -> Result<(ResolvedClient, AuthorizeRequestParams), Response> {
     // Step 1: client lookup + active check (errors → page).
     let oauth_client = lookup_and_check_active(state, client_id).await?;
@@ -1118,26 +1147,32 @@ async fn fetch_and_resolve_request_uri(
         response_type: query.response_type.as_deref(),
         scope: query.scope.as_deref(),
     };
-    let request_params =
-        match validate_request_object(state, &fetched_jwt, &oauth_client, Some(&query_hints)).await
-        {
-            Ok(params) => params,
-            Err(e) => {
-                let (error_code, description) = match &e {
-                    crate::error::ServiceError::OAuth { code, description } => {
-                        (code.as_str(), description.clone())
-                    }
-                    _ => ("invalid_request_object", e.to_string()),
-                };
-                return Err(AuthorizeDeniedTemplate {
-                    client_name: oauth_client.name,
-                    error_message: Tr::new("authorize-denied-invalid-request-object-coded")
-                        .arg("code", error_code)
-                        .arg("detail", description),
+    let request_params = match validate_request_object(
+        state,
+        &fetched_jwt,
+        &oauth_client,
+        Some(&query_hints),
+        arrival,
+    )
+    .await
+    {
+        Ok(params) => params,
+        Err(e) => {
+            let (error_code, description) = match &e {
+                crate::error::ServiceError::OAuth { code, description } => {
+                    (code.as_str(), description.clone())
                 }
-                .into_response());
+                _ => ("invalid_request_object", e.to_string()),
+            };
+            return Err(AuthorizeDeniedTemplate {
+                client_name: oauth_client.name,
+                error_message: Tr::new("authorize-denied-invalid-request-object-coded")
+                    .arg("code", error_code)
+                    .arg("detail", description),
             }
-        };
+            .into_response());
+        }
+    };
 
     // Step 6: extract redirect_uri and validate against registered URIs, then
     // apply the requested response_mode (see `with_requested_response_mode`).
@@ -1161,7 +1196,12 @@ async fn fetch_and_resolve_request_uri(
 ///
 /// Phase A: read pending → resolve client (lookup + active + redirect_uri re-validation).
 /// Phase C: session check → consume pending → max_age check + code issuance.
-async fn handle_pending_auth(state: &Arc<AppState>, pending_id: &str, jar: &CookieJar) -> Response {
+async fn handle_pending_auth(
+    state: &Arc<AppState>,
+    pending_id: &str,
+    jar: &CookieJar,
+    arrival: ArrivalTime,
+) -> Response {
     // Read the pending auth without spending it. The single-use claim is
     // consumed only after the session gate passes: consuming first meant a
     // session this endpoint refuses — or one lost mid-flow — burned the id,
@@ -1221,7 +1261,7 @@ async fn handle_pending_auth(state: &Arc<AppState>, pending_id: &str, jar: &Cook
     let auth_code_lifetime: i64 =
         crate::services::oidc::fapi::auth_code_lifetime_seconds(&resolved.client);
 
-    match check_session_for_authorization(state, session_token).await {
+    match check_session_for_authorization(state, session_token, arrival).await {
         Ok(AuthorizationSessionState::Authenticated {
             user,
             authenticator,
@@ -1260,6 +1300,7 @@ async fn handle_pending_auth(state: &Arc<AppState>, pending_id: &str, jar: &Cook
                 session_auth_time,
                 &authenticator,
                 auth_code_lifetime,
+                arrival,
             )
             .await
         }
@@ -1294,6 +1335,10 @@ async fn handle_pending_auth(state: &Arc<AppState>, pending_id: &str, jar: &Cook
 // ---------------------------------------------------------------------------
 
 /// Complete the pending auth flow: check access, check max_age, issue code.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "linear pending-authorization completion: client, pending record, session facts, clock"
+)]
 async fn complete_pending_auth(
     state: &Arc<AppState>,
     resolved: &ResolvedClient,
@@ -1302,6 +1347,7 @@ async fn complete_pending_auth(
     session_auth_time: Option<i64>,
     authenticator: &Authenticator,
     auth_code_lifetime: i64,
+    arrival: ArrivalTime,
 ) -> Response {
     // Check client access for the authenticated user.
     if let Err(e) = check_client_access(&resolved.client, user) {
@@ -1348,10 +1394,7 @@ async fn complete_pending_auth(
         && let Some(session_auth_time) = session_auth_time
         && session_auth_time < pending.created_at.as_second()
     {
-        let age_secs = jiff::Timestamp::now()
-            .as_second()
-            .saturating_sub(session_auth_time)
-            .max(0);
+        let age_secs = arrival.as_second().saturating_sub(session_auth_time).max(0);
         let max_age_u64 = u64::try_from(max_age).unwrap_or(0);
         let age_u64 = u64::try_from(age_secs).unwrap_or(u64::MAX);
         // Reject only when the session age *exceeds* max_age (strict `>`).
@@ -1682,6 +1725,7 @@ async fn authorize_authenticated_user(
     reauth_policy: ReauthPolicy,
     par_to_consume: Option<db::ParRef<'_>>,
     response_mode: ResponseMode,
+    arrival: ArrivalTime,
 ) -> Response {
     // Step 1: Check client access.
     if let Err(e) = check_client_access(oauth_client, user) {
@@ -1727,7 +1771,7 @@ async fn authorize_authenticated_user(
                     let Some(auth_time) = session_auth_time else {
                         return true;
                     };
-                    let elapsed = jiff::Timestamp::now().duration_since(
+                    let elapsed = arrival.timestamp().duration_since(
                         jiff::Timestamp::from_second(auth_time).unwrap_or_default(),
                     );
                     let limit =

--- a/crates/vouch-server/src/handlers/oidc/client_auth.rs
+++ b/crates/vouch-server/src/handlers/oidc/client_auth.rs
@@ -5,6 +5,7 @@
 //! (RFC 6749 Section 3.2) and the PAR endpoint (RFC 9126 Section 2).
 
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::error::{OAuthErrorCode, OAuthErrorResponse};
 use crate::services::oidc::{
     jwt_bearer::client_auth::{PendingJti, authenticate_client_jwt},
@@ -304,6 +305,7 @@ pub(crate) struct ClientAuthOutcome {
 pub(crate) async fn complete_client_auth(
     state: &Arc<AppState>,
     auth: ExtractedClientAuth,
+    arrival: ArrivalTime,
 ) -> Result<Option<ClientAuthOutcome>, Response> {
     match auth {
         ExtractedClientAuth::Secret {
@@ -328,7 +330,9 @@ pub(crate) async fn complete_client_auth(
         ExtractedClientAuth::JwtAssertion {
             client_assertion,
             client_id,
-        } => match authenticate_client_jwt(state, &client_assertion, client_id.as_deref()).await {
+        } => match authenticate_client_jwt(state, &client_assertion, client_id.as_deref(), arrival)
+            .await
+        {
             Ok((client, pending_jti, jwt_auth)) => {
                 let cid = client.client.client_id.clone();
                 Ok(Some(ClientAuthOutcome {

--- a/crates/vouch-server/src/handlers/oidc/fido2_challenge.rs
+++ b/crates/vouch-server/src/handlers/oidc/fido2_challenge.rs
@@ -44,6 +44,10 @@ pub(super) struct Fido2ChallengeResponse {
 ///
 /// Unauthenticated. No `client_id` is needed at this stage; client
 /// identification happens at the token endpoint via `client_assertion`.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "mints the challenge state token's expiry"
+)]
 pub(crate) async fn fido2_challenge(State(state): State<Arc<AppState>>) -> Response {
     let challenge = match generate_challenge() {
         Ok(c) => c,

--- a/crates/vouch-server/src/handlers/oidc/introspect.rs
+++ b/crates/vouch-server/src/handlers/oidc/introspect.rs
@@ -6,6 +6,7 @@
 //! - RFC 7662 - OAuth 2.0 Token Introspection
 
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::db::ClientInfo;
 use crate::error::ServiceError;
 use crate::handlers::extractors::OAuthForm;
@@ -154,6 +155,7 @@ impl ClientAuthFields for IntrospectRequest {
 /// Returns 200 OK regardless of whether the token was valid (security best practice).
 /// Supports `client_secret_basic`, `client_secret_post`, and `private_key_jwt` auth.
 pub(crate) async fn revoke(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     client_info: ClientInfo,
     headers: HeaderMap,
@@ -166,7 +168,7 @@ pub(crate) async fn revoke(
         Err(response) => return response,
     };
 
-    let (caller_client_id, pending_jti) = match complete_client_auth(&state, auth).await {
+    let (caller_client_id, pending_jti) = match complete_client_auth(&state, auth, arrival).await {
         Ok(Some(a)) => (a.client_id, a.pending_jti),
         Ok(None) => {
             // No credentials provided → 401 with the shared challenge.
@@ -214,6 +216,7 @@ pub(crate) async fn revoke(
 /// credentials, or `private_key_jwt` (RFC 7523).
 /// Returns token metadata if valid, or `{"active": false}` if invalid or auth fails.
 pub(crate) async fn introspect(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     OAuthForm(params): OAuthForm<IntrospectRequest>,
@@ -225,17 +228,18 @@ pub(crate) async fn introspect(
         Err(response) => return response,
     };
 
-    let (authenticated_client, pending_jti) = match complete_client_auth(&state, auth).await {
-        Ok(Some(a)) => (a.client.client, a.pending_jti),
-        Ok(None) => {
-            // No credentials provided → 401 with the shared challenge.
-            return with_client_auth_challenge(
-                ClientAuthPresentation::of(&headers, &params),
-                StatusCode::UNAUTHORIZED.into_response(),
-            );
-        }
-        Err(response) => return response,
-    };
+    let (authenticated_client, pending_jti) =
+        match complete_client_auth(&state, auth, arrival).await {
+            Ok(Some(a)) => (a.client.client, a.pending_jti),
+            Ok(None) => {
+                // No credentials provided → 401 with the shared challenge.
+                return with_client_auth_challenge(
+                    ClientAuthPresentation::of(&headers, &params),
+                    StatusCode::UNAUTHORIZED.into_response(),
+                );
+            }
+            Err(response) => return response,
+        };
 
     let wants_jwt = authenticated_client
         .introspection_signed_response_alg
@@ -249,6 +253,7 @@ pub(crate) async fn introspect(
         params.token.expose_secret(),
         params.token_type_hint.as_deref(),
         Some(client_id.as_str()),
+        arrival,
     )
     .await
     {

--- a/crates/vouch-server/src/handlers/oidc/logout.rs
+++ b/crates/vouch-server/src/handlers/oidc/logout.rs
@@ -24,6 +24,7 @@
 //! - <https://openid.net/specs/openid-connect-rpinitiated-1_0.html>
 
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::db;
 use crate::db::ClientInfo;
 use crate::handlers::{clear_session_cookie, hash_token};
@@ -324,6 +325,7 @@ pub(crate) async fn logout(
 /// redirects to the validated `post_logout_redirect_uri` (with `state` echoed as
 /// a query parameter) or renders the local done page.
 pub(crate) async fn logout_post(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     jar: CookieJar,
@@ -342,7 +344,14 @@ pub(crate) async fn logout_post(
     // Clear the browser session first (DB deletion + cache invalidation + audit
     // event). The user asked to log out, so a later redirect-validation database
     // error must not prevent logout.
-    clear_user_session(&state, &jar, &headers, verified_client_id.as_deref()).await;
+    clear_user_session(
+        &state,
+        &jar,
+        &headers,
+        verified_client_id.as_deref(),
+        arrival,
+    )
+    .await;
 
     let clear_cookie = clear_session_cookie().to_string();
 
@@ -450,6 +459,7 @@ async fn clear_user_session(
     jar: &CookieJar,
     headers: &HeaderMap,
     rp_client_id: Option<&str>,
+    arrival: ArrivalTime,
 ) {
     let Some(token) = jar
         .get(vouch_common::SESSION_COOKIE_NAME)
@@ -462,7 +472,7 @@ async fn clear_user_session(
 
     let session_info = match state
         .session_cache
-        .get_session_by_token_hash(&state.store, &token_hash)
+        .get_session_by_token_hash(&state.store, &token_hash, arrival)
         .await
     {
         Ok(info) => info,

--- a/crates/vouch-server/src/handlers/oidc/par.rs
+++ b/crates/vouch-server/src/handlers/oidc/par.rs
@@ -6,6 +6,7 @@ use super::client_auth::{
     with_client_auth_challenge,
 };
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::db::{self, CreateParParams, PAR_EXPIRES_IN};
 use crate::error::OAuthErrorCode;
 use crate::error::OAuthErrorResponse;
@@ -180,6 +181,7 @@ impl ClientAuthFields for ParRequest {
     reason = "single-pass FAPI 2.0 PAR validation per RFC 9126"
 )]
 pub(crate) async fn par(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     client_cert: OptionalClientCert,
     headers: HeaderMap,
@@ -219,7 +221,7 @@ pub(crate) async fn par(
     };
 
     // RFC 9126 Section 2: Client authentication is REQUIRED
-    let Some(any_auth) = (match complete_client_auth(&state, client_auth).await {
+    let Some(any_auth) = (match complete_client_auth(&state, client_auth, arrival).await {
         Ok(result) => result,
         Err(resp) => return resp,
     }) else {
@@ -313,37 +315,41 @@ pub(crate) async fn par(
     let dpop_header = headers
         .get(protocol::HEADER_DPOP)
         .and_then(|v| v.to_str().ok());
-    let dpop_proof = match validate_dpop_if_present(&state, dpop_header, "POST", "/oauth/par").await
-    {
-        Ok(proof) => proof,
-        Err(DpopError::UseNonce(nonce)) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                [(
-                    axum::http::header::HeaderName::from_static(protocol::HEADER_DPOP_NONCE),
-                    nonce.to_string(),
-                )],
-                Json(OAuthErrorResponse {
-                    error: OAuthErrorCode::UseDpopNonce.as_str().to_string(),
-                    error_description: Some(
-                        "Authorization server requires nonce in DPoP proof".to_string(),
-                    ),
-                    error_uri: None,
-                }),
-            )
-                .into_response();
-        }
-        Err(e @ DpopError::Database(_)) => {
-            return par_error_response(OAuthErrorCode::ServerError, presentation, &e.to_string());
-        }
-        Err(e) => {
-            return par_error_response(
-                OAuthErrorCode::InvalidDpopProof,
-                presentation,
-                &e.to_string(),
-            );
-        }
-    };
+    let dpop_proof =
+        match validate_dpop_if_present(&state, dpop_header, "POST", "/oauth/par", arrival).await {
+            Ok(proof) => proof,
+            Err(DpopError::UseNonce(nonce)) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    [(
+                        axum::http::header::HeaderName::from_static(protocol::HEADER_DPOP_NONCE),
+                        nonce.to_string(),
+                    )],
+                    Json(OAuthErrorResponse {
+                        error: OAuthErrorCode::UseDpopNonce.as_str().to_string(),
+                        error_description: Some(
+                            "Authorization server requires nonce in DPoP proof".to_string(),
+                        ),
+                        error_uri: None,
+                    }),
+                )
+                    .into_response();
+            }
+            Err(e @ DpopError::Database(_)) => {
+                return par_error_response(
+                    OAuthErrorCode::ServerError,
+                    presentation,
+                    &e.to_string(),
+                );
+            }
+            Err(e) => {
+                return par_error_response(
+                    OAuthErrorCode::InvalidDpopProof,
+                    presentation,
+                    &e.to_string(),
+                );
+            }
+        };
     let dpop_jkt = dpop_proof.as_ref().map(|p| p.jkt.as_str());
 
     // RFC 9449 Section 10: If both a DPoP proof header and a dpop_jkt request
@@ -381,16 +387,21 @@ pub(crate) async fn par(
     // RFC 9101: If request parameter is present, validate the Request Object JWT
     // and extract parameters from it instead of using the form fields.
     let (validated, jar_response_mode) = if let Some(ref request_jwt) = params.request {
-        let request_params =
-            match validate_request_object(&state, request_jwt, &authenticated_client.client, None)
-                .await
-            {
-                Ok(params) => params,
-                Err(e) => {
-                    let (error_code, description) = service_error_codes(&e);
-                    return par_error_response(error_code, presentation, &description);
-                }
-            };
+        let request_params = match validate_request_object(
+            &state,
+            request_jwt,
+            &authenticated_client.client,
+            None,
+            arrival,
+        )
+        .await
+        {
+            Ok(params) => params,
+            Err(e) => {
+                let (error_code, description) = service_error_codes(&e);
+                return par_error_response(error_code, presentation, &description);
+            }
+        };
 
         // client_id from JWT must match the authenticated client
         if request_params.client_id != authenticated_client.client.client_id {

--- a/crates/vouch-server/src/handlers/oidc/tests/aud_enforcement.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/aud_enforcement.rs
@@ -450,7 +450,7 @@ async fn test_cookie_only_path_rejects_narrowed_token() {
     )
     .await;
     let jar = CookieJar::new().add(Cookie::new(vouch_common::SESSION_COOKIE_NAME, narrowed));
-    let result = crate::handlers::extract_session_from_cookie(&state, &jar).await;
+    let result = crate::handlers::extract_session_from_cookie(&state, &jar, test_arrival()).await;
     assert!(
         result.is_err(),
         "narrowed token must be rejected on cookie-only paths"
@@ -469,7 +469,7 @@ async fn test_cookie_only_path_rejects_narrowed_token() {
     )
     .await;
     let jar = CookieJar::new().add(Cookie::new(vouch_common::SESSION_COOKIE_NAME, root_scoped));
-    let result = crate::handlers::extract_session_from_cookie(&state, &jar).await;
+    let result = crate::handlers::extract_session_from_cookie(&state, &jar, test_arrival()).await;
     assert!(
         result.is_ok(),
         "deployment-root audience must be accepted on cookie-only paths: {result:?}"

--- a/crates/vouch-server/src/handlers/oidc/tests/oidc_userinfo.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/oidc_userinfo.rs
@@ -127,6 +127,7 @@ async fn test_userinfo_no_email_when_scope_is_none() {
             client_auth: ClientAuthProof::NoAuth(NoClientAuth::internal_endpoint()),
             sender_constraint: SenderConstraintProof::no_registered_client(),
         },
+        test_arrival(),
     )
     .await
     .expect("issue token");

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc8693.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc8693.rs
@@ -962,12 +962,29 @@ async fn test_rfc8693_access_token_exp_not_capped_by_subject_ttl() {
          `expires_in` value reported to the client ({reported_expires_in}s)"
     );
 
-    // (3) The `sessions` row's `expires_at` must match the issued token's
+    // (3) The issued token must not outlive its subject in absolute terms.
+    //     The cap and the mint read one instant — the request's arrival — so
+    //     `exp_issued = arrival + min(session, subject_exp - arrival)` is at
+    //     or before `subject_exp`. Read from two clocks, the mint's later
+    //     stamp pushed `exp_issued` past `subject_exp` by the gap between
+    //     them, which the lifetime checks above cannot see: both the issued
+    //     `iat` and `exp` shift together.
+    let subject_exp = decode_jwt_payload(&subject_token)["exp"]
+        .as_i64()
+        .expect("subject exp present");
+    assert!(
+        issued_exp <= subject_exp,
+        "issued token exp ({issued_exp}) must not be later than the subject \
+         token's exp ({subject_exp}); an exchanged token may never outlive \
+         the token it was derived from"
+    );
+
+    // (4) The `sessions` row's `expires_at` must match the issued token's
     //     `exp` claim — the two records must not disagree for the same token.
     let issued_hash = crate::crypto::hash_token(issued_token);
     let session = state
         .session_cache
-        .get_session_by_token_hash(&state.store, &issued_hash)
+        .get_session_by_token_hash(&state.store, &issued_hash, test_arrival())
         .await
         .expect("session lookup")
         .expect("issued access token must be persisted as a session");
@@ -978,7 +995,7 @@ async fn test_rfc8693_access_token_exp_not_capped_by_subject_ttl() {
         session.expires_at.as_second()
     );
 
-    // (4) The `token_exchange` audit row's `expires_at` must agree with the
+    // (5) The `token_exchange` audit row's `expires_at` must agree with the
     //     issued token's actual `exp` — the audit row and the `sessions` row
     //     must record the same lifetime for one token. `issued_token_hash`
     //     is not indexed, so look the row up by the indexed subject_user_id
@@ -1496,7 +1513,7 @@ async fn test_rfc8693_id_token_not_persisted_as_session() {
     let hash = crate::crypto::hash_token(id_token);
     let session = state
         .session_cache
-        .get_session_by_token_hash(&state.store, &hash)
+        .get_session_by_token_hash(&state.store, &hash, test_arrival())
         .await
         .expect("session lookup");
     assert!(
@@ -1749,7 +1766,7 @@ async fn test_rfc8693_access_token_request_unaffected_by_id_token_branch() {
     let hash = crate::crypto::hash_token(access_token);
     let session = state
         .session_cache
-        .get_session_by_token_hash(&state.store, &hash)
+        .get_session_by_token_hash(&state.store, &hash, test_arrival())
         .await
         .expect("session lookup");
     assert!(

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -6,6 +6,7 @@ use super::client_auth::{
     extract_client_auth, extract_client_credentials, with_client_auth_challenge,
 };
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::db::JwtAssertionJtiClaim;
 use crate::error::OAuthErrorResponse;
 use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
@@ -383,6 +384,7 @@ const MAX_ASSERTION_LEN: usize = 8192;
 /// - `urn:ietf:params:oauth:grant-type:device_code` grant (RFC 8628 Section 3.4)
 /// - `urn:ietf:params:oauth:grant-type:token-exchange` grant (RFC 8693 Section 2.1)
 pub(crate) async fn token(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     client_info: crate::db::ClientInfo,
     client_cert: OptionalClientCert,
@@ -478,10 +480,19 @@ pub(crate) async fn token(
 
     match grant {
         GrantParams::AuthorizationCode(params) => {
-            handle_authorization_code_grant(State(state), client_cert, headers, auth, params).await
+            handle_authorization_code_grant(
+                arrival,
+                State(state),
+                client_cert,
+                headers,
+                auth,
+                params,
+            )
+            .await
         }
         GrantParams::ClientCredentials(params) => {
             handle_client_credentials_grant(
+                arrival,
                 State(state),
                 client_info,
                 client_cert,
@@ -492,10 +503,19 @@ pub(crate) async fn token(
             .await
         }
         GrantParams::DeviceCode(params) => {
-            handle_device_code_grant(State(state), client_info, client_cert, headers, params).await
+            handle_device_code_grant(
+                arrival,
+                State(state),
+                client_info,
+                client_cert,
+                headers,
+                params,
+            )
+            .await
         }
         GrantParams::TokenExchange(params) => {
             handle_token_exchange_grant(
+                arrival,
                 State(state),
                 client_info,
                 client_cert,
@@ -507,6 +527,7 @@ pub(crate) async fn token(
         }
         GrantParams::Fido2Assertion(params) => {
             handle_fido2_assertion_grant(
+                arrival,
                 State(state),
                 client_info,
                 client_cert,
@@ -674,6 +695,7 @@ async fn resolve_non_jwt_auth(
 
 /// Handle authorization code grant.
 async fn handle_authorization_code_grant(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     client_cert: OptionalClientCert,
     headers: HeaderMap,
@@ -694,7 +716,9 @@ async fn handle_authorization_code_grant(
             client_id,
         } = client_auth
         {
-            match authenticate_client_jwt(&state, &client_assertion, client_id.as_deref()).await {
+            match authenticate_client_jwt(&state, &client_assertion, client_id.as_deref(), arrival)
+                .await
+            {
                 Ok((client, pending_jti, auth)) => (Some(client), Some(pending_jti), Some(auth)),
                 Err(e) => return e.into_service_error().into_oauth_response().into_response(),
             }
@@ -712,23 +736,30 @@ async fn handle_authorization_code_grant(
     let dpop_header = headers
         .get(protocol::HEADER_DPOP)
         .and_then(|v| v.to_str().ok());
-    let dpop_proof =
-        match validate_dpop_if_present(&state, dpop_header, "POST", "/oauth/token").await {
-            Ok(proof) => proof,
-            Err(crate::services::oidc::dpop::DpopError::UseNonce(nonce)) => {
-                return dpop_use_nonce_response(&nonce);
-            }
-            Err(e @ crate::services::oidc::dpop::DpopError::Database(_)) => {
-                return ServiceError::oauth(OAuthErrorCode::ServerError, e.to_string())
-                    .into_oauth_response()
-                    .into_response();
-            }
-            Err(e) => {
-                return ServiceError::oauth(OAuthErrorCode::InvalidDpopProof, e.to_string())
-                    .into_oauth_response()
-                    .into_response();
-            }
-        };
+    let dpop_proof = match validate_dpop_if_present(
+        &state,
+        dpop_header,
+        "POST",
+        "/oauth/token",
+        arrival,
+    )
+    .await
+    {
+        Ok(proof) => proof,
+        Err(crate::services::oidc::dpop::DpopError::UseNonce(nonce)) => {
+            return dpop_use_nonce_response(&nonce);
+        }
+        Err(e @ crate::services::oidc::dpop::DpopError::Database(_)) => {
+            return ServiceError::oauth(OAuthErrorCode::ServerError, e.to_string())
+                .into_oauth_response()
+                .into_response();
+        }
+        Err(e) => {
+            return ServiceError::oauth(OAuthErrorCode::InvalidDpopProof, e.to_string())
+                .into_oauth_response()
+                .into_response();
+        }
+    };
 
     // For non-JWT auth, resolve `(AuthenticatedClient, ClientAuthProof)`
     // directly. The handler runs ALL non-JWT authentication itself so
@@ -820,7 +851,14 @@ async fn handle_authorization_code_grant(
         authorization_details: params.authorization_details.as_deref(),
     };
 
-    match exchange_authorization_code(&state, exchange_params, client_auth, sender_constraint).await
+    match exchange_authorization_code(
+        &state,
+        exchange_params,
+        client_auth,
+        sender_constraint,
+        arrival,
+    )
+    .await
     {
         Ok(result) => {
             crate::infra::metrics::record_auth_event("authorization_code_success");
@@ -845,7 +883,12 @@ async fn handle_authorization_code_grant(
 ///
 /// Requires client authentication via `client_secret_basic` or `client_secret_post`.
 /// Issues an access token with `hardware_verified: false` and no ID token.
+#[expect(
+    clippy::too_many_lines,
+    reason = "linear RFC 6749 §4.4 client-credentials grant: authenticate, bind, issue"
+)]
 async fn handle_client_credentials_grant(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     client_info: crate::db::ClientInfo,
     client_cert: OptionalClientCert,
@@ -859,7 +902,7 @@ async fn handle_client_credentials_grant(
         Err(resp) => return resp,
     };
 
-    let Some(any_auth) = (match complete_client_auth(&state, client_auth).await {
+    let Some(any_auth) = (match complete_client_auth(&state, client_auth, arrival).await {
         Ok(result) => result,
         Err(resp) => return resp,
     }) else {
@@ -908,23 +951,30 @@ async fn handle_client_credentials_grant(
     let dpop_header = headers
         .get(protocol::HEADER_DPOP)
         .and_then(|v| v.to_str().ok());
-    let dpop_proof =
-        match validate_dpop_if_present(&state, dpop_header, "POST", "/oauth/token").await {
-            Ok(proof) => proof,
-            Err(crate::services::oidc::dpop::DpopError::UseNonce(nonce)) => {
-                return dpop_use_nonce_response(&nonce);
-            }
-            Err(e @ crate::services::oidc::dpop::DpopError::Database(_)) => {
-                return ServiceError::oauth(OAuthErrorCode::ServerError, e.to_string())
-                    .into_oauth_response()
-                    .into_response();
-            }
-            Err(e) => {
-                return ServiceError::oauth(OAuthErrorCode::InvalidDpopProof, e.to_string())
-                    .into_oauth_response()
-                    .into_response();
-            }
-        };
+    let dpop_proof = match validate_dpop_if_present(
+        &state,
+        dpop_header,
+        "POST",
+        "/oauth/token",
+        arrival,
+    )
+    .await
+    {
+        Ok(proof) => proof,
+        Err(crate::services::oidc::dpop::DpopError::UseNonce(nonce)) => {
+            return dpop_use_nonce_response(&nonce);
+        }
+        Err(e @ crate::services::oidc::dpop::DpopError::Database(_)) => {
+            return ServiceError::oauth(OAuthErrorCode::ServerError, e.to_string())
+                .into_oauth_response()
+                .into_response();
+        }
+        Err(e) => {
+            return ServiceError::oauth(OAuthErrorCode::InvalidDpopProof, e.to_string())
+                .into_oauth_response()
+                .into_response();
+        }
+    };
 
     // FAPI 2.0 Section 5.3.2.1: sender-constrained access tokens required
     // (DPoP or mTLS), same as every other grant a FAPI client can reach.
@@ -992,6 +1042,7 @@ async fn handle_client_credentials_grant(
         params.scope.as_deref(),
         TokenBinding::new(dpop_proof.as_ref(), mtls_thumbprint.as_ref()),
         proof,
+        arrival,
     )
     .await
     {
@@ -1038,6 +1089,7 @@ async fn handle_client_credentials_grant(
 
 /// Handle device code grant.
 async fn handle_device_code_grant(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     client_info: crate::db::ClientInfo,
     client_cert: OptionalClientCert,
@@ -1050,6 +1102,7 @@ async fn handle_device_code_grant(
         client_cert,
         headers,
         &params.device_code,
+        arrival,
     )
     .await
     {
@@ -1154,6 +1207,7 @@ fn resolve_exchange_audience(
 /// authentication. The client_id in the authenticated credentials must
 /// match any client_id provided in the request body.
 async fn handle_token_exchange_grant(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     client_info: crate::db::ClientInfo,
     client_cert: OptionalClientCert,
@@ -1168,7 +1222,7 @@ async fn handle_token_exchange_grant(
     };
 
     // Authenticate client (required for token exchange)
-    let Some(any_auth) = (match complete_client_auth(&state, client_auth).await {
+    let Some(any_auth) = (match complete_client_auth(&state, client_auth, arrival).await {
         Ok(result) => result,
         Err(resp) => return resp,
     }) else {
@@ -1196,23 +1250,30 @@ async fn handle_token_exchange_grant(
     let dpop_header = headers
         .get(protocol::HEADER_DPOP)
         .and_then(|v| v.to_str().ok());
-    let dpop_proof =
-        match validate_dpop_if_present(&state, dpop_header, "POST", "/oauth/token").await {
-            Ok(proof) => proof,
-            Err(crate::services::oidc::dpop::DpopError::UseNonce(nonce)) => {
-                return dpop_use_nonce_response(&nonce);
-            }
-            Err(e @ crate::services::oidc::dpop::DpopError::Database(_)) => {
-                return ServiceError::oauth(OAuthErrorCode::ServerError, e.to_string())
-                    .into_oauth_response()
-                    .into_response();
-            }
-            Err(e) => {
-                return ServiceError::oauth(OAuthErrorCode::InvalidDpopProof, e.to_string())
-                    .into_oauth_response()
-                    .into_response();
-            }
-        };
+    let dpop_proof = match validate_dpop_if_present(
+        &state,
+        dpop_header,
+        "POST",
+        "/oauth/token",
+        arrival,
+    )
+    .await
+    {
+        Ok(proof) => proof,
+        Err(crate::services::oidc::dpop::DpopError::UseNonce(nonce)) => {
+            return dpop_use_nonce_response(&nonce);
+        }
+        Err(e @ crate::services::oidc::dpop::DpopError::Database(_)) => {
+            return ServiceError::oauth(OAuthErrorCode::ServerError, e.to_string())
+                .into_oauth_response()
+                .into_response();
+        }
+        Err(e) => {
+            return ServiceError::oauth(OAuthErrorCode::InvalidDpopProof, e.to_string())
+                .into_oauth_response()
+                .into_response();
+        }
+    };
 
     // RFC 8705 Section 2: Validate mTLS client auth if the client uses it.
     let mtls_verification =
@@ -1315,7 +1376,7 @@ async fn handle_token_exchange_grant(
         sender_constraint,
     };
 
-    match exchange_token(&state, exchange_params, proof).await {
+    match exchange_token(&state, exchange_params, proof, arrival).await {
         Ok(result) => token_success_response(TokenExchangeResponse {
             access_token: result.access_token,
             issued_token_type: result.issued_token_type,
@@ -1377,6 +1438,7 @@ impl ClientAuthFields for ClientAuthParams {
 /// Requires `private_key_jwt` client authentication and a FIDO2 assertion
 /// in the `assertion` parameter. Optionally requires DPoP for FAPI clients.
 async fn handle_fido2_assertion_grant(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     client_info: crate::db::ClientInfo,
     client_cert: OptionalClientCert,
@@ -1397,10 +1459,14 @@ async fn handle_fido2_assertion_grant(
         ExtractedClientAuth::JwtAssertion {
             client_assertion,
             client_id,
-        } => match authenticate_client_jwt(&state, &client_assertion, client_id.as_deref()).await {
-            Ok((client, pending_jti, auth)) => (client, pending_jti, auth),
-            Err(e) => return e.into_service_error().into_oauth_response().into_response(),
-        },
+        } => {
+            match authenticate_client_jwt(&state, &client_assertion, client_id.as_deref(), arrival)
+                .await
+            {
+                Ok((client, pending_jti, auth)) => (client, pending_jti, auth),
+                Err(e) => return e.into_service_error().into_oauth_response().into_response(),
+            }
+        }
         _ => {
             return token_error_response(
                 OAuthErrorCode::InvalidClient,
@@ -1414,23 +1480,30 @@ async fn handle_fido2_assertion_grant(
     let dpop_header = headers
         .get(protocol::HEADER_DPOP)
         .and_then(|v| v.to_str().ok());
-    let dpop_proof =
-        match validate_dpop_if_present(&state, dpop_header, "POST", "/oauth/token").await {
-            Ok(proof) => proof,
-            Err(crate::services::oidc::dpop::DpopError::UseNonce(nonce)) => {
-                return dpop_use_nonce_response(&nonce);
-            }
-            Err(e @ crate::services::oidc::dpop::DpopError::Database(_)) => {
-                return ServiceError::oauth(OAuthErrorCode::ServerError, e.to_string())
-                    .into_oauth_response()
-                    .into_response();
-            }
-            Err(e) => {
-                return ServiceError::oauth(OAuthErrorCode::InvalidDpopProof, e.to_string())
-                    .into_oauth_response()
-                    .into_response();
-            }
-        };
+    let dpop_proof = match validate_dpop_if_present(
+        &state,
+        dpop_header,
+        "POST",
+        "/oauth/token",
+        arrival,
+    )
+    .await
+    {
+        Ok(proof) => proof,
+        Err(crate::services::oidc::dpop::DpopError::UseNonce(nonce)) => {
+            return dpop_use_nonce_response(&nonce);
+        }
+        Err(e @ crate::services::oidc::dpop::DpopError::Database(_)) => {
+            return ServiceError::oauth(OAuthErrorCode::ServerError, e.to_string())
+                .into_oauth_response()
+                .into_response();
+        }
+        Err(e) => {
+            return ServiceError::oauth(OAuthErrorCode::InvalidDpopProof, e.to_string())
+                .into_oauth_response()
+                .into_response();
+        }
+    };
 
     let has_mtls_cert = client_cert.0.is_some();
 
@@ -1482,6 +1555,7 @@ async fn handle_fido2_assertion_grant(
         exchange_params,
         client_auth,
         sender_constraint,
+        arrival,
     )
     .await
     {

--- a/crates/vouch-server/src/handlers/oidc/userinfo.rs
+++ b/crates/vouch-server/src/handlers/oidc/userinfo.rs
@@ -7,6 +7,7 @@
 //! - RFC 8705 Section 3 - mTLS certificate-bound access tokens at resource endpoints
 
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::crypto::alg::JwsAlgorithm;
 use crate::crypto::keys::OidcSigningKey;
 use crate::db::{self};
@@ -74,6 +75,7 @@ struct UserInfoForm {
 /// Enforces mTLS certificate binding per RFC 8705 Section 3.
 #[expect(clippy::too_many_lines, reason = "linear OIDC userinfo claim assembly")]
 pub(crate) async fn userinfo(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     method: Method,
     headers: HeaderMap,
@@ -155,6 +157,7 @@ pub(crate) async fn userinfo(
             &full_uri,
             &state.store,
             state.config().dpop_max_age_seconds,
+            arrival,
         )
         .await
         {
@@ -263,7 +266,7 @@ pub(crate) async fn userinfo(
     }
 
     // Validate the session token
-    let result = match validate_session_token(&state, &token).await {
+    let result = match validate_session_token(&state, &token, arrival).await {
         Ok(Some(r)) => r,
         Ok(None) => {
             return oauth_error(
@@ -321,6 +324,10 @@ pub(crate) async fn userinfo(
 ///
 /// Signs the userinfo claims with the algorithm registered by the client.
 /// Returns `application/jwt` with the signed JWT, or a 500 error on signing failure.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "mints the signed userinfo JWT's iat and exp"
+)]
 async fn build_signed_userinfo_response(
     state: &AppState,
     client_id: &Option<String>,

--- a/crates/vouch-server/src/handlers/saml.rs
+++ b/crates/vouch-server/src/handlers/saml.rs
@@ -6,6 +6,7 @@
 //! - `POST /saml/acs` — Assertion Consumer Service: validates SAML responses and
 //!   completes the enrollment flow.
 
+use crate::arrival::ArrivalTime;
 use std::sync::Arc;
 
 use axum::{
@@ -71,6 +72,7 @@ pub(crate) async fn metadata(State(state): State<Arc<AppState>>) -> impl IntoRes
 /// Receives the IdP's SAML Response, validates it, and completes the
 /// enrollment flow identically to `oidc_callback()`.
 pub(crate) async fn acs(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     client_info: ClientInfo,
     Form(form): Form<SamlAcsForm>,
@@ -155,6 +157,7 @@ pub(crate) async fn acs(
         &form.saml_response,
         &stored_state.nonce,
         saml_provider,
+        arrival,
     ) {
         Ok(a) => a,
         Err(e) => {
@@ -195,6 +198,7 @@ pub(crate) async fn acs(
         identity,
         oidc_state_claim,
         client_info,
+        arrival,
     )
     .await
 }

--- a/crates/vouch-server/src/handlers/session.rs
+++ b/crates/vouch-server/src/handlers/session.rs
@@ -2,6 +2,7 @@
 //! Session extraction and cookie management for HTTP handlers.
 
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::crypto::hash_token;
 use crate::db;
 use crate::error::ServiceError;
@@ -86,6 +87,7 @@ async fn extract_resource_token(
     method: &str,
     uri: &str,
     client_cert: Option<&crate::services::oidc::mtls::ClientCertificate>,
+    arrival: ArrivalTime,
 ) -> Result<ValidatedResourceToken, ServiceError> {
     // Track DPoP source claim (custom claim for MCP attribution)
     let mut dpop_source: Option<String> = None;
@@ -113,7 +115,7 @@ async fn extract_resource_token(
     let token_hash = hash_token(&token);
     let session = state
         .session_cache
-        .get_session_by_token_hash(&state.store, &token_hash)
+        .get_session_by_token_hash(&state.store, &token_hash, arrival)
         .await?
         .ok_or_else(|| {
             ServiceError::api(
@@ -143,6 +145,7 @@ async fn extract_resource_token(
                         &full_uri,
                         &state.store,
                         config.dpop_max_age_seconds,
+                        arrival,
                     )
                     .await
                     {
@@ -373,6 +376,7 @@ async fn extract_token_from_parts(
     let client_cert = super::extractors::OptionalClientCert::from_request_parts(parts, state)
         .await
         .unwrap_or_else(|infallible| match infallible {});
+    let arrival = arrival_from_parts(parts, state).await?;
     let jar = CookieJar::from_headers(&parts.headers);
 
     extract_resource_token(
@@ -382,8 +386,21 @@ async fn extract_token_from_parts(
         parts.method.as_str(),
         uri.path(),
         client_cert.0.as_ref(),
+        arrival,
     )
     .await
+}
+
+/// Pull the request's arrival stamp inside an extractor, restating the
+/// missing-middleware failure as a `ServiceError` so it renders like every
+/// other extractor rejection on these routes.
+async fn arrival_from_parts(
+    parts: &mut http::request::Parts,
+    state: &Arc<AppState>,
+) -> Result<ArrivalTime, ServiceError> {
+    ArrivalTime::from_request_parts(parts, state)
+        .await
+        .map_err(|_| ServiceError::Internal("Request arrival time unavailable".to_string()))
 }
 
 impl axum::extract::FromRequestParts<Arc<AppState>> for AuthenticatedToken {
@@ -429,6 +446,7 @@ impl axum::extract::FromRequestParts<Arc<AppState>> for OptionalAuthenticatedTok
         let client_cert = super::extractors::OptionalClientCert::from_request_parts(parts, state)
             .await
             .unwrap_or_else(|infallible| match infallible {});
+        let arrival = arrival_from_parts(parts, state).await?;
         let token = extract_resource_token(
             state,
             &parts.headers,
@@ -436,6 +454,7 @@ impl axum::extract::FromRequestParts<Arc<AppState>> for OptionalAuthenticatedTok
             parts.method.as_str(),
             uri.path(),
             client_cert.0.as_ref(),
+            arrival,
         )
         .await?;
         Ok(Self(Some(token)))
@@ -474,7 +493,8 @@ impl axum::extract::FromRequestParts<Arc<AppState>> for SteppedUpToken {
         state: &Arc<AppState>,
     ) -> Result<Self, Self::Rejection> {
         let token = extract_token_from_parts(parts, state).await?;
-        key_svc::require_recent_hardware_verification(&token)?;
+        let arrival = arrival_from_parts(parts, state).await?;
+        key_svc::require_recent_hardware_verification(&token, arrival)?;
         Ok(Self(token))
     }
 }
@@ -508,12 +528,14 @@ pub(super) async fn resolve_token_email(
 pub(crate) async fn extract_session_from_cookie(
     state: &AppState,
     jar: &CookieJar,
+    arrival: ArrivalTime,
 ) -> Result<ValidatedResourceToken, ServiceError> {
     // Use an empty header map — cookie path only.
     // DPoP validation is skipped for the Cookie auth scheme, so method and uri
-    // are not used and can be empty strings.
+    // are not used and can be empty strings. `arrival` still applies: the
+    // session's `expires_at` is judged against it.
     let empty_headers = axum::http::HeaderMap::new();
-    extract_resource_token(state, &empty_headers, jar, "", "", None).await
+    extract_resource_token(state, &empty_headers, jar, "", "", None, arrival).await
 }
 
 /// Authorization scheme detected from the request.
@@ -606,8 +628,10 @@ pub(crate) async fn extract_user_with_org(
     method: &str,
     uri: &str,
     client_cert: Option<&crate::services::oidc::mtls::ClientCertificate>,
+    arrival: ArrivalTime,
 ) -> Result<(db::User, String), ServiceError> {
-    let token = extract_resource_token(state, headers, jar, method, uri, client_cert).await?;
+    let token =
+        extract_resource_token(state, headers, jar, method, uri, client_cert, arrival).await?;
     let user = load_active_user(state, &token.sub).await?;
 
     let org_id = user.org_id.clone().ok_or_else(|| {
@@ -635,9 +659,10 @@ pub(crate) async fn extract_org_admin(
     method: &str,
     uri: &str,
     client_cert: Option<&crate::services::oidc::mtls::ClientCertificate>,
+    arrival: ArrivalTime,
 ) -> Result<(db::User, String), ServiceError> {
     let (user, org_id) =
-        extract_user_with_org(state, headers, jar, method, uri, client_cert).await?;
+        extract_user_with_org(state, headers, jar, method, uri, client_cert, arrival).await?;
 
     if !user.is_org_admin {
         return Err(ServiceError::api(
@@ -694,7 +719,11 @@ pub(crate) fn clear_session_cookie() -> Cookie<'static> {
 }
 
 /// Helper to extract auth context from cookie jar using OAuth tokens.
-pub(crate) async fn get_resource_auth_context(state: &AppState, jar: &CookieJar) -> AuthContext {
+pub(crate) async fn get_resource_auth_context(
+    state: &AppState,
+    jar: &CookieJar,
+    arrival: ArrivalTime,
+) -> AuthContext {
     // Try to extract token from cookie
     let token = match jar.get(vouch_common::SESSION_COOKIE_NAME) {
         Some(c) => c.value(),
@@ -716,7 +745,7 @@ pub(crate) async fn get_resource_auth_context(state: &AppState, jar: &CookieJar)
     let token_hash = hash_token(token);
     match state
         .session_cache
-        .get_session_by_token_hash(&state.store, &token_hash)
+        .get_session_by_token_hash(&state.store, &token_hash, arrival)
         .await
     {
         Ok(Some(_)) => {}
@@ -757,8 +786,12 @@ pub(crate) async fn get_resource_auth_context(state: &AppState, jar: &CookieJar)
 /// by templates and browser UI handlers.
 ///
 /// Both names refer to the same OAuth-token-based auth context extraction.
-pub(crate) async fn get_auth_context(state: &AppState, jar: &CookieJar) -> AuthContext {
-    get_resource_auth_context(state, jar).await
+pub(crate) async fn get_auth_context(
+    state: &AppState,
+    jar: &CookieJar,
+    arrival: ArrivalTime,
+) -> AuthContext {
+    get_resource_auth_context(state, jar, arrival).await
 }
 
 #[cfg(test)]

--- a/crates/vouch-server/src/handlers/session/tests.rs
+++ b/crates/vouch-server/src/handlers/session/tests.rs
@@ -163,6 +163,7 @@ async fn test_mtls_bound_token_with_matching_cert_succeeds() {
         "GET",
         "/api/v1/applications",
         Some(&cert),
+        test_arrival(),
     )
     .await;
 
@@ -217,6 +218,7 @@ async fn test_mtls_bound_token_with_wrong_cert_rejected() {
         "GET",
         "/api/v1/applications",
         Some(&cert_b),
+        test_arrival(),
     )
     .await;
 

--- a/crates/vouch-server/src/infra/cleanup.rs
+++ b/crates/vouch-server/src/infra/cleanup.rs
@@ -156,6 +156,10 @@ pub fn start_cleanup_task(
 }
 
 /// Run all cleanup tasks once.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "background task, serving no request"
+)]
 pub async fn run_cleanup(
     store: &DocumentStore,
     audit: &AuditStore,

--- a/crates/vouch-server/src/infra/router.rs
+++ b/crates/vouch-server/src/infra/router.rs
@@ -216,6 +216,10 @@ pub fn build_app(state: Arc<AppState>, config: &config::ServerConfig) -> anyhow:
         request_id::request_span_middleware,
     ))
     .layer(request_id::set_request_id_layer())
+    // Outermost: every request-scoped time comparison downstream reads this
+    // one instant, so the stamp must be taken before any other layer can
+    // await. The last `.layer()` call is the outermost in tower/axum.
+    .layer(axum::middleware::from_fn(crate::arrival::arrival_layer))
     .with_state(state))
 }
 

--- a/crates/vouch-server/src/lib.rs
+++ b/crates/vouch-server/src/lib.rs
@@ -4,6 +4,21 @@
 //! This crate provides the Vouch identity server with OIDC provider,
 //! WebAuthn authentication, and credential issuance.
 
+// Request-path time comparisons take `arrival::ArrivalTime`, not their own
+// clock reading. `disallowed_methods` is configured in `.clippy.toml` and left
+// at `allow` workspace-wide; this is where it is switched on.
+#![warn(clippy::disallowed_methods)]
+// Test code stamps clocks freely: a test that needs an instant constructs one,
+// and the convention is about code serving a request. The non-test build of
+// this library still lints every production site.
+#![cfg_attr(
+    test,
+    expect(
+        clippy::disallowed_methods,
+        reason = "tests construct their own instants; the lint targets request-serving code"
+    )
+)]
+
 // Prevent test-utils from being enabled in any release build of this
 // library. The feature exposes `test_utils` (helpers that bypass FIDO2
 // and construct `GrantProof::TestingOnly` / `TestCoseVerifier`) — none
@@ -13,6 +28,7 @@
 #[cfg(all(feature = "test-utils", not(debug_assertions)))]
 compile_error!("test-utils feature must not be enabled in release builds");
 
+pub mod arrival;
 pub mod assurance;
 pub(crate) mod attestation;
 pub mod config;

--- a/crates/vouch-server/src/main.rs
+++ b/crates/vouch-server/src/main.rs
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Vouch identity server.
 
+// See the matching attribute in `lib.rs`: request-path comparisons take
+// `vouch_server::arrival::ArrivalTime` rather than reading their own clock.
+#![warn(clippy::disallowed_methods)]
+
 // Avoid musl's default allocator due to lackluster performance
 // https://nickb.dev/blog/default-musl-allocator-considered-harmful-to-performance
 #[cfg(target_env = "musl")]

--- a/crates/vouch-server/src/services/auth.rs
+++ b/crates/vouch-server/src/services/auth.rs
@@ -16,6 +16,7 @@
 //! The handlers remain thin, focusing on HTTP concerns.
 
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::assurance::{AuthMethod, HardwareVerification};
 use crate::crypto::hash_token;
 use crate::crypto::keys::OidcSigningKey;
@@ -734,6 +735,7 @@ pub(crate) async fn create_oauth_access_token(
     state: &AppState,
     params: CreateOAuthTokenParams<'_>,
     proof: TokenIssuanceProof,
+    arrival: ArrivalTime,
 ) -> ServiceResult<CreateSessionResult> {
     // Consume the witness. Its presence is the structural guarantee that the
     // caller has consumed the required replay primitives — once consumed
@@ -753,7 +755,12 @@ pub(crate) async fn create_oauth_access_token(
         "token issuance proof consumed"
     );
 
-    let now = Timestamp::now();
+    // The issued `exp` is measured from the request's arrival, the same
+    // instant any caller-supplied `max_lifetime_secs` was computed against.
+    // RFC 8693 exchange derives that ceiling from the subject token's
+    // remaining TTL; measuring it here from a second, later reading would
+    // let the exchanged token outlive its subject by the gap between the two.
+    let now = arrival.timestamp();
     // The lifetime in seconds is the configured `session_hours * 3600` unless
     // the caller supplied a ceiling (RFC 8693 token exchange caps the issued
     // token by the subject token's remaining TTL). The same value drives the

--- a/crates/vouch-server/src/services/idp/saml/authn_request.rs
+++ b/crates/vouch-server/src/services/idp/saml/authn_request.rs
@@ -141,6 +141,10 @@ fn generate_request_id() -> Result<String, AuthnRequestError> {
 }
 
 /// Return the current UTC time formatted as ISO 8601 (`YYYY-MM-DDTHH:MM:SSZ`).
+#[expect(
+    clippy::disallowed_methods,
+    reason = "mints the AuthnRequest IssueInstant"
+)]
 fn current_utc_iso8601() -> String {
     use jiff::Timestamp;
     let now = Timestamp::now();

--- a/crates/vouch-server/src/services/idp/saml/response.rs
+++ b/crates/vouch-server/src/services/idp/saml/response.rs
@@ -15,6 +15,7 @@
 //! - Clock skew tolerance is capped at 120 seconds
 //! - Replay prevention: callers must consume the state record after this returns Ok
 
+use crate::arrival::ArrivalTime;
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use jiff::Timestamp;
@@ -174,6 +175,7 @@ pub(crate) fn validate_saml_response(
     base64_response: &str,
     expected_request_id: &str,
     provider: &SamlProvider,
+    arrival: ArrivalTime,
 ) -> Result<SamlAssertion, ResponseError> {
     // Step 1: Base64-decode
     let xml_bytes = BASE64_STANDARD
@@ -306,7 +308,7 @@ pub(crate) fn validate_saml_response(
     validate_audience_restriction(assertion, &provider.sp_entity_id)?;
 
     // Step 10: Validate time conditions (Core 2.5.1)
-    let now = Timestamp::now();
+    let now = arrival.timestamp();
     validate_conditions(assertion, now)?;
 
     // Step 11: Validate SubjectConfirmation Method is bearer (Core 2.4.1.2)

--- a/crates/vouch-server/src/services/idp/saml/response/tests.rs
+++ b/crates/vouch-server/src/services/idp/saml/response/tests.rs
@@ -6,6 +6,7 @@
     reason = "test code: panic on assertion failure is acceptable"
 )]
 use super::*;
+use crate::test_utils::test_arrival;
 
 // =========================================================================
 // Timestamp parsing tests
@@ -448,8 +449,13 @@ fn invalid_base64_returns_decode_error() {
         domain_attribute: None,
     };
 
-    let err =
-        validate_saml_response("!!!not-valid-base64!!!", "_request_id", &provider).unwrap_err();
+    let err = validate_saml_response(
+        "!!!not-valid-base64!!!",
+        "_request_id",
+        &provider,
+        test_arrival(),
+    )
+    .unwrap_err();
     assert!(
         matches!(err, ResponseError::DecodeFailed(_)),
         "Expected DecodeFailed for invalid base64, got: {err}"
@@ -478,7 +484,8 @@ fn invalid_xml_returns_xml_parse_error() {
     };
 
     let bad_xml = BASE64_STANDARD.encode("<unclosed");
-    let err = validate_saml_response(&bad_xml, "_request_id", &provider).unwrap_err();
+    let err =
+        validate_saml_response(&bad_xml, "_request_id", &provider, test_arrival()).unwrap_err();
     assert!(
         matches!(err, ResponseError::XmlParse(_)),
         "Expected XmlParse for invalid XML, got: {err}"
@@ -1294,7 +1301,7 @@ fn validate_saml_response_rsa_signed_happy_path() {
     );
 
     let base64_response = B64.encode(xml.as_bytes());
-    let result = validate_saml_response(&base64_response, "_request001", &provider);
+    let result = validate_saml_response(&base64_response, "_request001", &provider, test_arrival());
     let assertion = result.expect("Expected Ok");
 
     assert_eq!(assertion.email, "alice@example.com");
@@ -1444,8 +1451,9 @@ fn validate_saml_response_comment_injection_does_not_truncate_identity() {
     assert_ne!(xml, injected_xml, "Injection must actually change the XML");
 
     let base64_response = B64.encode(injected_xml.as_bytes());
-    let assertion = validate_saml_response(&base64_response, "_request003", &provider)
-        .expect("comment injection leaves the signature valid, so validation succeeds");
+    let assertion =
+        validate_saml_response(&base64_response, "_request003", &provider, test_arrival())
+            .expect("comment injection leaves the signature valid, so validation succeeds");
 
     assert_eq!(
         assertion.email, "attacker@example.com.evil.tld",
@@ -1489,7 +1497,7 @@ fn validate_saml_response_tampered_email_fails_digest_check() {
     assert_ne!(xml, tampered_xml, "Tamper must actually change the XML");
 
     let base64_response = B64.encode(tampered_xml.as_bytes());
-    let result = validate_saml_response(&base64_response, "_request002", &provider);
+    let result = validate_saml_response(&base64_response, "_request002", &provider, test_arrival());
 
     assert!(
         result.is_err(),
@@ -1642,7 +1650,8 @@ fn xsw_nested_assertion_rejected() {
     );
 
     let base64_response = B64.encode(xsw_xml.as_bytes());
-    let result = validate_saml_response(&base64_response, "_request_xsw", &provider);
+    let result =
+        validate_saml_response(&base64_response, "_request_xsw", &provider, test_arrival());
 
     assert!(result.is_err(), "Expected Err for nested Assertion XSW");
     let err_msg = result.unwrap_err().to_string();
@@ -1675,7 +1684,7 @@ fn oversized_response_returns_decode_error() {
     // Create a payload that exceeds MAX_RESPONSE_BYTES when decoded
     let oversized = vec![b'A'; MAX_RESPONSE_BYTES + 1];
     let encoded = BASE64_STANDARD.encode(&oversized);
-    let err = validate_saml_response(&encoded, "_req", &provider).unwrap_err();
+    let err = validate_saml_response(&encoded, "_req", &provider, test_arrival()).unwrap_err();
     assert!(
         matches!(err, ResponseError::DecodeFailed(ref msg) if msg.contains("maximum size")),
         "Expected DecodeFailed for oversized response, got: {err}"
@@ -1890,7 +1899,8 @@ fn xsw_inresponseto_unsigned_response_missing_scd_irt_rejected() {
     );
 
     let base64_response = B64.encode(xml.as_bytes());
-    let result = validate_saml_response(&base64_response, "_attacker_req", &provider);
+    let result =
+        validate_saml_response(&base64_response, "_attacker_req", &provider, test_arrival());
 
     let err = result.unwrap_err();
     assert!(
@@ -1927,7 +1937,12 @@ fn xsw_inresponseto_unsigned_response_with_matching_scd_irt_passes() {
     );
 
     let base64_response = B64.encode(xml.as_bytes());
-    let result = validate_saml_response(&base64_response, "_request_irt_2", &provider);
+    let result = validate_saml_response(
+        &base64_response,
+        "_request_irt_2",
+        &provider,
+        test_arrival(),
+    );
     let assertion = result
         .expect("Expected Ok for assertion-only signed response with matching SCD.InResponseTo");
     assert_eq!(assertion.email, "alice@example.com");
@@ -1964,7 +1979,8 @@ fn xsw_inresponseto_scd_irt_mismatch_fails() {
     );
 
     let base64_response = B64.encode(xml.as_bytes());
-    let result = validate_saml_response(&base64_response, "_attacker_req", &provider);
+    let result =
+        validate_saml_response(&base64_response, "_attacker_req", &provider, test_arrival());
 
     let err = result.unwrap_err();
     assert!(
@@ -2020,7 +2036,8 @@ fn xsw_inresponseto_attack_scenario_rejected() {
 
     let base64_response = B64.encode(attacked_xml.as_bytes());
     // Attacker submits with their own request ID as expected.
-    let result = validate_saml_response(&base64_response, "_attacker_req", &provider);
+    let result =
+        validate_saml_response(&base64_response, "_attacker_req", &provider, test_arrival());
 
     let err = result.unwrap_err();
     assert!(
@@ -2061,7 +2078,7 @@ fn xsw_inresponseto_assertion_matches_but_response_differs_fails() {
     );
 
     let base64_response = B64.encode(xml.as_bytes());
-    let result = validate_saml_response(&base64_response, "_req_irt_5", &provider);
+    let result = validate_saml_response(&base64_response, "_req_irt_5", &provider, test_arrival());
 
     let err = result.unwrap_err();
     assert!(
@@ -2104,8 +2121,13 @@ fn response_signed_missing_scd_irt_is_still_rejected() {
     );
 
     let base64_response = B64.encode(xml.as_bytes());
-    let err = validate_saml_response(&base64_response, "_request_irt_6", &provider)
-        .expect_err("a solicited response must carry SubjectConfirmationData.InResponseTo");
+    let err = validate_saml_response(
+        &base64_response,
+        "_request_irt_6",
+        &provider,
+        test_arrival(),
+    )
+    .expect_err("a solicited response must carry SubjectConfirmationData.InResponseTo");
     assert!(
         matches!(err, ResponseError::MissingSubjectConfirmationInResponseTo),
         "Expected MissingSubjectConfirmationInResponseTo, got: {err}"
@@ -2139,7 +2161,12 @@ fn response_signed_with_scd_irt_passes() {
     );
 
     let base64_response = B64.encode(xml.as_bytes());
-    let result = validate_saml_response(&base64_response, "_request_irt_7", &provider);
+    let result = validate_saml_response(
+        &base64_response,
+        "_request_irt_7",
+        &provider,
+        test_arrival(),
+    );
     let assertion = result.expect("Expected Ok for Response-signed with matching SCD.InResponseTo");
     assert_eq!(assertion.email, "alice@example.com");
 }
@@ -2172,7 +2199,12 @@ fn response_signed_scd_irt_mismatch_fails() {
     );
 
     let base64_response = B64.encode(xml.as_bytes());
-    let result = validate_saml_response(&base64_response, "_request_irt_8", &provider);
+    let result = validate_saml_response(
+        &base64_response,
+        "_request_irt_8",
+        &provider,
+        test_arrival(),
+    );
 
     let err = result.unwrap_err();
     assert!(

--- a/crates/vouch-server/src/services/integrations/github/app.rs
+++ b/crates/vouch-server/src/services/integrations/github/app.rs
@@ -261,6 +261,10 @@ impl GitHubApp {
     ///
     /// RS256 signing is offloaded to a blocking thread to avoid starving
     /// the tokio runtime on 1-vCPU instances.
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "mints the GitHub App JWT's iat and exp"
+    )]
     pub async fn generate_app_jwt(&self) -> Result<String> {
         let now = jiff::Timestamp::now();
         // GitHub recommends setting iat to 60 seconds in the past to account for clock drift

--- a/crates/vouch-server/src/services/keys.rs
+++ b/crates/vouch-server/src/services/keys.rs
@@ -5,6 +5,7 @@
 //! It is used by both the API key handlers (Bearer token auth) and the enrollment
 //! key handlers (cookie-based auth).
 
+use crate::arrival::ArrivalTime;
 use crate::assurance::ACR_AAL3;
 use crate::db::documents::authenticator::AuthenticatorDoc;
 use crate::db::documents::session::SessionDoc;
@@ -85,6 +86,7 @@ pub(crate) async fn consume_registration_state(
 /// [`KEY_DELETE_MAX_AGE_SECS`].
 pub(crate) fn require_recent_hardware_verification(
     token: &crate::services::auth::ValidatedResourceToken,
+    arrival: ArrivalTime,
 ) -> Result<(), ServiceError> {
     if !token.hardware_verified {
         tracing::warn!(
@@ -101,16 +103,20 @@ pub(crate) fn require_recent_hardware_verification(
 
     // A hardware-verified session always records when. Epoch is the
     // fail-closed reading for a token that somehow lacks it.
-    require_fresh_timestamp(token.auth_time.unwrap_or(0), KEY_DELETE_MAX_AGE_SECS)
+    require_fresh_timestamp(
+        token.auth_time.unwrap_or(0),
+        KEY_DELETE_MAX_AGE_SECS,
+        arrival.as_second(),
+    )
 }
 
 /// Require the given issued-at or auth timestamp to be within `max_age_secs`
 /// seconds of the server's current wall clock and not in the future.
 ///
-/// A step-up ceremony dated after now is impossible, so no clock skew is
-/// tolerated: both a too-old and a future-dated timestamp fail closed (issue
-/// #1144). The bounds check is the [`crate::services::RecencyWindow`] shared
-/// with the DPoP proof-age gate.
+/// A step-up ceremony dated after `now` is impossible, so no clock skew is
+/// tolerated: both a too-old and a future-dated timestamp fail closed. The
+/// bounds check is the [`crate::services::RecencyWindow`] shared with the DPoP
+/// proof-age gate, and `now` is the request's arrival instant.
 ///
 /// # Errors
 ///
@@ -119,8 +125,9 @@ pub(crate) fn require_recent_hardware_verification(
 pub(crate) fn require_fresh_timestamp(
     issued_at: i64,
     max_age_secs: i64,
+    now: i64,
 ) -> Result<(), ServiceError> {
-    if crate::services::RecencyWindow::no_skew(max_age_secs).accepts(issued_at) {
+    if crate::services::RecencyWindow::no_skew(max_age_secs).accepts_at(now, issued_at) {
         return Ok(());
     }
     Err(ServiceError::StepUpRequired {
@@ -394,13 +401,13 @@ mod tests {
     #[test]
     fn test_require_fresh_timestamp_passes_for_fresh() {
         let iat = make_iat(5); // 5 seconds old
-        assert!(require_fresh_timestamp(iat, 60).is_ok());
+        assert!(require_fresh_timestamp(iat, 60, jiff::Timestamp::now().as_second()).is_ok());
     }
 
     #[test]
     fn test_require_fresh_timestamp_fails_for_stale() {
         let iat = make_iat(120); // 2 minutes old
-        let err = require_fresh_timestamp(iat, 60).unwrap_err();
+        let err = require_fresh_timestamp(iat, 60, jiff::Timestamp::now().as_second()).unwrap_err();
         assert!(
             matches!(
                 err,
@@ -417,13 +424,13 @@ mod tests {
     fn test_require_fresh_timestamp_boundary_exactly_at_max_age() {
         let iat = make_iat(60); // Exactly 60 seconds old
         // Session age == max_age is NOT > max_age, so it should pass
-        assert!(require_fresh_timestamp(iat, 60).is_ok());
+        assert!(require_fresh_timestamp(iat, 60, jiff::Timestamp::now().as_second()).is_ok());
     }
 
     #[test]
     fn test_require_fresh_timestamp_one_second_over() {
         let iat = make_iat(61); // 61 seconds old (1 second over)
-        let err = require_fresh_timestamp(iat, 60).unwrap_err();
+        let err = require_fresh_timestamp(iat, 60, jiff::Timestamp::now().as_second()).unwrap_err();
         assert!(
             matches!(err, ServiceError::StepUpRequired { .. }),
             "Expected StepUpRequired for timestamp 1 second over max_age"
@@ -516,7 +523,12 @@ mod tests {
     /// as freshly authenticated.
     #[test]
     fn test_require_fresh_timestamp_epoch_is_rejected() {
-        let err = require_fresh_timestamp(0, KEY_DELETE_MAX_AGE_SECS).unwrap_err();
+        let err = require_fresh_timestamp(
+            0,
+            KEY_DELETE_MAX_AGE_SECS,
+            jiff::Timestamp::now().as_second(),
+        )
+        .unwrap_err();
         assert!(
             matches!(
                 err,
@@ -541,7 +553,12 @@ mod tests {
     #[test]
     fn test_require_fresh_timestamp_future_is_rejected() {
         let future_iat = jiff::Timestamp::now().as_second() + 3600; // 1 h ahead
-        let err = require_fresh_timestamp(future_iat, KEY_DELETE_MAX_AGE_SECS).unwrap_err();
+        let err = require_fresh_timestamp(
+            future_iat,
+            KEY_DELETE_MAX_AGE_SECS,
+            jiff::Timestamp::now().as_second(),
+        )
+        .unwrap_err();
         assert!(
             matches!(
                 err,
@@ -560,6 +577,13 @@ mod tests {
     #[test]
     fn test_require_fresh_timestamp_now_passes() {
         let now = jiff::Timestamp::now().as_second();
-        assert!(require_fresh_timestamp(now, KEY_DELETE_MAX_AGE_SECS).is_ok());
+        assert!(
+            require_fresh_timestamp(
+                now,
+                KEY_DELETE_MAX_AGE_SECS,
+                jiff::Timestamp::now().as_second()
+            )
+            .is_ok()
+        );
     }
 }

--- a/crates/vouch-server/src/services/mod.rs
+++ b/crates/vouch-server/src/services/mod.rs
@@ -96,15 +96,12 @@ impl RecencyWindow {
         }
     }
 
-    /// Whether `issued_at` (Unix seconds) is within the window relative to the
-    /// current wall clock.
-    pub(crate) fn accepts(&self, issued_at: i64) -> bool {
-        self.accepts_at(jiff::Timestamp::now().as_second(), issued_at)
-    }
-
-    /// Whether `issued_at` is within the window relative to an explicit `now` —
-    /// for callers that have already stamped the time once (the DPoP validation
-    /// snapshots it at the request entry point) or for deterministic tests.
+    /// Whether `issued_at` is within the window relative to an explicit `now`.
+    ///
+    /// There is deliberately no ambient-clock overload: a window that reads
+    /// its own clock cannot be checked against the other time decisions in the
+    /// same request. Request-path callers pass
+    /// [`crate::arrival::ArrivalTime::as_second`]; tests pass a literal.
     pub(crate) fn accepts_at(&self, now: i64, issued_at: i64) -> bool {
         let age = now.saturating_sub(issued_at);
         // `age >= -clock_skew_secs`, written without negating so

--- a/crates/vouch-server/src/services/oidc/authorization.rs
+++ b/crates/vouch-server/src/services/oidc/authorization.rs
@@ -597,9 +597,10 @@ impl AuthorizationCode {
         signer: &crate::crypto::jwt::StateTokenSigner,
         expected_issuer: &str,
         expected_client_id: &str,
+        arrival: ArrivalTime,
     ) -> Result<Self, crate::crypto::jwt::StateTokenError> {
         let claims: Self = signer
-            .decode_state_token(token, JwtType::AuthorizationCode)
+            .decode_state_token(token, JwtType::AuthorizationCode, arrival.as_second())
             .await?;
 
         // RFC 8725 §3.8: Validate issuer
@@ -997,6 +998,7 @@ pub async fn decode_authorization_code(
         &state.state_signer,
         &state.config().base_url,
         client_id,
+        arrival,
     )
     .await
     .map_err(|_| {
@@ -1100,6 +1102,7 @@ mod tests {
     use super::*;
     use crate::crypto::alg::JwsAlgorithm;
     use crate::db::{FapiProfile, OAuthClientType, TokenEndpointAuthMethod};
+    use crate::test_utils::test_arrival;
 
     fn assert_oauth_error<T: std::fmt::Debug>(
         result: Result<T, ServiceError>,
@@ -1279,9 +1282,15 @@ mod tests {
         let code = test_auth_code("https://example.com", "client-a");
 
         let token = code.encode(&signer).await.unwrap();
-        let decoded = AuthorizationCode::decode(&token, &signer, "https://example.com", "client-a")
-            .await
-            .unwrap();
+        let decoded = AuthorizationCode::decode(
+            &token,
+            &signer,
+            "https://example.com",
+            "client-a",
+            test_arrival(),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(decoded.iss, "https://example.com");
         assert_eq!(decoded.aud, "client-a");
@@ -1297,8 +1306,14 @@ mod tests {
         let code = test_auth_code("https://attacker.com", "client-a");
 
         let token = code.encode(&signer).await.unwrap();
-        let result =
-            AuthorizationCode::decode(&token, &signer, "https://example.com", "client-a").await;
+        let result = AuthorizationCode::decode(
+            &token,
+            &signer,
+            "https://example.com",
+            "client-a",
+            test_arrival(),
+        )
+        .await;
 
         assert!(result.is_err(), "Wrong issuer must be rejected");
         let err = result.unwrap_err();
@@ -1324,6 +1339,7 @@ mod tests {
             &signer,
             "https://example.com",
             "client-b", // Different client_id
+            test_arrival(),
         )
         .await;
 
@@ -1352,8 +1368,14 @@ mod tests {
         let code = test_auth_code("https://example.com", "client-a");
 
         let token = code.encode(&signer_a).await.unwrap();
-        let result =
-            AuthorizationCode::decode(&token, &signer_b, "https://example.com", "client-a").await;
+        let result = AuthorizationCode::decode(
+            &token,
+            &signer_b,
+            "https://example.com",
+            "client-a",
+            test_arrival(),
+        )
+        .await;
 
         assert!(result.is_err(), "Wrong secret must be rejected");
     }

--- a/crates/vouch-server/src/services/oidc/authorization.rs
+++ b/crates/vouch-server/src/services/oidc/authorization.rs
@@ -6,6 +6,7 @@
 //! - RFC 7636 - PKCE (Proof Key for Code Exchange)
 
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::crypto::jwt::JwtType;
 use crate::db::{
     AccessScope, Authenticator, OAuthClient, ParConsumptionProof, ResponseMode,
@@ -838,12 +839,13 @@ fn validate_param_length(name: &str, value: &str, max_len: usize) -> ServiceResu
 pub async fn check_session_for_authorization(
     state: &Arc<AppState>,
     session_token: Option<&str>,
+    arrival: ArrivalTime,
 ) -> ServiceResult<AuthorizationSessionState> {
     let Some(token) = session_token else {
         return Ok(AuthorizationSessionState::NeedsAuth);
     };
 
-    match validate_session_token(state, token).await? {
+    match validate_session_token(state, token, arrival).await? {
         Some(validated) => {
             // Two separate facts, and the authorization flow needs both.
             //
@@ -901,6 +903,10 @@ pub async fn check_session_for_authorization(
 ///
 /// # Errors
 /// Returns `ServiceError` if encoding fails or database storage fails.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "mints the authorization code's expiry"
+)]
 pub async fn issue_authorization_code(
     state: &Arc<AppState>,
     params: AuthorizationCodeParams<'_>,
@@ -984,6 +990,7 @@ pub async fn decode_authorization_code(
     state: &Arc<AppState>,
     code: &str,
     client_id: &str,
+    arrival: ArrivalTime,
 ) -> ServiceResult<AuthorizationCode> {
     let auth_code = AuthorizationCode::decode(
         code,
@@ -999,8 +1006,9 @@ pub async fn decode_authorization_code(
         )
     })?;
 
-    // Check expiration
-    let now = Timestamp::now().as_second();
+    // Check expiration against the request's arrival, so this gate and the
+    // issued token's lifetime downstream are measured from one instant.
+    let now = arrival.as_second();
     if auth_code.exp < now {
         return Err(ServiceError::oauth(
             OAuthErrorCode::InvalidGrant,

--- a/crates/vouch-server/src/services/oidc/claims.rs
+++ b/crates/vouch-server/src/services/oidc/claims.rs
@@ -313,6 +313,10 @@ impl OidcIdTokenClaimsBuilder {
     /// # Errors
     ///
     /// Returns an error if required fields (issuer, subject, audience) are missing.
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "mints the ID token's iat and exp"
+    )]
     pub fn build(self) -> Result<OidcIdTokenClaims, ClaimsBuildError> {
         let now = jiff::Timestamp::now();
         let exp = now

--- a/crates/vouch-server/src/services/oidc/client_credentials.rs
+++ b/crates/vouch-server/src/services/oidc/client_credentials.rs
@@ -9,6 +9,7 @@
 //! Per RFC 6749 Section 4.4.3, no refresh token is included in the response.
 
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::assurance::HardwareVerification;
 use crate::db::{OAuthClient, SessionPurpose};
 use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
@@ -47,6 +48,7 @@ pub(crate) async fn exchange_client_credentials(
     requested_scope: Option<&str>,
     binding: TokenBinding<'_>,
     proof: TokenIssuanceProof,
+    arrival: ArrivalTime,
 ) -> ServiceResult<ClientCredentialsResult> {
     // Verify client has client_credentials in its registered grant_types
     let has_grant = client
@@ -90,6 +92,7 @@ pub(crate) async fn exchange_client_credentials(
             source_code_hash: None,
         },
         proof,
+        arrival,
     )
     .await?;
 
@@ -115,6 +118,7 @@ mod tests {
     use super::*;
     use crate::services::auth::{ClientAuthProof, GrantProof, SenderConstraintProof};
     use crate::services::oidc::OAuthScope;
+    use crate::test_utils::test_arrival;
     use secrecy::ExposeSecret;
 
     #[test]
@@ -200,6 +204,7 @@ mod tests {
                 ),
                 sender_constraint: SenderConstraintProof::no_registered_client(),
             },
+            test_arrival(),
         )
         .await
         .expect("exchange_client_credentials");

--- a/crates/vouch-server/src/services/oidc/dpop.rs
+++ b/crates/vouch-server/src/services/oidc/dpop.rs
@@ -183,7 +183,8 @@ pub struct ValidatedDpopProof {
     pub(crate) jti: String,
     /// Credential source identifier from the DPoP proof (custom claim).
     pub(crate) source: Option<String>,
-    /// The replay guarantee itself: the witness [`db::check_and_store_dpop_jti`]
+    /// The replay guarantee itself: the witness
+    /// [`db::check_and_store_dpop_jti_at_second`]
     /// returns when its atomic insert wins. Holding it is what makes "this
     /// `jti` was committed by this request" a property of the value rather
     /// than a claim in prose.
@@ -1472,7 +1473,7 @@ mod tests {
     // These two tests live in the `services` layer (not `db/tests/jti_replay.rs`)
     // because they reason about the *relationship* between two things the
     // `services` layer owns (`RecencyWindow`/`PROOF_SKEW_SECONDS` freshness)
-    // and one thing the `db` layer owns (`check_and_store_dpop_jti` /
+    // and one thing the `db` layer owns (`check_and_store_dpop_jti_at_second` /
     // `delete_expired_dpop_jtis` retention + cleanup). The `db` layer may not
     // import `services`, so the cross-layer invariant is anchored here, where
     // both sides are in scope. They use negative/positive `validity_seconds`
@@ -1489,7 +1490,7 @@ mod tests {
     #[tokio::test]
     async fn test_dpop_jti_retention_covers_skew_extended_freshness_window() {
         use crate::db::claim::ClaimError;
-        use crate::db::{check_and_store_dpop_jti, delete_expired_dpop_jtis};
+        use crate::db::{check_and_store_dpop_jti_at_second, delete_expired_dpop_jtis};
         use crate::services::RecencyWindow;
 
         let store = resource_test_store().await;
@@ -1511,9 +1512,14 @@ mod tests {
         // expired yet) without depending on real time.
         let elapsed_within = config_max_age + 30;
         let validity_within = fixed_retention.saturating_sub(elapsed_within);
-        let _claim = check_and_store_dpop_jti(&store, "retention-within-window", validity_within)
-            .await
-            .expect("first use commits the JTI");
+        let _claim = check_and_store_dpop_jti_at_second(
+            &store,
+            "retention-within-window",
+            jiff::Timestamp::now().as_second(),
+            validity_within,
+        )
+        .await
+        .expect("first use commits the JTI");
 
         // Cleanup of not-yet-expired rows is a no-op — the row survives the
         // whole freshness window.
@@ -1526,8 +1532,13 @@ mod tests {
         );
 
         // Replay is still blocked while the proof is fresh.
-        let blocked =
-            check_and_store_dpop_jti(&store, "retention-within-window", fixed_retention).await;
+        let blocked = check_and_store_dpop_jti_at_second(
+            &store,
+            "retention-within-window",
+            jiff::Timestamp::now().as_second(),
+            fixed_retention,
+        )
+        .await;
         assert!(
             matches!(blocked, Err(ClaimError::AlreadyConsumed)),
             "JTI retained for max_age + skew must block replay until the proof is stale: got {blocked:?}"
@@ -1545,9 +1556,14 @@ mod tests {
         //     and the proof is no longer fresh. ---
         let elapsed_past = config_max_age + skew + 1;
         let validity_past = fixed_retention.saturating_sub(elapsed_past);
-        let _claim = check_and_store_dpop_jti(&store, "retention-past-window", validity_past)
-            .await
-            .expect("first use commits the JTI");
+        let _claim = check_and_store_dpop_jti_at_second(
+            &store,
+            "retention-past-window",
+            jiff::Timestamp::now().as_second(),
+            validity_past,
+        )
+        .await
+        .expect("first use commits the JTI");
 
         let deleted = delete_expired_dpop_jtis(&store, "")
             .await
@@ -1575,7 +1591,7 @@ mod tests {
     #[tokio::test]
     async fn test_dpop_jti_old_retention_leaves_replay_gap_after_cleanup() {
         use crate::db::claim::ClaimError;
-        use crate::db::{check_and_store_dpop_jti, delete_expired_dpop_jtis};
+        use crate::db::{check_and_store_dpop_jti_at_second, delete_expired_dpop_jtis};
         use crate::services::RecencyWindow;
 
         let store = resource_test_store().await;
@@ -1590,13 +1606,24 @@ mod tests {
         // `config_max_age` only. A negative validity puts `expires_at` in the
         // past — simulating that `config_max_age` seconds have elapsed since
         // T0, without depending on real time.
-        let _claim = check_and_store_dpop_jti(&store, "old-retention-gap", -config_max_age)
-            .await
-            .expect("first use commits the JTI");
+        let _claim = check_and_store_dpop_jti_at_second(
+            &store,
+            "old-retention-gap",
+            jiff::Timestamp::now().as_second(),
+            -config_max_age,
+        )
+        .await
+        .expect("first use commits the JTI");
 
         // Even an expired-but-present row still blocks replay (PRIMARY KEY
         // collision); only cleanup removes it.
-        let blocked = check_and_store_dpop_jti(&store, "old-retention-gap", config_max_age).await;
+        let blocked = check_and_store_dpop_jti_at_second(
+            &store,
+            "old-retention-gap",
+            jiff::Timestamp::now().as_second(),
+            config_max_age,
+        )
+        .await;
         assert!(
             matches!(blocked, Err(ClaimError::AlreadyConsumed)),
             "expired-but-present JTI row must still block replay until cleanup: got {blocked:?}"
@@ -1616,7 +1643,13 @@ mod tests {
         // proof is still fresh (asserted below). `validate_dpop_common` MUST
         // NOT pass `config_max_age` here; the fix passes `config_max_age +
         // skew`.
-        let replayed = check_and_store_dpop_jti(&store, "old-retention-gap", config_max_age).await;
+        let replayed = check_and_store_dpop_jti_at_second(
+            &store,
+            "old-retention-gap",
+            jiff::Timestamp::now().as_second(),
+            config_max_age,
+        )
+        .await;
         assert!(
             replayed.is_ok(),
             "with the old max_age-only retention, cleanup reopens the replay gap: got {replayed:?}"

--- a/crates/vouch-server/src/services/oidc/dpop.rs
+++ b/crates/vouch-server/src/services/oidc/dpop.rs
@@ -12,10 +12,10 @@
 use aws_lc_rs::digest::{self, SHA256};
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 use subtle::ConstantTimeEq;
 
+use crate::arrival::ArrivalTime;
 use crate::crypto::alg::JwsAlgorithm;
 use crate::crypto::jwk::Jwk;
 use crate::crypto::jwt::{HeaderAlg, Jws, JwsError};
@@ -318,11 +318,10 @@ fn parse_and_verify_dpop_proof(proof: &str) -> Result<(DpopHeader, DpopClaims), 
 /// since it is the one field every caller stamps identically.
 #[derive(Clone, Copy)]
 pub struct DpopClaimsValidation<'a> {
-    /// Current time (seconds since epoch), stamped once by the caller at the
-    /// entry point and shared with the JTI retention computation
-    /// (`Timestamp::now().as_second()` in production via
-    /// [`validate_dpop_common`]; a fixed value in tests for deterministic
-    /// boundary checks). The freshness check and the JTI `expires_at` MUST
+    /// Current time (seconds since epoch), shared with the JTI retention
+    /// computation — the request's [`ArrivalTime`] in production via
+    /// [`validate_dpop_common`], a fixed value in tests for deterministic
+    /// boundary checks. The freshness check and the JTI `expires_at` MUST
     /// share this single instant — restamping `now` between the two lets
     /// the freshness window's upper bound drift past the replay record's
     /// `expires_at` and reopens a replay gap (RFC 9449 §11.1).
@@ -514,6 +513,10 @@ impl NoncePolicy {
 }
 
 /// multi-instance consistency.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "RFC 9449 proof validation inputs: proof, method, URIs, store, policy, clock"
+)]
 async fn validate_dpop_common(
     proof: &str,
     expected_method: &str,
@@ -522,23 +525,19 @@ async fn validate_dpop_common(
     config_max_age: i64,
     expected_ath: Option<&str>,
     nonce_policy: NoncePolicy,
+    arrival: ArrivalTime,
 ) -> Result<ValidatedDpopProof, DpopError> {
     // Parse header, verify signature, and extract claims in a single pass
     let (header, claims) = parse_and_verify_dpop_proof(proof)?;
 
-    // Stamp `now` ONCE, before any `await`, so the JTI retention and the
-    // freshness check share the same reference instant. The two previously
-    // stamped `Timestamp::now()` independently — `check_and_store_dpop_jti`
-    // stamped it internally for `expires_at` (T1), then this function
-    // stamped it again for `validate_dpop_claims` (T2 = T1 + Δ, after the
-    // DB insert's `await`). Because T2 ≥ T1, the freshness window's upper
-    // bound could land Δ past the JTI's `expires_at`, and `as_second()`
-    // floor-truncation added up to one more second of slack — together
-    // reopening a residual `Δ + 1` replay window between JTI cleanup and
-    // proof staleness (RFC 9449 §11.1). Passing the same `now` into
-    // `check_and_store_dpop_jti_at_second` and `validate_dpop_claims`
-    // eliminates the Δ; the `+1` round-up below covers the floor-slack.
-    let now = Timestamp::now();
+    // The JTI retention window and the proof-freshness window are two halves
+    // of one single-use guarantee, so they must be measured from one instant.
+    // Read separately — with the DB insert's `await` between them — retention
+    // would be anchored earlier than freshness, and the JTI row could be
+    // retired while its proof was still accepted (RFC 9449 §11.1). The
+    // request's arrival stamp is that one instant; the `+1` round-up below
+    // covers the remaining `as_second()` floor-truncation.
+    let now = arrival.timestamp();
 
     // Check for replay (JTI must be unique) — atomic INSERT on PRIMARY KEY.
     // The returned `DpopJtiClaim` is moved into the `ValidatedDpopProof`
@@ -553,21 +552,17 @@ async fn validate_dpop_common(
     // (floor-truncated), so a forward-skewed proof with `iat =
     // floor(now) + skew` stays freshness-accepted until the first second
     // at which `floor(T_replay) > iat + max_age`, i.e. until `floor(now) +
-    // skew + max_age + 1`. Retaining for only `config_max_age` (the
-    // pre-03203125 value) let the cleanup task delete the row inside that
-    // window. Committing for `config_max_age + PROOF_SKEW_SECONDS` from a
-    // `now_second` that is `floor(now) + 1` (the round-up) makes
+    // skew + max_age + 1`. Committing for `config_max_age +
+    // PROOF_SKEW_SECONDS` from a `now_second` of `floor(now) + 1` makes
     // `expires_at = floor(now) + 1 + max_age + skew` — exactly the first
     // second at which the freshness check rejects the proof — so a cleanup
-    // tick can never retire the row while the proof is still fresh.
-    // Without the `+1`, `as_second()` floor-truncation would leave a
-    // `1 − frac(now)`-second gap (the floor-slack) even with a single
-    // `now`. `now_second` is `floor(now) + 1` — the round-up over that
-    // truncation. `saturating_add` is panic-free and can never saturate in
-    // practice: jiff's representable second range is far below `i64::MAX`,
-    // so this is always the true `+1`. (If it ever did saturate,
-    // `Timestamp::from_second` inside the DB helper would return `Err` and
-    // surface as `ClaimError::Database`, not a panic.)
+    // tick can never retire the row while the proof is still fresh. The `+1`
+    // is the round-up over `as_second()` floor-truncation; without it a
+    // `1 − frac(now)`-second gap remains even on a single clock.
+    // `saturating_add` is panic-free and cannot saturate in practice —
+    // jiff's representable second range is far below `i64::MAX` — and if it
+    // ever did, `Timestamp::from_second` inside the DB helper returns `Err`
+    // and surfaces as `ClaimError::Database` rather than a panic.
     let now_second = now.as_second().saturating_add(1);
     let jti_retention = config_max_age.saturating_add(PROOF_SKEW_SECONDS);
     let jti_claim =
@@ -593,10 +588,10 @@ async fn validate_dpop_common(
 
     // Validate claims (method, URI, timestamp, nonce inline, ath)
     // Pass None for expected_nonce to skip redundant self-comparison;
-    // database nonce validation happens below. `now.as_second()` is the
-    // SAME instant that produced `now_second` above — not a fresh
-    // `Timestamp::now()` — so the freshness check and the JTI retention
-    // cannot drift apart across the DB insert's `await`.
+    // database nonce validation happens below. `now.as_second()` is the same
+    // arrival instant that produced `now_second` above, so the freshness
+    // check and the JTI retention cannot drift apart across the insert's
+    // `await`.
     validate_dpop_claims(
         &claims,
         &DpopClaimsValidation {
@@ -655,6 +650,7 @@ pub async fn validate_dpop_proof(
     accepted_uris: &[String],
     store: &DocumentStore,
     config_max_age: i64,
+    arrival: ArrivalTime,
 ) -> Result<ValidatedDpopProof, DpopError> {
     validate_dpop_common(
         proof,
@@ -664,6 +660,7 @@ pub async fn validate_dpop_proof(
         config_max_age,
         None, // No access token hash for token endpoint
         NoncePolicy::Required,
+        arrival,
     )
     .await
 }
@@ -688,6 +685,7 @@ pub async fn validate_dpop_at_resource(
     uri: &str,
     store: &DocumentStore,
     config_max_age: i64,
+    arrival: ArrivalTime,
 ) -> Result<ValidatedDpopProof, DpopError> {
     let expected_ath = compute_access_token_hash(access_token);
     let accepted_uris = vec![uri.to_string()];
@@ -699,6 +697,7 @@ pub async fn validate_dpop_at_resource(
         config_max_age,
         Some(&expected_ath),
         NoncePolicy::Optional,
+        arrival,
     )
     .await
 }
@@ -720,6 +719,8 @@ mod rfc9449_vectors;
 )]
 mod tests {
     use super::*;
+    use crate::test_utils::test_arrival;
+    use jiff::Timestamp;
 
     #[test]
     fn test_ec_jwk_thumbprint() {
@@ -1732,10 +1733,17 @@ mod tests {
         let proof = resource_test_dpop_proof(&key, &jwk, method, uri, access_token);
 
         let now_before = jiff::Timestamp::now().as_second();
-        let validated =
-            validate_dpop_at_resource(access_token, &proof, method, uri, &store, CONFIG_MAX_AGE)
-                .await
-                .expect("resource proof validates");
+        let validated = validate_dpop_at_resource(
+            access_token,
+            &proof,
+            method,
+            uri,
+            &store,
+            CONFIG_MAX_AGE,
+            test_arrival(),
+        )
+        .await
+        .expect("resource proof validates");
         let now_after = jiff::Timestamp::now().as_second();
 
         // Read the committed JTI back by its deterministic document ID.
@@ -1781,9 +1789,16 @@ mod tests {
         );
 
         // Replay of the same proof must be rejected while the row is present.
-        let replay =
-            validate_dpop_at_resource(access_token, &proof, method, uri, &store, CONFIG_MAX_AGE)
-                .await;
+        let replay = validate_dpop_at_resource(
+            access_token,
+            &proof,
+            method,
+            uri,
+            &store,
+            CONFIG_MAX_AGE,
+            test_arrival(),
+        )
+        .await;
         assert!(
             matches!(replay, Err(DpopError::ReplayDetected)),
             "an immediate replay of the same DPoP proof must be rejected: got {replay:?}"

--- a/crates/vouch-server/src/services/oidc/exchange.rs
+++ b/crates/vouch-server/src/services/oidc/exchange.rs
@@ -5,6 +5,7 @@
 //! - RFC 8693 - OAuth 2.0 Token Exchange
 
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::crypto::hash_token;
 use crate::db;
 use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
@@ -291,6 +292,7 @@ pub(crate) async fn exchange_token(
     state: &Arc<AppState>,
     params: TokenExchangeParams<'_>,
     proof: TokenIssuanceProof,
+    arrival: ArrivalTime,
 ) -> ServiceResult<TokenExchangeResult> {
     // Reject `actor_token` with `requested_token_type=id_token`. The ID-token
     // path issues a clean OIDC claim set and does not carry the `act` claim,
@@ -324,7 +326,7 @@ pub(crate) async fn exchange_token(
     let subject_token_hash = hash_token(subject_token);
     let subject_session = state
         .session_cache
-        .get_session_by_token_hash(&state.store, &subject_token_hash)
+        .get_session_by_token_hash(&state.store, &subject_token_hash, arrival)
         .await
         .map_err(|e| ServiceError::Internal(format!("Database error: {e}")))?
         .ok_or_else(|| {
@@ -366,6 +368,7 @@ pub(crate) async fn exchange_token(
             params.client_ip,
             params.client_id,
             params.audience,
+            arrival,
         )
         .await
         // RFC 8693 §2.2.2: a subject token "unacceptable based on policy"
@@ -406,7 +409,7 @@ pub(crate) async fn exchange_token(
         let actor_token_hash = hash_token(actor_token);
         let _actor_session = state
             .session_cache
-            .get_session_by_token_hash(&state.store, &actor_token_hash)
+            .get_session_by_token_hash(&state.store, &actor_token_hash, arrival)
             .await
             .map_err(|e| ServiceError::Internal(format!("Database error: {e}")))?
             .ok_or_else(|| {
@@ -473,10 +476,14 @@ pub(crate) async fn exchange_token(
     // including when the subject's integer-second remaining TTL is 0 — so an
     // exchanged access token never outlives its subject token (see
     // [`cap_lifetime_by_subject_ttl`]).
+    // The cap is measured from the request's arrival, and
+    // `create_oauth_access_token` stamps the issued `exp` from that same
+    // instant, so `exp_issued = arrival + min(session, subject_exp - arrival)`
+    // can never exceed `subject_exp`.
     let expires_in = cap_lifetime_by_subject_ttl(
         state.config().session_hours.saturating_mul(3600),
         subject_decoded.exp(),
-        Timestamp::now().as_second(),
+        arrival.as_second(),
     );
 
     // RFC 9068: Audience is the explicit audience param (target resource server),
@@ -525,6 +532,7 @@ pub(crate) async fn exchange_token(
                 org_domain: subject_session.org_domain.as_deref(),
                 client_id: params.client_id,
             },
+            arrival,
         )
         .await;
     }
@@ -604,6 +612,7 @@ pub(crate) async fn exchange_token(
             source_code_hash: subject_session.source_code_hash.as_deref(),
         },
         proof,
+        arrival,
     )
     .await?;
 
@@ -706,6 +715,7 @@ struct IdTokenContext<'a> {
 async fn issue_id_token(
     state: &Arc<AppState>,
     ctx: IdTokenContext<'_>,
+    arrival: ArrivalTime,
 ) -> ServiceResult<TokenExchangeResult> {
     let config = state.config();
 
@@ -748,7 +758,9 @@ async fn issue_id_token(
         .map_err(|e| ServiceError::Internal(format!("Failed to sign ID token: {e}")))?;
 
     // Log the exchange for audit (best-effort — failures are non-fatal).
-    let now = Timestamp::now();
+    // The recorded `expires_at` describes the token just signed, whose `exp`
+    // the claims builder derived from the same arrival instant.
+    let now = arrival.timestamp();
     let issued_token_hash = hash_token(&id_token);
     let expires_at = i64::try_from(expires_in)
         .ok()

--- a/crates/vouch-server/src/services/oidc/fido2_grant.rs
+++ b/crates/vouch-server/src/services/oidc/fido2_grant.rs
@@ -120,7 +120,11 @@ impl AssertionGrant {
     /// includes a member outside its length bounds), a challenge state that
     /// fails to decode or carries an unrepresentable `exp`, or a user handle
     /// that is not a UUID.
-    async fn validate(assertion: &str, state: &Arc<AppState>) -> ServiceResult<Self> {
+    async fn validate(
+        assertion: &str,
+        state: &Arc<AppState>,
+        arrival: ArrivalTime,
+    ) -> ServiceResult<Self> {
         let assertion_bytes = URL_SAFE_NO_PAD.decode(assertion).map_err(|_| {
             ServiceError::oauth(
                 OAuthErrorCode::InvalidGrant,
@@ -138,7 +142,11 @@ impl AssertionGrant {
 
         let challenge_state: Fido2ChallengeState = state
             .state_signer
-            .decode_state_token(payload.state.as_str(), JwtType::Fido2ChallengeState)
+            .decode_state_token(
+                payload.state.as_str(),
+                JwtType::Fido2ChallengeState,
+                arrival.as_second(),
+            )
             .await
             .map_err(|e| {
                 ServiceError::oauth(
@@ -222,7 +230,7 @@ pub(crate) async fn exchange_fido2_assertion(
 ) -> ServiceResult<Fido2AssertionResult> {
     // Parse and check the assertion. This reads only the assertion parameter,
     // so it completes before the challenge state is consumed below.
-    let grant = AssertionGrant::validate(params.assertion, state).await?;
+    let grant = AssertionGrant::validate(params.assertion, state, arrival).await?;
     let user_id = grant.user_id;
 
     // Mark challenge used + look up authenticator in parallel

--- a/crates/vouch-server/src/services/oidc/fido2_grant.rs
+++ b/crates/vouch-server/src/services/oidc/fido2_grant.rs
@@ -14,6 +14,7 @@
 //!    verifies WebAuthn assertion, and issues an OAuth access token.
 
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::assurance::HardwareVerification;
 use crate::crypto::jwt::JwtType;
 use crate::db::{self, AuthEventParams, AuthEventType};
@@ -217,6 +218,7 @@ pub(crate) async fn exchange_fido2_assertion(
     params: Fido2AssertionParams<'_>,
     client_auth: ClientAuthProof,
     sender_constraint: SenderConstraintProof,
+    arrival: ArrivalTime,
 ) -> ServiceResult<Fido2AssertionResult> {
     // Parse and check the assertion. This reads only the assertion parameter,
     // so it completes before the challenge state is consumed below.
@@ -363,6 +365,7 @@ pub(crate) async fn exchange_fido2_assertion(
             client_ip,
             &params.client.client.client_id,
             ad_value.as_ref(),
+            arrival,
         )
         .await
     {
@@ -440,6 +443,7 @@ pub(crate) async fn exchange_fido2_assertion(
             source_code_hash: None,
         },
         proof,
+        arrival,
     )
     .await?;
 

--- a/crates/vouch-server/src/services/oidc/introspection.rs
+++ b/crates/vouch-server/src/services/oidc/introspection.rs
@@ -6,6 +6,7 @@
 //! - RFC 7662 - OAuth 2.0 Token Introspection
 
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::crypto::hash_token;
 use crate::crypto::keys::OidcSigningKey;
 use crate::db;
@@ -104,6 +105,10 @@ struct IntrospectionJwtClaims {
 /// - Token data inside `token_introspection` claim
 /// - For inactive tokens: `{"token_introspection": {"active": false}}`
 /// - No top-level `sub` or `exp` (RFC 9701 Section 5.4)
+#[expect(
+    clippy::disallowed_methods,
+    reason = "mints the introspection response JWT's iat"
+)]
 pub(crate) async fn sign_introspection_jwt(
     result: &IntrospectionResult,
     issuer: &str,
@@ -158,6 +163,7 @@ pub async fn introspect_token(
     token: &str,
     _token_type_hint: Option<&str>,
     caller_client_id: Option<&str>,
+    arrival: ArrivalTime,
 ) -> ServiceResult<IntrospectionResult> {
     // Decode the token as an ES256 RFC 9068 access token
     let config = state.config();
@@ -172,7 +178,7 @@ pub async fn introspect_token(
     let token_hash = hash_token(token);
     let session = match state
         .session_cache
-        .get_session_by_token_hash(&state.store, &token_hash)
+        .get_session_by_token_hash(&state.store, &token_hash, arrival)
         .await
         .map_err(|e| ServiceError::Internal(format!("Database error: {e}")))?
     {
@@ -356,6 +362,7 @@ pub async fn revoke_token(
 )]
 mod tests {
     use super::*;
+    use crate::test_utils::test_arrival;
 
     #[test]
     fn test_inactive_result() {
@@ -492,7 +499,7 @@ mod tests {
         // mirroring the DB-error token test in handlers/oidc/tests).
         state.db.close().await;
 
-        let result = introspect_token(&state, &token, None, None).await;
+        let result = introspect_token(&state, &token, None, None, test_arrival()).await;
         assert!(
             matches!(result, Err(ServiceError::Internal(_))),
             "store failure must surface as ServiceError::Internal, got: {result:?}"

--- a/crates/vouch-server/src/services/oidc/jar.rs
+++ b/crates/vouch-server/src/services/oidc/jar.rs
@@ -13,6 +13,7 @@
 //! - FAPI 2.0 parameter consistency: query params must match JWT values
 
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::crypto::jwt::{Jws, JwsError};
 use crate::db::OAuthClient;
 use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
@@ -24,7 +25,6 @@ use crate::services::oidc::jwt_bearer::validate::{
 use crate::services::oidc::jwt_bearer::{
     find_matching_key_with_refresh_client, resolve_client_jwks,
 };
-use jiff::Timestamp;
 use serde::Deserialize;
 use std::sync::Arc;
 
@@ -331,6 +331,7 @@ pub async fn validate_request_object(
     request_jwt: &str,
     client: &OAuthClient,
     query_params: Option<&QueryParamHints<'_>>,
+    arrival: ArrivalTime,
 ) -> ServiceResult<AuthorizeRequestParams> {
     // 1. Parse and validate the header (algorithm + typ)
     let (_typ, assertion_header) = parse_request_object_header(request_jwt)?;
@@ -465,12 +466,7 @@ pub async fn validate_request_object(
     // 5. Validate temporal claims
     // FAPI 2.0 clients use a tighter 10-second clock skew tolerance.
     let clock_skew = super::fapi::clock_skew_seconds(client);
-    validate_temporal_claims(
-        &claims,
-        clock_skew,
-        client.is_fapi(),
-        Timestamp::now().as_second(),
-    )?;
+    validate_temporal_claims(&claims, clock_skew, client.is_fapi(), arrival.as_second())?;
 
     // 6. Validate issuer — must match client_id
     if let Some(ref iss) = claims.iss
@@ -700,8 +696,10 @@ fn validate_temporal_claims(
 mod tests {
     use super::*;
     use crate::crypto::alg::JwsAlgorithm;
+    use crate::test_utils::test_arrival;
     use base64::Engine as _;
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use jiff::Timestamp;
 
     // ========================================================================
     // Helper: Build a minimal JWT string from a raw header JSON object.
@@ -1419,7 +1417,8 @@ mod tests {
             "sanity: get_jwks_cache must error after dropping the documents table"
         );
 
-        let result = validate_request_object(&state, &request_jwt, &client, None).await;
+        let result =
+            validate_request_object(&state, &request_jwt, &client, None, test_arrival()).await;
         assert!(
             result.is_ok(),
             "inline-JWKS client must validate Request Object despite cache DB error: {result:?}"

--- a/crates/vouch-server/src/services/oidc/jarm.rs
+++ b/crates/vouch-server/src/services/oidc/jarm.rs
@@ -64,6 +64,10 @@ fn select_alg(_state: &AppState, client: &OAuthClient) -> &'static str {
 /// # Errors
 ///
 /// Returns an error if the signing key is unavailable or JWT signing fails.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "mints the JARM response JWT's iat and exp"
+)]
 pub async fn build_jarm_success_jwt(
     state: &Arc<AppState>,
     client: &OAuthClient,
@@ -98,6 +102,10 @@ pub async fn build_jarm_success_jwt(
 /// # Errors
 ///
 /// Returns an error if the signing key is unavailable or JWT signing fails.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "mints the JARM error JWT's iat and exp"
+)]
 pub async fn build_jarm_error_jwt(
     state: &Arc<AppState>,
     client: &OAuthClient,

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/client_auth.rs
@@ -11,6 +11,7 @@ use super::validate::{
     validate_jwt_assertion,
 };
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::db::claim::ClaimError;
 use crate::db::{self, JwtAssertionJtiClaim, OAuthClient, TokenEndpointAuthMethod};
 use crate::services::oidc::token::{AuthenticatedClient, ClientAuthError};
@@ -175,6 +176,7 @@ pub async fn authenticate_client_jwt(
     state: &Arc<AppState>,
     client_assertion: &str,
     client_id_hint: Option<&str>,
+    arrival: ArrivalTime,
 ) -> Result<(AuthenticatedClient, PendingJti, JwtAuthSucceeded), ClientAuthError> {
     // 1. Parse JWT header to get algorithm and kid
     let header = parse_assertion_header(client_assertion).map_err(|e| {
@@ -259,6 +261,7 @@ pub async fn authenticate_client_jwt(
         algorithm,
         &allowed_audiences,
         max_lifetime,
+        arrival.as_second(),
     )
     .map_err(|e| {
         tracing::debug!(

--- a/crates/vouch-server/src/services/oidc/jwt_bearer/validate.rs
+++ b/crates/vouch-server/src/services/oidc/jwt_bearer/validate.rs
@@ -7,7 +7,6 @@
 use crate::crypto::alg::JwsAlgorithm;
 use crate::crypto::jwt::{HeaderAlg, Jws, JwsError};
 use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
-use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
 /// Clock skew tolerance in seconds.
@@ -201,6 +200,8 @@ pub fn validate_client_assertion_algorithm(
 /// * `algorithm` - The expected algorithm
 /// * `expected_audiences` - Acceptable audience values (token endpoint URL, base URL, etc.)
 /// * `max_lifetime_seconds` - Maximum allowed assertion lifetime
+/// * `now` - Unix seconds the temporal claims are judged against (the
+///   request's [`crate::arrival::ArrivalTime`] in production)
 ///
 /// # Returns
 /// The validated assertion claims.
@@ -211,6 +212,7 @@ pub fn validate_jwt_assertion(
     algorithm: jsonwebtoken::Algorithm,
     expected_audiences: &[&str],
     max_lifetime_seconds: i64,
+    now: i64,
 ) -> ServiceResult<ValidatedJwtAssertion> {
     // Build validation settings
     let mut validation = jsonwebtoken::Validation::new(algorithm);
@@ -232,7 +234,6 @@ pub fn validate_jwt_assertion(
         )?;
 
     let claims = token_data.claims;
-    let now = Timestamp::now().as_second();
 
     // Validate expiration (RFC 7523 Section 3: MUST reject expired JWTs)
     if claims.exp < now.saturating_sub(CLOCK_SKEW_SECONDS) {
@@ -324,6 +325,7 @@ mod tests {
     use super::*;
     use base64::Engine as _;
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use jiff::Timestamp;
 
     // RFC 8725 §3.9: the audience claim may be a single string.
     #[test]
@@ -603,6 +605,7 @@ mod tests {
             jsonwebtoken::Algorithm::ES256,
             TEST_AUDIENCES,
             MAX_LIFETIME,
+            jiff::Timestamp::now().as_second(),
         );
 
         let validated = result.expect("valid JWT assertion should pass");
@@ -631,6 +634,7 @@ mod tests {
             jsonwebtoken::Algorithm::ES256,
             TEST_AUDIENCES,
             MAX_LIFETIME,
+            jiff::Timestamp::now().as_second(),
         );
 
         assert!(result.is_err(), "Expired JWT must be rejected");
@@ -662,6 +666,7 @@ mod tests {
             jsonwebtoken::Algorithm::ES256,
             TEST_AUDIENCES,
             MAX_LIFETIME,
+            jiff::Timestamp::now().as_second(),
         );
 
         assert!(
@@ -690,6 +695,7 @@ mod tests {
             jsonwebtoken::Algorithm::ES256,
             TEST_AUDIENCES,
             MAX_LIFETIME,
+            jiff::Timestamp::now().as_second(),
         );
 
         assert!(result.is_err(), "Future nbf must be rejected");
@@ -720,6 +726,7 @@ mod tests {
             jsonwebtoken::Algorithm::ES256,
             TEST_AUDIENCES,
             MAX_LIFETIME,
+            jiff::Timestamp::now().as_second(),
         );
 
         assert!(
@@ -749,6 +756,7 @@ mod tests {
             jsonwebtoken::Algorithm::ES256,
             TEST_AUDIENCES,
             MAX_LIFETIME,
+            jiff::Timestamp::now().as_second(),
         );
 
         assert!(result.is_err(), "Future iat must be rejected");
@@ -781,6 +789,7 @@ mod tests {
             jsonwebtoken::Algorithm::ES256,
             TEST_AUDIENCES,
             max_lifetime,
+            jiff::Timestamp::now().as_second(),
         );
 
         assert!(result.is_err(), "Excessive lifetime must be rejected");
@@ -813,6 +822,7 @@ mod tests {
             jsonwebtoken::Algorithm::ES256,
             TEST_AUDIENCES,
             max_lifetime,
+            jiff::Timestamp::now().as_second(),
         );
 
         assert!(
@@ -840,6 +850,7 @@ mod tests {
             jsonwebtoken::Algorithm::ES256,
             TEST_AUDIENCES,
             MAX_LIFETIME,
+            jiff::Timestamp::now().as_second(),
         );
 
         assert!(result.is_err(), "Wrong audience must be rejected");
@@ -883,6 +894,7 @@ mod tests {
             jsonwebtoken::Algorithm::ES256,
             fapi_audiences,
             MAX_LIFETIME,
+            jiff::Timestamp::now().as_second(),
         );
 
         assert!(
@@ -918,6 +930,7 @@ mod tests {
             jsonwebtoken::Algorithm::ES256,
             fapi_audiences,
             MAX_LIFETIME,
+            jiff::Timestamp::now().as_second(),
         );
 
         assert!(
@@ -949,6 +962,7 @@ mod tests {
             jsonwebtoken::Algorithm::ES256,
             TEST_AUDIENCES,
             MAX_LIFETIME,
+            jiff::Timestamp::now().as_second(),
         );
 
         assert!(
@@ -977,6 +991,7 @@ mod tests {
             jsonwebtoken::Algorithm::ES256,
             TEST_AUDIENCES,
             MAX_LIFETIME,
+            jiff::Timestamp::now().as_second(),
         );
 
         assert!(result.is_err(), "Wrong signing key must be rejected");

--- a/crates/vouch-server/src/services/oidc/org_keys/mod.rs
+++ b/crates/vouch-server/src/services/oidc/org_keys/mod.rs
@@ -209,6 +209,10 @@ async fn generate_key_material(alg: JwsAlgorithm) -> Result<KeyMaterial> {
 /// first use so relying-party caches are warm long before any rotate).
 /// Idempotent: the deterministic ID makes a concurrent creation or retry
 /// collide on the primary key rather than insert a duplicate.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "stamps a newly created signing key"
+)]
 async fn ensure_key(
     store: &DocumentStore,
     org_id: &str,

--- a/crates/vouch-server/src/services/oidc/org_keys/rotation.rs
+++ b/crates/vouch-server/src/services/oidc/org_keys/rotation.rs
@@ -175,6 +175,10 @@ fn revoke_ready_at(demoted_at: Timestamp, session_hours: u64) -> Result<Timestam
 /// a missing Next key (rows created before rotation existed) by staging one,
 /// outside any transaction — safe because the staged insert is idempotent.
 /// The rotate transaction re-checks every gate authoritatively.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "operator-driven key rotation, not a request-path comparison"
+)]
 async fn precheck_rotate_and_heal(state: &AppState, org_id: &str) -> Result<Option<RotateOutcome>> {
     let store = &state.store;
     let now = Timestamp::now();
@@ -353,6 +357,10 @@ async fn rotate_one_alg_in_tx(
 /// # Errors
 /// Returns an error if key generation or the transaction fails after the OCC
 /// retry budget is exhausted.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "operator-driven key rotation, not a request-path comparison"
+)]
 pub async fn rotate_org_keys(
     state: &AppState,
     org_id: &str,
@@ -444,6 +452,10 @@ pub async fn rotate_org_keys(
 ///
 /// # Errors
 /// Returns an error if the reads, the transaction, or the gate math fail.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "operator-driven key rotation, not a request-path comparison"
+)]
 pub async fn revoke_org_previous_keys(
     state: &AppState,
     org_id: &str,
@@ -619,6 +631,10 @@ struct EmergencyKeyPair {
 /// # Errors
 /// Returns an error if key generation or the transaction fails after the OCC
 /// retry budget is exhausted.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "operator-driven key rotation, not a request-path comparison"
+)]
 pub async fn emergency_rotate_org_keys(
     state: &AppState,
     org_id: &str,
@@ -728,6 +744,10 @@ pub(crate) struct OrgKeyPanel {
 /// # Errors
 /// Returns an error if the key list cannot be loaded or a stored key is
 /// missing its state timestamp.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "operator-driven key rotation, not a request-path comparison"
+)]
 pub(crate) async fn org_key_panel(state: &AppState, org_id: &str) -> Result<OrgKeyPanel> {
     let now = Timestamp::now();
     let mut docs = db::list_org_signing_keys(&state.store, org_id).await?;

--- a/crates/vouch-server/src/services/oidc/protected_resource.rs
+++ b/crates/vouch-server/src/services/oidc/protected_resource.rs
@@ -366,6 +366,10 @@ pub async fn build_protected_resource_metadata(
 ///   cache validation).
 ///
 /// The header's `typ` is [`SIGNED_METADATA_TYP`].
+#[expect(
+    clippy::disallowed_methods,
+    reason = "mints the protected-resource metadata iat"
+)]
 async fn build_signed_metadata(
     state: &Arc<AppState>,
     metadata: &ProtectedResourceMetadata,

--- a/crates/vouch-server/src/services/oidc/token.rs
+++ b/crates/vouch-server/src/services/oidc/token.rs
@@ -10,6 +10,7 @@ use super::authorization_details::AuthorizationDetails;
 use super::dpop::{self, CnfClaim, DpopError, ValidatedDpopProof};
 use super::scope::{OAuthScope, ScopeSet};
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::assurance::{ACR_AAL3, AuthMethod, HardwareVerification};
 use crate::crypto::hash_token;
 use crate::db::{self, Authenticator, OAuthClient, User};
@@ -313,9 +314,11 @@ pub(crate) async fn exchange_authorization_code(
     params: AuthCodeExchangeParams<'_>,
     client_auth: ClientAuthProof,
     sender_constraint: SenderConstraintProof,
+    arrival: ArrivalTime,
 ) -> ServiceResult<AuthCodeExchangeResult> {
     // Decode and validate the authorization code
-    let auth_code = decode_authorization_code(state, params.code, params.client_id).await?;
+    let auth_code =
+        decode_authorization_code(state, params.code, params.client_id, arrival).await?;
 
     // RFC 6749 Section 10.5: Enforce single-use authorization codes.
     // This MUST happen before any other validation to ensure codes are always
@@ -392,6 +395,7 @@ pub(crate) async fn exchange_authorization_code(
             source_code_hash: Some(&code_hash),
         },
         proof,
+        arrival,
     )
     .await?;
     let access_token = session_result.token;
@@ -974,6 +978,7 @@ struct IdTokenParams<'a> {
 }
 
 /// Generate an OIDC ID token.
+#[expect(clippy::disallowed_methods, reason = "mints the ID token's exp")]
 async fn generate_id_token(
     state: &Arc<AppState>,
     params: IdTokenParams<'_>,
@@ -1215,6 +1220,7 @@ pub async fn validate_dpop_if_present(
     dpop_header: Option<&str>,
     method: &str,
     uri: &str,
+    arrival: ArrivalTime,
 ) -> Result<Option<ValidatedDpopProof>, DpopError> {
     let dpop_proof = match dpop_header {
         Some(proof) => proof,
@@ -1244,6 +1250,7 @@ pub async fn validate_dpop_if_present(
         &accepted_uris,
         &state.store,
         config.dpop_max_age_seconds,
+        arrival,
     )
     .await
     {
@@ -1303,6 +1310,7 @@ pub struct OidcValidatedSession {
 pub async fn validate_session_token(
     state: &Arc<AppState>,
     token: &str,
+    arrival: ArrivalTime,
 ) -> ServiceResult<Option<OidcValidatedSession>> {
     // Decode the token as an ES256 RFC 9068 access token
     let config = state.config();
@@ -1315,7 +1323,7 @@ pub async fn validate_session_token(
     let token_hash = hash_token(token);
     let session = match state
         .session_cache
-        .get_session_by_token_hash(&state.store, &token_hash)
+        .get_session_by_token_hash(&state.store, &token_hash, arrival)
         .await
         .map_err(|e| ServiceError::Internal(format!("Database error: {e}")))?
     {

--- a/crates/vouch-server/src/services/policy/events.rs
+++ b/crates/vouch-server/src/services/policy/events.rs
@@ -11,6 +11,7 @@
 //! so an event without a principal can never match. This also means
 //! machine-only issuances (client-credentials tokens) are not counted.
 
+use crate::arrival::ArrivalTime;
 use crate::db::audit::{AuditEvent as AuditRow, AuditEventFilter, AuditEventKind, AuditStore};
 use dogwood_language::{Event, Value};
 
@@ -46,8 +47,9 @@ const FETCH_LIMIT: u64 = 10_000;
 pub(crate) async fn fetch_user_history(
     audit: &AuditStore,
     user_id: &str,
+    arrival: ArrivalTime,
 ) -> Result<Vec<AuditRow>, String> {
-    let now = jiff::Timestamp::now();
+    let now = arrival.timestamp();
     let floor = now
         .checked_sub(jiff::Span::new().hours(REPLAY_WINDOW_HOURS))
         .map_err(|e| format!("cannot compute replay window floor: {e}"))?;

--- a/crates/vouch-server/src/services/policy/mod.rs
+++ b/crates/vouch-server/src/services/policy/mod.rs
@@ -37,6 +37,7 @@ pub(crate) use preconfigured::{
 };
 pub(crate) use remediation::remediation_for_slug;
 
+use crate::arrival::ArrivalTime;
 use crate::db;
 use crate::error::{OAuthErrorCode, ServiceError, ServiceResult};
 use dogwood_language::{
@@ -543,6 +544,7 @@ async fn authorize_decision(
     request: DecisionRequest<'_>,
     active_slugs: &[String],
     active_custom: &[db::CustomPosturePolicy],
+    arrival: ArrivalTime,
 ) -> ServiceResult<()> {
     let DecisionRequest {
         org_id,
@@ -589,7 +591,7 @@ async fn authorize_decision(
     // Orgs running only device-posture policies never read event history,
     // so they pay neither the audit query nor the replay.
     let history = if needs_history {
-        events::fetch_user_history(&state.audit, user_id)
+        events::fetch_user_history(&state.audit, user_id, arrival)
             .await
             .map_err(|msg| {
                 tracing::error!(org_id, "policy history fetch failed: {msg}");
@@ -611,7 +613,9 @@ async fn authorize_decision(
                 ServiceError::Internal("policy engine unavailable".to_string())
             })?;
 
-    let now = jiff::Timestamp::now().as_second();
+    // The same instant the history window was cut at, so a policy rule and the
+    // events it reasons about are judged on one clock.
+    let now = arrival.as_second();
     let decision = engine::evaluate(lowered, &set.refs, &history, org_id, now, |ts| {
         decision_event(&kind, user_id, org_id, ts)
     })
@@ -653,6 +657,10 @@ async fn authorize_decision(
 /// Returns `ServiceError::Internal` if the engine itself is unavailable
 /// (embedded schema broken, composed set fails to lower) — also
 /// fail-closed: no token is issued.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "policy decision inputs: subject, client, posture, clock"
+)]
 pub(crate) async fn evaluate_posture_policies(
     state: &crate::AppState,
     org_id: &str,
@@ -661,6 +669,7 @@ pub(crate) async fn evaluate_posture_policies(
     client_ip: Option<std::net::IpAddr>,
     client_id: &str,
     authorization_details: Option<&serde_json::Value>,
+    arrival: ArrivalTime,
 ) -> ServiceResult<()> {
     let active_slugs = db::get_active_preconfigured_slugs(&state.store, org_id)
         .await
@@ -726,6 +735,7 @@ pub(crate) async fn evaluate_posture_policies(
         },
         &active_slugs,
         &active_custom,
+        arrival,
     )
     .await
 }
@@ -740,6 +750,10 @@ pub(crate) async fn evaluate_posture_policies(
 ///
 /// Returns `AccessDenied` when an active exchange policy denies, or
 /// `Internal` when the engine is unavailable (fail-closed).
+#[expect(
+    clippy::too_many_arguments,
+    reason = "policy decision inputs: subject, client, audience, clock"
+)]
 pub(crate) async fn evaluate_exchange_policies(
     state: &crate::AppState,
     org_id: &str,
@@ -748,6 +762,7 @@ pub(crate) async fn evaluate_exchange_policies(
     client_ip: Option<std::net::IpAddr>,
     client_id: &str,
     audience: Option<&str>,
+    arrival: ArrivalTime,
 ) -> ServiceResult<()> {
     let active_slugs = db::get_active_preconfigured_slugs(&state.store, org_id)
         .await
@@ -773,6 +788,7 @@ pub(crate) async fn evaluate_exchange_policies(
         },
         &active_slugs,
         &active_custom,
+        arrival,
     )
     .await
 }
@@ -827,6 +843,10 @@ fn extract_device_posture(ad_value: Option<&serde_json::Value>) -> ServiceResult
 /// Fuzzing entry for the runtime evaluation path. Builds a trace from raw
 /// row shapes and decides against the full preconfigured policy set — the
 /// same `engine::evaluate` call the login and exchange paths make.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "fuzz harness fixture, not request-serving code"
+)]
 #[cfg(any(test, feature = "test-utils"))]
 pub(crate) fn fuzz_evaluate_history(rows: &[(String, String, String, i64)]) {
     let Some(policy_schema) = schema::policy_schema() else {

--- a/crates/vouch-server/src/services/policy/tests.rs
+++ b/crates/vouch-server/src/services/policy/tests.rs
@@ -12,6 +12,7 @@
 
 use super::preconfigured::BASE_ALLOW;
 use super::*;
+use crate::test_utils::test_arrival;
 use vouch_common::posture::{EdrAgent, MdmAgent, OperatingSystem, PostureTypeTag};
 
 fn sample_posture() -> DevicePosture {
@@ -1897,6 +1898,7 @@ async fn test_authorize_decision_records_custom_policy_name_in_audit() {
         },
         &[],
         &custom,
+        test_arrival(),
     )
     .await;
     assert!(result.is_err(), "minimal posture must be denied");
@@ -1943,6 +1945,7 @@ async fn test_authorize_decision_records_preconfigured_slug_in_audit() {
         },
         &slugs,
         &[],
+        test_arrival(),
     )
     .await;
     assert!(
@@ -1989,6 +1992,7 @@ when temporal {
         },
         &[],
         &custom,
+        test_arrival(),
     )
     .await;
     assert!(
@@ -2044,6 +2048,7 @@ async fn test_authorize_decision_multi_rule_custom_policy_name_in_audit() {
         },
         &[],
         &custom,
+        test_arrival(),
     )
     .await;
     assert!(result.is_err(), "firewall disabled must deny");

--- a/crates/vouch-server/src/test_utils.rs
+++ b/crates/vouch-server/src/test_utils.rs
@@ -29,6 +29,7 @@ use crate::db::{CreateOAuthClientParams, Domain, Pool, RegistrationSource};
 use crate::infra::router::build_app;
 
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::config::{IdpConfig, OidcProviderConfig, ServerConfig};
 use crate::crypto::keys::OidcSigningKey;
 
@@ -123,6 +124,20 @@ pub fn test_config() -> ServerConfig {
         session_cache_max_capacity: 10_000,
         session_cache_ttl_secs: 30,
     }
+}
+
+/// The arrival stamp for a test that drives a service function directly,
+/// standing in for the router middleware that would supply one.
+///
+/// Use [`crate::arrival::ArrivalTime::for_test`] with an explicit instant
+/// instead whenever the test is *about* a time boundary.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "test fixtures construct their own instants"
+)]
+#[must_use]
+pub fn test_arrival() -> ArrivalTime {
+    ArrivalTime::for_test(jiff::Timestamp::now())
 }
 
 /// Create a test AppState with in-memory database.
@@ -1082,6 +1097,10 @@ pub struct TestSessionSpec<'a> {
 }
 
 impl Default for TestSessionSpec<'_> {
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "test fixtures construct their own instants"
+    )]
     fn default() -> Self {
         Self {
             user_id: "",
@@ -1174,6 +1193,7 @@ pub async fn create_test_session_with(state: &AppState, spec: TestSessionSpec<'_
             ),
             sender_constraint: SenderConstraintProof::no_registered_client(),
         },
+        test_arrival(),
     )
     .await
     .expect("Failed to create test session");
@@ -1264,6 +1284,10 @@ async fn forge_auth_time(
 /// [`TestSessionSpec`] so a test that has already moved a `spec` into
 /// [`create_test_session_with`] to mint `base` can still call this helper
 /// without rebuilding or cloning the struct.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "test fixtures construct their own instants"
+)]
 pub async fn forge_short_lived_access_token(
     state: &AppState,
     user_id: &str,
@@ -1825,6 +1849,10 @@ pub async fn make_test_access_token(key: &OidcSigningKey) -> String {
 ///
 /// `jti: None` generates a fresh UUID so repeated calls do not trip replay
 /// protection; pass `Some(..)` to exercise replay handling deliberately.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "test fixtures construct their own instants"
+)]
 #[must_use]
 pub fn build_client_assertion(
     client_id: &str,


### PR DESCRIPTION
Closes #1268.

Request-path time comparisons stamped `Timestamp::now()` independently at each
call site, so two comparisons serving one decision could observe instants
separated by however long the awaits between them took.

## The witness

`crates/vouch-server/src/arrival.rs` adds `ArrivalTime(Timestamp)`. Its
constructor is private to the module, so an `ArrivalTime` parameter is evidence
the value came from the middleware rather than from a fresh clock reading at the
call site — the same pattern as `AuthTime`.

`arrival_layer` is the outermost layer in `build_app`; handlers take the value
through a `FromRequestParts` extractor that fails closed with a 500 when the
middleware is not mounted. The extractor is generic over router state and
rejects with a bare `StatusCode`, so the module imports nothing above it and
`db` and `services` can take an `ArrivalTime` without a layering inversion.
`tests/arch_boundaries.rs` passes unchanged.

## What now reads the arrival stamp

DPoP proof freshness and JTI retention, the RFC 8693 exchange lifetime cap and
the issued token's `exp`, Request Object temporal claims (RFC 9101), JWT
assertion claims (RFC 7523), session expiry including `SessionCache`,
authorization-code expiry, OIDC `max_age` re-authentication on both branches,
SAML `Conditions`, device-code and enrollment-state expiry, OAuth client secret
active/expired classification, policy history windows, and state-token `exp`.

`RecencyWindow::accepts` is deleted rather than converted: an ambient-clock
overload sitting beside `accepts_at` is the shape that invited the drift.

## The RFC 8693 gap this closes

The exchange cap computed the subject token's remaining TTL against one clock
while `create_oauth_access_token` stamped the issued `exp` from a second,
several awaited DB operations later, so an exchanged token could outlive its
subject by the difference. Both now measure from the arrival instant, making
`exp_issued = arrival + min(session, subject_exp − arrival)` provably at or
before `subject_exp`.

`test_rfc8693_access_token_exp_not_capped_by_subject_ttl` gains the absolute
assertion — the existing checks compared the issued `exp` against its own `iat`,
which shifts together with it and so could not see the overshoot. Simulating a
five-second inter-stamp drift fails it with `issued token exp (1789135567) must
not be later than the subject token's exp (1789135562)`.

## Keeping it from coming back

`disallowed-methods` for `jiff::Timestamp::now` is configured once in
`.clippy.toml`, held at `allow` workspace-wide in `Cargo.toml`, and raised to
`warn` only in vouch-server's two crate roots — the CLI and agent have no
request to anchor to. Tests are exempt through a `cfg_attr(test, expect(...))`
at the crate root.

Ambient stamping is still correct in four places, and each site says which via
`#[expect]`: the arrival middleware itself; optimistic-concurrency retry
closures, which need a fresh per-attempt reading rather than a stale captured
one; `created_at` / `expires_at` row stamping and artifact minting; and
background tasks. The `db` layer carries these on its module declarations,
since stamping the timestamps it writes is that layer's job.

Reintroducing an ambient stamp in a converted comparison trips the lint.

## Two follow-on commits

**`judge state-token exp against the caller's clock`** —
`StateTokenSigner::decode_state_token` stamped its own clock on the KMS branch
and delegated `exp` to `jsonwebtoken`'s internal `SystemTime::now()` on the
Local one, while every caller re-checked the same expiry against a second
reading. Both branches now take `now` and apply the same `now > exp` rule; the
crypto layer takes Unix seconds rather than `ArrivalTime`, which lives above it.
`exp` stays mandatory, since `jsonwebtoken` had been enforcing its presence and
a state token without an expiry would be replayable forever.

**`drop the ambient-clock DPoP JTI overload`** — `check_and_store_dpop_jti`'s
own doc warned that production callers sharing a clock with a freshness check
must not use it. After the threading, no production caller did. Removed, with
its 21 test callers moved to `check_and_store_dpop_jti_at_second`.

## Verification

`make fmt`, `make lint` (zero warnings under `-D warnings`), `make test`, and
`make test-integration` all pass. Three `prek` hooks fail — `detect private
key`, `shfmt`, and `zizmor` — identically with these changes stashed, so they
are pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
