### PR TITLE
chore: treat Detail fix PRs as drafts, not merge candidates

### DIFF
--- a/.claude/skills/detail-triage/SKILL.md
+++ b/.claude/skills/detail-triage/SKILL.md
@@ -118,14 +118,33 @@ strongest class candidates in the batch, not the weakest.
 
 ## Step 3: Decide instance versus class
 
+**A Detail fix PR is a reviewed draft, never a merge candidate.** That is the
+standing policy (set 2026-09-12), and it replaces the earlier "bot PRs merge
+mostly as-is". Green CI, a detailed PR body, and a full test suite make a PR
+look finished; step 6 exists because two of the 22 in the 2026-09-11 batch were
+actively wrong under exactly that appearance.
+
+The policy is not a claim that Detail writes bad fixes — measured over 811
+merged PRs, its fixes are blamed by a later finding at roughly half the rate of
+human PRs (3.6% vs 7.6% within 14 days of merge, 4.3% vs 8.7% within 30). The
+point is that post-merge blame understates the defect rate, because the scanner
+does not re-find everything it introduces. Review is what closes that gap, and
+it is worth doing regardless of who wrote the fix.
+
 Three or more open instances of one pattern makes this decision mandatory, not
 optional. For each class pick one and record which:
 
-- **Instance** — genuinely isolated. Merge Detail's PR as-is once green, per the
-  standing strategy for bot PRs. No surrounding refactor.
+- **Instance** — genuinely isolated. Merge Detail's PR once it has been through
+  step 6 and is green. No surrounding refactor.
 - **Class** — one change that fixes every site found in step 2, per CLAUDE.md
   "fix the class, not the instance". Close Detail's individual PRs as superseded
   rather than merging them, and say so in each.
+
+**Never merge the instance PR for a finding that belongs to a class.** Merging
+it closes the instance and erases the evidence that the class exists, so the
+next pass rediscovers the same pattern at a different call site and the cycle
+repeats. Of every rule here, this is the one that would have changed the most
+outcomes historically.
 
 A class fix that lands without a guardrail will regress, so step 4 is part of
 the same PR, not a follow-up.

--- a/.claude/skills/detail-triage/references/volume-log.md
+++ b/.claude/skills/detail-triage/references/volume-log.md
@@ -75,6 +75,37 @@ Part of the rise is mechanical: Detail has merged 100+ PRs since early August,
 so its commits are increasingly the last to touch any line. That cannot explain
 the 09-08 cases, which are bugs in the added logic itself.
 
+### Fix quality, Detail vs human (2026-09-12)
+
+How often a merged PR is later blamed by a Detail finding, counting only PRs
+with the full window of exposure since merge
+(`detail-stats.py --fix-defect-rate 2026-09-12`):
+
+| window | Detail PRs | blamed | human PRs | blamed |
+|--------|-----------|--------|-----------|--------|
+| 14 days | 167 | 3.6% | 511 | 7.6% |
+| 30 days | 139 | 4.3% | 438 | 8.7% |
+| 60 days | 75 | 0.0% | 371 | 10.2% |
+
+The 60-day row is small-sample for Detail and covers only PRs merged before
+self-attribution began, so it should not be leaned on.
+
+Detail's fixes are blamed at roughly half the human rate. Not like-for-like —
+Detail PRs are small targeted fixes, human PRs include feature work — but it
+is strong enough to settle the question: auto-fixing is not a net source of
+defects, and disabling it would move the work to authors with a higher
+observed rate.
+
+What the number does *not* capture: review of the 2026-09-11 batch found real
+defects in 3 of 22 (14%), well above the 4.3% later-blame rate, because the
+scanner does not re-find everything it introduces. That gap is the entire
+argument for the disposition policy below.
+
+**Policy set 2026-09-12:** auto-fixing stays enabled; a Detail PR is a
+reviewed draft, not a merge candidate; and the instance PR for any finding
+belonging to a class of three or more is never merged, because merging it
+erases the evidence that the class exists.
+
 ### Batch under triage
 
 Issues #1279–#1302 (24) and fix PRs #1303–#1324 (22), all opened between

--- a/.claude/skills/detail-triage/scripts/detail-stats.py
+++ b/.claude/skills/detail-triage/scripts/detail-stats.py
@@ -229,6 +229,78 @@ def render_diff_sizes(rows: list[dict[str, object]]) -> None:
     print("  counted as production. Treat its prod figure as an upper bound.")
 
 
