### PR TITLE
fix(server): anchor db-layer expiry comparisons on request arrival

### DIFF
--- a/crates/vouch-server/src/db/audit.rs
+++ b/crates/vouch-server/src/db/audit.rs
@@ -373,6 +373,10 @@ impl AuditStore {
     /// Shared swallow-and-log behind [`Self::record_event`] and
     /// [`Self::record_event_with_domain`] — the one place audit write
     /// failures are formatted.
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "stamps the audit row's created_at"
+    )]
     async fn record_best_effort<D: AuditData>(
         &self,
         kind: AuditEventKind,
@@ -448,6 +452,10 @@ impl AuditStore {
     ///
     /// Returns an error if the database write fails.
     #[cfg(any(test, feature = "test-utils"))]
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "test fixture stamps its own instant"
+    )]
     pub async fn insert_json_event_for_test(
         &self,
         kind: AuditEventKind,

--- a/crates/vouch-server/src/db/authorization_codes.rs
+++ b/crates/vouch-server/src/db/authorization_codes.rs
@@ -56,12 +56,17 @@ pub struct AuthCodeClaim {
 /// rejected as `invalid_grant`. The caller is responsible for replay
 /// detection follow-up (revoking tokens for the affected user) based on
 /// the `AlreadyConsumed` signal.
+///
+/// `now` both decides the expiry comparison and stamps `consumed_at`, and
+/// request-path callers pass the request's [`crate::arrival::ArrivalTime`]
+/// instant. A clock stamped here would be ≥ arrival, making the expiry
+/// predicate stricter than every other check in the same token request and
+/// rejecting a code that was live when the request arrived.
 pub async fn try_consume_authorization_code(
     store: &DocumentStore,
     code_hash: &str,
+    now: Timestamp,
 ) -> std::result::Result<AuthCodeClaim, ClaimError> {
-    let now = Timestamp::now();
-
     let doc = store
         .find_one::<AuthorizationCodeDoc>("code_hash", code_hash)
         .await

--- a/crates/vouch-server/src/db/credentials.rs
+++ b/crates/vouch-server/src/db/credentials.rs
@@ -164,6 +164,10 @@ pub async fn record_ssh_certificate_issuance(
 }
 
 /// Get all non-expired issued SSH certificates for a user.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "filters a listing, not a request accept/reject"
+)]
 pub async fn get_issued_ssh_certificates_for_user(
     store: &DocumentStore,
     user_id: &str,
@@ -221,6 +225,10 @@ pub async fn is_ssh_certificate_revoked(store: &DocumentStore, serial: &str) -> 
 }
 
 /// Get all revoked SSH certificates (for KRL generation).
+#[expect(
+    clippy::disallowed_methods,
+    reason = "filters a KRL listing, not a request accept/reject"
+)]
 pub async fn get_revoked_ssh_certificates(
     store: &DocumentStore,
 ) -> Result<Vec<RevokedSshCertificate>> {
@@ -235,6 +243,10 @@ pub async fn get_revoked_ssh_certificates(
 
 /// Revoke all SSH certificates for a user by looking up issued certs
 /// and inserting a revocation record for each real serial.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "OCC retry re-reads the clock per attempt to stamp the revocation rows"
+)]
 pub(in crate::db) async fn revoke_all_ssh_certificates_for_user(
     store: &DocumentStore,
     user_id: &str,

--- a/crates/vouch-server/src/db/device_auth.rs
+++ b/crates/vouch-server/src/db/device_auth.rs
@@ -418,6 +418,10 @@ pub struct DeviceCodeClaim {
 /// code be redeemed when a retry lands past `expires_at`. The per-attempt
 /// stamp is authoritative for both the `data.expires_at <= now` gate and
 /// the `consumed_at` audit record.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "OCC retry re-reads the clock per attempt"
+)]
 pub async fn try_consume_device_auth(
     store: &DocumentStore,
     device_code_hash: &str,
@@ -475,6 +479,7 @@ pub async fn try_consume_device_auth(
 
 /// Update the last poll time for a device auth request.
 /// Returns true if poll was allowed, false if polling too fast.
+#[expect(clippy::disallowed_methods, reason = "stamps the row's last-poll time")]
 pub async fn update_device_auth_poll_time(
     store: &DocumentStore,
     id: &str,
@@ -562,12 +567,16 @@ pub async fn create_oidc_state(
 /// two concurrent enrollment-callback requests could both read the same
 /// state, both pass validation, and both proceed to issue tokens before
 /// either delete completed.
+///
+/// `now` both decides the expiry comparison and stamps `consumed_at`, so
+/// request-path callers pass the request's [`crate::arrival::ArrivalTime`]
+/// instant rather than letting this read a later clock than the rest of the
+/// callback's checks.
 pub async fn try_consume_oidc_state(
     store: &DocumentStore,
     state: &str,
+    now: Timestamp,
 ) -> std::result::Result<(OidcState, OidcStateClaim), ClaimError> {
-    let now = Timestamp::now();
-
     let doc = store
         .find_one::<OidcStateDoc>("state", state)
         .await

--- a/crates/vouch-server/src/db/documents/jwks_cache.rs
+++ b/crates/vouch-server/src/db/documents/jwks_cache.rs
@@ -45,6 +45,10 @@ impl JwksCacheDoc {
 
     /// Age of the cache in seconds (saturating at 0).
     #[must_use]
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "measures cache age for a refetch decision, not a request one"
+    )]
     pub fn age_seconds(&self) -> i64 {
         Timestamp::now()
             .as_second()

--- a/crates/vouch-server/src/db/dpop.rs
+++ b/crates/vouch-server/src/db/dpop.rs
@@ -43,6 +43,7 @@ fn deterministic_dpop_nonce_id(nonce: &str) -> String {
 /// Stores the nonce under a deterministic document ID derived from the
 /// nonce itself, so [`validate_and_consume_dpop_nonce`] can perform an
 /// atomic primary-key DELETE without a find-then-delete TOCTOU window.
+#[expect(clippy::disallowed_methods, reason = "stamps the nonce's expires_at")]
 pub async fn generate_dpop_nonce(store: &DocumentStore, validity_seconds: i64) -> Result<String> {
     let nonce = URL_SAFE_NO_PAD.encode(crate::crypto::generate_random_bytes(32)?);
     let now = Timestamp::now();
@@ -59,7 +60,7 @@ pub async fn generate_dpop_nonce(store: &DocumentStore, validity_seconds: i64) -
     Ok(nonce)
 }
 
-/// Atomically validate and consume a DPoP nonce.
+/// Atomically validate and consume a DPoP nonce, judged against `now`.
 ///
 /// Uses a single `DELETE WHERE id = ? AND expires_at > ?` statement, so the
 /// outcome is decided by the database row count — no find-then-delete race.
@@ -67,6 +68,14 @@ pub async fn generate_dpop_nonce(store: &DocumentStore, validity_seconds: i64) -
 /// concurrent caller) returns [`ClaimError::AlreadyConsumed`]. The three
 /// lost cases are deliberately indistinguishable: each is rejected the
 /// same way by RFC 9449.
+///
+/// `now` decides the expiry comparison, so a request-path caller passes the
+/// request's [`crate::arrival::ArrivalTime`] instant: this comparison is one
+/// of three serving a single DPoP decision, alongside the JTI retention
+/// commit and the freshness check, and all three must read one instant. A
+/// clock stamped here instead is always ≥ arrival, which makes the predicate
+/// strictly stricter and rejects a nonce that was still valid when the
+/// request arrived but expired during the intervening awaits.
 ///
 /// No witness type is returned because `ValidatedDpopProof` already
 /// carries the "DPoP validation succeeded" marker at the call site
@@ -76,11 +85,11 @@ pub async fn generate_dpop_nonce(store: &DocumentStore, validity_seconds: i64) -
 pub async fn validate_and_consume_dpop_nonce(
     store: &DocumentStore,
     nonce: &str,
+    now: &Timestamp,
 ) -> std::result::Result<(), ClaimError> {
     let id = deterministic_dpop_nonce_id(nonce);
-    let now = Timestamp::now();
     let won = store
-        .delete_if_not_expired(&id, &now)
+        .delete_if_not_expired(&id, now)
         .await
         .map_err(|e| ClaimError::Database(e.to_string()))?;
     if won {

--- a/crates/vouch-server/src/db/github.rs
+++ b/crates/vouch-server/src/db/github.rs
@@ -59,6 +59,7 @@ pub struct CreateGitHubInstallationParams<'a> {
 }
 
 /// Create a new GitHub App installation for an organization.
+#[expect(clippy::disallowed_methods, reason = "stamps the row's installed_at")]
 pub async fn create_github_installation(
     store: &DocumentStore,
     params: &CreateGitHubInstallationParams<'_>,
@@ -163,6 +164,7 @@ async fn resolve_installation_doc_id(
 /// Uses optimistic concurrency (`store.modify`) so concurrent webhook events
 /// targeting the same installation never produce a lost update. If the
 /// installation is deleted between index-resolve and modify, returns `Ok(false)`.
+#[expect(clippy::disallowed_methods, reason = "stamps the row's suspended_at")]
 pub async fn suspend_github_installation(
     store: &DocumentStore,
     installation_id: i64,

--- a/crates/vouch-server/src/db/jwks_cache.rs
+++ b/crates/vouch-server/src/db/jwks_cache.rs
@@ -32,6 +32,10 @@ pub async fn get_jwks_cache(
 /// Insert or update the JWKS cache for a parent document.
 ///
 /// Uses `DocumentStore::upsert` for last-write-wins idempotent semantics.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "stamps the cache row's cached_at"
+)]
 pub async fn upsert_jwks_cache(
     store: &DocumentStore,
     parent_id: &str,

--- a/crates/vouch-server/src/db/mod.rs
+++ b/crates/vouch-server/src/db/mod.rs
@@ -17,89 +17,40 @@
 // The db layer stamps the timestamps it writes — `created_at`, `expires_at`,
 // `last_used_at` — and re-reads the clock inside optimistic-concurrency retry
 // closures, which need a fresh reading per attempt rather than a stale captured
-// one. Neither is a request-path comparison, so the modules doing it carry an
+// one. Neither is a request-path comparison, so those sites carry an
 // expectation for `disallowed_methods`. A comparison that decides a request
 // takes `crate::arrival::ArrivalTime` instead; see `arrival.rs`.
-#[expect(
-    clippy::disallowed_methods,
-    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
-)]
+//
+// Each expectation is written on the function that stamps, never on the `mod`
+// declaration. A module-wide expectation covers whatever the module later
+// grows, and what these modules grew was request-deciding expiry comparisons
+// reading their own clock — the nonce consume, the authorization-code
+// consume, the PAR and pending-auth lookups, the SCIM token lookup — none of
+// which the lint could report while the exemption was granted per module.
 pub(crate) mod audit;
 mod authenticators;
-#[expect(
-    clippy::disallowed_methods,
-    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
-)]
 mod authorization_codes;
 mod challenge_states;
 pub(crate) mod claim;
 mod config;
-#[expect(
-    clippy::disallowed_methods,
-    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
-)]
 mod credentials;
-#[expect(
-    clippy::disallowed_methods,
-    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
-)]
 mod device_auth;
 pub(crate) mod document_type;
-#[expect(
-    clippy::disallowed_methods,
-    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
-)]
 pub(crate) mod documents;
