### PR TITLE
chore: fix the three failing prek hooks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
       id-token: write
       attestations: write
       artifact-metadata: write
-    uses: ./.github/workflows/reusable-build.yml
+    uses: $/.github/workflows/reusable-build.yml
     with:
       version: ${{ needs.version.outputs.version }}
     secrets:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,9 @@ repos:
       - id: check-toml
       - id: detect-private-key
         # Verified test vectors, PEM-header marker strings, and doc examples —
-        # not real secrets (see first-run audit).
+        # not real secrets (see first-run audit). The last two hold the same
+        # throwaway self-signed P-256 key (CN `vouch-pq-tls-test`) used to stand
+        # up in-process TLS servers in tests.
         exclude: |
           (?x)^(
             crates/vouch-httpsig/tests/rfc9421_vectors\.rs|
@@ -48,6 +50,7 @@ repos:
             crates/vouch-server/src/crypto/keys\.rs|
             crates/vouch-server/src/crypto/pem\.rs|
             crates/vouch-server/src/infra/jwks\.rs|
+            crates/vouch-server/src/handlers/oidc/tests/rfc9101\.rs|
             crates/vouch-tests/tests/pq_tls\.rs
           )$
       - id: mixed-line-ending

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,7 +83,12 @@ repos:
       # pre-existing findings block a commit only when that workflow is edited.
       - id: actionlint
         name: actionlint
-        entry: actionlint
+        # actionlint 1.7.12 does not recognise GitHub's `$/` self-repository
+        # `uses:` syntax (added 2026-07-30) and reports it as a malformed
+        # reusable-workflow reference. The pattern matches only `$/`-prefixed
+        # values, so a genuinely malformed reference still fails. Support is
+        # in rhysd/actionlint#732 — drop this flag once it ships.
+        entry: actionlint -ignore 'reusable workflow call "\$/[^"]+" at "uses" is not following the format'
         language: system
         files: ^\.github/workflows/.*\.ya?ml$
 

--- a/packaging/ami/add-gpg-key.sh
+++ b/packaging/ami/add-gpg-key.sh
@@ -3,4 +3,4 @@
 # Adds GPG key configuration for Amazon Linux 2023 repository
 
 repo_file=$1
-echo "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2023" >> "${repo_file}"
+echo "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2023" >>"${repo_file}"

--- a/packaging/ami/edit_boot_install.sh
+++ b/packaging/ami/edit_boot_install.sh
@@ -40,8 +40,8 @@ build_dir=$(dirname "$disk_image")
 pcr_values_file="$build_dir/pcr_measurements.json"
 
 if [ ! -b "$root_device" ]; then
-    echo "ERROR: Root device not found at: $root_device"
-    exit 1
+  echo "ERROR: Root device not found at: $root_device"
+  exit 1
 fi
 
 root_mount=$(findmnt -n -o TARGET "$root_device")
@@ -51,90 +51,90 @@ efi_mount="${root_mount}/boot/efi"
 echo "INFO: Checking EFI partition at: $efi_mount"
 
 if ! mountpoint -q "$efi_mount"; then
-    echo "ERROR: EFI partition not mounted at: $efi_mount"
-    exit 1
+  echo "ERROR: EFI partition not mounted at: $efi_mount"
+  exit 1
 fi
 
 EFI_BINARY=$(find "$efi_mount/EFI/BOOT/" -name "BOOT*.EFI" -printf "%f\n" 2>/dev/null | head -n1)
 
 if [ -z "$EFI_BINARY" ]; then
-    echo "ERROR: Could not find BOOT*.EFI in $efi_mount/EFI/BOOT/"
-    exit 1
+  echo "ERROR: Could not find BOOT*.EFI in $efi_mount/EFI/BOOT/"
+  exit 1
 fi
 
 if [ -f "$efi_mount/EFI/Linux/kiwi.efi" ]; then
-    echo "INFO: Found kiwi.efi at: $efi_mount/EFI/Linux/kiwi.efi"
+  echo "INFO: Found kiwi.efi at: $efi_mount/EFI/Linux/kiwi.efi"
 
