### PR TITLE
fix(oidc): enforce grant_types for the device_code grant

### DIFF
--- a/crates/vouch-common/src/protocol.rs
+++ b/crates/vouch-common/src/protocol.rs
@@ -67,6 +67,18 @@
 //! how a call site spells it, and it is the only spelling
 //! `HeaderName::from_static` accepts.
 
+/// RFC 6749 §4.1.3 (Access Token Request) — authorization code grant.
+///
+/// > grant_type
+/// >          REQUIRED.  Value MUST be set to "authorization_code".
+///
+/// <https://www.rfc-editor.org/rfc/rfc6749#section-4.1.3>
+///
+/// Also the value RFC 7591 §2 makes a registration's `grant_types` default to
+/// when the field is omitted, so the server's registration default and the
+/// authorization check for an absent list resolve to this one constant.
+pub const GRANT_TYPE_AUTHORIZATION_CODE: &str = "authorization_code";
+
 /// RFC 8628 §3.4 (Device Access Token Request) — device authorization grant.
 ///
 /// > grant_type

--- a/crates/vouch-server/src/db/oauth.rs
+++ b/crates/vouch-server/src/db/oauth.rs
@@ -16,6 +16,7 @@ use anyhow::Result;
 use axum::http::StatusCode;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
+use vouch_common::protocol;
 
 /// Maximum number of active (non-revoked, non-expired) secrets per OAuth client.
 ///
