### PR TITLE
fix(cli): resolve tool config paths as those tools document

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7485,7 +7485,6 @@ dependencies = [
  "clap",
  "clap_complete",
  "ctap-hid-fido2",
- "dirs",
  "ed25519-dalek 3.0.0",
  "gethostname",
  "hex",

--- a/crates/vouch-agent/src/ssh_agent/provisioning.rs
+++ b/crates/vouch-agent/src/ssh_agent/provisioning.rs
@@ -68,7 +68,7 @@ async fn try_load_from_disk(state: &Arc<AgentState>) -> Option<SshCredentials> {
     state.get_session().await?;
 
     // Check for default key and cert files on disk
-    let home = std::env::home_dir()?;
+    let home = vouch_common::paths::home_dir()?;
     let ssh_dir = home.join(".ssh");
     let key_path = ssh_dir.join(DEFAULT_KEY_NAME);
     let cert_path = ssh_dir.join(format!("{DEFAULT_KEY_NAME}-cert.pub"));

--- a/crates/vouch-cli/Cargo.toml
+++ b/crates/vouch-cli/Cargo.toml
@@ -31,7 +31,6 @@ base64 = { workspace = true, features = ["std"] }
 ciborium = { workspace = true }
 clap = { workspace = true, features = ["std", "derive", "env", "help", "usage", "error-context", "suggestions", "color"] }
 clap_complete = { workspace = true }
-dirs = { workspace = true }
 gethostname = { workspace = true }
 ed25519-dalek = { workspace = true }
 hex = { workspace = true, features = ["std"] }

--- a/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
+++ b/crates/vouch-cli/i18n/en-US/vouch-cli.ftl
@@ -1044,6 +1044,7 @@ setup-err-load-vouch-config = failed to load { -product } config
 setup-err-not-configured = not configured - run '{ -cmd } enroll' first
 setup-err-anthropic-not-enrolled = not configured — run '{ -cmd } enroll' first
 setup-err-no-home = could not determine home directory
+setup-err-no-appdata = could not determine the APPDATA directory
 
 ## server-url validation
 

--- a/crates/vouch-cli/src/commands/credential/ssh.rs
+++ b/crates/vouch-cli/src/commands/credential/ssh.rs
@@ -36,7 +36,8 @@ impl KeypairAction {
 
 /// Get the SSH directory path (~/.ssh).
 pub(crate) fn ssh_dir() -> Result<PathBuf> {
-    let home = dirs::home_dir().context(tr!("err-could-not-determine-home-directory"))?;
+    let home =
+        vouch_common::paths::home_dir().context(tr!("err-could-not-determine-home-directory"))?;
     Ok(home.join(".ssh"))
 }
 

--- a/crates/vouch-cli/src/commands/doctor.rs
+++ b/crates/vouch-cli/src/commands/doctor.rs
@@ -483,7 +483,7 @@ async fn check_session() -> CheckResult {
 
 /// Check SSH configuration for Vouch integration.
 fn check_ssh_config() -> CheckResult {
-    let home = match dirs::home_dir() {
+    let home = match vouch_common::paths::home_dir() {
         Some(h) => h,
         None => return CheckResult::fail("ssh", tr!("doctor-ssh-no-home")),
     };
@@ -551,7 +551,7 @@ fn check_ssm_config() -> CheckResult {
 
     let plugin_found = is_plugin_available();
 
-    let home = match dirs::home_dir() {
+    let home = match vouch_common::paths::home_dir() {
         Some(h) => h,
         None => return CheckResult::fail("ssm", tr!("doctor-ssm-no-home")),
     };

--- a/crates/vouch-cli/src/commands/setup/aws.rs
+++ b/crates/vouch-cli/src/commands/setup/aws.rs
@@ -57,7 +57,7 @@ fn sanitize_profile_name(name: &str) -> String {
 /// Open (or create) `~/.aws/config` and ensure the `.aws` directory exists.
 fn load_or_create_aws_config() -> Result<AwsConfig> {
     let config_path = AwsConfig::default_path()?;
-    let aws_dir = dirs::home_dir()
+    let aws_dir = vouch_common::paths::home_dir()
         .context(tr!("err-could-not-determine-home-directory"))?
         .join(".aws");
     ensure_secure_dir(&aws_dir)?;

--- a/crates/vouch-cli/src/commands/setup/codeartifact.rs
+++ b/crates/vouch-cli/src/commands/setup/codeartifact.rs
@@ -218,15 +218,8 @@ fn install_keyring_wrapper() -> Result<()> {
 /// Loads the existing pip.conf (if any), updates the `[global]` section
 /// with `index-url` and `keyring-provider`, preserving any other settings.
 fn write_pip_config(index_url: &str) -> Result<()> {
-    let config_dir = get_pip_config_dir()?;
-    std::fs::create_dir_all(&config_dir).with_context(|| {
-        vouch_cli::tr_args!(
-            "setup-ca-err-create-dir",
-            path = config_dir.display().to_string()
-        )
-    })?;
-
-    let config_path = config_dir.join("pip.conf");
+    let config_path = pip_config_path()?;
+    create_parent_dir(&config_path)?;
 
     // Load existing config or create new
     let mut ini = if config_path.exists() {
@@ -268,18 +261,84 @@ fn write_pip_config(index_url: &str) -> Result<()> {
     Ok(())
 }
 
-/// Get the pip config directory path.
-fn get_pip_config_dir() -> Result<std::path::PathBuf> {
-    // Respect PIP_CONFIG_FILE if set
-    if let Ok(pip_config) = std::env::var("PIP_CONFIG_FILE") {
-        let path = std::path::PathBuf::from(pip_config);
-        if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
-            return Ok(parent.to_path_buf());
-        }
+/// Create the directory holding `path`, if it does not already exist.
+fn create_parent_dir(path: &std::path::Path) -> Result<()> {
+    let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) else {
+        return Ok(());
+    };
+    std::fs::create_dir_all(parent).with_context(|| {
+        vouch_cli::tr_args!(
+            "setup-ca-err-create-dir",
+            path = parent.display().to_string()
+        )
+    })
+}
+
+/// Path to pip's user-level configuration file.
+///
+/// Mirrors pip's documented search order, which differs by platform. On macOS
+/// the choice is gated on which directory already exists, so vouch must probe
+/// rather than pick — writing `~/.config/pip/pip.conf` on a Mac that has a
+/// `~/Library/Application Support/pip` directory produces a file pip ignores.
+///
+/// See <https://pip.pypa.io/en/stable/topics/configuration/>.
+fn pip_config_path() -> Result<std::path::PathBuf> {
+    // PIP_CONFIG_FILE names the file itself, not its directory, and pip loads it
+    // last — overriding the user config rather than sitting beside it.
+    if let Some(explicit) = env_path("PIP_CONFIG_FILE") {
+        return Ok(explicit);
     }
 
-    let home = dirs::home_dir().with_context(|| vouch_cli::tr!("setup-err-no-home"))?;
-    Ok(home.join(".config").join("pip"))
+    // `cfg!` rather than `#[cfg]` so every branch is compiled — and its helper
+    // unit-tested — on every platform.
+    if cfg!(windows) {
+        // pip reads %APPDATA%\pip\pip.ini; note the extension differs from Unix.
+        let appdata =
+            env_path("APPDATA").with_context(|| vouch_cli::tr!("setup-err-no-appdata"))?;
+        return Ok(appdata.join("pip").join("pip.ini"));
+    }
+
+    if cfg!(target_os = "macos") {
+        let home =
+            vouch_common::paths::home_dir().with_context(|| vouch_cli::tr!("setup-err-no-home"))?;
+        return Ok(macos_pip_config_path(
+            env_path("XDG_DATA_HOME").as_deref(),
+            &home,
+        ));
+    }
+
+    let base = vouch_common::paths::xdg_config_home()
+        .with_context(|| vouch_cli::tr!("setup-err-no-home"))?;
+    Ok(base.join("pip").join("pip.conf"))
+}
+
+/// pip's macOS user-config location: the first candidate directory that exists,
+/// falling back to `~/.config/pip`.
+///
+/// `xdg_data_home` is the raw environment value — pip consults the *data* base
+/// here, not the config base, and only when the variable is set.
+fn macos_pip_config_path(
+    xdg_data_home: Option<&std::path::Path>,
+    home: &std::path::Path,
+) -> std::path::PathBuf {
+    let mut candidates: Vec<std::path::PathBuf> = Vec::new();
+    if let Some(data) = xdg_data_home {
+        candidates.push(data.join("pip"));
+    }
+    candidates.push(home.join("Library").join("Application Support").join("pip"));
+
+    let dir = candidates
+        .into_iter()
+        .find(|d| d.is_dir())
+        .unwrap_or_else(|| home.join(".config").join("pip"));
+    dir.join("pip.conf")
+}
+
+/// Read `var` as a path, treating unset and empty as absent.
+fn env_path(var: &str) -> Option<std::path::PathBuf> {
+    std::env::var_os(var)
+        .filter(|v| !v.is_empty())
+        .map(std::path::PathBuf::from)
 }
 
 /// Configure uv for CodeArtifact using the keyring credential helper.
@@ -287,8 +346,8 @@ fn get_pip_config_dir() -> Result<std::path::PathBuf> {
 /// uv supports the same `keyring` subprocess protocol as pip, but does NOT
 /// read `pip.conf`. Instead, it uses its own `uv.toml` configuration file.
 /// This sets up `keyring-provider = "subprocess"` and configures the
-/// CodeArtifact index in `~/.config/uv/uv.toml`, then reuses the same
-/// `~/.local/bin/keyring` wrapper that pip setup installs.
+/// CodeArtifact index in uv's `uv.toml`, then reuses the same `keyring`
+/// wrapper that pip setup installs.
 fn setup_uv(ca_host: &str, repository: &str) -> Result<()> {
     let index_url = format!("https://aws@{ca_host}/pypi/{repository}/simple/");
 
@@ -301,21 +360,14 @@ fn setup_uv(ca_host: &str, repository: &str) -> Result<()> {
     Ok(())
 }
 
-/// Write uv configuration file (`~/.config/uv/uv.toml`).
+/// Write uv's configuration file, at the path [`uv_config_path`] resolves.
 ///
 /// Loads the existing uv.toml (if any) via `toml_edit` to preserve other
 /// settings, then sets `keyring-provider = "subprocess"` and adds (or
 /// updates) a CodeArtifact index entry.
 fn write_uv_config(index_url: &str, repository: &str) -> Result<()> {
-    let config_dir = get_uv_config_dir()?;
-    std::fs::create_dir_all(&config_dir).with_context(|| {
-        vouch_cli::tr_args!(
-            "setup-ca-err-create-dir",
-            path = config_dir.display().to_string()
-        )
-    })?;
-
-    let config_path = config_dir.join("uv.toml");
+    let config_path = uv_config_path()?;
+    create_parent_dir(&config_path)?;
 
     // Load existing config or create new
     let content = if config_path.exists() {
@@ -390,18 +442,25 @@ fn write_uv_config(index_url: &str, repository: &str) -> Result<()> {
     Ok(())
 }
 
-/// Get the uv config directory path.
-fn get_uv_config_dir() -> Result<std::path::PathBuf> {
-    // Respect UV_CONFIG_FILE if set
-    if let Ok(uv_config) = std::env::var("UV_CONFIG_FILE") {
-        let path = std::path::PathBuf::from(uv_config);
-        if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
-            return Ok(parent.to_path_buf());
-        }
+/// Path to uv's user-level configuration file.
+///
+/// uv follows XDG on macOS as well as Linux, so — unlike pip — there is no
+/// Apple-specific location in the chain.
+/// See <https://docs.astral.sh/uv/reference/storage/>.
+fn uv_config_path() -> Result<std::path::PathBuf> {
+    // UV_CONFIG_FILE names the file itself, and replaces discovery entirely.
+    if let Some(explicit) = env_path("UV_CONFIG_FILE") {
+        return Ok(explicit);
     }
 
-    let home = dirs::home_dir().with_context(|| vouch_cli::tr!("setup-err-no-home"))?;
-    Ok(home.join(".config").join("uv"))
+    let base = if cfg!(windows) {
+        env_path("APPDATA").with_context(|| vouch_cli::tr!("setup-err-no-appdata"))?
+    } else {
+        vouch_common::paths::xdg_config_home()
+            .with_context(|| vouch_cli::tr!("setup-err-no-home"))?
+    };
+
+    Ok(base.join("uv").join("uv.toml"))
 }
 
 /// Configure npm for CodeArtifact.
@@ -478,7 +537,8 @@ fn warn_npmrc_conflict(existing: &str, ca_host: &str, repository: &str, setting_
 /// Preserves existing entries while updating/adding CodeArtifact-specific lines.
 /// Only lines matching this specific host/repo are replaced.
 fn write_npmrc(ca_host: &str, repository: &str, token: &str) -> Result<()> {
-    let home = dirs::home_dir().with_context(|| vouch_cli::tr!("setup-err-no-home"))?;
+    let home =
+        vouch_common::paths::home_dir().with_context(|| vouch_cli::tr!("setup-err-no-home"))?;
     let npmrc_path = home.join(".npmrc");
 
     let existing = if npmrc_path.exists() {
@@ -558,7 +618,8 @@ fn install_pnpm_token_helper() -> Result<std::path::PathBuf> {
 /// Preserves existing entries while updating/adding the `tokenHelper`
 /// directive for the given CodeArtifact registry.
 fn write_npmrc_pnpm(ca_host: &str, repository: &str, helper_path: &std::path::Path) -> Result<()> {
-    let home = dirs::home_dir().with_context(|| vouch_cli::tr!("setup-err-no-home"))?;
+    let home =
+        vouch_common::paths::home_dir().with_context(|| vouch_cli::tr!("setup-err-no-home"))?;
     let npmrc_path = home.join(".npmrc");
 
     let existing = if npmrc_path.exists() {
@@ -633,7 +694,8 @@ pub(crate) async fn auto_refresh_npmrc(server: &str) {
 /// Inner implementation for `auto_refresh_npmrc` that returns `Result`
 /// for ergonomic error handling.
 async fn try_refresh_npmrc(server: &str) -> Result<()> {
-    let home = dirs::home_dir().with_context(|| vouch_cli::tr!("setup-err-no-home"))?;
+    let home =
+        vouch_common::paths::home_dir().with_context(|| vouch_cli::tr!("setup-err-no-home"))?;
     let npmrc_path = home.join(".npmrc");
 
     let content = match std::fs::read_to_string(&npmrc_path) {
@@ -1153,5 +1215,87 @@ mod tests {
             let map: BTreeMap<&str, &str> = BTreeMap::new();
             let _ = rewrite_npmrc_tokens(&content, &map);
         }
+    }
+
+    // =========================================================================
+    // macos_pip_config_path tests
+    //
+    // pip's macOS search order is existence-gated, so the location depends on
+    // which directories are already on disk. Each case builds that state in a
+    // tempdir rather than mutating the environment. pip documents the order as:
+    // `$XDG_DATA_HOME/pip` (if set and present), then
+    // `~/Library/Application Support/pip` (if present), then `~/.config/pip`.
+    // <https://pip.pypa.io/en/stable/topics/configuration/>
+    // =========================================================================
+
+    /// `~/Library/Application Support/pip` for the given home.
+    fn apple_pip_dir(home: &std::path::Path) -> std::path::PathBuf {
+        home.join("Library").join("Application Support").join("pip")
+    }
+
+    #[test]
+    fn macos_pip_falls_back_to_xdg_config_when_nothing_exists() {
+        let home = tempfile::tempdir().unwrap();
+        let got = macos_pip_config_path(None, home.path());
+        assert_eq!(
+            got,
+            home.path().join(".config").join("pip").join("pip.conf")
+        );
+    }
+
+    #[test]
+    fn macos_pip_prefers_apple_dir_when_it_exists() {
+        let home = tempfile::tempdir().unwrap();
+        let apple = apple_pip_dir(home.path());
+        std::fs::create_dir_all(&apple).unwrap();
+
+        let got = macos_pip_config_path(None, home.path());
+        assert_eq!(got, apple.join("pip.conf"));
+    }
+
+    #[test]
+    fn macos_pip_prefers_xdg_data_home_over_apple_dir() {
+        let home = tempfile::tempdir().unwrap();
+        let data = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(apple_pip_dir(home.path())).unwrap();
+        let data_pip = data.path().join("pip");
+        std::fs::create_dir_all(&data_pip).unwrap();
+
+        let got = macos_pip_config_path(Some(data.path()), home.path());
+        assert_eq!(got, data_pip.join("pip.conf"));
+    }
+
+    #[test]
+    fn macos_pip_ignores_xdg_data_home_whose_pip_dir_is_absent() {
+        // pip gates on the directory existing, not merely on the variable
+        // being set — an unconditional write here would be ignored by pip.
+        let home = tempfile::tempdir().unwrap();
+        let data = tempfile::tempdir().unwrap();
+        let apple = apple_pip_dir(home.path());
+        std::fs::create_dir_all(&apple).unwrap();
+
+        let got = macos_pip_config_path(Some(data.path()), home.path());
+        assert_eq!(got, apple.join("pip.conf"));
+    }
+
+    #[test]
+    fn macos_pip_ignores_a_pip_path_that_is_a_file() {
+        let home = tempfile::tempdir().unwrap();
+        let apple = apple_pip_dir(home.path());
+        std::fs::create_dir_all(apple.parent().unwrap()).unwrap();
+        std::fs::write(&apple, b"not a directory").unwrap();
+
+        let got = macos_pip_config_path(None, home.path());
+        assert_eq!(
+            got,
+            home.path().join(".config").join("pip").join("pip.conf")
+        );
+    }
+
+    // -- env_path --
+
+    #[test]
+    fn env_path_treats_unset_as_absent() {
+        assert_eq!(env_path("VOUCH_TEST_DEFINITELY_UNSET_VAR"), None);
     }
 }

--- a/crates/vouch-cli/src/commands/setup/docker.rs
+++ b/crates/vouch-cli/src/commands/setup/docker.rs
@@ -167,10 +167,34 @@ fn create_credential_helper_symlink(
     crate::utils::create_symlink_with_fallback(vouch_path, symlink_path, &batch_content)
 }
 
-/// Configure ~/.docker/config.json with the credential helper.
+/// Path to the docker CLI's `config.json`.
+///
+/// `DOCKER_CONFIG` names the *directory* holding the file, not the file itself
+/// — the docker docs call it "the location of your client configuration files"
+/// and its default is the `~/.docker` directory.
+fn docker_config_path() -> Result<std::path::PathBuf> {
+    let home = vouch_common::paths::home_dir();
+    let env_dir = std::env::var_os("DOCKER_CONFIG").filter(|v| !v.is_empty());
+    docker_config_path_from(env_dir.as_deref(), home.as_deref())
+        .with_context(|| tr!("setup-err-no-home"))
+}
+
+/// [`docker_config_path`] over explicit inputs, so the directory-vs-file
+/// distinction is testable without mutating the process environment.
+fn docker_config_path_from(
+    env_dir: Option<&std::ffi::OsStr>,
+    home: Option<&std::path::Path>,
+) -> Option<std::path::PathBuf> {
+    let dir = match env_dir {
+        Some(explicit) => std::path::PathBuf::from(explicit),
+        None => home?.join(".docker"),
+    };
+    Some(dir.join("config.json"))
+}
+
+/// Configure the docker CLI's `config.json` with the credential helper.
 fn configure_docker_config(registries: &[String]) -> Result<()> {
-    let home = dirs::home_dir().with_context(|| tr!("setup-err-no-home"))?;
-    let docker_config_path = home.join(".docker/config.json");
+    let docker_config_path = docker_config_path()?;
 
     // Load existing config or create new
     let mut config: DockerConfig = if docker_config_path.exists() {
@@ -273,8 +297,7 @@ pub(crate) struct DockerSetupStatus {
 
 /// Get registries configured to use vouch in Docker config.
 fn get_configured_registries() -> Result<Vec<String>> {
-    let home = dirs::home_dir().context(tr!("err-could-not-determine-home-directory"))?;
-    let docker_config_path = home.join(".docker/config.json");
+    let docker_config_path = docker_config_path()?;
 
     if !docker_config_path.exists() {
         return Ok(Vec::new());
@@ -291,4 +314,43 @@ fn get_configured_registries() -> Result<Vec<String>> {
         .collect();
 
     Ok(registries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsStr;
+    use std::path::{Path, PathBuf};
+
+    // `DOCKER_CONFIG` is the one override among the tools vouch configures that
+    // names a *directory*: the docker docs describe it as "the location of your
+    // client configuration files", defaulting to the `~/.docker` directory.
+    // <https://docs.docker.com/reference/cli/docker/>
+
+    #[test]
+    fn docker_config_defaults_under_home() {
+        let home = Path::new("/home/alice");
+        let got = docker_config_path_from(None, Some(home));
+        assert_eq!(got, Some(home.join(".docker").join("config.json")));
+    }
+
+    #[test]
+    fn docker_config_env_is_a_directory_not_a_file() {
+        let got = docker_config_path_from(Some(OsStr::new("/etc/docker-conf")), None);
+        assert_eq!(got, Some(PathBuf::from("/etc/docker-conf/config.json")));
+    }
+
+    #[test]
+    fn docker_config_env_wins_over_home() {
+        let got = docker_config_path_from(
+            Some(OsStr::new("/etc/docker-conf")),
+            Some(Path::new("/home/alice")),
+        );
+        assert_eq!(got, Some(PathBuf::from("/etc/docker-conf/config.json")));
+    }
+
+    #[test]
+    fn docker_config_needs_home_when_env_is_absent() {
+        assert_eq!(docker_config_path_from(None, None), None);
+    }
 }

--- a/crates/vouch-cli/src/commands/setup/kubeconfig.rs
+++ b/crates/vouch-cli/src/commands/setup/kubeconfig.rs
@@ -129,7 +129,8 @@ pub(crate) fn default_kubeconfig_path() -> Result<PathBuf> {
         return Ok(path);
     }
 
-    let home = dirs::home_dir().with_context(|| vouch_cli::tr!("setup-err-no-home"))?;
+    let home =
+        vouch_common::paths::home_dir().with_context(|| vouch_cli::tr!("setup-err-no-home"))?;
     Ok(home.join(".kube").join("config"))
 }
 

--- a/crates/vouch-cli/src/commands/setup/openai.rs
+++ b/crates/vouch-cli/src/commands/setup/openai.rs
@@ -82,7 +82,7 @@ pub(crate) async fn run(args: SetupArgs<'_>) -> Result<()> {
 fn configure_codex(vouch_path: &str, force: bool) -> Result<PathBuf> {
     use vouch_cli::{tr, tr_args};
 
-    let home = dirs::home_dir().with_context(|| tr!("setup-err-no-home"))?;
+    let home = vouch_common::paths::home_dir().with_context(|| tr!("setup-err-no-home"))?;
     let codex_dir = home.join(".codex");
     let config_path = codex_dir.join("config.toml");
 

--- a/crates/vouch-cli/src/commands/setup/ssh.rs
+++ b/crates/vouch-cli/src/commands/setup/ssh.rs
@@ -15,19 +15,19 @@ use vouch_common::fs::{atomic_write, atomic_write_secure};
 
 /// Get the SSH config path (~/.ssh/config).
 pub(crate) fn ssh_config_path() -> Result<PathBuf> {
-    let home = dirs::home_dir().with_context(|| tr!("setup-err-no-home"))?;
+    let home = vouch_common::paths::home_dir().with_context(|| tr!("setup-err-no-home"))?;
     Ok(home.join(".ssh").join("config"))
 }
 
 /// Get the known hosts path (~/.ssh/known_hosts).
 fn known_hosts_path() -> Result<PathBuf> {
-    let home = dirs::home_dir().with_context(|| tr!("setup-err-no-home"))?;
+    let home = vouch_common::paths::home_dir().with_context(|| tr!("setup-err-no-home"))?;
     Ok(home.join(".ssh").join("known_hosts"))
 }
 
 /// Get the CA public key path.
 fn ca_key_path(server: &str) -> Result<PathBuf> {
-    let home = dirs::home_dir().with_context(|| tr!("setup-err-no-home"))?;
+    let home = vouch_common::paths::home_dir().with_context(|| tr!("setup-err-no-home"))?;
     // Sanitize server URL for filename: strip scheme, replace non-alphanumeric with underscores,
     // and collapse multiple underscores. e.g. "https://us.vouch.sh" → "vouch_ca_us_vouch_sh.pub"
     let safe_host = server
@@ -54,7 +54,7 @@ fn ca_key_path(server: &str) -> Result<PathBuf> {
 
 /// Get the default SSH key path (~/.ssh/id_ed25519_vouch).
 fn default_key_path() -> Result<PathBuf> {
-    let home = dirs::home_dir().with_context(|| tr!("setup-err-no-home"))?;
+    let home = vouch_common::paths::home_dir().with_context(|| tr!("setup-err-no-home"))?;
     Ok(home.join(".ssh").join("id_ed25519_vouch"))
 }
 

--- a/crates/vouch-cli/src/install_path.rs
+++ b/crates/vouch-cli/src/install_path.rs
@@ -63,7 +63,7 @@ fn stable_install_path(exe: PathBuf) -> PathBuf {
         {
             return via_path;
         }
-        let home = dirs::home_dir();
+        let home = vouch_common::paths::home_dir();
         for dir in stable_bin_dirs(home.as_deref()) {
             let candidate = dir.join(name);
             if points_to(&candidate, &target) {
@@ -129,6 +129,14 @@ fn stable_bin_dirs(home: Option<&Path>) -> Vec<PathBuf> {
         dirs.push(h.join(".nix-profile").join("bin"));
         dirs.push(h.join(".cargo").join("bin"));
         dirs.push(h.join(".local").join("bin"));
+    }
+    // `$XDG_BIN_HOME`, when it points somewhere other than the `~/.local/bin`
+    // already covered above. This is where vouch installs its own helpers, so a
+    // vouch symlinked there must resolve back to the running binary.
+    if let Some(bin) = vouch_common::paths::executable_dir()
+        && !dirs.contains(&bin)
+    {
+        dirs.push(bin);
     }
     dirs
 }
@@ -209,7 +217,7 @@ fn version_pin_hint(exe: &Path) -> Option<String> {
             stable = stable.display().to_string()
         ));
     }
-    if let Some(home) = dirs::home_dir()
+    if let Some(home) = vouch_common::paths::home_dir()
         && let Some(stable) = nix_profile_candidate(exe, &home)
     {
         return Some(tr_args!(

--- a/crates/vouch-cli/src/integrations/aws/config.rs
+++ b/crates/vouch-cli/src/integrations/aws/config.rs
@@ -41,7 +41,7 @@ pub(crate) struct AwsConfig {
 }
 
 impl AwsConfig {
-    /// Load AWS config from the default path (~/.aws/config).
+    /// Load AWS config from the path [`AwsConfig::default_path`] resolves.
     pub(crate) fn load() -> Result<Self> {
         let path = Self::default_path()?;
         Self::load_from(path)
@@ -263,10 +263,28 @@ impl AwsConfig {
         }
     }
 
-    /// Get the default AWS config path (~/.aws/config).
+    /// Get the AWS config path: `$AWS_CONFIG_FILE`, else `~/.aws/config`.
+    ///
+    /// `AWS_CONFIG_FILE` names the file itself. It is the only way to relocate
+    /// the config — the AWS CLI offers no equivalent command-line flag or
+    /// profile setting.
     pub(crate) fn default_path() -> Result<PathBuf> {
-        let home = dirs::home_dir().context(tr!("err-could-not-determine-home-directory"))?;
-        Ok(home.join(".aws").join("config"))
+        let home = vouch_common::paths::home_dir();
+        let env_file = std::env::var_os("AWS_CONFIG_FILE").filter(|v| !v.is_empty());
+        Self::config_path_from(env_file.as_deref(), home.as_deref())
+            .context(tr!("err-could-not-determine-home-directory"))
+    }
+
+    /// [`AwsConfig::default_path`] over explicit inputs, so the override is
+    /// testable without mutating the process environment.
+    fn config_path_from(
+        env_file: Option<&std::ffi::OsStr>,
+        home: Option<&std::path::Path>,
+    ) -> Option<PathBuf> {
+        match env_file {
+            Some(explicit) => Some(PathBuf::from(explicit)),
+            None => Some(home?.join(".aws").join("config")),
+        }
     }
 }
 
@@ -1033,5 +1051,33 @@ credential_process = vouch credential aws --role arn:aws:iam::222:role/Staging
         let config = AwsConfig::load_from(file.path().to_path_buf()).unwrap();
 
         assert_eq!(config.next_vouch_profile_name(), "vouch-3");
+    }
+
+    // -- config_path_from --
+    //
+    // `AWS_CONFIG_FILE` names the file itself, and the AWS CLI documents it as
+    // the only way to relocate the config: "You can't specify this value in a
+    // named profile setting or by using a command line parameter."
+    // <https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html>
+
+    #[test]
+    fn aws_config_defaults_under_home() {
+        let home = std::path::Path::new("/home/alice");
+        let got = AwsConfig::config_path_from(None, Some(home));
+        assert_eq!(got, Some(home.join(".aws").join("config")));
+    }
+
+    #[test]
+    fn aws_config_env_is_the_file_itself() {
+        let got = AwsConfig::config_path_from(
+            Some(std::ffi::OsStr::new("/etc/aws/alt.ini")),
+            Some(std::path::Path::new("/home/alice")),
+        );
+        assert_eq!(got, Some(PathBuf::from("/etc/aws/alt.ini")));
+    }
+
+    #[test]
+    fn aws_config_needs_home_when_env_is_absent() {
+        assert_eq!(AwsConfig::config_path_from(None, None), None);
     }
 }

--- a/crates/vouch-cli/src/integrations/cargo/config.rs
+++ b/crates/vouch-cli/src/integrations/cargo/config.rs
@@ -199,7 +199,8 @@ impl CargoConfig {
         }
 
         // Default to ~/.cargo/config.toml
-        let home = dirs::home_dir().context(tr!("err-could-not-determine-home-directory"))?;
+        let home = vouch_common::paths::home_dir()
+            .context(tr!("err-could-not-determine-home-directory"))?;
         Ok(home.join(".cargo").join("config.toml"))
     }
 

--- a/crates/vouch-cli/src/integrations/ssm.rs
+++ b/crates/vouch-cli/src/integrations/ssm.rs
@@ -47,7 +47,7 @@ impl IntegrationCheck for SsmIntegration {
     }
 
     fn check(&self) -> IntegrationState {
-        let home = match dirs::home_dir() {
+        let home = match vouch_common::paths::home_dir() {
             Some(h) => h,
             None => {
                 return IntegrationState::NotConfigured {

--- a/crates/vouch-cli/src/utils.rs
+++ b/crates/vouch-cli/src/utils.rs
@@ -44,13 +44,15 @@ pub(crate) fn shell_single_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', r"'\''"))
 }
 
-/// Get the path for a vouch helper binary in `~/.local/bin/`.
+/// Get the install path for a vouch helper binary.
 ///
 /// All vouch helper symlinks (docker-credential-vouch, git-remote-codecommit,
-/// keyring, vouch-pnpm-tokenhelper) live in `~/.local/bin/`.
+/// keyring, vouch-pnpm-tokenhelper) live in the user's executable directory —
+/// `$XDG_BIN_HOME`, or `~/.local/bin` when that is unset.
 pub(crate) fn vouch_helper_path(name: &str) -> Result<PathBuf> {
-    let home = dirs::home_dir().context(tr!("err-could-not-determine-home-directory"))?;
-    Ok(home.join(".local").join("bin").join(name))
+    let bin_dir = vouch_common::paths::executable_dir()
+        .context(tr!("err-could-not-determine-home-directory"))?;
+    Ok(bin_dir.join(name))
 }
 
 /// Check if a path is a symlink pointing to a vouch binary.
@@ -224,10 +226,16 @@ mod tests {
     // -- vouch_helper_path --
 
     #[test]
-    fn test_vouch_helper_path_ends_with_name() -> anyhow::Result<()> {
+    fn test_vouch_helper_path_is_in_the_executable_dir() -> anyhow::Result<()> {
+        // Not `~/.local/bin` literally: `$XDG_BIN_HOME` moves it, and the test
+        // may not mutate the environment to rule that out.
         let path = vouch_helper_path("keyring")?;
-        let expected: PathBuf = [".local", "bin", "keyring"].iter().collect();
-        assert!(path.ends_with(&expected), "got: {}", path.display());
+        assert_eq!(
+            path.parent().map(Path::to_path_buf),
+            vouch_common::paths::executable_dir(),
+            "got: {}",
+            path.display()
+        );
         Ok(())
     }
 

--- a/crates/vouch-common/src/paths.rs
+++ b/crates/vouch-common/src/paths.rs
@@ -15,9 +15,15 @@
 //! | data (keyring fallback key) | `XDG_DATA_HOME` → `~/.local/share` | `<base>/vouch/` |
 //! | cache (pid, agent log) | `XDG_CACHE_HOME` → `~/.cache` | `<base>/vouch/` |
 //! | runtime (sockets) | `XDG_RUNTIME_DIR` → cache fallback | `<base>/vouch/` |
+//! | helper binaries | `XDG_BIN_HOME` → `~/.local/bin` | `<base>/` |
 //!
 //! Per the spec, `XDG_*` values that are not absolute paths are ignored and the
 //! default is used instead.
+//!
+//! [`home_dir`] and the [`xdg_config_home`] / [`xdg_data_home`] bases are also
+//! exported. Those serve the inverse problem: locating the config of a tool
+//! vouch configures on the user's behalf (pip, uv, docker, aws), where the
+//! answer is whatever *that* tool documents, not vouch's layout.
 //!
 //! Earlier versions of vouch stored everything flat in `~/.vouch/`.
 //! [`migrate_legacy_layout`] relocates those files into the directories above
@@ -28,6 +34,17 @@ use std::path::{Path, PathBuf};
 
 /// Application sub-directory created under each XDG base directory.
 const APP_DIR: &str = "vouch";
+
+/// The user's home directory.
+///
+/// The one home-directory resolver for the workspace. `dirs::home_dir` reads
+/// `$HOME` and falls back to `getpwuid_r` on Unix; on Windows it asks for
+/// `FOLDERID_Profile` rather than trusting `%USERPROFILE%`. `std::env::home_dir`
+/// does neither, so callers must not reach for it.
+#[must_use]
+pub fn home_dir() -> Option<PathBuf> {
+    dirs::home_dir()
+}
 
 /// Resolve an XDG base directory from an env value and home directory.
 ///
@@ -56,7 +73,7 @@ fn resolve_base(
 fn vouch_subdir(var: &str, default_components: &[&str]) -> Option<PathBuf> {
     let base = resolve_base(
         std::env::var_os(var),
-        dirs::home_dir().as_deref(),
+        home_dir().as_deref(),
         default_components,
     )?;
     Some(base.join(APP_DIR))
@@ -105,6 +122,54 @@ pub fn runtime_dir() -> Option<PathBuf> {
         }
     }
     cache_dir()
+}
+
+/// Directory for user-installed executables: `<XDG_BIN_HOME|~/.local/bin>`.
+///
+/// Holds the helper binaries vouch symlinks into place (`docker-credential-vouch`,
+/// `git-remote-codecommit`, `keyring`, `vouch-pnpm-tokenhelper`). Unlike the
+/// directories above there is no `vouch` sub-directory: the callers of these
+/// helpers find them by name on `PATH`.
+///
+/// `XDG_BIN_HOME` is a widely-implemented convention rather than part of the
+/// XDG Base Directory Specification, which defines only the four `*_HOME`
+/// variables above and `XDG_RUNTIME_DIR`. As with those, it is honored on every
+/// platform — `dirs::executable_dir()` yields `None` on macOS and Windows.
+#[must_use]
+pub fn executable_dir() -> Option<PathBuf> {
+    resolve_base(
+        std::env::var_os("XDG_BIN_HOME"),
+        home_dir().as_deref(),
+        &[".local", "bin"],
+    )
+}
+
+/// XDG config base directory: `<XDG_CONFIG_HOME|~/.config>`.
+///
+/// The base itself, with no `vouch` sub-directory — for locating the config of
+/// a *different* tool that resolves its own paths the XDG way (uv, and pip
+/// everywhere but macOS). Use [`config_dir`] for vouch's own config.
+#[must_use]
+pub fn xdg_config_home() -> Option<PathBuf> {
+    resolve_base(
+        std::env::var_os("XDG_CONFIG_HOME"),
+        home_dir().as_deref(),
+        &[".config"],
+    )
+}
+
+/// XDG data base directory: `<XDG_DATA_HOME|~/.local/share>`.
+///
+/// The counterpart to [`xdg_config_home`]; see that function for when to reach
+/// for a base rather than [`data_dir`]. pip — alone among the tools vouch
+/// configures — looks under the *data* base on macOS.
+#[must_use]
+pub fn xdg_data_home() -> Option<PathBuf> {
+    resolve_base(
+        std::env::var_os("XDG_DATA_HOME"),
+        home_dir().as_deref(),
+        &[".local", "share"],
+    )
 }
 
 /// Path to the CLI configuration file (`<config>/vouch/config.json`).
@@ -296,7 +361,7 @@ pub fn migrate_legacy_layout() {
     reason = "runs from the CLI and agent entrypoints before tracing is initialized"
 )]
 fn migrate_legacy_vouch_dir() {
-    let Some(home) = dirs::home_dir() else {
+    let Some(home) = home_dir() else {
         return;
     };
     let legacy_dir = home.join(".vouch");
@@ -566,5 +631,31 @@ mod tests {
 
         assert!(prepare_private_dir(&path).is_err());
         Ok(())
+    }
+
+    // -- XDG base accessors --
+    //
+    // The accessors read the process environment, which tests must not mutate
+    // (`std::env::set_var` is unsafe under edition 2024 and racy in parallel
+    // tests). `resolve_base` above covers the env-vs-default logic; what is
+    // left to pin is the wiring — that each vouch directory is its XDG base
+    // plus `vouch`, whatever the base resolved to.
+
+    #[test]
+    fn config_dir_is_vouch_under_the_config_base() {
+        assert_eq!(config_dir(), xdg_config_home().map(|b| b.join(APP_DIR)));
+    }
+
+    #[test]
+    fn data_dir_is_vouch_under_the_data_base() {
+        assert_eq!(data_dir(), xdg_data_home().map(|b| b.join(APP_DIR)));
+    }
+
+    #[test]
+    fn executable_dir_resolves_wherever_home_does() {
+        // The reason this is not `dirs::executable_dir()`: that returns `None`
+        // on macOS and Windows, which would leave vouch with nowhere to install
+        // its helper binaries on two of three supported platforms.
+        assert_eq!(executable_dir().is_some(), home_dir().is_some());
     }
 }


### PR DESCRIPTION
vouch builds several foreign tools' config paths by hand from `$HOME`, ignoring the environment variables and platform rules those tools actually follow. This fixes four such gaps and consolidates home-directory resolution.

`crates/vouch-common/src/paths.rs` keeps its existing design — it deliberately avoids `dirs::config_dir()` and friends, since those return `~/Library/Application Support` on macOS and `%APPDATA%` on Windows while vouch wants XDG layout everywhere.

## pip and uv

Both now follow their documented search orders, which **differ on macOS**:

| | macOS user config | env var consulted |
|---|---|---|
| pip | `$XDG_DATA_HOME/pip` if set and present → `~/Library/Application Support/pip` if present → `~/.config/pip` | `XDG_DATA_HOME` |
| uv | `~/.config/uv/uv.toml`, always | `XDG_CONFIG_HOME` |

Three consequences the old code got wrong:

- pip's macOS chain is existence-gated, so writing `~/.config/pip/pip.conf` unconditionally produced a file pip ignores on any Mac that has a `~/Library/Application Support/pip` directory.
- On Windows pip reads `%APPDATA%\pip\pip.ini`; vouch wrote `pip.conf` under `~/.config`, where pip never looks.
- `PIP_CONFIG_FILE` and `UV_CONFIG_FILE` name a *file*, but the old code took `.parent()` and re-appended a fixed filename — `PIP_CONFIG_FILE=~/foo/mypip.ini` made vouch write `~/foo/pip.conf`.

Sources: [pip configuration](https://pip.pypa.io/en/stable/topics/configuration/), [uv storage](https://docs.astral.sh/uv/reference/storage/).

## AWS_CONFIG_FILE and DOCKER_CONFIG

Both are now honored, matching the `KUBECONFIG` / `CARGO_HOME` / `PIP_CONFIG_FILE` handling already in the crate. `DOCKER_CONFIG` is the one override of the four that names a **directory** rather than a file; `config.json` is appended to it. The two duplicated `home.join(".docker/config.json")` sites collapse into one resolver.

## Path accessors and the dirs consolidation

`vouch-common::paths` gains `home_dir()`, `executable_dir()`, `xdg_config_home()` and `xdg_data_home()`.

Helper binaries (`docker-credential-vouch`, `git-remote-codecommit`, `keyring`, `vouch-pnpm-tokenhelper`) install to `$XDG_BIN_HOME` when set, and `install_path.rs` probes that directory so a helper installed there still resolves back to the running binary. `executable_dir()` is hand-rolled rather than delegating to `dirs::executable_dir()`, which returns `None` on macOS and Windows and would leave vouch nowhere to install helpers on two of three supported platforms. `XDG_BIN_HOME` is a de-facto convention, not part of the XDG Base Directory Specification — the doc comment says so.

`vouch-agent` drops `std::env::home_dir()`, which lacks the `getpwuid_r` and `FOLDERID_Profile` fallbacks that `dirs::home_dir()` has, without re-adding the `dirs` dependency a prior audit removed. The remaining 17 `dirs::home_dir()` call sites in vouch-cli move to `paths::home_dir()`, leaving vouch-common as the only crate depending on `dirs`.

Platform branches use `cfg!()` rather than `#[cfg]` so every branch compiles and its helper is unit-testable on every platform.

## Tests

19 tests added or updated, none mutating process env vars — the resolvers take their inputs explicitly, and pip's existence-gated chain is exercised against real directories in a tempdir. One new i18n key (`setup-err-no-appdata`), since reusing "could not determine home directory" for a missing `%APPDATA%` would be wrong.

`cargo clippy --all-targets --all-features` clean with zero warnings; 5,598 unit tests and 407 integration tests pass; `prek run --all-files` passes; `make audit` clean. Two mutations against the pip logic (`is_dir()` → `exists()`, dropping the `XDG_DATA_HOME` branch) each fail a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)