-    echo "INFO: Removing existing $EFI_BINARY"
-    rm -f "$efi_mount/EFI/BOOT/$EFI_BINARY"
+  echo "INFO: Removing existing $EFI_BINARY"
+  rm -f "$efi_mount/EFI/BOOT/$EFI_BINARY"
 
-    echo "INFO: Moving kiwi.efi to $EFI_BINARY location"
-    cp "$efi_mount/EFI/Linux/kiwi.efi" "$efi_mount/EFI/BOOT/$EFI_BINARY"
+  echo "INFO: Moving kiwi.efi to $EFI_BINARY location"
+  cp "$efi_mount/EFI/Linux/kiwi.efi" "$efi_mount/EFI/BOOT/$EFI_BINARY"
 
-    echo "INFO: Removing /EFI/Linux directory"
-    rm -rf "$efi_mount/EFI/Linux"
+  echo "INFO: Removing /EFI/Linux directory"
+  rm -rf "$efi_mount/EFI/Linux"
 
-    if [ -d "$efi_mount/EFI/systemd" ]; then
-        echo "INFO: Removing /EFI/systemd directory"
-        rm -rf "$efi_mount/EFI/systemd"
-    fi
+  if [ -d "$efi_mount/EFI/systemd" ]; then
+    echo "INFO: Removing /EFI/systemd directory"
+    rm -rf "$efi_mount/EFI/systemd"
+  fi
 
-    # --- Secure Boot signing ---
-    # Sign the UKI with the DB key BEFORE computing PCR measurements
-    # so that PCR4 reflects the signed binary.
-    DB_KEY="${DB_KEY:-}"
-    DB_CRT="${DB_CRT:-}"
+  # --- Secure Boot signing ---
+  # Sign the UKI with the DB key BEFORE computing PCR measurements
+  # so that PCR4 reflects the signed binary.
+  DB_KEY="${DB_KEY:-}"
+  DB_CRT="${DB_CRT:-}"
 
-    if [ -n "$DB_KEY" ] && [ -n "$DB_CRT" ] && [ -f "$DB_KEY" ] && [ -f "$DB_CRT" ]; then
-        echo "INFO: Signing UKI with Secure Boot DB key"
-        UKI_PATH="$efi_mount/EFI/BOOT/$EFI_BINARY"
-        SIGNED_UKI="${UKI_PATH}.signed"
-
-        if sbsign --key "$DB_KEY" --cert "$DB_CRT" --output "$SIGNED_UKI" "$UKI_PATH"; then
-            mv "$SIGNED_UKI" "$UKI_PATH"
-            echo "SUCCESS: UKI signed with Secure Boot DB key"
-        else
-            echo "ERROR: Failed to sign UKI with sbsign"
-            exit 1
-        fi
-    else
-        echo "WARNING: Secure Boot DB key/cert not found, skipping UKI signing"
-        echo "  DB_KEY=${DB_KEY:-<not set>}"
-        echo "  DB_CRT=${DB_CRT:-<not set>}"
-    fi
-
-    # --- PCR4 and PCR7 measurement ---
-    if sudo "$root_mount/usr/bin/nitro-tpm-pcr-compute" \
-        --image "$efi_mount/EFI/BOOT/$EFI_BINARY" | tee "$pcr_values_file"; then
-        echo "SUCCESS: PCR4/PCR7 measurements computed and saved to: $pcr_values_file"
-    else
-        echo "ERROR: Failed to compute PCR measurements for UKI"
-        exit 1
-    fi
-
-    # --- PCR12 computation (kernel command line) ---
-    # PCR12 records the kernel command line embedded in the UKI.
-    # Extract the .cmdline section, hash it, and simulate a PCR extend
-    # from the initial all-zeros state.
-    echo "INFO: Computing PCR12 (kernel command line)"
-    CMDLINE_BIN=$(mktemp)
+  if [ -n "$DB_KEY" ] && [ -n "$DB_CRT" ] && [ -f "$DB_KEY" ] && [ -f "$DB_CRT" ]; then
+    echo "INFO: Signing UKI with Secure Boot DB key"
     UKI_PATH="$efi_mount/EFI/BOOT/$EFI_BINARY"
+    SIGNED_UKI="${UKI_PATH}.signed"
 