@@ -223,11 +224,16 @@ impl OAuthClient {
     /// Whether the client is registered (RFC 7591 §2 `grant_types`) for the
     /// grant whose `grant_type` wire value is `grant`.
     ///
-    /// Matches the enforcement pattern established by the `client_credentials`
-    /// grant handler: when `grant_types` is `None` the client is treated as
-    /// *not* authorized for any grant (returning `false`), so a manually-managed
-    /// client with no declared `grant_types` is rejected just like one that
-    /// declared `grant_types: ["authorization_code"]`. Callers pass the
+    /// A stored `None` means the registration omitted `grant_types`, and
+    /// RFC 7591 §2 fixes what that means — "If omitted, the default behavior
+    /// is that the client will use only the `authorization_code` Grant Type."
+    /// So `None` is the default list, not the empty one: it authorizes
+    /// `authorization_code` and nothing else. Dynamic registration
+    /// materializes that default when the field is absent
+    /// (`services/oidc/registration.rs`), so `None` only reaches here for a
+    /// manually-managed row, which the spec still entitles to the default.
+    ///
+    /// Callers pass the
     /// [`crate::services::oidc::grant_type::OAuthGrantType::as_str`] wire value
     /// so the comparison is against the same strings registration stores.
     ///
@@ -235,9 +241,10 @@ impl OAuthClient {
     /// authorized to use this authorization grant type."
     #[must_use]
     pub fn is_authorized_for_grant(&self, grant: &str) -> bool {
-        self.grant_types
-            .as_ref()
-            .is_some_and(|gts| gts.iter().any(|g| g == grant))
+        match self.grant_types.as_ref() {
+            Some(gts) => gts.iter().any(|g| g == grant),
+            None => grant == protocol::GRANT_TYPE_AUTHORIZATION_CODE,
+        }
     }
 }
 
@@ -2081,6 +2088,59 @@ pub async fn validate_oauth_client_credentials(
 )]
 mod tests {
     use super::*;
+
+    /// RFC 7591 §2 `grant_types`: "If omitted, the default behavior is that
+    /// the client will use only the `authorization_code` Grant Type." A
+    /// stored `None` is therefore the default list, not the empty one — it
+    /// authorizes `authorization_code` and rejects every other grant.
+    #[tokio::test]
+    async fn test_absent_grant_types_defaults_to_authorization_code() {
+        let store = test_store().await;
+        // `create_client_and_secret` registers with `grant_types: None`, which
+        // is exactly the absent-field row this test is about.
+        let (client, _secret, _hash) = create_client_and_secret(&store).await;
+        assert!(
+            client.grant_types.is_none(),
+            "fixture precondition: the stored row has no grant_types"
+        );
+
+        assert!(
+            client.is_authorized_for_grant("authorization_code"),
+            "RFC 7591 §2: omitted grant_types defaults to authorization_code"
+        );
+        for other in [
+            "client_credentials",
+            "urn:ietf:params:oauth:grant-type:device_code",
+            "urn:ietf:params:oauth:grant-type:token-exchange",
+        ] {
+            assert!(
+                !client.is_authorized_for_grant(other),
+                "the default list is authorization_code ONLY; {other} must be rejected"
+            );
+        }
+    }
+
+    /// An explicit list is honored verbatim — declaring `authorization_code`
+    /// is the same as omitting the field, and declaring something else does
+    /// not silently inherit the default.
+    #[tokio::test]
+    async fn test_explicit_grant_types_are_honored_verbatim() {
+        let store = test_store().await;
+        let (mut client, _secret, _hash) = create_client_and_secret(&store).await;
+
+        client.grant_types = Some(vec!["client_credentials".to_string()]);
+        assert!(client.is_authorized_for_grant("client_credentials"));
+        assert!(
+            !client.is_authorized_for_grant("authorization_code"),
+            "an explicit list that omits authorization_code must not inherit the default"
+        );
+
+        client.grant_types = Some(vec![]);
+        assert!(
+            !client.is_authorized_for_grant("authorization_code"),
+            "an explicitly empty list authorizes nothing — it is not the absent case"
+        );
+    }
 
     #[test]
     fn test_is_valid_post_logout_redirect_uri_str() {

--- a/crates/vouch-server/src/handlers/device.rs
+++ b/crates/vouch-server/src/handlers/device.rs
@@ -11,6 +11,7 @@ use crate::services::auth::{
 };
 use crate::services::oidc::ScopeSet;
 use crate::services::oidc::dpop::DpopError;
+use crate::services::oidc::grant_type::OAuthGrantType;
 use crate::services::oidc::token::validate_dpop_if_present;
 use aws_lc_rs::digest::{self, SHA256};
 use axum::{
@@ -93,7 +94,11 @@ pub(crate) async fn device_code(
 ) -> Result<Json<DeviceCodeResponse>, ServiceError> {
     tracing::info!("Device authorization request");
 
-    // If a client_id is provided, it must refer to a registered OAuth client.
+    // If a client_id is provided, it must refer to a registered OAuth client
+    // that is authorized (RFC 7591 §2 `grant_types`) for the device_code
+    // grant. Rejecting at creation avoids surfacing a usable `user_code` to
+    // the user for an unauthorized client; the redemption path re-checks so
+    // a client restricted mid-flow still cannot redeem.
     if let Some(client_id) = req.client_id.as_deref() {
         let client = db::get_oauth_client_by_client_id(&state.store, client_id)
             .await
@@ -104,10 +109,13 @@ pub(crate) async fn device_code(
                     "Failed to validate client_id",
                 )
             })?;
-        if client.is_none() {
+        let client = client.ok_or_else(|| {
+            ServiceError::oauth(OAuthErrorCode::InvalidClient, "Unknown client_id")
+        })?;
+        if !client.is_authorized_for_grant(OAuthGrantType::DeviceCode.as_str()) {
             return Err(ServiceError::oauth(
-                OAuthErrorCode::InvalidClient,
-                "Unknown client_id",
+                OAuthErrorCode::UnauthorizedClient,
+                "Client is not authorized for device_code grant",
             ));
         }
     }
@@ -391,6 +399,34 @@ pub(crate) async fn device_token(
                 },
                 None => None,
             };
+
+            // RFC 7591 §2 `grant_types` / RFC 6749 §5.2 `unauthorized_client`:
+            // the registered client loaded above for FAPI sender-constraint
+            // enforcement must also be authorized for the device_code grant
+            // before any token is issued. The other token-endpoint grants that
+            // load a registered client (`client_credentials`, `token_exchange`,
+            // `fido2_assertion`) enforce the same field via
+            // `is_authorized_for_grant`; the device-code grant authenticates by
+            // the consumed `device_code` (`ClientAuthProof::NoAuth`) rather
+            // than client credentials, so its client lookup happens here — this
+            // closes the registration-contract gap left by commit 45b8de2.
+            // Runs before `try_consume_device_auth` so an unauthorized client
+            // does not burn the single-use device code, matching the mTLS gate
+            // below. The built-in CLI flow carries no `client_id` and is
+            // unaffected: `oauth_client` is `None` and the guard is skipped.
+            if let Some(ref oc) = oauth_client
+                && !oc.is_authorized_for_grant(OAuthGrantType::DeviceCode.as_str())
+            {
+                return Err(oauth_error(
+                    StatusCode::UNAUTHORIZED,
+                    OAuthError {
+                        error: OAuthErrorCode::UnauthorizedClient.as_str().to_string(),
+                        error_description: Some(
+                            "Client is not authorized for device_code grant".to_string(),
+                        ),
+                    },
+                ));
+            }
 
             // RFC 8705 §2 / parity with the authorization-code, client-credentials,
             // refresh-token, and PAR grants: a client registered with

--- a/crates/vouch-server/src/handlers/oidc/tests/rfc8628.rs
+++ b/crates/vouch-server/src/handlers/oidc/tests/rfc8628.rs
@@ -349,3 +349,350 @@ async fn test_rfc8628_device_code_replay_revokes_only_that_code_s_token() {
     assert_token_alive(&app, &token_b, "a token from a different device code").await;
     assert_token_alive(&app, &token_c, "a token from a grant with no code").await;
 }
+
+// ========================================================================
+// RFC 7591 §2 `grant_types` enforcement for the device_code grant
+//
+// Commit 45b8de2 (`fix(oidc): enforce grant_types for token-exchange and
+// fido2-assertion`) added `is_authorized_for_grant` checks to every grant
+// handler that authenticates the client at the token endpoint
+// (`client_credentials`, `token_exchange`, `fido2_assertion`). The device_code
+// grant authenticates by the consumed `device_code` (`ClientAuthProof::NoAuth`)
+// rather than client credentials, so it was excluded — but `device_token`
+// still loads the registered client from the stored `client_id` for FAPI
+// sender-constraint enforcement, so the metadata needed to enforce
+// `grant_types` is available. These tests pin the fix: a client restricted to
+// `["authorization_code"]` (the dynamic-registration default when `grant_types`
+// is omitted) MUST receive HTTP 401 `unauthorized_client` at redemption, while
+// registered clients and the built-in CLI flow keep working (no regression).
+// Mirrors the `grant_types` enforcement tests in `rfc7523.rs`.
+// ========================================================================
+
+/// Set (or clear) the `grant_types` of an OAuth client, mirroring the
+/// `enable_grant_types` helper in `rfc7523.rs`. `None` means the client is not
+/// authorized for any grant (matching `is_authorized_for_grant`'s `None`
+/// semantics — a manually-managed client with no declared `grant_types`).
+async fn set_grant_types(
+    store: &db::store::DocumentStore,
+    client_id: &str,
+    grants: Option<&[&str]>,
+) {
+    let oauth_client = db::get_oauth_client_by_client_id(store, client_id)
+        .await
+        .expect("DB error")
+        .expect("Client not found");
+    let grants: Option<Vec<String>> = grants.map(|g| g.iter().map(|s| (*s).to_string()).collect());
+    store
+        .modify::<db::documents::oauth::OAuthClientDoc, _>(&oauth_client.id, |data| {
+            data.grant_types = grants.clone();
+        })
+        .await
+        .expect("Failed to update grant_types");
+}
+
+/// Like `setup_authorized_device` but stores a `client_id` on the device
+/// authorization request — exercising the registered-client redemption path
+/// (FAPI sender-constraint + `grant_types` enforcement). Creates the device
+/// auth directly in the store so the test isolates the *redemption* gate from
+/// the creation-endpoint gate.
+async fn setup_authorized_device_for_client(
+    state: &std::sync::Arc<crate::AppState>,
+    user: &crate::db::User,
+    authenticator_id: &str,
+    label: &str,
+    client_id: &str,
+) -> String {
+    let device_code = format!("grant_dev_{label}");
+    let expires_at = jiff::Timestamp::now()
+        .checked_add(jiff::Span::new().hours(1))
+        .expect("device code expiry");
+    let id = crate::db::create_device_auth_request(
+        &state.store,
+        &sha256_base64url(&device_code),
+        &format!("GD{label}"),
+        Some(client_id),
+        expires_at,
+        0,
+    )
+    .await
+    .expect("create device authorization request");
+    crate::db::authorize_device_auth(
+        &state.store,
+        crate::db::AuthorizeDeviceAuthParams {
+            id: &id,
+            user_id: &user.id,
+            user_email: &user.email,
+            authenticator_id,
+            verification: DeviceApproval::Observed(AuthTime::for_test(
+                jiff::Timestamp::now().as_second(),
+            )),
+        },
+    )
+    .await
+    .expect("approve device authorization");
+    device_code
+}
+
+/// RFC 7591 §2 / RFC 6749 §5.2 `unauthorized_client`: a client registered for
+/// `authorization_code` only (the dynamic-registration default when
+/// `grant_types` is omitted) MUST NOT be able to redeem a device code at the
+/// token endpoint — the device_code grant loads the registered client from
+/// the stored `client_id` and must enforce `grant_types` on the same lookup.
+#[tokio::test]
+async fn test_device_grant_rejects_redemption_for_client_not_registered_for_device_code() {
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "device-grant-unauth@example.com").await;
+    let auth = create_test_authenticator(&state.store, &user.id).await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+
+    // Restrict to authorization_code only — the default when `grant_types`
+    // is omitted via dynamic registration.
+    set_grant_types(
+        &state.store,
+        &client.client_id,
+        Some(&["authorization_code"]),
+    )
+    .await;
+
+    let device_code =
+        setup_authorized_device_for_client(&state, &user, &auth, "unauth", &client.client_id).await;
+
+    let (status, body) = poll_device_token(&app, &device_code).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "device_code grant must reject a client not registered for it: {body}"
+    );
+    let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(
+        error["error"], "unauthorized_client",
+        "rejected redemption must return unauthorized_client, not issue a token: {body}"
+    );
+}
+
+/// No-regression control: a client registered for the device_code grant (the
+/// `test_utils` default — all supported grants) redeems a device code and
+/// receives an access token attributed to its `client_id`.
+#[tokio::test]
+async fn test_device_grant_redeems_for_client_registered_for_device_code() {
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "device-grant-auth@example.com").await;
+    let auth = create_test_authenticator(&state.store, &user.id).await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+
+    let device_code =
+        setup_authorized_device_for_client(&state, &user, &auth, "auth", &client.client_id).await;
+
+    let (status, body) = poll_device_token(&app, &device_code).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "registered client should redeem: {body}"
+    );
+    let token_json: serde_json::Value =
+        serde_json::from_str(&body).expect("token response is JSON");
+    assert!(
+        token_json.get("access_token").is_some(),
+        "access_token must be issued to a client registered for device_code: {body}"
+    );
+}
+
+/// The `grant_types` gate runs before `try_consume_device_auth`, so an
+/// unauthorized client does not burn the single-use device code. Re-authorize
+/// the client for device_code and the *same* device code must then redeem —
+/// proving the rejection was the gate, not code consumption. Mirrors the
+/// fido2-assertion control in `rfc7523.rs`.
+#[tokio::test]
+async fn test_device_grant_gate_runs_before_consume_retry_after_re_authorize() {
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "device-grant-retry@example.com").await;
+    let auth = create_test_authenticator(&state.store, &user.id).await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+
+    set_grant_types(
+        &state.store,
+        &client.client_id,
+        Some(&["authorization_code"]),
+    )
+    .await;
+    let device_code =
+        setup_authorized_device_for_client(&state, &user, &auth, "retry", &client.client_id).await;
+
+    // First poll: rejected by the grant_types gate. The code is NOT consumed.
+    let (status, body) = poll_device_token(&app, &device_code).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED, "gate must reject: {body}");
+
+    // Re-authorize the client for device_code (toggle the gate off).
+    set_grant_types(
+        &state.store,
+        &client.client_id,
+        Some(&["urn:ietf:params:oauth:grant-type:device_code"]),
+    )
+    .await;
+
+    // Second poll on the SAME device code: succeeds, proving it was not burned.
+    let (status, body) = poll_device_token(&app, &device_code).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "the same device code must redeem once the client is re-authorized: {body}"
+    );
+    let token_json: serde_json::Value =
+        serde_json::from_str(&body).expect("token response is JSON");
+    assert!(
+        token_json.get("access_token").is_some(),
+        "access_token must be issued after re-authorization: {body}"
+    );
+}
+
+/// A manually-managed client with no declared `grant_types` (`None`) is
+/// treated as not authorized for any grant by `is_authorized_for_grant`, so
+/// the device_code redemption gate must reject it just like
+/// `["authorization_code"]`.
+#[tokio::test]
+async fn test_device_grant_rejects_redemption_for_client_with_no_grant_types() {
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "device-grant-none@example.com").await;
+    let auth = create_test_authenticator(&state.store, &user.id).await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+
+    set_grant_types(&state.store, &client.client_id, None).await;
+    let device_code =
+        setup_authorized_device_for_client(&state, &user, &auth, "none", &client.client_id).await;
+
+    let (status, body) = poll_device_token(&app, &device_code).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "device_code grant must reject a client with no grant_types: {body}"
+    );
+    let error: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(
+        error["error"], "unauthorized_client",
+        "expected unauthorized_client for a client with no grant_types: {body}"
+    );
+}
+
+/// The built-in CLI flow carries no `client_id`, so `oauth_client` is `None`
+/// and the `grant_types` gate is skipped — redemption must still succeed.
+/// Pins the no-`client_id` happy path against the new gate to guard against a
+/// future regression that moves the check out of the `Some(ref oc)` guard.
+#[tokio::test]
+async fn test_device_grant_no_client_id_builtin_flow_unaffected_by_gate() {
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "device-grant-cli@example.com").await;
+    let auth = create_test_authenticator(&state.store, &user.id).await;
+
+    // No client_id stored on the device authorization request.
+    let device_code = setup_authorized_device(&state, &user, &auth, "cli").await;
+
+    let (status, body) = poll_device_token(&app, &device_code).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "built-in CLI flow (no client_id) must still issue a token: {body}"
+    );
+    let token_json: serde_json::Value =
+        serde_json::from_str(&body).expect("token response is JSON");
+    assert!(
+        token_json.get("access_token").is_some(),
+        "access_token must be issued for the no-client_id flow: {body}"
+    );
+}
+
+/// Defense-in-depth (RFC 7591 §2): the device-authorization *creation*
+/// endpoint rejects a `client_id` not registered for the device_code grant
+/// before surfacing a usable `user_code`, so the user is never shown an
+/// authorization prompt for a flow the client cannot complete.
+#[tokio::test]
+async fn test_device_code_creation_rejects_client_not_registered_for_device_code() {
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "device-create-unauth@example.com").await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+
+    set_grant_types(
+        &state.store,
+        &client.client_id,
+        Some(&["authorization_code"]),
+    )
+    .await;
+
+    let (status, body) = http_post_form(
+        &app,
+        "/oauth/device",
+        &format!("client_id={}&scope=openid", client.client_id),
+        &[],
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "device code creation must reject a client not registered for device_code: {body}"
+    );
+    let resp: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    assert_eq!(
+        resp["error"], "unauthorized_client",
+        "creation must return unauthorized_client for an unauthorized client_id: {body}"
+    );
+    assert!(
+        resp.get("device_code").is_none(),
+        "no device_code should be surfaced for an unauthorized client: {body}"
+    );
+}
+
+/// End-to-end: a client registered for device_code creates a device
+/// authorization via `/oauth/device`, the user approves it, and polling
+/// `/oauth/token` returns an access token — verifying the full flow works
+/// alongside the new `grant_types` enforcement at both endpoints.
+#[tokio::test]
+async fn test_device_grant_end_to_end_registered_client_flow() {
+    let (app, state) = test_app().await;
+    let user = create_test_user(&state.store, "device-e2e@example.com").await;
+    let auth = create_test_authenticator(&state.store, &user.id).await;
+    let client = create_test_oauth_client(&state.store, &user.id).await;
+
+    // 1. Create the device authorization via the HTTP endpoint.
+    let (status, body) = http_post_form(
+        &app,
+        "/oauth/device",
+        &format!("client_id={}&scope=openid", client.client_id),
+        &[],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "create device auth: {body}");
+    let resp: serde_json::Value = serde_json::from_str(&body).expect("Valid JSON");
+    let device_code = resp["device_code"]
+        .as_str()
+        .expect("device_code")
+        .to_string();
+
+    // 2. Approve it (look up by the hashed code, the same way the handler does).
+    let request = db::get_device_auth_by_code_hash(&state.store, &sha256_base64url(&device_code))
+        .await
+        .expect("lookup device auth")
+        .expect("device auth exists");
+    crate::db::authorize_device_auth(
+        &state.store,
+        crate::db::AuthorizeDeviceAuthParams {
+            id: &request.id,
+            user_id: &user.id,
+            user_email: &user.email,
+            authenticator_id: &auth,
+            verification: DeviceApproval::Observed(AuthTime::for_test(
+                jiff::Timestamp::now().as_second(),
+            )),
+        },
+    )
+    .await
+    .expect("approve device auth");
+
+    // 3. Poll for a token.
+    let (status, body) = poll_device_token(&app, &device_code).await;
+    assert_eq!(status, StatusCode::OK, "end-to-end redeem: {body}");
+    let token_json: serde_json::Value =
+        serde_json::from_str(&body).expect("token response is JSON");
+    assert!(
+        token_json.get("access_token").is_some(),
+        "access_token must be issued end-to-end: {body}"
+    );
+}

