### PR TITLE
fix(server): serialize org-admin invariants on the organization row

### DIFF
--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -109,8 +109,9 @@ pub use store::{InvalidIndexValue, StoreTransaction};
 
 // Re-export user types and functions
 pub use users::{
-    User, delete_user, get_user_by_email, get_user_by_id, get_user_github_refresh_token,
-    get_user_org_domain, get_users_by_ids, get_users_by_org_paginated, update_user_active_status,
+    MemberDowngrade, MemberDowngradeError, User, delete_user, demote_or_deactivate_member,
+    get_user_by_email, get_user_by_id, get_user_github_refresh_token, get_user_org_domain,
+    get_users_by_ids, get_users_by_org_paginated, update_user_active_status,
     update_user_admin_status, update_user_github_identity,
 };
 

--- a/crates/vouch-server/src/db/tests/concurrency.rs
+++ b/crates/vouch-server/src/db/tests/concurrency.rs
@@ -1710,3 +1710,70 @@ async fn test_delete_authenticator_preserves_consumed_device_auth_for_replay_rev
         "the cascade must detach the consumed device-auth row from the deleted authenticator"
     );
 }
+
+/// #1285 — Two admins demoting each other at the same time must not leave the
+/// organization with zero admins.
+///
+/// Each write lands on a different user document, so per-document optimistic
+/// concurrency never sees a conflict; the organization row is what the two
+/// transactions are forced to collide on. Whichever ordering the backend
+/// picks, the loser re-runs its admin count against the committed state and
+/// finds itself removing the last admin.
+#[tokio::test]
+async fn test_mutual_admin_demote_concurrent() {
+    use crate::db::users::{MemberDowngrade, demote_or_deactivate_member, upsert_user_with_org};
+
+    let (store, _audit) = test_db().await;
+    let org = create_organization(&store, "mutual-demote.com", Some("Mutual"), None)
+        .await
+        .expect("create org");
+    let (admin_a, _) = upsert_user_with_org(
+        &store,
+        "a@mutual-demote.com",
+        Some("A"),
+        Some(&org.id),
+        true,
+    )
+    .await
+    .expect("create admin a");
+    let (admin_b, _) = upsert_user_with_org(
+        &store,
+        "b@mutual-demote.com",
+        Some("B"),
+        Some(&org.id),
+        true,
+    )
+    .await
+    .expect("create admin b");
+
+    let (store_a, store_b) = (store.clone(), store.clone());
+    let (target_a, target_b) = (admin_b.clone(), admin_a.clone());
+    let (result_a, result_b) = tokio::join!(
+        async move { demote_or_deactivate_member(&store_a, &target_a, MemberDowngrade::Demote).await },
+        async move { demote_or_deactivate_member(&store_b, &target_b, MemberDowngrade::Demote).await },
+    );
+
+    for (label, r) in [("a", &result_a), ("b", &result_b)] {
+        if let Err(e) = r {
+            let msg = format!("{e:#}");
+            assert!(
+                !msg.contains("deadlock"),
+                "task {label} must not fail with a DB deadlock: {msg}"
+            );
+        }
+    }
+
+    // The invariant, stated directly: the org still has an admin.
+    let members = crate::db::get_users_by_org_paginated(&store, &org.id, None, 100)
+        .await
+        .expect("list members")
+        .0;
+    let remaining = members
+        .iter()
+        .filter(|m| m.is_org_admin && m.active)
+        .count();
+    assert!(
+        remaining >= 1,
+        "at least one admin must survive; results a={result_a:?} b={result_b:?}"
+    );
+}

--- a/crates/vouch-server/src/db/tests/users_and_sessions.rs
+++ b/crates/vouch-server/src/db/tests/users_and_sessions.rs
@@ -692,3 +692,125 @@ async fn test_delete_sessions_for_oauth_client_targets_only_that_client() {
         .expect("delete for client-primary again");
     assert_eq!(deleted_again, 0, "re-deleting an empty index is a no-op");
 }