-    if objcopy -O binary -j .cmdline "$UKI_PATH" "$CMDLINE_BIN" 2>/dev/null; then
-        # SHA-384 hash of the command line content (matches NitroTPM PCR bank)
-        CMDLINE_HASH=$(sha384sum "$CMDLINE_BIN" | cut -d' ' -f1)
-        echo "INFO: Kernel command line SHA-384: $CMDLINE_HASH"
+    if sbsign --key "$DB_KEY" --cert "$DB_CRT" --output "$SIGNED_UKI" "$UKI_PATH"; then
+      mv "$SIGNED_UKI" "$UKI_PATH"
+      echo "SUCCESS: UKI signed with Secure Boot DB key"
+    else
+      echo "ERROR: Failed to sign UKI with sbsign"
+      exit 1
+    fi
+  else
+    echo "WARNING: Secure Boot DB key/cert not found, skipping UKI signing"
+    echo "  DB_KEY=${DB_KEY:-<not set>}"
+    echo "  DB_CRT=${DB_CRT:-<not set>}"
+  fi
 
-        # Simulate PCR extend: SHA-384(48_zero_bytes || cmdline_hash)
-        # Initial PCR state is 48 zero bytes (SHA-384 bank)
-        ZERO_PCR="000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-        PCR12=$(printf '%s%s' "$ZERO_PCR" "$CMDLINE_HASH" | xxd -r -p | sha384sum | cut -d' ' -f1)
-        echo "INFO: PCR12 value: $PCR12"
+  # --- PCR4 and PCR7 measurement ---
+  if sudo "$root_mount/usr/bin/nitro-tpm-pcr-compute" \
+    --image "$efi_mount/EFI/BOOT/$EFI_BINARY" | tee "$pcr_values_file"; then
+    echo "SUCCESS: PCR4/PCR7 measurements computed and saved to: $pcr_values_file"
+  else
+    echo "ERROR: Failed to compute PCR measurements for UKI"
+    exit 1
+  fi
 
-        # Merge PCR12 into the measurements JSON and flatten nested values
-        # nitro-tpm-pcr-compute nests PCR values under "Measurements",
-        # but the workflow reads from the top level.
-        python3 -c "
+  # --- PCR12 computation (kernel command line) ---
+  # PCR12 records the kernel command line embedded in the UKI.
+  # Extract the .cmdline section, hash it, and simulate a PCR extend
+  # from the initial all-zeros state.
+  echo "INFO: Computing PCR12 (kernel command line)"
+  CMDLINE_BIN=$(mktemp)
+  UKI_PATH="$efi_mount/EFI/BOOT/$EFI_BINARY"
+
+  if objcopy -O binary -j .cmdline "$UKI_PATH" "$CMDLINE_BIN" 2>/dev/null; then
+    # SHA-384 hash of the command line content (matches NitroTPM PCR bank)
+    CMDLINE_HASH=$(sha384sum "$CMDLINE_BIN" | cut -d' ' -f1)
+    echo "INFO: Kernel command line SHA-384: $CMDLINE_HASH"
+
+    # Simulate PCR extend: SHA-384(48_zero_bytes || cmdline_hash)
+    # Initial PCR state is 48 zero bytes (SHA-384 bank)
+    ZERO_PCR="000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    PCR12=$(printf '%s%s' "$ZERO_PCR" "$CMDLINE_HASH" | xxd -r -p | sha384sum | cut -d' ' -f1)
+    echo "INFO: PCR12 value: $PCR12"
+
+    # Merge PCR12 into the measurements JSON and flatten nested values
+    # nitro-tpm-pcr-compute nests PCR values under "Measurements",
+    # but the workflow reads from the top level.
+    python3 -c "
 import json
 with open('$pcr_values_file', 'r') as f:
     data = json.load(f)
@@ -147,13 +147,13 @@ with open('$pcr_values_file', 'w') as f:
     json.dump(data, f, indent=2)
 print('SUCCESS: PCR values merged into', '$pcr_values_file')
 "
-    else
-        echo "WARNING: Could not extract .cmdline section from UKI, skipping PCR12"
-    fi
-    rm -f "$CMDLINE_BIN"
+  else
+    echo "WARNING: Could not extract .cmdline section from UKI, skipping PCR12"
+  fi
+  rm -f "$CMDLINE_BIN"
 else