--- a/crates/vouch-server/src/services/oidc/grant_type.rs
+++ b/crates/vouch-server/src/services/oidc/grant_type.rs
@@ -62,7 +62,7 @@ impl OAuthGrantType {
     #[must_use]
     pub(crate) const fn as_str(self) -> &'static str {
         match self {
-            Self::AuthorizationCode => "authorization_code",
+            Self::AuthorizationCode => protocol::GRANT_TYPE_AUTHORIZATION_CODE,
             Self::ClientCredentials => "client_credentials",
             Self::DeviceCode => protocol::GRANT_TYPE_DEVICE_CODE,
             Self::TokenExchange => protocol::GRANT_TYPE_TOKEN_EXCHANGE,

--- a/crates/vouch-server/src/services/oidc/registration.rs
+++ b/crates/vouch-server/src/services/oidc/registration.rs
@@ -1154,10 +1154,14 @@ fn validate_grant_and_response_types(
         }
     }
 
+    // RFC 7591 §2: "If omitted, the default behavior is that the client will
+    // use only the `authorization_code` Grant Type." Materializing it here
+    // keeps the stored row explicit; `OAuthClient::is_authorized_for_grant`
+    // resolves an absent list to the same constant for rows written elsewhere.
     let grant_types = request
         .grant_types
         .take()
-        .unwrap_or_else(|| vec!["authorization_code".to_string()]);
+        .unwrap_or_else(|| vec![vouch_common::protocol::GRANT_TYPE_AUTHORIZATION_CODE.to_string()]);
     let response_types = request
         .response_types
         .take()

--- a/specs/coverage-baseline.tsv
+++ b/specs/coverage-baseline.tsv
@@ -2020,7 +2020,6 @@ rfc8414#6.1#cebb45a2	MUST	To protect against information disclosure and tamperin
 rfc8414#6.2#c52a5346	MUST	TLS certificate checking MUST be performed by the client, as described in Section 6.1, when making an authorization server metadata request.
 rfc8414#6.2#e2a2583e	MUST	To prevent this, the client MUST ensure that the issuer identifier URL it is using as the prefix for the metadata request exactly matches the value of the "issu
 rfc8628#5.1#047c935e	SHOULD	The user code SHOULD have enough entropy that, when combined with rate-limiting and other mitigations, a brute-force attack becomes infeasible.
-rfc8628#5.2#c2d84f9e	SHOULD	As the device code is not displayed to the user and thus there are no usability considerations on the length, a very high entropy code SHOULD be used.
 rfc8628#5.4#978bf787	SHOULD	To mitigate such an attack, it is RECOMMENDED to inform the user that they are authorizing a device during the user- interaction step (see Section 3.3) and to c
 rfc8628#5.4#def2895d	SHOULD	The authorization server SHOULD display information about the device so that the user could notice if a software client was attempting to impersonate a hardware
 rfc8628#5.5#fc8dab50	SHOULD	Devices SHOULD take into account the operating environment when considering how to communicate the code to the user to reduce the chances it will be observed by


### PR DESCRIPTION
Closes #1330. Replaces #1338 — same content, signed commits (#1338 carried an unsigned commit that the merge queue rejects).

## device_code was the last grant without a `grant_types` check

PR #1308 added `is_authorized_for_grant` to the token-exchange and fido2-assertion handlers, matching the pre-existing `client_credentials` check, and scoped itself to "every grant handler that authenticates a client". The device_code grant authenticates by the consumed `device_code` (`ClientAuthProof::NoAuth`) rather than client credentials, so it was excluded — but `device_token` still loads the registered client from the stored `client_id` for FAPI sender-constraint enforcement, so the metadata to enforce `grant_types` was already in hand.

The check now runs at both ends of the flow: at the device authorization request, so an unauthorized client never gets a `user_code` to show a person, and again at redemption, so a client restricted mid-flow cannot redeem. The redemption gate runs before `try_consume_device_auth` so a rejected client does not burn the single-use code. The built-in CLI flow carries no `client_id` and is unaffected.

## An absent `grant_types` is the RFC 7591 default, not the empty set

Enforcing the field exposed a second-order question: what a stored `grant_types: None` means. It was treated as authorizing nothing. RFC 7591 §2 says otherwise:

> If omitted, the default behavior is that the client will use only the "authorization_code" Grant Type.

So an absent list authorizes `authorization_code` and rejects every other grant — including device_code, which is what this PR's gate needs. Dynamic registration already materializes that default, so `None` only reaches the check for a manually-managed row, which the spec still entitles to the default.

The wire value moves to `vouch_common::protocol::GRANT_TYPE_AUTHORIZATION_CODE`, joining the three grant types already sourced from `protocol`, so the registration default and the authorization check resolve to one constant rather than two literals that can drift. That also keeps `db` from reaching up into `services` for `OAuthGrantType`, which would need a new entry in the arch-boundary exception table.

## Tests

Detail's original tests cover the device_code gate at both ends, including a client restricted to `["authorization_code"]` and a no-regression pass for registered clients and the CLI flow. Added two in `db/oauth.rs` for the default: an absent list authorizes `authorization_code` and nothing else, and an explicit list — including an explicitly empty one — is honored verbatim rather than inheriting the default.

`make fmt`, `make lint`, and `cargo test --all-features` (5719 passed, 0 failed) are clean. The spec-coverage baseline prune this PR needs is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)