+def fix_defect_rate(findings: list[Finding], author: str, today: date) -> list[dict[str, object]]:
+    """How often a merged PR is later blamed by a Detail finding, bot vs human.
+
+    This is the number the "draft, not merge candidate" policy rests on. If
+    Detail's fixes were markedly worse than ours, turning auto-fixing off would
+    be the right call; measured, they are not.
+
+    Exposure is controlled by only counting PRs that have had the full window
+    available since merge, and asking whether the *first* blame landed inside
+    it. Two caveats to state whenever quoting this: it is not like-for-like,
+    because Detail PRs are small targeted fixes while human PRs include feature
+    work; and post-merge blame understates the true defect rate, because the
+    scanner does not re-find everything it introduces.
+    """
+    proc = subprocess.run(
+        ["gh", "pr", "list", "--state", "merged", "--limit", "1000",
+         "--json", "number,author,mergedAt"],
+        capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        sys.exit(f"gh pr list failed: {proc.stderr.strip()}")
+
+    merged: dict[int, tuple[str, date]] = {}
+    for row in json.loads(proc.stdout):
+        login = (row.get("author") or {}).get("login") or ""
+        if not row.get("mergedAt") or login == "app/dependabot":
+            continue
+        merged[row["number"]] = (login, date.fromisoformat(row["mergedAt"][:10]))
+
+    first_blame: dict[int, date] = {}
+    for finding in findings:
+        pr = finding.introduced_pr
+        if pr is None:
+            continue
+        if pr not in first_blame or finding.detected < first_blame[pr]:
+            first_blame[pr] = finding.detected
+
+    rows: list[dict[str, object]] = []
+    for window in (14, 30, 60):
+        counts: dict[str, list[int]] = {"detail": [0, 0], "human": [0, 0]}
+        for number, (login, merged_on) in merged.items():
+            if (today - merged_on).days < window:
+                continue
+            group = "detail" if login == author else "human"
+            counts[group][0] += 1
+            blamed = first_blame.get(number)
+            if blamed and (blamed - merged_on).days <= window:
+                counts[group][1] += 1
+        rows.append({
+            "window_days": window,
+            "detail_eligible": counts["detail"][0], "detail_blamed": counts["detail"][1],
+            "human_eligible": counts["human"][0], "human_blamed": counts["human"][1],
+        })
+    return rows
+
+
+def render_fix_defect_rate(rows: list[dict[str, object]]) -> None:
+    def pct(hit: int, total: int) -> str:
+        return f"{hit / total * 100:.1f}%" if total else "-"
+
+    print("Merged PRs later blamed by a Detail finding, by author")
+    print(f"  {'window':>7} {'detail n':>9} {'detail':>7} {'human n':>8} {'human':>7}")
+    for row in rows:
+        print(f"  {row['window_days']:>6}d {row['detail_eligible']:9} "
+              f"{pct(row['detail_blamed'], row['detail_eligible']):>7} "
+              f"{row['human_eligible']:8} "
+              f"{pct(row['human_blamed'], row['human_eligible']):>7}")
+    print("\n  Not like-for-like: Detail PRs are small targeted fixes, human PRs")
+    print("  include feature work. Post-merge blame also understates the real")
+    print("  defect rate -- the scanner does not re-find all it introduces.")
+
+
 def percentile(values: list[int], fraction: float) -> int:
     """Nearest-rank percentile. Exact on small samples, unlike interpolation."""
     ordered = sorted(values)
@@ -360,6 +432,10 @@ def main() -> int:
     parser.add_argument("--pr-diff-sizes", metavar="RANGE",
                         help="split added lines into production vs test for these PRs "
                              "(e.g. 1303-1324 or 1303,1307); skips the issue analysis")
+    parser.add_argument("--fix-defect-rate", metavar="YYYY-MM-DD",
+                        help="how often merged PRs are later blamed by a finding, Detail "
+                             "vs human, as of this date; the evidence behind the "
+                             "draft-not-merge-candidate policy")
     parser.add_argument("--json", action="store_true", dest="as_json",
                         help="emit machine-readable output")
     args = parser.parse_args()
@@ -379,6 +455,15 @@ def main() -> int:
     if not findings:
         sys.exit(f"no issues authored by {args.author} found")
     findings.sort(key=lambda f: f.detected)
+
+    if args.fix_defect_rate:
+        rows = fix_defect_rate(findings, args.author, date.fromisoformat(args.fix_defect_rate))
+        if args.as_json:
+            json.dump(rows, sys.stdout, indent=2)
+            print()
+        else:
+            render_fix_defect_rate(rows)
+        return 0
 
     months, class_rows, unmatched = by_class(findings)
     self_caused_rows = self_caused(findings, fetch_fix_prs(args.author, args.limit))


### PR DESCRIPTION
Sets the standing policy for how Detail's auto-fix PRs are handled, and records the measurement it rests on.

## The rule

A Detail fix PR is a reviewed draft, not a merge candidate. It goes through the `detail-triage` skill's review step before it can be enqueued.

The instance PR for a finding that belongs to a class of three or more is never merged. Merging it closes the instance and erases the evidence that the class exists, so the next scan rediscovers the same pattern at a different call site.

Auto-fixing stays enabled.

## Why

Reviewing the 2026-09-11 batch found real defects in 3 of 22 PRs. Two reintroduced the class they were fixing: #1312 truncated SCIM member ids by mapping a byte offset across `to_lowercase` (Unicode lowercasing is not length-preserving), and #1321 corrupted any DN containing an escaped comma, including the example RFC 4514 §4 gives. Both were green, both carried tests, and both would have merged under the previous "merge mostly as-is" rule.

This is not a claim that Detail writes bad fixes. Across 811 merged PRs, its fixes are blamed by a later finding at roughly half the rate of human PRs:

| exposure window | Detail PRs | blamed | human PRs | blamed |
|---|---|---|---|---|
| 14 days | 167 | 3.6% | 511 | 7.6% |
| 30 days | 139 | 4.3% | 438 | 8.7% |

Not like-for-like — Detail PRs are small targeted fixes while human PRs include feature work — but enough to settle the question. Disabling auto-fixing would move the work to authors with a worse observed rate.

What the rate misses is that post-merge blame understates the true defect count, because the scanner does not re-find everything it introduces. Review closes that gap, and it is worth doing regardless of who wrote the fix.

## Changes

- `SKILL.md` step 3 states the policy and the class-instance rule, with the measurement and its caveats.
- `detail-stats.py --fix-defect-rate <date>` reproduces the table, so the premise stays checkable rather than becoming folklore.
- `references/volume-log.md` records the measured figures, the caveats, and the policy with its date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)