-    echo "ERROR: UKI not found at expected location: $efi_mount/EFI/Linux/kiwi.efi"
-    echo "DEBUG: Current EFI directory contents:"
-    ls -R "$efi_mount/EFI/"
-    exit 1
+  echo "ERROR: UKI not found at expected location: $efi_mount/EFI/Linux/kiwi.efi"
+  echo "DEBUG: Current EFI directory contents:"
+  ls -R "$efi_mount/EFI/"
+  exit 1
 fi

--- a/packaging/ami/generate-sb-keys.sh
+++ b/packaging/ami/generate-sb-keys.sh
@@ -50,29 +50,29 @@ set -euo pipefail
 # efitools is Linux-only. On macOS, re-exec this script inside a container.
 
 if [ "${1:-}" = "--docker" ]; then
-    shift
-    OUTPUT_DIR="${1:-./secureboot-keys}"
-    mkdir -p "$OUTPUT_DIR"
-    ABS_OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
-    SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+  shift
+  OUTPUT_DIR="${1:-./secureboot-keys}"
+  mkdir -p "$OUTPUT_DIR"
+  ABS_OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-    echo "=== Running in Docker (efitools is Linux-only) ==="
-    echo "Script: $SCRIPT_DIR/generate-sb-keys.sh"
-    echo "Output: $ABS_OUTPUT_DIR"
-    docker run --rm \
-        -v "$SCRIPT_DIR/generate-sb-keys.sh:/generate-sb-keys.sh:ro" \
-        -v "$ABS_OUTPUT_DIR:/output" \
-        ubuntu:24.04 \
-        bash -eux -c '
+  echo "=== Running in Docker (efitools is Linux-only) ==="
+  echo "Script: $SCRIPT_DIR/generate-sb-keys.sh"
+  echo "Output: $ABS_OUTPUT_DIR"
+  docker run --rm \
+    -v "$SCRIPT_DIR/generate-sb-keys.sh:/generate-sb-keys.sh:ro" \
+    -v "$ABS_OUTPUT_DIR:/output" \
+    ubuntu:24.04 \
+    bash -eux -c '
             apt-get update -qq
             apt-get install -y -qq efitools openssl python3 python3-pip 2>&1 | tail -1
             pip install --break-system-packages uefivars 2>&1 | tail -1
             bash /generate-sb-keys.sh /output
         '
-    echo ""
-    echo "Output written to: ${OUTPUT_DIR}/"
-    ls -la "${OUTPUT_DIR}/"
-    exit 0
+  echo ""
+  echo "Output written to: ${OUTPUT_DIR}/"
+  ls -la "${OUTPUT_DIR}/"
+  exit 0
 fi
 
 # --- Native mode (Linux) ---
@@ -80,7 +80,7 @@ fi
 OUTPUT_DIR="${1:-./secureboot-keys}"
 GUID="$(python3 -c 'import uuid; print(str(uuid.uuid4()))')"
 SUBJECT_PREFIX="/CN=Vouch Secure Boot"
-VALIDITY_DAYS=3650  # ~10 years
+VALIDITY_DAYS=3650 # ~10 years
 
 echo "=== Vouch UEFI Secure Boot Key Generation ==="
 echo "Output directory: ${OUTPUT_DIR}"
@@ -89,22 +89,22 @@ echo ""
 
 # Check prerequisites
 for cmd in openssl cert-to-efi-sig-list sign-efi-sig-list; do
-    if ! command -v "$cmd" &>/dev/null; then
-        echo "ERROR: Required command not found: $cmd"
-        echo ""
-        echo "On macOS, run with --docker flag instead:"
-        echo "  ./generate-sb-keys.sh --docker [output-dir]"
-        echo ""
-        echo "On Linux, install dependencies:"
-        echo "  apt install efitools openssl"
-        echo "  pip install uefivars"
-        exit 1
-    fi
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "ERROR: Required command not found: $cmd"
+    echo ""
+    echo "On macOS, run with --docker flag instead:"
+    echo "  ./generate-sb-keys.sh --docker [output-dir]"
+    echo ""
+    echo "On Linux, install dependencies:"
+    echo "  apt install efitools openssl"
+    echo "  pip install uefivars"
+    exit 1
+  fi
 done
 
 if ! command -v uefivars &>/dev/null; then