-#[expect(
-    clippy::disallowed_methods,
-    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
-)]
 pub(crate) mod dpop;
 pub(crate) mod dsql;
 mod enrollment;
-#[expect(
-    clippy::disallowed_methods,
-    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
-)]
 mod github;
-#[expect(
-    clippy::disallowed_methods,
-    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
-)]
 mod jwks_cache;
 pub(crate) mod migrations;
-#[expect(
-    clippy::disallowed_methods,
-    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
-)]
 mod oauth;
-#[expect(
-    clippy::disallowed_methods,
-    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
-)]
 mod organizations;
-#[expect(
-    clippy::disallowed_methods,
-    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
-)]
 pub(crate) mod par;
-#[expect(
-    clippy::disallowed_methods,
-    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
-)]
 mod pending_oauth;
 pub(crate) mod pool;
 mod posture_policies;
-#[expect(
-    clippy::disallowed_methods,
-    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
-)]
 mod scim;
 mod sessions;
-#[expect(
-    clippy::disallowed_methods,
-    reason = "db layer stamps row timestamps and re-reads the clock per OCC attempt"
-)]
 pub(crate) mod store;
 mod users;
 

--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -1172,6 +1172,10 @@ impl OAuthClientSecret {
 /// - `ServiceError::Api(409 "max_secrets_reached")` — cap already reached (terminal).
 /// - `ServiceError::Api(409 "conflict")` — OCC retry budget exhausted; caller may retry.
 /// - `ServiceError::Internal` — unexpected database or serialization error.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "stamps the secret's created_at and expires_at"
+)]
 pub async fn create_oauth_client_secret(
     store: &DocumentStore,
     oauth_client_id: &str,
@@ -1320,6 +1324,7 @@ pub async fn get_oauth_secret_by_hash(
 }
 
 /// Revoke all secrets for an OAuth client.
+#[expect(clippy::disallowed_methods, reason = "stamps the revocation time")]
 pub async fn revoke_all_oauth_client_secrets(
     store: &DocumentStore,
     oauth_client_id: &str,
@@ -1376,6 +1381,7 @@ pub async fn get_oauth_client_secret_by_id(
 /// - `ServiceError::Api(409 "last_secret")` — would leave zero active secrets (terminal).
 /// - `ServiceError::Api(409 "conflict")` — OCC retry budget exhausted; caller may retry.
 /// - `ServiceError::Internal` — unexpected database or serialization error.
+#[expect(clippy::disallowed_methods, reason = "stamps the revocation time")]
 pub async fn revoke_oauth_client_secret(
     store: &DocumentStore,
     secret_id: &str,
@@ -2040,10 +2046,16 @@ pub async fn delete_expired_jwt_assertion_jtis(store: &DocumentStore) -> Result<
 /// distinguishable from the HTTP client's perspective, and we never see
 /// the raw stored secret in application code. Do NOT replace this with
 /// a fetch-then-compare pattern; that would reintroduce a timing channel.
+///
+/// `now` decides the secret's validity window, so request-path callers pass
+/// the request's [`crate::arrival::ArrivalTime`] instant: this is the client
+/// authentication decision for the request, and it must read the same clock
+/// as the rest of that decision rather than one stamped later.
 pub async fn validate_oauth_client_credentials(
     store: &DocumentStore,
     client_id: &str,
     secret_hash: &str,
+    now: Timestamp,
 ) -> Result<Option<OAuthClient>> {
     let Some(client) = get_oauth_client_by_client_id(store, client_id).await? else {
         return Ok(None);
@@ -2061,7 +2073,6 @@ pub async fn validate_oauth_client_credentials(
         return Ok(None);
     }
 
-    let now = Timestamp::now();
     if !secret.is_valid(&now) {
         return Ok(None);
     }
@@ -2700,14 +2711,24 @@ mod tests {
             .await
             .expect("create second secret");
 
-        let result1 = validate_oauth_client_credentials(&store, &client.client_id, &hash1)
-            .await
-            .expect("validate with first");
+        let result1 = validate_oauth_client_credentials(
+            &store,
+            &client.client_id,
+            &hash1,
+            jiff::Timestamp::now(),
+        )
+        .await
+        .expect("validate with first");
         assert!(result1.is_some());
 
-        let result2 = validate_oauth_client_credentials(&store, &client.client_id, hash2)
-            .await
-            .expect("validate with second");
+        let result2 = validate_oauth_client_credentials(
+            &store,
+            &client.client_id,
+            hash2,
+            jiff::Timestamp::now(),
+        )
+        .await
+        .expect("validate with second");
         assert!(result2.is_some());
     }
 
@@ -2731,9 +2752,14 @@ mod tests {
             .await
             .expect("revoke");
 
-        let result = validate_oauth_client_credentials(&store, &client.client_id, &hash)
-            .await
-            .expect("validate");
+        let result = validate_oauth_client_credentials(
+            &store,
+            &client.client_id,
+            &hash,
+            jiff::Timestamp::now(),
+        )
+        .await
+        .expect("validate");
 
         assert!(result.is_none());
     }
@@ -2764,9 +2790,14 @@ mod tests {
         // Fault every `update_last_used_at` write with a non-retryable `Err`.
         store.set_last_used_remaining_successes(0);
 
-        let result = validate_oauth_client_credentials(&store, &client.client_id, &hash)
-            .await
-            .expect("credential validation must not fail when the last_used_at write fails");
+        let result = validate_oauth_client_credentials(
+            &store,
+            &client.client_id,
+            &hash,
+            jiff::Timestamp::now(),
+        )
+        .await
+        .expect("credential validation must not fail when the last_used_at write fails");
         assert!(
             result.is_some(),
             "validated client must be returned even under an injected last_used_at fault"
@@ -2774,9 +2805,14 @@ mod tests {
 
         // Control: with the fault cleared, validation still returns the client.
         store.set_last_used_remaining_successes(u64::MAX);
-        let result = validate_oauth_client_credentials(&store, &client.client_id, &hash)
-            .await
-            .expect("validate with fault cleared");
+        let result = validate_oauth_client_credentials(
+            &store,
+            &client.client_id,
+            &hash,
+            jiff::Timestamp::now(),
+        )
+        .await
+        .expect("validate with fault cleared");
         assert!(result.is_some());
     }
 

--- a/crates/vouch-server/src/db/organizations/domains.rs
+++ b/crates/vouch-server/src/db/organizations/domains.rs
@@ -202,6 +202,7 @@ impl crate::db::pool::RetryableError for MarkVerifiedError {
 /// TXT record before [`verify_additional_domain`] will mark the entry verified.
 /// Until then, the entry is stored on the org but is not indexed and does
 /// not participate in login matching.
+#[expect(clippy::disallowed_methods, reason = "stamps the row's added_at")]
 pub async fn add_additional_domain(
     store: &DocumentStore,
     org_id: &str,
@@ -331,6 +332,7 @@ pub async fn get_verification_token(
 /// the stored token. Re-runs the cross-org conflict check inside the
 /// transaction to guard against a TOCTOU race where another org verified
 /// the same domain between add and verify.
+#[expect(clippy::disallowed_methods, reason = "stamps the row's verified_at")]
 pub async fn mark_additional_domain_verified(
     store: &DocumentStore,
     org_id: &str,
@@ -873,6 +875,10 @@ pub async fn list_all_verified_additional_domains(
 ///
 /// Returns [`RecheckEffect::NotFound`] if the entry has been removed or is
 /// already unverified, so callers can stop tracking it.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "stamps the row's last-checked time"
+)]
 pub async fn record_recheck_result(
     store: &DocumentStore,
     org_id: &str,

--- a/crates/vouch-server/src/db/organizations/issuer.rs
+++ b/crates/vouch-server/src/db/organizations/issuer.rs
@@ -222,6 +222,10 @@ pub async fn list_org_signing_keys(
 /// immediately.
 ///
 /// Returns the normalized label on success.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "operator-driven claim, not a request-path comparison"
+)]
 pub async fn claim_subdomain(
     store: &DocumentStore,
     org_id: &str,
@@ -370,6 +374,7 @@ pub async fn claim_subdomain(
 /// Releasing is already disruptive (discovery returns 404 during the cooldown), so
 /// dropping a Previous key's still-valid tokens on release is acceptable: the caller
 /// should communicate the disruption to end users.
+#[expect(clippy::disallowed_methods, reason = "stamps the row's released_at")]
 pub async fn release_subdomain(store: &DocumentStore, org_id: &str) -> Result<Option<String>> {
     let result: Result<Option<String>, SubdomainClaimError> = crate::with_dsql_retry!(async {
         let mut tx = store.begin().await?;
@@ -459,6 +464,10 @@ pub(super) fn subdomain_to_release(data: &OrganizationDoc) -> Option<String> {
 /// Returns [`SubdomainClaimError::OccConflict`] when the claim slot loses its
 /// CAS race — callers run inside `with_dsql_retry!`, which re-runs the whole
 /// transaction from a fresh read. Other failures are terminal.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "stamps the claim slot's released_at"
+)]
 pub(super) async fn release_ineligible_subdomain(
     tx: &mut StoreTransaction<'_>,
     org_id: &str,

--- a/crates/vouch-server/src/db/par.rs
+++ b/crates/vouch-server/src/db/par.rs
@@ -135,6 +135,7 @@ pub(crate) const REQUEST_URI_URN_PREFIX: &str = "urn:ietf:params:oauth:request_u
 /// (typically a JWT assertion JTI) before persisting the PAR record.
 /// It is dropped immediately on entry — its only purpose is to make this
 /// PAR storage chokepoint unforgeable from outside the crate.
+#[expect(clippy::disallowed_methods, reason = "stamps the PAR row's expires_at")]
 pub(crate) async fn create_pushed_authorization_request(
     store: &DocumentStore,
     params: CreateParParams<'_>,
@@ -271,9 +272,8 @@ impl ParConsumptionProof {
     pub async fn consume(
         store: &DocumentStore,
         par: ParRef<'_>,
+        now: Timestamp,
     ) -> std::result::Result<Self, ClaimError> {
-        let now = Timestamp::now();
-
         let doc = store
             .find_one::<PushedAuthorizationRequestDoc>("request_uri", par.request_uri)
             .await
@@ -327,13 +327,17 @@ impl ParConsumptionProof {
 ///
 /// FAPI 2.0 Section 5.3.2.2 Note 3: request_uri values should be reusable
 /// until the authorization request has been completed (code issued).
+///
+/// `now` decides the expiry comparison, so request-path callers pass the
+/// request's [`crate::arrival::ArrivalTime`] instant. A clock stamped here
+/// would be ≥ arrival and could retire a `request_uri` that was still live
+/// when the authorization request arrived.
 pub async fn get_pushed_authorization_request(
     store: &DocumentStore,
     request_uri: &str,
     client_id: &str,
+    now: Timestamp,
 ) -> Result<Option<PushedAuthorizationRequest>> {
-    let now = Timestamp::now();
-
     let doc = store
         .find_one::<PushedAuthorizationRequestDoc>("request_uri", request_uri)
         .await?;
@@ -360,6 +364,7 @@ pub async fn get_pushed_authorization_request(
 ///
 /// Uses optimistic concurrency: if the PAR was consumed or modified concurrently
 /// the extension is silently skipped (the flow will fail at consume time).
+#[expect(clippy::disallowed_methods, reason = "stamps the row's new expires_at")]
 pub async fn extend_par_expiration(
     store: &DocumentStore,
     request_uri: &str,

--- a/crates/vouch-server/src/db/pending_oauth.rs
+++ b/crates/vouch-server/src/db/pending_oauth.rs
@@ -93,6 +93,10 @@ pub struct CreatePendingOAuthParams<'a> {
 }
 
 /// Create a pending OAuth authorization.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "stamps the row's created_at and expires_at"
+)]
 pub async fn create_pending_oauth_authorization(
     store: &DocumentStore,
     params: CreatePendingOAuthParams<'_>,
@@ -129,12 +133,16 @@ pub async fn create_pending_oauth_authorization(
 /// Get a pending OAuth authorization by ID.
 ///
 /// Returns None if not found, expired, or already consumed.
+///
+/// `now` decides the expiry comparison, so request-path callers pass the
+/// request's [`crate::arrival::ArrivalTime`] instant. A clock stamped here
+/// would be ≥ arrival and could drop a deferred login that was still
+/// resumable when the request arrived.
 pub async fn get_pending_oauth_authorization(
     store: &DocumentStore,
     id: &str,
+    now: Timestamp,
 ) -> Result<Option<PendingOAuthAuthorization>> {
-    let now = Timestamp::now();
-
     let doc = store.get::<PendingOAuthAuthDoc>(id).await?;
     match doc {
         Some(d) if d.data.consumed_at.is_none() && d.data.expires_at > now => {
@@ -175,12 +183,15 @@ pub(crate) struct PendingOauthClaim {
 /// All "lost" cases (not found, expired, already consumed, concurrent
 /// consumer won) map to [`ClaimError::AlreadyConsumed`] — deliberately
 /// indistinguishable, each rejected as an invalid `pending_auth`.
+///
+/// `now` both decides the expiry comparison and stamps `consumed_at`, so
+/// request-path callers pass the request's [`crate::arrival::ArrivalTime`]
+/// instant.
 pub(crate) async fn consume_pending_oauth_authorization(
     store: &DocumentStore,
     id: &str,
+    now: Timestamp,
 ) -> std::result::Result<(PendingOAuthAuthorization, PendingOauthClaim), ClaimError> {
-    let now = Timestamp::now();
-
     let doc = store
         .get::<PendingOAuthAuthDoc>(id)
         .await

--- a/crates/vouch-server/src/db/scim.rs
+++ b/crates/vouch-server/src/db/scim.rs
@@ -167,6 +167,7 @@ impl From<Document<ScimTokenDoc>> for ScimToken {
 pub async fn get_scim_token_by_hash(
     store: &DocumentStore,
     token_hash: &str,
+    now: Timestamp,
 ) -> Result<Option<ScimToken>> {
     let doc = store
         .find_one::<ScimTokenDoc>("token_hash", token_hash)
@@ -177,7 +178,6 @@ pub async fn get_scim_token_by_hash(
     };
 
     // Check expiration
-    let now = Timestamp::now();
     if let Some(expires_at) = doc.data.expires_at
         && expires_at <= now
     {
@@ -223,6 +223,10 @@ pub struct CreateScimTokenParams<'a> {
 /// - `ServiceError::NotFound` — organization does not exist.
 /// - `ServiceError::Api(409 "token_limit_reached")` — cap reached (terminal).
 /// - `ServiceError::Api(409 "conflict")` — OCC retry budget exhausted; caller may retry.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "stamps the token's created_at, and the cap count re-reads per OCC attempt"
+)]
 pub async fn create_scim_token(
     store: &DocumentStore,
     params: &CreateScimTokenParams<'_>,

--- a/crates/vouch-server/src/db/store.rs
+++ b/crates/vouch-server/src/db/store.rs
@@ -893,6 +893,10 @@ impl DocumentStore {
     /// # Errors
     ///
     /// Returns an error if serialization, encryption, or the database write fails.
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "stamps the row's created_at and updated_at"
+    )]
     pub async fn upsert<T: DocumentType>(&self, id: &str, doc: &T) -> Result<()> {
         crate::with_dsql_retry!(async {
             let SerializedDoc {
@@ -1229,6 +1233,7 @@ impl DocumentStore {
     /// # Errors
     ///
     /// Returns an error if the database write fails.
+    #[expect(clippy::disallowed_methods, reason = "stamps the row's last_used_at")]
     pub async fn update_last_used_at(&self, id: &str) -> Result<()> {
         #[cfg(test)]
         {
@@ -1349,6 +1354,10 @@ impl DocumentStore {
     ///
     /// Returns an error if serialization, encryption, or the database
     /// write fails.
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "OCC retry re-reads the clock per attempt"
+    )]
     pub async fn compare_and_update<T: DocumentType>(
         &self,
         id: &str,
@@ -1527,6 +1536,10 @@ impl DocumentStore {
     /// # Errors
     ///
     /// Returns an error if the database operation fails.
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "background sweep cutoff, serves no request"
+    )]
     pub async fn delete_expired(&self, doc_type: &str) -> Result<u64> {
         crate::with_dsql_retry!(async {
             let now = jiff::Timestamp::now().to_string();
@@ -1808,6 +1821,10 @@ impl StoreTransaction<'_> {
     ///
     /// Returns an error if serialization, encryption, or the database write
     /// fails.
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "stamps the row's created_at and updated_at"
+    )]
     pub async fn insert_with_id<T: DocumentType>(
         &mut self,
         id: &str,
@@ -1975,6 +1992,7 @@ impl StoreTransaction<'_> {
     ///
     /// Returns an error if serialization, encryption, or the database write
     /// fails.
+    #[expect(clippy::disallowed_methods, reason = "stamps the row's updated_at")]
     pub async fn update<T: DocumentType>(&mut self, id: &str, doc: &T) -> Result<()> {
         let SerializedDoc {
             encrypted,
@@ -2214,6 +2232,10 @@ impl StoreTransaction<'_> {
     /// or if a matched document changed since it was read ([`VersionConflict`]).
     /// Any error aborts the caller's transaction — the transaction is rolled
     /// back when dropped, so no partial batch is ever persisted.
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "OCC retry re-reads the clock per attempt"
+    )]
     pub async fn update_by_index<T, F>(
         &mut self,
         field: &str,
@@ -2382,6 +2404,10 @@ impl StoreTransaction<'_> {
     ///
     /// Returns an error if serialization, encryption, or the database
     /// write fails.
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "OCC retry re-reads the clock per attempt"
+    )]
     pub async fn compare_and_update<T: DocumentType>(
         &mut self,
         id: &str,

--- a/crates/vouch-server/src/db/tests.rs
+++ b/crates/vouch-server/src/db/tests.rs
@@ -6,6 +6,7 @@
 //! the file whose scope matches; add a new file (and list it here) when
 //! none does:
 //!
+//! - [`arrival_anchored_expiry`] — Request-deciding expiry comparisons read the caller's instant, not an ambient clock.
 //! - [`audit_events`] — Auth/key/device audit event logging and expiry.
 //! - [`authenticators`] — Authenticator (security key) CRUD and counting.
 //! - [`cascade_delete`] — Cascade deletion of users and OAuth clients with their dependent rows.
@@ -101,6 +102,7 @@ fn test_org_doc(domain: &str) -> crate::db::documents::organization::Organizatio
     }
 }
 
+mod arrival_anchored_expiry;
 mod audit_events;
 mod authenticators;
 mod cascade_delete;

--- a/crates/vouch-server/src/db/tests/arrival_anchored_expiry.rs
+++ b/crates/vouch-server/src/db/tests/arrival_anchored_expiry.rs
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//! Request-deciding expiry comparisons are judged against the caller's
+//! instant, not a clock the helper stamps itself.
+#![expect(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "test code: panic on assertion failure is acceptable; cast bounds are obvious in test fixtures"
+)]
+
+use super::*;
+
+// ========================================================================
+// Every helper below decides whether a request succeeds by comparing a
+// stored `expires_at` against an instant. That instant is the request's
+// `ArrivalTime`, threaded in by the caller, because the same decision is
+// made by several comparisons and they must all read one clock.
+//
+// A helper that stamped its own clock would read an instant strictly later
+// than arrival, so a record still live when the request arrived could be
+// rejected if it expired during the intervening awaits — a spurious
+// rejection at the tail of every lifetime.
+//
+// Each test seeds a record that is ALREADY EXPIRED against the wall clock
+// and passes an instant from before that expiry. The helper must accept.
+// That can only pass if the comparison reads the parameter, so an ambient
+// clock reintroduced into any of these helpers fails the test outright
+// rather than flaking on a second boundary.
+// ========================================================================
+
+/// An instant comfortably in the past, and a record expiring just after it.
+/// Both are far enough from "now" that no scheduling delay can blur them.
+fn arrival_and_expiry() -> (jiff::Timestamp, jiff::Timestamp) {
+    let arrival: jiff::Timestamp = "2020-01-01T00:00:00Z".parse().unwrap();
+    let expires_at: jiff::Timestamp = "2020-01-01T00:01:00Z".parse().unwrap();
+    (arrival, expires_at)
+}
+
+#[tokio::test]
+async fn authorization_code_consume_reads_the_callers_instant() {
+    let (store, _audit) = test_db().await;
+    let (arrival, expires_at) = arrival_and_expiry();
+
+    store_authorization_code(
+        &store,
+        "arrival-code-hash",
+        "client-arrival",
+        "user-arrival",
+        expires_at,
+        None,
+    )
+    .await
+    .expect("seed authorization code");
+
+    let _claim = try_consume_authorization_code(&store, "arrival-code-hash", arrival)
+        .await
+        .expect("a code live at the caller's instant must be consumable");
+}
+
+#[tokio::test]
+async fn authorization_code_consume_still_rejects_a_code_expired_at_that_instant() {
+    use crate::db::claim::ClaimError;
+    let (store, _audit) = test_db().await;
+    let (_, expires_at) = arrival_and_expiry();
+
+    store_authorization_code(
+        &store,
+        "arrival-stale-hash",
+        "client-arrival",
+        "user-arrival",
+        expires_at,
+        None,
+    )
+    .await
+    .expect("seed authorization code");
+
+    // One second past the record's expiry: the parameter decides both ways,
+    // so threading it cannot have turned the check off.
+    let after = expires_at
+        .checked_add(jiff::SignedDuration::from_secs(1))
+        .unwrap();
+    let err = try_consume_authorization_code(&store, "arrival-stale-hash", after)
+        .await
+        .expect_err("a code expired at the caller's instant must be rejected");
+    assert!(
+        matches!(err, ClaimError::AlreadyConsumed),
+        "expired code must report AlreadyConsumed, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn pending_oauth_lookup_reads_the_callers_instant() {
+    let (store, _audit) = test_db().await;
+
+    // `create_pending_oauth_authorization` stamps a 10-minute expiry from the
+    // wall clock. The record is therefore live now and expired at any instant
+    // past that window, so the two lookups below can only disagree if the
+    // comparison reads the instant it is given.
+    let id = create_pending_oauth_authorization(
+        &store,
+        CreatePendingOAuthParams {
+            client_id: "client-arrival",
+            redirect_uri: "https://example.com/cb",
+            response_type: "code",
+            state: None,
+            scope: None,
+            nonce: None,
+            code_challenge: None,
+            code_challenge_method: None,
+            resource: None,
+            acr_values: None,
+            max_age: None,
+            prompt: None,
+            dpop_jkt: None,
+            authorization_details: None,
+            response_mode: crate::db::documents::oauth::ResponseMode::Query,
+            par_request_uri: None,
+        },
+    )
+    .await
+    .expect("seed pending oauth authorization");
+
+    assert!(
+        get_pending_oauth_authorization(&store, &id, jiff::Timestamp::now())
+            .await
+            .expect("lookup must not error")
+            .is_some(),
+        "the record is live at the current instant"
+    );
+
+    let past_window: jiff::Timestamp = "2099-12-31T23:59:59Z".parse().unwrap();
+    assert!(
+        get_pending_oauth_authorization(&store, &id, past_window)
+            .await
+            .expect("lookup must not error")
+            .is_none(),
+        "the same record must read as expired at an instant past its window, \
+         which is only possible if the comparison uses the caller's instant"
+    );
+}
+
+#[tokio::test]
+async fn scim_token_lookup_reads_the_callers_instant() {
+    let (store, _audit) = test_db().await;
+    let (arrival, expires_at) = arrival_and_expiry();
+    seed_test_org(&store).await;
+
+    let token = create_scim_token(
+        &store,
+        &CreateScimTokenParams {
+            org_id: TEST_ORG_ID,
+            token_hash: "arrival-scim-hash",
+            description: Some("arrival token"),
+            expires_at: Some(expires_at),
+            scope: ScimScopeSet::default(),
+        },
+    )
+    .await
+    .expect("seed scim token");
+    assert!(!token.is_empty(), "token id returned");
+
+    assert!(
+        get_scim_token_by_hash(&store, "arrival-scim-hash", arrival)
+            .await
+            .expect("lookup must not error")
+            .is_some(),
+        "a token live at the caller's instant must authenticate"
+    );
+    assert!(
+        get_scim_token_by_hash(&store, "arrival-scim-hash", jiff::Timestamp::now())
+            .await
+            .expect("lookup must not error")
+            .is_none(),
+        "the same token must read as expired at the current instant"
+    );
+}
+
+#[tokio::test]
+async fn dpop_nonce_consume_reads_the_callers_instant() {
+    use crate::db::claim::ClaimError;
+    let (store, _audit) = test_db().await;
+
+    // The nonce's expiry is stamped from the wall clock at generation, so it
+    // is live now and expired at any instant past that 300-second window.
+    let nonce = generate_dpop_nonce(&store, 300).await.expect("seed nonce");
+    let past_window: jiff::Timestamp = "2099-12-31T23:59:59Z".parse().unwrap();
+
+    let err = validate_and_consume_dpop_nonce(&store, &nonce, &past_window)
+        .await
+        .expect_err("a nonce expired at the caller's instant must be rejected");
+    assert!(
+        matches!(err, ClaimError::AlreadyConsumed),
+        "an expired nonce must report AlreadyConsumed, got: {err:?}"
+    );
+
+    // The rejected attempt must not have consumed the row: the same nonce
+    // still works when judged against an instant inside its window. This is
+    // the direction that matters — an ambient clock here would be later than
+    // the request's arrival and could reject a nonce that was still live.
+    validate_and_consume_dpop_nonce(&store, &nonce, &jiff::Timestamp::now())
+        .await
+        .expect("a nonce live at the caller's instant must be consumable");
+}

--- a/crates/vouch-server/src/db/tests/concurrency.rs
+++ b/crates/vouch-server/src/db/tests/concurrency.rs
@@ -41,8 +41,8 @@ async fn test_authorization_code_consume_concurrent() {
     let store_a = store.clone();
     let store_b = store.clone();
     let (result_a, result_b) = tokio::join!(
-        try_consume_authorization_code(&store_a, "race-code-hash"),
-        try_consume_authorization_code(&store_b, "race-code-hash"),
+        try_consume_authorization_code(&store_a, "race-code-hash", jiff::Timestamp::now()),
+        try_consume_authorization_code(&store_b, "race-code-hash", jiff::Timestamp::now()),
     );
 
     let a_won = result_a.is_ok();
@@ -143,8 +143,12 @@ async fn test_dpop_nonce_consume_concurrent() {
     let nonce_a = nonce.clone();
     let nonce_b = nonce.clone();
     let (result_a, result_b) = tokio::join!(
-        async move { validate_and_consume_dpop_nonce(&store_a, &nonce_a).await },
-        async move { validate_and_consume_dpop_nonce(&store_b, &nonce_b).await },
+        async move {
+            validate_and_consume_dpop_nonce(&store_a, &nonce_a, &jiff::Timestamp::now()).await
+        },
+        async move {
+            validate_and_consume_dpop_nonce(&store_b, &nonce_b, &jiff::Timestamp::now()).await
+        },
     );
 
     let a_won = result_a.is_ok();
@@ -197,8 +201,12 @@ async fn test_pending_oauth_consume_concurrent() {
     let id_a = id.clone();
     let id_b = id.clone();
     let (result_a, result_b) = tokio::join!(
-        async move { consume_pending_oauth_authorization(&store_a, &id_a).await },
-        async move { consume_pending_oauth_authorization(&store_b, &id_b).await },
+        async move {
+            consume_pending_oauth_authorization(&store_a, &id_a, jiff::Timestamp::now()).await
+        },
+        async move {
+            consume_pending_oauth_authorization(&store_b, &id_b, jiff::Timestamp::now()).await
+        },
     );
 
     let a_won = result_a.is_ok();

--- a/crates/vouch-server/src/db/tests/oauth_clients.rs
+++ b/crates/vouch-server/src/db/tests/oauth_clients.rs
@@ -865,9 +865,14 @@ async fn test_revoke_all_oauth_client_secrets_blocks_subsequent_credential_valid
     // Sanity: validate succeeds before revoke_all_oauth_client_secrets. If
     // this fails, the test fixture did not seed a usable secret and the
     // assertion below would pass vacuously.
-    let pre = validate_oauth_client_credentials(&store, &app.client_id, &secret_hash)
-        .await
-        .expect("validate before revoke must not error");
+    let pre = validate_oauth_client_credentials(
+        &store,
+        &app.client_id,
+        &secret_hash,
+        jiff::Timestamp::now(),
+    )
+    .await
+    .expect("validate before revoke must not error");
     assert!(
         pre.is_some(),
         "secret must validate before revoke_all_oauth_client_secrets — \
@@ -886,9 +891,14 @@ async fn test_revoke_all_oauth_client_secrets_blocks_subsequent_credential_valid
     // After the revoke commit, validation must fail (return None). This is
     // what closes the concurrent-mint window the delete path's
     // secret-revoke-first ordering exploits.
-    let post = validate_oauth_client_credentials(&store, &app.client_id, &secret_hash)
-        .await
-        .expect("validate after revoke must not error");
+    let post = validate_oauth_client_credentials(
+        &store,
+        &app.client_id,
+        &secret_hash,
+        jiff::Timestamp::now(),
+    )
+    .await
+    .expect("validate after revoke must not error");
     assert!(
         post.is_none(),
         "validate_oauth_client_credentials must return None after \
@@ -982,7 +992,13 @@ async fn test_delete_oauth_client_revokes_secrets_before_sweeps_closes_concurren
             // §2a interleaving: `validate_oauth_client_credentials` running at
             // the precise instant between `revoke_all_oauth_client_secrets`'s
             // commit and the first session sweep's commit.
-            let r = validate_oauth_client_credentials(&store, &client_id, &secret_hash).await;
+            let r = validate_oauth_client_credentials(
+                &store,
+                &client_id,
+                &secret_hash,
+                jiff::Timestamp::now(),
+            )
+            .await;
             *outcome.lock().expect("outcome lock") = Some(r);
         })
     }));

--- a/crates/vouch-server/src/db/tests/oidc_state.rs
+++ b/crates/vouch-server/src/db/tests/oidc_state.rs
@@ -50,7 +50,7 @@ async fn test_oidc_state_consume_happy_path() {
     let expires_at: jiff::Timestamp = "2099-12-31T23:59:59Z".parse().unwrap();
     let device_auth_id = seed_oidc_state(&store, "happy-state", expires_at).await;
 
-    let (data, _claim) = try_consume_oidc_state(&store, "happy-state")
+    let (data, _claim) = try_consume_oidc_state(&store, "happy-state", jiff::Timestamp::now())
         .await
         .expect("first consume must succeed");
 
@@ -69,11 +69,11 @@ async fn test_oidc_state_consume_replay_rejected() {
     let expires_at: jiff::Timestamp = "2099-12-31T23:59:59Z".parse().unwrap();
     seed_oidc_state(&store, "replay-state", expires_at).await;
 
-    let _first = try_consume_oidc_state(&store, "replay-state")
+    let _first = try_consume_oidc_state(&store, "replay-state", jiff::Timestamp::now())
         .await
         .expect("first consume must succeed");
 
-    let replayed = try_consume_oidc_state(&store, "replay-state").await;
+    let replayed = try_consume_oidc_state(&store, "replay-state", jiff::Timestamp::now()).await;
     assert!(
         matches!(replayed, Err(ClaimError::AlreadyConsumed)),
         "second consume must be rejected as AlreadyConsumed, got: {replayed:?}"
@@ -88,7 +88,7 @@ async fn test_oidc_state_consume_expired_rejected() {
     let expires_at: jiff::Timestamp = "2000-01-01T00:00:00Z".parse().unwrap();
     seed_oidc_state(&store, "expired-state", expires_at).await;
 
-    let result = try_consume_oidc_state(&store, "expired-state").await;
+    let result = try_consume_oidc_state(&store, "expired-state", jiff::Timestamp::now()).await;
     assert!(
         matches!(result, Err(ClaimError::AlreadyConsumed)),
         "expired state must be reported as AlreadyConsumed (indistinguishable \
@@ -101,7 +101,7 @@ async fn test_oidc_state_consume_not_found_rejected() {
     use crate::db::claim::ClaimError;
     let (store, _audit) = test_db().await;
 
-    let result = try_consume_oidc_state(&store, "never-existed").await;
+    let result = try_consume_oidc_state(&store, "never-existed", jiff::Timestamp::now()).await;
     assert!(
         matches!(result, Err(ClaimError::AlreadyConsumed)),
         "missing state must be reported as AlreadyConsumed: got {result:?}"
@@ -118,8 +118,8 @@ async fn test_oidc_state_consume_concurrent() {
     let store_a = store.clone();
     let store_b = store.clone();
     let (result_a, result_b) = tokio::join!(
-        try_consume_oidc_state(&store_a, "race-state"),
-        try_consume_oidc_state(&store_b, "race-state"),
+        try_consume_oidc_state(&store_a, "race-state", jiff::Timestamp::now()),
+        try_consume_oidc_state(&store_b, "race-state", jiff::Timestamp::now()),
     );
 
     let a_won = result_a.is_ok();

--- a/crates/vouch-server/src/db/tests/scim_tokens.rs
+++ b/crates/vouch-server/src/db/tests/scim_tokens.rs
@@ -40,7 +40,7 @@ async fn test_scim_token_management() {
     assert!(!token_id.is_empty());
 
     // Get by hash
-    let token = get_scim_token_by_hash(&store, token_hash)
+    let token = get_scim_token_by_hash(&store, token_hash, jiff::Timestamp::now())
         .await
         .expect("Failed to get token")
         .expect("Token should exist");
@@ -53,7 +53,7 @@ async fn test_scim_token_management() {
         .await
         .expect("Failed to update last used");
 
-    let token = get_scim_token_by_hash(&store, token_hash)
+    let token = get_scim_token_by_hash(&store, token_hash, jiff::Timestamp::now())
         .await
         .expect("Failed to get token")
         .expect("Token should exist");
@@ -77,7 +77,7 @@ async fn test_scim_token_management() {
     );
 
     // Verify token still exists
-    let token = get_scim_token_by_hash(&store, token_hash)
+    let token = get_scim_token_by_hash(&store, token_hash, jiff::Timestamp::now())
         .await
         .expect("Query should succeed");
     assert!(
@@ -91,7 +91,7 @@ async fn test_scim_token_management() {
         .expect("Failed to delete token");
     assert!(deleted, "Should delete token belonging to correct org");
 
-    let token = get_scim_token_by_hash(&store, token_hash)
+    let token = get_scim_token_by_hash(&store, token_hash, jiff::Timestamp::now())
         .await
         .expect("Query should succeed");
 
@@ -140,14 +140,14 @@ async fn test_expired_scim_tokens_excluded_from_active_count() {
 
     // An expired token cannot authenticate...
     assert!(
-        get_scim_token_by_hash(&store, "expired-1")
+        get_scim_token_by_hash(&store, "expired-1", jiff::Timestamp::now())
             .await
             .expect("lookup expired token")
             .is_none(),
         "an expired token must not authenticate"
     );
     assert!(
-        get_scim_token_by_hash(&store, "active-1")
+        get_scim_token_by_hash(&store, "active-1", jiff::Timestamp::now())
             .await
             .expect("lookup active token")
             .is_some(),

--- a/crates/vouch-server/src/handlers/api/org/audit.rs
+++ b/crates/vouch-server/src/handlers/api/org/audit.rs
@@ -157,16 +157,17 @@ async fn authenticate(
 
     if let Some(token) = crate::http::strip_auth_scheme(auth_header, protocol::AUTH_SCHEME_BEARER) {
         let token_hash = hex::encode(digest::digest(&SHA256, token.as_bytes()));
-        let token_record = db::get_scim_token_by_hash(&state.store, &token_hash)
-            .await
-            .map_err(|e| {
-                tracing::error!(error = %e, "failed to look up org API token");
-                ServiceError::api(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "db_error",
-                    "Database error",
-                )
-            })?;
+        let token_record =
+            db::get_scim_token_by_hash(&state.store, &token_hash, arrival.timestamp())
+                .await
+                .map_err(|e| {
+                    tracing::error!(error = %e, "failed to look up org API token");
+                    ServiceError::api(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "db_error",
+                        "Database error",
+                    )
+                })?;
 
         if let Some(token_record) = token_record {
             let org_id = token_record.org_id.ok_or_else(|| {

--- a/crates/vouch-server/src/handlers/browser_login.rs
+++ b/crates/vouch-server/src/handlers/browser_login.rs
@@ -319,7 +319,7 @@ pub(crate) async fn login_page(
 
     // Look up pending auth to check prompt and get client name.
     let pending = if let Some(ref pending_id) = query.pending_auth {
-        db::get_pending_oauth_authorization(&state.store, pending_id)
+        db::get_pending_oauth_authorization(&state.store, pending_id, arrival.timestamp())
             .await
             .ok()
             .flatten()
@@ -1222,10 +1222,14 @@ mod tests {
             resp.headers.get("location")
         );
         assert!(
-            crate::db::get_pending_oauth_authorization(&state.store, &pending_id)
-                .await
-                .expect("pending lookup")
-                .is_some(),
+            crate::db::get_pending_oauth_authorization(
+                &state.store,
+                &pending_id,
+                jiff::Timestamp::now(),
+            )
+            .await
+            .expect("pending lookup")
+            .is_some(),
             "rendering the form must not spend the single-use pending id"
         );
     }

--- a/crates/vouch-server/src/handlers/certification.rs
+++ b/crates/vouch-server/src/handlers/certification.rs
@@ -113,7 +113,13 @@ pub(crate) async fn complete_login(
     // ── 2. Validate pending authorization exists (read, don't consume) ────
     // The pending auth will be consumed by the authorize endpoint when
     // it issues the authorization code via handle_pending_auth.
-    match db::get_pending_oauth_authorization(&state.store, &query.pending_auth).await {
+    match db::get_pending_oauth_authorization(
+        &state.store,
+        &query.pending_auth,
+        arrival.timestamp(),
+    )
+    .await
+    {
         Ok(Some(_)) => {}
         Ok(None) => {
             tracing::warn!(
@@ -244,6 +250,7 @@ pub(crate) async fn complete_login(
 /// form, or query-string redirect) via the shared `oauth_error_response`
 /// helper.
 pub(crate) async fn deny_login(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     Query(query): Query<CompleteLoginQuery>,
 ) -> Response {
@@ -264,14 +271,19 @@ pub(crate) async fn deny_login(
 
     // Consume pending authorization. The `_claim` witness is bound to
     // satisfy `#[must_use]`; downstream code uses `pending` directly.
-    let (pending, _claim) =
-        match db::consume_pending_oauth_authorization(&state.store, &query.pending_auth).await {
-            Ok(pair) => pair,
-            Err(db::claim::ClaimError::AlreadyConsumed) => {
-                return StatusCode::NOT_FOUND.into_response();
-            }
-            Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
-        };
+    let (pending, _claim) = match db::consume_pending_oauth_authorization(
+        &state.store,
+        &query.pending_auth,
+        arrival.timestamp(),
+    )
+    .await
+    {
+        Ok(pair) => pair,
+        Err(db::claim::ClaimError::AlreadyConsumed) => {
+            return StatusCode::NOT_FOUND.into_response();
+        }
+        Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    };
 
     // Build the access_denied error response, dispatching on response_mode:
     // - Jwt:      JARM signed JWT delivered via the `response` query parameter.

--- a/crates/vouch-server/src/handlers/enroll.rs
+++ b/crates/vouch-server/src/handlers/enroll.rs
@@ -588,7 +588,7 @@ pub(crate) async fn oidc_callback(
     // get-then-delete pattern, closing the read-vs-consume TOCTOU that
     // let two concurrent callbacks both pass validation and issue tokens.
     let (stored_state, oidc_state_claim) =
-        match db::try_consume_oidc_state(&state.store, &oidc_state).await {
+        match db::try_consume_oidc_state(&state.store, &oidc_state, arrival.timestamp()).await {
             Ok(pair) => pair,
             Err(db::ClaimError::AlreadyConsumed) => {
                 return ErrorTemplate {

--- a/crates/vouch-server/src/handlers/enroll/tests.rs
+++ b/crates/vouch-server/src/handlers/enroll/tests.rs
@@ -407,9 +407,10 @@ async fn test_oidc_callback_rejects_replayed_state() {
     .expect("create_oidc_state");
 
     // Pre-consume to simulate a successful prior callback.
-    let _claim = crate::db::try_consume_oidc_state(&state.store, oidc_state_value)
-        .await
-        .expect("pre-consume must succeed");
+    let _claim =
+        crate::db::try_consume_oidc_state(&state.store, oidc_state_value, jiff::Timestamp::now())
+            .await
+            .expect("pre-consume must succeed");
 
     // Submit the callback with the now-consumed state. The handler
     // calls `try_consume_oidc_state` first, which returns
@@ -900,7 +901,7 @@ async fn seed_and_consume_oidc_state(
     )
     .await
     .expect("create_oidc_state");
-    crate::db::try_consume_oidc_state(&state.store, state_value)
+    crate::db::try_consume_oidc_state(&state.store, state_value, jiff::Timestamp::now())
         .await
         .expect("consume oidc state")
 }

--- a/crates/vouch-server/src/handlers/oidc/authorize.rs
+++ b/crates/vouch-server/src/handlers/oidc/authorize.rs
@@ -854,6 +854,7 @@ async fn handle_jar_request(
 async fn lookup_par(
     state: &Arc<AppState>,
     ctx: ParRequestContext<'_>,
+    arrival: ArrivalTime,
 ) -> Result<db::PushedAuthorizationRequest, Response> {
     let ParRequestContext {
         request_uri,
@@ -861,7 +862,14 @@ async fn lookup_par(
         fallback_redirect_uri,
         response_mode,
     } = ctx;
-    match db::get_pushed_authorization_request(&state.store, request_uri, client_id).await {
+    match db::get_pushed_authorization_request(
+        &state.store,
+        request_uri,
+        client_id,
+        arrival.timestamp(),
+    )
+    .await
+    {
         Ok(Some(p)) => Ok(p),
         Ok(None) => {
             tracing::warn!(
@@ -928,7 +936,7 @@ async fn handle_par_request(
     arrival: ArrivalTime,
 ) -> Response {
     // FAPI 2.0 Section 5.3.2.2 Note 3: Look up the PAR without consuming it.
-    let par = match lookup_par(state, ctx).await {
+    let par = match lookup_par(state, ctx, arrival).await {
         Ok(p) => p,
         Err(resp) => return resp,
     };
@@ -1207,28 +1215,31 @@ async fn handle_pending_auth(
     // session this endpoint refuses — or one lost mid-flow — burned the id,
     // so the user's retry could only ever see "session expired" (#1168).
     // Same check-before-spend ordering as the OIDC callback (#1071).
-    let pending = match db::get_pending_oauth_authorization(&state.store, pending_id).await {
-        Ok(Some(pending)) => pending,
-        Ok(None) => {
-            tracing::warn!(
-                pending_id,
-                "Pending OAuth authorization not found or expired"
-            );
-            return AuthorizeDeniedTemplate {
-                client_name: "Unknown Application".to_string(),
-                error_message: Tr::new("authorize-denied-session-expired"),
+    let pending =
+        match db::get_pending_oauth_authorization(&state.store, pending_id, arrival.timestamp())
+            .await
+        {
+            Ok(Some(pending)) => pending,
+            Ok(None) => {
+                tracing::warn!(
+                    pending_id,
+                    "Pending OAuth authorization not found or expired"
+                );
+                return AuthorizeDeniedTemplate {
+                    client_name: "Unknown Application".to_string(),
+                    error_message: Tr::new("authorize-denied-session-expired"),
+                }
+                .into_response();
             }
-            .into_response();
-        }
-        Err(e) => {
-            tracing::error!("Failed to retrieve pending OAuth authorization: {}", e);
-            return AuthorizeDeniedTemplate {
-                client_name: "Unknown Application".to_string(),
-                error_message: Tr::new("authorize-denied-generic"),
+            Err(e) => {
+                tracing::error!("Failed to retrieve pending OAuth authorization: {}", e);
+                return AuthorizeDeniedTemplate {
+                    client_name: "Unknown Application".to_string(),
+                    error_message: Tr::new("authorize-denied-generic"),
+                }
+                .into_response();
             }
-            .into_response();
-        }
-    };
+        };
 
     // Phase A: re-validate client active + redirect_uri (errors → page).
     // This guards against the client being deactivated or redirect_uri removed
@@ -1270,28 +1281,33 @@ async fn handle_pending_auth(
             // The session is acceptable — spend the single-use claim. The
             // `_claim` witness is bound to satisfy `#[must_use]`; completion
             // uses `pending` (the consumed record's data), not the pre-read.
-            let (pending, _claim) =
-                match db::consume_pending_oauth_authorization(&state.store, pending_id).await {
-                    Ok(pair) => pair,
-                    // Lost the claim race to a concurrent submission of the
-                    // same id, or the record expired between read and claim.
-                    Err(db::claim::ClaimError::AlreadyConsumed) => {
-                        tracing::warn!(pending_id, "Pending OAuth authorization already consumed");
-                        return AuthorizeDeniedTemplate {
-                            client_name: resolved.client.name.clone(),
-                            error_message: Tr::new("authorize-denied-session-expired"),
-                        }
-                        .into_response();
+            let (pending, _claim) = match db::consume_pending_oauth_authorization(
+                &state.store,
+                pending_id,
+                arrival.timestamp(),
+            )
+            .await
+            {
+                Ok(pair) => pair,
+                // Lost the claim race to a concurrent submission of the
+                // same id, or the record expired between read and claim.
+                Err(db::claim::ClaimError::AlreadyConsumed) => {
+                    tracing::warn!(pending_id, "Pending OAuth authorization already consumed");
+                    return AuthorizeDeniedTemplate {
+                        client_name: resolved.client.name.clone(),
+                        error_message: Tr::new("authorize-denied-session-expired"),
                     }
-                    Err(e) => {
-                        tracing::error!("Failed to consume pending OAuth authorization: {}", e);
-                        return AuthorizeDeniedTemplate {
-                            client_name: resolved.client.name.clone(),
-                            error_message: Tr::new("authorize-denied-generic"),
-                        }
-                        .into_response();
+                    .into_response();
+                }
+                Err(e) => {
+                    tracing::error!("Failed to consume pending OAuth authorization: {}", e);
+                    return AuthorizeDeniedTemplate {
+                        client_name: resolved.client.name.clone(),
+                        error_message: Tr::new("authorize-denied-generic"),
                     }
-                };
+                    .into_response();
+                }
+            };
             complete_pending_auth(
                 state,
                 &resolved,
@@ -1457,7 +1473,7 @@ async fn complete_pending_auth(
                 client_id: &pending.client_id,
                 mode: db::ParConsumptionMode::SkipExpiry,
             };
-            match db::ParConsumptionProof::consume(&state.store, par).await {
+            match db::ParConsumptionProof::consume(&state.store, par, arrival.timestamp()).await {
                 Ok(proof) => proof,
                 Err(db::claim::ClaimError::AlreadyConsumed) => {
                     return resolved
@@ -1831,6 +1847,7 @@ async fn authorize_authenticated_user(
         authenticator,
         par_to_consume,
         response_mode,
+        arrival,
     )
     .await
 }
@@ -1913,6 +1930,7 @@ async fn issue_code_after_reauth_check(
     authenticator: &Authenticator,
     par_to_consume: Option<db::ParRef<'_>>,
     response_mode: ResponseMode,
+    arrival: ArrivalTime,
 ) -> Response {
     // Steps 5 & 6: Validate requested ACR (RFC 9470) and `resource` against the
     // client's registered URIs (RFC 8707). Shared with `complete_pending_auth`
@@ -1936,34 +1954,36 @@ async fn issue_code_after_reauth_check(
     // Step 7: Consume PAR if applicable (code issuance, not initial authorize visit).
     let par_proof = match par_to_consume {
         None => db::ParConsumptionProof::not_pushed(),
-        Some(par) => match db::ParConsumptionProof::consume(&state.store, par).await {
-            Ok(proof) => proof,
-            Err(db::claim::ClaimError::AlreadyConsumed) => {
-                return oauth_error_response(
-                    state,
-                    oauth_client,
-                    validated.redirect_uri(),
-                    OAuthErrorCode::InvalidRequest,
-                    "The request_uri has already been used or is invalid",
-                    validated.state(),
-                    response_mode,
-                )
-                .await;
+        Some(par) => {
+            match db::ParConsumptionProof::consume(&state.store, par, arrival.timestamp()).await {
+                Ok(proof) => proof,
+                Err(db::claim::ClaimError::AlreadyConsumed) => {
+                    return oauth_error_response(
+                        state,
+                        oauth_client,
+                        validated.redirect_uri(),
+                        OAuthErrorCode::InvalidRequest,
+                        "The request_uri has already been used or is invalid",
+                        validated.state(),
+                        response_mode,
+                    )
+                    .await;
+                }
+                Err(e) => {
+                    tracing::error!("Failed to consume PAR: {e}");
+                    return oauth_error_response(
+                        state,
+                        oauth_client,
+                        validated.redirect_uri(),
+                        OAuthErrorCode::ServerError,
+                        "Failed to process pushed authorization request",
+                        validated.state(),
+                        response_mode,
+                    )
+                    .await;
+                }
             }
-            Err(e) => {
-                tracing::error!("Failed to consume PAR: {e}");
-                return oauth_error_response(
-                    state,
-                    oauth_client,
-                    validated.redirect_uri(),
-                    OAuthErrorCode::ServerError,
-                    "Failed to process pushed authorization request",
-                    validated.state(),
-                    response_mode,
-                )
-                .await;
-            }
-        },
+        }
     };
 
     // Step 8: Issue authorization code.

--- a/crates/vouch-server/src/handlers/oidc/client_auth.rs
+++ b/crates/vouch-server/src/handlers/oidc/client_auth.rs
@@ -313,7 +313,7 @@ pub(crate) async fn complete_client_auth(
             presentation,
         } => {
             let client_id = creds.client_id.clone();
-            match authenticate_client(state, &creds).await {
+            match authenticate_client(state, &creds, arrival).await {
                 Ok((client, secret_verification)) => Ok(Some(ClientAuthOutcome {
                     client,
                     client_id,
@@ -351,7 +351,7 @@ pub(crate) async fn complete_client_auth(
                 client_id: client_id.clone(),
                 client_secret: None,
             };
-            match authenticate_client(state, &creds).await {
+            match authenticate_client(state, &creds, arrival).await {
                 Ok((client, secret_verification)) => Ok(Some(ClientAuthOutcome {
                     client,
                     client_id,

--- a/crates/vouch-server/src/handlers/oidc/tests/e2e.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/e2e.rs
@@ -21,10 +21,14 @@ async fn test_client_secret_hash_roundtrip() {
     // db::validate_oauth_client_credentials finds the secret when we
     // hash the plaintext secret with the same function.
     let secret_hash = crate::handlers::hash_token(&client.client_secret);
-    let result =
-        crate::db::validate_oauth_client_credentials(&state.store, &client.client_id, &secret_hash)
-            .await
-            .expect("DB query should succeed");
+    let result = crate::db::validate_oauth_client_credentials(
+        &state.store,
+        &client.client_id,
+        &secret_hash,
+        jiff::Timestamp::now(),
+    )
+    .await
+    .expect("DB query should succeed");
 
     assert!(
         result.is_some(),

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc6749_authorize.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc6749_authorize.rs
@@ -1705,10 +1705,14 @@ async fn test_pending_auth_with_bootstrap_session_returns_to_login_and_preserves
         "must return to /login carrying the same pending id, got: {location}"
     );
     assert!(
-        crate::db::get_pending_oauth_authorization(&state.store, &pending_id)
-            .await
-            .expect("pending lookup")
-            .is_some(),
+        crate::db::get_pending_oauth_authorization(
+            &state.store,
+            &pending_id,
+            jiff::Timestamp::now()
+        )
+        .await
+        .expect("pending lookup")
+        .is_some(),
         "the refused session must not spend the single-use pending id"
     );
 
@@ -1770,10 +1774,14 @@ async fn test_pending_auth_without_session_returns_to_login_and_preserves_pendin
         "must return to /login carrying the same pending id, got: {location}"
     );
     assert!(
-        crate::db::get_pending_oauth_authorization(&state.store, &pending_id)
-            .await
-            .expect("pending lookup")
-            .is_some(),
+        crate::db::get_pending_oauth_authorization(
+            &state.store,
+            &pending_id,
+            jiff::Timestamp::now()
+        )
+        .await
+        .expect("pending lookup")
+        .is_some(),
         "the sessionless return must not spend the single-use pending id"
     );
 }

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc7591.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc7591.rs
@@ -2372,7 +2372,7 @@ async fn test_rfc7591_dpop_bound_token_with_replayed_nonce() {
     let nonce = crate::db::generate_dpop_nonce(&state.store, 300)
         .await
         .expect("generate nonce");
-    crate::db::validate_and_consume_dpop_nonce(&state.store, &nonce)
+    crate::db::validate_and_consume_dpop_nonce(&state.store, &nonce, &jiff::Timestamp::now())
         .await
         .expect("consume nonce");
 

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc9126.rs
@@ -1245,6 +1245,7 @@ async fn test_rfc9126_consume_par_with_stale_version_returns_false() {
             client_id: &client.client_id,
             mode: db::ParConsumptionMode::EnforceExpiry,
         },
+        jiff::Timestamp::now(),
     )
     .await
     .expect("First consumption should succeed");
@@ -1269,6 +1270,7 @@ async fn test_rfc9126_consume_par_with_stale_version_returns_false() {
             client_id: &client.client_id,
             mode: db::ParConsumptionMode::EnforceExpiry,
         },
+        jiff::Timestamp::now(),
     )
     .await;
     assert!(
@@ -1332,6 +1334,7 @@ async fn test_rfc9126_consume_par_concurrent_replay() {
                     client_id: &client_id_a,
                     mode: db::ParConsumptionMode::EnforceExpiry,
                 },
+                jiff::Timestamp::now(),
             )
             .await
         },
@@ -1343,6 +1346,7 @@ async fn test_rfc9126_consume_par_concurrent_replay() {
                     client_id: &client_id_b,
                     mode: db::ParConsumptionMode::EnforceExpiry,
                 },
+                jiff::Timestamp::now(),
             )
             .await
         },
@@ -1738,6 +1742,7 @@ async fn test_rfc9126_par_already_consumed_returns_error_not_login() {
             client_id: &client.client_id,
             mode: crate::db::ParConsumptionMode::EnforceExpiry,
         },
+        jiff::Timestamp::now(),
     )
     .await
     .expect("Pre-consumption should succeed");

--- a/crates/vouch-server/src/handlers/oidc/token.rs
+++ b/crates/vouch-server/src/handlers/oidc/token.rs
@@ -581,6 +581,7 @@ async fn resolve_non_jwt_auth(
     headers: &HeaderMap,
     auth: &ClientAuthParams,
     client_cert: &OptionalClientCert,
+    arrival: ArrivalTime,
 ) -> Result<
     (
         crate::services::oidc::token::AuthenticatedClient,
@@ -603,7 +604,7 @@ async fn resolve_non_jwt_auth(
     // mTLS is the auth method — the secret is intentionally NOT validated).
     // In that case we fall through to the mTLS dispatch below.
     let secret_auth_outcome = if c.client_secret.is_some() {
-        match crate::services::oidc::token::authenticate_client(state, &c).await {
+        match crate::services::oidc::token::authenticate_client(state, &c, arrival).await {
             Ok((auth_client, Some(verification))) => {
                 return Ok((auth_client, ClientAuthProof::ClientSecret(verification)));
             }
@@ -768,7 +769,7 @@ async fn handle_authorization_code_grant(
     let non_jwt_auth = if has_jwt_assertion {
         None
     } else {
-        match resolve_non_jwt_auth(&state, &headers, &auth, &client_cert).await {
+        match resolve_non_jwt_auth(&state, &headers, &auth, &client_cert, arrival).await {
             Ok(pair) => Some(pair),
             // RFC 6749 §5.2: every failure inside `resolve_non_jwt_auth` is a
             // client-authentication failure, so a client that used

--- a/crates/vouch-server/src/handlers/saml.rs
+++ b/crates/vouch-server/src/handlers/saml.rs
@@ -106,7 +106,7 @@ pub(crate) async fn acs(
     // `GrantProof::EnrollmentBootstrap`. Replaces the prior
     // get-then-delete pattern, closing the read-vs-consume TOCTOU.
     let (stored_state, oidc_state_claim) =
-        match db::try_consume_oidc_state(&state.store, &relay_state).await {
+        match db::try_consume_oidc_state(&state.store, &relay_state, arrival.timestamp()).await {
             Ok(pair) => pair,
             Err(db::ClaimError::AlreadyConsumed) => {
                 return ErrorTemplate {

--- a/crates/vouch-server/src/handlers/scim/groups.rs
+++ b/crates/vouch-server/src/handlers/scim/groups.rs
@@ -17,6 +17,7 @@ use super::types::{
 };
 use super::urn;
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::db;
 use crate::db::{ScimFilterError, ScimScope};
 use crate::error::ServiceError;
@@ -25,6 +26,7 @@ use crate::error::ServiceError;
 ///
 /// Returns a paginated list of Group resources, with optional filtering.
 pub(crate) async fn list_groups(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Query(query): Query<ScimListQuery>,
@@ -38,7 +40,7 @@ pub(crate) async fn list_groups(
     }
 
     // Authenticate and check scope
-    let auth = match authenticate_scim(&state, &headers).await {
+    let auth = match authenticate_scim(&state, &headers, arrival).await {
         Ok(auth) => auth,
         Err((status, json)) => return (status, json).into_response(),
     };
@@ -194,6 +196,7 @@ fn members_read_error_response() -> Response {
 ///
 /// Creates a new Group resource. Returns 201 Created on success.
 pub(crate) async fn create_group(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Json(group): Json<ScimGroup>,
@@ -211,7 +214,7 @@ pub(crate) async fn create_group(
     }
 
     // Authenticate and check scope
-    let auth = match authenticate_scim(&state, &headers).await {
+    let auth = match authenticate_scim(&state, &headers, arrival).await {
         Ok(auth) => auth,
         Err((status, json)) => return (status, json).into_response(),
     };
@@ -273,6 +276,7 @@ pub(crate) async fn create_group(
 ///
 /// Retrieves a single Group resource by ID, including its members.
 pub(crate) async fn get_group(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Path(id): Path<String>,
@@ -283,7 +287,7 @@ pub(crate) async fn get_group(
     }
 
     // Authenticate
-    let auth = match authenticate_scim(&state, &headers).await {
+    let auth = match authenticate_scim(&state, &headers, arrival).await {
         Ok(auth) => auth,
         Err((status, json)) => return (status, json).into_response(),
     };
@@ -480,6 +484,7 @@ async fn record_partial_group_update(
 }
 
 pub(crate) async fn patch_group(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Path(id): Path<String>,
@@ -491,7 +496,7 @@ pub(crate) async fn patch_group(
     }
 
     // Authenticate and check scope
-    let auth = match authenticate_scim(&state, &headers).await {
+    let auth = match authenticate_scim(&state, &headers, arrival).await {
         Ok(auth) => auth,
         Err((status, json)) => return (status, json).into_response(),
     };
@@ -635,6 +640,7 @@ pub(crate) async fn patch_group(
 /// Permanently deletes a Group resource. Returns 204 No Content on success.
 /// Group membership records are cascade-deleted.
 pub(crate) async fn delete_group(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Path(id): Path<String>,
@@ -645,7 +651,7 @@ pub(crate) async fn delete_group(
     }
 
     // Authenticate and check scope
-    let auth = match authenticate_scim(&state, &headers).await {
+    let auth = match authenticate_scim(&state, &headers, arrival).await {
         Ok(auth) => auth,
         Err((status, json)) => return (status, json).into_response(),
     };

--- a/crates/vouch-server/src/handlers/scim/mod.rs
+++ b/crates/vouch-server/src/handlers/scim/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod types;
 pub(crate) mod urn;
 pub(crate) mod users;
 
+use crate::arrival::ArrivalTime;
 use aws_lc_rs::digest::{self, SHA256};
 use axum::{
     Json,
@@ -147,9 +148,14 @@ impl ScimAuth {
 /// SCIM endpoints require authentication via OAuth 2.0 Bearer Token
 /// (RFC 6750). The token is validated against the SCIM token store.
 /// Returns the token ID and scope for authorization checks.
+///
+/// Takes the request's [`ArrivalTime`] because the token-expiry comparison
+/// decides this request, so it reads the same instant as every other
+/// temporal check serving it.
 pub(crate) async fn authenticate_scim(
     state: &AppState,
     headers: &HeaderMap,
+    arrival: ArrivalTime,
 ) -> Result<ScimAuth, (StatusCode, Json<ScimError>)> {
     let auth_header = headers
         .get("authorization")
@@ -171,7 +177,7 @@ pub(crate) async fn authenticate_scim(
     let token_hash = hex::encode(digest::digest(&SHA256, token.as_bytes()));
 
     // Verify token exists and is valid
-    let token_record = db::get_scim_token_by_hash(&state.store, &token_hash)
+    let token_record = db::get_scim_token_by_hash(&state.store, &token_hash, arrival.timestamp())
         .await
         .map_err(|_| {
             (

--- a/crates/vouch-server/src/handlers/scim/users.rs
+++ b/crates/vouch-server/src/handlers/scim/users.rs
@@ -17,6 +17,7 @@ use super::types::{
 };
 use super::urn;
 use crate::AppState;
+use crate::arrival::ArrivalTime;
 use crate::db;
 use crate::db::{ScimFilterError, ScimScope};
 use crate::redact_email;
@@ -25,6 +26,7 @@ use crate::redact_email;
 ///
 /// Returns a paginated list of User resources, with optional filtering.
 pub(crate) async fn list_users(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Query(query): Query<ScimListQuery>,
@@ -38,7 +40,7 @@ pub(crate) async fn list_users(
     }
 
     // Authenticate and check scope
-    let auth = match authenticate_scim(&state, &headers).await {
+    let auth = match authenticate_scim(&state, &headers, arrival).await {
         Ok(auth) => auth,
         Err((status, json)) => return (status, json).into_response(),
     };
@@ -192,12 +194,13 @@ pub(super) fn create_scim_user_error_response(
 /// Creates a new User resource. Returns 201 Created on success,
 /// 409 Conflict if the user already exists (RFC 7644 Section 3.3.1).
 pub(crate) async fn create_user(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Json(user): Json<ScimUser>,
 ) -> Response {
     // Authenticate and check scope
-    let auth = match authenticate_scim(&state, &headers).await {
+    let auth = match authenticate_scim(&state, &headers, arrival).await {
         Ok(auth) => auth,
         Err((status, json)) => return (status, json).into_response(),
     };
@@ -293,6 +296,7 @@ pub(crate) async fn create_user(
 ///
 /// Retrieves a single User resource by ID.
 pub(crate) async fn get_user(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Path(id): Path<String>,
@@ -303,7 +307,7 @@ pub(crate) async fn get_user(
     }
 
     // Authenticate
-    let auth = match authenticate_scim(&state, &headers).await {
+    let auth = match authenticate_scim(&state, &headers, arrival).await {
         Ok(auth) => auth,
         Err((status, json)) => return (status, json).into_response(),
     };
@@ -402,6 +406,7 @@ const USER_ATTRIBUTES: &[Attribute<UserPatch>] = &[
 /// remove) applied against [`USER_ATTRIBUTES`]. Deactivating a user
 /// invalidates all sessions and revokes SSH certificates.
 pub(crate) async fn patch_user(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Path(id): Path<String>,
@@ -413,7 +418,7 @@ pub(crate) async fn patch_user(
     }
 
     // Authenticate and check scope
-    let auth = match authenticate_scim(&state, &headers).await {
+    let auth = match authenticate_scim(&state, &headers, arrival).await {
         Ok(auth) => auth,
         Err((status, json)) => return (status, json).into_response(),
     };
@@ -585,6 +590,7 @@ pub(crate) async fn patch_user(
 /// Permanently deletes a User resource. Returns 204 No Content on success.
 /// All sessions are invalidated and SSH certificates are revoked.
 pub(crate) async fn delete_user(
+    arrival: ArrivalTime,
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Path(id): Path<String>,
@@ -595,7 +601,7 @@ pub(crate) async fn delete_user(
     }
 
     // Authenticate and check scope
-    let auth = match authenticate_scim(&state, &headers).await {
+    let auth = match authenticate_scim(&state, &headers, arrival).await {
         Ok(auth) => auth,
         Err((status, json)) => return (status, json).into_response(),
     };

--- a/crates/vouch-server/src/handlers/session/tests.rs
+++ b/crates/vouch-server/src/handlers/session/tests.rs
@@ -394,7 +394,7 @@ async fn test_dpop_use_nonce_at_resource_returns_nonce_header() {
     let nonce = crate::db::generate_dpop_nonce(&state.store, 300)
         .await
         .expect("generate nonce");
-    crate::db::validate_and_consume_dpop_nonce(&state.store, &nonce)
+    crate::db::validate_and_consume_dpop_nonce(&state.store, &nonce, &jiff::Timestamp::now())
         .await
         .expect("consume nonce");
 

--- a/crates/vouch-server/src/infra/httpsig.rs
+++ b/crates/vouch-server/src/infra/httpsig.rs
@@ -181,6 +181,11 @@ impl KeyResolver for OAuthClientKeyResolver {
     /// issuance path (`generate_dpop_nonce`): both are opaque random
     /// single-use values with the same validity window, and the atomic
     /// delete-if-not-expired gives single-use semantics on every backend.
+    ///
+    /// Unlike the DPoP path, the expiry comparison here reads an ambient
+    /// clock: `vouch_httpsig`'s `NonceValidator` trait passes only the nonce,
+    /// so there is no request instant to anchor to. Threading one would mean
+    /// widening a trait in a crate that has no concept of an Axum request.
     fn validate_nonce(
         &self,
         nonce: &str,
@@ -190,8 +195,14 @@ impl KeyResolver for OAuthClientKeyResolver {
 
         // Own the nonce: the returned future may only borrow `self`.
         let nonce = nonce.to_string();
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "the httpsig nonce validator trait carries no request instant"
+        )]
+        let now = jiff::Timestamp::now();
         async move {
-            match crate::db::validate_and_consume_dpop_nonce(&self.state.store, &nonce).await {
+            match crate::db::validate_and_consume_dpop_nonce(&self.state.store, &nonce, &now).await
+            {
                 Ok(()) => NonceValidation::Valid,
                 Err(
                     crate::db::ClaimError::AlreadyConsumed | crate::db::ClaimError::InvalidInput(_),

--- a/crates/vouch-server/src/services/oidc/dpop.rs
+++ b/crates/vouch-server/src/services/oidc/dpop.rs
@@ -611,7 +611,7 @@ async fn validate_dpop_common(
     // successfully" guarantee is carried forward by the returned
     // `ValidatedDpopProof`.
     if let Some(nonce) = claims.nonce.as_deref() {
-        match db::validate_and_consume_dpop_nonce(store, nonce).await {
+        match db::validate_and_consume_dpop_nonce(store, nonce, &now).await {
             Ok(()) => {}
             Err(db::claim::ClaimError::AlreadyConsumed) => {
                 let new_nonce = db::generate_dpop_nonce(store, NONCE_VALIDITY_SECONDS)

--- a/crates/vouch-server/src/services/oidc/token.rs
+++ b/crates/vouch-server/src/services/oidc/token.rs
@@ -326,7 +326,7 @@ pub(crate) async fn exchange_authorization_code(
     // The returned witness is the structural proof threaded into the
     // TokenIssuanceProof below — the only path to `GrantProof::AuthorizationCode`.
     let code_hash = hash_token(params.code);
-    let auth_code_claim = enforce_single_use_code(state, &code_hash, &auth_code).await?;
+    let auth_code_claim = enforce_single_use_code(state, &code_hash, &auth_code, arrival).await?;
 
     let user = load_and_validate_grant_subject(state, &auth_code).await?;
 
@@ -589,8 +589,9 @@ async fn enforce_single_use_code(
     state: &Arc<AppState>,
     code_hash: &str,
     auth_code: &AuthorizationCode,
+    arrival: ArrivalTime,
 ) -> ServiceResult<crate::db::AuthCodeClaim> {
-    match db::try_consume_authorization_code(&state.store, code_hash).await {
+    match db::try_consume_authorization_code(&state.store, code_hash, arrival.timestamp()).await {
         Ok(claim) => Ok(claim),
         Err(db::claim::ClaimError::AlreadyConsumed) => {
             tracing::warn!(
@@ -838,6 +839,7 @@ impl AuthorizationCode {
 pub async fn authenticate_client(
     state: &Arc<AppState>,
     credentials: &ClientCredentials,
+    arrival: ArrivalTime,
 ) -> Result<(AuthenticatedClient, Option<ClientSecretVerification>), ClientAuthError> {
     // Look up the client
     let client = db::get_oauth_client_by_client_id(&state.store, &credentials.client_id)
@@ -909,6 +911,7 @@ pub async fn authenticate_client(
             &state.store,
             &credentials.client_id,
             &secret_hash,
+            arrival.timestamp(),
         )
         .await?;
 
@@ -2035,7 +2038,12 @@ mod tests {
             client_secret: Some(SecretString::from(client.client_secret.clone())),
         };
 
-        let result = authenticate_client(&state, &creds).await;
+        let result = authenticate_client(
+            &state,
+            &creds,
+            crate::arrival::ArrivalTime::for_test(jiff::Timestamp::now()),
+        )
+        .await;
         assert!(
             result.is_ok(),
             "secret-based auth must not fail when only the last_used_at write fails: {result:?}"
@@ -2085,7 +2093,12 @@ mod tests {
             client_secret: Some(SecretString::from(client.client_secret.clone())),
         };
 
-        let result = authenticate_client(&state, &creds).await;
+        let result = authenticate_client(
+            &state,
+            &creds,
+            crate::arrival::ArrivalTime::for_test(jiff::Timestamp::now()),
+        )
+        .await;
         assert!(
             matches!(result, Err(ClientAuthError::FapiSecretRejected)),
             "a FAPI client's secret must be refused, got {result:?}"


### PR DESCRIPTION
Closes #1337. Supersedes #1345.

## The class

Nine helpers in `db/` decide whether a request succeeds by comparing a stored `expires_at` against an instant, and each stamped its own clock to do it. That clock is always at or after the request's arrival instant, so the predicate is stricter than every other check serving the same decision — a record still live when the request arrived can be rejected because it expired during the intervening awaits.

Detail reported one instance (#1337, the DPoP nonce consume). A structural search found five. Removing the blanket lint exemption described below and letting clippy speak found nine:

| helper | the decision it makes |
|---|---|
| `validate_and_consume_dpop_nonce` | rejects a DPoP proof (the reported instance) |
| `try_consume_authorization_code` | rejects an authorization-code redemption |
| `get_pushed_authorization_request` | rejects a `request_uri` at `/authorize` |
| `get_pending_oauth_authorization` | rejects a deferred-login resume |
| `get_scim_token_by_hash` | rejects a SCIM bearer token |
| `validate_oauth_client_credentials` | client authentication at the token endpoint |
| `try_consume_oidc_state` | the enrollment and SAML callback consume |
| `ParClaim::consume` | the PAR consume under `EnforceExpiry` |
| `consume_pending_oauth_authorization` | the deferred-login consume |

## The fix

Each helper takes the instant as a parameter, matching the shape `get_session_by_token_hash` already used in the same layer, and every request-path caller passes `arrival.timestamp()`. Where a helper both compares and stamps (`consumed_at`), one instant now serves both, so no ambient clock remains in those functions.

The SCIM handlers gain an `ArrivalTime` extractor so `authenticate_scim` has one to thread. `infra/httpsig.rs` keeps an ambient clock deliberately: its nonce validator comes from a `vouch_httpsig` trait that carries no request instant, and widening that trait would mean giving a crate with no concept of an Axum request one. The `#[expect]` there says so.

## The guardrail, and why the class was this large

`db/mod.rs` granted `#[expect(clippy::disallowed_methods)]` on fourteen `mod` declarations, all with the same blanket reason about row stamping and OCC retries. Because the exemption was granted per *module*, it also covered whatever those modules grew later — and what they grew was request-deciding expiry comparisons. That is why four of the nine above were invisible to both the scanner and a hand search.

Those blanket exemptions are gone, replaced by 33 per-function ones that each name the sanctioned case they cover: row stamping, an OCC retry's per-attempt reading, or a background sweep.

Verified by breaking it: reintroducing `let now = Timestamp::now()` into `try_consume_authorization_code` now produces a clippy error under `-D warnings`, where under the module-wide exemption it was silent.

## Tests

New `db/tests/arrival_anchored_expiry.rs` (5 tests) pins that each helper's verdict follows the instant it is given rather than the wall clock — seeding records that are live at one instant and expired at another, and asserting both directions so threading the parameter cannot have turned a check off.

`make fmt`, `make lint` (`-D warnings`), and `cargo test --all-features` (5715 passed, 0 failed) are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)