+
+// ============================================================================
+// Last-admin floor (#1285)
+// ============================================================================
+
+/// Create an org with `n` active admins; returns (org_id, admin_ids).
+async fn org_with_admins(store: &DocumentStore, domain: &str, n: usize) -> (String, Vec<String>) {
+    let org = crate::db::organizations::create_organization(store, domain, Some("Floor Org"), None)
+        .await
+        .expect("create org");
+    let mut ids = Vec::new();
+    for i in 0..n {
+        let (id, _) = upsert_user_with_org(
+            store,
+            &format!("admin{i}@{domain}"),
+            Some(&format!("Admin {i}")),
+            Some(&org.id),
+            true,
+        )
+        .await
+        .expect("create admin");
+        ids.push(id);
+    }
+    (org.id, ids)
+}
+
+#[tokio::test]
+async fn test_demote_refuses_the_last_admin() {
+    let (store, _audit) = test_db().await;
+    let (_org_id, admins) = org_with_admins(&store, "last-admin-demote.example", 2).await;
+
+    // Two admins: demoting one is fine.
+    assert!(
+        demote_or_deactivate_member(
+            &store,
+            admins.get(1).expect("second admin"),
+            MemberDowngrade::Demote
+        )
+        .await
+        .expect("first demote succeeds")
+    );
+
+    // One left: demoting them would leave the org unadministrable.
+    let err = demote_or_deactivate_member(
+        &store,
+        admins.first().expect("first admin"),
+        MemberDowngrade::Demote,
+    )
+    .await
+    .expect_err("demoting the last admin must be refused");
+    assert!(
+        matches!(err, MemberDowngradeError::LastAdmin),
+        "got {err:?}"
+    );
+
+    let still_admin = get_user_by_id(&store, admins.first().expect("first admin"))
+        .await
+        .expect("read admin")
+        .expect("admin exists");
+    assert!(
+        still_admin.is_org_admin,
+        "the refused demote must not apply"
+    );
+}
+
+#[tokio::test]
+async fn test_deactivate_refuses_the_last_admin() {
+    let (store, _audit) = test_db().await;
+    let (_org_id, admins) = org_with_admins(&store, "last-admin-deactivate.example", 1).await;
+
+    let err = demote_or_deactivate_member(
+        &store,
+        admins.first().expect("first admin"),
+        MemberDowngrade::Deactivate,
+    )
+    .await
+    .expect_err("deactivating the last admin must be refused");
+    assert!(
+        matches!(err, MemberDowngradeError::LastAdmin),
+        "got {err:?}"
+    );
+
+    let still_active = get_user_by_id(&store, admins.first().expect("first admin"))
+        .await
+        .expect("read admin")
+        .expect("admin exists");
+    assert!(still_active.active, "the refused deactivate must not apply");
+    assert!(still_active.is_org_admin);
+}
+
+#[tokio::test]
+async fn test_floor_does_not_block_non_admin_members() {
+    let (store, _audit) = test_db().await;
+    let (org_id, _admins) = org_with_admins(&store, "floor-nonadmin.example", 1).await;
+    let (member_id, _) = upsert_user_with_org(
+        &store,
+        "member@floor-nonadmin.example",
+        Some("Member"),
+        Some(&org_id),
+        false,
+    )
+    .await
+    .expect("create member");
+
+    // The floor counts admins, so a plain member is unaffected by it even
+    // though the org has exactly one admin.
+    assert!(
+        demote_or_deactivate_member(&store, &member_id, MemberDowngrade::Deactivate)
+            .await
+            .expect("deactivating a non-admin is always allowed")
+    );
+}
+
+#[tokio::test]
+async fn test_downgrade_reports_missing_member() {
+    let (store, _audit) = test_db().await;
+    assert!(
+        !demote_or_deactivate_member(&store, "no-such-user", MemberDowngrade::Demote)
+            .await
+            .expect("a missing member is not an error")
+    );
+}

--- a/crates/vouch-server/src/db/users.rs
+++ b/crates/vouch-server/src/db/users.rs
@@ -254,6 +254,133 @@ async fn org_admin_successor(
     Ok(admin_ids.into_iter().next())
 }
 