-    echo "ERROR: uefivars not found. Install with: pip install uefivars"
-    exit 1
+  echo "ERROR: uefivars not found. Install with: pip install uefivars"
+  exit 1
 fi
 
 mkdir -p "${OUTPUT_DIR}"
@@ -114,16 +114,16 @@ mkdir -p "${OUTPUT_DIR}"
 echo "=== Generating RSA-4096 key pairs ==="
 
 for name in PK KEK DB; do
-    echo "Generating ${name} key pair..."
-    openssl req -new -x509 \
-        -newkey rsa:4096 \
-        -sha256 \
-        -days "${VALIDITY_DAYS}" \
-        -nodes \
-        -subj "${SUBJECT_PREFIX} ${name}" \
-        -keyout "${OUTPUT_DIR}/${name}.key" \
-        -out "${OUTPUT_DIR}/${name}.crt"
-    chmod 600 "${OUTPUT_DIR}/${name}.key"
+  echo "Generating ${name} key pair..."
+  openssl req -new -x509 \
+    -newkey rsa:4096 \
+    -sha256 \
+    -days "${VALIDITY_DAYS}" \
+    -nodes \
+    -subj "${SUBJECT_PREFIX} ${name}" \
+    -keyout "${OUTPUT_DIR}/${name}.key" \
+    -out "${OUTPUT_DIR}/${name}.crt"
+  chmod 600 "${OUTPUT_DIR}/${name}.key"
 done
 
 echo ""
@@ -133,10 +133,10 @@ echo ""
 echo "=== Generating EFI Signature Lists ==="
 
 for name in PK KEK DB; do
-    echo "Creating ${name}.esl..."
-    cert-to-efi-sig-list -g "${GUID}" \
-        "${OUTPUT_DIR}/${name}.crt" \
-        "${OUTPUT_DIR}/${name}.esl"
+  echo "Creating ${name}.esl..."
+  cert-to-efi-sig-list -g "${GUID}" \
+    "${OUTPUT_DIR}/${name}.crt" \
+    "${OUTPUT_DIR}/${name}.esl"
 done
 
 echo ""
@@ -148,29 +148,29 @@ echo "=== Generating signed .auth variables ==="
 # PK signs itself
 echo "Signing PK.auth (self-signed)..."
 sign-efi-sig-list -g "${GUID}" \
-    -k "${OUTPUT_DIR}/PK.key" \
-    -c "${OUTPUT_DIR}/PK.crt" \
-    PK \
-    "${OUTPUT_DIR}/PK.esl" \
-    "${OUTPUT_DIR}/PK.auth"
+  -k "${OUTPUT_DIR}/PK.key" \
+  -c "${OUTPUT_DIR}/PK.crt" \
+  PK \
+  "${OUTPUT_DIR}/PK.esl" \
+  "${OUTPUT_DIR}/PK.auth"
 
 # PK signs KEK
 echo "Signing KEK.auth (signed by PK)..."
 sign-efi-sig-list -g "${GUID}" \
-    -k "${OUTPUT_DIR}/PK.key" \
-    -c "${OUTPUT_DIR}/PK.crt" \
-    KEK \
-    "${OUTPUT_DIR}/KEK.esl" \
-    "${OUTPUT_DIR}/KEK.auth"
+  -k "${OUTPUT_DIR}/PK.key" \
+  -c "${OUTPUT_DIR}/PK.crt" \
+  KEK \
+  "${OUTPUT_DIR}/KEK.esl" \
+  "${OUTPUT_DIR}/KEK.auth"
 
 # KEK signs DB
 echo "Signing DB.auth (signed by KEK)..."
 sign-efi-sig-list -g "${GUID}" \
-    -k "${OUTPUT_DIR}/KEK.key" \
-    -c "${OUTPUT_DIR}/KEK.crt" \
-    db \
-    "${OUTPUT_DIR}/DB.esl" \
-    "${OUTPUT_DIR}/DB.auth"
+  -k "${OUTPUT_DIR}/KEK.key" \
+  -c "${OUTPUT_DIR}/KEK.crt" \
+  db \
+  "${OUTPUT_DIR}/DB.esl" \
+  "${OUTPUT_DIR}/DB.auth"
 
 echo ""
 
@@ -179,10 +179,10 @@ echo ""
 echo "=== Generating UEFI variable store ==="
 
 uefivars -i none -o aws \
-    -P "${OUTPUT_DIR}/PK.esl" \
-    -K "${OUTPUT_DIR}/KEK.esl" \
-    -b "${OUTPUT_DIR}/DB.esl" \
-    -O "${OUTPUT_DIR}/uefi-vars.b64"
+  -P "${OUTPUT_DIR}/PK.esl" \
+  -K "${OUTPUT_DIR}/KEK.esl" \
+  -b "${OUTPUT_DIR}/DB.esl" \
+  -O "${OUTPUT_DIR}/uefi-vars.b64"
 
 echo ""
 

--- a/packaging/postinstall-server.sh
+++ b/packaging/postinstall-server.sh
@@ -15,8 +15,8 @@ mkdir -p /etc/vouch-server
 chmod 750 /etc/vouch-server
 
 # Grant capability to bind privileged ports (80, 443)
-if command -v setcap &> /dev/null; then
-    setcap 'cap_net_bind_service=+ep' /usr/bin/vouch-server || true
+if command -v setcap &>/dev/null; then
+  setcap 'cap_net_bind_service=+ep' /usr/bin/vouch-server || true
 fi
 
 echo ""


### PR DESCRIPTION
`prek run --all-files` had three failing hooks on `main`. All three were
latent rather than new: `detect-private-key`, `shfmt`, and `zizmor` are scoped
to staged files, so a finding only blocks a commit that touches the file
carrying it. None of the three is run in CI, so nothing else caught them.

`prek run --all-files` now passes clean.

## detect-private-key

`crates/vouch-server/src/handlers/oidc/tests/rfc9101.rs` carries a PEM private
key. It is byte-identical to the throwaway self-signed P-256 key
(CN `vouch-pq-tls-test`) in `crates/vouch-tests/tests/pq_tls.rs`, which is
already on the exclude list — both stand up an in-process TLS server so a test
can drive an HTTPS-only fetch path. Added to the same list.

The duplication is worth noting separately: two copies of one fixture is how
the second copy escaped the exclusion in the first place. Collapsing them into
a shared test fixture would be a better end state, but it crosses a crate
boundary and is not hook cleanup, so it is left alone here.

## shfmt

Four `packaging/` scripts predate the hook, using four-space indentation and a
space before `>>`. Reformatted with `shfmt -i 2 -w`.

The change is whitespace only — `git diff -w` over `packaging/` is empty — all
four still pass `bash -n`, and `shellcheck` reports no change.

## zizmor

One `low` finding: `release.yml` called its reusable workflow with the
workspace-relative `./` form rather than GitHub's `$/` self-repository syntax.
Now `uses: $/.github/workflows/reusable-build.yml`.

Both constraints GitHub documents on `$/` were checked and do not apply: the
syntax is unavailable on GitHub Enterprise Server (this repo is on
github.com) and needs runner 2.336.0 or newer (every runner in
`reusable-build.yml` is GitHub-hosted).

`actionlint` 1.7.12 does not recognise the syntax yet and reports it as a
malformed reusable-workflow reference, so the hook gains an `-ignore` pattern
matched to `$/`-prefixed values only. Verified narrow: substituting a
malformed reference of a different shape still fails the hook. Support is in
rhysd/actionlint#732, and the flag comes out when that ships.

### One thing to confirm at the next release

This line feeds the Sigstore signer identity that `CONTRIBUTING.md:374` tells
verifiers to pin:

```bash
gh attestation verify vouch-v<version>-<target>.tar.gz \
  --owner vouch-sh \
  --signer-workflow vouch-sh/vouch/.github/workflows/reusable-build.yml
```

GitHub does not document what `job_workflow_ref` resolves to under `$/`, and
it cannot be exercised without cutting a release. `--signer-workflow` matches
on the `owner/repo/path` portion, so it should be unaffected, but that is
reasoning rather than evidence — worth running the command against the first
artifact built after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