+/// The member change being applied by [`demote_or_deactivate_member`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemberDowngrade {
+    /// Clear `is_org_admin`, leaving the account active.
+    Demote,
+    /// Clear `active`, which also removes the account from the admin count.
+    Deactivate,
+}
+
+/// Failure modes of [`demote_or_deactivate_member`].
+#[derive(Debug, thiserror::Error)]
+pub enum MemberDowngradeError {
+    /// The change would leave the organization with no active admin.
+    #[error("organization would be left with no active admin")]
+    LastAdmin,
+    /// Another transaction changed the organization row while this change was
+    /// counting admins.
+    #[error("organization changed during member downgrade")]
+    OccConflict,
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+impl super::pool::RetryableError for MemberDowngradeError {
+    fn is_retryable(&self) -> bool {
+        match self {
+            Self::OccConflict => true,
+            Self::LastAdmin => false,
+            Self::Other(e) => super::pool::is_retryable_db_error(e),
+        }
+    }
+}
+
+/// Demote or deactivate an org member, refusing to remove the last admin.
+///
+/// Returns `Ok(false)` when the target no longer exists.
+///
+/// "At least one active admin per organization" is a cross-row invariant: it
+/// is a property of the member set, not of any single user document. The
+/// handlers' own "cannot demote yourself" check enforces it only by accident
+/// — it holds for one request at a time, and two admins who downgrade *each
+/// other* simultaneously both pass it, because neither request can see the
+/// other. Each write then lands on a different user document, so per-document
+/// optimistic concurrency never notices, and the organization is left with no
+/// admin and no way back in.
+///
+/// So the admin count and the write share one transaction, and the
+/// organization row is version-bumped to serialize them (CLAUDE.md rule 10).
+/// The org row is what concurrent downgrades collide on; DSQL is OCC-only and
+/// has no `SELECT … FOR UPDATE`, so forcing writers onto one row is what makes
+/// the guard atomic on every backend. The version is captured *before* the
+/// member scan for the reason spelled out in [`delete_user`]: read afterwards,
+/// it would already carry a sibling's bump and the compare-and-update would
+/// wrongly succeed.
+///
+/// # Errors
+///
+/// [`MemberDowngradeError::LastAdmin`] when the target is the organization's
+/// only remaining active admin, and [`MemberDowngradeError::OccConflict`] when
+/// a concurrent change to the organization won the race — retried by
+/// `with_dsql_retry!`, which re-runs the count against the committed state.
+pub async fn demote_or_deactivate_member(
+    store: &DocumentStore,
+    user_id: &str,
+    change: MemberDowngrade,
+) -> std::result::Result<bool, MemberDowngradeError> {
+    crate::with_dsql_retry!(async {
+        let mut tx = store.begin().await?;
+
+        let Some(user_doc) = tx.get::<UserDoc>(user_id).await? else {
+            return Ok(false);
+        };
+        let org_id = user_doc.data.org_id.clone();
+
+        // Version first, then the predicate read it must guard.
+        let org_doc = match org_id.as_deref() {
+            Some(id) => {
+                tx.get::<super::documents::organization::OrganizationDoc>(id)
+                    .await?
+            }
+            None => None,
+        };
+
+        // Only a change that removes an *active admin* can breach the floor.
+        // Demoting a plain member, or deactivating one, cannot.
+        let removes_an_admin = user_doc.data.is_org_admin && user_doc.data.active;
+        if removes_an_admin && let Some(id) = org_id.as_deref() {
+            let members = tx.find_all::<UserDoc>("org_id", id).await?;
+            let other_admins = members
+                .iter()
+                .filter(|m| m.data.is_org_admin && m.data.active && m.id != user_id)
+                .count();
+            if other_admins == 0 {
+                return Err(MemberDowngradeError::LastAdmin);
+            }
+        }
+
+        let mut updated = user_doc.data.clone();
+        match change {
+            MemberDowngrade::Demote => updated.is_org_admin = false,
+            MemberDowngrade::Deactivate => updated.active = false,
+        }
+        // Guard the user row on the version this transaction read, so a
+        // concurrent edit to the same member is not overwritten blindly.
+        if !tx
+            .compare_and_update(user_id, user_doc.version, &updated)
+            .await?
+        {
+            return Err(MemberDowngradeError::OccConflict);
+        }
+
+        if let Some(id) = org_id.as_deref()
+            && let Some(org_doc) = org_doc
+        {
+            let won = tx
+                .compare_and_update(id, org_doc.version, &org_doc.data)
+                .await?;
+            if !won {
+                return Err(MemberDowngradeError::OccConflict);
+            }
+        }
+
+        tx.commit().await?;
+        Ok(true)
+    })
+}
+
 /// Delete a user and all associated data atomically.
 ///
 /// Wraps all cascade deletes in a single transaction so that a partial
@@ -348,6 +475,22 @@ pub async fn delete_user(store: &DocumentStore, user_id: &str) -> Result<bool, D
         // overwritten with the stale doc: the cascade fails with a retryable
         // `VersionConflict` and the entry-point `with_dsql_retry!` re-runs
         // it from a fresh read.
+        // Capture the org row's version *before* the member scan that chooses
+        // the successor. The scan is the predicate read this guard exists to
+        // serialize, so the version has to be the one the scan saw. Reading it
+        // afterwards defeats the guard: under PostgreSQL READ COMMITTED every
+        // statement takes a fresh snapshot, so a sibling delete that committed
+        // between the scan and the version read yields the already-bumped
+        // version here, the compare-and-update below matches, and both
+        // transactions commit having each chosen the other as successor.
+        let org_doc = match org_id.as_deref() {
+            Some(id) => {
+                tx.get::<super::documents::organization::OrganizationDoc>(id)
+                    .await?
+            }
+            None => None,
+        };
+
         let successor = org_admin_successor(&mut tx, org_id.as_deref(), user_id).await?;
         tx.update_by_index::<OAuthClientDoc, _>("user_id", user_id, |d| {
             d.user_id = match (d.access_scope, successor.as_deref()) {
@@ -377,9 +520,7 @@ pub async fn delete_user(store: &DocumentStore, user_id: &str) -> Result<bool, D
         // administrative action, so serializing per organization costs
         // little.
         if let Some(ref org_id) = org_id
-            && let Some(org_doc) = tx
-                .get::<super::documents::organization::OrganizationDoc>(org_id)
-                .await?
+            && let Some(org_doc) = org_doc
         {
             let won = tx
                 .compare_and_update(org_id, org_doc.version, &org_doc.data)

--- a/crates/vouch-server/src/handlers/admin/members.rs
+++ b/crates/vouch-server/src/handlers/admin/members.rs
@@ -165,7 +165,10 @@ pub(crate) async fn demote_member(
         ));
     }
 
-    let updated = db::update_user_admin_status(&state.store, &target_id, false).await?;
+    let updated =
+        db::demote_or_deactivate_member(&state.store, &target_id, db::MemberDowngrade::Demote)
+            .await
+            .map_err(last_admin_error)?;
     if !updated {
         return Err(member_gone());
     }
@@ -221,12 +224,23 @@ pub(crate) async fn deactivate_member(
         &target_id,
         "User deactivated by admin",
         &admin.id,
-        || db::update_user_active_status(&state.store, &target_id, false),
+        // The last-admin floor is enforced inside this write, so it can only
+        // fail after revocation has run. That is the same shape as any other
+        // persist failure here: the member keeps `active = true` and their
+        // credentials are revoked but re-obtainable, so the organization
+        // still has its admin and the operation is retryable.
+        || {
+            db::demote_or_deactivate_member(
+                &state.store,
+                &target_id,
+                db::MemberDowngrade::Deactivate,
+            )
+        },
     )
     .await
     .map_err(|e| match e {
         crate::services::auth::DeactivationError::Revoke(err) => err,
-        crate::services::auth::DeactivationError::Persist(err) => ServiceError::from(err),
+        crate::services::auth::DeactivationError::Persist(err) => last_admin_error(err),
     })?;
     if !updated {
         return Err(member_gone());
@@ -472,6 +486,25 @@ pub(crate) async fn remove_member(
 /// mutation. The DB layer reported no document to change, so returning an
 /// error (instead of logging an audit event and redirecting with success)
 /// keeps the audit log truthful.
+/// Map a member-downgrade failure onto its wire response.
+///
+/// `LastAdmin` is the caller's mistake, not a fault: an organization with no
+/// admin cannot be administered back into shape, so the request is refused
+/// with a 400 the admin can act on. Everything else keeps its usual mapping.
+fn last_admin_error(err: db::MemberDowngradeError) -> ServiceError {
+    match err {
+        db::MemberDowngradeError::LastAdmin => ServiceError::api(
+            StatusCode::BAD_REQUEST,
+            "last_admin",
+            "Cannot remove the organization's only remaining admin",
+        ),
+        db::MemberDowngradeError::OccConflict => ServiceError::Internal(
+            "Organization changed during member update; please retry".to_string(),
+        ),
+        db::MemberDowngradeError::Other(e) => ServiceError::from(e),
+    }
+}
+
 fn member_gone() -> ServiceError {
     ServiceError::api(StatusCode::NOT_FOUND, "not_found", "User not found")
 }
@@ -1773,14 +1806,18 @@ mod tests {
         // admin's read and the update produced a success redirect plus a
         // fraudulent audit event. The modify hook deletes the target's doc
         // on the first OCC attempt, deterministically forcing the miss.
+        //
+        // Covers the two actions that still write through `store.modify`.
+        // `demote` and `deactivate` now read the member and write it inside
+        // one transaction (the last-admin floor has to count admins and write
+        // atomically), so there is no window between the read and the write
+        // for a delete to land in — the race this test forces cannot occur on
+        // those paths. Their equivalent contract, that a missing member
+        // yields `Ok(false)` rather than a phantom success, is pinned by
+        // `db::tests::users_and_sessions::test_downgrade_reports_missing_member`.
         use std::sync::{Arc, Mutex};
 
-        for (action, kind) in [
-            ("promote", "admin_promote"),
-            ("demote", "admin_demote"),
-            ("deactivate", "admin_deactivate"),
-            ("activate", "admin_activate"),
-        ] {
+        for (action, kind) in [("promote", "admin_promote"), ("activate", "admin_activate")] {
             let target_slot: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
             let slot = Arc::clone(&target_slot);
             let (app, state) = test_app_with_modify_hook(move |store| {


### PR DESCRIPTION
Closes #1283. Closes #1285.

Two cross-row invariants were enforced per-document, which cannot work when the rows differ. Both now serialize on the organization row per CLAUDE.md rule 10.

## #1283 — version read after the predicate read

`delete_user` already serialized concurrent deletions on the org row, but read the org's version *after* the member scan that picks a successor for the departing user's org-scoped applications.

Under PostgreSQL READ COMMITTED every statement takes a fresh snapshot, so a sibling delete committing between the scan and the version read supplied the already-bumped version. The compare-and-update then matched, both transactions committed, and each had chosen the other as successor — leaving org-scoped applications owned by a deleted user. Application management is creator-only, so those applications become permanently unmanageable.

The version is now captured before the scan it is meant to guard.

## #1285 — the last-admin floor did not exist

"At least one active admin per organization" had no enforcement. The handlers' "cannot demote yourself" check maintained it only by accident: it is per-request, so two admins who demote each other at the same time both pass it. Each write lands on a different user document, so per-document optimistic concurrency never sees a conflict, and the organization ends with no admin and no way back in.

`demote_or_deactivate_member` now counts active admins and performs the write in one transaction, version-bumping the org row so concurrent downgrades collide, and returns `LastAdmin` when the target is the only active admin left. The handler maps that to a 400 the admin can act on.

Deactivation revokes credentials before persisting (#1116), so a `LastAdmin` refusal surfaces after revocation has run. That is the same shape as any other persist failure on that path: the member keeps `active = true`, their credentials are revoked but re-obtainable, and the operation is retryable.

## Tests

Each new test was verified to fail with the floor removed and pass with it:

- `test_demote_refuses_the_last_admin`, `test_deactivate_refuses_the_last_admin` — the floor, and that a refused change does not apply.
- `test_mutual_admin_demote_concurrent` — two admins demoting each other concurrently; asserts an admin survives.
- `test_floor_does_not_block_non_admin_members`, `test_downgrade_reports_missing_member` — the floor counts admins only, and a missing member is `Ok(false)` rather than an error.

`test_member_actions_return_404_when_target_vanishes_mid_update` now covers promote and activate only. Demote and deactivate read and write inside one transaction, so the mid-update window that test forces no longer exists on those paths; the missing-member contract is pinned at the db layer instead.

**#1283 has no new test.** Its correctness argument is about statement-level snapshot semantics under READ COMMITTED, which the SQLite test harness does not reproduce, so any test I added would pass with or without the fix. Flagging that rather than shipping a test that proves nothing.

`cargo clippy --all-targets --all-features` clean, 3730 unit tests and all 29 integration suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)